### PR TITLE
#51744: Fix Quasar data-movement builds using common memmove helpers

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -99,6 +99,21 @@ FORCE_INLINE noc_traits_t<UnicastEndpoint>::dst_args_type self_l1_dst_args(Noc n
 // (WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). When the copy is not deferred (!copy_async), drain
 // the last written word (blocking load + memory clobber) so the copy is processed before the caller
 // publishes / NoC-reads the destination -- the counterpart of the NoC path's completion barrier.
+//
+// TODO(ARCH_QUASAR): this CPU-copy fallback is NOT fully cache-coherent on Quasar. Quasar's data path is
+// Core -> L1 D$ -> L2 -> TL1, and invalidate_l1_cache() is a no-op there (risc_common.h), so:
+//   (a) SOURCE read: if the source was just NoC-written into a reused CB, the RISC's cached line can be
+//       stale; a correct read needs invalidate_l2_cache_range(src, bytes) before the memmove.
+//   (b) DEST publish: the CPU stores land in L1 D$/L2, not TL1. The drain below only reads back the dirty
+//       L1D line (a LOCAL ordering barrier) -- unlike WH/BH load_blocking it does NOT publish to TL1, so a
+//       later NoC / other-agent read of the destination can see stale data. A correct publish needs
+//       flush_l2_cache_range(dst, bytes) after the memmove; the copy_async=true path skips even the drain.
+// This is a PRE-EXISTING gap that was previously unreachable on Quasar (this header didn't compile for
+// Quasar DM); it is a fallback path (tt_memmove only calls it on overlapping self-copy or the misaligned
+// fallback), it is off the resnet critical path, and it does not manifest on the emulator (flat memory,
+// no cache hierarchy modeled). Deferred to a follow-up (needs HW validation), tracked in issue #51763;
+// the flush/invalidate primitives + the ARCH_QUASAR&&COMPILE_FOR_DM pattern already exist (see the #50329
+// tilize-padding fix).
 template <bool copy_async>
 FORCE_INLINE void copy_via_memmove(const uint32_t dst_l1_addr, const uint32_t src_l1_addr, const uint32_t bytes) {
     invalidate_l1_cache();
@@ -113,7 +128,10 @@ FORCE_INLINE void copy_via_memmove(const uint32_t dst_l1_addr, const uint32_t sr
             volatile tt_l1_ptr uint32_t* drain_ptr =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>((dst_l1_addr + bytes - 1) & ~uint32_t{3});
 #if defined(ARCH_QUASAR)
-            (void)*drain_ptr;  // Quasar has no ckernel::load_blocking; a volatile load is a blocking read.
+            // Quasar has no ckernel::load_blocking. This volatile load is a LOCAL ordering barrier only
+            // (reads back the dirty L1D line); it does NOT flush L2->TL1 for cross-agent visibility -- see
+            // the TODO(ARCH_QUASAR) coherency note above.
+            (void)*drain_ptr;
 #else
             (void)ckernel::load_blocking(drain_ptr);
 #endif

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -15,7 +15,14 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
-#include "ckernel.h"  // ckernel::load_blocking (store-drain in copy_via_memmove)
+#if !defined(ARCH_QUASAR)
+// ckernel::load_blocking (store-drain in copy_via_memmove) — WH/BH only. On Quasar this header is
+// unusable from a data-movement (DM) build: ckernel.h -> ckernel_addrmod.h -> ckernel_trisc_id.h #errors
+// unless COMPILE_FOR_TRISC is defined, and Quasar's ckernel.h has no load_blocking. The Quasar drain
+// below uses a plain volatile load instead, so ckernel.h is not needed here on Quasar. (tt_l1_ptr comes
+// from risc_attribs.h, not ckernel.h, so guarding this include does not lose it.)
+#include "ckernel.h"
+#endif
 
 constexpr uint64_t ALIGN_REQ_64 = 64;
 constexpr uint64_t MASK_64 = 0xFFFFFFFFFFFFFFC0;
@@ -95,13 +102,21 @@ FORCE_INLINE noc_traits_t<UnicastEndpoint>::dst_args_type self_l1_dst_args(Noc n
 template <bool copy_async>
 FORCE_INLINE void copy_via_memmove(const uint32_t dst_l1_addr, const uint32_t src_l1_addr, const uint32_t bytes) {
     invalidate_l1_cache();
-    memmove((void*)(dst_l1_addr), (void*)(src_l1_addr), (size_t)(bytes));
+    // Cast the L1 address (uint32_t) to a pointer through uintptr_t: a bare (void*)(uint32_t) is an
+    // int-to-pointer cast that -Werror=int-to-pointer-cast rejects on Quasar (64-bit pointers). uintptr_t
+    // is the correct width on every arch, so this is a no-op change for WH/BH.
+    memmove((void*)(uintptr_t)(dst_l1_addr), (void*)(uintptr_t)(src_l1_addr), (size_t)(bytes));
     if constexpr (!copy_async) {
         if (bytes != 0) {
             // Drain the 4B-aligned word holding the last written byte: in-bounds and aligned for any
             // size/alignment (dst may be sub-word-aligned on the misaligned path).
-            (void)ckernel::load_blocking(
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>((dst_l1_addr + bytes - 1) & ~uint32_t{3}));
+            volatile tt_l1_ptr uint32_t* drain_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>((dst_l1_addr + bytes - 1) & ~uint32_t{3});
+#if defined(ARCH_QUASAR)
+            (void)*drain_ptr;  // Quasar has no ckernel::load_blocking; a volatile load is a blocking read.
+#else
+            (void)ckernel::load_blocking(drain_ptr);
+#endif
         }
     }
 }


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #51744 

  ttnn/.../data_movement/common/kernels/common.hpp is a shared kernel header included by ~20+ data-movement (DM-thread) kernels. It
  currently fails to compile on Quasar DM builds (COMPILE_FOR_DM), which blocks every Quasar op whose reader/writer includes it            (transpose, reshape, fold, slice, tilize, padded_slice, slice_write, …). This makes the header Quasar-DM-safe, with no change to
  Wormhole/Blackhole behavior. 
  
  Problem
  
  copy_via_memmove() was updated to use ckernel::load_blocking() as a store-drain, which pulled in three WH/BH-only assumptions that
  break on Quasar DM:                                  
                                                                                                                                           1. #include "ckernel.h" — on Quasar, ckernel.h → ckernel_addrmod.h → ckernel_trisc_id.h #errors unless COMPILE_FOR_TRISC is defined,
  which it is not in a DM build.
  2. ckernel::load_blocking does not exist on Quasar (WH-only).
  3. memmove((void*)(dst_l1_addr), …) — a bare (void*)(uint32_t) cast trips -Werror=int-to-pointer-cast on Quasar (64-bit pointers).       WH/BH (32-bit) don't warn.                                                                      
  
  Symptom:
  dm3 build failed ... #error "COMPILE_FOR_TRISC must be defined ..."
  'load_blocking' is not a member of 'ckernel'
  cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
  
  Fix
  
  - Guard #include "ckernel.h" with #if !defined(ARCH_QUASAR). tt_l1_ptr comes from risc_attribs.h (not ckernel.h), so guarding the
  include loses nothing on Quasar.
  - Cast the memmove L1 addresses through uintptr_t ((void*)(uintptr_t)(...)) — correct width on every arch, a no-op for WH/BH.
  - Guard the store-drain: WH/BH keep ckernel::load_blocking(drain_ptr); Quasar uses an equivalent plain volatile load (void)*drain_ptr
  (a blocking read achieving the same store-visibility drain). 

  Why WH/BH are unaffected
  
  On non-Quasar builds ARCH_QUASAR is undefined, so the ckernel.h include and the ckernel::load_blocking drain are compiled exactly as
  before; the only universal change is the uintptr_t cast, which is a no-op on 32-bit targets.
  
  Notes 
  
  This is a shared-header compatibility fix, not a Quasar-only workaround — it corrects a DM-common header hard-depending on a
  compute-only header (ckernel.h) that is unavailable on Quasar DM. Any Quasar DM kernel including common.hpp was affected.
 
Tested locally that
```
TT_METAL_WATCHER_DISABLE_NOC_SANITIZE=1 TT_METAL_WATCHER=10 TTNN_CONFIG_OVERRIDES='{"enable_fast_runtime_mode": false, "enable_logging": true}' pytest -q models/demos/vision/classification/resnet50/quasar/tests/ops/test_reshape_tiled.py
```
fails with compiler error without this change and passes with this change.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-51744_qsr_common)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-51744_qsr_common)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-51744_qsr_common)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-51744_qsr_common)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=bbradel-51744_qsr_common)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:bbradel-51744_qsr_common)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-51744_qsr_common)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-51744_qsr_common)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-51744_qsr_common)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-51744_qsr_common)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-51744_qsr_common)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-51744_qsr_common)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-51744_qsr_common)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-51744_qsr_common)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-51744_qsr_common)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-51744_qsr_common)