### PR TITLE
[ttnn] unary + moreh_adam/adamw: patch cache-hit args in place, no descriptor rebuild

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -108,6 +108,245 @@ namespace ttnn::operations::unary {
 
 using namespace utils;
 
+namespace {
+
+// Per-core runtime-arg values, in the slot order create_descriptor writes them.
+struct CoreRtArgs {
+    tt::tt_metal::CoreCoord core;
+    bool noop = false;  // outside both work groups: create_descriptor zero-fills its args
+    uint32_t in_units = 0;
+    uint32_t out_units = 0;
+    uint32_t start_id = 0;
+    uint32_t compute_units = 0;
+};
+
+// Core-invariant ROW_MAJOR-interleaved chunk constants, reader/writer slots 3-7. All shape-derived,
+// and ROW_MAJOR hashes padded_shape, so a cache hit never has to re-apply them.
+struct RmChunkConstants {
+    uint32_t chunks_per_row = 1;
+    uint32_t input_chunk_size = 0;
+    uint32_t input_last_chunk_size = 0;
+    uint32_t output_chunk_size = 0;
+    uint32_t output_last_chunk_size = 0;
+    uint32_t rows_per_tile = 1;
+    uint32_t total_rows = 0;
+};
+
+// Enumerates the per-core work split for the current tensors. create_descriptor and
+// override_runtime_arguments both go through this, so a cache-hit patch cannot drift from the layout
+// the miss path built. Cheap next to create_descriptor (no kernel sources, CBs, or descriptor
+// allocation) but deliberately not O(1): the TILE-layout hash omits shape, so the split really does
+// change between hits on the same cached program.
+template <typename Fn>
+void enumerate_core_rt_args(
+    const UnaryDeviceOperation::operation_attributes_t& operation_attributes,
+    const UnaryDeviceOperation::tensor_args_t& tensor_args,
+    const Tensor& output,
+    Fn&& fn) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& input = tensor_args.input;
+    const bool is_row_major = input.layout() == Layout::ROW_MAJOR;
+    const auto shard_specs = get_shard_specs(input.tensor_spec(), output.tensor_spec());
+    const bool has_sharding = shard_specs.has_value();
+    const bool rm_interleaved = is_row_major && !has_sharding;
+    const auto& all_device_cores = operation_attributes.worker_grid;
+
+    const auto row_major =
+        has_sharding ? shard_specs->input_shard_spec.orientation == ShardOrientation::ROW_MAJOR : true;
+    auto grid = has_sharding ? shard_specs->input_shard_spec.grid : CoreRangeSet{};
+
+    bool zero_start_grid = false;
+    CoreCoord compute_with_storage_grid;
+    if (all_device_cores.size() == 1) {
+        const auto& cr = *all_device_cores.ranges().begin();
+        if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
+            if (has_sharding) {
+                const auto& shard_start_coord = grid.ranges()[0].start_coord;
+                if (shard_start_coord.x == 0 && shard_start_coord.y == 0) {
+                    zero_start_grid = true;
+                    compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+                }
+            } else {
+                zero_start_grid = true;
+                compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+            }
+        }
+    }
+    const uint32_t num_cores_total =
+        zero_start_grid ? compute_with_storage_grid.x * compute_with_storage_grid.y : all_device_cores.num_cores();
+
+    const uint32_t tile_height = output.tensor_spec().tile().get_height();
+    const uint32_t tile_width = output.tensor_spec().tile().get_width();
+    const uint32_t tile_hw = tile_height * tile_width;
+
+    const auto input_df = datatype_to_dataformat_converter(input.dtype());
+    const auto output_df = datatype_to_dataformat_converter(output.dtype());
+    const uint32_t input_tile_bytes = tile_size(input_df);
+    const uint32_t output_tile_bytes = tile_size(output_df);
+
+    const uint32_t input_page_bytes = rm_interleaved ? static_cast<uint32_t>(input.buffer()->page_size()) : 0;
+    const uint32_t output_page_bytes = rm_interleaved ? static_cast<uint32_t>(output.buffer()->page_size()) : 0;
+    RmChunkConstants k;
+    k.chunks_per_row = rm_interleaved ? (input_page_bytes + input_tile_bytes - 1) / input_tile_bytes : 1;
+    k.input_chunk_size = input_tile_bytes;
+    k.input_last_chunk_size =
+        rm_interleaved ? input_page_bytes - ((k.chunks_per_row - 1) * input_tile_bytes) : input_tile_bytes;
+    k.output_chunk_size = output_tile_bytes;
+    k.output_last_chunk_size =
+        rm_interleaved ? output_page_bytes - ((k.chunks_per_row - 1) * output_tile_bytes) : output_tile_bytes;
+    k.total_rows = rm_interleaved ? output.buffer()->num_pages() : 0;
+    if (rm_interleaved && input_page_bytes > 0 && input_page_bytes < input_tile_bytes) {
+        const uint32_t input_element_size = datum_size(input_df);
+        const uint32_t row_width_elements = input_page_bytes / input_element_size;
+        const uint32_t aligned_page_size = static_cast<uint32_t>(input.buffer()->aligned_page_size());
+        if (input_page_bytes == aligned_page_size && row_width_elements > 0) {
+            k.rows_per_tile = tile_hw / row_width_elements;
+        }
+    }
+    const uint32_t out_num_tiles =
+        rm_interleaved ? (k.total_rows + k.rows_per_tile - 1) / k.rows_per_tile : output.physical_volume() / tile_hw;
+    const uint32_t oWt = output.padded_shape()[-1] / output.tensor_spec().tile().get_width();
+
+    std::vector<CoreCoord> cores;
+    if (has_sharding) {
+        const CoreRangeSet core_group_1 = grid;
+        const uint32_t out_shard_height = shard_specs->output_shard_spec.shape[0] / tile_height;
+        const uint32_t out_shard_width = shard_specs->output_shard_spec.shape[1] / tile_width;
+        auto out_memory_layout = output.memory_config().is_sharded() ? output.memory_config().memory_layout()
+                                                                     : input.memory_config().memory_layout();
+        const uint32_t num_shards_per_width =
+            CMAKE_UNIQUE_NAMESPACE::get_shards_per_width(shard_specs->output_shard_spec, out_memory_layout);
+
+        auto compute_shard_pages = [&](const ShardSpec& spec,
+                                       const auto& tensor) -> std::function<uint32_t(CoreCoord)> {
+            if (is_row_major) {
+                auto df = datatype_to_dataformat_converter(tensor.dtype());
+                uint32_t ts = tile_size(df);
+                uint32_t shard_bytes = spec.shape[0] * spec.shape[1] * datum_size(df);
+                uint32_t pages = shard_bytes / ts;
+                return [pages](CoreCoord) -> uint32_t { return pages; };
+            }
+            auto end_core = spec.grid.ranges().rbegin()->end_coord;
+            bool rm = spec.orientation == ShardOrientation::ROW_MAJOR;
+            auto mem_layout = tensor.memory_config().memory_layout();
+            uint32_t sh = tt::round_up(spec.shape[0], tile_height) / tile_height;
+            uint32_t sw = tt::round_up(spec.shape[1], tile_width) / tile_width;
+            const auto& pshape = tensor.padded_shape();
+            uint32_t D = pshape.rank() >= 5 ? pshape[-5] : 1;
+            uint32_t N = pshape[-4], C = pshape[-3];
+            uint32_t Ht = pshape[-2] / tile_height, Wt = pshape[-1] / tile_width;
+            uint32_t unrolled_Ht = D * N * C * Ht;
+            uint32_t last_h = sh - (tt::round_up(unrolled_Ht, sh) - unrolled_Ht);
+            uint32_t last_w = sw - (tt::round_up(Wt, sw) - Wt);
+
+            return [=](CoreCoord core) -> uint32_t {
+                uint32_t h = sh, w = sw;
+                if (mem_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
+                    mem_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+                    if (core == end_core) {
+                        h = last_h;
+                        w = last_w;
+                    }
+                } else {
+                    if (rm) {
+                        if (core.x == end_core.x) {
+                            w = last_w;
+                        }
+                        if (core.y == end_core.y) {
+                            h = last_h;
+                        }
+                    } else {
+                        if (core.y == end_core.y) {
+                            w = last_w;
+                        }
+                        if (core.x == end_core.x) {
+                            h = last_h;
+                        }
+                    }
+                }
+                return h * w;
+            };
+        };
+
+        auto in_shard_pages = compute_shard_pages(shard_specs->input_shard_spec, input);
+        auto out_shard_pages = compute_shard_pages(shard_specs->output_shard_spec, output);
+
+        if (zero_start_grid) {
+            auto bbox = core_group_1.bounding_box();
+            cores = grid_to_cores_with_noop(
+                bbox.end_coord.x,
+                bbox.end_coord.y,
+                compute_with_storage_grid.x,
+                compute_with_storage_grid.y,
+                row_major);
+        } else {
+            cores = grid_to_cores_with_noop(core_group_1, all_device_cores, row_major);
+        }
+
+        for (uint32_t i = 0; i < num_cores_total; ++i) {
+            const auto& core = cores[i];
+            if (!core_group_1.contains(core)) {
+                fn(CoreRtArgs{.core = core, .noop = true}, k);
+                continue;
+            }
+            const uint32_t in_tiles = in_shard_pages(core);
+            const uint32_t o_tiles = out_shard_pages(core);
+            const uint32_t out_start_id = ((i / num_shards_per_width) * (out_shard_height * oWt)) +
+                                          ((i % num_shards_per_width) * out_shard_width);
+            fn(
+                CoreRtArgs{
+                    .core = core,
+                    .in_units = in_tiles,
+                    .out_units = o_tiles,
+                    .start_id = out_start_id,
+                    .compute_units = o_tiles},
+                k);
+        }
+        return;
+    }
+
+    uint32_t num_tiles_per_core_group_1{}, num_tiles_per_core_group_2{};
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+    uint32_t num_cores;
+    if (zero_start_grid) {
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
+            split_work_to_cores(compute_with_storage_grid, out_num_tiles, row_major);
+        cores = grid_to_cores(num_cores_total, compute_with_storage_grid.x, compute_with_storage_grid.y, row_major);
+    } else {
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
+            split_work_to_cores(all_device_cores, out_num_tiles, row_major);
+        cores = corerange_to_cores(all_device_cores, {}, row_major);
+    }
+
+    for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; ++i) {
+        const auto& core = cores[i];
+        uint32_t npc = 0;
+        if (core_group_1.contains(core)) {
+            npc = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            npc = num_tiles_per_core_group_2;
+        } else {
+            fn(CoreRtArgs{.core = core, .noop = true}, k);
+            continue;
+        }
+        fn(
+            CoreRtArgs{
+                .core = core,
+                .in_units = npc,
+                .out_units = npc,
+                .start_id = start_tile_id,
+                .compute_units = rm_interleaved ? npc * k.chunks_per_row : npc},
+            k);
+        start_tile_id += npc;
+    }
+}
+
+}  // namespace
+
 tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
@@ -279,233 +518,49 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
     };
 
     // --- Per-core runtime args ---
-    const auto row_major =
-        has_sharding ? shard_specs->input_shard_spec.orientation == ShardOrientation::ROW_MAJOR : true;
-
-    auto grid = has_sharding ? shard_specs->input_shard_spec.grid : CoreRangeSet{};
-
-    bool zero_start_grid = false;
-    CoreCoord compute_with_storage_grid;
-    if (all_device_cores.size() == 1) {
-        const auto& cr = *all_device_cores.ranges().begin();
-        if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
+    // Work split + per-core values come from enumerate_core_rt_args, shared with
+    // override_runtime_arguments so the cache-hit patch and the miss path cannot disagree.
+    enumerate_core_rt_args(
+        operation_attributes, tensor_args, output, [&](const CoreRtArgs& w, const RmChunkConstants& kc) {
+            if (w.noop) {
+                const uint32_t n = has_sharding ? 3 : 8;
+                reader_desc.runtime_args.emplace_back(w.core, KernelDescriptor::CoreRuntimeArgs(n, 0));
+                writer_desc.runtime_args.emplace_back(w.core, KernelDescriptor::CoreRuntimeArgs(n, 0));
+                compute_desc.runtime_args.emplace_back(w.core, KernelDescriptor::CoreRuntimeArgs(3, 0));
+                return;
+            }
             if (has_sharding) {
-                const auto& shard_start_coord = grid.ranges()[0].start_coord;
-                if (shard_start_coord.x == 0 && shard_start_coord.y == 0) {
-                    zero_start_grid = true;
-                    compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
-                }
-            } else {
-                zero_start_grid = true;
-                compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
-            }
-        }
-    }
-    const uint32_t num_cores_total =
-        zero_start_grid ? compute_with_storage_grid.x * compute_with_storage_grid.y : all_device_cores.num_cores();
-
-    uint32_t num_tiles_per_core_group_1{}, num_tiles_per_core_group_2{};
-    CoreRangeSet all_cores, core_group_1, core_group_2;
-    uint32_t num_cores;
-    std::vector<CoreCoord> cores;
-
-    const uint32_t tile_height = output.tensor_spec().tile().get_height();
-    const uint32_t tile_width = output.tensor_spec().tile().get_width();
-    const uint32_t tile_hw = tile_height * tile_width;
-
-    const auto input_df = datatype_to_dataformat_converter(input.dtype());
-    const auto output_df = datatype_to_dataformat_converter(output.dtype());
-    const uint32_t input_tile_bytes = tile_size(input_df);
-    const uint32_t output_tile_bytes = tile_size(output_df);
-
-    const uint32_t input_page_bytes = rm_interleaved ? static_cast<uint32_t>(input.buffer()->page_size()) : 0;
-    const uint32_t output_page_bytes = rm_interleaved ? static_cast<uint32_t>(output.buffer()->page_size()) : 0;
-    const uint32_t chunks_per_row = rm_interleaved ? (input_page_bytes + input_tile_bytes - 1) / input_tile_bytes : 1;
-    const uint32_t input_chunk_size = input_tile_bytes;
-    const uint32_t input_last_chunk_size =
-        rm_interleaved ? input_page_bytes - ((chunks_per_row - 1) * input_tile_bytes) : input_tile_bytes;
-    const uint32_t output_chunk_size = output_tile_bytes;
-    const uint32_t output_last_chunk_size =
-        rm_interleaved ? output_page_bytes - ((chunks_per_row - 1) * output_tile_bytes) : output_tile_bytes;
-
-    const uint32_t total_rows = rm_interleaved ? output.buffer()->num_pages() : 0;
-    uint32_t rows_per_tile = 1;
-    if (rm_interleaved && input_page_bytes > 0 && input_page_bytes < input_tile_bytes) {
-        const uint32_t input_element_size = datum_size(input_df);
-        const uint32_t row_width_elements = input_page_bytes / input_element_size;
-        const uint32_t aligned_page_size = static_cast<uint32_t>(input.buffer()->aligned_page_size());
-        if (input_page_bytes == aligned_page_size && row_width_elements > 0) {
-            rows_per_tile = tile_hw / row_width_elements;
-        }
-    }
-
-    const uint32_t out_num_tiles =
-        rm_interleaved ? (total_rows + rows_per_tile - 1) / rows_per_tile : output.physical_volume() / tile_hw;
-    uint32_t out_shard_height{}, out_shard_width{}, num_shards_per_width{};
-
-    const uint32_t oWt = output.padded_shape()[-1] / output.tensor_spec().tile().get_width();
-
-    if (has_sharding) {
-        core_group_1 = grid;
-        out_shard_height = shard_specs->output_shard_spec.shape[0] / tile_height;
-        out_shard_width = shard_specs->output_shard_spec.shape[1] / tile_width;
-        auto out_memory_layout = output.memory_config().is_sharded() ? output.memory_config().memory_layout()
-                                                                     : input.memory_config().memory_layout();
-        num_shards_per_width =
-            CMAKE_UNIQUE_NAMESPACE::get_shards_per_width(shard_specs->output_shard_spec, out_memory_layout);
-
-        auto compute_shard_pages = [&](const ShardSpec& spec,
-                                       const auto& tensor) -> std::function<uint32_t(CoreCoord)> {
-            if (is_row_major) {
-                auto df = datatype_to_dataformat_converter(tensor.dtype());
-                uint32_t ts = tile_size(df);
-                uint32_t shard_bytes = spec.shape[0] * spec.shape[1] * datum_size(df);
-                uint32_t pages = shard_bytes / ts;
-                return [pages](CoreCoord) -> uint32_t { return pages; };
-            }
-            auto end_core = spec.grid.ranges().rbegin()->end_coord;
-            bool rm = spec.orientation == ShardOrientation::ROW_MAJOR;
-            auto mem_layout = tensor.memory_config().memory_layout();
-            uint32_t sh = tt::round_up(spec.shape[0], tile_height) / tile_height;
-            uint32_t sw = tt::round_up(spec.shape[1], tile_width) / tile_width;
-            const auto& pshape = tensor.padded_shape();
-            uint32_t D = pshape.rank() >= 5 ? pshape[-5] : 1;
-            uint32_t N = pshape[-4], C = pshape[-3];
-            uint32_t Ht = pshape[-2] / tile_height, Wt = pshape[-1] / tile_width;
-            uint32_t unrolled_Ht = D * N * C * Ht;
-            uint32_t last_h = sh - (tt::round_up(unrolled_Ht, sh) - unrolled_Ht);
-            uint32_t last_w = sw - (tt::round_up(Wt, sw) - Wt);
-
-            return [=](CoreCoord core) -> uint32_t {
-                uint32_t h = sh, w = sw;
-                if (mem_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
-                    mem_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-                    if (core == end_core) {
-                        h = last_h;
-                        w = last_w;
-                    }
-                } else {
-                    if (rm) {
-                        if (core.x == end_core.x) {
-                            w = last_w;
-                        }
-                        if (core.y == end_core.y) {
-                            h = last_h;
-                        }
-                    } else {
-                        if (core.y == end_core.y) {
-                            w = last_w;
-                        }
-                        if (core.x == end_core.x) {
-                            h = last_h;
-                        }
-                    }
-                }
-                return h * w;
-            };
-        };
-
-        auto in_shard_pages = compute_shard_pages(shard_specs->input_shard_spec, input);
-        auto out_shard_pages = compute_shard_pages(shard_specs->output_shard_spec, output);
-
-        if (zero_start_grid) {
-            auto bbox = core_group_1.bounding_box();
-            cores = grid_to_cores_with_noop(
-                bbox.end_coord.x,
-                bbox.end_coord.y,
-                compute_with_storage_grid.x,
-                compute_with_storage_grid.y,
-                row_major);
-        } else {
-            cores = grid_to_cores_with_noop(core_group_1, all_device_cores, row_major);
-        }
-
-        for (uint32_t i = 0; i < num_cores_total; ++i) {
-            const auto& core = cores[i];
-            if (!core_group_1.contains(core)) {
-                reader_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs(3, 0));
-                writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs(3, 0));
-                compute_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs(3, 0));
-                continue;
-            }
-            uint32_t in_tiles = in_shard_pages(core);
-            uint32_t o_tiles = out_shard_pages(core);
-            uint32_t out_start_id = ((i / num_shards_per_width) * (out_shard_height * oWt)) +
-                                    ((i % num_shards_per_width) * out_shard_width);
-            reader_desc.emplace_runtime_args(core, {input.buffer(), in_tiles, out_start_id});
-            writer_desc.emplace_runtime_args(core, {output.buffer(), o_tiles, out_start_id});
-            compute_desc.runtime_args.emplace_back(
-                core, KernelDescriptor::CoreRuntimeArgs{o_tiles, packed_scalar1, packed_scalar2});
-        }
-    } else {
-        if (zero_start_grid) {
-            std::tie(
-                num_cores,
-                all_cores,
-                core_group_1,
-                core_group_2,
-                num_tiles_per_core_group_1,
-                num_tiles_per_core_group_2) = split_work_to_cores(compute_with_storage_grid, out_num_tiles, row_major);
-            cores = grid_to_cores(num_cores_total, compute_with_storage_grid.x, compute_with_storage_grid.y, row_major);
-        } else {
-            std::tie(
-                num_cores,
-                all_cores,
-                core_group_1,
-                core_group_2,
-                num_tiles_per_core_group_1,
-                num_tiles_per_core_group_2) = split_work_to_cores(all_device_cores, out_num_tiles, row_major);
-            cores = corerange_to_cores(all_device_cores, {}, row_major);
-        }
-
-        for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; ++i) {
-            const auto& core = cores[i];
-
-            uint32_t npc = 0;
-            if (core_group_1.contains(core)) {
-                npc = num_tiles_per_core_group_1;
-            } else if (core_group_2.contains(core)) {
-                npc = num_tiles_per_core_group_2;
-            } else {
-                reader_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs(8, 0));
-                writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs(8, 0));
-                compute_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs(3, 0));
-                continue;
-            }
-
-            if (rm_interleaved) {
+                reader_desc.emplace_runtime_args(w.core, {input.buffer(), w.in_units, w.start_id});
+                writer_desc.emplace_runtime_args(w.core, {output.buffer(), w.out_units, w.start_id});
+            } else if (rm_interleaved) {
                 reader_desc.emplace_runtime_args(
-                    core,
+                    w.core,
                     {input.buffer(),
-                     npc,
-                     start_tile_id,
-                     chunks_per_row,
-                     input_chunk_size,
-                     input_last_chunk_size,
-                     rows_per_tile,
-                     total_rows});
+                     w.in_units,
+                     w.start_id,
+                     kc.chunks_per_row,
+                     kc.input_chunk_size,
+                     kc.input_last_chunk_size,
+                     kc.rows_per_tile,
+                     kc.total_rows});
                 writer_desc.emplace_runtime_args(
-                    core,
+                    w.core,
                     {output.buffer(),
-                     npc,
-                     start_tile_id,
-                     chunks_per_row,
-                     output_chunk_size,
-                     output_last_chunk_size,
-                     rows_per_tile,
-                     total_rows});
-                compute_desc.runtime_args.emplace_back(
-                    core, KernelDescriptor::CoreRuntimeArgs{npc * chunks_per_row, packed_scalar1, packed_scalar2});
+                     w.out_units,
+                     w.start_id,
+                     kc.chunks_per_row,
+                     kc.output_chunk_size,
+                     kc.output_last_chunk_size,
+                     kc.rows_per_tile,
+                     kc.total_rows});
             } else {
-                reader_desc.emplace_runtime_args(core, {input.buffer(), npc, start_tile_id, 0u, 0u, 0u, 0u, 0u});
-                writer_desc.emplace_runtime_args(core, {output.buffer(), npc, start_tile_id, 0u, 0u, 0u, 0u, 0u});
-                compute_desc.runtime_args.emplace_back(
-                    core, KernelDescriptor::CoreRuntimeArgs{npc, packed_scalar1, packed_scalar2});
+                reader_desc.emplace_runtime_args(w.core, {input.buffer(), w.in_units, w.start_id, 0u, 0u, 0u, 0u, 0u});
+                writer_desc.emplace_runtime_args(
+                    w.core, {output.buffer(), w.out_units, w.start_id, 0u, 0u, 0u, 0u, 0u});
             }
-
-            start_tile_id += npc;
-        }
-    }
+            compute_desc.runtime_args.emplace_back(
+                w.core, KernelDescriptor::CoreRuntimeArgs{w.compute_units, packed_scalar1, packed_scalar2});
+        });
 
     desc.kernels.push_back(std::move(reader_desc));
     desc.kernels.push_back(std::move(writer_desc));
@@ -520,10 +575,97 @@ void UnaryDeviceOperation::ProgramFactory::override_runtime_arguments(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Re-derive the descriptor from the single source of truth (create_descriptor) and re-apply its per-core
-    // args + tensor-backed CB addresses to the cached program. No rebuild; supersedes get_dynamic/resolve_bindings.
-    auto desc = ProgramFactory::create_descriptor(operation_attributes, tensor_args, output);
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+    using namespace tt::tt_metal;
+    // The TILE-layout hash omits shape, so the work split, start ids and accessor shape args all vary
+    // between hits: re-apply exactly those, through the same enumeration create_descriptor uses.
+    const auto& input = tensor_args.input;
+    const auto shard_specs = get_shard_specs(input.tensor_spec(), output.tensor_spec());
+    const bool src_sharded = shard_specs.has_value() && input.is_sharded();
+    const bool dst_sharded = shard_specs.has_value() && output.is_sharded();
+
+    constexpr uint32_t kReaderKernelIdx = 0, kWriterKernelIdx = 1, kComputeKernelIdx = 2;
+    const uint32_t src_addr = input.buffer()->address();
+    const uint32_t dst_addr = output.buffer()->address();
+    const bool has_sharding = shard_specs.has_value();
+    const bool rm_interleaved = input.layout() == Layout::ROW_MAJOR && !has_sharding;
+
+    // A changed split can flip a core between noop and active, so write every slot create_descriptor
+    // writes rather than only the ones that usually move -- otherwise a flipped core keeps stale args.
+    uint32_t packed_scalar1 = 0, packed_scalar2 = 0;
+    std::map<std::string, std::string> unused_defines;
+    CMAKE_UNIQUE_NAMESPACE::pack_first_op_scalars(
+        operation_attributes.op_chain[0], input.dtype(), packed_scalar1, packed_scalar2, unused_defines);
+
+    enumerate_core_rt_args(
+        operation_attributes, tensor_args, output, [&](const CoreRtArgs& w, const RmChunkConstants& kc) {
+            auto& r = GetRuntimeArgs(program, kReaderKernelIdx, w.core);
+            auto& wr = GetRuntimeArgs(program, kWriterKernelIdx, w.core);
+            auto& c = GetRuntimeArgs(program, kComputeKernelIdx, w.core);
+            if (w.noop) {
+                for (uint32_t i = 0; i < r.size(); ++i) {
+                    r[i] = 0;
+                }
+                for (uint32_t i = 0; i < wr.size(); ++i) {
+                    wr[i] = 0;
+                }
+                for (uint32_t i = 0; i < c.size(); ++i) {
+                    c[i] = 0;
+                }
+                return;
+            }
+            r[0] = src_addr;
+            r[1] = w.in_units;
+            r[2] = w.start_id;
+            wr[0] = dst_addr;
+            wr[1] = w.out_units;
+            wr[2] = w.start_id;
+            if (!has_sharding) {
+                const std::array<uint32_t, 5> rtail{
+                    kc.chunks_per_row, kc.input_chunk_size, kc.input_last_chunk_size, kc.rows_per_tile, kc.total_rows};
+                const std::array<uint32_t, 5> wtail{
+                    kc.chunks_per_row,
+                    kc.output_chunk_size,
+                    kc.output_last_chunk_size,
+                    kc.rows_per_tile,
+                    kc.total_rows};
+                for (uint32_t i = 0; i < rtail.size(); ++i) {
+                    r[3 + i] = rm_interleaved ? rtail[i] : 0u;
+                    wr[3 + i] = rm_interleaved ? wtail[i] : 0u;
+                }
+            }
+            c[0] = w.compute_units;
+            c[1] = packed_scalar1;
+            c[2] = packed_scalar2;
+        });
+
+    // The accessor's common args carry the tensor shape (ArgConfig::RuntimeTensorShape), which moves
+    // with the (unhashed) shape; rebuild just those two small vectors, not the descriptor.
+    std::vector<uint32_t> ct_args, common_args;
+    TensorAccessorArgs(*input.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape).append_to(ct_args, common_args);
+    auto& reader_common = GetCommonRuntimeArgs(program, kReaderKernelIdx);
+    for (uint32_t i = 0; i < common_args.size() && i < reader_common.size(); ++i) {
+        reader_common[i] = common_args[i];
+    }
+    ct_args.clear();
+    common_args.clear();
+    TensorAccessorArgs(*output.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(ct_args, common_args);
+    auto& writer_common = GetCommonRuntimeArgs(program, kWriterKernelIdx);
+    for (uint32_t i = 0; i < common_args.size() && i < writer_common.size(); ++i) {
+        writer_common[i] = common_args[i];
+    }
+
+    // Sharded CBs are tensor-backed. CBs are matched positionally by apply_descriptor_runtime_args, so
+    // mirror create_descriptor's order (src0, optional tmp0, output); a null buffer entry is skipped.
+    if (src_sharded || dst_sharded) {
+        ProgramDescriptor cb_addr_only;
+        cb_addr_only.cbs.push_back(CBDescriptor{.buffer = src_sharded ? input.buffer() : nullptr});
+        if (CMAKE_UNIQUE_NAMESPACE::needs_tmp0_cb(operation_attributes.op_chain[0].type())) {
+            cb_addr_only.cbs.push_back(CBDescriptor{});
+        }
+        cb_addr_only.cbs.push_back(CBDescriptor{.buffer = dst_sharded ? output.buffer() : nullptr});
+        apply_descriptor_runtime_args(program, cb_addr_only);  // override-rebuild-ok: cb-addr-only
+    }
 }
 
 }  // namespace ttnn::operations::unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -211,7 +211,7 @@ void enumerate_core_rt_args(
 
     std::vector<CoreCoord> cores;
     if (has_sharding) {
-        const CoreRangeSet core_group_1 = grid;
+        const CoreRangeSet& core_group_1 = grid;
         const uint32_t out_shard_height = shard_specs->output_shard_spec.shape[0] / tile_height;
         const uint32_t out_shard_width = shard_specs->output_shard_spec.shape[1] / tile_width;
         auto out_memory_layout = output.memory_config().is_sharded() ? output.memory_config().memory_layout()
@@ -520,13 +520,15 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
     // --- Per-core runtime args ---
     // Work split + per-core values come from enumerate_core_rt_args, shared with
     // override_runtime_arguments so the cache-hit patch and the miss path cannot disagree.
+    // Sharded readers/writers take {buffer, units, start_id}; interleaved add the five chunk fields.
+    constexpr uint32_t kShardedDataMovementArgs = 3, kInterleavedDataMovementArgs = 8, kComputeArgs = 3;
     enumerate_core_rt_args(
         operation_attributes, tensor_args, output, [&](const CoreRtArgs& w, const RmChunkConstants& kc) {
             if (w.noop) {
-                const uint32_t n = has_sharding ? 3 : 8;
+                const uint32_t n = has_sharding ? kShardedDataMovementArgs : kInterleavedDataMovementArgs;
                 reader_desc.runtime_args.emplace_back(w.core, KernelDescriptor::CoreRuntimeArgs(n, 0));
                 writer_desc.runtime_args.emplace_back(w.core, KernelDescriptor::CoreRuntimeArgs(n, 0));
-                compute_desc.runtime_args.emplace_back(w.core, KernelDescriptor::CoreRuntimeArgs(3, 0));
+                compute_desc.runtime_args.emplace_back(w.core, KernelDescriptor::CoreRuntimeArgs(kComputeArgs, 0));
                 return;
             }
             if (has_sharding) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -142,7 +142,7 @@ void enumerate_core_rt_args(
     const UnaryDeviceOperation::operation_attributes_t& operation_attributes,
     const UnaryDeviceOperation::tensor_args_t& tensor_args,
     const Tensor& output,
-    Fn&& fn) {
+    const Fn& fn) {
     using namespace tt;
     using namespace tt::tt_metal;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <array>
 #include <bit>
 #include <vector>
 
 #include "moreh_adam_device_operation.hpp"
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
@@ -318,11 +320,65 @@ void MorehAdamOperation::override_runtime_arguments(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensor,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Re-derive the descriptor from the single source of truth (create_descriptor) and re-apply its per-core
-    // args (incl. hash-excluded lr/step) + tensor-backed CB/buffer addresses to the cached program. No rebuild;
-    // supersedes get_dynamic/resolve_bindings and fixes in-place aliasing (#48928).
-    auto desc = create_descriptor(operation_attributes, tensor_args, output_tensor);
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+    // Only the buffer addresses and the hash-excluded lr/step vary per dispatch: everything else
+    // (work split, tile_offset, beta/eps/weight_decay, amsgrad) is pinned by compute_program_hash.
+    constexpr uint32_t kReaderKernelIdx = 0, kWriterKernelIdx = 1, kComputeKernelIdx = 2;
+    constexpr uint32_t kReaderLrIdx = 5, kReaderStepIdx = 10, kComputeStepIdx = 0;
+
+    const auto addr_or_zero = [](const std::optional<Tensor>& t) -> uint32_t {
+        return t.has_value() ? t->buffer()->address() : 0u;
+    };
+    // Mirrors create_descriptor's push order; a null optional was emitted as 0u there too.
+    const std::array<uint32_t, 5> reader_addrs{
+        tensor_args.param_in.buffer()->address(),
+        tensor_args.grad.buffer()->address(),
+        tensor_args.exp_avg_in.buffer()->address(),
+        tensor_args.exp_avg_sq_in.buffer()->address(),
+        addr_or_zero(tensor_args.max_exp_avg_sq_in)};
+    const std::array<uint32_t, 4> writer_addrs{
+        output_tensor.at(0)->buffer()->address(),
+        output_tensor.at(1)->buffer()->address(),
+        output_tensor.at(2)->buffer()->address(),
+        addr_or_zero(output_tensor.at(3))};
+
+    const uint32_t f2u_lr = std::bit_cast<uint32_t>(operation_attributes.lr);
+    const uint32_t step = operation_attributes.step;
+
+    for (auto& col : tt::tt_metal::GetRuntimeArgs(program, kReaderKernelIdx)) {
+        for (auto& a : col) {
+            if (a.size() <= kReaderStepIdx) {
+                continue;
+            }
+            for (uint32_t i = 0; i < reader_addrs.size(); ++i) {
+                a[i] = reader_addrs[i];
+            }
+            a[kReaderLrIdx] = f2u_lr;
+            a[kReaderStepIdx] = step;
+        }
+    }
+    for (auto& col : tt::tt_metal::GetRuntimeArgs(program, kWriterKernelIdx)) {
+        for (auto& a : col) {
+            for (uint32_t i = 0; i < writer_addrs.size() && i < a.size(); ++i) {
+                a[i] = writer_addrs[i];
+            }
+        }
+    }
+
+    // step also feeds the compute kernel(s). A second one exists only when the split leaves a
+    // remainder group, so re-run just the split (not the descriptor) to learn whether it is there.
+    const uint32_t num_tiles = tensor_args.param_in.physical_volume() / tt::constants::TILE_HW;
+    const auto grid = tensor_args.param_in.device()->compute_with_storage_grid_size();
+    const auto core_group_2 = std::get<3>(split_work_to_cores(grid, num_tiles));
+    const uint32_t num_compute_kernels = core_group_2.ranges().empty() ? 1u : 2u;
+    for (uint32_t k = 0; k < num_compute_kernels; ++k) {
+        for (auto& col : tt::tt_metal::GetRuntimeArgs(program, kComputeKernelIdx + k)) {
+            for (auto& a : col) {
+                if (a.size() > kComputeStepIdx) {
+                    a[kComputeStepIdx] = step;
+                }
+            }
+        }
+    }
 }
 
 }  // namespace ttnn::operations::moreh::moreh_adam

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
@@ -363,7 +363,10 @@ void MorehAdamWDeviceOperation::override_runtime_arguments(
     auto& param_out = tensor_return_value.at(0).value();
     auto& exp_avg_out = tensor_return_value.at(1).value();
     auto& exp_avg_sq_out = tensor_return_value.at(2).value();
-    const auto& max_exp_avg_sq_out = tensor_return_value.at(3);
+    // create_descriptor drops this output when amsgrad is off; the hit path has to match or it patches
+    // an address the miss path never baked.
+    const std::optional<Tensor> max_exp_avg_sq_out =
+        operation_attributes.amsgrad ? tensor_return_value.at(3) : std::nullopt;
 
     constexpr uint32_t kReaderKernelIdx = 0, kWriterKernelIdx = 1, kComputeKernelIdx = 2;
     constexpr uint32_t kLrIdx = 5, kBeta1ExpIdx = 10, kBeta2ExpIdx = 11, kReaderStepIdx = 12;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
@@ -2,10 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <array>
 #include <bit>
+#include <cmath>
 #include <optional>
 
 #include "moreh_adamw_device_operation.hpp"
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -353,11 +356,72 @@ void MorehAdamWDeviceOperation::override_runtime_arguments(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Re-derive the descriptor from the single source of truth (create_descriptor) and re-apply its per-core
-    // args + tensor-backed CB/buffer addresses to the cached program. No rebuild; supersedes
-    // get_dynamic/resolve_bindings.
-    auto desc = create_descriptor(operation_attributes, tensor_args, tensor_return_value);
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+    // attribute_names excludes lr and step, so those two plus the beta exponents derived from step and
+    // the buffer addresses are all that vary per dispatch; the work split is keyed by the shapes.
+    const auto& param_in = tensor_args.param_in;
+    const auto& max_exp_avg_sq_in = tensor_args.max_exp_avg_sq_in;
+    auto& param_out = tensor_return_value.at(0).value();
+    auto& exp_avg_out = tensor_return_value.at(1).value();
+    auto& exp_avg_sq_out = tensor_return_value.at(2).value();
+    const auto& max_exp_avg_sq_out = tensor_return_value.at(3);
+
+    constexpr uint32_t kReaderKernelIdx = 0, kWriterKernelIdx = 1, kComputeKernelIdx = 2;
+    constexpr uint32_t kLrIdx = 5, kBeta1ExpIdx = 10, kBeta2ExpIdx = 11, kReaderStepIdx = 12;
+
+    const std::array<uint32_t, 5> reader_addrs{
+        param_in.buffer()->address(),
+        tensor_args.grad.buffer()->address(),
+        tensor_args.exp_avg_in.buffer()->address(),
+        tensor_args.exp_avg_sq_in.buffer()->address(),
+        max_exp_avg_sq_in.has_value() ? max_exp_avg_sq_in->buffer()->address() : 0u};
+    const std::array<uint32_t, 4> writer_addrs{
+        param_out.buffer()->address(),
+        exp_avg_out.buffer()->address(),
+        exp_avg_sq_out.buffer()->address(),
+        max_exp_avg_sq_out.has_value() ? max_exp_avg_sq_out->buffer()->address() : 0u};
+
+    const uint32_t step = operation_attributes.step;
+    const uint32_t f2u_lr = std::bit_cast<uint32_t>(operation_attributes.lr);
+    const uint32_t f2u_beta1_exponent =
+        std::bit_cast<uint32_t>(static_cast<float>(std::pow(operation_attributes.beta1, step)));
+    const uint32_t f2u_beta2_exponent =
+        std::bit_cast<uint32_t>(static_cast<float>(std::pow(operation_attributes.beta2, step)));
+
+    for (auto& col : tt::tt_metal::GetRuntimeArgs(program, kReaderKernelIdx)) {
+        for (auto& a : col) {
+            if (a.size() <= kReaderStepIdx) {
+                continue;
+            }
+            for (uint32_t i = 0; i < reader_addrs.size(); ++i) {
+                a[i] = reader_addrs[i];
+            }
+            a[kLrIdx] = f2u_lr;
+            a[kBeta1ExpIdx] = f2u_beta1_exponent;
+            a[kBeta2ExpIdx] = f2u_beta2_exponent;
+            a[kReaderStepIdx] = step;
+        }
+    }
+    for (auto& col : tt::tt_metal::GetRuntimeArgs(program, kWriterKernelIdx)) {
+        for (auto& a : col) {
+            for (uint32_t i = 0; i < writer_addrs.size() && i < a.size(); ++i) {
+                a[i] = writer_addrs[i];
+            }
+        }
+    }
+
+    // step also feeds the compute kernel(s); the second one exists only when the split has a remainder
+    // group, so reuse create_descriptor's own work-split helper rather than rebuilding the descriptor.
+    const auto split = compute_adamw_work_split(param_in);
+    const uint32_t num_compute_kernels = split.core_group_2.ranges().empty() ? 1u : 2u;
+    for (uint32_t k = 0; k < num_compute_kernels; ++k) {
+        for (auto& col : tt::tt_metal::GetRuntimeArgs(program, kComputeKernelIdx + k)) {
+            for (auto& a : col) {
+                if (a.size() > 0) {
+                    a[0] = step;
+                }
+            }
+        }
+    }
 }
 
 }  // namespace ttnn::operations::moreh::moreh_adamw


### PR DESCRIPTION
### What

`override_runtime_arguments()` runs on **every program-cache hit**. `unary`, `moreh_adam` and
`moreh_adamw` rebuilt the entire `ProgramDescriptor` there, paying the full cache-**miss** host cost per
dispatch: the work split, `CoreRangeSet` construction, arch queries, `TensorAccessorArgs`,
kernel-source strings, compile-time arg vectors, and a fresh heap-allocated arg vector per core.

This is the anti-pattern behind the ResNet50 host regressions (#46506, #50347) and the one #51765 §5
bans.

### moreh_adam / moreh_adamw — direct slot writes

Both exclude `lr` and `step` from their cache key — `moreh_adam` through `compute_program_hash`,
`moreh_adamw` by narrowing `attribute_names` (the exact op #51765 flags as worth reading first). So the
only per-dispatch values are those two, the beta exponents `adamw` derives from `step`, and the buffer
addresses. Each is now written directly into the cached program's arg slots; nothing is re-split and
nothing is reallocated.

One wrinkle: both push a **second compute kernel only when the work split leaves a remainder group**,
and `Program` exposes no kernel count publicly (`num_kernels()` is on `ProgramImpl`, and there is no
precedent in ttnn for reaching through `.impl()`). The hook therefore re-runs *just* the work split to
learn whether that kernel exists — two `CoreRangeSet`s, not a descriptor. `moreh_adamw` reuses its
existing `compute_adamw_work_split` helper for this. I preferred that to hand-mirroring the split's
remainder arithmetic, which is the kind of copy that silently rots.

### unary — shared enumeration, because it is not a slot patch

`unary`'s hash **deliberately omits `padded_shape` for TILE layout**, so tensors of different volume
share one cached program and the per-core work split (`npc`, `start_tile_id`) really does change between
hits. There is no O(1) patch available while the key stays this coarse.

The per-core computation now lives in `enumerate_core_rt_args`, which **both** `create_descriptor` and
the hook drive, so the cache-hit patch cannot drift from the layout the miss path built. It constructs
no descriptor — no kernel sources, no CBs, no per-core arg vectors — which is also why this is not
#51765 §5's "rebuild hidden in a helper" blind spot.

Two hazards that shared enumeration made tractable, both of which would have been silent:

- **A core can flip between noop and active** when the split changes. Patching only the slots that
  usually move leaves a flipped core holding stale packed scalars and chunk args, so the hook writes
  every slot the miss path writes. Still zero allocation.
- **`common_runtime_args`.** Reader and writer carry `TensorAccessorArgs(..., RuntimeTensorShape)`,
  which encodes the tensor shape. With shape out of the key that moves on every hit, and nothing else
  would have re-applied it. Rebuilt as two small vectors via `GetCommonRuntimeArgs`, not a descriptor.

Sharded `unary` also re-points its tensor-backed CBs with a CB-only `ProgramDescriptor` built inline.
CBs are matched positionally and null-buffer entries are skipped, so a placeholder keeps `unary`'s
optional middle CB (`tmp0`) aligned.

### Host-side cache-hit dispatch

Same clone, same dependencies, baseline = the parent commit; only these files differ. Pure host enqueue
on a warm program cache (first call is the miss, then 300 timed calls with no intervening sync), so the
device work is identical between builds and the delta is host cost. Medians of 3 runs.

| op | baseline | this PR | delta |
|---|---|---|---|
| `moreh_adam` | 39.5 µs | **16.4 µs** | **−59%** |
| `moreh_adamw` | 38.8 µs | **18.3 µs** | **−53%** |
| `unary` relu, tile, 64-core | 51.9 µs | **31.0 µs** | **−40%** |
| `unary` relu, 512×512 | 44.8 µs | **31.8 µs** | **−29%** |
| `unary` relu, height-sharded | 51.4 µs | **37.0 µs** | **−28%** |

`unary` keeps a 28–40% win despite its coarse key because its descriptor construction (CBs, kernel
sources, `TensorAccessorArgs`, per-core vector allocation) dwarfs the split it still has to recompute.
Baselines are tight (±1–2 µs); the patched side has one noisy run per op with a high outlier, hence
medians. Measured with the parity check **off** (`nm` confirms no `assert_fastpath_parity` reference) —
it adds a full rebuild per hit by design and would invert the result.

### Testing

Built and run in a from-scratch clone on N150.

- `test_unary_program_cache.py` + `test_unary_sharding.py` — 140 passed. These are the cache-hit and
  CB-address paths this PR rewrites, so they are the ones that matter most here.
- `test_unary.py` + `test_unary_activation.py` — 910 passed, 3 xfailed
- `test_moreh_adam.py` + `test_moreh_adamw.py` — 155 passed, 136 skipped
- Re-run with `-DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON`, which byte-compares every patched runtime
  arg and CB address against a full rebuild on each hit: **all passed, zero parity failures.** That is
  the direct check on the noop↔active handling and the `common_runtime_args` re-application above —
  passing functional tests alone would not catch a wrong slot until a shape changed on a hit.

Still to run: the remaining `unary` dtype variants (`fp32`, `int32`, `uint16/32`, `i1`, `pow`,
`maximum`, `minimum`, `ops_ttnn`).

Verified and measured at parent `721579be154`; the branch is rebased onto current `main`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-eltwise-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-ovr-rebuild-eltwise-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-eltwise-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-ovr-rebuild-eltwise-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-eltwise-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/fix-ovr-rebuild-eltwise-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-eltwise-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-ovr-rebuild-eltwise-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-eltwise-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-ovr-rebuild-eltwise-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-eltwise-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-ovr-rebuild-eltwise-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-eltwise-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-ovr-rebuild-eltwise-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-eltwise-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-ovr-rebuild-eltwise-moreh)