### PR TITLE
[ttnn] mesh_partition: share slice's cache-hit patch instead of rebuilding

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
@@ -43,9 +43,8 @@ struct MeshPartitionDeviceOperation {
             const std::vector<ttnn::Tensor>&)>;
 
         // -- shared variables --------------------------------------------
-        // Slice factories are ProgramDescriptor-based; on cache hit we re-run
-        // the matching factory's create_descriptor with the per-coord slice
-        // attrs and let apply_descriptor_runtime_args patch the cached Program.
+        // Remembers which slice factory built this coord's Program so the cache hit patches the
+        // slot layout that factory baked (see patch_slice_program_addresses).
         struct shared_variables_t {
             prim::SliceDeviceOperation::program_factory_t slice_program_factory;
         };

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
+#include <tt-metalium/host_api.hpp>
 
 namespace ttnn::operations::ccl {
 namespace detail {
@@ -148,26 +149,11 @@ void MeshPartitionDeviceOperation::MeshPartition::override_runtime_arguments(
         auto [slice_attrs, slice_tensor_args] =
             compute_slice_parameters(operation_attributes, tensor_args, mesh_coordinate);
 
-        // Re-apply this coord's per-dispatch state to the cached Program. CB total_size/page_size are
-        // not re-applied on a hit, so any sizing that varies across calls must be in compute_program_hash().
-        std::visit(
-            [&](auto&& program_factory) {
-                using Factory = std::decay_t<decltype(program_factory)>;
-                // Height-sharded RM is CB-bound: only the two sharded CB addresses change on a hit (per-core
-                // reader args are cache-keyed), so patch just those in O(1) rather than re-running the
-                // O(num_cores) per-core arg walk. Mirrors the SliceDeviceOperation fix (this op drives the
-                // factory directly). CB order matches create_descriptor: src0 (input), c_16 (output).
-                if constexpr (std::is_same_v<Factory, ttnn::prim::SliceRmShardedProgramFactory>) {
-                    tt::tt_metal::ProgramDescriptor cb_addr_only;
-                    cb_addr_only.cbs.push_back(tt::tt_metal::CBDescriptor{.buffer = slice_tensor_args.input.buffer()});
-                    cb_addr_only.cbs.push_back(tt::tt_metal::CBDescriptor{.buffer = tensor_return_value.buffer()});
-                    tt::tt_metal::apply_descriptor_runtime_args(program, cb_addr_only);
-                } else {
-                    auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
-                    tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
-                }
-            },
-            shared_variables.slice_program_factory);
+        // Re-apply this coord's per-dispatch state to the cached Program, through the same patch the
+        // slice op uses -- addresses only. CB total_size/page_size are not re-applied on a hit, so any
+        // sizing that varies across calls must be in compute_program_hash().
+        ttnn::prim::patch_slice_program_addresses(
+            program, shared_variables.slice_program_factory, slice_attrs, slice_tensor_args, tensor_return_value);
     }
 }
 


### PR DESCRIPTION
### What

`mesh_partition` drives `slice`'s program factories directly, and its cache-hit hook rebuilt the whole
`ProgramDescriptor` for every factory except the height-sharded RM one — paying the full cache-**miss**
host cost on every program-cache hit, per coordinate. That is the anti-pattern #51765 §5 bans.

It has no custom `compute_program_hash`, so the default reflection hash keys the shapes and every
work-split arg with them; only the buffer addresses move on a hit.

The hook now calls `patch_slice_program_addresses` — the same function
`SliceDeviceOperation::override_runtime_arguments` uses — so the per-factory slot layout lives in one
place instead of being mirrored here. The previous code already special-cased `SliceRmShardedProgramFactory`
with an inline CB-address patch and rebuilt everything else; both branches now go through the shared
function, which is why this PR is a net deletion.

**Stacked on #51784**, which adds that function.

### Host-side cache-hit dispatch

**No number for this op.** `mesh_partition`'s suites
(`tests/nightly/t3000/ccl/test_mesh_partition.py` and the TG variant) need multi-device, and the host
used for this work has a single device. I am not going to quote `slice`'s numbers as if they were
`mesh_partition`'s.

What the shared code path *is* measured at, in #51784 on N150: `slice` tile 48.7 → 35.4 µs (−27%).
`mesh_partition` executes the same patch per coordinate, so the direction is not in question, but the
magnitude here is unverified.

### Testing

- Compiles clean in a from-scratch clone.
- The shared patch function is covered by `slice`'s suite (439 passed) **and** by that suite re-run under
  `-DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON`, which byte-compares every patched runtime arg and CB
  address against a full rebuild on each hit — zero parity failures. Since `mesh_partition` calls the
  same function, its per-factory slot handling is exercised there.
- **Not run: the multi-device suites.** These need a T3K/TG dispatch before merge. Flagging rather than
  letting this ride on `slice`'s coverage, because the thing `slice` cannot cover is the per-coordinate
  loop and the cached `shared_variables.slice_program_factory` this hook reads.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-ovr-rebuild-ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-ovr-rebuild-ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/fix-ovr-rebuild-ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-ovr-rebuild-ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-ovr-rebuild-ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-ovr-rebuild-ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-ovr-rebuild-ccl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-ovr-rebuild-ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-ovr-rebuild-ccl)