### PR TITLE
test-dispatch: add opt-in reuse-build-run-id input

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -1,5 +1,6 @@
 name: "Build tt-metal artifacts"
 permissions:
+  actions: read
   contents: read
   packages: write
 on:

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -69,6 +69,7 @@ jobs:
     needs: check-harbor
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
+      actions: read
       contents: read
       packages: write
     secrets: inherit

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -53,6 +53,11 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      reuse-build-run-id:
+        required: false
+        type: string
+        default: ""
+        description: "Workflow run ID to reuse the build artifact from (skips the build)"
 
 run-name: ${{ inputs.description }}
 jobs:
@@ -75,6 +80,7 @@ jobs:
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       build-type: ${{ inputs.build-type || 'Release' }}
       enable-lto: ${{ inputs.enable-lto || false }}
+      use-artifacts-from-run: ${{ inputs.reuse-build-run-id }}
   test-dispatch:
     needs: [check-harbor, build-artifact]
     timeout-minutes: 120


### PR DESCRIPTION
## Summary
- Adds an opt-in `reuse-build-run-id` input to `test-dispatch.yaml`, threaded straight through to `build-artifact.yaml`'s existing `use-artifacts-from-run` input.
- Default is empty, matching today's behavior exactly — every existing caller of this workflow is unaffected.

## Why
`tt-dm-codegen`'s cross-arch verification dispatches `test-dispatch.yaml` once per arch after a port ships. It's adding an automatic follow-up "retest" dispatch for cases that miss wall-clock parity in CI but where device time is fine (the common false-positive shape seen on tt-metal#49888 and tt-metal#50700) — re-measuring just the flagged cases across a handful of fresh-process windows to separate a real regression from host-side CI noise.

That retest only needs the exact same build the primary dispatch already produced (it doesn't touch anything binary-affecting — same commit, same tracy setting), so paying for a full rebuild a second time is pure waste. `build-artifact.yaml` already supports skipping the build via `use-artifacts-from-run`; `test-dispatch.yaml` just never exposed it. This PR only adds that pass-through.

## Test plan
- [ ] YAML validated (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test-dispatch.yaml'))"`)
- [ ] Manually dispatch `test-dispatch.yaml` with `reuse-build-run-id` pointing at a recent successful run and confirm the `build-artifact` job is skipped in favor of `download-artifacts`
- [ ] Manually dispatch `test-dispatch.yaml` with `reuse-build-run-id` left empty (default) and confirm behavior is unchanged from before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ebanerjee/test-dispatch-reuse-build-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ebanerjee/test-dispatch-reuse-build-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ebanerjee/test-dispatch-reuse-build-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ebanerjee/test-dispatch-reuse-build-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ebanerjee/test-dispatch-reuse-build-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ebanerjee/test-dispatch-reuse-build-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/test-dispatch-reuse-build-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/test-dispatch-reuse-build-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ebanerjee/test-dispatch-reuse-build-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ebanerjee/test-dispatch-reuse-build-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ebanerjee/test-dispatch-reuse-build-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ebanerjee/test-dispatch-reuse-build-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ebanerjee/test-dispatch-reuse-build-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ebanerjee/test-dispatch-reuse-build-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ebanerjee/test-dispatch-reuse-build-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ebanerjee/test-dispatch-reuse-build-artifact)