### PR TITLE
[Performance] reduce_scatter "direct" algorithm for small shapes

### DIFF
--- a/tests/nightly/t3000/ccl/test_reduce_scatter_minimal_direct.py
+++ b/tests/nightly/t3000/ccl/test_reduce_scatter_minimal_direct.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Correctness coverage for ttnn.experimental.reduce_scatter_minimal_direct.
+
+The direct (one-shot) reduce-scatter unicasts each destination's slice straight to that destination
+instead of relaying it around the ring. It is Ring-only and op-managed (no caller semaphores, no
+barrier semaphore), so the matrix here is deliberately narrower than the minimal_async one: small
+shapes, two scatter dims, trace on and off, and the three persistent-buffer modes.
+
+`run_reduce_scatter_minimal_direct_impl` is shared -- tests/nightly/tg/ccl and the blackhole_CI
+box/galaxy modules import it and only supply their own device fixture and parametrization.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import skip_for_blackhole
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+# Persistent-buffer modes, spelled out because they select different code paths in the op:
+#   "both"    -- {output, staging} from the op's helper. The writer's start barrier is COMPILE-TIME
+#                skipped in this mode (a pinned staging address makes it unnecessary).
+#   "staging"  -- caller-owned output + reduce_scatter_minimal_direct_create_staging_buffer, the
+#                convenience path for callers that already have an output tensor.
+#   "none"    -- op allocates both, which is what compiles the start barrier in.
+PERSISTENT_MODES = ["both", "staging", "none"]
+
+
+def run_reduce_scatter_minimal_direct_impl(
+    mesh_device,
+    num_devices,
+    rs_input_shape,
+    dim,
+    num_links,
+    rs_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_rs,
+    num_iters=1,
+    enable_trace=True,
+    cluster_axis=None,
+    persistent_mode="both",
+):
+    """rs_input_shape is the PER-DEVICE input; the global tensor is that with `dim` scaled by
+    num_devices and sharded across the mesh, so the op reduces over num_devices and scatters `dim`."""
+    torch.manual_seed(0)
+    assert persistent_mode in PERSISTENT_MODES, f"unknown persistent_mode {persistent_mode}"
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    rs_output_shape = rs_input_shape[:]
+    rs_output_shape[dim] //= num_devices
+
+    logger.info(f"reduce_scatter_minimal_direct shape {rs_input_shape} dim {dim} dtype {rs_input_dtype}")
+    logger.info(f"num_devices {num_devices} num_links {num_links} cluster_axis {cluster_axis}")
+    logger.info(f"trace {enable_trace} num_iters {num_iters} persistent {persistent_mode}")
+
+    ##### Input setup: a distinct tensor per iteration, so a stale result cannot pass #####
+    tt_input_tensor_mesh_list = []
+    torch_input_tensor_list = []
+    for _ in range(num_iters):
+        rs_global_input_shape = rs_input_shape[:]
+        rs_global_input_shape[dim] *= num_devices
+        rs_input_tensor = torch.rand(rs_global_input_shape).bfloat16()
+        torch_input_tensor_list.append(torch.chunk(rs_input_tensor, num_devices, dim))
+        tt_input_tensor_mesh_list.append(
+            ttnn.from_torch(
+                rs_input_tensor,
+                device=mesh_device,
+                layout=layout,
+                dtype=rs_input_dtype,
+                memory_config=mem_config_input,
+                mesh_mapper=ttnn.create_mesh_mapper(
+                    mesh_device,
+                    ttnn.MeshMapperConfig(
+                        [ttnn.PlacementReplicate(), ttnn.PlacementShard(dim)], ttnn.MeshShape(1, num_devices)
+                    ),
+                ),
+            )
+        )
+
+    # The op reads its topology from the hardware rather than taking it as an argument, and hard-fails
+    # on anything but a ring. Ask what this placement actually resolves to and skip if the devices along
+    # cluster_axis do not wrap -- a partial row/column is a line, not a small ring.
+    usable_topology = ttnn.get_usable_topology(tt_input_tensor_mesh_list[0], cluster_axis=cluster_axis)
+    if usable_topology != ttnn.Topology.Ring:
+        pytest.skip(
+            f"reduce_scatter_minimal_direct is Ring-only; {num_devices} device(s) on cluster_axis "
+            f"{cluster_axis} of mesh {tuple(mesh_device.shape)} resolve to {usable_topology}"
+        )
+
+    ##### Persistent buffers, one set per iteration (so every iteration's output is verifiable) #####
+    persistent_buffers_list = []
+    for i in range(num_iters):
+        if persistent_mode == "both":
+            persistent_buffers_list.append(
+                ttnn.experimental.reduce_scatter_minimal_direct_create_persistent_buffers(
+                    tt_input_tensor_mesh_list[i], dim=dim, cluster_axis=cluster_axis
+                )
+            )
+        elif persistent_mode == "staging":
+            output_buffer = ttnn.from_torch(
+                torch.zeros(rs_output_shape),
+                device=mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=rs_input_dtype,
+                memory_config=mem_config_rs,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            )
+            staging_buffer = ttnn.experimental.reduce_scatter_minimal_direct_create_staging_buffer(
+                tt_input_tensor_mesh_list[i], dim=dim, cluster_axis=cluster_axis
+            )
+            persistent_buffers_list.append([output_buffer, staging_buffer])
+        else:
+            persistent_buffers_list.append(None)
+
+    ##### Torch golden #####
+    torch_reduce_scatter_output_list = []
+    for i in range(num_iters):
+        reduce_output = torch.sum(torch.stack(torch_input_tensor_list[i]), dim=0)
+        torch_reduce_scatter_output_list.append(torch.chunk(reduce_output, num_devices, dim))
+
+    def run_op(i):
+        return ttnn.experimental.reduce_scatter_minimal_direct(
+            tt_input_tensor_mesh_list[i],
+            dim=dim,
+            cluster_axis=cluster_axis,
+            num_links=num_links,
+            memory_config=mem_config_rs,
+            persistent_buffers=persistent_buffers_list[i],
+            subdevice_id=worker_sub_device_id,
+        )
+
+    tt_reduce_scatter_output_list = []
+    if enable_trace:
+        for i in range(num_iters):  # compile
+            run_op(i)
+        logger.info("Done compiling op")
+
+        trace_output_list = []
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        for i in range(num_iters):
+            trace_output_list.append(run_op(i))
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        logger.info("Done capturing trace")
+
+        ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+        logger.info("Done executing trace")
+
+        for tt_tensor in trace_output_list:
+            tt_rs_out = ttnn.from_device(tt_tensor)
+            tt_reduce_scatter_output_list.append(
+                ttnn.to_torch(tt_rs_out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=dim))
+            )
+        ttnn.release_trace(mesh_device, trace_id)
+    else:
+        for i in range(num_iters):
+            tt_reduce_scatter_output_tensor = run_op(i)
+            ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+            tt_rs_out = ttnn.from_device(tt_reduce_scatter_output_tensor)
+            tt_reduce_scatter_output_list.append(
+                ttnn.to_torch(tt_rs_out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=dim))
+            )
+            logger.info(f"Done iteration {i}")
+
+    for i in range(num_iters):
+        torch_rs_out = torch.cat(torch_reduce_scatter_output_list[i], dim)
+        eq, output = comp_pcc(tt_reduce_scatter_output_list[i], torch_rs_out)
+        logger.info(f"{output}, iteration {i}")
+        assert eq, f"iteration {i} FAILED: {output}"
+
+    mesh_device.reset_sub_device_stall_group()
+
+
+# Small shapes, two scatter dims. Every scatter dim is 8 tiles/pages wide, so the same shapes are
+# valid on any ring size that divides 8 (2, 4, 8) and the destinations below can size their ring
+# from the mesh they are handed.
+RS_DIRECT_SHAPES = [
+    ([1, 1, 32, 256], 3),  # scatter the last dim: 8 tiles wide -> 1 tile/device at N=8
+    ([1, 1, 256, 128], 2),  # scatter height: 8 tiles tall -> 1 tile/device at N=8
+]
+RS_DIRECT_SHAPE_IDS = ["dim3_w256", "dim2_h256"]
+
+RS_DIRECT_TRACE_CASES = [(True, 3), (False, 2)]
+RS_DIRECT_TRACE_IDS = ["trace", "no_trace"]
+
+RS_DIRECT_DRAM_MEM_CONFIG = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+
+@skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize("rs_input_dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("rs_input_shape, dim", RS_DIRECT_SHAPES, ids=RS_DIRECT_SHAPE_IDS)
+@pytest.mark.parametrize("enable_trace, num_iters", RS_DIRECT_TRACE_CASES, ids=RS_DIRECT_TRACE_IDS)
+@pytest.mark.parametrize("persistent_mode", PERSISTENT_MODES)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}],
+    indirect=True,
+    ids=["fabric_ring"],
+)
+def test_reduce_scatter_minimal_direct(
+    mesh_device,
+    num_links,
+    rs_input_shape,
+    dim,
+    rs_input_dtype,
+    enable_trace,
+    num_iters,
+    persistent_mode,
+):
+    run_reduce_scatter_minimal_direct_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        ttnn.TILE_LAYOUT,
+        RS_DIRECT_DRAM_MEM_CONFIG,
+        RS_DIRECT_DRAM_MEM_CONFIG,
+        num_iters=num_iters,
+        enable_trace=enable_trace,
+        persistent_mode=persistent_mode,
+    )

--- a/tests/nightly/t3000/ccl/test_reduce_scatter_minimal_direct.py
+++ b/tests/nightly/t3000/ccl/test_reduce_scatter_minimal_direct.py
@@ -90,12 +90,13 @@ def run_reduce_scatter_minimal_direct_impl(
         )
 
     # The op reads its topology from the hardware rather than taking it as an argument, and hard-fails
-    # on anything but a ring. Ask what this placement actually resolves to and skip if the devices along
-    # cluster_axis do not wrap -- a partial row/column is a line, not a small ring.
+    # on anything that does not wrap. Ask what this placement actually resolves to and skip if the devices
+    # along cluster_axis do not -- a partial row/column is a line, not a small ring. A 2D-fabric torus axis
+    # reports Torus rather than Ring, and is equally valid: both mean the axis wraps.
     usable_topology = ttnn.get_usable_topology(tt_input_tensor_mesh_list[0], cluster_axis=cluster_axis)
-    if usable_topology != ttnn.Topology.Ring:
+    if usable_topology not in (ttnn.Topology.Ring, ttnn.Topology.Torus):
         pytest.skip(
-            f"reduce_scatter_minimal_direct is Ring-only; {num_devices} device(s) on cluster_axis "
+            f"reduce_scatter_minimal_direct needs an axis that wraps; {num_devices} device(s) on cluster_axis "
             f"{cluster_axis} of mesh {tuple(mesh_device.shape)} resolve to {usable_topology}"
         )
 

--- a/tests/nightly/t3000/ccl/test_reduce_scatter_minimal_direct.py
+++ b/tests/nightly/t3000/ccl/test_reduce_scatter_minimal_direct.py
@@ -71,7 +71,11 @@ def run_reduce_scatter_minimal_direct_impl(
     for _ in range(num_iters):
         rs_global_input_shape = rs_input_shape[:]
         rs_global_input_shape[dim] *= num_devices
-        rs_input_tensor = torch.rand(rs_global_input_shape).bfloat16()
+        # Match the torch dtype to the ttnn one. For float32 this matters: the op derives fp32_dest_acc_en
+        # from the input dtype, so feeding bf16-rounded data would hide a reducer compiled in the wrong
+        # destination-accumulator mode behind an already-bf16 golden.
+        torch_dtype = torch.float32 if rs_input_dtype == ttnn.float32 else torch.bfloat16
+        rs_input_tensor = torch.rand(rs_global_input_shape).to(torch_dtype)
         torch_input_tensor_list.append(torch.chunk(rs_input_tensor, num_devices, dim))
         tt_input_tensor_mesh_list.append(
             ttnn.from_torch(
@@ -235,4 +239,37 @@ def test_reduce_scatter_minimal_direct(
         num_iters=num_iters,
         enable_trace=enable_trace,
         persistent_mode=persistent_mode,
+    )
+
+
+# FLOAT32 regression: the geometry sets fp32_dest_acc_en from the input dtype (which halves max_dst_size
+# from 8 to 4 tiles per chunk), so the compute kernel MUST be built with the same flag. It previously took
+# a default-constructed ComputeConfigDescriptor, whose fp32_dest_acc_en is false, and reduced float32
+# inputs in bf16-precision destination registers. Kept as its own case rather than another axis on the
+# matrix above: one shape is enough to pin the dest-accumulator mode, and the rest of the coverage is
+# dtype-independent.
+@skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize("rs_input_shape, dim", [([1, 1, 32, 256], 3)], ids=["dim3_w256"])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}],
+    indirect=True,
+    ids=["fabric_ring"],
+)
+def test_reduce_scatter_minimal_direct_float32(mesh_device, num_links, rs_input_shape, dim):
+    run_reduce_scatter_minimal_direct_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        rs_input_shape,
+        dim,
+        num_links,
+        ttnn.float32,
+        ttnn.TILE_LAYOUT,
+        RS_DIRECT_DRAM_MEM_CONFIG,
+        RS_DIRECT_DRAM_MEM_CONFIG,
+        num_iters=2,
+        enable_trace=False,
+        persistent_mode="none",
     )

--- a/tests/nightly/t3000/ccl/test_reduce_scatter_minimal_direct.py
+++ b/tests/nightly/t3000/ccl/test_reduce_scatter_minimal_direct.py
@@ -71,9 +71,7 @@ def run_reduce_scatter_minimal_direct_impl(
     for _ in range(num_iters):
         rs_global_input_shape = rs_input_shape[:]
         rs_global_input_shape[dim] *= num_devices
-        # Match the torch dtype to the ttnn one. For float32 this matters: the op derives fp32_dest_acc_en
-        # from the input dtype, so feeding bf16-rounded data would hide a reducer compiled in the wrong
-        # destination-accumulator mode behind an already-bf16 golden.
+        # Must follow rs_input_dtype: bf16-rounded input would hide an fp32 dest-accumulator bug.
         torch_dtype = torch.float32 if rs_input_dtype == ttnn.float32 else torch.bfloat16
         rs_input_tensor = torch.rand(rs_global_input_shape).to(torch_dtype)
         torch_input_tensor_list.append(torch.chunk(rs_input_tensor, num_devices, dim))
@@ -242,12 +240,8 @@ def test_reduce_scatter_minimal_direct(
     )
 
 
-# FLOAT32 regression: the geometry sets fp32_dest_acc_en from the input dtype (which halves max_dst_size
-# from 8 to 4 tiles per chunk), so the compute kernel MUST be built with the same flag. It previously took
-# a default-constructed ComputeConfigDescriptor, whose fp32_dest_acc_en is false, and reduced float32
-# inputs in bf16-precision destination registers. Kept as its own case rather than another axis on the
-# matrix above: one shape is enough to pin the dest-accumulator mode, and the rest of the coverage is
-# dtype-independent.
+# FLOAT32 regression: pins the compute kernel's fp32_dest_acc_en to the value the geometry assumed.
+# One shape suffices; a dtype axis on the matrix above would double it for no extra coverage.
 @skip_for_blackhole("Requires wormhole_b0 to run")
 @pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])

--- a/tests/nightly/tg/ccl/test_reduce_scatter_minimal_direct.py
+++ b/tests/nightly/tg/ccl/test_reduce_scatter_minimal_direct.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""TG coverage for ttnn.experimental.reduce_scatter_minimal_direct.
+
+Shares run_reduce_scatter_minimal_direct_impl with the t3000 module (same import convention the
+minimal_async TG test uses); this module only picks the submesh and the parametrization.
+
+The op derives its topology from the hardware rather than taking it as an argument, so the ring must
+be a full mesh row/column -- hence the cluster-axis-0 submesh of the whole 8-device dimension.
+"""
+
+import pytest
+
+import ttnn
+from models.common.utility_functions import skip_for_blackhole
+from tests.nightly.t3000.ccl.test_reduce_scatter_minimal_direct import (
+    PERSISTENT_MODES,
+    RS_DIRECT_DRAM_MEM_CONFIG,
+    RS_DIRECT_SHAPE_IDS,
+    RS_DIRECT_SHAPES,
+    RS_DIRECT_TRACE_CASES,
+    RS_DIRECT_TRACE_IDS,
+    run_reduce_scatter_minimal_direct_impl,
+)
+
+
+@skip_for_blackhole("This test is for wormhole")
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize("rs_input_dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("rs_input_shape, dim", RS_DIRECT_SHAPES, ids=RS_DIRECT_SHAPE_IDS)
+@pytest.mark.parametrize("enable_trace, num_iters", RS_DIRECT_TRACE_CASES, ids=RS_DIRECT_TRACE_IDS)
+# "both" and "none" are the two that matter here: they select whether the writer's start barrier is
+# compiled in. The "staging" helper path is covered on t3000/blackhole.
+@pytest.mark.parametrize("persistent_mode", [m for m in PERSISTENT_MODES if m != "staging"])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 90112}],
+    indirect=True,
+    ids=["fabric_ring"],
+)
+def test_reduce_scatter_minimal_direct(
+    mesh_device,
+    num_links,
+    rs_input_shape,
+    dim,
+    rs_input_dtype,
+    enable_trace,
+    num_iters,
+    persistent_mode,
+):
+    cluster_axis = 0
+    num_devices = tuple(mesh_device.shape)[cluster_axis]
+    if num_devices < 2:
+        pytest.skip(f"reduce_scatter needs a ring of at least 2, got {num_devices} on axis {cluster_axis}")
+    submesh_device = mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+
+    run_reduce_scatter_minimal_direct_impl(
+        submesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        ttnn.TILE_LAYOUT,
+        RS_DIRECT_DRAM_MEM_CONFIG,
+        RS_DIRECT_DRAM_MEM_CONFIG,
+        num_iters=num_iters,
+        enable_trace=enable_trace,
+        cluster_axis=cluster_axis,
+        persistent_mode=persistent_mode,
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_minimal_direct_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_minimal_direct_bh.py
@@ -128,3 +128,57 @@ def test_reduce_scatter_minimal_direct_sharded(
         enable_trace=enable_trace,
         persistent_mode="none",
     )
+
+
+@skip_for_wormhole_b0()
+@skip_for_n_or_less_dev(1)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize("rs_input_dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("rs_input_shape, dim", RS_DIRECT_SHAPES, ids=RS_DIRECT_SHAPE_IDS)
+@pytest.mark.parametrize("persistent_mode", PERSISTENT_MODES)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X, "trace_region_size": 1171456}],
+    indirect=True,
+    ids=["fabric_2d_torus_x"],
+)
+def test_reduce_scatter_minimal_direct_2d_torus(
+    mesh_device,
+    num_links,
+    rs_input_shape,
+    dim,
+    rs_input_dtype,
+    persistent_mode,
+):
+    """2D-fabric coverage. On 2D the op cannot route by hop count -- the fabric routes by DESTINATION
+    NODE -- so the factory re-derives each send's direction from the control plane. This exercises that
+    path; the 1D cases above cannot, since 1D routing is direction-agnostic by construction.
+
+    Mesh orientation matters and is not interchangeable. axis_topology binds a mesh-VIEW axis index to a
+    fabric dimension (axis 1 -> X), while the torus config wraps a PHYSICAL dimension. On this 2x4 box
+    the length-4 ring is the X dimension, so it must be viewed as 2x4 with cluster_axis=1 under TORUS_X.
+    Viewed as 4x2, TORUS_X reports the 4-axis as Linear (the op refuses) and TORUS_Y reports it as Torus
+    while physically wrapping the length-2 dimension -- a wrap that does not exist. The factory now
+    catches that second case with a single-hop neighbour check rather than hanging.
+    """
+    cluster_axis = 1
+    num_devices = mesh_device.shape[cluster_axis]
+    if rs_input_shape[dim] % num_devices:
+        pytest.skip(f"scatter dim {dim} (size {rs_input_shape[dim]}) does not split across {num_devices} devices")
+
+    run_reduce_scatter_minimal_direct_impl(
+        mesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        ttnn.TILE_LAYOUT,
+        RS_DIRECT_DRAM_MEM_CONFIG,
+        RS_DIRECT_DRAM_MEM_CONFIG,
+        num_iters=2,
+        enable_trace=False,
+        cluster_axis=cluster_axis,
+        persistent_mode=persistent_mode,
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_minimal_direct_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_minimal_direct_bh.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Blackhole box coverage for ttnn.experimental.reduce_scatter_minimal_direct.
+
+Shares run_reduce_scatter_minimal_direct_impl with the t3000 module -- the driver takes the device as
+an argument, so the bh_1d_mesh_device fixture drops straight in.
+
+The op reads its topology from the hardware instead of taking it as an argument, so it needs a ring
+that wraps: the whole 1D mesh. num_devices therefore comes from the fixture (validated by
+validate_test) rather than being parametrized, which also lets the same cases run on 4- and 8-device
+boxes -- every scatter dim below is 8 pages wide, so it splits evenly either way.
+"""
+
+import pytest
+
+import ttnn
+from models.common.utility_functions import skip_for_n_or_less_dev, skip_for_wormhole_b0
+from tests.nightly.t3000.ccl.test_reduce_scatter_minimal_direct import (
+    PERSISTENT_MODES,
+    RS_DIRECT_DRAM_MEM_CONFIG,
+    RS_DIRECT_SHAPE_IDS,
+    RS_DIRECT_SHAPES,
+    RS_DIRECT_TRACE_CASES,
+    RS_DIRECT_TRACE_IDS,
+    run_reduce_scatter_minimal_direct_impl,
+)
+from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gather_nightly import validate_test
+
+
+@skip_for_wormhole_b0()
+@skip_for_n_or_less_dev(1)
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize("rs_input_dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("rs_input_shape, dim", RS_DIRECT_SHAPES, ids=RS_DIRECT_SHAPE_IDS)
+@pytest.mark.parametrize("enable_trace, num_iters", RS_DIRECT_TRACE_CASES, ids=RS_DIRECT_TRACE_IDS)
+@pytest.mark.parametrize("persistent_mode", PERSISTENT_MODES)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}],
+    indirect=True,
+    ids=["fabric_ring"],
+)
+def test_reduce_scatter_minimal_direct_ring(
+    bh_1d_mesh_device,
+    num_links,
+    rs_input_shape,
+    dim,
+    rs_input_dtype,
+    enable_trace,
+    num_iters,
+    persistent_mode,
+):
+    num_devices = bh_1d_mesh_device.get_num_devices()
+    validate_test(num_devices, ttnn.Topology.Ring, bh_1d_mesh_device.shape, 0)
+    if rs_input_shape[dim] % num_devices:
+        pytest.skip(f"scatter dim {dim} (size {rs_input_shape[dim]}) does not split across {num_devices} devices")
+
+    run_reduce_scatter_minimal_direct_impl(
+        bh_1d_mesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        ttnn.TILE_LAYOUT,
+        RS_DIRECT_DRAM_MEM_CONFIG,
+        RS_DIRECT_DRAM_MEM_CONFIG,
+        num_iters=num_iters,
+        enable_trace=enable_trace,
+        persistent_mode=persistent_mode,
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_minimal_direct_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_minimal_direct_bh.py
@@ -71,3 +71,60 @@ def test_reduce_scatter_minimal_direct_ring(
         enable_trace=enable_trace,
         persistent_mode=persistent_mode,
     )
+
+
+@skip_for_wormhole_b0()
+@skip_for_n_or_less_dev(1)
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize("rs_input_dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("enable_trace, num_iters", RS_DIRECT_TRACE_CASES, ids=RS_DIRECT_TRACE_IDS)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}],
+    indirect=True,
+    ids=["fabric_ring"],
+)
+def test_reduce_scatter_minimal_direct_sharded(
+    bh_1d_mesh_device,
+    num_links,
+    rs_input_dtype,
+    enable_trace,
+    num_iters,
+):
+    """Width-sharded L1 in and out. ttnn.reduce_scatter routes sharded cases to this op, so the sharded
+    layout needs coverage even though the op's own staging is always interleaved/L1-sharded on its own
+    terms. Buffers are op-allocated (persistent_mode="none"), which is how that dispatch calls it.
+
+    Sized off the ring: input width = num_devices^2 tiles over a num_devices-wide core grid, so the
+    input shards num_devices tiles/core and the output (num_devices tiles wide) shards 1 tile/core --
+    valid on any ring size this box presents.
+    """
+    num_devices = bh_1d_mesh_device.get_num_devices()
+    validate_test(num_devices, ttnn.Topology.Ring, bh_1d_mesh_device.shape, 0)
+
+    rs_input_shape = [1, 1, 32, 32 * num_devices * num_devices]
+    output_shape = list(rs_input_shape)
+    output_shape[3] //= num_devices
+
+    def width_sharded(shape):
+        return ttnn.create_sharded_memory_config(
+            tuple(shape),
+            core_grid=ttnn.CoreGrid(y=1, x=num_devices),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+
+    run_reduce_scatter_minimal_direct_impl(
+        bh_1d_mesh_device,
+        num_devices,
+        rs_input_shape,
+        3,
+        num_links,
+        rs_input_dtype,
+        ttnn.TILE_LAYOUT,
+        width_sharded(rs_input_shape),
+        width_sharded(output_shape),
+        num_iters=num_iters,
+        enable_trace=enable_trace,
+        persistent_mode="none",
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_minimal_direct_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_minimal_direct_bh.py
@@ -219,6 +219,10 @@ def test_reduce_scatter_minimal_direct_2d_torus(
     if len(mesh_shape) != 2:
         pytest.skip(f"2D-fabric test needs a 2D system mesh, got {mesh_shape}")
     num_devices = mesh_shape[cluster_axis]
+    if num_devices < 2:
+        # A one-device axis is not a ring to scatter over, and the split check below cannot catch it:
+        # every dim divides by 1. skip_for_n_or_less_dev counts the whole mesh, so it passes here.
+        pytest.skip(f"cluster axis {cluster_axis} of mesh {mesh_shape} has {num_devices} device")
     if rs_input_shape[dim] % num_devices:
         pytest.skip(f"scatter dim {dim} (size {rs_input_shape[dim]}) does not split across {num_devices} devices")
 

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_minimal_direct_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_scatter_minimal_direct_bh.py
@@ -10,12 +10,14 @@ an argument, so the bh_1d_mesh_device fixture drops straight in.
 The op reads its topology from the hardware instead of taking it as an argument, so it needs a ring
 that wraps: the whole 1D mesh. num_devices therefore comes from the fixture (validated by
 validate_test) rather than being parametrized, which also lets the same cases run on 4- and 8-device
-boxes -- every scatter dim below is 8 pages wide, so it splits evenly either way.
+boxes -- every scatter dim below is 8 pages wide, so it splits evenly either way. The 2D case takes
+its mesh from the system mesh for the same reason, via bh_torus_mesh_device below.
 """
 
 import pytest
 
 import ttnn
+from conftest import reset_fabric, set_fabric
 from models.common.utility_functions import skip_for_n_or_less_dev, skip_for_wormhole_b0
 from tests.nightly.t3000.ccl.test_reduce_scatter_minimal_direct import (
     PERSISTENT_MODES,
@@ -26,7 +28,55 @@ from tests.nightly.t3000.ccl.test_reduce_scatter_minimal_direct import (
     RS_DIRECT_TRACE_IDS,
     run_reduce_scatter_minimal_direct_impl,
 )
+from tests.scripts.common import get_updated_device_params
 from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gather_nightly import validate_test
+
+
+@pytest.fixture(scope="function")
+def bh_torus_mesh_device(request, silicon_arch_name, silicon_arch_blackhole, device_params):
+    """The 2D mesh this box actually presents under the requested torus fabric.
+
+    Neither shared fixture can supply that. `mesh_device` opens the shape the caller parametrizes and
+    `bh_2d_mesh_device` opens one hardcoded per device count (4x2 on eight devices) -- but the system
+    mesh is a function of the fabric config, and a torus config is not FABRIC_2D. Auto-discovery keeps
+    only what it can wire up, and in run 30838619957 a LoudBox that had opened an eight-device 2D mesh
+    minutes earlier under FABRIC_2D reported a four-device 2x2 system mesh under TORUS_X. Asking for a
+    shape the control plane did not discover aborts inside open_mesh_device, and by then the fixture
+    has already latched the fabric
+    config process-wide with no path to unlatch it -- which is how one unopenable mesh turned into 236
+    errors, every later test in that job dying on the latch instead of on its own merits.
+
+    So: latch the fabric first, ask what came back, open exactly that. Whether the result is big enough
+    to scatter over is the test's business, not the fixture's.
+    """
+    request.node.pci_ids = ttnn.get_pcie_device_ids()
+
+    updated_device_params = get_updated_device_params(device_params)
+    fabric_config = updated_device_params.pop("fabric_config", None)
+    fabric_tensix_config = updated_device_params.pop("fabric_tensix_config", None)
+    reliability_mode = updated_device_params.pop("reliability_mode", None)
+    fabric_manager = updated_device_params.pop("fabric_manager", None)
+    fabric_router_config = updated_device_params.pop("fabric_router_config", None)
+    set_fabric(fabric_config, reliability_mode, fabric_tensix_config, fabric_manager, fabric_router_config)
+
+    try:
+        # local_shape() rather than shape(): on a multi-host mesh only this host's devices are ours to
+        # open. These boxes are single-host, where the two are the same.
+        mesh_shape = ttnn._ttnn.multi_device.SystemMeshDescriptor().local_shape()
+        mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, **updated_device_params)
+    except Exception:
+        # Unlatch, or the rest of the session inherits a fabric config it never asked for.
+        reset_fabric(fabric_config)
+        raise
+
+    try:
+        yield mesh_device
+    finally:
+        for submesh in mesh_device.get_submeshes():
+            ttnn.close_mesh_device(submesh)
+        ttnn.close_mesh_device(mesh_device)
+        reset_fabric(fabric_config)
+        del mesh_device
 
 
 @skip_for_wormhole_b0()
@@ -132,7 +182,6 @@ def test_reduce_scatter_minimal_direct_sharded(
 
 @skip_for_wormhole_b0()
 @skip_for_n_or_less_dev(1)
-@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize("rs_input_dtype", [ttnn.bfloat16], ids=["bf16"])
 @pytest.mark.parametrize("rs_input_shape, dim", RS_DIRECT_SHAPES, ids=RS_DIRECT_SHAPE_IDS)
@@ -144,7 +193,7 @@ def test_reduce_scatter_minimal_direct_sharded(
     ids=["fabric_2d_torus_x"],
 )
 def test_reduce_scatter_minimal_direct_2d_torus(
-    mesh_device,
+    bh_torus_mesh_device,
     num_links,
     rs_input_shape,
     dim,
@@ -156,14 +205,20 @@ def test_reduce_scatter_minimal_direct_2d_torus(
     path; the 1D cases above cannot, since 1D routing is direction-agnostic by construction.
 
     Mesh orientation matters and is not interchangeable. axis_topology binds a mesh-VIEW axis index to a
-    fabric dimension (axis 1 -> X), while the torus config wraps a PHYSICAL dimension. On this 2x4 box
-    the length-4 ring is the X dimension, so it must be viewed as 2x4 with cluster_axis=1 under TORUS_X.
-    Viewed as 4x2, TORUS_X reports the 4-axis as Linear (the op refuses) and TORUS_Y reports it as Torus
-    while physically wrapping the length-2 dimension -- a wrap that does not exist. The factory now
-    catches that second case with a single-hop neighbour check rather than hanging.
+    fabric dimension (axis 1 -> X), while the torus config wraps a PHYSICAL dimension, so a view whose
+    axis 1 is not the box's X dimension either gets refused (TORUS_X reports that axis Linear) or -- the
+    dangerous one -- reported as a Torus wrapping a dimension that does not physically wrap, which the
+    factory catches with a single-hop neighbour check rather than hanging. Taking the view straight from
+    the system mesh removes the choice: axis 1 of the discovered shape IS the box's X dimension, so
+    cluster_axis=1 is correct on any box, and a box whose X dimension does not wrap under TORUS_X skips
+    below on its resolved topology instead of running a mislabelled ring.
     """
+    mesh_device = bh_torus_mesh_device
+    mesh_shape = tuple(mesh_device.shape)
     cluster_axis = 1
-    num_devices = mesh_device.shape[cluster_axis]
+    if len(mesh_shape) != 2:
+        pytest.skip(f"2D-fabric test needs a 2D system mesh, got {mesh_shape}")
+    num_devices = mesh_shape[cluster_axis]
     if rs_input_shape[dim] % num_devices:
         pytest.skip(f"scatter dim {dim} (size {rs_input_shape[dim]}) does not split across {num_devices} devices")
 

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/nightly/test_reduce_scatter_minimal_direct_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/nightly/test_reduce_scatter_minimal_direct_bh.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Blackhole galaxy coverage for ttnn.experimental.reduce_scatter_minimal_direct.
+
+Shares run_reduce_scatter_minimal_direct_impl with the t3000 module -- the driver takes the device as
+an argument, so the bh_2d_mesh_device fixture drops straight in.
+
+The op reads its topology from the hardware instead of taking it as an argument, so the collective
+must span a FULL mesh row (a partial row has no wraparound and is not a ring). num_devices is
+therefore taken from the mesh's cluster-axis extent rather than parametrized -- the neighbouring
+minimal_async ring test hardcodes a 4-device group on an 8-wide axis and is currently skipped for
+hanging, which is exactly the failure mode this avoids.
+"""
+
+import pytest
+
+import ttnn
+from models.common.utility_functions import skip_for_n_or_less_dev, skip_for_wormhole_b0
+from tests.nightly.t3000.ccl.test_reduce_scatter_minimal_direct import (
+    PERSISTENT_MODES,
+    RS_DIRECT_DRAM_MEM_CONFIG,
+    RS_DIRECT_SHAPE_IDS,
+    RS_DIRECT_SHAPES,
+    RS_DIRECT_TRACE_CASES,
+    RS_DIRECT_TRACE_IDS,
+    run_reduce_scatter_minimal_direct_impl,
+)
+
+
+@skip_for_wormhole_b0()
+@skip_for_n_or_less_dev(1)
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize("cluster_axis", [1], ids=["axis1"])
+@pytest.mark.parametrize("rs_input_dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("rs_input_shape, dim", RS_DIRECT_SHAPES, ids=RS_DIRECT_SHAPE_IDS)
+@pytest.mark.parametrize("enable_trace, num_iters", RS_DIRECT_TRACE_CASES, ids=RS_DIRECT_TRACE_IDS)
+# "both" and "none" are the two that matter here: they select whether the writer's start barrier is
+# compiled in. The "staging" helper path is covered on t3000 and the blackhole box.
+@pytest.mark.parametrize("persistent_mode", [m for m in PERSISTENT_MODES if m != "staging"])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}],
+    indirect=True,
+    ids=["fabric_ring"],
+)
+def test_reduce_scatter_minimal_direct_ring(
+    bh_2d_mesh_device,
+    num_links,
+    cluster_axis,
+    rs_input_shape,
+    dim,
+    rs_input_dtype,
+    enable_trace,
+    num_iters,
+    persistent_mode,
+):
+    num_devices = tuple(bh_2d_mesh_device.shape)[cluster_axis]
+    if num_devices < 2:
+        pytest.skip(f"reduce_scatter needs a ring of at least 2, got {num_devices} on axis {cluster_axis}")
+    if rs_input_shape[dim] % num_devices:
+        pytest.skip(f"scatter dim {dim} (size {rs_input_shape[dim]}) does not split across {num_devices} devices")
+
+    run_reduce_scatter_minimal_direct_impl(
+        bh_2d_mesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        ttnn.TILE_LAYOUT,
+        RS_DIRECT_DRAM_MEM_CONFIG,
+        RS_DIRECT_DRAM_MEM_CONFIG,
+        num_iters=num_iters,
+        enable_trace=enable_trace,
+        cluster_axis=cluster_axis,
+        persistent_mode=persistent_mode,
+    )

--- a/tt_metal/fabric/hw/inc/api_common.h
+++ b/tt_metal/fabric/hw/inc/api_common.h
@@ -307,6 +307,7 @@ static FORCE_INLINE void populate_unicast_scatter_write_fields(
             accumulated += chunk;
             packet_header->command_fields.unicast_scatter_write.chunk_size[i] = chunk;
         }
+
         if constexpr (update_payload_size) {
             ASSERT(accumulated < payload_size);
         }

--- a/tt_metal/fabric/hw/inc/api_common.h
+++ b/tt_metal/fabric/hw/inc/api_common.h
@@ -307,7 +307,6 @@ static FORCE_INLINE void populate_unicast_scatter_write_fields(
             accumulated += chunk;
             packet_header->command_fields.unicast_scatter_write.chunk_size[i] = chunk;
         }
-
         if constexpr (update_payload_size) {
             ASSERT(accumulated < payload_size);
         }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -14,9 +14,81 @@
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 #include "ttnn/operations/experimental/ccl/composite_common.hpp"
+#include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp"
+#include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp"
+
+#include <cstdlib>
 
 namespace ttnn {
 using namespace ttnn::operations::ccl;
+
+namespace {
+
+// --- Direct (one-shot) reduce-scatter dispatch policy ---
+//
+// reduce_scatter_minimal_direct unicasts every destination's slice STRAIGHT to that destination: one
+// fabric traversal instead of the ring's N/2 store-and-forward steps, in exchange for ~2.3x the link
+// traffic (a distance-h contribution crosses h links). So it is a latency play -- it wins while the
+// collective is dominated by fill latency and loses once it is bandwidth-bound, by a margin that grows
+// with size.
+//
+// MEASURED 2026-07-30, blackhole 1x8 ring, bf16/bf8, trace, op-allocated buffers (which is how this
+// dispatch calls it, so the writer's start barrier is compiled in) -- direct/ring ratio by per-device
+// input size: see the threshold below. Past the crossover the ring op wins and keeps pulling away
+// (1.55x at 512K elements, 3.52x at 5M, 3.95x at 25M).
+//
+// TTNN_DISABLE_RS_DIRECT=1 forces the ring op regardless -- an escape hatch while this path is new,
+// since it routes the default ttnn.reduce_scatter onto an experimental op.
+constexpr uint64_t k_direct_rs_max_input_bytes = 0;  // PLACEHOLDER -- set from the crossover sweep
+
+bool direct_reduce_scatter_disabled() {
+    const char* env = std::getenv("TTNN_DISABLE_RS_DIRECT");
+    return env != nullptr && env[0] != '\0' && env[0] != '0';
+}
+
+bool use_direct_reduce_scatter(
+    const ttnn::Tensor& input_tensor,
+    int32_t dim,
+    std::optional<uint32_t> cluster_axis,
+    tt::tt_fabric::Topology topology,
+    const ttnn::MemoryConfig& output_memory_config,
+    const std::optional<ttnn::Tensor>& optional_output_tensor,
+    std::optional<uint32_t> chunks_per_sync,
+    std::optional<uint32_t> num_workers_per_link,
+    std::optional<uint32_t> num_buffers_per_channel,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    if (direct_reduce_scatter_disabled()) {
+        return false;
+    }
+    if (topology != tt::tt_fabric::Topology::Ring) {
+        return false;
+    }
+    // The direct op has no tuning knobs and no compute-kernel config of its own (it derives
+    // fp32_dest_acc from the dtype). Honour an explicit request for any of them by staying on the ring
+    // op rather than silently dropping it.
+    if (chunks_per_sync.has_value() || num_workers_per_link.has_value() || num_buffers_per_channel.has_value() ||
+        compute_kernel_config.has_value()) {
+        return false;
+    }
+    // Only interleaved has been validated end-to-end; the staging aliasing and the tiled output walk
+    // both assume it.
+    if (input_tensor.memory_config().is_sharded() || output_memory_config.is_sharded()) {
+        return false;
+    }
+    if (optional_output_tensor.has_value() && optional_output_tensor->memory_config().is_sharded()) {
+        return false;
+    }
+    // Structural constraints (ring, TILE, whole-page split, 1D fabric) are the op's own to state.
+    if (!ttnn::experimental::reduce_scatter_minimal_direct_is_applicable(input_tensor, dim, cluster_axis)) {
+        return false;
+    }
+    // Size gate: physical per-device input bytes, so block-float dtypes are counted as they actually
+    // land in DRAM rather than by logical element count.
+    const auto* buffer = input_tensor.buffer();
+    return buffer != nullptr && static_cast<uint64_t>(buffer->size()) <= k_direct_rs_max_input_bytes;
+}
+
+}  // namespace
 
 ttnn::Tensor reduce_scatter(
     const ttnn::Tensor& input_tensor,
@@ -88,6 +160,34 @@ ttnn::Tensor reduce_scatter(
             resolved_compute_kernel_config,
             use_l1_small_for_semaphores);
     }
+    // Small-shape fast path: one fabric hop per contribution instead of the ring's N/2 relay steps.
+    // Gated on topology/layout/size -- see use_direct_reduce_scatter. Called through the prim so the
+    // caller's optional output tensor can be reused without also having to own the staging buffer;
+    // staging stays op-allocated, which is what compiles the writer's start barrier in.
+    if (use_direct_reduce_scatter(
+            input_tensor,
+            dim,
+            cluster_axis,
+            topology_,
+            memory_config_,
+            optional_output_tensor,
+            chunks_per_sync,
+            num_workers_per_link,
+            num_buffers_per_channel,
+            compute_kernel_config)) {
+        return ttnn::prim::reduce_scatter_minimal_direct(
+                   input_tensor,
+                   static_cast<int32_t>(normalized_dim),
+                   memory_config_,
+                   cluster_axis,
+                   num_links_,
+                   optional_output_tensor,
+                   /*persistent_staging_tensor=*/std::nullopt,
+                   subdevice_id,
+                   /*sub_core_grid=*/std::nullopt)
+            .at(0);
+    }
+
     return ttnn::prim::reduce_scatter(
                input_tensor,
                normalized_dim,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -17,8 +17,6 @@
 #include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp"
 
-#include <cstdlib>
-
 namespace ttnn {
 using namespace ttnn::operations::ccl;
 
@@ -32,34 +30,33 @@ namespace {
 // collective is dominated by fill latency and loses once it is bandwidth-bound, by a margin that grows
 // with size.
 //
-// MEASURED 2026-07-30, blackhole 1x8 ring, bf16/bf8, trace, op-allocated buffers (which is how this
-// dispatch calls it, so the writer's start barrier is compiled in) -- direct/ring ratio by per-device
-// input size: see the threshold below. Past the crossover the ring op wins and keeps pulling away
-// (1.55x at 512K elements, 3.52x at 5M, 3.95x at 25M).
+// MEASURED 2026-07-31, blackhole 1x8 ring, trace, op-allocated buffers -- which is how THIS dispatch
+// calls it, so the writer's start barrier is compiled in and the numbers below include it. Ratio is
+// direct/ring, so < 1.00 means direct wins; per-device input bytes on the left:
 //
-// TTNN_DISABLE_RS_DIRECT=1 forces the ring op regardless -- an escape hatch while this path is new,
-// since it routes the default ttnn.reduce_scatter onto an experimental op.
-constexpr uint64_t k_direct_rs_max_input_bytes = 0;  // PLACEHOLDER -- set from the crossover sweep
-
-bool direct_reduce_scatter_disabled() {
-    const char* env = std::getenv("TTNN_DISABLE_RS_DIRECT");
-    return env != nullptr && env[0] != '\0' && env[0] != '0';
-}
+//     bf16                              bf8
+//      16 KB  0.54                       8 KB  0.66
+//      64 KB  0.70 / 0.56 (repeats)     34 KB  0.52
+//     128 KB  0.65                      68 KB  0.55
+//     256 KB  0.59                     136 KB  0.69
+//     448 KB  0.78, 0.85               238 KB  0.62, 0.63
+//    1024 KB  1.29  <-- ring wins      544 KB  0.98  (tie)
+//
+// The crossover sits between 448 KB and 1 MB, so the gate is 512 KB. Past it the ring op keeps pulling
+// away -- independently confirmed on device crit-path time: 1.55x at 512K elements, 3.52x at 5M,
+// 3.95x at 25M. bf8 is still break-even at 544 KB, so a single byte-based gate is slightly
+// conservative for it; that costs nothing, since it is a tie there anyway.
+constexpr uint64_t k_direct_rs_max_input_bytes = 512ull << 10;
 
 bool use_direct_reduce_scatter(
     const ttnn::Tensor& input_tensor,
     int32_t dim,
     std::optional<uint32_t> cluster_axis,
     tt::tt_fabric::Topology topology,
-    const ttnn::MemoryConfig& output_memory_config,
-    const std::optional<ttnn::Tensor>& optional_output_tensor,
     std::optional<uint32_t> chunks_per_sync,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
-    if (direct_reduce_scatter_disabled()) {
-        return false;
-    }
     if (topology != tt::tt_fabric::Topology::Ring) {
         return false;
     }
@@ -68,14 +65,6 @@ bool use_direct_reduce_scatter(
     // op rather than silently dropping it.
     if (chunks_per_sync.has_value() || num_workers_per_link.has_value() || num_buffers_per_channel.has_value() ||
         compute_kernel_config.has_value()) {
-        return false;
-    }
-    // Only interleaved has been validated end-to-end; the staging aliasing and the tiled output walk
-    // both assume it.
-    if (input_tensor.memory_config().is_sharded() || output_memory_config.is_sharded()) {
-        return false;
-    }
-    if (optional_output_tensor.has_value() && optional_output_tensor->memory_config().is_sharded()) {
         return false;
     }
     // Structural constraints (ring, TILE, whole-page split, 1D fabric) are the op's own to state.
@@ -169,8 +158,6 @@ ttnn::Tensor reduce_scatter(
             dim,
             cluster_axis,
             topology_,
-            memory_config_,
-            optional_output_tensor,
             chunks_per_sync,
             num_workers_per_link,
             num_buffers_per_channel,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -57,7 +57,8 @@ bool use_direct_reduce_scatter(
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
-    if (topology != tt::tt_fabric::Topology::Ring) {
+    // The axis has to wrap: Ring on a 1D fabric, Torus on a 2D one.
+    if (!tt::tt_fabric::is_ring_or_torus(topology)) {
         return false;
     }
     // The direct op has no tuning knobs and no compute-kernel config of its own (it derives

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -4,6 +4,11 @@
 
 #include "ttnn/common/queue_id.hpp"
 
+#include <mutex>
+#include <set>
+#include <tuple>
+#include <tt-logger/tt-logger.hpp>
+
 #include "reduce_scatter.hpp"
 #include "device/reduce_scatter_device_operation.hpp"
 #include "ttnn/operation.hpp"
@@ -47,6 +52,20 @@ namespace {
 // 3.95x at 25M. bf8 is still break-even at 544 KB, so a single byte-based gate is slightly
 // conservative for it; that costs nothing, since it is a tie there anyway.
 constexpr uint64_t k_direct_rs_max_input_bytes = 512ull << 10;
+
+// tt::tt_fabric::Topology is a scoped enum with no fmt formatter, and Ring-vs-Torus is worth reading in
+// the dispatch warning below: it separates the 1D hop-count routing regime from the 2D
+// destination-node one, which the direct op handles along different code paths.
+const char* direct_rs_topology_name(tt::tt_fabric::Topology topology) {
+    switch (topology) {
+        case tt::tt_fabric::Topology::Ring: return "Ring";
+        case tt::tt_fabric::Topology::Torus: return "Torus";
+        case tt::tt_fabric::Topology::Linear: return "Linear";
+        case tt::tt_fabric::Topology::Mesh: return "Mesh";
+        case tt::tt_fabric::Topology::NeighborExchange: return "NeighborExchange";
+    }
+    return "unknown";
+}
 
 bool use_direct_reduce_scatter(
     const ttnn::Tensor& input_tensor,
@@ -163,6 +182,42 @@ ttnn::Tensor reduce_scatter(
             num_workers_per_link,
             num_buffers_per_channel,
             compute_kernel_config)) {
+        // Diagnostic: the direct path is otherwise completely silent (no logging, and no perf model, so
+        // it reports PM_IDEAL 0.0), which makes "did this shape take the fast path?" unanswerable from a
+        // CI log. Warning level so it survives default log filtering. Deduplicated by shape rather than
+        // emitted once per process: reduce_scatter runs inside per-step model loops, so an unconditional
+        // warning would flood, but one line per distinct call site is bounded and says which shapes hit.
+        {
+            // Non-const so decltype(key) is a valid std::set value_type.
+            auto key = std::make_tuple(
+                ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis),
+                input_tensor.buffer()->size(),
+                static_cast<int>(input_tensor.dtype()),
+                normalized_dim);
+            static std::mutex direct_warned_mutex;
+            static std::set<decltype(key)> direct_warned;
+            bool first_for_shape = false;
+            {
+                std::lock_guard<std::mutex> lock(direct_warned_mutex);
+                first_for_shape = direct_warned.insert(key).second;
+            }
+            if (first_for_shape) {
+                log_warning(
+                    tt::LogOp,
+                    "reduce_scatter: taking the DIRECT (one-shot) path -- num_devices={}, per-device input "
+                    "{} B (gate {} B), dtype={}, scatter dim={}, shape={}, topology={}. The {} B gate is "
+                    "calibrated on a 1x8 Blackhole ring at 2 links only; other ring sizes and link counts "
+                    "are unvalidated. Emitted once per distinct shape.",
+                    std::get<0>(key),
+                    input_tensor.buffer()->size(),
+                    k_direct_rs_max_input_bytes,
+                    input_tensor.dtype(),
+                    normalized_dim,
+                    input_tensor.padded_shape(),
+                    direct_rs_topology_name(topology_),
+                    k_direct_rs_max_input_bytes);
+            }
+        }
         return ttnn::prim::reduce_scatter_minimal_direct(
                    input_tensor,
                    static_cast<int32_t>(normalized_dim),

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -53,9 +53,8 @@ namespace {
 // conservative for it; that costs nothing, since it is a tie there anyway.
 constexpr uint64_t k_direct_rs_max_input_bytes = 512ull << 10;
 
-// tt::tt_fabric::Topology is a scoped enum with no fmt formatter, and Ring-vs-Torus is worth reading in
-// the dispatch warning below: it separates the 1D hop-count routing regime from the 2D
-// destination-node one, which the direct op handles along different code paths.
+// Topology is a scoped enum with no fmt formatter; Ring vs Torus is worth reading in the warning below
+// (it separates the 1D hop-count routing regime from the 2D destination-node one).
 const char* direct_rs_topology_name(tt::tt_fabric::Topology topology) {
     switch (topology) {
         case tt::tt_fabric::Topology::Ring: return "Ring";
@@ -89,12 +88,9 @@ bool use_direct_reduce_scatter(
         compute_kernel_config.has_value()) {
         return false;
     }
-    // Same reasoning for the two options the direct op cannot express. Its staging buffer is not the ring
-    // op's intermediate -- placement (L1-sharded / L1-interleaved / DRAM) is derived from the shape by
-    // reduce_scatter_direct_staging_spec and is not caller-selectable -- so an explicit
-    // intermediate_memory_config could not be honoured. Semaphore placement is likewise the factory's own
-    // choice. Note use_l1_small_for_semaphores is a plain bool, so "explicitly false" is indistinguishable
-    // from the default; only an explicit true can be detected and declined here.
+    // Same for the two the direct op cannot express: staging placement is shape-derived, not caller-
+    // selectable, and semaphore placement is the factory's. use_l1_small_for_semaphores is a plain bool,
+    // so only an explicit true is detectable.
     if (intermediate_memory_config.has_value() || use_l1_small_for_semaphores) {
         return false;
     }
@@ -195,11 +191,9 @@ ttnn::Tensor reduce_scatter(
             compute_kernel_config,
             intermediate_memory_config,
             use_l1_small_for_semaphores)) {
-        // Diagnostic: the direct path is otherwise completely silent (no logging, and no perf model, so
-        // it reports PM_IDEAL 0.0), which makes "did this shape take the fast path?" unanswerable from a
-        // CI log. Warning level so it survives default log filtering. Deduplicated by shape rather than
-        // emitted once per process: reduce_scatter runs inside per-step model loops, so an unconditional
-        // warning would flood, but one line per distinct call site is bounded and says which shapes hit.
+        // The direct path is otherwise silent (no logging, no perf model), so a CI log cannot answer
+        // "did this shape take it?". Warning level to survive filtering; deduplicated by shape because
+        // reduce_scatter runs inside per-step model loops.
         {
             // Non-const so decltype(key) is a valid std::set value_type.
             auto key = std::make_tuple(

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -191,9 +191,6 @@ ttnn::Tensor reduce_scatter(
             compute_kernel_config,
             intermediate_memory_config,
             use_l1_small_for_semaphores)) {
-        // The direct path is otherwise silent (no logging, no perf model), so a CI log cannot answer
-        // "did this shape take it?". Warning level to survive filtering; deduplicated by shape because
-        // reduce_scatter runs inside per-step model loops.
         {
             // Non-const so decltype(key) is a valid std::set value_type.
             auto key = std::make_tuple(
@@ -209,20 +206,17 @@ ttnn::Tensor reduce_scatter(
                 first_for_shape = direct_warned.insert(key).second;
             }
             if (first_for_shape) {
-                log_warning(
+                log_debug(
                     tt::LogOp,
                     "reduce_scatter: taking the DIRECT (one-shot) path -- num_devices={}, per-device input "
-                    "{} B (gate {} B), dtype={}, scatter dim={}, shape={}, topology={}. The {} B gate is "
-                    "calibrated on a 1x8 Blackhole ring at 2 links only; other ring sizes and link counts "
-                    "are unvalidated. Emitted once per distinct shape.",
+                    "{} B (gate {} B), dtype={}, scatter dim={}, shape={}, topology={}.",
                     std::get<0>(key),
                     input_tensor.buffer()->size(),
                     k_direct_rs_max_input_bytes,
                     input_tensor.dtype(),
                     normalized_dim,
                     input_tensor.padded_shape(),
-                    direct_rs_topology_name(topology_),
-                    k_direct_rs_max_input_bytes);
+                    direct_rs_topology_name(topology_));
             }
         }
         return ttnn::prim::reduce_scatter_minimal_direct(

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -53,19 +53,6 @@ namespace {
 // conservative for it; that costs nothing, since it is a tie there anyway.
 constexpr uint64_t k_direct_rs_max_input_bytes = 512ull << 10;
 
-// Topology is a scoped enum with no fmt formatter; Ring vs Torus is worth reading in the warning below
-// (it separates the 1D hop-count routing regime from the 2D destination-node one).
-const char* direct_rs_topology_name(tt::tt_fabric::Topology topology) {
-    switch (topology) {
-        case tt::tt_fabric::Topology::Ring: return "Ring";
-        case tt::tt_fabric::Topology::Torus: return "Torus";
-        case tt::tt_fabric::Topology::Linear: return "Linear";
-        case tt::tt_fabric::Topology::Mesh: return "Mesh";
-        case tt::tt_fabric::Topology::NeighborExchange: return "NeighborExchange";
-    }
-    return "unknown";
-}
-
 bool use_direct_reduce_scatter(
     const ttnn::Tensor& input_tensor,
     int32_t dim,
@@ -209,14 +196,13 @@ ttnn::Tensor reduce_scatter(
                 log_debug(
                     tt::LogOp,
                     "reduce_scatter: taking the DIRECT (one-shot) path -- num_devices={}, per-device input "
-                    "{} B (gate {} B), dtype={}, scatter dim={}, shape={}, topology={}.",
+                    "{} B (gate {} B), dtype={}, scatter dim={}, shape={}.",
                     std::get<0>(key),
                     input_tensor.buffer()->size(),
                     k_direct_rs_max_input_bytes,
                     input_tensor.dtype(),
                     normalized_dim,
-                    input_tensor.padded_shape(),
-                    direct_rs_topology_name(topology_));
+                    input_tensor.padded_shape());
             }
         }
         return ttnn::prim::reduce_scatter_minimal_direct(

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -75,7 +75,9 @@ bool use_direct_reduce_scatter(
     std::optional<uint32_t> chunks_per_sync,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel,
-    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    const std::optional<ttnn::MemoryConfig>& intermediate_memory_config,
+    bool use_l1_small_for_semaphores) {
     // The axis has to wrap: Ring on a 1D fabric, Torus on a 2D one.
     if (!tt::tt_fabric::is_ring_or_torus(topology)) {
         return false;
@@ -85,6 +87,15 @@ bool use_direct_reduce_scatter(
     // op rather than silently dropping it.
     if (chunks_per_sync.has_value() || num_workers_per_link.has_value() || num_buffers_per_channel.has_value() ||
         compute_kernel_config.has_value()) {
+        return false;
+    }
+    // Same reasoning for the two options the direct op cannot express. Its staging buffer is not the ring
+    // op's intermediate -- placement (L1-sharded / L1-interleaved / DRAM) is derived from the shape by
+    // reduce_scatter_direct_staging_spec and is not caller-selectable -- so an explicit
+    // intermediate_memory_config could not be honoured. Semaphore placement is likewise the factory's own
+    // choice. Note use_l1_small_for_semaphores is a plain bool, so "explicitly false" is indistinguishable
+    // from the default; only an explicit true can be detected and declined here.
+    if (intermediate_memory_config.has_value() || use_l1_small_for_semaphores) {
         return false;
     }
     // Structural constraints (ring, TILE, whole-page split, 1D fabric) are the op's own to state.
@@ -181,7 +192,9 @@ ttnn::Tensor reduce_scatter(
             chunks_per_sync,
             num_workers_per_link,
             num_buffers_per_channel,
-            compute_kernel_config)) {
+            compute_kernel_config,
+            intermediate_memory_config,
+            use_l1_small_for_semaphores)) {
         // Diagnostic: the direct path is otherwise completely silent (no logging, and no perf model, so
         // it reports PM_IDEAL 0.0), which makes "did this shape take the fast path?" unanswerable from a
         // CI log. Warning level so it survives default log filtering. Deduplicated by shape rather than

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
@@ -26,6 +26,7 @@ file(
     llama_reduce_scatter_create_heads/device/kernels/*.cpp
     neighbor_pad_async/device/kernels/*.cpp
     reduce_scatter_minimal_async/device/kernels/*.cpp
+    reduce_scatter_minimal_direct/device/kernels/*.cpp
     ring_attention_all_gather_async/device/kernels/*.cpp
     ring_attention_all_gather_async/device/kernels/*.hpp
     rms_allgather/device/kernels/*.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ccl_experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ccl_experimental_nanobind.cpp
@@ -20,6 +20,7 @@
 #include "ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async_nanobind.hpp"
+#include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads_nanobind.hpp"
@@ -55,6 +56,7 @@ void py_module(nb::module_& mod) {
     ccl::bind_matmul_reduce_scatter_async(mod);
     ccl::bind_rs_matmul(mod);
     ccl::bind_reduce_scatter_minimal_async(mod);
+    ccl::bind_reduce_scatter_minimal_direct(mod);
     ccl::bind_strided_reduce_scatter_async(mod);
     ccl::bind_all_reduce_async(mod);
     ccl::bind_llama_reduce_scatter(mod);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_compute.cpp
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <algorithm>
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/dataflow/circular_buffer.h"
+
+// Direct (one-shot) reduce-scatter reduce kernel: one N-way sum per chunk, where the N blocks of
+// cb_reduce are this device's own slice (block 0) plus the N-1 contributions the other devices unicast
+// into staging. Block b tile t sits at cb index b*tile_granularity + t.
+//
+// The N blocks are folded pairwise into DST (num_devices/2 math ops per output tile). The first fold is
+// a non-accumulating add (or a copy when N is odd) so nothing depends on DST being zero at acquire.
+//
+// PER-LAUNCH STATE ON A COMPUTE KERNEL. This body runs on ALL THREE TRISCs, so a naive private counter
+// deadlocks: each TRISC would read AND increment it, they would disagree on the parity, and unpack would
+// wait on one CB half while pack pushed the other. The safe shape, used below, is that all three TRISCs
+// READ the counter at the top of kernel_main and exactly ONE (pack) writes it back at the very bottom.
+// That is race-free because program launches serialize per device -- no TRISC of the next launch can
+// start before every TRISC of this one has finished -- and pack cannot reach its increment early, since
+// its work depends on math, which depends on unpack.
+//
+// The parity picks which half of cb_reduce holds this invocation's data, and is needed only on the
+// aliased path, where cb_reduce is this core's staging shard and remote senders write into it with no
+// flow control (half_stride_tiles is 0 otherwise, making the offset vanish).
+void kernel_main() {
+    constexpr uint32_t tile_granularity = get_compile_time_arg_val(0);
+    constexpr uint32_t num_devices = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_reduce_id = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_out_id = get_compile_time_arg_val(3);
+    constexpr uint32_t half_stride_tiles = get_compile_time_arg_val(4);
+
+    constexpr uint32_t block_stride = tile_granularity;
+    constexpr uint32_t group_pages = num_devices * tile_granularity;
+
+    uint32_t arg_idx = 0;
+    // This core's partition of every slice: chunk_count chunks / tile_count tiles.
+    const uint32_t chunk_count = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t tile_count = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t gen_addr = get_arg_val<uint32_t>(arg_idx++);  // this core's private invocation counter
+
+    auto* gen_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(gen_addr);
+    const uint32_t invocation = *gen_ptr;
+    // Constant tile-index offset into the parity half. The CB read pointer still walks half 0 one group
+    // per chunk (the reader pushes there), so this offset alone reaches the right half -- indices stay
+    // inside the CB because chunk_count <= chunks_per_slice.
+    const uint32_t half_off = (invocation & 1u) * half_stride_tiles;
+
+    CircularBuffer cb_reduce(cb_reduce_id);
+    CircularBuffer cb_out(cb_out_id);
+
+    compute_kernel_hw_startup(cb_reduce_id, cb_reduce_id, cb_out_id);
+    // Init hoisted OUT of the chunk loop: with an even block count every fold accumulates into DST, which
+    // tile_regs_acquire leaves zeroed, so one add_tiles_init(acc) covers the whole kernel. (The odd-N path
+    // still has to switch between copy and accumulating-add per chunk.) all_reduce_async's reduction.cpp
+    // relies on the same zero-at-acquire property; a wrong assumption here shows up immediately as a PCC
+    // failure, not as silent drift.
+    if constexpr (num_devices % 2 == 0) {
+        add_tiles_init(cb_reduce_id, cb_reduce_id, true);
+    }
+
+    uint32_t tiles_done = 0;
+    for (uint32_t k = 0; k < chunk_count; ++k) {
+        // Only n = tiles_in_chunk tiles are valid in the last (partial) chunk; the CB slot is always a
+        // full group so the reader's coalesced reads stay aligned.
+        const uint32_t n = std::min(tile_granularity, tile_count - tiles_done);
+
+        cb_reduce.wait_front(group_pages);
+        tile_regs_acquire();
+
+        uint32_t block = 0;
+        if constexpr (num_devices % 2 != 0) {
+            // Odd block count: seed DST with block0, leaving an even number to fold pairwise.
+            copy_tile_init(cb_reduce_id);
+            for (uint32_t t = 0; t < n; ++t) {
+                copy_tile(cb_reduce_id, half_off + t, t);
+            }
+            add_tiles_init(cb_reduce_id, cb_reduce_id, true);
+            block = 1;
+        }
+        for (; block + 1 < num_devices; block += 2) {
+            const uint32_t a = half_off + block * block_stride;
+            const uint32_t b = half_off + (block + 1) * block_stride;
+            for (uint32_t t = 0; t < n; ++t) {
+                add_tiles(cb_reduce_id, cb_reduce_id, a + t, b + t, t);
+            }
+        }
+        tile_regs_commit();
+        cb_reduce.pop_front(group_pages);
+
+        cb_out.reserve_back(tile_granularity);
+        tile_regs_wait();
+        for (uint32_t t = 0; t < n; ++t) {
+            pack_tile(t, cb_out_id, t);
+        }
+        tile_regs_release();
+        cb_out.push_back(tile_granularity);
+
+        tiles_done += n;
+    }
+
+#ifdef UCK_CHLKC_PACK
+    // Exactly one TRISC advances the shared counter, and only after all of this launch's work (pack is
+    // last in the unpack -> math -> pack chain). See the per-launch-state note at the top.
+    *gen_ptr = invocation + 1;
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_compute.cpp
@@ -25,8 +25,6 @@ namespace detail {
 // copy-pasted from api/dataflow/dataflow_api.h
 FORCE_INLINE
 void noc_semaphore_set(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
-    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_SET, false, -1);
-
     // set semaphore value to val
     (*sem_addr) = val;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_compute.cpp
@@ -16,17 +16,22 @@
 // The N blocks are folded pairwise into DST (num_devices/2 math ops per output tile). The first fold is
 // a non-accumulating add (or a copy when N is odd) so nothing depends on DST being zero at acquire.
 //
-// PER-LAUNCH STATE ON A COMPUTE KERNEL. This body runs on ALL THREE TRISCs, so a naive private counter
-// deadlocks: each TRISC would read AND increment it, they would disagree on the parity, and unpack would
-// wait on one CB half while pack pushed the other. The safe shape, used below, is that all three TRISCs
-// READ the counter at the top of kernel_main and exactly ONE (pack) writes it back at the very bottom.
-// That is race-free because program launches serialize per device -- no TRISC of the next launch can
-// start before every TRISC of this one has finished -- and pack cannot reach its increment early, since
-// its work depends on math, which depends on unpack.
-//
 // The parity picks which half of cb_reduce holds this invocation's data, and is needed only on the
 // aliased path, where cb_reduce is this core's staging shard and remote senders write into it with no
 // flow control (half_stride_tiles is 0 otherwise, making the offset vanish).
+
+namespace detail {
+
+// copy-pasted from api/dataflow/dataflow_api.h
+FORCE_INLINE
+void noc_semaphore_set(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
+    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_SET, false, -1);
+
+    // set semaphore value to val
+    (*sem_addr) = val;
+}
+
+}  // namespace detail
 void kernel_main() {
     constexpr uint32_t tile_granularity = get_compile_time_arg_val(0);
     constexpr uint32_t num_devices = get_compile_time_arg_val(1);
@@ -44,6 +49,7 @@ void kernel_main() {
     const uint32_t gen_addr = get_arg_val<uint32_t>(arg_idx++);  // this core's private invocation counter
 
     auto* gen_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(gen_addr);
+    invalidate_l1_cache();
     const uint32_t invocation = *gen_ptr;
     // Constant tile-index offset into the parity half. The CB read pointer still walks half 0 one group
     // per chunk (the reader pushes there), so this offset alone reaches the right half -- indices stay
@@ -54,11 +60,6 @@ void kernel_main() {
     CircularBuffer cb_out(cb_out_id);
 
     compute_kernel_hw_startup(cb_reduce_id, cb_reduce_id, cb_out_id);
-    // Init hoisted OUT of the chunk loop: with an even block count every fold accumulates into DST, which
-    // tile_regs_acquire leaves zeroed, so one add_tiles_init(acc) covers the whole kernel. (The odd-N path
-    // still has to switch between copy and accumulating-add per chunk.) all_reduce_async's reduction.cpp
-    // relies on the same zero-at-acquire property; a wrong assumption here shows up immediately as a PCC
-    // failure, not as silent drift.
     if constexpr (num_devices % 2 == 0) {
         add_tiles_init(cb_reduce_id, cb_reduce_id, true);
     }
@@ -103,9 +104,7 @@ void kernel_main() {
         tiles_done += n;
     }
 
-#ifdef UCK_CHLKC_PACK
     // Exactly one TRISC advances the shared counter, and only after all of this launch's work (pack is
     // last in the unpack -> math -> pack chain). See the per-launch-state note at the top.
-    *gen_ptr = invocation + 1;
-#endif
+    PACK((*gen_ptr = invocation + 1));
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_compute.cpp
@@ -40,8 +40,7 @@ void kernel_main() {
     constexpr uint32_t block_stride = tile_granularity;
     constexpr uint32_t group_pages = num_devices * tile_granularity;
 
-    // Bring the compute hardware up first: everything it needs is compile-time, so there is no reason for
-    // any runtime-state access (arg reads, the L1 generation counter, CB objects) to precede it.
+    // Up first: its args are all compile-time, so no runtime-state access need precede it.
     compute_kernel_hw_startup(cb_reduce_id, cb_reduce_id, cb_out_id);
 
     uint32_t arg_idx = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_compute.cpp
@@ -40,6 +40,10 @@ void kernel_main() {
     constexpr uint32_t block_stride = tile_granularity;
     constexpr uint32_t group_pages = num_devices * tile_granularity;
 
+    // Bring the compute hardware up first: everything it needs is compile-time, so there is no reason for
+    // any runtime-state access (arg reads, the L1 generation counter, CB objects) to precede it.
+    compute_kernel_hw_startup(cb_reduce_id, cb_reduce_id, cb_out_id);
+
     uint32_t arg_idx = 0;
     // This core's partition of every slice: chunk_count chunks / tile_count tiles.
     const uint32_t chunk_count = get_arg_val<uint32_t>(arg_idx++);
@@ -57,7 +61,6 @@ void kernel_main() {
     CircularBuffer cb_reduce(cb_reduce_id);
     CircularBuffer cb_out(cb_out_id);
 
-    compute_kernel_hw_startup(cb_reduce_id, cb_reduce_id, cb_out_id);
     if constexpr (num_devices % 2 == 0) {
         add_tiles_init(cb_reduce_id, cb_reduce_id, true);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_reader.cpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+
+#include <cstdint>
+#include <algorithm>
+
+using address_t = uint32_t;
+
+// Direct (one-shot) reduce-scatter reader, CB producer, no fabric. Two phases:
+//
+//   1. SEND phase: for every remote destination j (in the writer's send order, farthest ring distance
+//      first), read this core's tile range of local input slice j into cb_send. The writer drains it
+//      straight onto the fabric as a multi-hop unicast into device j's staging.
+//   2. REDUCE phase: wait until every other device's contribution to OUR slice has landed (one atomic
+//      inc per source, fused onto that source's last payload packet -- per-source counters, so an
+//      absolute wait cannot be satisfied by a neighbour that has raced ahead), then feed the reducer
+//      num_devices blocks per chunk: block 0 = our own local slice read from the input tensor,
+//      blocks 1..N-1 = the other devices' contributions read out of staging (one coalesced read each).
+//      Our own block is read BEFORE the arrival waits (it depends on no arrival), so it lands for free
+//      while we spin instead of adding a DRAM round trip after the last packet arrives.
+//
+// Staging is double-buffered by invocation parity: a device that is one invocation ahead of us writes
+// into the other half, so it cannot clobber data we have not reduced yet. Two invocations ahead is
+// impossible (it would require our previous program to have completed). Parity comes from this core's
+// private invocation counter (`gen`), which this reader owns and bumps at the end; the writer keeps its
+// own identical counter, so the two kernels always agree without any cross-kernel handshake.
+void kernel_main() {
+    constexpr uint32_t tile_bytes = get_compile_time_arg_val(0);        // single tile bytes (real dtype)
+    constexpr uint32_t tile_granularity = get_compile_time_arg_val(1);  // tiles per chunk
+    constexpr uint32_t chunks_per_slice = get_compile_time_arg_val(2);
+    // Whole-slice tile count; this core's tile budget arrives as a runtime arg (tile_count) instead.
+    [[maybe_unused]] constexpr uint32_t pages_per_slice = get_compile_time_arg_val(3);
+    constexpr uint32_t slice_Wt = get_compile_time_arg_val(4);     // slice width in tiles (per-row run)
+    constexpr uint32_t width_tiles = get_compile_time_arg_val(5);  // input row width in tiles
+    constexpr uint32_t num_devices = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_send_id = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_reduce_id = get_compile_time_arg_val(8);
+    // Arrivals land directly in cb_reduce (staging is this core's L1 shard, aliased into the CB), so the
+    // whole staging readback below disappears -- see the factory's CB comment.
+    constexpr bool arrivals_in_cb = get_compile_time_arg_val(9) != 0;
+    constexpr uint32_t half_stride_tiles = get_compile_time_arg_val(10);  // tiles in one parity half
+    constexpr auto input_args = TensorAccessorArgs<11>();
+    constexpr auto staging_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t num_dests = num_devices - 1;  // remote destinations == remote sources
+
+    size_t ai = 0;
+    const address_t input_addr = get_arg_val<address_t>(ai++);
+    const address_t staging_addr = get_arg_val<address_t>(ai++);
+    const uint32_t device_idx = get_arg_val<uint32_t>(ai++);
+    // This core's partition: chunks [chunk_start, chunk_start + chunk_count) == tiles
+    // [tile_start, tile_start + tile_count) of every slice.
+    const uint32_t chunk_start = get_arg_val<uint32_t>(ai++);
+    const uint32_t chunk_count = get_arg_val<uint32_t>(ai++);
+    const uint32_t tile_start = get_arg_val<uint32_t>(ai++);
+    const uint32_t tile_count = get_arg_val<uint32_t>(ai++);
+    const address_t gen_addr = get_arg_val<uint32_t>(ai++);  // this core's private invocation counter
+    // Arrival counters, one per remote source (never reset -- see the parity note above). Followed by
+    // the send-order destination slice list, shared with the writer.
+    const size_t arrival_sems = ai;
+    ai += num_dests;
+    const size_t dest_slices = ai;
+    ai += num_dests;
+
+    auto input_acc = TensorAccessor(input_args, input_addr);  // tiled (page = tile_bytes)
+
+    Noc noc;
+    CircularBuffer cb_send(cb_send_id);
+    CircularBuffer cb_reduce(cb_reduce_id);
+
+    auto* gen_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(gen_addr);
+    const uint32_t invocation = *gen_ptr;
+    // Staging half for this invocation (see the parity note above), in whichever unit the path needs:
+    // interleaved staging indexes by page, the aliased CB by a constant tile-index offset.
+    const uint32_t staging_half = (invocation & 1u) * (num_devices * chunks_per_slice);
+    const uint32_t half_off_bytes = (invocation & 1u) * half_stride_tiles * tile_bytes;
+
+    // Where this core's tile range starts in the per-slice input walk: tile tile_start of a slice sits
+    // at row tile_start/slice_Wt, column tile_start%slice_Wt (loop-invariant, so hoisted).
+    const uint32_t in_row_off_init = (tile_start / slice_Wt) * width_tiles;
+    const uint32_t in_page_in_row_init = tile_start % slice_Wt;
+
+    // Reads this core's tile range of local input slice `j`, chunk `k`, into L1 at `l1` (per tile: the
+    // input is bank-interleaved and a slice is strided). Walk state is carried by the caller.
+    auto read_local_chunk = [&](uint32_t j, uint32_t& row_off, uint32_t& page_in_row, uint32_t l1, uint32_t tiles) {
+        const uint32_t tile_id_start = j * slice_Wt;
+        for (uint32_t t = 0; t < tiles; ++t) {
+            const uint32_t tid = tile_id_start + row_off + page_in_row;
+            if (++page_in_row == slice_Wt) {
+                row_off += width_tiles;
+                page_in_row = 0;
+            }
+            noc.async_read(input_acc, CoreLocalMem<uint32_t>(l1), tile_bytes, {.page_id = tid}, {}, {});
+            l1 += tile_bytes;
+        }
+    };
+
+    // ---- Phase 1: local input slices -> cb_send (one slice per remote destination, send order) ----
+    // CB granularity is fixed at tile_granularity (a chunk always occupies a full tg-page slot so slots
+    // stay aligned and no read ever wraps the CB); only tiles_in_chunk tiles are valid in a partial chunk.
+    for (uint32_t dst = 0; dst < num_dests; ++dst) {
+        const uint32_t j = get_arg_val<uint32_t>(dest_slices + dst);
+        uint32_t row_off = in_row_off_init;
+        uint32_t page_in_row = in_page_in_row_init;
+        uint32_t tiles_done = 0;
+        for (uint32_t k = 0; k < chunk_count; ++k) {
+            const uint32_t tiles_in_chunk = std::min(tile_granularity, tile_count - tiles_done);
+            cb_send.reserve_back(tile_granularity);
+            read_local_chunk(j, row_off, page_in_row, cb_send.get_write_ptr(), tiles_in_chunk);
+            noc.async_read_barrier();
+            cb_send.push_back(tile_granularity);
+            tiles_done += tiles_in_chunk;
+        }
+    }
+
+    // ---- Phase 2: feed the reducer num_devices blocks per chunk ----
+    {
+        uint32_t row_off = in_row_off_init;
+        uint32_t page_in_row = in_page_in_row_init;
+        uint32_t tiles_done = 0;
+        for (uint32_t k = 0; k < chunk_count; ++k) {
+            const uint32_t tiles_in_chunk = std::min(tile_granularity, tile_count - tiles_done);
+            cb_reduce.reserve_back(num_devices * tile_granularity);
+            // On the aliased path the CB write pointer walks half 0, and the parity half is a constant
+            // byte offset on top of it -- the same offset compute applies to its tile indices.
+            const uint32_t base = cb_reduce.get_write_ptr() + half_off_bytes;
+
+            // block 0: our own contribution, straight out of the input tensor. Issued before the arrival
+            // waits below so it lands while we spin.
+            read_local_chunk(device_idx, row_off, page_in_row, base, tiles_in_chunk);
+
+            if (k == 0) {
+                // Every remote contribution to our own slice has landed (whole tile range, all chunks).
+                for (uint32_t s = 0; s < num_dests; ++s) {
+                    auto* sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_val<uint32_t>(arrival_sems + s));
+                    noc_semaphore_wait_min(sem, invocation + 1);
+                }
+            }
+
+            // blocks 1..N-1: the remote contributions. On the aliased path the senders already wrote them
+            // into these exact CB slots, so there is nothing to do -- which is the point of that path:
+            // these reads sit strictly AFTER the last arrival, so even out of L1 they are N-1 NoC round
+            // trips of pure post-gate latency.
+            if constexpr (!arrivals_in_cb) {
+                auto staging_acc = TensorAccessor(staging_args, staging_addr);  // chunk-paged
+                uint32_t block = 1;
+                for (uint32_t s = 0; s < num_devices; ++s) {
+                    if (s == device_idx) {
+                        continue;
+                    }
+                    noc.async_read(
+                        staging_acc,
+                        CoreLocalMem<uint32_t>(base + block * tile_granularity * tile_bytes),
+                        tiles_in_chunk * tile_bytes,
+                        {.page_id = staging_half + s * chunks_per_slice + chunk_start + k},
+                        {},
+                        {});
+                    ++block;
+                }
+            }
+
+            noc.async_read_barrier();
+            cb_reduce.push_back(num_devices * tile_granularity);
+            tiles_done += tiles_in_chunk;
+        }
+    }
+
+    // This invocation is done consuming the arrival counters; advance our private generation so the next
+    // one waits on absolute position invocation+2 (the counters themselves are deliberately never reset:
+    // a device that has already moved on would have its increments silently destroyed).
+    noc_semaphore_set(gen_ptr, invocation + 1);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_reader.cpp
@@ -37,8 +37,11 @@ void kernel_main() {
     constexpr uint32_t chunks_per_slice = get_compile_time_arg_val(2);
     // Whole-slice tile count; this core's tile budget arrives as a runtime arg (tile_count) instead.
     [[maybe_unused]] constexpr uint32_t pages_per_slice = get_compile_time_arg_val(3);
-    constexpr uint32_t slice_Wt = get_compile_time_arg_val(4);     // slice width in tiles (per-row run)
-    constexpr uint32_t width_tiles = get_compile_time_arg_val(5);  // input row width in tiles
+    // Slice walk in page space: a slice is `slice_run_pages` contiguous input pages every `stride_pages`.
+    // Scattering the last dim gives run = the slice's width in tiles and stride = the full row; any other
+    // dim just changes these two numbers (see ReduceScatterDirectGeometry on the host side).
+    constexpr uint32_t slice_run_pages = get_compile_time_arg_val(4);
+    constexpr uint32_t stride_pages = get_compile_time_arg_val(5);
     constexpr uint32_t num_devices = get_compile_time_arg_val(6);
     constexpr uint32_t cb_send_id = get_compile_time_arg_val(7);
     constexpr uint32_t cb_reduce_id = get_compile_time_arg_val(8);
@@ -83,19 +86,19 @@ void kernel_main() {
     const uint32_t half_off_bytes = (invocation & 1u) * half_stride_tiles * tile_bytes;
 
     // Where this core's tile range starts in the per-slice input walk: tile tile_start of a slice sits
-    // at row tile_start/slice_Wt, column tile_start%slice_Wt (loop-invariant, so hoisted).
-    const uint32_t in_row_off_init = (tile_start / slice_Wt) * width_tiles;
-    const uint32_t in_page_in_row_init = tile_start % slice_Wt;
+    // in run tile_start/slice_run_pages, at offset tile_start%slice_run_pages (loop-invariant, hoisted).
+    const uint32_t in_run_off_init = (tile_start / slice_run_pages) * stride_pages;
+    const uint32_t in_page_in_run_init = tile_start % slice_run_pages;
 
     // Reads this core's tile range of local input slice `j`, chunk `k`, into L1 at `l1` (per tile: the
     // input is bank-interleaved and a slice is strided). Walk state is carried by the caller.
-    auto read_local_chunk = [&](uint32_t j, uint32_t& row_off, uint32_t& page_in_row, uint32_t l1, uint32_t tiles) {
-        const uint32_t tile_id_start = j * slice_Wt;
+    auto read_local_chunk = [&](uint32_t j, uint32_t& run_off, uint32_t& page_in_run, uint32_t l1, uint32_t tiles) {
+        const uint32_t tile_id_start = j * slice_run_pages;
         for (uint32_t t = 0; t < tiles; ++t) {
-            const uint32_t tid = tile_id_start + row_off + page_in_row;
-            if (++page_in_row == slice_Wt) {
-                row_off += width_tiles;
-                page_in_row = 0;
+            const uint32_t tid = tile_id_start + run_off + page_in_run;
+            if (++page_in_run == slice_run_pages) {
+                run_off += stride_pages;
+                page_in_run = 0;
             }
             noc.async_read(input_acc, CoreLocalMem<uint32_t>(l1), tile_bytes, {.page_id = tid}, {}, {});
             l1 += tile_bytes;
@@ -107,13 +110,13 @@ void kernel_main() {
     // stay aligned and no read ever wraps the CB); only tiles_in_chunk tiles are valid in a partial chunk.
     for (uint32_t dst = 0; dst < num_dests; ++dst) {
         const uint32_t j = get_arg_val<uint32_t>(dest_slices + dst);
-        uint32_t row_off = in_row_off_init;
-        uint32_t page_in_row = in_page_in_row_init;
+        uint32_t run_off = in_run_off_init;
+        uint32_t page_in_run = in_page_in_run_init;
         uint32_t tiles_done = 0;
         for (uint32_t k = 0; k < chunk_count; ++k) {
             const uint32_t tiles_in_chunk = std::min(tile_granularity, tile_count - tiles_done);
             cb_send.reserve_back(tile_granularity);
-            read_local_chunk(j, row_off, page_in_row, cb_send.get_write_ptr(), tiles_in_chunk);
+            read_local_chunk(j, run_off, page_in_run, cb_send.get_write_ptr(), tiles_in_chunk);
             noc.async_read_barrier();
             cb_send.push_back(tile_granularity);
             tiles_done += tiles_in_chunk;
@@ -122,8 +125,8 @@ void kernel_main() {
 
     // ---- Phase 2: feed the reducer num_devices blocks per chunk ----
     {
-        uint32_t row_off = in_row_off_init;
-        uint32_t page_in_row = in_page_in_row_init;
+        uint32_t run_off = in_run_off_init;
+        uint32_t page_in_run = in_page_in_run_init;
         uint32_t tiles_done = 0;
         for (uint32_t k = 0; k < chunk_count; ++k) {
             const uint32_t tiles_in_chunk = std::min(tile_granularity, tile_count - tiles_done);
@@ -134,7 +137,7 @@ void kernel_main() {
 
             // block 0: our own contribution, straight out of the input tensor. Issued before the arrival
             // waits below so it lands while we spin.
-            read_local_chunk(device_idx, row_off, page_in_row, base, tiles_in_chunk);
+            read_local_chunk(device_idx, run_off, page_in_run, base, tiles_in_chunk);
 
             if (k == 0) {
                 // Every remote contribution to our own slice has landed (whole tile range, all chunks).

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_reader.cpp
@@ -23,8 +23,6 @@ using address_t = uint32_t;
 //      absolute wait cannot be satisfied by a neighbour that has raced ahead), then feed the reducer
 //      num_devices blocks per chunk: block 0 = our own local slice read from the input tensor,
 //      blocks 1..N-1 = the other devices' contributions read out of staging (one coalesced read each).
-//      Our own block is read BEFORE the arrival waits (it depends on no arrival), so it lands for free
-//      while we spin instead of adding a DRAM round trip after the last packet arrives.
 //
 // Staging is double-buffered by invocation parity: a device that is one invocation ahead of us writes
 // into the other half, so it cannot clobber data we have not reduced yet. Two invocations ahead is
@@ -175,8 +173,5 @@ void kernel_main() {
         }
     }
 
-    // This invocation is done consuming the arrival counters; advance our private generation so the next
-    // one waits on absolute position invocation+2 (the counters themselves are deliberately never reset:
-    // a device that has already moved on would have its increments silently destroyed).
     noc_semaphore_set(gen_ptr, invocation + 1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_reader.cpp
@@ -139,12 +139,8 @@ void kernel_main() {
 
             if (k == 0) {
                 // Every remote contribution to our own slice has landed (whole tile range, all chunks).
-                //
-                // Deliberately the free noc_semaphore_wait_min rather than a typed Semaphore<>: these are
-                // GlobalSemaphore ADDRESSES handed over as runtime args, and Semaphore<>'s only constructor
-                // takes a per-program semaphore_id which it resolves through get_semaphore<>() -- a
-                // different allocation entirely, so it cannot name a global semaphore. Semaphore::wait_min
-                // forwards to exactly this free function anyway.
+                // Free function because these arrive as GlobalSemaphore addresses; Semaphore<> takes a
+                // program-scoped id. Allocating these program-scoped instead would allow the typed API.
                 for (uint32_t s = 0; s < num_dests; ++s) {
                     auto* sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_val<uint32_t>(arrival_sems + s));
                     noc_semaphore_wait_min(sem, invocation + 1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_reader.cpp
@@ -139,6 +139,12 @@ void kernel_main() {
 
             if (k == 0) {
                 // Every remote contribution to our own slice has landed (whole tile range, all chunks).
+                //
+                // Deliberately the free noc_semaphore_wait_min rather than a typed Semaphore<>: these are
+                // GlobalSemaphore ADDRESSES handed over as runtime args, and Semaphore<>'s only constructor
+                // takes a per-program semaphore_id which it resolves through get_semaphore<>() -- a
+                // different allocation entirely, so it cannot name a global semaphore. Semaphore::wait_min
+                // forwards to exactly this free function anyway.
                 for (uint32_t s = 0; s < num_dests; ++s) {
                     auto* sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_val<uint32_t>(arrival_sems + s));
                     noc_semaphore_wait_min(sem, invocation + 1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_writer.cpp
@@ -47,7 +47,10 @@ void kernel_main() {
     // see the factory's CB comment. Off this path we write the interleaved staging tensor via its accessor.
     constexpr bool arrivals_in_cb = get_compile_time_arg_val(8) != 0;
     constexpr uint32_t half_stride_tiles = get_compile_time_arg_val(9);  // tiles in one parity half
-    constexpr auto staging_args = TensorAccessorArgs<10>();
+    // Start barrier: hold every send until all peers have entered this invocation. Needed only when the
+    // op allocates its own buffers -- see the block that runs it, below.
+    constexpr bool needs_init_sync = get_compile_time_arg_val(10) != 0;
+    constexpr auto staging_args = TensorAccessorArgs<11>();
     constexpr auto output_args = TensorAccessorArgs<staging_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t num_dests = num_devices - 1;
@@ -65,6 +68,11 @@ void kernel_main() {
     const uint8_t peer_core_x = get_arg_val<uint32_t>(ai++);    // mirror core (deterministic placement)
     const uint8_t peer_core_y = get_arg_val<uint32_t>(ai++);
     const uint32_t num_connections = get_arg_val<uint32_t>(ai++);  // 1 (fwd only) or 2 (fwd + bwd)
+    // Start-barrier counter (same address on every peer) and the two multicast hop ranges that between
+    // them cover the ring exactly once. Always passed so the arg layout does not depend on the CT flag.
+    const address_t init_sem = get_arg_val<uint32_t>(ai++);
+    const uint8_t fwd_mcast_range = static_cast<uint8_t>(get_arg_val<uint32_t>(ai++));
+    const uint8_t bwd_mcast_range = static_cast<uint8_t>(get_arg_val<uint32_t>(ai++));
     // Per-destination route, in send order (shared order with the reader's cb_send production).
     const size_t dest_conn = ai;
     ai += num_dests;
@@ -110,6 +118,47 @@ void kernel_main() {
     // already overlaps the reader's first input read, which runs on another RISC); the win on this axis came
     // from the SPLIT CLOSE at the end. Kept deferred anyway since it cannot hurt.
     fabric_connection.open_finish();
+
+    // ---- Optional start barrier ----
+    //
+    // Our sends target the peer's staging buffer at OUR OWN staging address (the mesh allocator is
+    // lockstep, so the buffer sits at the same address on every device). That identity holds only if the
+    // peer is on the same invocation as us -- and the parity double-buffer deliberately tolerates one
+    // invocation of skew. With persistent buffers that is harmless: the address is pinned for the cached
+    // program's lifetime, so a one-invocation-ahead sender writes the other parity half of the SAME
+    // buffer, which is exactly what the parity scheme is for. When the op allocates its own buffers the
+    // address is only stable as long as the allocator happens to repeat itself; a sender that has moved
+    // on to invocation i+1 would write at i+1's address into a peer still on i, where that address may
+    // belong to some other live buffer entirely (or not be allocated yet on the very first invocation).
+    //
+    // So: when either buffer is op-allocated, hold every send until all N-1 peers have entered this
+    // invocation. Two multicasts (one per direction, hop ranges chosen host-side to cover the ring
+    // exactly once) instead of N-1 unicasts. The counter is never reset -- like the arrival counters, we
+    // wait on an absolute position, so a peer that raced ahead cannot satisfy an earlier wait.
+    if constexpr (needs_init_sync) {
+        auto init_pkt = PacketHeaderPool::allocate_header(1);
+        const uint64_t init_noc_addr = safe_get_noc_addr(peer_core_x, peer_core_y, init_sem, 0);
+        // Connection 0 = forward, 1 = backward; a range is 0 only when that connection is not open.
+        if (fwd_mcast_range > 0) {
+            fabric_api::fabric_multicast_noc_unicast_atomic_inc(
+                &fabric_connection.get(0).sender,
+                init_pkt,
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_noc_addr, 1u},
+                /*start_distance=*/1,
+                fwd_mcast_range);
+            noc.async_writes_flushed();  // on the wire before the header is re-patched below
+        }
+        if (bwd_mcast_range > 0) {
+            fabric_api::fabric_multicast_noc_unicast_atomic_inc(
+                &fabric_connection.get(1).sender,
+                init_pkt,
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_noc_addr, 1u},
+                /*start_distance=*/1,
+                bwd_mcast_range);
+            noc.async_writes_flushed();
+        }
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_sem), (invocation + 1) * num_dests);
+    }
 
     for (uint32_t dst = 0; dst < num_dests; ++dst) {
         const uint8_t hops = static_cast<uint8_t>(get_arg_val<uint32_t>(dest_hops + dst));

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_writer.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <algorithm>
+#include <type_traits>
 
 // Brings the fabric linear-api headers + the `fabric_api` alias + PacketHeaderPool.
 #include "cpp/ttnn/operations/ccl/all_gather/device/kernels/unicast_common.hpp"
@@ -80,6 +81,12 @@ void kernel_main() {
     ai += num_dests;
     const size_t dest_block = ai;  // our block index inside that destination's reduce group (aliased path)
     ai += num_dests;
+    // Destination chip/mesh per destination -- only read on a 2D fabric, which routes by destination
+    // node rather than by hop count. See set_route_2d below.
+    const size_t dest_chip = ai;
+    ai += num_dests;
+    const size_t dest_mesh = ai;
+    ai += num_dests;
     size_t arg_for_fab = ai;  // fabric connection args are appended last
 
     auto output_acc = TensorAccessor(output_args, output_addr);  // tiled (page = tile_bytes)
@@ -114,6 +121,20 @@ void kernel_main() {
 
     const uint64_t arrival_noc_addr = safe_get_noc_addr(peer_core_x, peer_core_y, arrival_sem, 0);
 
+    // 1D routing takes the distance straight from the packet header's hop count, so a header is ready to
+    // send once set_state has stamped num_hops on it. A 2D fabric instead routes by DESTINATION NODE:
+    // set_state leaves the route empty (it only fills it in the RoutingPlaneConnectionManager overloads),
+    // so the route has to be programmed onto each header for each destination. Keyed on the header type,
+    // exactly as the all_gather FabricWriter does it, so the 1D path compiles to nothing.
+    auto set_route_2d = [&](volatile PACKET_HEADER_TYPE* hdr, uint32_t dst) {
+        if constexpr (std::is_base_of_v<tt::tt_fabric::HybridMeshPacketHeader, PACKET_HEADER_TYPE>) {
+            fabric_set_unicast_route(
+                reinterpret_cast<volatile tt::tt_fabric::HybridMeshPacketHeader*>(hdr),
+                static_cast<uint16_t>(get_arg_val<uint32_t>(dest_chip + dst)),
+                static_cast<uint16_t>(get_arg_val<uint32_t>(dest_mesh + dst)));
+        }
+    };
+
     // MEASURED: deferring open_finish past the header setup is worth nothing on its own (the handshake
     // already overlaps the reader's first input read, which runs on another RISC); the win on this axis came
     // from the SPLIT CLOSE at the end. Kept deferred anyway since it cannot hurt.
@@ -138,24 +159,45 @@ void kernel_main() {
     if constexpr (needs_init_sync) {
         auto init_pkt = PacketHeaderPool::allocate_header(1);
         const uint64_t init_noc_addr = safe_get_noc_addr(peer_core_x, peer_core_y, init_sem, 0);
-        // Connection 0 = forward, 1 = backward; a range is 0 only when that connection is not open.
-        if (fwd_mcast_range > 0) {
-            fabric_api::fabric_multicast_noc_unicast_atomic_inc(
-                &fabric_connection.get(0).sender,
-                init_pkt,
-                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_noc_addr, 1u},
-                /*start_distance=*/1,
-                fwd_mcast_range);
-            noc.async_writes_flushed();  // on the wire before the header is re-patched below
-        }
-        if (bwd_mcast_range > 0) {
-            fabric_api::fabric_multicast_noc_unicast_atomic_inc(
-                &fabric_connection.get(1).sender,
-                init_pkt,
-                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_noc_addr, 1u},
-                /*start_distance=*/1,
-                bwd_mcast_range);
-            noc.async_writes_flushed();
+        if constexpr (std::is_base_of_v<tt::tt_fabric::HybridMeshPacketHeader, PACKET_HEADER_TYPE>) {
+            // 2D: a multicast would need fabric_set_mcast_route (a mcast START node plus per-direction hop
+            // counts), and on a torus it is not obvious the wrap is even expressible. The barrier is one
+            // atomic inc per peer, once per invocation, and only on the non-persistent path -- so just
+            // reuse the per-destination unicast routes the data path already programs correctly. Same
+            // set_state -> set route -> with_state idiom as the payload loop below.
+            for (uint32_t dst = 0; dst < num_dests; ++dst) {
+                auto* sender = &fabric_connection.get(get_arg_val<uint32_t>(dest_conn + dst)).sender;
+                fabric_api::fabric_unicast_noc_unicast_atomic_inc_set_state<
+                    UnicastAtomicIncUpdateMask::DstAddr | UnicastAtomicIncUpdateMask::Val |
+                    UnicastAtomicIncUpdateMask::Flush>(
+                    init_pkt,
+                    static_cast<uint8_t>(get_arg_val<uint32_t>(dest_hops + dst)),
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_noc_addr, 1u});
+                set_route_2d(init_pkt, dst);
+                fabric_api::fabric_unicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::None>(
+                    sender, init_pkt);
+                noc.async_writes_flushed();  // on the wire before the header is re-patched for the next dst
+            }
+        } else {
+            // Connection 0 = forward, 1 = backward; a range is 0 only when that connection is not open.
+            if (fwd_mcast_range > 0) {
+                fabric_api::fabric_multicast_noc_unicast_atomic_inc(
+                    &fabric_connection.get(0).sender,
+                    init_pkt,
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_noc_addr, 1u},
+                    /*start_distance=*/1,
+                    fwd_mcast_range);
+                noc.async_writes_flushed();  // on the wire before the header is re-patched below
+            }
+            if (bwd_mcast_range > 0) {
+                fabric_api::fabric_multicast_noc_unicast_atomic_inc(
+                    &fabric_connection.get(1).sender,
+                    init_pkt,
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_noc_addr, 1u},
+                    /*start_distance=*/1,
+                    bwd_mcast_range);
+                noc.async_writes_flushed();
+            }
         }
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_sem), (invocation + 1) * num_dests);
     }
@@ -178,6 +220,8 @@ void kernel_main() {
                 0u,   // semaphore dst (patched per packet)
                 1u},  // increment 1 (flush defaults true: payload lands before the inc is applied)
             /*packet_size_bytes=*/0);
+        set_route_2d(data_pkt, dst);
+        set_route_2d(fused_pkt, dst);
 
         uint32_t tiles_done = 0;
         for (uint32_t k = 0; k < chunk_count; ++k) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_writer.cpp
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+#include "tt_metal/fabric/hw/inc/noc_addr.h"
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+#include "tt_metal/fabric/hw/inc/linear/addrgen_api.h"  // tt_fabric::addrgen_detail::get_noc_address
+#include "tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp"
+
+#include <cstdint>
+#include <algorithm>
+
+// Brings the fabric linear-api headers + the `fabric_api` alias + PacketHeaderPool.
+#include "cpp/ttnn/operations/ccl/all_gather/device/kernels/unicast_common.hpp"
+
+using address_t = uint32_t;
+
+// Direct (one-shot) reduce-scatter writer: owns the fabric, sends this core's tile range of local input
+// slice j to device j for every remote j, then writes the locally reduced output slice.
+//
+// Every send is a MULTI-HOP unicast (num_hops = ring distance, direction = which of the two connections),
+// so a contribution reaches its destination without any intermediate device staging/reducing it -- one
+// fabric traversal instead of the ring's N/2 store-and-forward steps. That is the whole point of this op.
+// Destinations are visited farthest-first (host-ordered), since the destination cannot start reducing
+// until its last contribution lands.
+//
+// Every destination writes into the SAME place: staging slot `device_idx` (indexed by SOURCE, so no two
+// senders collide), chunk sub-range [chunk_start, chunk_start + chunk_count), in the invocation-parity
+// half. So only the route changes per destination -- the dst addresses are computed once per chunk.
+// The arrival increment for a destination rides that destination's LAST payload packet (fused
+// write+atomic-inc), targeting the mirror core's per-source arrival counter.
+void kernel_main() {
+    constexpr uint32_t tile_bytes = get_compile_time_arg_val(0);
+    constexpr uint32_t tile_granularity = get_compile_time_arg_val(1);
+    constexpr uint32_t chunks_per_slice = get_compile_time_arg_val(2);
+    [[maybe_unused]] constexpr uint32_t pages_per_slice = get_compile_time_arg_val(3);
+    constexpr uint32_t num_devices = get_compile_time_arg_val(4);
+    constexpr uint32_t interm_tiles_per_packet = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_send_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_out_id = get_compile_time_arg_val(7);
+    // Send straight into the destination's reduce CB (its staging is an L1 shard aliased into that CB) --
+    // see the factory's CB comment. Off this path we write the interleaved staging tensor via its accessor.
+    constexpr bool arrivals_in_cb = get_compile_time_arg_val(8) != 0;
+    constexpr uint32_t half_stride_tiles = get_compile_time_arg_val(9);  // tiles in one parity half
+    constexpr auto staging_args = TensorAccessorArgs<10>();
+    constexpr auto output_args = TensorAccessorArgs<staging_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t num_dests = num_devices - 1;
+
+    size_t ai = 0;
+    const address_t staging_addr = get_arg_val<address_t>(ai++);
+    const address_t output_addr = get_arg_val<address_t>(ai++);
+    const uint32_t device_idx = get_arg_val<uint32_t>(ai++);
+    const uint32_t chunk_start = get_arg_val<uint32_t>(ai++);
+    const uint32_t chunk_count = get_arg_val<uint32_t>(ai++);
+    const uint32_t tile_start = get_arg_val<uint32_t>(ai++);
+    const uint32_t tile_count = get_arg_val<uint32_t>(ai++);
+    const address_t gen_addr = get_arg_val<uint32_t>(ai++);     // this core's private invocation counter
+    const address_t arrival_sem = get_arg_val<uint32_t>(ai++);  // our source slot's counter on every peer
+    const uint8_t peer_core_x = get_arg_val<uint32_t>(ai++);    // mirror core (deterministic placement)
+    const uint8_t peer_core_y = get_arg_val<uint32_t>(ai++);
+    const uint32_t num_connections = get_arg_val<uint32_t>(ai++);  // 1 (fwd only) or 2 (fwd + bwd)
+    // Per-destination route, in send order (shared order with the reader's cb_send production).
+    const size_t dest_conn = ai;
+    ai += num_dests;
+    const size_t dest_hops = ai;
+    ai += num_dests;
+    const size_t dest_block = ai;  // our block index inside that destination's reduce group (aliased path)
+    ai += num_dests;
+    size_t arg_for_fab = ai;  // fabric connection args are appended last
+
+    auto output_acc = TensorAccessor(output_args, output_addr);  // tiled (page = tile_bytes)
+
+    Noc noc;
+    CircularBuffer cb_send(cb_send_id);
+    CircularBuffer cb_out(cb_out_id);
+
+    auto* gen_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(gen_addr);
+    const uint32_t invocation = *gen_ptr;
+    // Same parity the peers' readers (and reducers) will use for this invocation -- see the reader's
+    // parity note. Every peer runs the identical chunk partition, so our local chunk index k is also the
+    // destination's, and the only per-destination term is which block of its group we own.
+    const uint32_t staging_half = (invocation & 1u) * (num_devices * chunks_per_slice);
+    const uint32_t dst_page_base = staging_half + device_idx * chunks_per_slice + chunk_start;
+    const uint32_t half_off_bytes = (invocation & 1u) * half_stride_tiles * tile_bytes;
+    constexpr uint32_t chunk_bytes = tile_granularity * tile_bytes;  // one block of one chunk
+
+    // Connection 0 = forward neighbour, 1 = backward (host order); 1D routing takes the distance from the
+    // packet header's hop count, so a header can be reused across both directions. Only START the open
+    // here: open_finish carries a barrier, so it is deferred until just before the first send, leaving the
+    // handshake to overlap the header setup below (and the reader's first input read).
+    auto fabric_connection = tt::tt_fabric::RoutingPlaneConnectionManager::build_from_args<
+        tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
+        arg_for_fab, num_connections);
+
+    // One header for plain payload packets, one for the fused write+atomic-inc that closes a destination.
+    // Both are re-set_state'd per destination (that is where num_hops lives); safe because every packet is
+    // flushed before the next one re-patches a header.
+    auto data_pkt = PacketHeaderPool::allocate_header(1);
+    auto fused_pkt = PacketHeaderPool::allocate_header(1);
+
+    const uint64_t arrival_noc_addr = safe_get_noc_addr(peer_core_x, peer_core_y, arrival_sem, 0);
+
+    // MEASURED: deferring open_finish past the header setup is worth nothing on its own (the handshake
+    // already overlaps the reader's first input read, which runs on another RISC); the win on this axis came
+    // from the SPLIT CLOSE at the end. Kept deferred anyway since it cannot hurt.
+    fabric_connection.open_finish();
+
+    for (uint32_t dst = 0; dst < num_dests; ++dst) {
+        const uint8_t hops = static_cast<uint8_t>(get_arg_val<uint32_t>(dest_hops + dst));
+        auto* sender = &fabric_connection.get(get_arg_val<uint32_t>(dest_conn + dst)).sender;
+        // Aliased path: our slot in the destination's reduce CB. The shard is height-sharded, so it sits
+        // at the same L1 address on the mirror core of every device -- our own staging address serves.
+        const uint32_t block_base =
+            arrivals_in_cb ? staging_addr + half_off_bytes + get_arg_val<uint32_t>(dest_block + dst) * chunk_bytes : 0u;
+
+        fabric_api::fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::None>(data_pkt, hops);
+        fabric_api::fabric_unicast_noc_fused_unicast_with_atomic_inc_set_state<
+            UnicastFusedAtomicIncUpdateMask::Val | UnicastFusedAtomicIncUpdateMask::Flush>(
+            fused_pkt,
+            hops,
+            tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{
+                0u,   // write dst (patched per packet)
+                0u,   // semaphore dst (patched per packet)
+                1u},  // increment 1 (flush defaults true: payload lands before the inc is applied)
+            /*packet_size_bytes=*/0);
+
+        uint32_t tiles_done = 0;
+        for (uint32_t k = 0; k < chunk_count; ++k) {
+            const uint32_t tiles_in_chunk = std::min(tile_granularity, tile_count - tiles_done);
+            cb_send.wait_front(tile_granularity);
+            const uint32_t rd = cb_send.get_read_ptr();
+
+            // Contiguous chunk -> peer staging page (dst_page_base + k), split into full packets. Flush
+            // after EACH packet: the header is re-patched per write, so a packet must be on the wire
+            // before the next one reuses it.
+            for (uint32_t t = 0; t < tiles_in_chunk; t += interm_tiles_per_packet) {
+                const uint32_t tiles_in_pkt = std::min(tiles_in_chunk - t, interm_tiles_per_packet);
+                const uint16_t payload = tiles_in_pkt * tile_bytes;
+                uint64_t dst_noc;
+                if constexpr (arrivals_in_cb) {
+                    // Chunk-major within the half: the destination's CB read pointer advances one
+                    // num_devices-block group per chunk, so consecutive chunks are a group apart.
+                    dst_noc = safe_get_noc_addr(
+                        peer_core_x, peer_core_y, block_base + k * num_devices * chunk_bytes + t * tile_bytes, 0);
+                } else {
+                    auto staging_acc = TensorAccessor(staging_args, staging_addr);  // chunk-paged
+                    dst_noc =
+                        tt::tt_fabric::addrgen_detail::get_noc_address(staging_acc, dst_page_base + k, t * tile_bytes);
+                }
+                const bool last_packet = (k == chunk_count - 1) && (t + interm_tiles_per_packet >= tiles_in_chunk);
+                if (last_packet) {
+                    // Closes this destination: in-order delivery on the connection means every earlier
+                    // payload of ours has landed before the inc is applied.
+                    fabric_api::fabric_unicast_noc_fused_unicast_with_atomic_inc_with_state<
+                        UnicastFusedAtomicIncUpdateMask::WriteDstAddr | UnicastFusedAtomicIncUpdateMask::SemaphoreAddr |
+                        UnicastFusedAtomicIncUpdateMask::PayloadSize>(
+                        sender,
+                        fused_pkt,
+                        rd + t * tile_bytes,
+                        tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{dst_noc, arrival_noc_addr, 1u},
+                        payload);
+                } else {
+                    fabric_api::fabric_unicast_noc_unicast_write_with_state<
+                        UnicastWriteUpdateMask::DstAddr | UnicastWriteUpdateMask::PayloadSize>(
+                        sender,
+                        data_pkt,
+                        rd + t * tile_bytes,
+                        tt::tt_fabric::NocUnicastCommandHeader{dst_noc},
+                        payload);
+                }
+                noc.async_writes_flushed();
+            }
+
+            cb_send.pop_front(tile_granularity);
+            tiles_done += tiles_in_chunk;
+        }
+    }
+
+    // Reduced output slice -> tiled local output, per tile (contiguous page order).
+    {
+        uint32_t out_tile = tile_start;
+        uint32_t tiles_done = 0;
+        for (uint32_t k = 0; k < chunk_count; ++k) {
+            const uint32_t tiles_in_chunk = std::min(tile_granularity, tile_count - tiles_done);
+            cb_out.wait_front(tile_granularity);
+            const uint32_t rd = cb_out.get_read_ptr();
+            for (uint32_t t = 0; t < tiles_in_chunk; ++t) {
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(rd + t * tile_bytes), output_acc, tile_bytes, {}, {.page_id = out_tile}, {});
+                ++out_tile;
+            }
+            // Only needs the payload to have LEFT L1 before the slot is handed back to compute; the final
+            // write barrier below still guarantees the writes actually completed before the op ends.
+            noc.async_writes_flushed();
+            cb_out.pop_front(tile_granularity);
+            tiles_done += tiles_in_chunk;
+        }
+    }
+
+    noc_semaphore_set(gen_ptr, invocation + 1);
+
+    // Split close: start the teardown handshake, then drain our own barriers while it runs. ONE write
+    // barrier is enough -- it is what actually completes the output writes (the loop above only flushed
+    // them) and any fabric payload writes; nothing is issued after it, and close_finish covers the
+    // teardown's own traffic. The extra trailing barrier this kernel used to carry (inherited from the
+    // unicast writer) was a redundant round-trip wait on the critical path.
+    fabric_connection.close_start();
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
+    fabric_connection.close_finish();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_writer.cpp
@@ -160,6 +160,9 @@ void kernel_main() {
                 noc.async_writes_flushed();
             }
         }
+        // Free noc_semaphore_wait_min by necessity, not preference: init_sem is a GlobalSemaphore ADDRESS
+        // from a runtime arg, while Semaphore<> can only be built from a per-program semaphore_id that it
+        // resolves via get_semaphore<>(). See the matching note in the reader.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_sem), (invocation + 1) * num_dests);
     }
 
@@ -253,8 +256,11 @@ void kernel_main() {
 
     fabric_connection.close_start();
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    // Barrier through the Noc object rather than the free functions: both resolve to noc_index today, so
+    // this is not a live difference, but it keeps the NoC selection in one place -- constructing `noc` with
+    // an explicit id would otherwise leave these two barriers silently on the default NoC.
+    noc.async_write_barrier();
+    noc.async_atomic_barrier();
 
     fabric_connection.close_finish();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_writer.cpp
@@ -160,9 +160,7 @@ void kernel_main() {
                 noc.async_writes_flushed();
             }
         }
-        // Free noc_semaphore_wait_min by necessity, not preference: init_sem is a GlobalSemaphore ADDRESS
-        // from a runtime arg, while Semaphore<> can only be built from a per-program semaphore_id that it
-        // resolves via get_semaphore<>(). See the matching note in the reader.
+        // Free function: init_sem arrives as a GlobalSemaphore address. See the reader's note.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_sem), (invocation + 1) * num_dests);
     }
 
@@ -256,9 +254,7 @@ void kernel_main() {
 
     fabric_connection.close_start();
 
-    // Barrier through the Noc object rather than the free functions: both resolve to noc_index today, so
-    // this is not a live difference, but it keeps the NoC selection in one place -- constructing `noc` with
-    // an explicit id would otherwise leave these two barriers silently on the default NoC.
+    // Via the Noc object so an explicitly-constructed `noc` cannot leave these on the default NoC.
     noc.async_write_barrier();
     noc.async_atomic_barrier();
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/reduce_scatter_minimal_direct_writer.cpp
@@ -16,7 +16,6 @@
 #include <algorithm>
 #include <type_traits>
 
-// Brings the fabric linear-api headers + the `fabric_api` alias + PacketHeaderPool.
 #include "cpp/ttnn/operations/ccl/all_gather/device/kernels/unicast_common.hpp"
 
 using address_t = uint32_t;
@@ -24,17 +23,6 @@ using address_t = uint32_t;
 // Direct (one-shot) reduce-scatter writer: owns the fabric, sends this core's tile range of local input
 // slice j to device j for every remote j, then writes the locally reduced output slice.
 //
-// Every send is a MULTI-HOP unicast (num_hops = ring distance, direction = which of the two connections),
-// so a contribution reaches its destination without any intermediate device staging/reducing it -- one
-// fabric traversal instead of the ring's N/2 store-and-forward steps. That is the whole point of this op.
-// Destinations are visited farthest-first (host-ordered), since the destination cannot start reducing
-// until its last contribution lands.
-//
-// Every destination writes into the SAME place: staging slot `device_idx` (indexed by SOURCE, so no two
-// senders collide), chunk sub-range [chunk_start, chunk_start + chunk_count), in the invocation-parity
-// half. So only the route changes per destination -- the dst addresses are computed once per chunk.
-// The arrival increment for a destination rides that destination's LAST payload packet (fused
-// write+atomic-inc), targeting the mirror core's per-source arrival counter.
 void kernel_main() {
     constexpr uint32_t tile_bytes = get_compile_time_arg_val(0);
     constexpr uint32_t tile_granularity = get_compile_time_arg_val(1);
@@ -48,8 +36,6 @@ void kernel_main() {
     // see the factory's CB comment. Off this path we write the interleaved staging tensor via its accessor.
     constexpr bool arrivals_in_cb = get_compile_time_arg_val(8) != 0;
     constexpr uint32_t half_stride_tiles = get_compile_time_arg_val(9);  // tiles in one parity half
-    // Start barrier: hold every send until all peers have entered this invocation. Needed only when the
-    // op allocates its own buffers -- see the block that runs it, below.
     constexpr bool needs_init_sync = get_compile_time_arg_val(10) != 0;
     constexpr auto staging_args = TensorAccessorArgs<11>();
     constexpr auto output_args = TensorAccessorArgs<staging_args.next_compile_time_args_offset()>();
@@ -69,8 +55,6 @@ void kernel_main() {
     const uint8_t peer_core_x = get_arg_val<uint32_t>(ai++);    // mirror core (deterministic placement)
     const uint8_t peer_core_y = get_arg_val<uint32_t>(ai++);
     const uint32_t num_connections = get_arg_val<uint32_t>(ai++);  // 1 (fwd only) or 2 (fwd + bwd)
-    // Start-barrier counter (same address on every peer) and the two multicast hop ranges that between
-    // them cover the ring exactly once. Always passed so the arg layout does not depend on the CT flag.
     const address_t init_sem = get_arg_val<uint32_t>(ai++);
     const uint8_t fwd_mcast_range = static_cast<uint8_t>(get_arg_val<uint32_t>(ai++));
     const uint8_t bwd_mcast_range = static_cast<uint8_t>(get_arg_val<uint32_t>(ai++));
@@ -113,9 +97,6 @@ void kernel_main() {
         tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
         arg_for_fab, num_connections);
 
-    // One header for plain payload packets, one for the fused write+atomic-inc that closes a destination.
-    // Both are re-set_state'd per destination (that is where num_hops lives); safe because every packet is
-    // flushed before the next one re-patches a header.
     auto data_pkt = PacketHeaderPool::allocate_header(1);
     auto fused_pkt = PacketHeaderPool::allocate_header(1);
 
@@ -124,8 +105,7 @@ void kernel_main() {
     // 1D routing takes the distance straight from the packet header's hop count, so a header is ready to
     // send once set_state has stamped num_hops on it. A 2D fabric instead routes by DESTINATION NODE:
     // set_state leaves the route empty (it only fills it in the RoutingPlaneConnectionManager overloads),
-    // so the route has to be programmed onto each header for each destination. Keyed on the header type,
-    // exactly as the all_gather FabricWriter does it, so the 1D path compiles to nothing.
+    // so the route has to be programmed onto each header for each destination.
     auto set_route_2d = [&](volatile PACKET_HEADER_TYPE* hdr, uint32_t dst) {
         if constexpr (std::is_base_of_v<tt::tt_fabric::HybridMeshPacketHeader, PACKET_HEADER_TYPE>) {
             fabric_set_unicast_route(
@@ -135,27 +115,8 @@ void kernel_main() {
         }
     };
 
-    // MEASURED: deferring open_finish past the header setup is worth nothing on its own (the handshake
-    // already overlaps the reader's first input read, which runs on another RISC); the win on this axis came
-    // from the SPLIT CLOSE at the end. Kept deferred anyway since it cannot hurt.
     fabric_connection.open_finish();
 
-    // ---- Optional start barrier ----
-    //
-    // Our sends target the peer's staging buffer at OUR OWN staging address (the mesh allocator is
-    // lockstep, so the buffer sits at the same address on every device). That identity holds only if the
-    // peer is on the same invocation as us -- and the parity double-buffer deliberately tolerates one
-    // invocation of skew. With persistent buffers that is harmless: the address is pinned for the cached
-    // program's lifetime, so a one-invocation-ahead sender writes the other parity half of the SAME
-    // buffer, which is exactly what the parity scheme is for. When the op allocates its own buffers the
-    // address is only stable as long as the allocator happens to repeat itself; a sender that has moved
-    // on to invocation i+1 would write at i+1's address into a peer still on i, where that address may
-    // belong to some other live buffer entirely (or not be allocated yet on the very first invocation).
-    //
-    // So: when either buffer is op-allocated, hold every send until all N-1 peers have entered this
-    // invocation. Two multicasts (one per direction, hop ranges chosen host-side to cover the ring
-    // exactly once) instead of N-1 unicasts. The counter is never reset -- like the arrival counters, we
-    // wait on an absolute position, so a peer that raced ahead cannot satisfy an earlier wait.
     if constexpr (needs_init_sync) {
         auto init_pkt = PacketHeaderPool::allocate_header(1);
         const uint64_t init_noc_addr = safe_get_noc_addr(peer_core_x, peer_core_y, init_sem, 0);
@@ -229,9 +190,6 @@ void kernel_main() {
             cb_send.wait_front(tile_granularity);
             const uint32_t rd = cb_send.get_read_ptr();
 
-            // Contiguous chunk -> peer staging page (dst_page_base + k), split into full packets. Flush
-            // after EACH packet: the header is re-patched per write, so a packet must be on the wire
-            // before the next one reuses it.
             for (uint32_t t = 0; t < tiles_in_chunk; t += interm_tiles_per_packet) {
                 const uint32_t tiles_in_pkt = std::min(tiles_in_chunk - t, interm_tiles_per_packet);
                 const uint16_t payload = tiles_in_pkt * tile_bytes;
@@ -248,8 +206,6 @@ void kernel_main() {
                 }
                 const bool last_packet = (k == chunk_count - 1) && (t + interm_tiles_per_packet >= tiles_in_chunk);
                 if (last_packet) {
-                    // Closes this destination: in-order delivery on the connection means every earlier
-                    // payload of ours has landed before the inc is applied.
                     fabric_api::fabric_unicast_noc_fused_unicast_with_atomic_inc_with_state<
                         UnicastFusedAtomicIncUpdateMask::WriteDstAddr | UnicastFusedAtomicIncUpdateMask::SemaphoreAddr |
                         UnicastFusedAtomicIncUpdateMask::PayloadSize>(
@@ -288,23 +244,17 @@ void kernel_main() {
                     CoreLocalMem<uint32_t>(rd + t * tile_bytes), output_acc, tile_bytes, {}, {.page_id = out_tile}, {});
                 ++out_tile;
             }
-            // Only needs the payload to have LEFT L1 before the slot is handed back to compute; the final
-            // write barrier below still guarantees the writes actually completed before the op ends.
             noc.async_writes_flushed();
             cb_out.pop_front(tile_granularity);
             tiles_done += tiles_in_chunk;
         }
     }
-
     noc_semaphore_set(gen_ptr, invocation + 1);
 
-    // Split close: start the teardown handshake, then drain our own barriers while it runs. ONE write
-    // barrier is enough -- it is what actually completes the output writes (the loop above only flushed
-    // them) and any fabric payload writes; nothing is issued after it, and close_finish covers the
-    // teardown's own traffic. The extra trailing barrier this kernel used to carry (inherited from the
-    // unicast writer) was a redundant round-trip wait on the critical path.
     fabric_connection.close_start();
+
     noc_async_write_barrier();
     noc_async_atomic_barrier();
+
     fabric_connection.close_finish();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
@@ -6,6 +6,7 @@
 
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/experimental/fabric/pipeline_builder.hpp>
 #include "ttnn/global_semaphore.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 
@@ -23,6 +24,34 @@ constexpr uint32_t direct_cb_send_id = tt::CBIndex::c_0;    // local input slice
 constexpr uint32_t direct_cb_reduce_id = tt::CBIndex::c_1;  // num_devices blocks per chunk (own + arrivals)
 constexpr uint32_t direct_cb_out_id = tt::CBIndex::c_16;    // reduced result (compute -> writer)
 }  // namespace
+
+bool reduce_scatter_direct_fabric_supported(
+    const ttnn::MeshDevice& mesh_device,
+    tt::tt_fabric::FabricConfig fabric_config,
+    tt::tt_fabric::Topology axis_topology) {
+    if (!::tt::tt_fabric::is_2d_fabric_config(fabric_config)) {
+        return true;  // 1D fabric: the case the kernels were written for
+    }
+    // See the header: on a 2D fabric the ACTIVE AXIS must be a straight wrapping line of the mesh.
+    // cluster_axis already confines the collective to one axis, so the mesh's other extent is irrelevant
+    // -- a 2x4 with a torus X axis is four independent 4-rings, each exactly the degenerate case the
+    // kernels want. What is NOT allowed is a 1xN logical VIEW that snakes across a larger physical grid:
+    // there the "ring" mixes X and Y hops, and 2D destination-node routing cannot agree with our
+    // hop-count/direction model. A torus axis_topology is precisely the signal that the axis wraps within
+    // its own dimension, so it is the whole test.
+    (void)mesh_device;
+    return ::tt::tt_fabric::is_ring_or_torus(axis_topology);
+}
+
+uint32_t reduce_scatter_direct_active_axis(const ReduceScatterMinimalDirectParams& args) {
+    uint32_t active_axis = 0;
+    for (uint32_t a = 0; a < 2; ++a) {
+        if (args.axis_num_devices[a] > 1) {
+            active_axis = a;
+        }
+    }
+    return args.cluster_axis.value_or(active_axis);
+}
 
 ReduceScatterDirectGeometry reduce_scatter_direct_geometry(
     const ReduceScatterMinimalDirectParams& args, const ttnn::Tensor& input_tensor, bool fp32_dest_acc_en) {
@@ -232,17 +261,15 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
     tt::tt_metal::Program program{};
     auto* mesh_device = input_tensor.device();
 
-    const bool fabric_is_2d = ::tt::tt_fabric::is_2d_fabric_config(operation_attributes.fabric_config);
-    TT_FATAL(!fabric_is_2d, "reduce_scatter_minimal_direct supports Fabric_1D only");
-
-    uint32_t active_axis = 0;
-    for (uint32_t a = 0; a < 2; ++a) {
-        if (operation_attributes.axis_num_devices[a] > 1) {
-            active_axis = a;
-        }
-    }
-    const uint32_t axis = operation_attributes.cluster_axis.value_or(active_axis);
+    const uint32_t axis = reduce_scatter_direct_active_axis(operation_attributes);
     const auto topology = operation_attributes.axis_topology[axis];
+    TT_FATAL(
+        reduce_scatter_direct_fabric_supported(*mesh_device, operation_attributes.fabric_config, topology),
+        "reduce_scatter_minimal_direct needs a 1D fabric, or a 2D fabric that collapses to one wrapping "
+        "line (torus axis + 1xN/Nx1 mesh); got fabric {} on a {} mesh with axis topology {}",
+        operation_attributes.fabric_config,
+        mesh_device->shape(),
+        topology);
     TT_FATAL(
         tt::tt_fabric::is_ring_or_torus(topology),
         "reduce_scatter_minimal_direct supports Ring topology only (a line would need per-destination "
@@ -403,6 +430,12 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
         uint32_t slice;  // destination device == the input slice it wants
         uint32_t conn;   // 0 = forward connection, 1 = backward
         uint32_t hops;
+        // Destination chip/mesh, for 2D fabric. 1D routing takes the distance from the packet header's
+        // hop count, but a 2D fabric routes by DESTINATION NODE, so the header carries a route programmed
+        // with fabric_set_unicast_route (see the writer). Resolved here because only the host knows the
+        // ring's physical layout.
+        uint32_t chip_id;
+        uint32_t mesh_id;
     };
     std::vector<Dest> dests;
     dests.reserve(num_devices - 1);
@@ -413,7 +446,94 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
         const uint32_t fwd_hops = (j + num_devices - device_idx) % num_devices;
         const uint32_t bwd_hops = (device_idx + num_devices - j) % num_devices;
         const bool use_fwd = fwd_hops <= bwd_hops;
-        dests.push_back(Dest{j, use_fwd ? 0u : 1u, use_fwd ? fwd_hops : bwd_hops});
+        const uint32_t hops = use_fwd ? fwd_hops : bwd_hops;
+        // Walk `hops` steps in the chosen direction to land on device j's coordinate.
+        const auto dest_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            input_tensor, sender_device_coord, use_fwd ? static_cast<int>(hops) : -static_cast<int>(hops), topology, axis);
+        TT_FATAL(dest_coord.has_value(), "ring neighbour {} hops away must exist", hops);
+        const auto dest_node = mesh_device->get_fabric_node_id(*dest_coord);
+        dests.push_back(Dest{
+            j,
+            use_fwd ? 0u : 1u,
+            hops,
+            dest_node.chip_id,
+            static_cast<uint32_t>(*dest_node.mesh_id)});
+    }
+    // On a 2D fabric, WE do not get to choose the direction. The header carries an absolute route from
+    // the routing table (fabric_set_unicast_route -> decode_route_to_buffer), and a packet must be handed
+    // to the router in that route's first-hop direction; push it into the other connection and it enters a
+    // router carrying a foreign route, which hangs. Our ring arithmetic above picks the shorter way round,
+    // which for an even ring's antipode (and anywhere the table breaks a tie the other way) can disagree.
+    // So on 2D, re-derive conn from the fabric's own answer. Purely a direction fix -- `hops` stays as
+    // computed, since 2D ignores it and 1D never reaches this block.
+    if (::tt::tt_fabric::is_2d_fabric_config(operation_attributes.fabric_config)) {
+        const auto self_node = mesh_device->get_fabric_node_id(sender_device_coord);
+        const auto fwd_dir = tt::tt_fabric::pipeline_get_forwarding_direction(
+            self_node, mesh_device->get_fabric_node_id(*fwd_coord));
+        const auto bwd_dir = tt::tt_fabric::pipeline_get_forwarding_direction(
+            self_node, mesh_device->get_fabric_node_id(*bwd_coord));
+
+        // The axis_topology we were handed is not trustworthy on its own: it binds a MESH-VIEW axis index
+        // to a fabric dimension (axis 1 -> X, axis 0 -> Y), while a torus fabric config wraps a PHYSICAL
+        // dimension. Open this box's 2x4 as 4x2 and the two disagree -- FABRIC_2D_TORUS_Y makes axis 0
+        // report Torus, but what it physically wraps is the length-2 dimension, not the 4-ring the
+        // collective runs on. The op then believes in a wrap that does not exist and hangs.
+        //
+        // So verify the wrap for real: a ring neighbour must be reachable in ONE hop (an actual cable in
+        // that direction), not by a long way round. Cheap, and it turns that hang into a clear message.
+        auto assert_single_hop = [&](const ttnn::MeshCoordinate& neighbor_coord,
+                                     const std::optional<tt::tt_fabric::RoutingDirection>& dir,
+                                     const char* which) {
+            const auto neighbor = mesh_device->get_fabric_node_id(neighbor_coord);
+            TT_FATAL(
+                dir.has_value(),
+                "reduce_scatter_minimal_direct: no fabric route to the {} ring neighbour (chip {})",
+                which,
+                neighbor.chip_id);
+            const auto neighbors = tt::tt_fabric::pipeline_get_chip_neighbors(self_node, *dir);
+            const auto it = neighbors.find(*neighbor.mesh_id);
+            const bool adjacent =
+                it != neighbors.end() && std::find(it->second.begin(), it->second.end(), neighbor.chip_id) !=
+                                             it->second.end();
+            TT_FATAL(
+                adjacent,
+                "reduce_scatter_minimal_direct: the {} ring neighbour (chip {}) is not one hop away in "
+                "direction {}, so the active axis does not physically wrap even though its topology reports "
+                "as a torus. This happens when the mesh VIEW's axis order does not match the fabric "
+                "dimension the torus config wraps -- e.g. this 2x4 box opened as 4x2 under TORUS_Y. Open "
+                "the mesh so the collective's axis is the dimension the config actually wraps.",
+                which,
+                neighbor.chip_id,
+                static_cast<int>(*dir));
+        };
+        assert_single_hop(*fwd_coord, fwd_dir, "forward");
+        assert_single_hop(*bwd_coord, bwd_dir, "backward");
+
+        for (auto& d : dests) {
+            const auto dir = tt::tt_fabric::pipeline_get_forwarding_direction(
+                self_node, tt::tt_fabric::FabricNodeId(tt::tt_fabric::MeshId{d.mesh_id}, d.chip_id));
+            TT_FATAL(
+                dir.has_value(),
+                "no fabric route from this device to ring member {} (chip {}) on a 2D fabric",
+                d.slice,
+                d.chip_id);
+            if (fwd_dir.has_value() && *dir == *fwd_dir) {
+                d.conn = 0;
+            } else if (bwd_dir.has_value() && *dir == *bwd_dir) {
+                d.conn = 1;
+            } else {
+                TT_THROW(
+                    "reduce_scatter_minimal_direct: the fabric routes to ring member {} (chip {}) via direction "
+                    "{}, which is neither of this device's ring-neighbour directions (fwd {}, bwd {}). The ring "
+                    "is not a straight line in one fabric dimension, so destination-node routing cannot follow "
+                    "it.",
+                    d.slice,
+                    d.chip_id,
+                    static_cast<int>(*dir),
+                    fwd_dir.has_value() ? std::to_string(static_cast<int>(*fwd_dir)) : std::string("none"),
+                    bwd_dir.has_value() ? std::to_string(static_cast<int>(*bwd_dir)) : std::string("none"));
+            }
+        }
     }
     std::stable_sort(dests.begin(), dests.end(), [](const Dest& a, const Dest& b) { return a.hops > b.hops; });
     const bool uses_backward = std::any_of(dests.begin(), dests.end(), [](const Dest& d) { return d.conn == 1; });
@@ -428,19 +548,24 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
         ++mcast_range[d.conn];
         max_hops[d.conn] = std::max(max_hops[d.conn], d.hops);
     }
-    for (uint32_t c = 0; c < 2; ++c) {
+    // 1D only: on 2D the barrier sends one unicast per peer (reusing the data path's per-destination
+    // routes), so it needs no contiguous hop ranges -- and the direction fix-up above can legitimately
+    // split the destinations in a way these would reject.
+    if (!::tt::tt_fabric::is_2d_fabric_config(operation_attributes.fabric_config)) {
+        for (uint32_t c = 0; c < 2; ++c) {
+            TT_FATAL(
+                mcast_range[c] == max_hops[c],
+                "start-barrier multicast assumes direction {}'s destinations are hops 1..{} with no gaps, but the "
+                "{} destinations routed that way reach out to {} hops",
+                c,
+                mcast_range[c],
+                mcast_range[c],
+                max_hops[c]);
+        }
         TT_FATAL(
-            mcast_range[c] == max_hops[c],
-            "start-barrier multicast assumes direction {}'s destinations are hops 1..{} with no gaps, but the "
-            "{} destinations routed that way reach out to {} hops",
-            c,
-            mcast_range[c],
-            mcast_range[c],
-            max_hops[c]);
+            mcast_range[1] == 0 || num_connections == 2,
+            "start barrier would multicast backward on a connection that was never opened");
     }
-    TT_FATAL(
-        mcast_range[1] == 0 || num_connections == 2,
-        "start barrier would multicast backward on a connection that was never opened");
 
     // --- Runtime args ---
     const auto sender_fabric_node_id = mesh_device->get_fabric_node_id(sender_device_coord);
@@ -506,6 +631,14 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
         // Only the aliased path reads these (off it, the sender indexes staging by source directly).
         for (const auto& d : dests) {
             writer_rt.push_back(device_idx < d.slice ? device_idx + 1 : device_idx);
+        }
+        // 2D-fabric route targets, ignored by the 1D path. MUST stay last before the fabric connection
+        // args -- the writer reads conn, hops, block, chip, mesh in exactly this order.
+        for (const auto& d : dests) {
+            writer_rt.push_back(d.chip_id);
+        }
+        for (const auto& d : dests) {
+            writer_rt.push_back(d.mesh_id);
         }
         // Fabric connections, appended last: index 0 = forward neighbour, 1 = backward, both on this
         // worker's own routing plane so the links stay independent.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
@@ -1,0 +1,479 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "reduce_scatter_minimal_direct_factory.hpp"
+
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/hal.hpp>
+#include "ttnn/global_semaphore.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp"
+
+#include <algorithm>
+#include <set>
+#include <vector>
+
+namespace ttnn::experimental::prim {
+
+using namespace ::ttnn::ccl;
+
+namespace {
+// Prefixed because the ccl ops share a unity-build translation unit with their siblings.
+constexpr uint32_t direct_cb_send_id = tt::CBIndex::c_0;    // local input slices queued for the fabric
+constexpr uint32_t direct_cb_reduce_id = tt::CBIndex::c_1;  // num_devices blocks per chunk (own + arrivals)
+constexpr uint32_t direct_cb_out_id = tt::CBIndex::c_16;    // reduced result (compute -> writer)
+}  // namespace
+
+uint32_t reduce_scatter_direct_num_links(const ReduceScatterMinimalDirectParams& args, uint32_t chunks_per_slice) {
+    // Clamped to chunks_per_slice so no worker is handed zero chunks.
+    return std::min(std::max(1u, args.num_links), chunks_per_slice);
+}
+
+std::pair<CoreRangeSet, std::vector<CoreCoord>> reduce_scatter_direct_worker_cores(
+    const ReduceScatterMinimalDirectParams& args, ttnn::MeshDevice* mesh_device, uint32_t chunks_per_slice) {
+    const uint32_t num_links = reduce_scatter_direct_num_links(args, chunks_per_slice);
+    auto [all_core_range, worker_cores_vec] = ttnn::ccl::choose_worker_cores(
+        num_links,
+        /*num_cores_per_link=*/1,
+        mesh_device,
+        args.subdevice_id,
+        /*core_grid_offset=*/CoreCoord{0, 0},
+        args.sub_core_grid);
+    TT_FATAL(
+        worker_cores_vec.size() == num_links,
+        "reduce_scatter_minimal_direct needs {} worker cores (one per link) but got {}",
+        num_links,
+        worker_cores_vec.size());
+
+    std::set<CoreRange> worker_core_set;
+    for (const auto& c : worker_cores_vec) {
+        worker_core_set.emplace(c);
+    }
+    return {CoreRangeSet(worker_core_set), std::move(worker_cores_vec)};
+}
+
+////////////////////////////////////////////////////////////////
+// Direct (one-shot) reduce-scatter.
+//
+// Ring devices 0..N-1. Output slice j (on device j) = sum_k X_k^j. Every device sends slice j straight to
+// device j as a single multi-hop fabric unicast (num_hops = ring distance, nearest direction), landing in
+// device j's staging slot indexed by the SENDER, with a fused atomic inc on the last packet. Once all N-1
+// arrival counters have advanced, the destination reduces the N-1 arrivals together with its own slice and
+// writes the output. No device ever relays or accumulates another device's partial: latency is one fabric
+// traversal instead of the ring's N/2 store-and-forward steps, at ~2.3x the link traffic.
+//
+// One worker core per fabric link, owning that link's forward AND backward connection, plus a contiguous
+// chunk sub-range of every slice (the only place parallelism exists -- every contribution is one hop).
+// Staging is double-buffered by invocation parity so a device one invocation ahead cannot clobber data we
+// have not reduced yet; see the reader kernel for the full argument.
+////////////////////////////////////////////////////////////////
+
+ReduceScatterMinimalDirectMeshWorkloadFactory::cached_mesh_workload_t
+ReduceScatterMinimalDirectMeshWorkloadFactory::create_mesh_workload(
+    const ReduceScatterMinimalDirectParams& operation_attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const ReduceScatterMinimalDirectInputs& tensor_args,
+    tensor_return_value_t& output_tensors) {
+    tt::tt_metal::distributed::MeshWorkload workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+
+    auto* mesh_device = tensor_args.input_tensor.device();
+    auto subdevice_id = operation_attributes.subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
+    auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
+    if (operation_attributes.sub_core_grid.has_value()) {
+        available_cores = available_cores.intersection(operation_attributes.sub_core_grid.value());
+    }
+    ttsl::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
+
+    // One arrival counter per SOURCE device (so every counter has exactly one sender -- an absolute wait on
+    // it can never be satisfied by a different device that raced ahead), plus the reader's and writer's
+    // private invocation counters. Allocate in L1_SMALL when available.
+    bool l1_small_size = mesh_device->allocator()->get_bank_size(tt::tt_metal::BufferType::L1_SMALL);
+    auto sem_buffer_type = l1_small_size > 0 ? tt::tt_metal::BufferType::L1_SMALL : tt::tt_metal::BufferType::L1;
+    std::vector<tt::tt_metal::GlobalSemaphore> arrival_sems;
+    arrival_sems.reserve(operation_attributes.num_devices);
+    for (uint32_t s = 0; s < operation_attributes.num_devices; ++s) {
+        arrival_sems.push_back(
+            ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type));
+    }
+    auto reader_gen_sem =
+        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
+    auto writer_gen_sem =
+        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
+    auto compute_gen_sem =
+        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
+    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevices);
+
+    for (const auto& coord : tensor_coords.coords()) {
+        auto cached_program = create_at(
+            operation_attributes,
+            coord,
+            tensor_args,
+            output_tensors,
+            arrival_sems,
+            reader_gen_sem,
+            writer_gen_sem,
+            compute_gen_sem);
+        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
+        shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
+    }
+
+    return cached_mesh_workload_t{std::move(workload), std::move(shared_variables)};
+}
+
+ReduceScatterMinimalDirectMeshWorkloadFactory::cached_program_t
+ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
+    const ReduceScatterMinimalDirectParams& operation_attributes,
+    const ttnn::MeshCoordinate& sender_device_coord,
+    const ReduceScatterMinimalDirectInputs& tensor_args,
+    const tensor_return_value_t& output_tensors,
+    const std::vector<tt::tt_metal::GlobalSemaphore>& arrival_sems,
+    const tt::tt_metal::GlobalSemaphore& reader_gen_sem,
+    const tt::tt_metal::GlobalSemaphore& writer_gen_sem,
+    const tt::tt_metal::GlobalSemaphore& compute_gen_sem) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto& output_tensor = output_tensors.at(0);
+    const auto& staging = output_tensors.at(1);
+    tt::tt_metal::Program program{};
+    auto* mesh_device = input_tensor.device();
+
+    const bool fabric_is_2d = ::tt::tt_fabric::is_2d_fabric_config(operation_attributes.fabric_config);
+    TT_FATAL(!fabric_is_2d, "reduce_scatter_minimal_direct supports Fabric_1D only");
+
+    uint32_t active_axis = 0;
+    for (uint32_t a = 0; a < 2; ++a) {
+        if (operation_attributes.axis_num_devices[a] > 1) {
+            active_axis = a;
+        }
+    }
+    const uint32_t axis = operation_attributes.cluster_axis.value_or(active_axis);
+    const auto topology = operation_attributes.axis_topology[axis];
+    TT_FATAL(
+        tt::tt_fabric::is_ring_or_torus(topology),
+        "reduce_scatter_minimal_direct supports Ring topology only (a line would need per-destination "
+        "direction clamping)");
+
+    const uint32_t num_devices = operation_attributes.num_devices;
+    const uint32_t device_idx = ::ttnn::ccl::get_linearized_index_from_physical_coord(
+        input_tensor, sender_device_coord, operation_attributes.cluster_axis);
+
+    auto fwd_coord =
+        ::ttnn::ccl::get_physical_neighbor_from_physical_coord(input_tensor, sender_device_coord, 1, topology, axis);
+    auto bwd_coord =
+        ::ttnn::ccl::get_physical_neighbor_from_physical_coord(input_tensor, sender_device_coord, -1, topology, axis);
+    TT_FATAL(fwd_coord.has_value() && bwd_coord.has_value(), "ring must have both neighbors");
+
+    // Scatter on the last (width) dim only, TILE layout.
+    TT_FATAL(input_tensor.layout() == ttnn::TILE_LAYOUT, "requires TILE layout");
+    const auto padded_shape = input_tensor.padded_shape();
+    const uint32_t rank = padded_shape.rank();
+    TT_FATAL(
+        operation_attributes.dim == static_cast<int32_t>(rank) - 1,
+        "reduce_scatter_minimal_direct supports scatter on the last dim only, got dim {}",
+        operation_attributes.dim);
+
+    const uint32_t num_input_pages = input_tensor.buffer()->num_pages();
+    TT_FATAL(
+        num_input_pages % num_devices == 0, "input pages {} must divide num_devices {}", num_input_pages, num_devices);
+    const uint32_t pages_per_slice = num_input_pages / num_devices;  // tiles per slice (== output tiles)
+
+    const uint32_t tile_width = input_tensor.tensor_spec().tile().get_width();
+    TT_FATAL(
+        padded_shape[rank - 1] % (num_devices * tile_width) == 0,
+        "last dim {} must be divisible by num_devices*tile_width ({}*{})",
+        padded_shape[rank - 1],
+        num_devices,
+        tile_width);
+    const uint32_t width_tiles = padded_shape[rank - 1] / tile_width;
+    const uint32_t slice_Wt = width_tiles / num_devices;  // slice width in tiles (per-row run of the input walk)
+
+    // Chunk-paged staging geometry, shared with the ring ops (a chunk = tile_granularity tiles stored
+    // contiguously, so one contribution chunk is one coalesced fabric write).
+    const bool fp32_dest_acc_en = (input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32);
+    const auto sp = ttnn::experimental::ccl::reduce_scatter_ring_interm_staging_params(
+        input_tensor, topology, static_cast<uint32_t>(operation_attributes.dim), num_devices, fp32_dest_acc_en);
+    TT_FATAL(sp.use_contiguous, "contiguous staging path required (Ring topology, scatter dim != 0)");
+    const uint32_t single_tile_bytes = sp.single_tile_bytes;
+    const uint32_t tile_granularity = sp.tile_granularity;                // tiles per chunk
+    const uint32_t interm_tiles_per_packet = sp.interm_tiles_per_packet;  // tiles per fabric packet
+    const uint32_t chunks_per_slice = sp.chunks_per_channel;              // dim = last -> slice_C == 1
+    TT_FATAL(interm_tiles_per_packet >= 1, "a tile must fit in a fabric packet");
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    TT_FATAL(
+        sp.page_bytes % dram_alignment == 0,
+        "staging page_bytes {} must be a multiple of DRAM alignment {}",
+        sp.page_bytes,
+        dram_alignment);
+
+    // --- Core selection: one worker core per link. Unlike the store-and-forward ring op there is no
+    // per-direction core: a contribution's direction is a property of its DESTINATION, so a single worker
+    // owns both of its link's connections and fans out to every destination itself. Placement is
+    // deterministic, so worker `link` sits at the same logical coords on every device -- which is what lets
+    // a sender target the mirror core's staging slot + arrival counter without any exchange.
+    //
+    // MEASURED (2026-07-28, rs_8K): splitting the destination list across extra "helper" sender cores on
+    // the spare (link, direction) channels made it WORSE (device crit-path 7.7 -> 8.5us, within-iter spread
+    // 0.9 -> 1.9us). Every added core pays the per-core fixed cost (kernel launch + fabric connection
+    // open/close) and the op's duration is the max over its cores, so shortening the reducer's serial send
+    // work by ~3 units does not pay for it. Do not re-add destination-parallel senders without first
+    // shrinking that fixed cost.
+    const uint32_t num_links = reduce_scatter_direct_num_links(operation_attributes, chunks_per_slice);
+    auto [worker_core_range, worker_cores_vec] =
+        reduce_scatter_direct_worker_cores(operation_attributes, mesh_device, chunks_per_slice);
+
+    // Chunk partition across the per-link workers: worker l gets base_chunks (+1 for the first `extra`).
+    // Only a slice's very last chunk can be partial, so only the last worker's tile_count is ever clipped.
+    const uint32_t base_chunks = chunks_per_slice / num_links;
+    const uint32_t extra_chunks = chunks_per_slice % num_links;
+
+    // --- Circular buffers (real-tile granularity).
+    //
+    // ARRIVALS_IN_CB (staging is L1-sharded): cb_reduce IS this core's staging shard, so a sender's fabric
+    // packet lands directly in the slot the reducer unpacks from and nothing reads staging on the receive
+    // side. That forces the shard's exact geometry -- 2 parity halves x chunks_per_slice chunks x
+    // num_devices blocks x tile_granularity tiles -- since the CB read pointer advances one N-block group
+    // per chunk and the parity half is reached as a constant tile-index offset on top of it.
+    //
+    // Otherwise cb_reduce is an ordinary double-buffered CB the reader fills by reading staging over the
+    // NoC (the fallback for shapes whose shard will not fit one core).
+    const bool arrivals_in_cb = staging.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    const uint32_t half_stride_tiles = chunks_per_slice * num_devices * tile_granularity;
+    const uint32_t cb_reduce_pages = arrivals_in_cb ? 2 * half_stride_tiles : 2 * num_devices * tile_granularity;
+    // The parity offset every kernel applies. Zero off the aliased path: there cb_reduce is an ordinary
+    // two-group CB with no parity halves to choose between, and a non-zero offset would push the reader
+    // and the reducer clean off the end of it on odd invocations.
+    const uint32_t parity_stride_tiles = arrivals_in_cb ? half_stride_tiles : 0u;
+
+    const uint32_t cb_page_size = single_tile_bytes;
+    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    for (auto [cb_id, num_pages] : std::initializer_list<std::pair<uint32_t, uint32_t>>{
+             {direct_cb_send_id, 2 * tile_granularity}, {direct_cb_out_id, 2 * tile_granularity}}) {
+        tt::tt_metal::CircularBufferConfig cfg =
+            tt::tt_metal::CircularBufferConfig(num_pages * cb_page_size, {{cb_id, df}})
+                .set_page_size(cb_id, cb_page_size);
+        CreateCircularBuffer(program, worker_core_range, cfg);
+    }
+
+    tt::tt_metal::CircularBufferConfig reduce_cb_cfg =
+        tt::tt_metal::CircularBufferConfig(cb_reduce_pages * cb_page_size, {{direct_cb_reduce_id, df}})
+            .set_page_size(direct_cb_reduce_id, cb_page_size);
+    if (arrivals_in_cb) {
+        TT_FATAL(
+            staging.buffer()->aligned_page_size() * staging.buffer()->shard_spec().shape()[0] ==
+                cb_reduce_pages * cb_page_size,
+            "sharded staging shard ({} rows x {} B) must be exactly the reduce CB ({} tiles x {} B); the "
+            "staging spec and the factory disagree on the shard geometry",
+            staging.buffer()->shard_spec().shape()[0],
+            staging.buffer()->aligned_page_size(),
+            cb_reduce_pages,
+            cb_page_size);
+        reduce_cb_cfg = reduce_cb_cfg.set_globally_allocated_address(*staging.buffer());
+    }
+    const auto reduce_cb_handle = CreateCircularBuffer(program, worker_core_range, reduce_cb_cfg);
+
+    // --- Kernels ---
+    std::vector<uint32_t> reader_ct_args = {
+        single_tile_bytes,
+        tile_granularity,
+        chunks_per_slice,
+        pages_per_slice,
+        slice_Wt,
+        width_tiles,
+        num_devices,
+        direct_cb_send_id,
+        direct_cb_reduce_id,
+        (uint32_t)arrivals_in_cb,
+        parity_stride_tiles};
+    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_ct_args);  // tiled
+    tt::tt_metal::TensorAccessorArgs(staging.buffer()).append_to(reader_ct_args);       // chunk-paged
+
+    std::vector<uint32_t> writer_ct_args = {
+        single_tile_bytes,
+        tile_granularity,
+        chunks_per_slice,
+        pages_per_slice,
+        num_devices,
+        interm_tiles_per_packet,
+        direct_cb_send_id,
+        direct_cb_out_id,
+        (uint32_t)arrivals_in_cb,
+        parity_stride_tiles};
+    tt::tt_metal::TensorAccessorArgs(staging.buffer()).append_to(writer_ct_args);        // chunk-paged
+    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_ct_args);  // tiled
+
+    std::vector<uint32_t> compute_ct_args = {
+        tile_granularity, num_devices, direct_cb_reduce_id, direct_cb_out_id, parity_stride_tiles};
+
+    auto reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/"
+        "reduce_scatter_minimal_direct_reader.cpp",
+        worker_core_range,
+        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+    auto writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/"
+        "reduce_scatter_minimal_direct_writer.cpp",
+        worker_core_range,
+        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+    auto compute_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/"
+        "reduce_scatter_minimal_direct_compute.cpp",
+        worker_core_range,
+        tt::tt_metal::ComputeConfig{.compile_args = compute_ct_args});
+
+    // --- Destination order: farthest ring distance first, since a destination cannot start reducing until
+    // its last contribution lands. Direction is whichever way round the ring is shorter (ties -> forward,
+    // which also puts an even ring's antipode on the forward link).
+    struct Dest {
+        uint32_t slice;  // destination device == the input slice it wants
+        uint32_t conn;   // 0 = forward connection, 1 = backward
+        uint32_t hops;
+    };
+    std::vector<Dest> dests;
+    dests.reserve(num_devices - 1);
+    for (uint32_t j = 0; j < num_devices; ++j) {
+        if (j == device_idx) {
+            continue;
+        }
+        const uint32_t fwd_hops = (j + num_devices - device_idx) % num_devices;
+        const uint32_t bwd_hops = (device_idx + num_devices - j) % num_devices;
+        const bool use_fwd = fwd_hops <= bwd_hops;
+        dests.push_back(Dest{j, use_fwd ? 0u : 1u, use_fwd ? fwd_hops : bwd_hops});
+    }
+    std::stable_sort(dests.begin(), dests.end(), [](const Dest& a, const Dest& b) { return a.hops > b.hops; });
+    const bool uses_backward = std::any_of(dests.begin(), dests.end(), [](const Dest& d) { return d.conn == 1; });
+    const uint32_t num_connections = uses_backward ? 2u : 1u;
+
+    // --- Runtime args ---
+    const auto sender_fabric_node_id = mesh_device->get_fabric_node_id(sender_device_coord);
+    const uint32_t input_addr = input_tensor.buffer()->address();
+    const uint32_t output_addr = output_tensor.buffer()->address();
+    const uint32_t staging_addr = staging.buffer()->address();
+
+    for (uint32_t link = 0; link < num_links; ++link) {
+        const CoreCoord core = worker_cores_vec[link];
+        const uint32_t chunk_start = link * base_chunks + std::min(link, extra_chunks);
+        const uint32_t chunk_count = base_chunks + (link < extra_chunks ? 1u : 0u);
+        const uint32_t tile_start = chunk_start * tile_granularity;
+        const uint32_t tile_count = std::min(chunk_count * tile_granularity, pages_per_slice - tile_start);
+        // Mirror core: deterministic placement means the peer's worker `link` is at these same coords.
+        const CoreCoord peer_core = mesh_device->worker_core_from_logical_core(core);
+
+        std::vector<uint32_t> reader_rt = {
+            input_addr,
+            staging_addr,
+            device_idx,
+            chunk_start,
+            chunk_count,
+            tile_start,
+            tile_count,
+            reader_gen_sem.address()};
+        for (uint32_t s = 0; s < num_devices; ++s) {
+            if (s != device_idx) {
+                reader_rt.push_back(arrival_sems[s].address());
+            }
+        }
+        for (const auto& d : dests) {
+            reader_rt.push_back(d.slice);
+        }
+        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, {core}, reader_rt);
+
+        std::vector<uint32_t> compute_rt = {chunk_count, tile_count, compute_gen_sem.address()};
+        tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, {core}, compute_rt);
+
+        std::vector<uint32_t> writer_rt = {
+            staging_addr,
+            output_addr,
+            device_idx,
+            chunk_start,
+            chunk_count,
+            tile_start,
+            tile_count,
+            writer_gen_sem.address(),
+            arrival_sems[device_idx].address(),  // our source slot's counter, same address on every peer
+            (uint32_t)peer_core.x,
+            (uint32_t)peer_core.y,
+            num_connections};
+        for (const auto& d : dests) {
+            writer_rt.push_back(d.conn);
+        }
+        for (const auto& d : dests) {
+            writer_rt.push_back(d.hops);
+        }
+        // Our block index in the destination's N-block reduce group. The destination lays its blocks out
+        // as [own, then every other device in ascending order], so a source before it shifts up by one.
+        // Only the aliased path reads these (off it, the sender indexes staging by source directly).
+        for (const auto& d : dests) {
+            writer_rt.push_back(device_idx < d.slice ? device_idx + 1 : device_idx);
+        }
+        // Fabric connections, appended last: index 0 = forward neighbour, 1 = backward, both on this
+        // worker's own routing plane so the links stay independent.
+        std::vector<tt::tt_fabric::FabricNodeId> dst_nodes = {mesh_device->get_fabric_node_id(*fwd_coord)};
+        std::vector<uint32_t> link_indices = {link};
+        if (uses_backward) {
+            dst_nodes.push_back(mesh_device->get_fabric_node_id(*bwd_coord));
+            link_indices.push_back(link);
+        }
+        append_routing_plane_connection_manager_rt_args(
+            sender_fabric_node_id,
+            dst_nodes,
+            link_indices,
+            program,
+            writer_kernel_id,
+            {core},
+            writer_rt,
+            tt::tt_fabric::FabricApiType::Linear);
+        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, {core}, writer_rt);
+    }
+
+    shared_variables_t shared_variables{
+        .worker_cores = worker_cores_vec,
+        .reader_kernel_id = reader_kernel_id,
+        .compute_kernel_id = compute_kernel_id,
+        .writer_kernel_id = writer_kernel_id,
+        .arrival_sems = arrival_sems,
+        .reader_gen_sem = reader_gen_sem,
+        .writer_gen_sem = writer_gen_sem,
+        .compute_gen_sem = compute_gen_sem,
+        .reduce_cb_handle = arrivals_in_cb ? std::optional{reduce_cb_handle} : std::nullopt,
+    };
+    return {std::move(program), std::move(shared_variables)};
+}
+
+void ReduceScatterMinimalDirectMeshWorkloadFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const ReduceScatterMinimalDirectParams& /*operation_attributes*/,
+    const ReduceScatterMinimalDirectInputs& tensor_args,
+    tensor_return_value_t& output_tensors) {
+    const uint32_t input_addr = tensor_args.input_tensor.buffer()->address();
+    const uint32_t output_addr = output_tensors.at(0).buffer()->address();
+    const uint32_t staging_addr = output_tensors.at(1).buffer()->address();
+
+    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+        auto& sv = cached_workload.shared_variables.at(coordinate_range);
+        auto& reader_args_by_core = GetRuntimeArgs(program, sv.reader_kernel_id);
+        auto& writer_args_by_core = GetRuntimeArgs(program, sv.writer_kernel_id);
+
+        // On the aliased path cb_reduce lives on top of the staging buffer, so it has to follow it.
+        if (sv.reduce_cb_handle.has_value()) {
+            UpdateDynamicCircularBufferAddress(program, *sv.reduce_cb_handle, *output_tensors.at(1).buffer());
+        }
+
+        // Only the tensor addresses move. The semaphores are owned by shared_variables (their addresses are
+        // fixed for the cached program's lifetime) and the chunk partition / destination routes are
+        // geometry-derived, so both stay valid.
+        for (const auto& core : sv.worker_cores) {
+            auto& r = reader_args_by_core[core.x][core.y];
+            r[0] = input_addr;
+            r[1] = staging_addr;
+            auto& w = writer_args_by_core[core.x][core.y];
+            w[0] = staging_addr;
+            w[1] = output_addr;
+        }
+    }
+}
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
@@ -176,14 +176,25 @@ std::pair<CoreRangeSet, std::vector<CoreCoord>> reduce_scatter_direct_worker_cor
 // have not reduced yet; see the reader kernel for the full argument.
 ////////////////////////////////////////////////////////////////
 
-ReduceScatterMinimalDirectMeshWorkloadFactory::cached_mesh_workload_t
-ReduceScatterMinimalDirectMeshWorkloadFactory::create_mesh_workload(
+namespace {
+
+// Per-coordinate ProgramDescriptor. Declared here, defined below create_workload_descriptor.
+tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
     const ReduceScatterMinimalDirectParams& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const ttnn::MeshCoordinate& sender_device_coord,
     const ReduceScatterMinimalDirectInputs& tensor_args,
-    tensor_return_value_t& output_tensors) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    const std::vector<Tensor>& output_tensors,
+    const std::vector<tt::tt_metal::GlobalSemaphore>& sems,
+    bool needs_init_sync);
+
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor ReduceScatterMinimalDirectProgramFactory::create_workload_descriptor(
+    const ReduceScatterMinimalDirectParams& operation_attributes,
+    const ReduceScatterMinimalDirectInputs& tensor_args,
+    tensor_return_value_t& output_tensors,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor workload_descriptor;
 
     auto* mesh_device = tensor_args.input_tensor.device();
     auto subdevice_id = operation_attributes.subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
@@ -196,23 +207,17 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_mesh_workload(
     // One arrival counter per SOURCE device (so every counter has exactly one sender -- an absolute wait on
     // it can never be satisfied by a different device that raced ahead), plus the reader's and writer's
     // private invocation counters. Allocate in L1_SMALL when available.
+    // Parked on the descriptor's `semaphores` slot, which keeps them alive for the cached workload's
+    // lifetime -- the kernels take their addresses as runtime args. Order is the contract in
+    // SemaphoreIndex: arrivals [0..N-1], then reader_gen, writer_gen, compute_gen, init_sync.
     bool l1_small_size = mesh_device->allocator()->get_bank_size(tt::tt_metal::BufferType::L1_SMALL);
     auto sem_buffer_type = l1_small_size > 0 ? tt::tt_metal::BufferType::L1_SMALL : tt::tt_metal::BufferType::L1;
-    std::vector<tt::tt_metal::GlobalSemaphore> arrival_sems;
-    arrival_sems.reserve(operation_attributes.num_devices);
-    for (uint32_t s = 0; s < operation_attributes.num_devices; ++s) {
-        arrival_sems.push_back(
+    auto& sems = workload_descriptor.semaphores;
+    sems.reserve(SemaphoreIndex::count(operation_attributes.num_devices));
+    for (size_t s = 0; s < SemaphoreIndex::count(operation_attributes.num_devices); ++s) {
+        sems.push_back(
             ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type));
     }
-    auto reader_gen_sem =
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
-    auto writer_gen_sem =
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
-    auto compute_gen_sem =
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
-    // Start-barrier counter, only consumed when the writer's init sync is compiled in (below).
-    auto init_sync_sem =
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
     tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevices);
 
     // The writer's start barrier is needed only when the op allocates a buffer a peer writes into, since
@@ -224,41 +229,32 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_mesh_workload(
     const bool needs_init_sync =
         !(tensor_args.persistent_output_tensor.has_value() && tensor_args.persistent_staging_tensor.has_value());
 
+    // One descriptor per coordinate: the program depends on the sender coordinate (device_idx, ring
+    // neighbours, per-destination hop/direction/route table), so the mesh cannot share one.
     for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(
-            operation_attributes,
-            coord,
-            tensor_args,
-            output_tensors,
-            arrival_sems,
-            reader_gen_sem,
-            writer_gen_sem,
-            compute_gen_sem,
-            init_sync_sem,
-            needs_init_sync);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
+        workload_descriptor.programs.push_back(
+            {ttnn::MeshCoordinateRange(coord),
+             build_program_descriptor_at(
+                 operation_attributes, coord, tensor_args, output_tensors, sems, needs_init_sync)});
     }
 
-    return cached_mesh_workload_t{std::move(workload), std::move(shared_variables)};
+    return workload_descriptor;
 }
 
-ReduceScatterMinimalDirectMeshWorkloadFactory::cached_program_t
-ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
+namespace {
+
+tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
     const ReduceScatterMinimalDirectParams& operation_attributes,
     const ttnn::MeshCoordinate& sender_device_coord,
     const ReduceScatterMinimalDirectInputs& tensor_args,
-    const tensor_return_value_t& output_tensors,
-    const std::vector<tt::tt_metal::GlobalSemaphore>& arrival_sems,
-    const tt::tt_metal::GlobalSemaphore& reader_gen_sem,
-    const tt::tt_metal::GlobalSemaphore& writer_gen_sem,
-    const tt::tt_metal::GlobalSemaphore& compute_gen_sem,
-    const tt::tt_metal::GlobalSemaphore& init_sync_sem,
+    const std::vector<Tensor>& output_tensors,
+    const std::vector<tt::tt_metal::GlobalSemaphore>& sems,
     bool needs_init_sync) {
+    using SemaphoreIndex = ReduceScatterMinimalDirectProgramFactory::SemaphoreIndex;
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& output_tensor = output_tensors.at(0);
     const auto& staging = output_tensors.at(1);
-    tt::tt_metal::Program program{};
+    tt::tt_metal::ProgramDescriptor desc;
     auto* mesh_device = input_tensor.device();
 
     const uint32_t axis = reduce_scatter_direct_active_axis(operation_attributes);
@@ -347,15 +343,14 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
     tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     for (auto [cb_id, num_pages] : std::initializer_list<std::pair<uint32_t, uint32_t>>{
              {direct_cb_send_id, 2 * tile_granularity}, {direct_cb_out_id, 2 * tile_granularity}}) {
-        tt::tt_metal::CircularBufferConfig cfg =
-            tt::tt_metal::CircularBufferConfig(num_pages * cb_page_size, {{cb_id, df}})
-                .set_page_size(cb_id, cb_page_size);
-        CreateCircularBuffer(program, worker_core_range, cfg);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = num_pages * cb_page_size,
+            .core_ranges = worker_core_range,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_id), .data_format = df, .page_size = cb_page_size}}},
+        });
     }
 
-    tt::tt_metal::CircularBufferConfig reduce_cb_cfg =
-        tt::tt_metal::CircularBufferConfig(cb_reduce_pages * cb_page_size, {{direct_cb_reduce_id, df}})
-            .set_page_size(direct_cb_reduce_id, cb_page_size);
     if (arrivals_in_cb) {
         TT_FATAL(
             staging.buffer()->aligned_page_size() * staging.buffer()->shard_spec().shape()[0] ==
@@ -366,9 +361,17 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
             staging.buffer()->aligned_page_size(),
             cb_reduce_pages,
             cb_page_size);
-        reduce_cb_cfg = reduce_cb_cfg.set_globally_allocated_address(*staging.buffer());
     }
-    const auto reduce_cb_handle = CreateCircularBuffer(program, worker_core_range, reduce_cb_cfg);
+    // On the aliased path the reduce CB IS this core's staging shard, so it is backed by the staging
+    // buffer (the descriptor equivalent of set_globally_allocated_address). Handing the framework the
+    // Buffer* is also what lets it re-point the CB on a cache hit when the tensor moves.
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = cb_reduce_pages * cb_page_size,
+        .core_ranges = worker_core_range,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(direct_cb_reduce_id), .data_format = df, .page_size = cb_page_size}}},
+        .buffer = arrivals_in_cb ? staging.buffer() : nullptr,
+    });
 
     // --- Kernels ---
     std::vector<uint32_t> reader_ct_args = {
@@ -404,24 +407,29 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
     std::vector<uint32_t> compute_ct_args = {
         tile_granularity, num_devices, direct_cb_reduce_id, direct_cb_out_id, parity_stride_tiles};
 
-    auto reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/"
-        "reduce_scatter_minimal_direct_reader.cpp",
-        worker_core_range,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
-    auto writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/"
-        "reduce_scatter_minimal_direct_writer.cpp",
-        worker_core_range,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
-    auto compute_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/"
-        "reduce_scatter_minimal_direct_compute.cpp",
-        worker_core_range,
-        tt::tt_metal::ComputeConfig{.compile_args = compute_ct_args});
+    // Push the kernels NOW, before the per-link runtime-arg loop, so they can be referred to by stable
+    // index -- both emplace_runtime_args() and the fabric helper's ProgramDescriptor overload take a
+    // KernelHandle that indexes into desc.kernels.
+    constexpr const char* kernel_dir =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/";
+    desc.kernels.push_back(tt::tt_metal::KernelDescriptor{
+        .kernel_source = std::string(kernel_dir) + "reduce_scatter_minimal_direct_reader.cpp",
+        .core_ranges = worker_core_range,
+        .compile_time_args = std::move(reader_ct_args),
+        .config = tt::tt_metal::ReaderConfigDescriptor{}});
+    desc.kernels.push_back(tt::tt_metal::KernelDescriptor{
+        .kernel_source = std::string(kernel_dir) + "reduce_scatter_minimal_direct_writer.cpp",
+        .core_ranges = worker_core_range,
+        .compile_time_args = std::move(writer_ct_args),
+        .config = tt::tt_metal::WriterConfigDescriptor{}});
+    desc.kernels.push_back(tt::tt_metal::KernelDescriptor{
+        .kernel_source = std::string(kernel_dir) + "reduce_scatter_minimal_direct_compute.cpp",
+        .core_ranges = worker_core_range,
+        .compile_time_args = std::move(compute_ct_args),
+        .config = tt::tt_metal::ComputeConfigDescriptor{}});
+    constexpr tt::tt_metal::KernelHandle reader_kernel_id = 0;
+    constexpr tt::tt_metal::KernelHandle writer_kernel_id = 1;
+    constexpr tt::tt_metal::KernelHandle compute_kernel_id = 2;
 
     // --- Destination order: farthest ring distance first, since a destination cannot start reducing until
     // its last contribution lands. Direction is whichever way round the ring is shorter (ties -> forward,
@@ -449,15 +457,14 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
         const uint32_t hops = use_fwd ? fwd_hops : bwd_hops;
         // Walk `hops` steps in the chosen direction to land on device j's coordinate.
         const auto dest_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
-            input_tensor, sender_device_coord, use_fwd ? static_cast<int>(hops) : -static_cast<int>(hops), topology, axis);
+            input_tensor,
+            sender_device_coord,
+            use_fwd ? static_cast<int>(hops) : -static_cast<int>(hops),
+            topology,
+            axis);
         TT_FATAL(dest_coord.has_value(), "ring neighbour {} hops away must exist", hops);
         const auto dest_node = mesh_device->get_fabric_node_id(*dest_coord);
-        dests.push_back(Dest{
-            j,
-            use_fwd ? 0u : 1u,
-            hops,
-            dest_node.chip_id,
-            static_cast<uint32_t>(*dest_node.mesh_id)});
+        dests.push_back(Dest{j, use_fwd ? 0u : 1u, hops, dest_node.chip_id, static_cast<uint32_t>(*dest_node.mesh_id)});
     }
     // On a 2D fabric, WE do not get to choose the direction. The header carries an absolute route from
     // the routing table (fabric_set_unicast_route -> decode_route_to_buffer), and a packet must be handed
@@ -468,10 +475,10 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
     // computed, since 2D ignores it and 1D never reaches this block.
     if (::tt::tt_fabric::is_2d_fabric_config(operation_attributes.fabric_config)) {
         const auto self_node = mesh_device->get_fabric_node_id(sender_device_coord);
-        const auto fwd_dir = tt::tt_fabric::pipeline_get_forwarding_direction(
-            self_node, mesh_device->get_fabric_node_id(*fwd_coord));
-        const auto bwd_dir = tt::tt_fabric::pipeline_get_forwarding_direction(
-            self_node, mesh_device->get_fabric_node_id(*bwd_coord));
+        const auto fwd_dir =
+            tt::tt_fabric::pipeline_get_forwarding_direction(self_node, mesh_device->get_fabric_node_id(*fwd_coord));
+        const auto bwd_dir =
+            tt::tt_fabric::pipeline_get_forwarding_direction(self_node, mesh_device->get_fabric_node_id(*bwd_coord));
 
         // The axis_topology we were handed is not trustworthy on its own: it binds a MESH-VIEW axis index
         // to a fabric dimension (axis 1 -> X, axis 0 -> Y), while a torus fabric config wraps a PHYSICAL
@@ -492,9 +499,8 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
                 neighbor.chip_id);
             const auto neighbors = tt::tt_fabric::pipeline_get_chip_neighbors(self_node, *dir);
             const auto it = neighbors.find(*neighbor.mesh_id);
-            const bool adjacent =
-                it != neighbors.end() && std::find(it->second.begin(), it->second.end(), neighbor.chip_id) !=
-                                             it->second.end();
+            const bool adjacent = it != neighbors.end() &&
+                                  std::find(it->second.begin(), it->second.end(), neighbor.chip_id) != it->second.end();
             TT_FATAL(
                 adjacent,
                 "reduce_scatter_minimal_direct: the {} ring neighbour (chip {}) is not one hop away in "
@@ -568,10 +574,15 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
     }
 
     // --- Runtime args ---
+    // Tensor base addresses are pushed as Buffer* (see the RTArgList builds below) so the framework
+    // records a BufferBinding at that position and patches it on the cache-hit fast path. Everything else
+    // here is geometry- or semaphore-derived and fixed for the cached workload's lifetime.
     const auto sender_fabric_node_id = mesh_device->get_fabric_node_id(sender_device_coord);
-    const uint32_t input_addr = input_tensor.buffer()->address();
-    const uint32_t output_addr = output_tensor.buffer()->address();
-    const uint32_t staging_addr = staging.buffer()->address();
+    const auto& reader_gen_sem = sems[SemaphoreIndex::reader_gen(num_devices)];
+    const auto& writer_gen_sem = sems[SemaphoreIndex::writer_gen(num_devices)];
+    const auto& compute_gen_sem = sems[SemaphoreIndex::compute_gen(num_devices)];
+    const auto& init_sync_sem = sems[SemaphoreIndex::init_sync(num_devices)];
+    const auto& arrival_sems = sems;  // indexed by SOURCE device: SemaphoreIndex::arrival_base + s
 
     for (uint32_t link = 0; link < num_links; ++link) {
         const CoreCoord core = worker_cores_vec[link];
@@ -582,9 +593,13 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
         // Mirror core: deterministic placement means the peer's worker `link` is at these same coords.
         const CoreCoord peer_core = mesh_device->worker_core_from_logical_core(core);
 
+        // Built as a plain vector first, then promoted, exactly as the writer below does: positions 0/1
+        // are buffer base addresses and become Buffer* bindings, everything after is a plain value.
+        // GlobalSemaphore addresses ride along as plain values -- they are workload-scoped (parked on
+        // WorkloadDescriptor::semaphores) so they do not move across cache hits and need no binding.
         std::vector<uint32_t> reader_rt = {
-            input_addr,
-            staging_addr,
+            0u,  // input base address  -- replaced by a Buffer* binding below
+            0u,  // staging base address -- replaced by a Buffer* binding below
             device_idx,
             chunk_start,
             chunk_count,
@@ -593,27 +608,37 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
             reader_gen_sem.address()};
         for (uint32_t s = 0; s < num_devices; ++s) {
             if (s != device_idx) {
-                reader_rt.push_back(arrival_sems[s].address());
+                reader_rt.push_back(arrival_sems[SemaphoreIndex::arrival_base + s].address());
             }
         }
         for (const auto& d : dests) {
             reader_rt.push_back(d.slice);
         }
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, {core}, reader_rt);
+        tt::tt_metal::KernelDescriptor::RTArgList reader_rt_args;
+        reader_rt_args.reserve(reader_rt.size());
+        reader_rt_args.push_back(input_tensor.buffer());
+        reader_rt_args.push_back(staging.buffer());
+        for (size_t i = 2; i < reader_rt.size(); ++i) {
+            reader_rt_args.push_back(reader_rt[i]);
+        }
+        desc.kernels[reader_kernel_id].emplace_runtime_args(core, reader_rt_args);
 
-        std::vector<uint32_t> compute_rt = {chunk_count, tile_count, compute_gen_sem.address()};
-        tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, {core}, compute_rt);
+        const std::vector<uint32_t> compute_rt = {chunk_count, tile_count, compute_gen_sem.address()};
+        desc.kernels[compute_kernel_id].emplace_runtime_args(core, {compute_rt[0], compute_rt[1], compute_rt[2]});
 
+        // Built as a plain vector first: the fabric helper appends to one, and only positions 0/1 need to
+        // become Buffer* bindings, which happens in the RTArgList promotion below.
         std::vector<uint32_t> writer_rt = {
-            staging_addr,
-            output_addr,
+            0u,  // staging base address -- replaced by a Buffer* binding below
+            0u,  // output base address  -- replaced by a Buffer* binding below
             device_idx,
             chunk_start,
             chunk_count,
             tile_start,
             tile_count,
             writer_gen_sem.address(),
-            arrival_sems[device_idx].address(),  // our source slot's counter, same address on every peer
+            // our source slot's counter, same address on every peer
+            arrival_sems[SemaphoreIndex::arrival_base + device_idx].address(),
             (uint32_t)peer_core.x,
             (uint32_t)peer_core.y,
             num_connections,
@@ -648,64 +673,35 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
             dst_nodes.push_back(mesh_device->get_fabric_node_id(*bwd_coord));
             link_indices.push_back(link);
         }
+        // The helper's ProgramDescriptor overload indexes desc.kernels via the KernelHandle to add
+        // per-kernel defines, and appends the connection args (plus, on a 2D mesh, extra header words)
+        // onto writer_rt.
+        tt::tt_metal::KernelHandle writer_kernel_handle = writer_kernel_id;
         append_routing_plane_connection_manager_rt_args(
             sender_fabric_node_id,
             dst_nodes,
             link_indices,
-            program,
-            writer_kernel_id,
-            {core},
+            desc,
+            writer_kernel_handle,
+            core,
             writer_rt,
             tt::tt_fabric::FabricApiType::Linear);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, {core}, writer_rt);
+
+        // Promote to an RTArgList, swapping positions 0/1 for Buffer* so the framework records their
+        // BufferBindings; every other position keeps the value computed above.
+        tt::tt_metal::KernelDescriptor::RTArgList writer_rt_args;
+        writer_rt_args.reserve(writer_rt.size());
+        writer_rt_args.push_back(staging.buffer());
+        writer_rt_args.push_back(output_tensor.buffer());
+        for (size_t i = 2; i < writer_rt.size(); ++i) {
+            writer_rt_args.push_back(writer_rt[i]);
+        }
+        desc.kernels[writer_kernel_id].emplace_runtime_args(core, writer_rt_args);
     }
 
-    shared_variables_t shared_variables{
-        .worker_cores = worker_cores_vec,
-        .reader_kernel_id = reader_kernel_id,
-        .compute_kernel_id = compute_kernel_id,
-        .writer_kernel_id = writer_kernel_id,
-        .arrival_sems = arrival_sems,
-        .reader_gen_sem = reader_gen_sem,
-        .writer_gen_sem = writer_gen_sem,
-        .compute_gen_sem = compute_gen_sem,
-        .init_sync_sem = init_sync_sem,
-        .reduce_cb_handle = arrivals_in_cb ? std::optional{reduce_cb_handle} : std::nullopt,
-    };
-    return {std::move(program), std::move(shared_variables)};
+    return desc;
 }
 
-void ReduceScatterMinimalDirectMeshWorkloadFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const ReduceScatterMinimalDirectParams& /*operation_attributes*/,
-    const ReduceScatterMinimalDirectInputs& tensor_args,
-    tensor_return_value_t& output_tensors) {
-    const uint32_t input_addr = tensor_args.input_tensor.buffer()->address();
-    const uint32_t output_addr = output_tensors.at(0).buffer()->address();
-    const uint32_t staging_addr = output_tensors.at(1).buffer()->address();
-
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& sv = cached_workload.shared_variables.at(coordinate_range);
-        auto& reader_args_by_core = GetRuntimeArgs(program, sv.reader_kernel_id);
-        auto& writer_args_by_core = GetRuntimeArgs(program, sv.writer_kernel_id);
-
-        // On the aliased path cb_reduce lives on top of the staging buffer, so it has to follow it.
-        if (sv.reduce_cb_handle.has_value()) {
-            UpdateDynamicCircularBufferAddress(program, *sv.reduce_cb_handle, *output_tensors.at(1).buffer());
-        }
-
-        // Only the tensor addresses move. The semaphores are owned by shared_variables (their addresses are
-        // fixed for the cached program's lifetime) and the chunk partition / destination routes are
-        // geometry-derived, so both stay valid.
-        for (const auto& core : sv.worker_cores) {
-            auto& r = reader_args_by_core[core.x][core.y];
-            r[0] = input_addr;
-            r[1] = staging_addr;
-            auto& w = writer_args_by_core[core.x][core.y];
-            w[0] = staging_addr;
-            w[1] = output_addr;
-        }
-    }
-}
+}  // namespace
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
@@ -25,6 +25,81 @@ constexpr uint32_t direct_cb_reduce_id = tt::CBIndex::c_1;  // num_devices block
 constexpr uint32_t direct_cb_out_id = tt::CBIndex::c_16;    // reduced result (compute -> writer)
 }  // namespace
 
+ReduceScatterDirectGeometry reduce_scatter_direct_geometry(
+    const ReduceScatterMinimalDirectParams& args, const ttnn::Tensor& input_tensor, bool fp32_dest_acc_en) {
+    const uint32_t num_devices = args.num_devices;
+    TT_FATAL(input_tensor.layout() == ttnn::TILE_LAYOUT, "reduce_scatter_minimal_direct requires TILE layout");
+
+    const auto padded_shape = input_tensor.padded_shape();
+    const uint32_t rank = padded_shape.rank();
+    TT_FATAL(rank >= 2, "reduce_scatter_minimal_direct requires a rank >= 2 input, got rank {}", rank);
+    TT_FATAL(
+        args.dim >= 0 && args.dim < static_cast<int32_t>(rank),
+        "scatter dim {} out of range for rank {}",
+        args.dim,
+        rank);
+    const uint32_t dim = static_cast<uint32_t>(args.dim);
+
+    // Size of dim `d` in PAGES: the two innermost dims are counted in tiles, the rest in elements.
+    const auto tile = input_tensor.tensor_spec().tile();
+    const auto dim_pages = [&](uint32_t d) -> uint32_t {
+        if (d == rank - 1) {
+            return padded_shape[d] / tile.get_width();
+        }
+        if (d == rank - 2) {
+            return padded_shape[d] / tile.get_height();
+        }
+        return padded_shape[d];
+    };
+
+    // Only the two innermost dims can carry tile padding, and scattering a padded dim would hand the
+    // last device a slice of padding rather than data -- the op slices in page space.
+    TT_FATAL(
+        dim < rank - 2 || padded_shape[dim] == input_tensor.logical_shape()[dim],
+        "scatter dim {} is tile-padded (logical {} vs padded {}); slice boundaries would not line up with "
+        "the logical tensor",
+        args.dim,
+        input_tensor.logical_shape()[dim],
+        padded_shape[dim]);
+
+    const uint32_t dim_size_pages = dim_pages(dim);
+    TT_FATAL(
+        dim_size_pages % num_devices == 0,
+        "scatter dim {} (padded size {}, {} pages) must split into {} whole-page slices",
+        args.dim,
+        padded_shape[dim],
+        dim_size_pages,
+        num_devices);
+
+    uint32_t inner_pages = 1;  // pages under one index of the scatter dim
+    for (uint32_t d = dim + 1; d < rank; ++d) {
+        inner_pages *= dim_pages(d);
+    }
+
+    const uint32_t num_input_pages = input_tensor.buffer()->num_pages();
+    TT_FATAL(
+        num_input_pages % num_devices == 0, "input pages {} must divide num_devices {}", num_input_pages, num_devices);
+
+    // Chunking / packet sizing is shared with the ring ops (a chunk = tile_granularity tiles stored
+    // contiguously, so one contribution chunk is one coalesced fabric write). Only the size fields are
+    // taken from there: its chunk COUNTS are per-4D-channel, which this op does not need -- a slice is
+    // chunked as one flat page run regardless of how many batches/channels it spans.
+    const auto sp = ttnn::experimental::ccl::reduce_scatter_ring_interm_staging_params(
+        input_tensor, ttnn::ccl::Topology::Ring, dim, num_devices, fp32_dest_acc_en);
+
+    const uint32_t pages_per_slice = num_input_pages / num_devices;
+    return ReduceScatterDirectGeometry{
+        .single_tile_bytes = sp.single_tile_bytes,
+        .tile_granularity = sp.tile_granularity,
+        .interm_tiles_per_packet = sp.interm_tiles_per_packet,
+        .page_bytes = sp.page_bytes,
+        .pages_per_slice = pages_per_slice,
+        .chunks_per_slice = (pages_per_slice + sp.tile_granularity - 1) / sp.tile_granularity,
+        .slice_run_pages = (dim_size_pages / num_devices) * inner_pages,
+        .stride_pages = dim_size_pages * inner_pages,
+    };
+}
+
 uint32_t reduce_scatter_direct_num_links(const ReduceScatterMinimalDirectParams& args, uint32_t chunks_per_slice) {
     // Clamped to chunks_per_slice so no worker is handed zero chunks.
     return std::min(std::max(1u, args.num_links), chunks_per_slice);
@@ -164,46 +239,23 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
         ::ttnn::ccl::get_physical_neighbor_from_physical_coord(input_tensor, sender_device_coord, -1, topology, axis);
     TT_FATAL(fwd_coord.has_value() && bwd_coord.has_value(), "ring must have both neighbors");
 
-    // Scatter on the last (width) dim only, TILE layout.
-    TT_FATAL(input_tensor.layout() == ttnn::TILE_LAYOUT, "requires TILE layout");
-    const auto padded_shape = input_tensor.padded_shape();
-    const uint32_t rank = padded_shape.rank();
-    TT_FATAL(
-        operation_attributes.dim == static_cast<int32_t>(rank) - 1,
-        "reduce_scatter_minimal_direct supports scatter on the last dim only, got dim {}",
-        operation_attributes.dim);
-
-    const uint32_t num_input_pages = input_tensor.buffer()->num_pages();
-    TT_FATAL(
-        num_input_pages % num_devices == 0, "input pages {} must divide num_devices {}", num_input_pages, num_devices);
-    const uint32_t pages_per_slice = num_input_pages / num_devices;  // tiles per slice (== output tiles)
-
-    const uint32_t tile_width = input_tensor.tensor_spec().tile().get_width();
-    TT_FATAL(
-        padded_shape[rank - 1] % (num_devices * tile_width) == 0,
-        "last dim {} must be divisible by num_devices*tile_width ({}*{})",
-        padded_shape[rank - 1],
-        num_devices,
-        tile_width);
-    const uint32_t width_tiles = padded_shape[rank - 1] / tile_width;
-    const uint32_t slice_Wt = width_tiles / num_devices;  // slice width in tiles (per-row run of the input walk)
-
-    // Chunk-paged staging geometry, shared with the ring ops (a chunk = tile_granularity tiles stored
-    // contiguously, so one contribution chunk is one coalesced fabric write).
+    // Scatter geometry in page space -- the scatter dim only shows up as the (run, stride) pair the
+    // reader walks a slice with. See ReduceScatterDirectGeometry.
     const bool fp32_dest_acc_en = (input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32);
-    const auto sp = ttnn::experimental::ccl::reduce_scatter_ring_interm_staging_params(
-        input_tensor, topology, static_cast<uint32_t>(operation_attributes.dim), num_devices, fp32_dest_acc_en);
-    TT_FATAL(sp.use_contiguous, "contiguous staging path required (Ring topology, scatter dim != 0)");
-    const uint32_t single_tile_bytes = sp.single_tile_bytes;
-    const uint32_t tile_granularity = sp.tile_granularity;                // tiles per chunk
-    const uint32_t interm_tiles_per_packet = sp.interm_tiles_per_packet;  // tiles per fabric packet
-    const uint32_t chunks_per_slice = sp.chunks_per_channel;              // dim = last -> slice_C == 1
+    const auto geom = reduce_scatter_direct_geometry(operation_attributes, input_tensor, fp32_dest_acc_en);
+    const uint32_t pages_per_slice = geom.pages_per_slice;  // tiles per slice (== output tiles)
+    const uint32_t slice_run_pages = geom.slice_run_pages;
+    const uint32_t stride_pages = geom.stride_pages;
+    const uint32_t single_tile_bytes = geom.single_tile_bytes;
+    const uint32_t tile_granularity = geom.tile_granularity;                // tiles per chunk
+    const uint32_t interm_tiles_per_packet = geom.interm_tiles_per_packet;  // tiles per fabric packet
+    const uint32_t chunks_per_slice = geom.chunks_per_slice;
     TT_FATAL(interm_tiles_per_packet >= 1, "a tile must fit in a fabric packet");
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
     TT_FATAL(
-        sp.page_bytes % dram_alignment == 0,
+        geom.page_bytes % dram_alignment == 0,
         "staging page_bytes {} must be a multiple of DRAM alignment {}",
-        sp.page_bytes,
+        geom.page_bytes,
         dram_alignment);
 
     // --- Core selection: one worker core per link. Unlike the store-and-forward ring op there is no
@@ -278,8 +330,8 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
         tile_granularity,
         chunks_per_slice,
         pages_per_slice,
-        slice_Wt,
-        width_tiles,
+        slice_run_pages,
+        stride_pages,
         num_devices,
         direct_cb_send_id,
         direct_cb_reduce_id,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/hal.hpp>
 #include "ttnn/global_semaphore.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
-#include "ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp"
 
 #include <algorithm>
 #include <set>
@@ -80,21 +79,25 @@ ReduceScatterDirectGeometry reduce_scatter_direct_geometry(
     TT_FATAL(
         num_input_pages % num_devices == 0, "input pages {} must divide num_devices {}", num_input_pages, num_devices);
 
-    // Chunking / packet sizing is shared with the ring ops (a chunk = tile_granularity tiles stored
-    // contiguously, so one contribution chunk is one coalesced fabric write). Only the size fields are
-    // taken from there: its chunk COUNTS are per-4D-channel, which this op does not need -- a slice is
-    // chunked as one flat page run regardless of how many batches/channels it spans.
-    const auto sp = ttnn::experimental::ccl::reduce_scatter_ring_interm_staging_params(
-        input_tensor, ttnn::ccl::Topology::Ring, dim, num_devices, fp32_dest_acc_en);
+    // Chunk / packet sizing, matching the ring ops' contiguous path (a chunk = tile_granularity tiles
+    // stored contiguously, so one contribution chunk is one coalesced fabric write; the granularity is
+    // capped by what DST can hold for the reduce). Computed here rather than taken from
+    // reduce_scatter_ring_interm_staging_params: that helper's chunk COUNTS are per-4D-channel, so
+    // consuming it would drag this op's ND support back through a canonical-4D mapping it does not need.
+    const uint32_t single_tile_bytes = input_tensor.buffer()->page_size();
+    const uint32_t interm_tiles_per_packet =
+        static_cast<uint32_t>(tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes()) / single_tile_bytes;
+    const uint32_t max_dst_size = fp32_dest_acc_en ? 4u : 8u;
+    const uint32_t tile_granularity = std::min(4u * std::min(4u, interm_tiles_per_packet), max_dst_size);
 
     const uint32_t pages_per_slice = num_input_pages / num_devices;
     return ReduceScatterDirectGeometry{
-        .single_tile_bytes = sp.single_tile_bytes,
-        .tile_granularity = sp.tile_granularity,
-        .interm_tiles_per_packet = sp.interm_tiles_per_packet,
-        .page_bytes = sp.page_bytes,
+        .single_tile_bytes = single_tile_bytes,
+        .tile_granularity = tile_granularity,
+        .interm_tiles_per_packet = interm_tiles_per_packet,
+        .page_bytes = tile_granularity * single_tile_bytes,
         .pages_per_slice = pages_per_slice,
-        .chunks_per_slice = (pages_per_slice + sp.tile_granularity - 1) / sp.tile_granularity,
+        .chunks_per_slice = (pages_per_slice + tile_granularity - 1) / tile_granularity,
         .slice_run_pages = (dim_size_pages / num_devices) * inner_pages,
         .stride_pages = dim_size_pages * inner_pages,
     };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
@@ -181,7 +181,19 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_mesh_workload(
         ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
     auto compute_gen_sem =
         ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
+    // Start-barrier counter, only consumed when the writer's init sync is compiled in (below).
+    auto init_sync_sem =
+        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
     tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevices);
+
+    // The writer's start barrier is needed only when the op allocates a buffer a peer writes into, since
+    // then its address is not pinned across invocations -- see the writer kernel's barrier comment. Both
+    // buffers gate it: staging is the address peers actually target, and the output is included because
+    // it is the caller's declaration that this call reuses a stable buffer set. Baked in as a compile-time
+    // arg so the fully-persistent path pays nothing; compute_program_hash folds the flag in, so the two
+    // variants can never share a cached program.
+    const bool needs_init_sync =
+        !(tensor_args.persistent_output_tensor.has_value() && tensor_args.persistent_staging_tensor.has_value());
 
     for (const auto& coord : tensor_coords.coords()) {
         auto cached_program = create_at(
@@ -192,7 +204,9 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_mesh_workload(
             arrival_sems,
             reader_gen_sem,
             writer_gen_sem,
-            compute_gen_sem);
+            compute_gen_sem,
+            init_sync_sem,
+            needs_init_sync);
         workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
         shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
     }
@@ -209,7 +223,9 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
     const std::vector<tt::tt_metal::GlobalSemaphore>& arrival_sems,
     const tt::tt_metal::GlobalSemaphore& reader_gen_sem,
     const tt::tt_metal::GlobalSemaphore& writer_gen_sem,
-    const tt::tt_metal::GlobalSemaphore& compute_gen_sem) {
+    const tt::tt_metal::GlobalSemaphore& compute_gen_sem,
+    const tt::tt_metal::GlobalSemaphore& init_sync_sem,
+    bool needs_init_sync) {
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& output_tensor = output_tensors.at(0);
     const auto& staging = output_tensors.at(1);
@@ -353,7 +369,8 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
         direct_cb_send_id,
         direct_cb_out_id,
         (uint32_t)arrivals_in_cb,
-        parity_stride_tiles};
+        parity_stride_tiles,
+        (uint32_t)needs_init_sync};
     tt::tt_metal::TensorAccessorArgs(staging.buffer()).append_to(writer_ct_args);        // chunk-paged
     tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_ct_args);  // tiled
 
@@ -401,6 +418,29 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
     std::stable_sort(dests.begin(), dests.end(), [](const Dest& a, const Dest& b) { return a.hops > b.hops; });
     const bool uses_backward = std::any_of(dests.begin(), dests.end(), [](const Dest& d) { return d.conn == 1; });
     const uint32_t num_connections = uses_backward ? 2u : 1u;
+
+    // Start-barrier multicast ranges, derived from the same destination split so they cannot drift from
+    // it: nearest-direction routing gives each direction a set of hops that is contiguous from 1, so a
+    // direction's range is just its destination count, and the two together cover every peer exactly once.
+    uint32_t mcast_range[2] = {0u, 0u};
+    uint32_t max_hops[2] = {0u, 0u};
+    for (const auto& d : dests) {
+        ++mcast_range[d.conn];
+        max_hops[d.conn] = std::max(max_hops[d.conn], d.hops);
+    }
+    for (uint32_t c = 0; c < 2; ++c) {
+        TT_FATAL(
+            mcast_range[c] == max_hops[c],
+            "start-barrier multicast assumes direction {}'s destinations are hops 1..{} with no gaps, but the "
+            "{} destinations routed that way reach out to {} hops",
+            c,
+            mcast_range[c],
+            mcast_range[c],
+            max_hops[c]);
+    }
+    TT_FATAL(
+        mcast_range[1] == 0 || num_connections == 2,
+        "start barrier would multicast backward on a connection that was never opened");
 
     // --- Runtime args ---
     const auto sender_fabric_node_id = mesh_device->get_fabric_node_id(sender_device_coord);
@@ -451,7 +491,10 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
             arrival_sems[device_idx].address(),  // our source slot's counter, same address on every peer
             (uint32_t)peer_core.x,
             (uint32_t)peer_core.y,
-            num_connections};
+            num_connections,
+            init_sync_sem.address(),  // same address on every peer's mirror core
+            mcast_range[0],
+            mcast_range[1]};
         for (const auto& d : dests) {
             writer_rt.push_back(d.conn);
         }
@@ -493,6 +536,7 @@ ReduceScatterMinimalDirectMeshWorkloadFactory::create_at(
         .reader_gen_sem = reader_gen_sem,
         .writer_gen_sem = writer_gen_sem,
         .compute_gen_sem = compute_gen_sem,
+        .init_sync_sem = init_sync_sem,
         .reduce_cb_handle = arrivals_in_cb ? std::optional{reduce_cb_handle} : std::nullopt,
     };
     return {std::move(program), std::move(shared_variables)};

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
@@ -400,9 +400,8 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
         .kernel_source = std::string(kernel_dir) + "reduce_scatter_minimal_direct_compute.cpp",
         .core_ranges = worker_core_range,
         .compile_time_args = std::move(compute_ct_args),
-        // fp32_dest_acc_en MUST match the value the geometry was computed with: it halves max_dst_size
-        // (8 -> 4 tiles), so a mismatch both mis-sizes the chunk and -- worse -- would accumulate FLOAT32
-        // inputs in bf16-precision dest registers. ComputeConfigDescriptor defaults it to false.
+        // MUST match the geometry's value (it halves max_dst_size 8 -> 4); the descriptor defaults to
+        // false, which would accumulate FLOAT32 in bf16-precision dest registers.
         .config = tt::tt_metal::ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en}});
     constexpr tt::tt_metal::KernelHandle reader_kernel_id = 0;
     constexpr tt::tt_metal::KernelHandle writer_kernel_id = 1;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
@@ -400,7 +400,10 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
         .kernel_source = std::string(kernel_dir) + "reduce_scatter_minimal_direct_compute.cpp",
         .core_ranges = worker_core_range,
         .compile_time_args = std::move(compute_ct_args),
-        .config = tt::tt_metal::ComputeConfigDescriptor{}});
+        // fp32_dest_acc_en MUST match the value the geometry was computed with: it halves max_dst_size
+        // (8 -> 4 tiles), so a mismatch both mis-sizes the chunk and -- worse -- would accumulate FLOAT32
+        // inputs in bf16-precision dest registers. ComputeConfigDescriptor defaults it to false.
+        .config = tt::tt_metal::ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en}});
     constexpr tt::tt_metal::KernelHandle reader_kernel_id = 0;
     constexpr tt::tt_metal::KernelHandle writer_kernel_id = 1;
     constexpr tt::tt_metal::KernelHandle compute_kernel_id = 2;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
@@ -19,7 +19,6 @@ namespace ttnn::experimental::prim {
 using namespace ::ttnn::ccl;
 
 namespace {
-// Prefixed because the ccl ops share a unity-build translation unit with their siblings.
 constexpr uint32_t direct_cb_send_id = tt::CBIndex::c_0;    // local input slices queued for the fabric
 constexpr uint32_t direct_cb_reduce_id = tt::CBIndex::c_1;  // num_devices blocks per chunk (own + arrivals)
 constexpr uint32_t direct_cb_out_id = tt::CBIndex::c_16;    // reduced result (compute -> writer)
@@ -58,7 +57,7 @@ ReduceScatterDirectGeometry reduce_scatter_direct_geometry(
     const uint32_t num_devices = args.num_devices;
     TT_FATAL(input_tensor.layout() == ttnn::TILE_LAYOUT, "reduce_scatter_minimal_direct requires TILE layout");
 
-    const auto padded_shape = input_tensor.padded_shape();
+    const auto& padded_shape = input_tensor.padded_shape();
     const uint32_t rank = padded_shape.rank();
     TT_FATAL(rank >= 2, "reduce_scatter_minimal_direct requires a rank >= 2 input, got rank {}", rank);
     TT_FATAL(
@@ -108,11 +107,6 @@ ReduceScatterDirectGeometry reduce_scatter_direct_geometry(
     TT_FATAL(
         num_input_pages % num_devices == 0, "input pages {} must divide num_devices {}", num_input_pages, num_devices);
 
-    // Chunk / packet sizing, matching the ring ops' contiguous path (a chunk = tile_granularity tiles
-    // stored contiguously, so one contribution chunk is one coalesced fabric write; the granularity is
-    // capped by what DST can hold for the reduce). Computed here rather than taken from
-    // reduce_scatter_ring_interm_staging_params: that helper's chunk COUNTS are per-4D-channel, so
-    // consuming it would drag this op's ND support back through a canonical-4D mapping it does not need.
     const uint32_t single_tile_bytes = input_tensor.buffer()->page_size();
     const uint32_t interm_tiles_per_packet =
         static_cast<uint32_t>(tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes()) / single_tile_bytes;
@@ -142,7 +136,7 @@ std::pair<CoreRangeSet, std::vector<CoreCoord>> reduce_scatter_direct_worker_cor
     const uint32_t num_links = reduce_scatter_direct_num_links(args, chunks_per_slice);
     auto [all_core_range, worker_cores_vec] = ttnn::ccl::choose_worker_cores(
         num_links,
-        /*num_cores_per_link=*/1,
+        /*num_workers_per_link=*/1,
         mesh_device,
         args.subdevice_id,
         /*core_grid_offset=*/CoreCoord{0, 0},
@@ -220,17 +214,9 @@ tt::tt_metal::WorkloadDescriptor ReduceScatterMinimalDirectProgramFactory::creat
     }
     tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevices);
 
-    // The writer's start barrier is needed only when the op allocates a buffer a peer writes into, since
-    // then its address is not pinned across invocations -- see the writer kernel's barrier comment. Both
-    // buffers gate it: staging is the address peers actually target, and the output is included because
-    // it is the caller's declaration that this call reuses a stable buffer set. Baked in as a compile-time
-    // arg so the fully-persistent path pays nothing; compute_program_hash folds the flag in, so the two
-    // variants can never share a cached program.
     const bool needs_init_sync =
         !(tensor_args.persistent_output_tensor.has_value() && tensor_args.persistent_staging_tensor.has_value());
 
-    // One descriptor per coordinate: the program depends on the sender coordinate (device_idx, ring
-    // neighbours, per-destination hop/direction/route table), so the mesh cannot share one.
     for (const auto& coord : tensor_coords.coords()) {
         workload_descriptor.programs.push_back(
             {ttnn::MeshCoordinateRange(coord),
@@ -305,13 +291,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
     // owns both of its link's connections and fans out to every destination itself. Placement is
     // deterministic, so worker `link` sits at the same logical coords on every device -- which is what lets
     // a sender target the mirror core's staging slot + arrival counter without any exchange.
-    //
-    // MEASURED (2026-07-28, rs_8K): splitting the destination list across extra "helper" sender cores on
-    // the spare (link, direction) channels made it WORSE (device crit-path 7.7 -> 8.5us, within-iter spread
-    // 0.9 -> 1.9us). Every added core pays the per-core fixed cost (kernel launch + fabric connection
-    // open/close) and the op's duration is the max over its cores, so shortening the reducer's serial send
-    // work by ~3 units does not pay for it. Do not re-add destination-parallel senders without first
-    // shrinking that fixed cost.
     const uint32_t num_links = reduce_scatter_direct_num_links(operation_attributes, chunks_per_slice);
     auto [worker_core_range, worker_cores_vec] =
         reduce_scatter_direct_worker_cores(operation_attributes, mesh_device, chunks_per_slice);
@@ -362,9 +341,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
             cb_reduce_pages,
             cb_page_size);
     }
-    // On the aliased path the reduce CB IS this core's staging shard, so it is backed by the staging
-    // buffer (the descriptor equivalent of set_globally_allocated_address). Handing the framework the
-    // Buffer* is also what lets it re-point the CB on a cache hit when the tensor moves.
+    // On the aliased path the reduce CB IS this core's staging shard, so it is backed by the staging buffer
     desc.cbs.push_back(tt::tt_metal::CBDescriptor{
         .total_size = cb_reduce_pages * cb_page_size,
         .core_ranges = worker_core_range,
@@ -407,9 +384,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
     std::vector<uint32_t> compute_ct_args = {
         tile_granularity, num_devices, direct_cb_reduce_id, direct_cb_out_id, parity_stride_tiles};
 
-    // Push the kernels NOW, before the per-link runtime-arg loop, so they can be referred to by stable
-    // index -- both emplace_runtime_args() and the fabric helper's ProgramDescriptor overload take a
-    // KernelHandle that indexes into desc.kernels.
     constexpr const char* kernel_dir =
         "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/kernels/";
     desc.kernels.push_back(tt::tt_metal::KernelDescriptor{
@@ -466,10 +440,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
         const auto dest_node = mesh_device->get_fabric_node_id(*dest_coord);
         dests.push_back(Dest{j, use_fwd ? 0u : 1u, hops, dest_node.chip_id, static_cast<uint32_t>(*dest_node.mesh_id)});
     }
-    // On a 2D fabric, WE do not get to choose the direction. The header carries an absolute route from
-    // the routing table (fabric_set_unicast_route -> decode_route_to_buffer), and a packet must be handed
-    // to the router in that route's first-hop direction; push it into the other connection and it enters a
-    // router carrying a foreign route, which hangs. Our ring arithmetic above picks the shorter way round,
+    // On a 2D fabric, WE do not get to choose the direction. Our ring arithmetic above picks the shorter way round,
     // which for an even ring's antipode (and anywhere the table breaks a tie the other way) can disagree.
     // So on 2D, re-derive conn from the fabric's own answer. Purely a direction fix -- `hops` stays as
     // computed, since 2D ignores it and 1D never reaches this block.
@@ -480,14 +451,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
         const auto bwd_dir =
             tt::tt_fabric::pipeline_get_forwarding_direction(self_node, mesh_device->get_fabric_node_id(*bwd_coord));
 
-        // The axis_topology we were handed is not trustworthy on its own: it binds a MESH-VIEW axis index
-        // to a fabric dimension (axis 1 -> X, axis 0 -> Y), while a torus fabric config wraps a PHYSICAL
-        // dimension. Open this box's 2x4 as 4x2 and the two disagree -- FABRIC_2D_TORUS_Y makes axis 0
-        // report Torus, but what it physically wraps is the length-2 dimension, not the 4-ring the
-        // collective runs on. The op then believes in a wrap that does not exist and hangs.
-        //
-        // So verify the wrap for real: a ring neighbour must be reachable in ONE hop (an actual cable in
-        // that direction), not by a long way round. Cheap, and it turns that hang into a clear message.
         auto assert_single_hop = [&](const ttnn::MeshCoordinate& neighbor_coord,
                                      const std::optional<tt::tt_fabric::RoutingDirection>& dir,
                                      const char* which) {
@@ -574,9 +537,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
     }
 
     // --- Runtime args ---
-    // Tensor base addresses are pushed as Buffer* (see the RTArgList builds below) so the framework
-    // records a BufferBinding at that position and patches it on the cache-hit fast path. Everything else
-    // here is geometry- or semaphore-derived and fixed for the cached workload's lifetime.
     const auto sender_fabric_node_id = mesh_device->get_fabric_node_id(sender_device_coord);
     const auto& reader_gen_sem = sems[SemaphoreIndex::reader_gen(num_devices)];
     const auto& writer_gen_sem = sems[SemaphoreIndex::writer_gen(num_devices)];
@@ -593,10 +553,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
         // Mirror core: deterministic placement means the peer's worker `link` is at these same coords.
         const CoreCoord peer_core = mesh_device->worker_core_from_logical_core(core);
 
-        // Built as a plain vector first, then promoted, exactly as the writer below does: positions 0/1
-        // are buffer base addresses and become Buffer* bindings, everything after is a plain value.
-        // GlobalSemaphore addresses ride along as plain values -- they are workload-scoped (parked on
-        // WorkloadDescriptor::semaphores) so they do not move across cache hits and need no binding.
         std::vector<uint32_t> reader_rt = {
             0u,  // input base address  -- replaced by a Buffer* binding below
             0u,  // staging base address -- replaced by a Buffer* binding below
@@ -626,8 +582,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
         const std::vector<uint32_t> compute_rt = {chunk_count, tile_count, compute_gen_sem.address()};
         desc.kernels[compute_kernel_id].emplace_runtime_args(core, {compute_rt[0], compute_rt[1], compute_rt[2]});
 
-        // Built as a plain vector first: the fabric helper appends to one, and only positions 0/1 need to
-        // become Buffer* bindings, which happens in the RTArgList promotion below.
         std::vector<uint32_t> writer_rt = {
             0u,  // staging base address -- replaced by a Buffer* binding below
             0u,  // output base address  -- replaced by a Buffer* binding below
@@ -687,8 +641,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
             writer_rt,
             tt::tt_fabric::FabricApiType::Linear);
 
-        // Promote to an RTArgList, swapping positions 0/1 for Buffer* so the framework records their
-        // BufferBindings; every other position keeps the value computed above.
         tt::tt_metal::KernelDescriptor::RTArgList writer_rt_args;
         writer_rt_args.reserve(writer_rt.size());
         writer_rt_args.push_back(staging.buffer());

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
@@ -75,6 +75,10 @@ struct ReduceScatterMinimalDirectMeshWorkloadFactory {
         tt::tt_metal::GlobalSemaphore reader_gen_sem;
         tt::tt_metal::GlobalSemaphore writer_gen_sem;
         tt::tt_metal::GlobalSemaphore compute_gen_sem;
+        // Writer start-barrier counter: every peer's mirror core increments it once per invocation, and
+        // the writer holds its sends until all N-1 have. Only read when the writer's init sync is
+        // compiled in (op-allocated buffers); held here so its address stays valid either way.
+        tt::tt_metal::GlobalSemaphore init_sync_sem;
         // Set only on the sharded path, where cb_reduce is globally allocated on top of the staging
         // tensor and so has to be rebound whenever that buffer moves.
         std::optional<tt::tt_metal::CBHandle> reduce_cb_handle;
@@ -106,7 +110,9 @@ private:
         const std::vector<tt::tt_metal::GlobalSemaphore>& arrival_sems,
         const tt::tt_metal::GlobalSemaphore& reader_gen_sem,
         const tt::tt_metal::GlobalSemaphore& writer_gen_sem,
-        const tt::tt_metal::GlobalSemaphore& compute_gen_sem);
+        const tt::tt_metal::GlobalSemaphore& compute_gen_sem,
+        const tt::tt_metal::GlobalSemaphore& init_sync_sem,
+        bool needs_init_sync);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
@@ -15,7 +15,7 @@
 
 namespace ttnn::experimental::prim {
 
-// Page-space geometry of the scatter, for ANY scatter dim.
+// Page-space geometry of the scatter, for ANY scatter dim and ANY rank.
 //
 // The tiled input buffer is a row-major array of pages over [d0, ..., d_{rank-3}, Ht, Wt]. Slicing it on
 // dim `d` cuts a middle axis of that array, so slice j of every "outer" index (the product of the dims
@@ -25,6 +25,11 @@ namespace ttnn::experimental::prim {
 // chunking, staging, the output write -- only ever sees the resulting linear page order of a slice.
 // The last dim is the degenerate case with stride == one row and run == the slice's width in tiles;
 // dim 0 is the other degenerate case with a single run (outer == 1), so the stride is never taken.
+//
+// This is also why the op needs no ND -> canonical-4D collapse (the (B, C, Ht, Wt) + normalized_dim
+// mapping the ring ops carry, whose kernels are a fixed 4-level nested loop): the pair above already IS
+// that collapse. Everything below the scatter dim folds into `inner_pages` and everything above folds
+// into the outer count, for any rank >= 2 -- rank never reaches a kernel.
 struct ReduceScatterDirectGeometry {
     uint32_t single_tile_bytes;        // bytes per tile
     uint32_t tile_granularity;         // tiles per chunk (compute/CB granularity)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
@@ -9,6 +9,7 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/global_semaphore.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 #include <utility>
 #include <vector>
@@ -41,7 +42,7 @@ struct ReduceScatterDirectGeometry {
     uint32_t stride_pages;             // input pages between the starts of consecutive runs
 };
 
-// Single source of truth for the geometry above, shared by compute_output_specs (which sizes staging
+// Single source of truth for the geometry above, shared by `compute_output_specs` (which sizes staging
 // from it) and the program factory (which wires it into the kernels), so the two can never disagree.
 ReduceScatterDirectGeometry reduce_scatter_direct_geometry(
     const ReduceScatterMinimalDirectParams& args, const ttnn::Tensor& input_tensor, bool fp32_dest_acc_en);
@@ -75,67 +76,49 @@ uint32_t reduce_scatter_direct_num_links(const ReduceScatterMinimalDirectParams&
 std::pair<CoreRangeSet, std::vector<CoreCoord>> reduce_scatter_direct_worker_cores(
     const ReduceScatterMinimalDirectParams& args, ttnn::MeshDevice* mesh_device, uint32_t chunks_per_slice);
 
-// Direct (one-shot) reduce-scatter program factory: one MeshWorkload per participating device
-// coordinate via create_at, cached and rebound by override_runtime_arguments. Returns two tensors --
-// [0] output slice, [1] staging for the incoming contributions.
-struct ReduceScatterMinimalDirectMeshWorkloadFactory {
-    struct shared_variables_t {
-        // One worker core per link (each owns that link's fwd + bwd connection).
-        std::vector<tt::tt_metal::CoreCoord> worker_cores;
-        tt::tt_metal::KernelHandle reader_kernel_id{};
-        tt::tt_metal::KernelHandle compute_kernel_id{};
-        tt::tt_metal::KernelHandle writer_kernel_id{};
-        // Arrival counters indexed by SOURCE device: source s increments arrival_sems[s] on every peer's
-        // mirror core, so each counter has exactly one sender and an absolute wait on it cannot be
-        // satisfied by a different (raced-ahead) device. Never reset; waits target base + 1 where base is
-        // the reader's private invocation counter.
-        std::vector<tt::tt_metal::GlobalSemaphore> arrival_sems;
-        // Per-core private invocation counters (one per kernel). Each is bumped once per program launch by
-        // its owner, so all three always read the same invocation index without any cross-kernel
-        // handshake -- that index drives the staging double-buffer parity. The compute one is only read on
-        // the sharded path (where compute must pick a parity half itself); its body runs on all three
-        // TRISCs, so exactly one of them (PACK) does the increment.
-        tt::tt_metal::GlobalSemaphore reader_gen_sem;
-        tt::tt_metal::GlobalSemaphore writer_gen_sem;
-        tt::tt_metal::GlobalSemaphore compute_gen_sem;
-        // Writer start-barrier counter: every peer's mirror core increments it once per invocation, and
-        // the writer holds its sends until all N-1 have. Only read when the writer's init sync is
-        // compiled in (op-allocated buffers); held here so its address stays valid either way.
-        tt::tt_metal::GlobalSemaphore init_sync_sem;
-        // Set only on the sharded path, where cb_reduce is globally allocated on top of the staging
-        // tensor and so has to be rebound whenever that buffer moves.
-        std::optional<tt::tt_metal::CBHandle> reduce_cb_handle;
-    };
-
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+// Direct (one-shot) reduce-scatter program factory. Declarative workload-scoped form: the framework
+// builds and caches the MeshWorkload from the descriptor we return. Returns two tensors -- [0] output
+// slice, [1] staging for the incoming contributions.
+//
+// create_workload_descriptor() runs ONCE per workload (cache miss):
+//   1. Allocates the GlobalSemaphores and parks them on WorkloadDescriptor::semaphores, which keeps them
+//      alive for the cached workload's lifetime -- every kernel takes their addresses as runtime args.
+//      Order is fixed and read back by index: [0 .. num_devices-1] the per-SOURCE arrival counters, then
+//      reader_gen, writer_gen, compute_gen, init_sync. See semaphore_index below.
+//        - arrival counters are indexed by SOURCE device, so each has exactly one sender and an absolute
+//          wait on it cannot be satisfied by a different (raced-ahead) device. Never reset.
+//        - the three *_gen counters are per-kernel private invocation counters, each bumped once per
+//          launch by its owner, so all three read the same invocation index with no cross-kernel
+//          handshake -- that index drives the staging double-buffer parity. (compute's body runs on all
+//          three TRISCs, so exactly one of them (PACK) does the increment.)
+//        - init_sync is the writer's start barrier, only read when that barrier is compiled in.
+//   2. Runs the distributed Synchronize so every device sees the semaphores before any program launches.
+//   3. Emits ONE ProgramDescriptor per mesh coordinate: the program depends on the sender coordinate
+//      (device_idx, ring neighbours, and the per-destination hop/direction/route table), so the mesh
+//      cannot share a single descriptor.
+//
+// Buffer base addresses are bound as Buffer* through emplace_runtime_args(), and the aliased reduce CB
+// via CBDescriptor::buffer, so the framework patches them on the cache-hit fast path -- no manual
+// override_runtime_arguments() hook.
+struct ReduceScatterMinimalDirectProgramFactory {
     using tensor_return_value_t = std::vector<Tensor>;
 
-    static cached_mesh_workload_t create_mesh_workload(
-        const ReduceScatterMinimalDirectParams& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const ReduceScatterMinimalDirectInputs& tensor_args,
-        tensor_return_value_t& output_tensors);
+    // Layout of WorkloadDescriptor::semaphores. Kept next to the factory so the producer and every
+    // consumer index it the same way.
+    struct SemaphoreIndex {
+        static constexpr size_t arrival_base = 0;  // + source device index
+        static size_t reader_gen(uint32_t num_devices) { return num_devices; }
+        static size_t writer_gen(uint32_t num_devices) { return num_devices + 1; }
+        static size_t compute_gen(uint32_t num_devices) { return num_devices + 2; }
+        static size_t init_sync(uint32_t num_devices) { return num_devices + 3; }
+        static size_t count(uint32_t num_devices) { return num_devices + 4; }
+    };
 
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_workload,
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const ReduceScatterMinimalDirectParams& operation_attributes,
         const ReduceScatterMinimalDirectInputs& tensor_args,
-        tensor_return_value_t& output_tensors);
-
-private:
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create_at(
-        const ReduceScatterMinimalDirectParams& operation_attributes,
-        const ttnn::MeshCoordinate& sender_device_coord,
-        const ReduceScatterMinimalDirectInputs& tensor_args,
-        const tensor_return_value_t& output_tensors,
-        const std::vector<tt::tt_metal::GlobalSemaphore>& arrival_sems,
-        const tt::tt_metal::GlobalSemaphore& reader_gen_sem,
-        const tt::tt_metal::GlobalSemaphore& writer_gen_sem,
-        const tt::tt_metal::GlobalSemaphore& compute_gen_sem,
-        const tt::tt_metal::GlobalSemaphore& init_sync_sem,
-        bool needs_init_sync);
+        tensor_return_value_t& output_tensors,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "reduce_scatter_minimal_direct_op_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/global_semaphore.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace ttnn::experimental::prim {
+
+// Worker-core selection: one core per link, each owning that link's fwd + bwd connection. Factored out
+// so the resolved link count and the core placement are defined in exactly one place.
+uint32_t reduce_scatter_direct_num_links(const ReduceScatterMinimalDirectParams& args, uint32_t chunks_per_slice);
+std::pair<CoreRangeSet, std::vector<CoreCoord>> reduce_scatter_direct_worker_cores(
+    const ReduceScatterMinimalDirectParams& args, ttnn::MeshDevice* mesh_device, uint32_t chunks_per_slice);
+
+// Direct (one-shot) reduce-scatter program factory: one MeshWorkload per participating device
+// coordinate via create_at, cached and rebound by override_runtime_arguments. Returns two tensors --
+// [0] output slice, [1] staging for the incoming contributions.
+struct ReduceScatterMinimalDirectMeshWorkloadFactory {
+    struct shared_variables_t {
+        // One worker core per link (each owns that link's fwd + bwd connection).
+        std::vector<tt::tt_metal::CoreCoord> worker_cores;
+        tt::tt_metal::KernelHandle reader_kernel_id{};
+        tt::tt_metal::KernelHandle compute_kernel_id{};
+        tt::tt_metal::KernelHandle writer_kernel_id{};
+        // Arrival counters indexed by SOURCE device: source s increments arrival_sems[s] on every peer's
+        // mirror core, so each counter has exactly one sender and an absolute wait on it cannot be
+        // satisfied by a different (raced-ahead) device. Never reset; waits target base + 1 where base is
+        // the reader's private invocation counter.
+        std::vector<tt::tt_metal::GlobalSemaphore> arrival_sems;
+        // Per-core private invocation counters (one per kernel). Each is bumped once per program launch by
+        // its owner, so all three always read the same invocation index without any cross-kernel
+        // handshake -- that index drives the staging double-buffer parity. The compute one is only read on
+        // the sharded path (where compute must pick a parity half itself); its body runs on all three
+        // TRISCs, so exactly one of them (PACK) does the increment.
+        tt::tt_metal::GlobalSemaphore reader_gen_sem;
+        tt::tt_metal::GlobalSemaphore writer_gen_sem;
+        tt::tt_metal::GlobalSemaphore compute_gen_sem;
+        // Set only on the sharded path, where cb_reduce is globally allocated on top of the staging
+        // tensor and so has to be rebound whenever that buffer moves.
+        std::optional<tt::tt_metal::CBHandle> reduce_cb_handle;
+    };
+
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+    using tensor_return_value_t = std::vector<Tensor>;
+
+    static cached_mesh_workload_t create_mesh_workload(
+        const ReduceScatterMinimalDirectParams& operation_attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const ReduceScatterMinimalDirectInputs& tensor_args,
+        tensor_return_value_t& output_tensors);
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_workload,
+        const ReduceScatterMinimalDirectParams& operation_attributes,
+        const ReduceScatterMinimalDirectInputs& tensor_args,
+        tensor_return_value_t& output_tensors);
+
+private:
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create_at(
+        const ReduceScatterMinimalDirectParams& operation_attributes,
+        const ttnn::MeshCoordinate& sender_device_coord,
+        const ReduceScatterMinimalDirectInputs& tensor_args,
+        const tensor_return_value_t& output_tensors,
+        const std::vector<tt::tt_metal::GlobalSemaphore>& arrival_sems,
+        const tt::tt_metal::GlobalSemaphore& reader_gen_sem,
+        const tt::tt_metal::GlobalSemaphore& writer_gen_sem,
+        const tt::tt_metal::GlobalSemaphore& compute_gen_sem);
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
@@ -15,6 +15,32 @@
 
 namespace ttnn::experimental::prim {
 
+// Page-space geometry of the scatter, for ANY scatter dim.
+//
+// The tiled input buffer is a row-major array of pages over [d0, ..., d_{rank-3}, Ht, Wt]. Slicing it on
+// dim `d` cuts a middle axis of that array, so slice j of every "outer" index (the product of the dims
+// before d) is a CONTIGUOUS run of `slice_run_pages` pages starting at j * slice_run_pages, and
+// consecutive runs sit `stride_pages` apart. That is the only thing the scatter dim changes: the reader
+// walks (run, stride) instead of a hardcoded (slice_Wt, width_tiles) pair, and everything downstream --
+// chunking, staging, the output write -- only ever sees the resulting linear page order of a slice.
+// The last dim is the degenerate case with stride == one row and run == the slice's width in tiles;
+// dim 0 is the other degenerate case with a single run (outer == 1), so the stride is never taken.
+struct ReduceScatterDirectGeometry {
+    uint32_t single_tile_bytes;        // bytes per tile
+    uint32_t tile_granularity;         // tiles per chunk (compute/CB granularity)
+    uint32_t interm_tiles_per_packet;  // max tiles carried in one fabric packet
+    uint32_t page_bytes;               // staging row width == tile_granularity * single_tile_bytes
+    uint32_t pages_per_slice;          // tiles in one slice (== output tiles)
+    uint32_t chunks_per_slice;         // ceil(pages_per_slice / tile_granularity)
+    uint32_t slice_run_pages;          // contiguous pages of a slice, per outer index
+    uint32_t stride_pages;             // input pages between the starts of consecutive runs
+};
+
+// Single source of truth for the geometry above, shared by compute_output_specs (which sizes staging
+// from it) and the program factory (which wires it into the kernels), so the two can never disagree.
+ReduceScatterDirectGeometry reduce_scatter_direct_geometry(
+    const ReduceScatterMinimalDirectParams& args, const ttnn::Tensor& input_tensor, bool fp32_dest_acc_en);
+
 // Worker-core selection: one core per link, each owning that link's fwd + bwd connection. Factored out
 // so the resolved link count and the core placement are defined in exactly one place.
 uint32_t reduce_scatter_direct_num_links(const ReduceScatterMinimalDirectParams& args, uint32_t chunks_per_slice);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
@@ -46,6 +46,29 @@ struct ReduceScatterDirectGeometry {
 ReduceScatterDirectGeometry reduce_scatter_direct_geometry(
     const ReduceScatterMinimalDirectParams& args, const ttnn::Tensor& input_tensor, bool fp32_dest_acc_en);
 
+// Which fabric configurations this op can run on.
+//
+// Every send is a multi-hop unicast to one of the two ring directions, over a
+// RoutingPlaneConnectionManager built as FabricApiType::Linear. The requirement is that the ACTIVE AXIS
+// be a TORUS: it wraps, so every destination is reachable by travelling one direction along a single
+// fabric dimension, with no turn (a plain 2D mesh resolves to Topology::Mesh and is rejected here).
+//
+// The mesh's OTHER extent is irrelevant -- cluster_axis already confines the collective to one axis, so a
+// 2x4 with a torus X axis is four independent 4-rings, each exactly the degenerate case above.
+//
+// What this cannot express, and what the factory rejects with a throw rather than a hang: a logical 1xN
+// VIEW that snakes across a larger physical grid (this 2x4 box opened as 1x8 maps to chips 0,1,2,3,7,6,5,4).
+// There the "ring" mixes X and Y hops, and 2D routing -- which is by DESTINATION NODE, not hop count --
+// cannot be made to follow it. See the factory's direction fix-up for why that matters.
+bool reduce_scatter_direct_fabric_supported(
+    const ttnn::MeshDevice& mesh_device,
+    tt::tt_fabric::FabricConfig fabric_config,
+    tt::tt_fabric::Topology axis_topology);
+
+// Resolves the collective's axis the same way the factory does: the caller's cluster_axis if given,
+// else the last axis with more than one device.
+uint32_t reduce_scatter_direct_active_axis(const ReduceScatterMinimalDirectParams& args);
+
 // Worker-core selection: one core per link, each owning that link's fwd + bwd connection. Factored out
 // so the resolved link count and the core placement are defined in exactly one place.
 uint32_t reduce_scatter_direct_num_links(const ReduceScatterMinimalDirectParams& args, uint32_t chunks_per_slice);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
@@ -26,11 +26,6 @@ namespace ttnn::experimental::prim {
 // chunking, staging, the output write -- only ever sees the resulting linear page order of a slice.
 // The last dim is the degenerate case with stride == one row and run == the slice's width in tiles;
 // dim 0 is the other degenerate case with a single run (outer == 1), so the stride is never taken.
-//
-// This is also why the op needs no ND -> canonical-4D collapse (the (B, C, Ht, Wt) + normalized_dim
-// mapping the ring ops carry, whose kernels are a fixed 4-level nested loop): the pair above already IS
-// that collapse. Everything below the scatter dim folds into `inner_pages` and everything above folds
-// into the outer count, for any rank >= 2 -- rank never reaches a kernel.
 struct ReduceScatterDirectGeometry {
     uint32_t single_tile_bytes;        // bytes per tile
     uint32_t tile_granularity;         // tiles per chunk (compute/CB granularity)
@@ -53,14 +48,6 @@ ReduceScatterDirectGeometry reduce_scatter_direct_geometry(
 // RoutingPlaneConnectionManager built as FabricApiType::Linear. The requirement is that the ACTIVE AXIS
 // be a TORUS: it wraps, so every destination is reachable by travelling one direction along a single
 // fabric dimension, with no turn (a plain 2D mesh resolves to Topology::Mesh and is rejected here).
-//
-// The mesh's OTHER extent is irrelevant -- cluster_axis already confines the collective to one axis, so a
-// 2x4 with a torus X axis is four independent 4-rings, each exactly the degenerate case above.
-//
-// What this cannot express, and what the factory rejects with a throw rather than a hang: a logical 1xN
-// VIEW that snakes across a larger physical grid (this 2x4 box opened as 1x8 maps to chips 0,1,2,3,7,6,5,4).
-// There the "ring" mixes X and Y hops, and 2D routing -- which is by DESTINATION NODE, not hop count --
-// cannot be made to follow it. See the factory's direction fix-up for why that matters.
 bool reduce_scatter_direct_fabric_supported(
     const ttnn::MeshDevice& mesh_device,
     tt::tt_fabric::FabricConfig fabric_config,
@@ -80,26 +67,6 @@ std::pair<CoreRangeSet, std::vector<CoreCoord>> reduce_scatter_direct_worker_cor
 // builds and caches the MeshWorkload from the descriptor we return. Returns two tensors -- [0] output
 // slice, [1] staging for the incoming contributions.
 //
-// create_workload_descriptor() runs ONCE per workload (cache miss):
-//   1. Allocates the GlobalSemaphores and parks them on WorkloadDescriptor::semaphores, which keeps them
-//      alive for the cached workload's lifetime -- every kernel takes their addresses as runtime args.
-//      Order is fixed and read back by index: [0 .. num_devices-1] the per-SOURCE arrival counters, then
-//      reader_gen, writer_gen, compute_gen, init_sync. See semaphore_index below.
-//        - arrival counters are indexed by SOURCE device, so each has exactly one sender and an absolute
-//          wait on it cannot be satisfied by a different (raced-ahead) device. Never reset.
-//        - the three *_gen counters are per-kernel private invocation counters, each bumped once per
-//          launch by its owner, so all three read the same invocation index with no cross-kernel
-//          handshake -- that index drives the staging double-buffer parity. (compute's body runs on all
-//          three TRISCs, so exactly one of them (PACK) does the increment.)
-//        - init_sync is the writer's start barrier, only read when that barrier is compiled in.
-//   2. Runs the distributed Synchronize so every device sees the semaphores before any program launches.
-//   3. Emits ONE ProgramDescriptor per mesh coordinate: the program depends on the sender coordinate
-//      (device_idx, ring neighbours, and the per-destination hop/direction/route table), so the mesh
-//      cannot share a single descriptor.
-//
-// Buffer base addresses are bound as Buffer* through emplace_runtime_args(), and the aliased reduce CB
-// via CBDescriptor::buffer, so the framework patches them on the cache-hit fast path -- no manual
-// override_runtime_arguments() hook.
 struct ReduceScatterMinimalDirectProgramFactory {
     using tensor_return_value_t = std::vector<Tensor>;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
@@ -118,8 +118,17 @@ void ReduceScatterMinimalDirectDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(args.dim >= 0 && args.dim < rank, "Resolved scatter dim {} out of range for {}D input", args.dim, rank);
     TT_FATAL(args.num_devices > 1, "reduce_scatter collective requires num_devices > 1, got {}", args.num_devices);
 
-    const bool fabric_is_2d = ::tt::tt_fabric::is_2d_fabric_config(args.fabric_config);
-    TT_FATAL(!fabric_is_2d, "reduce_scatter_minimal_direct supports Fabric_1D ring only, not Fabric_2D");
+    // Fabric gate -- see reduce_scatter_direct_fabric_supported. NOTE this runs only on a program-cache
+    // miss, and is skipped entirely under fast runtime mode, so the factory repeats it as the backstop.
+    const uint32_t fabric_axis = reduce_scatter_direct_active_axis(args);
+    TT_FATAL(
+        reduce_scatter_direct_fabric_supported(
+            *input_tensor.device(), args.fabric_config, args.axis_topology[fabric_axis]),
+        "reduce_scatter_minimal_direct needs a 1D fabric, or a 2D fabric whose ACTIVE AXIS wraps (a torus "
+        "axis); got fabric {} on a {} mesh with axis topology {}",
+        args.fabric_config,
+        input_tensor.device()->shape(),
+        args.axis_topology[fabric_axis]);
     TT_FATAL(
         input_tensor.logical_shape()[args.dim] % args.num_devices == 0,
         "scatter dim {} (size {}) must be divisible by num_devices {}",

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "reduce_scatter_minimal_direct_op_device_operation.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/ccl/common/host/moe_utils.hpp"
+#include "ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+
+#include <tt-metalium/host_api.hpp>
+
+#include <algorithm>
+
+namespace ttnn::experimental::prim {
+
+using namespace ::ttnn::ccl;
+
+namespace {
+
+// Staging placement, in preference order.
+//
+// SHARDED (the fast path): one L1 shard per worker core, aliased directly into that core's reduce CB, so
+// a sender's fabric packet lands in the exact CB slot the reducer unpacks from and the receive side never
+// reads staging at all. That readback is pure post-gate latency -- it happens strictly after the last
+// arrival, and even out of L1 it is N-1 NoC round trips plus a barrier on the critical path. Requires the
+// whole per-core shard (both parity halves, every source, every chunk this core owns) to fit the
+// per-core budget below.
+//
+// INTERLEAVED L1 / DRAM (fallbacks): the original layout, read back by the reader over the NoC. Anything
+// whose shard is too big for one core still runs, just without the aliasing win.
+//
+// Both the factory and the persistent-buffer helper get this from compute_output_specs, so there is a
+// single decision point; the factory recognises the fast path by the memory layout being sharded.
+constexpr uint64_t k_l1_staging_budget_bytes = 4ull << 20;  // interleaved-L1 fallback, total across banks
+constexpr uint64_t k_l1_shard_budget_bytes = 640ull << 10;  // aliased-CB path, PER worker core
+
+}  // namespace
+
+// Chunk-paged staging spec, doubled: the first half serves even invocations, the second odd ones (see the
+// reader kernel's parity note).
+//
+// Interleaved layout: 2 * num_devices * chunks_per_slice pages of page_bytes, page
+// (half + s * chunks_per_slice + chunk) holding source device s's contribution to our slice.
+//
+// Sharded layout: the same content re-grouped so it can double as the reduce CB, which forces
+// chunk-major ordering (the CB read pointer advances one N-block group per chunk) and per-core scoping
+// (a core only stages the chunks it owns). Row (half + k * num_devices + b) of a core's shard holds
+// block b of that core's k-th chunk: b == 0 is the core's own contribution, written locally by the
+// reader, and b == 1..N-1 are the remote sources in ascending device order skipping ourselves. Rows are
+// sized by chunks_per_slice rather than the actual per-core chunk count so the spec stays independent of
+// how the chunks happen to be partitioned across workers.
+static ttnn::TensorSpec reduce_scatter_direct_staging_spec(
+    const ReduceScatterMinimalDirectParams& args, const ttnn::Tensor& input_tensor, bool fp32_dest_acc_en) {
+    const uint32_t num_devices = args.num_devices;
+    const auto params = ttnn::experimental::ccl::reduce_scatter_ring_interm_staging_params(
+        input_tensor, ttnn::ccl::Topology::Ring, static_cast<uint32_t>(args.dim), num_devices, fp32_dest_acc_en);
+    TT_FATAL(
+        params.use_contiguous,
+        "reduce_scatter_minimal_direct requires the contiguous staging path (Ring topology, scatter dim != 0)");
+    TT_FATAL(
+        params.total_chunks == num_devices * params.chunks_per_channel,
+        "reduce_scatter_minimal_direct addresses staging as num_devices x chunks_per_slice, so the input must "
+        "have a single channel per slice (total_chunks {} != num_devices {} * chunks_per_channel {})",
+        params.total_chunks,
+        num_devices,
+        params.chunks_per_channel);
+
+    const auto row_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR);
+    const uint32_t shard_rows = 2 * params.chunks_per_channel * num_devices;
+    const uint64_t shard_bytes = uint64_t{shard_rows} * params.page_bytes;
+
+    if (shard_bytes <= k_l1_shard_budget_bytes) {
+        // Sharded over the WHOLE compute grid, deliberately, rather than over the worker cores: this spec
+        // is also what reduce_scatter_minimal_direct_create_persistent_buffers allocates from, and that
+        // helper cannot know the resolved num_links / subdevice / sub_core_grid. Sizing the shard by
+        // chunks_per_slice (the most chunks any single worker could own) and covering every core the
+        // factory could possibly pick makes the spec depend only on the input, so a persistent buffer can
+        // never disagree with the program about the shard geometry. Workers are always a subset of this
+        // grid, and each of them finds its shard at the same address.
+        const auto grid = input_tensor.device()->compute_with_storage_grid_size();
+        const CoreRangeSet shard_grid(CoreRange({0, 0}, {grid.x - 1, grid.y - 1}));
+        const uint32_t num_shards = grid.x * grid.y;
+        // Height-sharded: every shard sits at the SAME L1 address on every core of every device, which is
+        // what lets a sender address the mirror core's reduce CB with nothing but its own staging address.
+        tt::tt_metal::ShardSpec shard_spec(
+            shard_grid, {shard_rows, params.page_bytes}, tt::tt_metal::ShardOrientation::ROW_MAJOR);
+        return ttnn::TensorSpec(
+            ttnn::Shape({num_shards * shard_rows, params.page_bytes}),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::UINT8,
+                row_config,
+                tt::tt_metal::MemoryConfig(
+                    tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED, tt::tt_metal::BufferType::L1, shard_spec)));
+    }
+
+    const uint64_t total_bytes = 2ull * params.total_chunks * params.page_bytes;
+    const auto buffer_type =
+        total_bytes <= k_l1_staging_budget_bytes ? tt::tt_metal::BufferType::L1 : tt::tt_metal::BufferType::DRAM;
+
+    // Opaque byte-staging, same layout contract as the ring op's intermediate: row-major UINT8, page (row)
+    // = one chunk (page_bytes, DRAM-aligned). Interleaved so chunks spread across banks. The mesh
+    // allocator is lockstep, so the buffer lands at the same address on every device -- required, since a
+    // sender computes the destination address from its own accessor.
+    return ttnn::TensorSpec(
+        ttnn::Shape({2 * params.total_chunks, params.page_bytes}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::UINT8,
+            row_config,
+            tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, buffer_type)));
+}
+
+void ReduceScatterMinimalDirectDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t&, const tensor_args_t&) {}
+
+void ReduceScatterMinimalDirectDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor must be allocated in a buffer on device!");
+
+    const int32_t rank = static_cast<int32_t>(input_tensor.logical_shape().rank());
+    TT_FATAL(args.dim >= 0 && args.dim < rank, "Resolved scatter dim {} out of range for {}D input", args.dim, rank);
+    TT_FATAL(args.num_devices > 1, "reduce_scatter collective requires num_devices > 1, got {}", args.num_devices);
+
+    const bool fabric_is_2d = ::tt::tt_fabric::is_2d_fabric_config(args.fabric_config);
+    TT_FATAL(!fabric_is_2d, "reduce_scatter_minimal_direct supports Fabric_1D ring only, not Fabric_2D");
+    TT_FATAL(
+        input_tensor.logical_shape()[args.dim] % args.num_devices == 0,
+        "scatter dim {} (size {}) must be divisible by num_devices {}",
+        args.dim,
+        input_tensor.logical_shape()[args.dim],
+        args.num_devices);
+
+    auto specs = compute_output_specs(args, tensor_args);
+    if (tensor_args.persistent_output_tensor.has_value()) {
+        const auto& out = tensor_args.persistent_output_tensor.value();
+        TT_FATAL(out.storage_type() == StorageType::DEVICE, "Persistent output tensor must be on device!");
+        TT_FATAL(
+            out.dtype() == input_tensor.dtype(),
+            "Output dtype {} must match input {}",
+            out.dtype(),
+            input_tensor.dtype());
+        TT_FATAL(
+            out.logical_shape() == specs.at(0).logical_shape(),
+            "Persistent output shape {} must be {}",
+            out.logical_shape(),
+            specs.at(0).logical_shape());
+    }
+    if (tensor_args.persistent_staging_tensor.has_value()) {
+        const auto& staging = tensor_args.persistent_staging_tensor.value();
+        TT_FATAL(staging.storage_type() == StorageType::DEVICE, "Persistent staging tensor must be on device!");
+        TT_FATAL(
+            staging.logical_shape() == specs.at(1).logical_shape() &&
+                staging.memory_config() == specs.at(1).memory_config(),
+            "Persistent staging tensor must come from reduce_scatter_minimal_direct_create_persistent_buffers: "
+            "expected shape {} in {}, got shape {} in {}",
+            specs.at(1).logical_shape(),
+            specs.at(1).memory_config(),
+            staging.logical_shape(),
+            staging.memory_config());
+    }
+}
+
+ReduceScatterMinimalDirectDeviceOperation::spec_return_value_t
+ReduceScatterMinimalDirectDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto page_config = input_tensor.tensor_spec().page_config();
+    const auto dtype = input_tensor.dtype();
+
+    // [0] output slice: input shape with the scatter dim reduced by num_devices.
+    auto out_shape = input_tensor.logical_shape();
+    out_shape[args.dim] /= args.num_devices;
+    TensorSpec output_spec(out_shape, tt::tt_metal::TensorLayout(dtype, page_config, args.output_mem_config));
+
+    // [1] staging for the incoming contributions (see reduce_scatter_direct_staging_spec).
+    const bool fp32_dest_acc_en = (dtype == DataType::FLOAT32);
+    auto staging_spec = reduce_scatter_direct_staging_spec(args, input_tensor, fp32_dest_acc_en);
+
+    return {output_spec, staging_spec};
+}
+
+ReduceScatterMinimalDirectDeviceOperation::tensor_return_value_t
+ReduceScatterMinimalDirectDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    auto specs = compute_output_specs(args, tensor_args);
+    auto* device = tensor_args.input_tensor.device();
+
+    Tensor output = tensor_args.persistent_output_tensor.has_value() ? tensor_args.persistent_output_tensor.value()
+                                                                     : create_device_tensor(specs.at(0), device);
+    Tensor staging = tensor_args.persistent_staging_tensor.has_value() ? tensor_args.persistent_staging_tensor.value()
+                                                                       : create_device_tensor(specs.at(1), device);
+    return {std::move(output), std::move(staging)};
+}
+
+ReduceScatterMinimalDirectDeviceOperation::program_factory_t
+ReduceScatterMinimalDirectDeviceOperation::select_program_factory(const operation_attributes_t&, const tensor_args_t&) {
+    return program_factory_t{ReduceScatterMinimalDirectMeshWorkloadFactory{}};
+}
+
+// Build the operation attributes + inputs by querying the machine/fabric setup, mirroring the unicast op.
+static std::tuple<ReduceScatterMinimalDirectParams, ReduceScatterMinimalDirectInputs> build_operation_args(
+    const Tensor& input_tensor,
+    int32_t dim,
+    const MemoryConfig& output_mem_config,
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> num_links,
+    const std::optional<Tensor>& persistent_output_tensor,
+    const std::optional<Tensor>& persistent_staging_tensor,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    const std::optional<CoreRangeSet>& sub_core_grid) {
+    auto* mesh_device = input_tensor.device();
+    TT_FATAL(mesh_device != nullptr, "Input tensor must be on a mesh device for reduce_scatter_minimal_direct");
+
+    const auto mesh_shape = mesh_device->shape();
+    const auto fabric_config = tt::tt_fabric::GetFabricConfig();
+    std::array<tt::tt_fabric::Topology, 2> axis_topology{
+        tt::tt_fabric::Topology::Linear, tt::tt_fabric::Topology::Linear};
+    std::array<uint32_t, 2> axis_num_devices{1u, 1u};
+    std::array<uint32_t, 2> axis_num_links{0u, 0u};
+    for (uint32_t axis = 0; axis < 2; ++axis) {
+        const bool is_axis_active = mesh_shape[axis] > 1 && cluster_axis.value_or(axis) == axis;
+        if (!is_axis_active) {
+            continue;
+        }
+        axis_topology[axis] = ::ttnn::ccl::get_axis_topology(input_tensor, fabric_config, axis);
+        axis_num_devices[axis] = ::ttnn::ccl::get_topological_dimension(input_tensor, axis);
+        axis_num_links[axis] = ttnn::operations::ccl::common::get_num_links(*mesh_device, axis);
+    }
+    const uint32_t num_devices = axis_num_devices[0] * axis_num_devices[1];
+    const size_t packet_size = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
+
+    uint32_t active_axis = 0;
+    for (uint32_t a = 0; a < 2; ++a) {
+        if (axis_num_devices[a] > 1) {
+            active_axis = a;
+        }
+    }
+    const uint32_t available_links = std::max(1u, axis_num_links[cluster_axis.value_or(active_axis)]);
+    const uint32_t resolved_num_links = num_links.value_or(available_links);
+    TT_FATAL(
+        resolved_num_links >= 1 && resolved_num_links <= available_links,
+        "reduce_scatter_minimal_direct num_links {} must be in [1, {}] (links available on axis {})",
+        resolved_num_links,
+        available_links,
+        cluster_axis.value_or(active_axis));
+
+    const uint32_t rank = input_tensor.logical_shape().rank();
+    const int32_t scatter_dim = (dim < 0) ? static_cast<int32_t>(rank) + dim : dim;
+
+    return {
+        ReduceScatterMinimalDirectParams{
+            scatter_dim,
+            output_mem_config,
+            cluster_axis,
+            fabric_config,
+            axis_topology,
+            axis_num_devices,
+            axis_num_links,
+            num_devices,
+            packet_size,
+            resolved_num_links,
+            subdevice_id,
+            sub_core_grid},
+        ReduceScatterMinimalDirectInputs{
+            .input_tensor = input_tensor,
+            .persistent_output_tensor = persistent_output_tensor,
+            .persistent_staging_tensor = persistent_staging_tensor}};
+}
+
+}  // namespace ttnn::experimental::prim
+
+namespace ttnn::prim {
+
+std::vector<ttnn::Tensor> reduce_scatter_minimal_direct(
+    const ttnn::Tensor& input_tensor,
+    int32_t dim,
+    const ttnn::MemoryConfig& output_mem_config,
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> num_links,
+    const std::optional<ttnn::Tensor>& persistent_output_tensor,
+    const std::optional<ttnn::Tensor>& persistent_staging_tensor,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
+    const std::optional<CoreRangeSet>& sub_core_grid) {
+    auto [params, inputs] = ttnn::experimental::prim::build_operation_args(
+        input_tensor,
+        dim,
+        output_mem_config,
+        cluster_axis,
+        num_links,
+        persistent_output_tensor,
+        persistent_staging_tensor,
+        sub_device_id,
+        sub_core_grid);
+    return ttnn::device_operation::launch<ttnn::experimental::prim::ReduceScatterMinimalDirectDeviceOperation>(
+        params, inputs);
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
@@ -193,6 +193,20 @@ ReduceScatterMinimalDirectDeviceOperation::select_program_factory(const operatio
     return program_factory_t{ReduceScatterMinimalDirectMeshWorkloadFactory{}};
 }
 
+std::uint64_t ReduceScatterMinimalDirectDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // Default hash plus the two "was a persistent buffer supplied?" bits. Those bits pick the writer's
+    // start barrier, which is compiled into the kernel, so a program built with the barrier omitted must
+    // never be served to a call that allocates its own buffers. Stated explicitly rather than left to how
+    // the default hash happens to treat an engaged vs empty optional tensor field.
+    return ttsl::hash::hash_objects_with_default_seed(
+        ttsl::hash::type_hash<ReduceScatterMinimalDirectDeviceOperation>,
+        args,
+        tensor_args,
+        tensor_args.persistent_output_tensor.has_value(),
+        tensor_args.persistent_staging_tensor.has_value());
+}
+
 // Build the operation attributes + inputs by querying the machine/fabric setup, mirroring the unicast op.
 static std::tuple<ReduceScatterMinimalDirectParams, ReduceScatterMinimalDirectInputs> build_operation_args(
     const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
@@ -16,6 +16,7 @@
 namespace ttnn::experimental::prim {
 
 using namespace ::ttnn::ccl;
+using tt::tt_metal::TensorSpec;
 
 namespace {
 
@@ -51,7 +52,7 @@ constexpr uint64_t k_l1_shard_budget_bytes = 640ull << 10;  // aliased-CB path, 
 // reader, and b == 1..N-1 are the remote sources in ascending device order skipping ourselves. Rows are
 // sized by chunks_per_slice rather than the actual per-core chunk count so the spec stays independent of
 // how the chunks happen to be partitioned across workers.
-static ttnn::TensorSpec reduce_scatter_direct_staging_spec(
+static TensorSpec reduce_scatter_direct_staging_spec(
     const ReduceScatterMinimalDirectParams& args, const ttnn::Tensor& input_tensor, bool fp32_dest_acc_en) {
     const uint32_t num_devices = args.num_devices;
     // A slice is chunked as one flat page run (chunks_per_slice), whatever dim it was cut on -- the
@@ -78,7 +79,7 @@ static ttnn::TensorSpec reduce_scatter_direct_staging_spec(
         // what lets a sender address the mirror core's reduce CB with nothing but its own staging address.
         tt::tt_metal::ShardSpec shard_spec(
             shard_grid, {shard_rows, geom.page_bytes}, tt::tt_metal::ShardOrientation::ROW_MAJOR);
-        return ttnn::TensorSpec(
+        return TensorSpec(
             ttnn::Shape({num_shards * shard_rows, geom.page_bytes}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::UINT8,
@@ -95,7 +96,7 @@ static ttnn::TensorSpec reduce_scatter_direct_staging_spec(
     // = one chunk (page_bytes, DRAM-aligned). Interleaved so chunks spread across banks. The mesh
     // allocator is lockstep, so the buffer lands at the same address on every device -- required, since a
     // sender computes the destination address from its own accessor.
-    return ttnn::TensorSpec(
+    return TensorSpec(
         ttnn::Shape({2 * total_chunks, geom.page_bytes}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::UINT8,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
@@ -7,7 +7,6 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
-#include "ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
 #include <tt-metalium/host_api.hpp>
@@ -55,22 +54,14 @@ constexpr uint64_t k_l1_shard_budget_bytes = 640ull << 10;  // aliased-CB path, 
 static ttnn::TensorSpec reduce_scatter_direct_staging_spec(
     const ReduceScatterMinimalDirectParams& args, const ttnn::Tensor& input_tensor, bool fp32_dest_acc_en) {
     const uint32_t num_devices = args.num_devices;
-    const auto params = ttnn::experimental::ccl::reduce_scatter_ring_interm_staging_params(
-        input_tensor, ttnn::ccl::Topology::Ring, static_cast<uint32_t>(args.dim), num_devices, fp32_dest_acc_en);
-    TT_FATAL(
-        params.use_contiguous,
-        "reduce_scatter_minimal_direct requires the contiguous staging path (Ring topology, scatter dim != 0)");
-    TT_FATAL(
-        params.total_chunks == num_devices * params.chunks_per_channel,
-        "reduce_scatter_minimal_direct addresses staging as num_devices x chunks_per_slice, so the input must "
-        "have a single channel per slice (total_chunks {} != num_devices {} * chunks_per_channel {})",
-        params.total_chunks,
-        num_devices,
-        params.chunks_per_channel);
+    // A slice is chunked as one flat page run (chunks_per_slice), whatever dim it was cut on -- the
+    // reader walks it linearly, so staging never needs a per-batch/channel axis.
+    const auto geom = reduce_scatter_direct_geometry(args, input_tensor, fp32_dest_acc_en);
+    const uint32_t total_chunks = num_devices * geom.chunks_per_slice;
 
     const auto row_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR);
-    const uint32_t shard_rows = 2 * params.chunks_per_channel * num_devices;
-    const uint64_t shard_bytes = uint64_t{shard_rows} * params.page_bytes;
+    const uint32_t shard_rows = 2 * geom.chunks_per_slice * num_devices;
+    const uint64_t shard_bytes = uint64_t{shard_rows} * geom.page_bytes;
 
     if (shard_bytes <= k_l1_shard_budget_bytes) {
         // Sharded over the WHOLE compute grid, deliberately, rather than over the worker cores: this spec
@@ -86,9 +77,9 @@ static ttnn::TensorSpec reduce_scatter_direct_staging_spec(
         // Height-sharded: every shard sits at the SAME L1 address on every core of every device, which is
         // what lets a sender address the mirror core's reduce CB with nothing but its own staging address.
         tt::tt_metal::ShardSpec shard_spec(
-            shard_grid, {shard_rows, params.page_bytes}, tt::tt_metal::ShardOrientation::ROW_MAJOR);
+            shard_grid, {shard_rows, geom.page_bytes}, tt::tt_metal::ShardOrientation::ROW_MAJOR);
         return ttnn::TensorSpec(
-            ttnn::Shape({num_shards * shard_rows, params.page_bytes}),
+            ttnn::Shape({num_shards * shard_rows, geom.page_bytes}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::UINT8,
                 row_config,
@@ -96,7 +87,7 @@ static ttnn::TensorSpec reduce_scatter_direct_staging_spec(
                     tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED, tt::tt_metal::BufferType::L1, shard_spec)));
     }
 
-    const uint64_t total_bytes = 2ull * params.total_chunks * params.page_bytes;
+    const uint64_t total_bytes = 2ull * total_chunks * geom.page_bytes;
     const auto buffer_type =
         total_bytes <= k_l1_staging_budget_bytes ? tt::tt_metal::BufferType::L1 : tt::tt_metal::BufferType::DRAM;
 
@@ -105,7 +96,7 @@ static ttnn::TensorSpec reduce_scatter_direct_staging_spec(
     // allocator is lockstep, so the buffer lands at the same address on every device -- required, since a
     // sender computes the destination address from its own accessor.
     return ttnn::TensorSpec(
-        ttnn::Shape({2 * params.total_chunks, params.page_bytes}),
+        ttnn::Shape({2 * total_chunks, geom.page_bytes}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::UINT8,
             row_config,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
@@ -200,7 +200,7 @@ ReduceScatterMinimalDirectDeviceOperation::create_output_tensors(
 
 ReduceScatterMinimalDirectDeviceOperation::program_factory_t
 ReduceScatterMinimalDirectDeviceOperation::select_program_factory(const operation_attributes_t&, const tensor_args_t&) {
-    return program_factory_t{ReduceScatterMinimalDirectMeshWorkloadFactory{}};
+    return program_factory_t{ReduceScatterMinimalDirectProgramFactory{}};
 }
 
 std::uint64_t ReduceScatterMinimalDirectDeviceOperation::compute_program_hash(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
@@ -24,13 +24,11 @@ namespace {
 //
 // SHARDED (the fast path): one L1 shard per worker core, aliased directly into that core's reduce CB, so
 // a sender's fabric packet lands in the exact CB slot the reducer unpacks from and the receive side never
-// reads staging at all. That readback is pure post-gate latency -- it happens strictly after the last
-// arrival, and even out of L1 it is N-1 NoC round trips plus a barrier on the critical path. Requires the
-// whole per-core shard (both parity halves, every source, every chunk this core owns) to fit the
-// per-core budget below.
+// reads staging at all. Requires the whole per-core shard (both parity halves, every source,
+// every chunk this core owns) to fit the per-core budget below.
 //
-// INTERLEAVED L1 / DRAM (fallbacks): the original layout, read back by the reader over the NoC. Anything
-// whose shard is too big for one core still runs, just without the aliasing win.
+// INTERLEAVED L1 / DRAM (fallbacks) read back by the reader over the NoC. Anything
+// whose shard is too big for one core.
 //
 // Both the factory and the persistent-buffer helper get this from compute_output_specs, so there is a
 // single decision point; the factory recognises the fast path by the memory layout being sharded.
@@ -65,13 +63,7 @@ static TensorSpec reduce_scatter_direct_staging_spec(
     const uint64_t shard_bytes = uint64_t{shard_rows} * geom.page_bytes;
 
     if (shard_bytes <= k_l1_shard_budget_bytes) {
-        // Sharded over the WHOLE compute grid, deliberately, rather than over the worker cores: this spec
-        // is also what reduce_scatter_minimal_direct_create_persistent_buffers allocates from, and that
-        // helper cannot know the resolved num_links / subdevice / sub_core_grid. Sizing the shard by
-        // chunks_per_slice (the most chunks any single worker could own) and covering every core the
-        // factory could possibly pick makes the spec depend only on the input, so a persistent buffer can
-        // never disagree with the program about the shard geometry. Workers are always a subset of this
-        // grid, and each of them finds its shard at the same address.
+        // Sharded over the WHOLE compute grid.
         const auto grid = input_tensor.device()->compute_with_storage_grid_size();
         const CoreRangeSet shard_grid(CoreRange({0, 0}, {grid.x - 1, grid.y - 1}));
         const uint32_t num_shards = grid.x * grid.y;
@@ -94,8 +86,7 @@ static TensorSpec reduce_scatter_direct_staging_spec(
 
     // Opaque byte-staging, same layout contract as the ring op's intermediate: row-major UINT8, page (row)
     // = one chunk (page_bytes, DRAM-aligned). Interleaved so chunks spread across banks. The mesh
-    // allocator is lockstep, so the buffer lands at the same address on every device -- required, since a
-    // sender computes the destination address from its own accessor.
+    // allocator is lockstep, so the buffer lands at the same address on every device
     return TensorSpec(
         ttnn::Shape({2 * total_chunks, geom.page_bytes}),
         tt::tt_metal::TensorLayout(
@@ -217,7 +208,6 @@ std::uint64_t ReduceScatterMinimalDirectDeviceOperation::compute_program_hash(
         tensor_args.persistent_staging_tensor.has_value());
 }
 
-// Build the operation attributes + inputs by querying the machine/fabric setup, mirroring the unicast op.
 static std::tuple<ReduceScatterMinimalDirectParams, ReduceScatterMinimalDirectInputs> build_operation_args(
     const Tensor& input_tensor,
     int32_t dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
@@ -95,15 +95,57 @@ static TensorSpec reduce_scatter_direct_staging_spec(
             tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, buffer_type)));
 }
 
+// Checks that must run on EVERY invocation, not just the cache miss that built the program. On a hit the
+// cached workload is reused and only buffer addresses are patched from these tensors, so anything that
+// would make a same-shaped tensor address differently -- page config, memory config, dtype, a different
+// mesh device, or an unallocated buffer -- has to be re-verified each time. Comparing the full
+// tensor_spec() is what the regular reduce-scatter cache-hit validator does
+// (reduce_scatter_device_operation.cpp:32-40), and for the persistent buffers it is also exactly the
+// documented contract: they are required to come from reduce_scatter_minimal_direct_create_persistent_buffers,
+// which builds them from this same compute_output_specs, so a conforming tensor matches byte for byte.
+static void validate_direct_tensors_every_invocation(
+    const ReduceScatterMinimalDirectDeviceOperation::operation_attributes_t& args,
+    const ReduceScatterMinimalDirectDeviceOperation::tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor must be allocated in a buffer on device!");
+    auto* mesh_device = input_tensor.device();
+    TT_FATAL(mesh_device != nullptr, "Input tensor must be on a mesh device!");
+
+    const auto specs = ReduceScatterMinimalDirectDeviceOperation::compute_output_specs(args, tensor_args);
+    const auto check = [&](const std::optional<Tensor>& maybe, size_t idx, const char* what) {
+        if (!maybe.has_value()) {
+            return;
+        }
+        const auto& tensor = maybe.value();
+        TT_FATAL(tensor.storage_type() == StorageType::DEVICE, "Persistent {} tensor must be on device!", what);
+        TT_FATAL(tensor.buffer() != nullptr, "Persistent {} tensor must be allocated in a buffer on device!", what);
+        TT_FATAL(
+            tensor.device() == mesh_device,
+            "Persistent {} tensor must live on the same mesh device as the input",
+            what);
+        TT_FATAL(
+            tensor.tensor_spec() == specs.at(idx),
+            "Persistent {} tensor spec {} does not match the computed spec {}; persistent buffers must come "
+            "from reduce_scatter_minimal_direct_create_persistent_buffers",
+            what,
+            tensor.tensor_spec(),
+            specs.at(idx));
+    };
+    check(tensor_args.persistent_output_tensor, 0, "output");
+    check(tensor_args.persistent_staging_tensor, 1, "staging");
+}
+
 void ReduceScatterMinimalDirectDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t&, const tensor_args_t&) {}
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_direct_tensors_every_invocation(args, tensor_args);
+}
 
 void ReduceScatterMinimalDirectDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
 
-    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be on device!");
-    TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor must be allocated in a buffer on device!");
+    validate_direct_tensors_every_invocation(args, tensor_args);
 
     const int32_t rank = static_cast<int32_t>(input_tensor.logical_shape().rank());
     TT_FATAL(args.dim >= 0 && args.dim < rank, "Resolved scatter dim {} out of range for {}D input", args.dim, rank);
@@ -127,34 +169,8 @@ void ReduceScatterMinimalDirectDeviceOperation::validate_on_program_cache_miss(
         input_tensor.logical_shape()[args.dim],
         args.num_devices);
 
-    auto specs = compute_output_specs(args, tensor_args);
-    if (tensor_args.persistent_output_tensor.has_value()) {
-        const auto& out = tensor_args.persistent_output_tensor.value();
-        TT_FATAL(out.storage_type() == StorageType::DEVICE, "Persistent output tensor must be on device!");
-        TT_FATAL(
-            out.dtype() == input_tensor.dtype(),
-            "Output dtype {} must match input {}",
-            out.dtype(),
-            input_tensor.dtype());
-        TT_FATAL(
-            out.logical_shape() == specs.at(0).logical_shape(),
-            "Persistent output shape {} must be {}",
-            out.logical_shape(),
-            specs.at(0).logical_shape());
-    }
-    if (tensor_args.persistent_staging_tensor.has_value()) {
-        const auto& staging = tensor_args.persistent_staging_tensor.value();
-        TT_FATAL(staging.storage_type() == StorageType::DEVICE, "Persistent staging tensor must be on device!");
-        TT_FATAL(
-            staging.logical_shape() == specs.at(1).logical_shape() &&
-                staging.memory_config() == specs.at(1).memory_config(),
-            "Persistent staging tensor must come from reduce_scatter_minimal_direct_create_persistent_buffers: "
-            "expected shape {} in {}, got shape {} in {}",
-            specs.at(1).logical_shape(),
-            specs.at(1).memory_config(),
-            staging.logical_shape(),
-            staging.memory_config());
-    }
+    // Persistent-buffer specs are checked by validate_direct_tensors_every_invocation above, which also
+    // runs on cache hits.
 }
 
 ReduceScatterMinimalDirectDeviceOperation::spec_return_value_t
@@ -222,6 +238,23 @@ static std::tuple<ReduceScatterMinimalDirectParams, ReduceScatterMinimalDirectIn
     TT_FATAL(mesh_device != nullptr, "Input tensor must be on a mesh device for reduce_scatter_minimal_direct");
 
     const auto mesh_shape = mesh_device->shape();
+    // A 2-element per-axis table is indexed by cluster_axis below, so an out-of-range axis has to be a
+    // controlled failure here rather than an out-of-bounds read on the way to device-op validation.
+    TT_FATAL(
+        !cluster_axis.has_value() || cluster_axis.value() < 2,
+        "reduce_scatter_minimal_direct cluster_axis {} is out of range; only axes 0 and 1 exist",
+        cluster_axis.value_or(0));
+    // An absent cluster_axis means "the one axis that wraps", which is only unambiguous on a line mesh.
+    // On a mesh with both extents > 1 the loop below would activate BOTH axes, making num_devices their
+    // product while active_axis (and hence the fabric connections the factory opens) covers only one --
+    // the kernels would then wait on contributions from devices they cannot route to, and hang. Require
+    // the caller to name the axis instead. reduce_scatter_minimal_direct_is_applicable declines the same
+    // case, so the ttnn.reduce_scatter dispatch stays on the ring op rather than reaching this TT_FATAL.
+    TT_FATAL(
+        cluster_axis.has_value() || mesh_shape[0] == 1 || mesh_shape[1] == 1,
+        "reduce_scatter_minimal_direct requires an explicit cluster_axis on a {} mesh: with both extents "
+        "greater than one there is no single implied ring axis",
+        mesh_shape);
     const auto fabric_config = tt::tt_fabric::GetFabricConfig();
     std::array<tt::tt_fabric::Topology, 2> axis_topology{
         tt::tt_fabric::Topology::Linear, tt::tt_fabric::Topology::Linear};

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
@@ -95,14 +95,9 @@ static TensorSpec reduce_scatter_direct_staging_spec(
             tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, buffer_type)));
 }
 
-// Checks that must run on EVERY invocation, not just the cache miss that built the program. On a hit the
-// cached workload is reused and only buffer addresses are patched from these tensors, so anything that
-// would make a same-shaped tensor address differently -- page config, memory config, dtype, a different
-// mesh device, or an unallocated buffer -- has to be re-verified each time. Comparing the full
-// tensor_spec() is what the regular reduce-scatter cache-hit validator does
-// (reduce_scatter_device_operation.cpp:32-40), and for the persistent buffers it is also exactly the
-// documented contract: they are required to come from reduce_scatter_minimal_direct_create_persistent_buffers,
-// which builds them from this same compute_output_specs, so a conforming tensor matches byte for byte.
+// Runs on EVERY invocation: a program-cache hit reuses the workload and only patches buffer addresses,
+// so anything that would make a same-shaped tensor address differently must be re-checked. Full
+// tensor_spec() equality matches the ring op's validator and the create_persistent_buffers contract.
 static void validate_direct_tensors_every_invocation(
     const ReduceScatterMinimalDirectDeviceOperation::operation_attributes_t& args,
     const ReduceScatterMinimalDirectDeviceOperation::tensor_args_t& tensor_args) {
@@ -169,8 +164,7 @@ void ReduceScatterMinimalDirectDeviceOperation::validate_on_program_cache_miss(
         input_tensor.logical_shape()[args.dim],
         args.num_devices);
 
-    // Persistent-buffer specs are checked by validate_direct_tensors_every_invocation above, which also
-    // runs on cache hits.
+    // Persistent-buffer specs: see validate_direct_tensors_every_invocation.
 }
 
 ReduceScatterMinimalDirectDeviceOperation::spec_return_value_t
@@ -238,18 +232,14 @@ static std::tuple<ReduceScatterMinimalDirectParams, ReduceScatterMinimalDirectIn
     TT_FATAL(mesh_device != nullptr, "Input tensor must be on a mesh device for reduce_scatter_minimal_direct");
 
     const auto mesh_shape = mesh_device->shape();
-    // A 2-element per-axis table is indexed by cluster_axis below, so an out-of-range axis has to be a
-    // controlled failure here rather than an out-of-bounds read on the way to device-op validation.
+    // cluster_axis indexes 2-element tables below: fail cleanly rather than read out of bounds.
     TT_FATAL(
         !cluster_axis.has_value() || cluster_axis.value() < 2,
         "reduce_scatter_minimal_direct cluster_axis {} is out of range; only axes 0 and 1 exist",
         cluster_axis.value_or(0));
-    // An absent cluster_axis means "the one axis that wraps", which is only unambiguous on a line mesh.
-    // On a mesh with both extents > 1 the loop below would activate BOTH axes, making num_devices their
-    // product while active_axis (and hence the fabric connections the factory opens) covers only one --
-    // the kernels would then wait on contributions from devices they cannot route to, and hang. Require
-    // the caller to name the axis instead. reduce_scatter_minimal_direct_is_applicable declines the same
-    // case, so the ttnn.reduce_scatter dispatch stays on the ring op rather than reaching this TT_FATAL.
+    // An absent cluster_axis only names a unique wrapping axis on a line mesh. With both extents > 1 the
+    // loop below activates BOTH axes, so num_devices becomes their product while routing covers one --
+    // the kernels then await contributions they cannot route to, and hang. is_applicable declines it too.
     TT_FATAL(
         cluster_axis.has_value() || mesh_shape[0] == 1 || mesh_shape[1] == 1,
         "reduce_scatter_minimal_direct requires an explicit cluster_axis on a {} mesh: with both extents "

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp
@@ -29,6 +29,9 @@ struct ReduceScatterMinimalDirectDeviceOperation {
     // [0] = output slice, [1] = staging for the incoming contributions.
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    // Custom, because whether each persistent buffer was SUPPLIED (not just its spec) selects the
+    // writer's start barrier, which is a compile-time arg. See the factory.
+    static std::uint64_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp
@@ -19,7 +19,7 @@ namespace ttnn::experimental::prim {
 struct ReduceScatterMinimalDirectDeviceOperation {
     using operation_attributes_t = ReduceScatterMinimalDirectParams;
     using tensor_args_t = ReduceScatterMinimalDirectInputs;
-    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+    using spec_return_value_t = std::vector<tt::tt_metal::TensorSpec>;
     using tensor_return_value_t = std::vector<Tensor>;
     using program_factory_t = std::variant<ReduceScatterMinimalDirectMeshWorkloadFactory>;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp
@@ -21,7 +21,7 @@ struct ReduceScatterMinimalDirectDeviceOperation {
     using tensor_args_t = ReduceScatterMinimalDirectInputs;
     using spec_return_value_t = std::vector<tt::tt_metal::TensorSpec>;
     using tensor_return_value_t = std::vector<Tensor>;
-    using program_factory_t = std::variant<ReduceScatterMinimalDirectMeshWorkloadFactory>;
+    using program_factory_t = std::variant<ReduceScatterMinimalDirectProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "reduce_scatter_minimal_direct_op_device_operation_types.hpp"
+#include "reduce_scatter_minimal_direct_factory.hpp"
+#include "ttnn/device_operation.hpp"
+
+#include <optional>
+#include <variant>
+#include <vector>
+
+namespace ttnn::experimental::prim {
+
+// Device operation for the direct (one-shot) reduce-scatter. Modern device_operation::launch pattern:
+// the primitive is the free function ttnn::prim::reduce_scatter_minimal_direct below.
+struct ReduceScatterMinimalDirectDeviceOperation {
+    using operation_attributes_t = ReduceScatterMinimalDirectParams;
+    using tensor_args_t = ReduceScatterMinimalDirectInputs;
+    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+    using tensor_return_value_t = std::vector<Tensor>;
+    using program_factory_t = std::variant<ReduceScatterMinimalDirectMeshWorkloadFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    // [0] = output slice, [1] = staging for the incoming contributions.
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::experimental::prim
+
+namespace ttnn::prim {
+
+// Primitive entry (registered by definition, via device_operation::launch). Returns [output, staging];
+// the host entry returns index 0.
+std::vector<ttnn::Tensor> reduce_scatter_minimal_direct(
+    const ttnn::Tensor& input_tensor,
+    int32_t dim,
+    const ttnn::MemoryConfig& output_mem_config,
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> num_links,
+    const std::optional<ttnn::Tensor>& persistent_output_tensor,
+    const std::optional<ttnn::Tensor>& persistent_staging_tensor,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
+    const std::optional<CoreRangeSet>& sub_core_grid);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp
@@ -14,8 +14,7 @@
 
 namespace ttnn::experimental::prim {
 
-// Device operation for the direct (one-shot) reduce-scatter. Modern device_operation::launch pattern:
-// the primitive is the free function ttnn::prim::reduce_scatter_minimal_direct below.
+// Device operation for the direct (one-shot) reduce-scatter.
 struct ReduceScatterMinimalDirectDeviceOperation {
     using operation_attributes_t = ReduceScatterMinimalDirectParams;
     using tensor_args_t = ReduceScatterMinimalDirectInputs;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation_types.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <tt_stl/reflection.hpp>
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::experimental::prim {
+
+// Direct (one-shot) reduce-scatter: latency-optimal sibling of reduce_scatter_minimal_unicast.
+//
+// Instead of a store-and-forward ring (N/2 hops, each paying a full read-add-send worker round trip),
+// every device unicasts each destination's slice STRAIGHT to that destination over the fabric
+// (num_hops = ring distance, no intermediate device touches the data), bumps a per-source arrival
+// counter with the send's last packet, and once all N-1 contributions have landed reduces them together
+// with its own slice and writes the output. Fabric traffic is ~2.3x the ring's bandwidth-optimal volume
+// (a distance-h contribution crosses h links), so this is a latency play for small/medium shapes, not a
+// bandwidth play. Inspired by the native all_reduce_async (mcast-then-local-reduce).
+//
+// The program-cache hash auto-reflects over these fields; all are stable/structural.
+struct ReduceScatterMinimalDirectParams {
+    int32_t dim = 0;
+    MemoryConfig output_mem_config;
+    std::optional<uint32_t> cluster_axis;
+
+    // Fabric setup / per-axis geometry (an inactive axis has num_devices = 1, num_links = 0, Linear).
+    tt::tt_fabric::FabricConfig fabric_config{};
+    std::array<tt::tt_fabric::Topology, 2> axis_topology{};
+    std::array<uint32_t, 2> axis_num_devices{};
+    std::array<uint32_t, 2> axis_num_links{};
+    uint32_t num_devices = 0;
+    size_t packet_size = 0;
+    // Resolved number of fabric links. One worker core per link, owning that link's forward AND backward
+    // connection plus a contiguous sub-range of every slice's chunks. The factory clamps it to
+    // chunks_per_slice so no worker is given zero work.
+    uint32_t num_links = 1;
+
+    // Worker-core selection.
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id;
+    std::optional<CoreRangeSet> sub_core_grid;
+};
+
+struct ReduceScatterMinimalDirectInputs {
+    Tensor input_tensor;
+    // Optional caller-provided persistent buffers (reused across invocations to skip re-allocation).
+    // Index convention mirrors create_output_tensors: [0] = output slice, [1] = staging (holds the
+    // incoming contributions, indexed by SOURCE device, double-buffered by invocation parity).
+    std::optional<Tensor> persistent_output_tensor;
+    std::optional<Tensor> persistent_staging_tensor;
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation_types.hpp
@@ -19,14 +19,13 @@
 
 namespace ttnn::experimental::prim {
 
-// Direct (one-shot) reduce-scatter: latency-optimal sibling of reduce_scatter_minimal_unicast.
+// Direct (one-shot) reduce-scatter
 //
 // Instead of a store-and-forward ring (N/2 hops, each paying a full read-add-send worker round trip),
 // every device unicasts each destination's slice STRAIGHT to that destination over the fabric
 // (num_hops = ring distance, no intermediate device touches the data), bumps a per-source arrival
 // counter with the send's last packet, and once all N-1 contributions have landed reduces them together
-// with its own slice and writes the output. Fabric traffic is ~2.3x the ring's bandwidth-optimal volume
-// (a distance-h contribution crosses h links), so this is a latency play for small/medium shapes, not a
+// with its own slice and writes the output. This is a latency play for small/medium shapes, not a
 // bandwidth play. Inspired by the native all_reduce_async (mcast-then-local-reduce).
 //
 // The program-cache hash auto-reflects over these fields; all are stable/structural.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "reduce_scatter_minimal_direct.hpp"
+#include "device/reduce_scatter_minimal_direct_op_device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+
+namespace ttnn::experimental {
+
+ttnn::Tensor reduce_scatter_minimal_direct(
+    const ttnn::Tensor& input_tensor,
+    int32_t dim,
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<std::vector<ttnn::Tensor>>& persistent_buffers,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
+    const std::optional<CoreRangeSet>& sub_core_grid) {
+    std::optional<ttnn::Tensor> persistent_output;
+    std::optional<ttnn::Tensor> persistent_staging;
+    if (persistent_buffers.has_value()) {
+        const auto& b = persistent_buffers.value();
+        TT_FATAL(
+            b.size() == 2,
+            "reduce_scatter_minimal_direct persistent_buffers must be {{output, staging}}, got {}",
+            b.size());
+        persistent_output = b[0];
+        persistent_staging = b[1];
+    }
+
+    auto result = ttnn::prim::reduce_scatter_minimal_direct(
+        input_tensor,
+        dim,
+        memory_config.value_or(input_tensor.memory_config()),
+        cluster_axis,
+        num_links,
+        persistent_output,
+        persistent_staging,
+        sub_device_id,
+        sub_core_grid);
+
+    return result.at(0);
+}
+
+std::vector<ttnn::Tensor> reduce_scatter_minimal_direct_create_persistent_buffers(
+    const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis) {
+    // Route through the device op's own spec computation so a caller-provided buffer set is byte-identical
+    // to what the op would have allocated itself (including the staging L1/DRAM placement decision).
+    auto* device = input_tensor.device();
+    TT_FATAL(device != nullptr, "input tensor must be on device to allocate persistent buffers");
+
+    ttnn::experimental::prim::ReduceScatterMinimalDirectInputs inputs{.input_tensor = input_tensor};
+    const uint32_t rank = input_tensor.logical_shape().rank();
+    const int32_t scatter_dim = (dim < 0) ? static_cast<int32_t>(rank) + dim : dim;
+
+    const uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
+    ttnn::experimental::prim::ReduceScatterMinimalDirectParams params{};
+    params.dim = scatter_dim;
+    params.output_mem_config = input_tensor.memory_config();
+    params.cluster_axis = cluster_axis;
+    params.num_devices = num_devices;
+
+    auto specs =
+        ttnn::experimental::prim::ReduceScatterMinimalDirectDeviceOperation::compute_output_specs(params, inputs);
+    std::vector<ttnn::Tensor> buffers;
+    buffers.reserve(specs.size());
+    for (const auto& spec : specs) {
+        buffers.push_back(create_device_tensor(spec, device));
+    }
+    return buffers;
+}
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
@@ -44,6 +44,62 @@ ttnn::Tensor reduce_scatter_minimal_direct(
     return result.at(0);
 }
 
+bool reduce_scatter_minimal_direct_is_applicable(
+    const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis) {
+    // Each check below is the non-throwing twin of a TT_FATAL in the device op / its geometry helper;
+    // see the header note. Ordered cheapest-first, and every one of them is structural -- nothing here
+    // decides whether direct is worth using.
+    auto* mesh_device = input_tensor.device();
+    if (mesh_device == nullptr || input_tensor.storage_type() != tt::tt_metal::StorageType::DEVICE) {
+        return false;
+    }
+    if (input_tensor.layout() != ttnn::TILE_LAYOUT) {
+        return false;
+    }
+    if (::tt::tt_fabric::is_2d_fabric_config(tt::tt_fabric::GetFabricConfig())) {
+        return false;  // Fabric_1D only
+    }
+
+    const uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
+    if (num_devices < 2) {
+        return false;
+    }
+    // Ring only: a line would need per-destination direction clamping. get_usable_topology demotes a
+    // ring request to linear when the devices along the axis do not actually wrap.
+    if (::ttnn::ccl::get_usable_topology(input_tensor, ttnn::ccl::Topology::Ring, cluster_axis) !=
+        ttnn::ccl::Topology::Ring) {
+        return false;
+    }
+
+    const auto padded_shape = input_tensor.padded_shape();
+    const uint32_t rank = padded_shape.rank();
+    if (rank < 2) {
+        return false;
+    }
+    const int32_t scatter_dim = (dim < 0) ? static_cast<int32_t>(rank) + dim : dim;
+    if (scatter_dim < 0 || scatter_dim >= static_cast<int32_t>(rank)) {
+        return false;
+    }
+    const uint32_t d = static_cast<uint32_t>(scatter_dim);
+
+    // Page-space split, matching reduce_scatter_direct_geometry: the two innermost dims count in tiles.
+    const auto tile = input_tensor.tensor_spec().tile();
+    uint32_t dim_size_pages = padded_shape[d];
+    if (d == rank - 1) {
+        dim_size_pages /= tile.get_width();
+    } else if (d == rank - 2) {
+        dim_size_pages /= tile.get_height();
+        // A tile-padded scatter dim would hand the last device a slice of padding rather than data.
+        if (padded_shape[d] != input_tensor.logical_shape()[d]) {
+            return false;
+        }
+    }
+    if (d == rank - 1 && padded_shape[d] != input_tensor.logical_shape()[d]) {
+        return false;
+    }
+    return dim_size_pages > 0 && dim_size_pages % num_devices == 0;
+}
+
 namespace {
 
 // Both allocators below go through the device op's own compute_output_specs, so a caller-provided

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
@@ -56,18 +56,22 @@ bool reduce_scatter_minimal_direct_is_applicable(
     if (input_tensor.layout() != ttnn::TILE_LAYOUT) {
         return false;
     }
-    if (::tt::tt_fabric::is_2d_fabric_config(tt::tt_fabric::GetFabricConfig())) {
-        return false;  // Fabric_1D only
-    }
-
     const uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
     if (num_devices < 2) {
         return false;
     }
-    // Ring only: a line would need per-destination direction clamping. get_usable_topology demotes a
-    // ring request to linear when the devices along the axis do not actually wrap.
-    if (::ttnn::ccl::get_usable_topology(input_tensor, ttnn::ccl::Topology::Ring, cluster_axis) !=
-        ttnn::ccl::Topology::Ring) {
+    // The axis must WRAP -- ring on a 1D fabric, torus on a 2D one. A line would need per-destination
+    // direction clamping; get_usable_topology reports what the placement actually resolves to, demoting
+    // a non-wrapping axis to linear/mesh.
+    const auto usable_topology = ::ttnn::ccl::get_usable_topology(input_tensor, std::nullopt, cluster_axis);
+    if (!::tt::tt_fabric::is_ring_or_torus(usable_topology)) {
+        return false;
+    }
+    // Same fabric rule the device op enforces (reduce_scatter_direct_fabric_supported): a 2D fabric is
+    // only usable when it collapses to one wrapping line, which needs a 1xN / Nx1 mesh on top of the
+    // torus axis above.
+    if (!prim::reduce_scatter_direct_fabric_supported(
+            *mesh_device, tt::tt_fabric::GetFabricConfig(), usable_topology)) {
         return false;
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
@@ -44,32 +44,50 @@ ttnn::Tensor reduce_scatter_minimal_direct(
     return result.at(0);
 }
 
+namespace {
+
+// Both allocators below go through the device op's own compute_output_specs, so a caller-provided
+// buffer is byte-identical to what the op would have allocated itself -- including the staging
+// L1-sharded / L1-interleaved / DRAM placement decision, which depends on the shape and would be
+// impossible for a caller to reproduce by hand.
+std::vector<ttnn::TensorSpec> reduce_scatter_minimal_direct_buffer_specs(
+    const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis) {
+    ttnn::experimental::prim::ReduceScatterMinimalDirectInputs inputs{.input_tensor = input_tensor};
+    const uint32_t rank = input_tensor.logical_shape().rank();
+
+    ttnn::experimental::prim::ReduceScatterMinimalDirectParams params{};
+    params.dim = (dim < 0) ? static_cast<int32_t>(rank) + dim : dim;
+    params.output_mem_config = input_tensor.memory_config();
+    params.cluster_axis = cluster_axis;
+    params.num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
+
+    return ttnn::experimental::prim::ReduceScatterMinimalDirectDeviceOperation::compute_output_specs(params, inputs);
+}
+
+}  // namespace
+
 std::vector<ttnn::Tensor> reduce_scatter_minimal_direct_create_persistent_buffers(
     const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis) {
-    // Route through the device op's own spec computation so a caller-provided buffer set is byte-identical
-    // to what the op would have allocated itself (including the staging L1/DRAM placement decision).
     auto* device = input_tensor.device();
     TT_FATAL(device != nullptr, "input tensor must be on device to allocate persistent buffers");
 
-    ttnn::experimental::prim::ReduceScatterMinimalDirectInputs inputs{.input_tensor = input_tensor};
-    const uint32_t rank = input_tensor.logical_shape().rank();
-    const int32_t scatter_dim = (dim < 0) ? static_cast<int32_t>(rank) + dim : dim;
-
-    const uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
-    ttnn::experimental::prim::ReduceScatterMinimalDirectParams params{};
-    params.dim = scatter_dim;
-    params.output_mem_config = input_tensor.memory_config();
-    params.cluster_axis = cluster_axis;
-    params.num_devices = num_devices;
-
-    auto specs =
-        ttnn::experimental::prim::ReduceScatterMinimalDirectDeviceOperation::compute_output_specs(params, inputs);
+    auto specs = reduce_scatter_minimal_direct_buffer_specs(input_tensor, dim, cluster_axis);
     std::vector<ttnn::Tensor> buffers;
     buffers.reserve(specs.size());
     for (const auto& spec : specs) {
         buffers.push_back(create_device_tensor(spec, device));
     }
     return buffers;
+}
+
+ttnn::Tensor reduce_scatter_minimal_direct_create_staging_buffer(
+    const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis) {
+    auto* device = input_tensor.device();
+    TT_FATAL(device != nullptr, "input tensor must be on device to allocate the staging buffer");
+
+    // Index 1 is the staging spec, by the same create_output_tensors convention the op uses.
+    auto specs = reduce_scatter_minimal_direct_buffer_specs(input_tensor, dim, cluster_axis);
+    return create_device_tensor(specs.at(1), device);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
@@ -50,7 +50,7 @@ bool reduce_scatter_minimal_direct_is_applicable(
     // see the header note. Ordered cheapest-first, and every one of them is structural -- nothing here
     // decides whether direct is worth using.
     auto* mesh_device = input_tensor.device();
-    if (mesh_device == nullptr || input_tensor.storage_type() != tt::tt_metal::StorageType::DEVICE) {
+    if (mesh_device == nullptr || input_tensor.storage_type() != StorageType::DEVICE) {
         return false;
     }
     if (input_tensor.layout() != ttnn::TILE_LAYOUT) {
@@ -106,7 +106,7 @@ namespace {
 // buffer is byte-identical to what the op would have allocated itself -- including the staging
 // L1-sharded / L1-interleaved / DRAM placement decision, which depends on the shape and would be
 // impossible for a caller to reproduce by hand.
-std::vector<ttnn::TensorSpec> reduce_scatter_minimal_direct_buffer_specs(
+std::vector<tt::tt_metal::TensorSpec> reduce_scatter_minimal_direct_buffer_specs(
     const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis) {
     ttnn::experimental::prim::ReduceScatterMinimalDirectInputs inputs{.input_tensor = input_tensor};
     const uint32_t rank = input_tensor.logical_shape().rank();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
@@ -56,6 +56,14 @@ bool reduce_scatter_minimal_direct_is_applicable(
     if (input_tensor.layout() != ttnn::TILE_LAYOUT) {
         return false;
     }
+    // Twin of the two axis TT_FATALs in build_operation_args: only axes 0 and 1 exist, and an absent
+    // cluster_axis only names a unique ring axis on a line mesh. On a mesh with both extents > 1 an
+    // axis-less call would count devices on both axes while routing on one, so decline it here and let
+    // the caller stay on the ring op.
+    const auto mesh_shape = mesh_device->shape();
+    if (cluster_axis.has_value() ? cluster_axis.value() >= 2 : (mesh_shape[0] > 1 && mesh_shape[1] > 1)) {
+        return false;
+    }
     const uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
     if (num_devices < 2) {
         return false;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
@@ -56,10 +56,7 @@ bool reduce_scatter_minimal_direct_is_applicable(
     if (input_tensor.layout() != ttnn::TILE_LAYOUT) {
         return false;
     }
-    // Twin of the two axis TT_FATALs in build_operation_args: only axes 0 and 1 exist, and an absent
-    // cluster_axis only names a unique ring axis on a line mesh. On a mesh with both extents > 1 an
-    // axis-less call would count devices on both axes while routing on one, so decline it here and let
-    // the caller stay on the ring op.
+    // Twin of the axis TT_FATALs in build_operation_args; declining here keeps callers on the ring op.
     const auto mesh_shape = mesh_device->shape();
     if (cluster_axis.has_value() ? cluster_axis.value() >= 2 : (mesh_shape[0] > 1 && mesh_shape[1] > 1)) {
         return false;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
@@ -69,7 +69,7 @@ bool reduce_scatter_minimal_direct_is_applicable(
         return false;
     }
 
-    const auto padded_shape = input_tensor.padded_shape();
+    const auto& padded_shape = input_tensor.padded_shape();
     const uint32_t rank = padded_shape.rank();
     if (rank < 2) {
         return false;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
@@ -60,16 +60,10 @@ bool reduce_scatter_minimal_direct_is_applicable(
     if (num_devices < 2) {
         return false;
     }
-    // The axis must WRAP -- ring on a 1D fabric, torus on a 2D one. A line would need per-destination
-    // direction clamping; get_usable_topology reports what the placement actually resolves to, demoting
-    // a non-wrapping axis to linear/mesh.
     const auto usable_topology = ::ttnn::ccl::get_usable_topology(input_tensor, std::nullopt, cluster_axis);
     if (!::tt::tt_fabric::is_ring_or_torus(usable_topology)) {
         return false;
     }
-    // Same fabric rule the device op enforces (reduce_scatter_direct_fabric_supported): a 2D fabric is
-    // only usable when it collapses to one wrapping line, which needs a 1xN / Nx1 mesh on top of the
-    // torus axis above.
     if (!prim::reduce_scatter_direct_fabric_supported(
             *mesh_device, tt::tt_fabric::GetFabricConfig(), usable_topology)) {
         return false;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
@@ -38,6 +38,18 @@ ttnn::Tensor reduce_scatter_minimal_direct(
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
     const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
 
+// Whether this op can run a given case AT ALL -- structural constraints only (ring topology, TILE
+// layout, a scatter dim that splits into whole pages, 1D fabric). It says nothing about whether direct
+// is the FASTER choice; that policy lives at the ttnn::reduce_scatter dispatch site, which pairs this
+// with a data-volume gate.
+//
+// Mirrors the op's own validation, which stays authoritative: this predicate exists so a dispatcher can
+// ask without risking a TT_FATAL, so anything it lets through must also pass
+// ReduceScatterMinimalDirectDeviceOperation::validate_on_program_cache_miss and
+// reduce_scatter_direct_geometry. Keep the two in sync.
+bool reduce_scatter_minimal_direct_is_applicable(
+    const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis = std::nullopt);
+
 // Allocate the persistent buffer set {output, staging} sized to match a given input.
 std::vector<ttnn::Tensor> reduce_scatter_minimal_direct_create_persistent_buffers(
     const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
@@ -42,4 +42,14 @@ ttnn::Tensor reduce_scatter_minimal_direct(
 std::vector<ttnn::Tensor> reduce_scatter_minimal_direct_create_persistent_buffers(
     const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis = std::nullopt);
 
+// Allocate ONLY the staging buffer (element [1] of the set above), for callers that own their output
+// tensor already and just want the op's staging half. The output is an ordinary tiled tensor a caller
+// can build directly (the input shape with `dim` divided by the ring size); staging is the part that
+// cannot be reproduced by hand -- it is an opaque chunk-paged UINT8 tensor whose page size follows the
+// op's chunk granularity and whose placement (L1 height-sharded over the whole compute grid / L1
+// interleaved / DRAM) is chosen from the shape. Pass the result through as
+// persistent_buffers = {your_output, this}. `dim` and `cluster_axis` must match the op call.
+ttnn::Tensor reduce_scatter_minimal_direct_create_staging_buffer(
+    const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis = std::nullopt);
+
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+#include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+
+namespace ttnn::experimental {
+
+// Direct (one-shot) reduce-scatter: latency-optimal sibling of reduce_scatter_minimal_unicast.
+//
+// Every device unicasts each destination's slice straight to that destination (multi-hop fabric unicast,
+// no intermediate device touches the data), increments a per-source arrival counter with the send's last
+// packet, and once all N-1 contributions have landed reduces them with its own slice into the output. One
+// fabric traversal instead of the ring's N/2 store-and-forward steps, at ~2.3x the link traffic -- a
+// latency play for small/medium shapes, not a bandwidth play.
+//
+// Minimal-first: Ring, TILE layout, scatter dim == last dim and divisible by the ring size, one worker
+// core per link (which owns that link's forward and backward connection), no mux.
+//
+// persistent_buffers, when provided, must be exactly {output, staging} as produced by
+// reduce_scatter_minimal_direct_create_persistent_buffers.
+ttnn::Tensor reduce_scatter_minimal_direct(
+    const ttnn::Tensor& input_tensor,
+    int32_t dim,
+    std::optional<uint32_t> cluster_axis = std::nullopt,
+    std::optional<uint32_t> num_links = std::nullopt,
+    const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<std::vector<ttnn::Tensor>>& persistent_buffers = std::nullopt,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+
+// Allocate the persistent buffer set {output, staging} sized to match a given input.
+std::vector<ttnn::Tensor> reduce_scatter_minimal_direct_create_persistent_buffers(
+    const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis = std::nullopt);
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
@@ -22,8 +22,9 @@ namespace ttnn::experimental {
 // fabric traversal instead of the ring's N/2 store-and-forward steps, at ~2.3x the link traffic -- a
 // latency play for small/medium shapes, not a bandwidth play.
 //
-// Minimal-first: Ring, TILE layout, any scatter dim (divisible by the ring size in tile/page units), one
-// worker core per link (which owns that link's forward and backward connection), no mux.
+// Minimal-first: Ring, TILE layout, any rank >= 2 and any scatter dim (divisible by the ring size in
+// tile/page units), one worker core per link (which owns that link's forward and backward connection),
+// no mux.
 //
 // persistent_buffers, when provided, must be exactly {output, staging} as produced by
 // reduce_scatter_minimal_direct_create_persistent_buffers.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
@@ -22,8 +22,8 @@ namespace ttnn::experimental {
 // fabric traversal instead of the ring's N/2 store-and-forward steps, at ~2.3x the link traffic -- a
 // latency play for small/medium shapes, not a bandwidth play.
 //
-// Minimal-first: Ring, TILE layout, scatter dim == last dim and divisible by the ring size, one worker
-// core per link (which owns that link's forward and backward connection), no mux.
+// Minimal-first: Ring, TILE layout, any scatter dim (divisible by the ring size in tile/page units), one
+// worker core per link (which owns that link's forward and backward connection), no mux.
 //
 // persistent_buffers, when provided, must be exactly {output, staging} as produced by
 // reduce_scatter_minimal_direct_create_persistent_buffers.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
@@ -28,8 +28,9 @@ ttnn::Tensor reduce_scatter_minimal_direct(
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
     const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
 
-// Whether this op can run a given case AT ALL -- structural constraints only (ring topology, TILE
-// layout, a scatter dim that splits into whole pages, 1D fabric).
+// Whether this op can run a given case AT ALL -- structural constraints only (TILE layout, a scatter dim
+// that splits into whole pages, and a single WRAPPING axis: a Ring on a 1D fabric or a Torus axis on a 2D
+// one. On a mesh with both extents > 1 the wrapping axis must be named explicitly via cluster_axis).
 bool reduce_scatter_minimal_direct_is_applicable(
     const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
@@ -14,17 +14,7 @@
 
 namespace ttnn::experimental {
 
-// Direct (one-shot) reduce-scatter: latency-optimal sibling of reduce_scatter_minimal_unicast.
-//
-// Every device unicasts each destination's slice straight to that destination (multi-hop fabric unicast,
-// no intermediate device touches the data), increments a per-source arrival counter with the send's last
-// packet, and once all N-1 contributions have landed reduces them with its own slice into the output. One
-// fabric traversal instead of the ring's N/2 store-and-forward steps, at ~2.3x the link traffic -- a
-// latency play for small/medium shapes, not a bandwidth play.
-//
-// Minimal-first: Ring, TILE layout, any rank >= 2 and any scatter dim (divisible by the ring size in
-// tile/page units), one worker core per link (which owns that link's forward and backward connection),
-// no mux.
+// Direct (one-shot) reduce-scatter: good for latency bound, small shapes.
 //
 // persistent_buffers, when provided, must be exactly {output, staging} as produced by
 // reduce_scatter_minimal_direct_create_persistent_buffers.
@@ -39,14 +29,7 @@ ttnn::Tensor reduce_scatter_minimal_direct(
     const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
 
 // Whether this op can run a given case AT ALL -- structural constraints only (ring topology, TILE
-// layout, a scatter dim that splits into whole pages, 1D fabric). It says nothing about whether direct
-// is the FASTER choice; that policy lives at the ttnn::reduce_scatter dispatch site, which pairs this
-// with a data-volume gate.
-//
-// Mirrors the op's own validation, which stays authoritative: this predicate exists so a dispatcher can
-// ask without risking a TT_FATAL, so anything it lets through must also pass
-// ReduceScatterMinimalDirectDeviceOperation::validate_on_program_cache_miss and
-// reduce_scatter_direct_geometry. Keep the two in sync.
+// layout, a scatter dim that splits into whole pages, 1D fabric).
 bool reduce_scatter_minimal_direct_is_applicable(
     const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis = std::nullopt);
 
@@ -55,8 +38,7 @@ std::vector<ttnn::Tensor> reduce_scatter_minimal_direct_create_persistent_buffer
     const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis = std::nullopt);
 
 // Allocate ONLY the staging buffer (element [1] of the set above), for callers that own their output
-// tensor already and just want the op's staging half. The output is an ordinary tiled tensor a caller
-// can build directly (the input shape with `dim` divided by the ring size); staging is the part that
+// tensor already and just want the op's staging half. staging is the part that
 // cannot be reproduced by hand -- it is an opaque chunk-paged UINT8 tensor whose page size follows the
 // op's chunk granularity and whose placement (L1 height-sharded over the whole compute grid / L1
 // interleaved / DRAM) is chosen from the shape. Pass the result through as

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "reduce_scatter_minimal_direct_nanobind.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/vector.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+void bind_reduce_scatter_minimal_direct(nb::module_& mod) {
+    ttnn::bind_function<"reduce_scatter_minimal_direct", "ttnn.experimental.">(
+        mod,
+        R"doc(
+        Experimental direct (one-shot) reduce-scatter across a 1D ring of devices.
+
+        Every device unicasts each destination's slice straight to that destination over the fabric (a
+        multi-hop unicast; no intermediate device stages or accumulates it), then reduces the arrivals
+        with its own slice. One fabric traversal instead of the ring's N/2 store-and-forward steps, at
+        ~2.3x the link traffic: a latency play for small/medium shapes.
+
+        Args:
+            input_tensor (ttnn.Tensor): multi-device tensor.
+            dim (int): Dimension to scatter (must be the last dim).
+
+        Keyword Args:
+            cluster_axis (int, optional): mesh axis to run the collective on. Defaults to the active axis.
+            num_links (int, optional): fabric links to spread the collective over; one worker core per
+                link, each owning that link's forward and backward connection plus a contiguous
+                sub-range of every slice's chunks. Defaults to every link available on the active axis.
+            memory_config (ttnn.MemoryConfig, optional): output memory config. Defaults to input's.
+            persistent_buffers (List[ttnn.Tensor], optional): {output, staging} from
+                reduce_scatter_minimal_direct_create_persistent_buffers, reused to skip re-allocation.
+            subdevice_id (ttnn.SubDeviceId, optional).
+            sub_core_grid (ttnn.CoreRangeSet, optional).
+
+        Returns:
+            ttnn.Tensor: the reduced output slice for this device.
+        )doc",
+        &ttnn::experimental::reduce_scatter_minimal_direct,
+        nb::arg("input_tensor"),
+        nb::arg("dim"),
+        nb::kw_only(),
+        nb::arg("cluster_axis") = nb::none(),
+        nb::arg("num_links") = nb::none(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("persistent_buffers") = nb::none(),
+        nb::arg("subdevice_id") = nb::none(),
+        nb::arg("sub_core_grid") = nb::none());
+
+    ttnn::bind_function<"reduce_scatter_minimal_direct_create_persistent_buffers", "ttnn.experimental.">(
+        mod,
+        R"doc(
+        Allocate the persistent buffer set {output, staging} sized to a given input, for reuse across
+        reduce_scatter_minimal_direct invocations. `dim` and `cluster_axis` must match those passed to
+        the op.
+
+        Returns:
+            List[ttnn.Tensor]: [output, staging] on the input tensor's device.
+        )doc",
+        &ttnn::experimental::reduce_scatter_minimal_direct_create_persistent_buffers,
+        nb::arg("input_tensor"),
+        nb::arg("dim"),
+        nb::kw_only(),
+        nb::arg("cluster_axis") = nb::none());
+}
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.cpp
@@ -29,7 +29,7 @@ void bind_reduce_scatter_minimal_direct(nb::module_& mod) {
         ~2.3x the link traffic: a latency play for small/medium shapes.
 
         Args:
-            input_tensor (ttnn.Tensor): multi-device tensor.
+            input_tensor (ttnn.Tensor): multi-device tensor, TILE layout, any rank >= 2.
             dim (int): Dimension to scatter. Any dim, provided it splits into `num_devices` whole
                 slices in tile/page units (the two innermost dims are counted in tiles).
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.cpp
@@ -73,6 +73,30 @@ void bind_reduce_scatter_minimal_direct(nb::module_& mod) {
         nb::arg("dim"),
         nb::kw_only(),
         nb::arg("cluster_axis") = nb::none());
+
+    ttnn::bind_function<"reduce_scatter_minimal_direct_create_staging_buffer", "ttnn.experimental.">(
+        mod,
+        R"doc(
+        Allocate just the staging buffer for reduce_scatter_minimal_direct, for callers that already own
+        their output tensor.
+
+        The output is an ordinary tiled tensor a caller can build directly (the input shape with `dim`
+        divided by the ring size). The staging buffer is the part that cannot be reproduced by hand: an
+        opaque chunk-paged UINT8 tensor whose page size follows the op's internal chunk granularity and
+        whose placement (L1 height-sharded across the whole compute grid, L1 interleaved, or DRAM) is
+        chosen from the shape. This helper reuses the op's own sizing, so the result is guaranteed to
+        match. Pass it through as persistent_buffers = [your_output, result]. Equivalent to element 1 of
+        reduce_scatter_minimal_direct_create_persistent_buffers, without allocating an output you would
+        throw away. `dim` and `cluster_axis` must match those passed to the op.
+
+        Returns:
+            ttnn.Tensor: the staging buffer, allocated on the input tensor's device.
+        )doc",
+        &ttnn::experimental::reduce_scatter_minimal_direct_create_staging_buffer,
+        nb::arg("input_tensor"),
+        nb::arg("dim"),
+        nb::kw_only(),
+        nb::arg("cluster_axis") = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.cpp
@@ -30,7 +30,8 @@ void bind_reduce_scatter_minimal_direct(nb::module_& mod) {
 
         Args:
             input_tensor (ttnn.Tensor): multi-device tensor.
-            dim (int): Dimension to scatter (must be the last dim).
+            dim (int): Dimension to scatter. Any dim, provided it splits into `num_devices` whole
+                slices in tile/page units (the two innermost dims are counted in tiles).
 
         Keyword Args:
             cluster_axis (int, optional): mesh axis to run the collective on. Defaults to the active axis.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.cpp
@@ -21,7 +21,10 @@ void bind_reduce_scatter_minimal_direct(nb::module_& mod) {
     ttnn::bind_function<"reduce_scatter_minimal_direct", "ttnn.experimental.">(
         mod,
         R"doc(
-        Experimental direct (one-shot) reduce-scatter across a 1D ring of devices.
+        Experimental direct (one-shot) reduce-scatter along a wrapping axis of devices: a Ring on a 1D
+        fabric, or a Torus axis on a 2D fabric. On a mesh with both extents greater than one, name the
+        wrapping axis explicitly with ``cluster_axis`` -- there is no implied axis and the op will reject
+        the call.
 
         Every device unicasts each destination's slice straight to that destination over the fabric (a
         multi-hop unicast; no intermediate device stages or accumulates it), then reduces the arrivals

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.hpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
+namespace ttnn::operations::experimental::ccl {
+
+void bind_reduce_scatter_minimal_direct(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/sources.cmake
@@ -57,6 +57,9 @@ set(TTNN_OP_EXPERIMENTAL_CCL_SRCS
     reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
     reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.cpp
     reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+    reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.cpp
+    reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.cpp
+    reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.cpp
     send_recv_async/send_async/send_async.cpp
     send_recv_async/send_async/device/send_async_op_device_operation.cpp
     send_recv_async/send_async/device/send_async_op_program_factory.cpp
@@ -111,6 +114,10 @@ set(TTNN_OP_EXPERIMENTAL_CCL_API_HEADERS
     reduce_scatter_minimal_async/device/reduce_scatter_ring_program_factory.hpp
     reduce_scatter_minimal_async/device/reduce_scatter_line_program_factory.hpp
     reduce_scatter_minimal_async/reduce_scatter_minimal_async.hpp
+    reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation.hpp
+    reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_op_device_operation_types.hpp
+    reduce_scatter_minimal_direct/device/reduce_scatter_minimal_direct_factory.hpp
+    reduce_scatter_minimal_direct/reduce_scatter_minimal_direct.hpp
 )
 
 # Registered on the shared `ttnn` Python module target from
@@ -133,6 +140,7 @@ set(TTNN_OP_EXPERIMENTAL_CCL_NANOBIND_SRCS
     all_to_all_async/all_to_all_async_nanobind.cpp
     all_to_all_async_generic/all_to_all_async_generic_nanobind.cpp
     reduce_scatter_minimal_async/reduce_scatter_minimal_async_nanobind.cpp
+    reduce_scatter_minimal_direct/reduce_scatter_minimal_direct_nanobind.cpp
     strided_reduce_scatter_async/strided_reduce_scatter_async_nanobind.cpp
     minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_nanobind.cpp
     all_gather_matmul_async/all_gather_matmul_async_nanobind.cpp


### PR DESCRIPTION
 Adds an experimental CCL op, reduce_scatter_minimal_direct, and auto-dispatches to it from ttnn.reduce_scatter for small shapes. No API change; purely additive.
  
  Instead of the ring's N/2 store-and-forward relay steps, each device unicasts every destination's slice straight to that destination — one fabric traversal, one turnaround instead of N/2+1. That trades a constant latency saving against ~2.3× the link traffic at N=8 (a distance-h contribution crosses h links), so it wins while the collective is fill-latency-bound and loses once it is bandwidth-bound. Fully general on ND-shape, reduction dimension, memory_config but does require TILE_LAYOUT.
  
  **Dispatch**
  
  ttnn::reduce_scatter routes to the direct op only when all hold, else falls through to the existing ring op unchanged:
  
  - topology is Ring or Torus (the axis must wrap)
  - TILE layout, rank ≥ 2, whole-page split on the scatter dim
  - no explicit chunks_per_sync / num_workers_per_link / num_buffers_per_channel / compute_kernel_config  passing any of these keeps you on the ring op rather than  silently dropping it
  - per-device input ≤ 512 KB

  **Tests**
  New suites for T3000 and TG (test_reduce_scatter_minimal_direct.py) plus Blackhole variants.

  
<img width="2673" height="1193" alt="rs_utilization" src="https://github.com/user-attachments/assets/fbe7bfbd-bd24-42e6-903b-a51bfff9b6f9" />


**Notes:**
we are doing a somewhat unusual double-buffering scheme for the staging buffer that allows Op executions to be interleaved, eg op call 0 uses buffer half 0, op call 1 uses buffer 1, op call 3 uses buffer 0 etc... This allows us to execute barrier free. There is a dedicated semaphore to track invocation, and no zero-ing out of semaphores at the end of the op. This scheme is unusual but seems to work. 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/experimental-direct-rs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/experimental-direct-rs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/experimental-direct-rs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/experimental-direct-rs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amorrison/experimental-direct-rs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amorrison/experimental-direct-rs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/experimental-direct-rs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/experimental-direct-rs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/experimental-direct-rs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/experimental-direct-rs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/experimental-direct-rs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/experimental-direct-rs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/experimental-direct-rs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/experimental-direct-rs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/experimental-direct-rs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/experimental-direct-rs)
## Validation

### CI — dispatch reachability

We  added a temporary warning when `ttnn.reduce_scatter` selects the direct op, which made reachability measurable rather than inferred. Across the completed jobs of run [31187690448](https://github.com/tenstorrent/tt-metal/actions/runs/31187690448), **4 jobs dispatch and all 4 pass**:

| Job | N | per-device bytes | dtype | shape / dim | site |
|---|---|---|---|---|---|
| Qwen3-32B unit (Galaxy) x6 | 4, 8 | 170 KB, **425 KB** | bf8 | `[1,1,128,1280]`, `[1,1,128,3200]` dim 3 | `llama_ccl.py` |
| GPT-OSS 120B e2e [wh_galaxy_perf] | 4 | 32 KB | bf16 | `[128,128]` dim 0 | `experts/prefill.py` routing_weights |
| GPT-OSS 20B e2e [bh_quietbox_2] | 4 | 383 KB | bf8 | `[1,1,128,2880]` dim 2 | `experts/prefill.py` hidden_states |
| GPT-OSS 120B e2e [bh_quietbox_2] | 4 | 383 KB | bf8 | `[1,1,128,2880]` dim 2 | same |

Everything else measured **0 dispatches**, for three distinct reasons: Gemma-4 passes `Topology.Linear` explicitly; `tt_dit`/Flux calls `reduce_scatter_minimal_async` directly and never reaches the gate; and GPT-OSS's `hidden_size = 2880` (90 tiles) blocks most of its call sites on scatter-dim divisibility. The blast radius is narrower than a call-site survey suggests — 2 models, not 9.

### Failure triage — 9 failures, none attributable to this change

All 9 have 0 direct dispatches, i.e. the direct op did not execute in any of them.

| Job | Cause |
|---|---|
| Gemma-4-12B e2e [bh_quietbox_2] | PCC `0.9378978280024141` — bit-identical on both main baselines |
| Llama 3.3-70B e2e (Galaxy) | golden divergence at char 155; same job on main 08-04 fails worse (top-1 7.0% vs >=94.5%) |
| Qwen3-32B e2e (Galaxy) | box presented a 2x2 mesh, needs 8x4 -> `requested_size <= system_size` |
| GPT-OSS 120B unit [wh_galaxy] | same mesh-shape TT_FATAL |
| Llama 3.1-8B DP (Galaxy) | HuggingFace unreachable, cache missing |
| Llama 3.1-8B DP [bh_quietbox_2] | perf gate fails for being **better** than target (TTFT 0.01415 vs lower bound 0.01615; decode 149 t/s vs 83.5 target) — stale targets. DP-4 on 4 chips gives single-device submeshes, so there is no CCL in the timed path |
| Flux.1 schnell [bh_quietbox_2] | job timeout |
| TT-DiT common unit [bh_quietbox_2] | job timeout; also timed out on main 07-27 |
| Wan2.2-I2V-A14B unit [wh_galaxy] | VBench quality gate |

For context, `bh_quietbox_2` was unhealthy in an earlier run of this branch ([31045856024](https://github.com/tenstorrent/tt-metal/actions/runs/31045856024)); four of its failures there — GPT-OSS 20B e2e, Qwen2.5-32B e2e, Qwen3.6-27B e2e and the Llama DP perf gate — all pass or reverse on healthy hardware in this run.
