### PR TITLE
Fix TT-DiT persistent reduce-scatter buffer shape

### DIFF
--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -142,8 +142,13 @@ class CCLManager:
             output_buffer_shape = list(shape)
             output_buffer_shape[dim] //= self.mesh_device.shape[mesh_axis]
 
+            # The op's tiled intermediate is input-shaped, except on Linear topology where it holds
+            # two slices stacked on dim 0. Matching this exactly is required: reduce_scatter rejects
+            # an intermediate that is neither the tiled spec nor the contiguous staging buffer.
+            # TODO: Switch over to using reduce_scatter_minimal_async_create_intermediate_buffer.
             intermediate_buffer_shape = list(shape)
-            intermediate_buffer_shape = [2] + intermediate_buffer_shape
+            if self.topology == ttnn.Topology.Linear:
+                intermediate_buffer_shape[0] *= 2
             for _ in range(2):
                 intermediate_buffer = bf16_tensor(torch.empty(intermediate_buffer_shape), device=self.mesh_device)
                 output_buffer = bf16_tensor(torch.empty(output_buffer_shape), device=self.mesh_device)


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
`e4afdb1a8e6 Fri Jul 31 08:30:57 2026  [Performance] Ring reduce-scatter: contiguous intermediate (#50933)` tightened validation of caller-supplied persistent intermediates, and CCLManager's reduce-scatter ping-pong buffer has always been the wrong shape — it just was never checked before.

### Notes for reviewers
This is a stop gap fix. When all changes to MMRS for tt_dit are settled, we can tackle the todo of migrating over to the contiguous intermediate.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sadesoye/mmrs_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sadesoye/mmrs_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sadesoye/mmrs_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sadesoye/mmrs_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sadesoye/mmrs_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sadesoye/mmrs_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/mmrs_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/mmrs_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sadesoye/mmrs_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sadesoye/mmrs_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sadesoye/mmrs_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sadesoye/mmrs_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/mmrs_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/mmrs_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sadesoye/mmrs_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sadesoye/mmrs_buffer)