### PR TITLE
Fix ttnn.split padded-shape leak and non-aligned TILE fast-path

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py
@@ -872,3 +872,40 @@ def test_split_int_remainder(device, shape, split_size, dim):
     tt_out = ttnn.split(tt_in, split_size, dim=dim, memory_config=L1)
     assert len(tt_out) == 2, f"Expected 2 output chunks, got {len(tt_out)}"
     _check(tt_out, ref)
+
+
+# ---- Regression: logical-vs-padded shape in split output (#51214 items 6+7) ----
+
+
+@pytest.mark.parametrize(
+    "shape, split_size",
+    [
+        # Item 7: logical width not tile-aligned → must take slice fallback, not TILE kernel.
+        # Mid-tile slice bounds (50..100) are the first TILE coverage of that path in this file.
+        ([128, 100], 50),
+        # Item 6: padded height must not leak into chunk logical shape. N=2 → two-chunk helper.
+        ([100, 128], 64),
+        # Item 6 via N>2: routes through ttnn::prim::split directly (not the two-chunk helper).
+        ([100, 128], 32),
+        # Same padded/logical class on the batch>1 reshape path inside split_last_dim_two_chunks_tiled.
+        # On main this used padded Y=128 against logical height 100 and volume-mismatched.
+        ([2, 1, 100, 128], 64),
+    ],
+    ids=[
+        "item7_non_aligned_width_slice_fallback",
+        "item6_n2_padded_height",
+        "item6_n4_prim_split",
+        "item6_batch_gt1_reshape",
+    ],
+)
+def test_split_logical_vs_padded_shape(device, shape, split_size):
+    """#51214 items 6+7: chunk logical shapes and values must follow logical_shape, not padding."""
+    torch.manual_seed(42)
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, split_size, dim=-1)
+
+    tt_in = _from_torch(t, device, mc=DRAM)
+    tt_out = ttnn.split(tt_in, split_size, dim=-1, memory_config=DRAM)
+    # _check asserts chunk count, per-chunk shape, and values. A padded_shape leak shows up as
+    # shape mismatch (e.g. [128,64] vs [100,64]); a wrong TILE-kernel split shows up as value mismatch.
+    _check(tt_out, ref)

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py
@@ -892,3 +892,40 @@ def test_split_int_remainder(device, shape, split_size, dim):
     tt_out = ttnn.split(tt_in, split_size, dim=dim, memory_config=L1)
     assert len(tt_out) == 2, f"Expected 2 output chunks, got {len(tt_out)}"
     _check(tt_out, ref)
+
+
+# ---- Regression: logical-vs-padded shape in split output (#51214 items 6+7) ----
+
+
+@pytest.mark.parametrize(
+    "shape, split_size",
+    [
+        # Item 7: logical width not tile-aligned → must take slice fallback, not TILE kernel.
+        # Mid-tile slice bounds (50..100) are the first TILE coverage of that path in this file.
+        ([128, 100], 50),
+        # Item 6: padded height must not leak into chunk logical shape. N=2 → two-chunk helper.
+        ([100, 128], 64),
+        # Item 6 via N>2: routes through ttnn::prim::split directly (not the two-chunk helper).
+        ([100, 128], 32),
+        # Same padded/logical class on the batch>1 reshape path inside split_last_dim_two_chunks_tiled.
+        # On main this used padded Y=128 against logical height 100 and volume-mismatched.
+        ([2, 1, 100, 128], 64),
+    ],
+    ids=[
+        "item7_non_aligned_width_slice_fallback",
+        "item6_n2_padded_height",
+        "item6_n4_prim_split",
+        "item6_batch_gt1_reshape",
+    ],
+)
+def test_split_logical_vs_padded_shape(device, shape, split_size):
+    """#51214 items 6+7: chunk logical shapes and values must follow logical_shape, not padding."""
+    torch.manual_seed(42)
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, split_size, dim=-1)
+
+    tt_in = _from_torch(t, device, mc=DRAM)
+    tt_out = ttnn.split(tt_in, split_size, dim=-1, memory_config=DRAM)
+    # _check asserts chunk count, per-chunk shape, and values. A padded_shape leak shows up as
+    # shape mismatch (e.g. [128,64] vs [100,64]); a wrong TILE-kernel split shows up as value mismatch.
+    _check(tt_out, ref)

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.cpp
@@ -31,6 +31,13 @@ void SplitDeviceOperation::validate_on_program_cache_miss(
         args.dim >= 0 && args.dim < static_cast<int>(input_tensor.padded_shape().rank()),
         "Dim being split must be from 0 to rank - 1");
     TT_FATAL(input_tensor.padded_shape()[0] == 1, "shape[0] must be 1 (batch 1 only)");
+    // Guards the % args.num_splits checks below. Note: launch() runs compute_output_specs first
+    // (which also divides by num_splits), so a 0 would fault there before this validate — unreachable
+    // in practice (composite rejects empty split_sizes; prim::split is not Python-bound).
+    TT_FATAL(args.num_splits > 0, "num_splits must be non-zero");
+    // The logical check below is the real precondition for correct chunk widths. Once
+    // logical[dim] % (num_splits × tile) == 0 holds, padded[dim] == logical[dim] for TILE, so the
+    // two padded divisibility checks that follow are implied — kept for their targeted messages.
     TT_FATAL(
         input_tensor.padded_shape()[args.dim] % args.num_splits == 0,
         "Dim being split must be evenly divisible by number of splits");
@@ -40,12 +47,27 @@ void SplitDeviceOperation::validate_on_program_cache_miss(
         "Tile count in split dim ({} tiles) must be divisible by num_splits ({})",
         input_tensor.padded_shape()[args.dim] / tile_size,
         args.num_splits);
+    // The kernel splits on padded tile boundaries. compute_output_specs reports logical chunk
+    // widths, which only match the kernel when the logical dim is tile-aligned and the logical
+    // tile count divides by num_splits. Without this, a direct prim::split call (bypassing the
+    // composite can_use_tile_kernel guard) would emit wrong-data chunks whose reported width
+    // truncates (e.g. logical 100 / 2 = 50 while the kernel writes 64).
+    // Not reachable from pytest: prim::split has no nanobind binding; only the composite is exposed.
+    TT_FATAL(
+        input_tensor.logical_shape()[args.dim] % (args.num_splits * tile_size) == 0,
+        "logical dim {} ({}) must be divisible by num_splits ({}) × tile ({})",
+        args.dim,
+        input_tensor.logical_shape()[args.dim],
+        args.num_splits,
+        tile_size);
 }
 
 SplitDeviceOperation::spec_return_value_t SplitDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    auto input_shape_array = input_tensor.padded_shape().to_array_4D();
+    // First divisor use in the launch path (create_output_tensors → here, before validate).
+    TT_FATAL(args.num_splits > 0, "num_splits must be non-zero");
+    auto input_shape_array = input_tensor.logical_shape().to_array_4D();
     auto output_shape_array = input_shape_array;
     output_shape_array[args.dim] /= args.num_splits;
     tt::tt_metal::TensorSpec spec(

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.cpp
@@ -31,9 +31,6 @@ void SplitDeviceOperation::validate_on_program_cache_miss(
         args.dim >= 0 && args.dim < static_cast<int>(input_tensor.padded_shape().rank()),
         "Dim being split must be from 0 to rank - 1");
     TT_FATAL(input_tensor.padded_shape()[0] == 1, "shape[0] must be 1 (batch 1 only)");
-    // The logical check below is the real precondition for correct chunk widths. Once
-    // logical[dim] % (num_splits × tile) == 0 holds, padded[dim] == logical[dim] for TILE, so the
-    // two padded divisibility checks that follow are implied — kept for their targeted messages.
     TT_FATAL(
         input_tensor.padded_shape()[args.dim] % args.num_splits == 0,
         "Dim being split must be evenly divisible by number of splits");
@@ -43,12 +40,8 @@ void SplitDeviceOperation::validate_on_program_cache_miss(
         "Tile count in split dim ({} tiles) must be divisible by num_splits ({})",
         input_tensor.padded_shape()[args.dim] / tile_size,
         args.num_splits);
-    // The kernel splits on padded tile boundaries. compute_output_specs reports logical chunk
-    // widths, which only match the kernel when the logical dim is tile-aligned and the logical
-    // tile count divides by num_splits. Without this, a direct prim::split call (bypassing the
-    // composite can_use_tile_kernel guard) would emit wrong-data chunks whose reported width
-    // truncates (e.g. logical 100 / 2 = 50 while the kernel writes 64).
-    // Not reachable from pytest: prim::split has no nanobind binding; only the composite is exposed.
+    // Kernel splits on padded tile boundaries; logical dim must match so reported chunk widths
+    // agree with what the kernel writes.
     TT_FATAL(
         input_tensor.logical_shape()[args.dim] % (args.num_splits * tile_size) == 0,
         "logical dim {} ({}) must be divisible by num_splits ({}) × tile ({})",
@@ -61,7 +54,6 @@ void SplitDeviceOperation::validate_on_program_cache_miss(
 SplitDeviceOperation::spec_return_value_t SplitDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    // First divisor use in the launch path (create_output_tensors → here, before validate).
     TT_FATAL(args.num_splits > 0, "num_splits must be non-zero");
     auto input_shape_array = input_tensor.logical_shape().to_array_4D();
     auto output_shape_array = input_shape_array;

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.cpp
@@ -31,10 +31,6 @@ void SplitDeviceOperation::validate_on_program_cache_miss(
         args.dim >= 0 && args.dim < static_cast<int>(input_tensor.padded_shape().rank()),
         "Dim being split must be from 0 to rank - 1");
     TT_FATAL(input_tensor.padded_shape()[0] == 1, "shape[0] must be 1 (batch 1 only)");
-    // Guards the % args.num_splits checks below. Note: launch() runs compute_output_specs first
-    // (which also divides by num_splits), so a 0 would fault there before this validate — unreachable
-    // in practice (composite rejects empty split_sizes; prim::split is not Python-bound).
-    TT_FATAL(args.num_splits > 0, "num_splits must be non-zero");
     // The logical check below is the real precondition for correct chunk widths. Once
     // logical[dim] % (num_splits × tile) == 0 holds, padded[dim] == logical[dim] for TILE, so the
     // two padded divisibility checks that follow are implied — kept for their targeted messages.

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.cpp
@@ -31,6 +31,7 @@ void SplitDeviceOperation::validate_on_program_cache_miss(
         args.dim >= 0 && args.dim < static_cast<int>(input_tensor.padded_shape().rank()),
         "Dim being split must be from 0 to rank - 1");
     TT_FATAL(input_tensor.padded_shape()[0] == 1, "shape[0] must be 1 (batch 1 only)");
+    TT_FATAL(args.num_splits > 0, "num_splits must be non-zero");
     TT_FATAL(
         input_tensor.padded_shape()[args.dim] % args.num_splits == 0,
         "Dim being split must be evenly divisible by number of splits");

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -26,24 +26,33 @@ std::vector<Tensor> impl_split_last_dim_two_chunks_tiled(const Tensor& input_ten
 }
 
 std::vector<Tensor> split_last_dim_two_chunks_tiled(const Tensor& input_tensor, const MemoryConfig& mem_config) {
-    const auto& shape = input_tensor.padded_shape();
-    const bool pre_post_reshape = shape[0] > 1;
+    // Collapse/expand must keep logical and padded shapes distinct. The span overload of
+    // reshape_on_device passes the inferred logical shape as the padded shape too, so for
+    // logical [2,1,100,128] / padded [2,1,128,128] it would produce metadata [1,2,100,128]
+    // instead of preserving padded height 128 — and the split factory then counts
+    // num_tiles_dim_2 = 100/32 = 3 instead of 128/32 = 4.
+    const auto& logical = input_tensor.logical_shape();
+    const auto& padded = input_tensor.padded_shape();
+    const bool pre_post_reshape = logical[0] > 1;
 
     if (!pre_post_reshape) {
         return impl_split_last_dim_two_chunks_tiled(input_tensor, mem_config);
     }
 
-    const int Y = shape[2], X = shape[3];
-    const Tensor& reshaped_tensor =
-        ttnn::reshape_on_device(input_tensor, ttsl::SmallVector<int32_t>{1, -1, Y, X}, mem_config);
+    const uint32_t collapsed = logical[0] * logical[1];
+    const ttnn::Shape logical_collapsed({1u, collapsed, logical[2], logical[3]});
+    const ttnn::Shape padded_collapsed({1u, collapsed, padded[2], padded[3]});
+    const Tensor reshaped_tensor =
+        ttnn::reshape_on_device(input_tensor, logical_collapsed, padded_collapsed, mem_config);
 
     auto part_reshaped = impl_split_last_dim_two_chunks_tiled(reshaped_tensor, mem_config);
 
     std::vector<Tensor> results;
     results.reserve(part_reshaped.size());
+    const ttnn::Shape logical_restored({logical[0], logical[1], logical[2], logical[3] / 2});
+    const ttnn::Shape padded_restored({padded[0], padded[1], padded[2], padded[3] / 2});
     for (auto& part : part_reshaped) {
-        results.emplace_back(
-            ttnn::reshape_on_device(part, ttsl::SmallVector<int32_t>{-1, (int32_t)shape[1], Y, X / 2}, mem_config));
+        results.emplace_back(ttnn::reshape_on_device(part, logical_restored, padded_restored, mem_config));
     }
 
     return results;
@@ -321,6 +330,7 @@ std::vector<ttnn::Tensor> split(
     //   - input is TILE layout, rank >= 2
     //   - at least 2 tiles in each of the last two dims
     //   - padded tile count in the split dim is divisible by num_chunks
+    //   - logical last dim is tile-aligned (otherwise padded/logical split boundaries diverge)
     //   - it all fits the core grid: z_4d <= grid_dim_x and num_chunks <= grid_dim_y
     //   - shape4d[0] == 1 for N>2 (the N==2 path collapses batch via reshape instead)
     // Sharded input/output are handled natively on both paths (no de-shard step).
@@ -358,11 +368,18 @@ std::vector<ttnn::Tensor> split(
     // Guard against grid_dim_y/num_chunks == 0 (invalid CoreRange in program factory).
     bool chunks_fit_in_y_grid = (num_chunks <= grid_dim_y);
 
+    // The native TILE kernel splits padded tiles; when the logical last dim is not tile-aligned
+    // (e.g. logical 100, padded 128, split 2 → kernel gives two [64] but user wanted two [50]),
+    // the padded split boundary does not coincide with the logical one → wrong data. Cases this
+    // newly excludes were never a correct fast path — they produced wrong chunk widths — so this
+    // is not a perf regression.
+    bool logical_last_dim_tile_aligned = (input_shape[-1] % tt::constants::TILE_WIDTH == 0);
+
     bool can_use_tile_kernel = is_equal_n_way_split && normalized_dim == static_cast<int64_t>(input_shape.rank()) - 1 &&
                                input_tensor.layout() == Layout::TILE && input_shape.rank() >= 2 && fits_in_core_grid &&
                                input_shape[-2] / tt::constants::TILE_HEIGHT >= 2 &&
                                input_shape[-1] / tt::constants::TILE_WIDTH >= 2 && tiles_divisible_by_chunks &&
-                               batch_ok_for_n_gt2 && chunks_fit_in_y_grid;
+                               batch_ok_for_n_gt2 && chunks_fit_in_y_grid && logical_last_dim_tile_aligned;
 
     if (can_use_tile_kernel) {
         ttnn::Tensor input_tensor_4d;
@@ -383,7 +400,12 @@ std::vector<ttnn::Tensor> split(
         results.reserve(num_chunks);
         for (const auto& t : outputs_4d) {
             ttsl::SmallVector<uint32_t> final_shape(input_shape.cbegin(), input_shape.cend());
-            final_shape.back() = t.logical_shape()[-1];
+            final_shape.back() /= num_chunks;
+            TT_FATAL(
+                final_shape.back() == t.logical_shape()[-1],
+                "Split kernel output width ({}) does not match expected logical chunk width ({})",
+                t.logical_shape()[-1],
+                final_shape.back());
             results.emplace_back(ttnn::view(t, ttnn::Shape(final_shape)));
         }
     } else {

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -26,11 +26,8 @@ std::vector<Tensor> impl_split_last_dim_two_chunks_tiled(const Tensor& input_ten
 }
 
 std::vector<Tensor> split_last_dim_two_chunks_tiled(const Tensor& input_tensor, const MemoryConfig& mem_config) {
-    // Collapse/expand must keep logical and padded shapes distinct. The span overload of
-    // reshape_on_device passes the inferred logical shape as the padded shape too, so for
-    // logical [2,1,100,128] / padded [2,1,128,128] it would produce metadata [1,2,100,128]
-    // instead of preserving padded height 128 — and the split factory then counts
-    // num_tiles_dim_2 = 100/32 = 3 instead of 128/32 = 4.
+    // Use the (logical, padded) reshape overload so TILE padding is preserved across the
+    // batch collapse/expand.
     const auto& logical = input_tensor.logical_shape();
     const auto& padded = input_tensor.padded_shape();
     const bool pre_post_reshape = logical[0] > 1;
@@ -368,11 +365,8 @@ std::vector<ttnn::Tensor> split(
     // Guard against grid_dim_y/num_chunks == 0 (invalid CoreRange in program factory).
     bool chunks_fit_in_y_grid = (num_chunks <= grid_dim_y);
 
-    // The native TILE kernel splits padded tiles; when the logical last dim is not tile-aligned
-    // (e.g. logical 100, padded 128, split 2 → kernel gives two [64] but user wanted two [50]),
-    // the padded split boundary does not coincide with the logical one → wrong data. Cases this
-    // newly excludes were never a correct fast path — they produced wrong chunk widths — so this
-    // is not a perf regression.
+    // TILE kernel splits on padded boundaries; require logical last-dim tile alignment so those
+    // match the caller's chunk widths.
     bool logical_last_dim_tile_aligned = (input_shape[-1] % tt::constants::TILE_WIDTH == 0);
 
     bool can_use_tile_kernel = is_equal_n_way_split && normalized_dim == static_cast<int64_t>(input_shape.rank()) - 1 &&


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/51764 

## Summary
* **Item 6:** `compute_output_specs` used `padded_shape()` for the output `TensorSpec` logical shape. On main this was a hard crash: `ttnn::view` volume mismatch (8192 vs 6400) for logical `[100,128]` split into 2 — not silent wrong data.
* **Allocation is unchanged:** `TensorSpec(Shape([1,1,100,64]), TILE)` still pads height 100→128, so the buffer is still `[1,1,128,64]` (4 tiles). The program factory reads `input_tensor.padded_shape()` and never the output's logical shape, so the kernel is untouched — this only fixes what the output tensor reports.
* **Item 7:** `can_use_tile_kernel` only checked padded tile divisibility. For logical `[128,100]` split into 2 it selected the TILE kernel and produced `[128,64]` instead of `[128,50]`. The new `logical[-1] % TILE_WIDTH == 0` guard excludes only cases that were already wrong; there is no correct fast path being lost.
* **Sibling path:** `split_last_dim_two_chunks_tiled` also used `padded_shape()` for its batch>1 reshape (`Y = shape[2]`). Logical `[2,1,100,128]` hit the same class one batch dim away from the item-6 test. Now uses `logical_shape()`.
* **Device-op precondition:** `validate_on_program_cache_miss` now requires `logical[dim] % (num_splits × tile) == 0`, so a direct `prim::split` cannot bypass the composite guard and emit truncated logical widths against padded kernel output.

## Notes

* The new device-op logical `TT_FATAL` (and `num_splits > 0`) are not pytest-reachable: `prim::split` has no nanobind binding; only the composite `ttnn.split` is exposed. Same defensive posture as the composite-unreachable guards on the moe remap PR.
* Once `logical[dim] % (num_splits × tile) == 0` holds, the pre-existing padded divisibility checks are implied (`padded == logical` for TILE). They stay for targeted error messages.
* Item 7 is not a perf regression: excluded cases were producing wrong chunk widths, not a correct fast path.

### Pipeline status

- [x] Sanity
- [x] (Runtime) Sanity Test
- [x] BHPC
- [x] Nightly 
- [x] All model test
- [x] Single card
- [x] T3K
- [x] Galaxy

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/split_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/split_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/split_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/split_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/split_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/split_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/split_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/split_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/split_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/split_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/split_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/split_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/split_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/split_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/split_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/split_bug)