### PR TITLE
[Cleanup] Fix offset pointers in I2S and S2I

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -30,13 +30,21 @@ void kernel_main() {
     DataflowBuffer dfb_in0(dfb_id_in0);
     DataflowBuffer dfb_in1(cb_id_in1);
 
-    const auto s0 = TensorAccessor(src_args, src_addr + aligned_input_width_offset_bytes);
+    // The accessor base must stay the unshifted buffer base: Metal 2.0 supplies it from the tensor
+    // binding and offers no seam for a pre-offset base. The per-core column shift rides each read
+    // as a source `offset_bytes` instead, which resolves to the same NoC address.
+    const auto s0 = TensorAccessor(src_args, src_addr);
     uint32_t stick_id = start_id;
     dfb_in0.reserve_back(block_height);
     if (aligned) {
         uint32_t dest_off = 0;
         for (uint32_t h = 0; h < block_height; ++h) {
-            noc.async_read(s0, dfb_in0, block_width_bytes, {.page_id = stick_id}, {.offset_bytes = dest_off});
+            noc.async_read(
+                s0,
+                dfb_in0,
+                block_width_bytes,
+                {.page_id = stick_id, .offset_bytes = aligned_input_width_offset_bytes},
+                {.offset_bytes = dest_off});
             stick_id++;
             dest_off += padded_block_width_bytes;
         }
@@ -84,7 +92,7 @@ void kernel_main() {
                         s0,
                         dfb_in1,
                         aligned_block_width_bytes,
-                        {.page_id = stick_id},
+                        {.page_id = stick_id, .offset_bytes = aligned_input_width_offset_bytes},
                         {.offset_bytes = scratch_offsets[slot]},
                         NocOptVals{.trid = static_cast<uint8_t>(active_trid)});
                     dest_offsets[slot] = dest_off;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -19,7 +19,10 @@ void kernel_main() {
     constexpr uint32_t dfb_id_out0 = get_compile_time_arg_val(0);
     constexpr auto dst_args = TensorAccessorArgs<1>();
 
-    const auto s0 = TensorAccessor(dst_args, dst_addr + input_width_offset_bytes);
+    // The accessor base must stay the unshifted buffer base: Metal 2.0 supplies it from the tensor
+    // binding and offers no seam for a pre-offset base. The per-core column shift rides each write
+    // as a destination `offset_bytes` instead, which resolves to the same NoC address.
+    const auto s0 = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
     DataflowBuffer dfb_out(dfb_id_out0);
@@ -29,7 +32,11 @@ void kernel_main() {
     uint32_t cb_read_offset = 0;
     for (uint32_t h = 0; h < block_height; ++h) {
         noc.async_write(
-            dfb_out, s0, block_width_bytes, {.offset_bytes = cb_read_offset}, {.page_id = stick_id, .offset_bytes = 0});
+            dfb_out,
+            s0,
+            block_width_bytes,
+            {.offset_bytes = cb_read_offset},
+            {.page_id = stick_id, .offset_bytes = input_width_offset_bytes});
         stick_id++;
         cb_read_offset += padded_block_width_bytes;
     }


### PR DESCRIPTION
### Summary
These ops use offset base pointers (i.e. setting base address to be base+offset), instead of keeping the actual base address and using the offset parameter. This blocks Metal 2.0 porting.

This PR changes them to simply always use the base address untouched, and supply the extra offset in separately. No changes are expected.

CI runs are pending
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/S2I_OffsetPointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/S2I_OffsetPointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/S2I_OffsetPointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/S2I_OffsetPointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=edwinlee/S2I_OffsetPointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:edwinlee/S2I_OffsetPointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/S2I_OffsetPointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/S2I_OffsetPointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/S2I_OffsetPointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/S2I_OffsetPointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/S2I_OffsetPointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/S2I_OffsetPointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/S2I_OffsetPointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/S2I_OffsetPointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/S2I_OffsetPointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/S2I_OffsetPointer)