### PR TITLE
Performance: cut the per-page cost of the fast dispatch prefetcher's relay_paged read loop

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -754,6 +754,18 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, Sending131072Pages) {
     }
 }
 
+// Covers the band of page sizes that take more than one NoC packet each but still stream through the prefetcher's
+// scratch buffer, between the single-packet read path and the one for pages too large to buffer. 32 KB clears the
+// largest NOC_MAX_BURST_SIZE (16 KB on Blackhole) while staying under both the scratch buffer and the max prefetch
+// command size. The other page sizes here are all a single packet.
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiPacketPagesStreamedThroughScratch) {
+    for (const auto& mesh_device : devices_) {
+        TestBufferConfig config = {.num_pages = 32, .page_size = 32 * 1024, .buftype = BufferType::DRAM};
+        local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
+            mesh_device, mesh_device->mesh_command_queue(), config);
+    }
+}
+
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestPageLargerThanAndUnalignedToTransferPage) {
     constexpr uint32_t num_round_robins = 2;
     for (const auto& mesh_device : devices_) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -754,10 +754,12 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, Sending131072Pages) {
     }
 }
 
-// Covers the band of page sizes that take more than one NoC packet each but still stream through the prefetcher's
-// scratch buffer, between the single-packet read path and the one for pages too large to buffer. 32 KB clears the
-// largest NOC_MAX_BURST_SIZE (16 KB on Blackhole) while staying under both the scratch buffer and the max prefetch
-// command size. The other page sizes here are all a single packet.
+// Covers the band of page sizes that take more than one NoC burst each but still stream through the prefetcher's
+// scratch buffer, between the single-burst read path and the one for pages too large to buffer. The other page sizes
+// here all fit in one burst. 32 KB clears Blackhole's 16 KB NOC_MAX_BURST_SIZE while staying under the worker
+// prefetcher's scratch buffer and the max prefetch command size. It does not clear Quasar's 64 KB burst, and it
+// exceeds the 19 KB scratch of an eth prefetcher, so on those two it exercises the single-burst and the large-page
+// path respectively rather than the one it is named for.
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiPacketPagesStreamedThroughScratch) {
     for (const auto& mesh_device : devices_) {
         TestBufferConfig config = {.num_pages = 32, .page_size = 32 * 1024, .buftype = BufferType::DRAM};

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v1.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v1.h
@@ -1520,7 +1520,7 @@ template <
 inline __attribute__((always_inline)) void noc_read_with_state(
     uint32_t noc, uint64_t src_addr, uint32_t dst_addr, uint32_t size) {
     static_assert(noc_mode != DM_DYNAMIC_NOC, "Quasar does not support DYNAMIC_NOC as it has only 1 NOC");
-    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+    if constexpr (send && noc_mode == DM_DYNAMIC_NOC) {
         inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
     }
 
@@ -1546,7 +1546,10 @@ inline __attribute__((always_inline)) void noc_read_with_state(
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     }
 
-    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+    // Only a call that issues a transaction has a response to account for. ncrisc_noc_reads_flushed() compares this
+    // counter against NIU_MST_RD_RESP_RECEIVED, so counting a call that merely programs state would leave
+    // noc_async_read_barrier() waiting on a response that was never requested.
+    if constexpr (send && noc_mode == DM_DEDICATED_NOC) {
         noc_reads_num_issued[noc] += 1;
     }
 }

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -1541,9 +1541,10 @@ inline __attribute__((always_inline)) void noc_read_with_state(
     }
     if constexpr (send) {
         __builtin_riscv_ttrocc_cmdbuf_issue_trans(cmd_buf);
+        // Only a call that issues a transaction has a response to account for. Counting one that merely programs
+        // state would overstate the reads in flight, which is what noc_common_read_with_state avoids on tt-1xx.
+        noc_reads_num_issued[noc] += 1;
     }
-
-    noc_reads_num_issued[noc] += 1;
 }
 
 // Same as above, but with src_noc_addr giving the source NOC address separately.
@@ -1575,9 +1576,10 @@ inline __attribute__((always_inline)) void noc_read_with_state(
     }
     if constexpr (send) {
         __builtin_riscv_ttrocc_cmdbuf_issue_trans(cmd_buf);
+        // Only a call that issues a transaction has a response to account for. Counting one that merely programs
+        // state would overstate the reads in flight, which is what noc_common_read_with_state avoids on tt-1xx.
+        noc_reads_num_issued[noc] += 1;
     }
-
-    noc_reads_num_issued[noc] += 1;
 }
 
 // clang-format off

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1322,8 +1322,14 @@ FORCE_INLINE uint32_t read_pages_into_scratch(
 
 // Picks the read loop for this command. The two flags are fixed for the whole command, so the choice is made once
 // per chunk and each loop body is free of it.
+//
+// Deliberately out of line. Inlined, the three loops below were emitted at both call sites and for both values of
+// is_dram -- twelve read loops, half of them redundant, and 1.7 KB of dispatch code that the eth prefetcher's 22 KB
+// kernel region does not have. Out of line the loops are still inlined here, so the per-page work is unchanged, and
+// the one call per scratch buffer is amortized over every page read into it: on Blackhole a 64 MB paged read holds
+// to within 0.5% from 32 B pages up, on DRAM and on L1.
 template <bool is_dram, typename AddrGen>
-FORCE_INLINE uint32_t read_pages_into_scratch(
+__attribute__((noinline)) uint32_t read_pages_into_scratch(
     bool single_read,
     bool folded_offset,
     const AddrGen& addr_gen,

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1130,18 +1130,34 @@ public:
         }
     }
 
+    // Pages between the current one and the end of its row, inclusive. A run of that many pages shares one folded
+    // local address, so a caller that reads them together knows its run length before it starts.
+    FORCE_INLINE uint32_t pages_until_row_end() const { return num_banks - bank_; }
+
     // Steps to the next page. Returns whether the row advanced, i.e. whether a folded local address changed.
     FORCE_INLINE bool advance() {
-        ++bank_;
-#if ASSERT_ENABLED
-        page_id_++;
-#endif
+        step();
         if (bank_ == num_banks) {
-            bank_ = 0;
-            row_addr_ += page_size_;
+            wrap_row();
             return true;
         }
         return false;
+    }
+
+    // Steps to the next page without testing for the end of the row. For callers that bounded their run by
+    // pages_until_row_end() and so already know the row cannot end under them; they finish with wrap_row() if the run
+    // reached the end.
+    FORCE_INLINE void advance_within_row() {
+        step();
+        ASSERT(bank_ <= num_banks);
+    }
+
+    // Moves to the first page of the next row, from a bank index that advance_within_row() left at the end of this
+    // one.
+    FORCE_INLINE void wrap_row() {
+        ASSERT(bank_ == num_banks);
+        bank_ = 0;
+        row_addr_ += page_size_;
     }
 
 #if ASSERT_ENABLED
@@ -1154,6 +1170,13 @@ public:
 #endif
 
 private:
+    FORCE_INLINE void step() {
+        ++bank_;
+#if ASSERT_ENABLED
+        page_id_++;
+#endif
+    }
+
     uint32_t bank_ = 0;
     uint32_t row_addr_ = 0;
     uint32_t page_size_ = 0;
@@ -1161,6 +1184,28 @@ private:
     uint32_t page_id_ = 0;
 #endif
 };
+
+// The cross-check against the accessor the walk replaces. Wrapped rather than left to ASSERT, whose disabled form
+// still has to parse its expression, and matches() and the page id it needs only exist in an assert-enabled build.
+template <bool folded, bool is_dram, typename AddrGen>
+FORCE_INLINE void assert_walker_matches(
+    [[maybe_unused]] const InterleavedBankWalker<is_dram>& walker, [[maybe_unused]] const AddrGen& addr_gen) {
+#if ASSERT_ENABLED
+    ASSERT(walker.template matches<folded>(addr_gen));
+#endif
+}
+
+// Issues one page read. flags says which of the address registers this read still has to program.
+template <enum CQNocFlags flags>
+FORCE_INLINE void issue_page_read(uint32_t coord, uint32_t local_addr, uint32_t dst_addr, uint32_t page_size) {
+    // Keep the reads visible to watcher and to noc tracing, both of which noc_async_read would have done. Both
+    // compile out of a release build.
+    RECORD_NOC_EVENT_WITH_ADDR(
+        NocEventType::READ, dst_addr, get_noc_addr_helper(coord, local_addr), page_size, -1, false, noc_index);
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_index, get_noc_addr_helper(coord, local_addr), dst_addr, page_size);
+    noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, flags, CQ_NOC_SEND, CQ_NOC_WAIT>(
+        noc_index, coord, local_addr, dst_addr, 0);
+}
 
 // Issues the reads that fill one scratch buffer with whole pages, advancing the walker past them and returning the
 // number of bytes read.
@@ -1170,8 +1215,10 @@ private:
 // packet needs neither: every page in the command is the same size, so the caller programs the length once and each
 // read then writes only the addresses. single_packet asserts both halves of that.
 //
-// folded_offset additionally drops the local address from all but the first read of each row, leaving only the
-// coordinate and the destination. It requires the walker to have been built with fold_offset set.
+// folded_offset additionally drops the local address from all but the first read of a row, leaving only the
+// coordinate and the destination. It requires the walker to have been built with fold_offset set. The pages sharing
+// an address are consecutive, and how many of them there are is known before the run starts, so they are read by a
+// loop that counts them rather than one that re-tests every page for the row having changed.
 template <bool single_packet, bool folded_offset, bool is_dram, typename AddrGen>
 FORCE_INLINE uint32_t read_pages_into_scratch(
     [[maybe_unused]] const AddrGen& addr_gen,
@@ -1180,46 +1227,65 @@ FORCE_INLINE uint32_t read_pages_into_scratch(
     uint32_t amt_to_read,
     uint32_t page_size) {
     uint32_t amt_read = 0;
-    // The first read of a chunk always programs the address: the walker may have started mid-row, and a chunk
-    // boundary is not a row boundary.
-    bool row_changed = true;
-    while (amt_to_read >= page_size) {
-#if ASSERT_ENABLED
-        // Guarded rather than left to ASSERT, whose disabled form still has to parse the expression -- matches() and
-        // the page id it needs only exist in an assert-enabled build.
-        ASSERT(walker.template matches<folded_offset>(addr_gen));
-#endif
-        const uint32_t coord = walker.coord();
-        const uint32_t local_addr = walker.template local_addr<folded_offset>();
-        if constexpr (single_packet) {
-            // Keep the reads visible to watcher and to noc tracing, both of which noc_async_read would have done.
-            // Both compile out of a release build.
-            RECORD_NOC_EVENT_WITH_ADDR(
-                NocEventType::READ,
-                scratch_read_addr,
-                get_noc_addr_helper(coord, local_addr),
-                page_size,
-                -1,
-                false,
-                noc_index);
-            DEBUG_SANITIZE_NOC_READ_TRANSACTION(
-                noc_index, get_noc_addr_helper(coord, local_addr), scratch_read_addr, page_size);
-            if constexpr (folded_offset) {
-                if (row_changed) {
-                    noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SNDl, CQ_NOC_SEND, CQ_NOC_WAIT>(
-                        noc_index, coord, local_addr, scratch_read_addr, 0);
-                } else {
-                    noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sNDl, CQ_NOC_SEND, CQ_NOC_WAIT>(
-                        noc_index, coord, local_addr, scratch_read_addr, 0);
-                }
-            } else {
-                noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SNDl, CQ_NOC_SEND, CQ_NOC_WAIT>(
-                    noc_index, coord, local_addr, scratch_read_addr, 0);
+
+    if constexpr (folded_offset) {
+        // Runs that finish a row. The first run is however much of the current row is left, since a chunk boundary is
+        // not a row boundary; every run after it starts at bank 0 and so is a whole row.
+        uint32_t run_pages = walker.pages_until_row_end();
+        uint32_t run_bytes = run_pages * page_size;
+        while (run_bytes <= amt_to_read) {
+            const uint32_t local_addr = walker.template local_addr<true>();
+            assert_walker_matches<true>(walker, addr_gen);
+            issue_page_read<CQ_NOC_SNDl>(walker.coord(), local_addr, scratch_read_addr, page_size);
+            walker.advance_within_row();
+            scratch_read_addr += page_size;
+            for (uint32_t left = run_pages - 1; left != 0; left--) {
+                assert_walker_matches<true>(walker, addr_gen);
+                issue_page_read<CQ_NOC_sNDl>(walker.coord(), local_addr, scratch_read_addr, page_size);
+                walker.advance_within_row();
+                scratch_read_addr += page_size;
             }
+            walker.wrap_row();
+            amt_to_read -= run_bytes;
+            amt_read += run_bytes;
+            run_pages = InterleavedBankWalker<is_dram>::num_banks;
+            run_bytes = run_pages * page_size;
+        }
+
+        // What is left is short of finishing the row, so it is still all one address and still needs it programmed
+        // only once. It cannot reach the end of the row, so the walker needs no wrap.
+        if (amt_to_read >= page_size) {
+            const uint32_t local_addr = walker.template local_addr<true>();
+            assert_walker_matches<true>(walker, addr_gen);
+            issue_page_read<CQ_NOC_SNDl>(walker.coord(), local_addr, scratch_read_addr, page_size);
+            walker.advance_within_row();
+            scratch_read_addr += page_size;
+            amt_to_read -= page_size;
+            amt_read += page_size;
+            while (amt_to_read >= page_size) {
+                assert_walker_matches<true>(walker, addr_gen);
+                issue_page_read<CQ_NOC_sNDl>(walker.coord(), local_addr, scratch_read_addr, page_size);
+                walker.advance_within_row();
+                scratch_read_addr += page_size;
+                amt_to_read -= page_size;
+                amt_read += page_size;
+            }
+        }
+        return amt_read;
+    }
+
+    // Banks whose base offsets differ put consecutive pages at different addresses, so every read programs one. Same
+    // for the multi-packet case, which has to reprogram the length as well and so goes back through noc_async_read.
+    while (amt_to_read >= page_size) {
+        assert_walker_matches<false>(walker, addr_gen);
+        const uint32_t coord = walker.coord();
+        const uint32_t local_addr = walker.template local_addr<false>();
+        if constexpr (single_packet) {
+            issue_page_read<CQ_NOC_SNDl>(coord, local_addr, scratch_read_addr, page_size);
         } else {
             noc_async_read(get_noc_addr_helper(coord, local_addr), scratch_read_addr, page_size);
         }
-        row_changed = walker.advance();
+        walker.advance();
         scratch_read_addr += page_size;
         amt_to_read -= page_size;
         amt_read += page_size;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1072,6 +1072,42 @@ uint32_t process_relay_paged_cmd_large(
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
+// Issues the reads that fill one scratch buffer with whole pages, advancing page_id past them and returning the
+// number of bytes read.
+//
+// noc_async_read reprograms the transaction length on every read, and ahead of that has to test the length against
+// NOC_MAX_BURST_SIZE to decide whether the transfer needs splitting across packets. A page that fits in a single
+// packet needs neither: every page in the command is the same size, so the caller programs the length once and each
+// read then writes only the addresses. That removes one of the five (Wormhole) or six (Blackhole) command buffer
+// register writes each page costs, which is the whole per-page issue cost at the page sizes where this loop, rather
+// than DRAM, is the bottleneck.
+//
+// single_packet asserts both halves of that: pages fit in one packet, and the caller has programmed the length.
+template <bool single_packet, typename AddrGen>
+FORCE_INLINE uint32_t read_pages_into_scratch(
+    const AddrGen& addr_gen, uint32_t& page_id, uint32_t scratch_read_addr, uint32_t amt_to_read, uint32_t page_size) {
+    uint32_t amt_read = 0;
+    while (amt_to_read >= page_size) {
+        uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+        if constexpr (single_packet) {
+            // Keep the reads visible to watcher and to noc tracing, both of which noc_async_read would have done.
+            // Both compile out of a release build.
+            RECORD_NOC_EVENT_WITH_ADDR(
+                NocEventType::READ, scratch_read_addr, noc_addr, page_size, -1, false, noc_index);
+            DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_index, noc_addr, scratch_read_addr, page_size);
+            noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SNDl, CQ_NOC_SEND, CQ_NOC_WAIT>(
+                noc_index, noc_addr, scratch_read_addr, 0);
+        } else {
+            noc_async_read(noc_addr, scratch_read_addr, page_size);
+        }
+        scratch_read_addr += page_size;
+        page_id++;
+        amt_to_read -= page_size;
+        amt_read += page_size;
+    }
+    return amt_read;
+}
+
 // This fn prefetches data from DRAM memory and writes data to the dispatch core.
 // Reading from DRAM has the following characteristics:
 //  - latency is moderately high ~400 cycles on WH
@@ -1132,15 +1168,18 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
     uint64_t read_wlength = (uint64_t)pages * page_size;
     uint32_t scratch_read_addr = scratch_db_base;
     uint32_t amt_to_read = (scratch_db_buf_size > read_wlength) ? read_wlength : scratch_db_buf_size;
-    uint32_t amt_read = 0;
-    while (amt_to_read >= page_size) {
-        uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-        noc_async_read(noc_addr, scratch_read_addr, page_size);
-        scratch_read_addr += page_size;
-        page_id++;
-        amt_to_read -= page_size;
-        amt_read += page_size;
+
+    // Every page in this command is the same size, so when a page fits in one packet the transaction length is
+    // programmed here and left alone for the rest of the command: the only NoC state the reads below share the
+    // command buffer with is their own, since the writes to the dispatcher go out on a different one.
+    const bool single_packet = page_size <= NOC_MAX_BURST_SIZE;
+    if (single_packet) {
+        noc_async_read_one_packet_set_state(addr_gen.get_noc_addr(page_id), page_size);
     }
+
+    uint32_t amt_read =
+        single_packet ? read_pages_into_scratch<true>(addr_gen, page_id, scratch_read_addr, amt_to_read, page_size)
+                      : read_pages_into_scratch<false>(addr_gen, page_id, scratch_read_addr, amt_to_read, page_size);
     // The fences are to prevent any compiler reordering of instructions around the division. The latency of the
     // division is hidden by the latency of the noc_async_read_barrier().
     std::atomic_signal_fence(std::memory_order_acq_rel);
@@ -1188,15 +1227,10 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
 
             uint32_t amt_to_write = amt_read;
             amt_to_read = (scratch_db_buf_size > read_length) ? read_length : scratch_db_buf_size;
-            amt_read = 0;
-            while (amt_to_read >= page_size) {
-                uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-                noc_async_read(noc_addr, scratch_read_addr, page_size);
-                scratch_read_addr += page_size;
-                page_id++;
-                amt_to_read -= page_size;
-                amt_read += page_size;
-            }
+            amt_read =
+                single_packet
+                    ? read_pages_into_scratch<true>(addr_gen, page_id, scratch_read_addr, amt_to_read, page_size)
+                    : read_pages_into_scratch<false>(addr_gen, page_id, scratch_read_addr, amt_to_read, page_size);
 
             // Third step - write from DB
             uint32_t npages =

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1123,10 +1123,13 @@ public:
     // two always agree.
     FORCE_INLINE InterleavedBankWalker(
         uint32_t page_id, uint32_t bank_base_address, uint32_t page_size, bool fold_offset) :
-        page_size_(page_size) {
+        // A page occupies a whole allocator-aligned slot in its bank, so the row stride is the page size rounded up to
+        // that alignment, not the page size itself. The two differ only for a command whose page size is not already
+        // aligned, which no buffer read generates but the command permits.
+        row_stride_(align_power_of_2(page_size, interleaved_addr_gen::get_allocator_alignment<is_dram>())) {
         const uint32_t row = interleaved_addr_gen::get_bank_offset_index<is_dram>(page_id);
         bank_ = interleaved_addr_gen::get_bank_index<is_dram>(page_id, row);
-        row_addr_ = bank_base_address + row * page_size;
+        row_addr_ = bank_base_address + row * row_stride_;
         if (fold_offset) {
             row_addr_ += interleaved_addr_gen::get_bank_offset<is_dram>(0);
         }
@@ -1173,7 +1176,7 @@ public:
     FORCE_INLINE void wrap_row() {
         ASSERT(bank_ == num_banks);
         bank_ = 0;
-        row_addr_ += page_size_;
+        row_addr_ += row_stride_;
     }
 
 #if ASSERT_ENABLED
@@ -1195,7 +1198,7 @@ private:
 
     uint32_t bank_ = 0;
     uint32_t row_addr_ = 0;
-    uint32_t page_size_ = 0;
+    uint32_t row_stride_ = 0;
 #if ASSERT_ENABLED
     uint32_t page_id_ = 0;
 #endif

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1072,40 +1072,179 @@ uint32_t process_relay_paged_cmd_large(
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
-// Issues the reads that fill one scratch buffer with whole pages, advancing page_id past them and returning the
+// Walks interleaved pages in page order, one bank per step.
+//
+// Interleaved layout sends consecutive pages to consecutive banks, so page order visits the bank cycle in order and
+// the in-bank offset only advances when that cycle wraps. TensorAccessor::get_noc_addr instead recovers both from the
+// page id on every page, which costs two magic-multiply divisions by the bank count -- one for the in-bank offset and
+// one for the coordinate, which derives the bank a second time -- plus assembling a 64-bit address that the NoC API
+// immediately takes back apart. Tracking the cycle turns that into an increment and a compare, and lets the
+// coordinate and the local address go to the command buffer separately.
+//
+// A page's local address is row_addr + bank_offset[bank]. Where all banks share one offset it folds into row_addr,
+// and then the local address is the same for a whole row of pages and only the coordinate has to be reprogrammed per
+// read. That holds for L1 always, and for DRAM wherever the SoC descriptor gives every DRAM view the same
+// address_offset (Blackhole). Wormhole DRAM is the exception: its views alternate a 1 GB offset, so consecutive
+// pages there really do sit at different local addresses.
+template <bool is_dram>
+class InterleavedBankWalker {
+public:
+    static constexpr uint32_t num_banks = is_dram ? NUM_DRAM_BANKS : NUM_L1_BANKS;
+
+    // Whether all banks share one base offset, which is the precondition for the fold_offset ctor argument. The
+    // table is fixed once firmware init writes it, so this only depends on the arch and its harvesting.
+    static FORCE_INLINE bool offsets_uniform() {
+        const uint32_t first = interleaved_addr_gen::get_bank_offset<is_dram>(0);
+        for (uint32_t bank = 1; bank < num_banks; bank++) {
+            if (interleaved_addr_gen::get_bank_offset<is_dram>(bank) != first) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // fold_offset must be offsets_uniform(). Callers pass it as a template argument to local_addr() as well, so the
+    // two always agree.
+    FORCE_INLINE InterleavedBankWalker(
+        uint32_t page_id, uint32_t bank_base_address, uint32_t page_size, bool fold_offset) :
+        page_size_(page_size) {
+        const uint32_t row = interleaved_addr_gen::get_bank_offset_index<is_dram>(page_id);
+        bank_ = interleaved_addr_gen::get_bank_index<is_dram>(page_id, row);
+        row_addr_ = bank_base_address + row * page_size;
+        if (fold_offset) {
+            row_addr_ += interleaved_addr_gen::get_bank_offset<is_dram>(0);
+        }
+#if ASSERT_ENABLED
+        page_id_ = page_id;
+#endif
+    }
+
+    FORCE_INLINE uint32_t coord() const { return interleaved_addr_gen::get_noc_xy<is_dram>(bank_, noc_index); }
+
+    template <bool folded>
+    FORCE_INLINE uint32_t local_addr() const {
+        if constexpr (folded) {
+            return row_addr_;
+        } else {
+            return row_addr_ + interleaved_addr_gen::get_bank_offset<is_dram>(bank_);
+        }
+    }
+
+    // Steps to the next page. Returns whether the row advanced, i.e. whether a folded local address changed.
+    FORCE_INLINE bool advance() {
+        ++bank_;
+#if ASSERT_ENABLED
+        page_id_++;
+#endif
+        if (bank_ == num_banks) {
+            bank_ = 0;
+            row_addr_ += page_size_;
+            return true;
+        }
+        return false;
+    }
+
+#if ASSERT_ENABLED
+    // Cross-checks the walk against the accessor it replaces, so a watcher build reports any layout this hand-rolled
+    // address generation gets wrong rather than silently reading the wrong pages.
+    template <bool folded, typename AddrGen>
+    FORCE_INLINE bool matches(const AddrGen& addr_gen) const {
+        return get_noc_addr_helper(coord(), local_addr<folded>()) == addr_gen.get_noc_addr(page_id_);
+    }
+#endif
+
+private:
+    uint32_t bank_ = 0;
+    uint32_t row_addr_ = 0;
+    uint32_t page_size_ = 0;
+#if ASSERT_ENABLED
+    uint32_t page_id_ = 0;
+#endif
+};
+
+// Issues the reads that fill one scratch buffer with whole pages, advancing the walker past them and returning the
 // number of bytes read.
 //
 // noc_async_read reprograms the transaction length on every read, and ahead of that has to test the length against
 // NOC_MAX_BURST_SIZE to decide whether the transfer needs splitting across packets. A page that fits in a single
 // packet needs neither: every page in the command is the same size, so the caller programs the length once and each
-// read then writes only the addresses. That removes one of the five (Wormhole) or six (Blackhole) command buffer
-// register writes each page costs, which is the whole per-page issue cost at the page sizes where this loop, rather
-// than DRAM, is the bottleneck.
+// read then writes only the addresses. single_packet asserts both halves of that.
 //
-// single_packet asserts both halves of that: pages fit in one packet, and the caller has programmed the length.
-template <bool single_packet, typename AddrGen>
+// folded_offset additionally drops the local address from all but the first read of each row, leaving only the
+// coordinate and the destination. It requires the walker to have been built with fold_offset set.
+template <bool single_packet, bool folded_offset, bool is_dram, typename AddrGen>
 FORCE_INLINE uint32_t read_pages_into_scratch(
-    const AddrGen& addr_gen, uint32_t& page_id, uint32_t scratch_read_addr, uint32_t amt_to_read, uint32_t page_size) {
+    [[maybe_unused]] const AddrGen& addr_gen,
+    InterleavedBankWalker<is_dram>& walker,
+    uint32_t scratch_read_addr,
+    uint32_t amt_to_read,
+    uint32_t page_size) {
     uint32_t amt_read = 0;
+    // The first read of a chunk always programs the address: the walker may have started mid-row, and a chunk
+    // boundary is not a row boundary.
+    bool row_changed = true;
     while (amt_to_read >= page_size) {
-        uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+#if ASSERT_ENABLED
+        // Guarded rather than left to ASSERT, whose disabled form still has to parse the expression -- matches() and
+        // the page id it needs only exist in an assert-enabled build.
+        ASSERT(walker.template matches<folded_offset>(addr_gen));
+#endif
+        const uint32_t coord = walker.coord();
+        const uint32_t local_addr = walker.template local_addr<folded_offset>();
         if constexpr (single_packet) {
             // Keep the reads visible to watcher and to noc tracing, both of which noc_async_read would have done.
             // Both compile out of a release build.
             RECORD_NOC_EVENT_WITH_ADDR(
-                NocEventType::READ, scratch_read_addr, noc_addr, page_size, -1, false, noc_index);
-            DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_index, noc_addr, scratch_read_addr, page_size);
-            noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SNDl, CQ_NOC_SEND, CQ_NOC_WAIT>(
-                noc_index, noc_addr, scratch_read_addr, 0);
+                NocEventType::READ,
+                scratch_read_addr,
+                get_noc_addr_helper(coord, local_addr),
+                page_size,
+                -1,
+                false,
+                noc_index);
+            DEBUG_SANITIZE_NOC_READ_TRANSACTION(
+                noc_index, get_noc_addr_helper(coord, local_addr), scratch_read_addr, page_size);
+            if constexpr (folded_offset) {
+                if (row_changed) {
+                    noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SNDl, CQ_NOC_SEND, CQ_NOC_WAIT>(
+                        noc_index, coord, local_addr, scratch_read_addr, 0);
+                } else {
+                    noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sNDl, CQ_NOC_SEND, CQ_NOC_WAIT>(
+                        noc_index, coord, local_addr, scratch_read_addr, 0);
+                }
+            } else {
+                noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SNDl, CQ_NOC_SEND, CQ_NOC_WAIT>(
+                    noc_index, coord, local_addr, scratch_read_addr, 0);
+            }
         } else {
-            noc_async_read(noc_addr, scratch_read_addr, page_size);
+            noc_async_read(get_noc_addr_helper(coord, local_addr), scratch_read_addr, page_size);
         }
+        row_changed = walker.advance();
         scratch_read_addr += page_size;
-        page_id++;
         amt_to_read -= page_size;
         amt_read += page_size;
     }
     return amt_read;
+}
+
+// Picks the read loop for this command. The two flags are fixed for the whole command, so the choice is made once
+// per chunk and each loop body is free of it.
+template <bool is_dram, typename AddrGen>
+FORCE_INLINE uint32_t read_pages_into_scratch(
+    bool single_packet,
+    bool folded_offset,
+    const AddrGen& addr_gen,
+    InterleavedBankWalker<is_dram>& walker,
+    uint32_t scratch_read_addr,
+    uint32_t amt_to_read,
+    uint32_t page_size) {
+    if (!single_packet) {
+        return read_pages_into_scratch<false, false>(addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
+    }
+    if (folded_offset) {
+        return read_pages_into_scratch<true, true>(addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
+    }
+    return read_pages_into_scratch<true, false>(addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
 }
 
 // This fn prefetches data from DRAM memory and writes data to the dispatch core.
@@ -1177,9 +1316,14 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
         noc_async_read_one_packet_set_state(addr_gen.get_noc_addr(page_id), page_size);
     }
 
-    uint32_t amt_read =
-        single_packet ? read_pages_into_scratch<true>(addr_gen, page_id, scratch_read_addr, amt_to_read, page_size)
-                      : read_pages_into_scratch<false>(addr_gen, page_id, scratch_read_addr, amt_to_read, page_size);
+    // Folding the shared bank offset into the row address is only worth a separate loop when there is at least one
+    // full row of pages to spread the saved address writes over.
+    const bool folded_offset = single_packet && pages >= InterleavedBankWalker<is_dram>::num_banks &&
+                               InterleavedBankWalker<is_dram>::offsets_uniform();
+    InterleavedBankWalker<is_dram> walker(page_id, base_addr, page_size, folded_offset);
+
+    uint32_t amt_read = read_pages_into_scratch(
+        single_packet, folded_offset, addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
     // The fences are to prevent any compiler reordering of instructions around the division. The latency of the
     // division is hidden by the latency of the noc_async_read_barrier().
     std::atomic_signal_fence(std::memory_order_acq_rel);
@@ -1227,10 +1371,8 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
 
             uint32_t amt_to_write = amt_read;
             amt_to_read = (scratch_db_buf_size > read_length) ? read_length : scratch_db_buf_size;
-            amt_read =
-                single_packet
-                    ? read_pages_into_scratch<true>(addr_gen, page_id, scratch_read_addr, amt_to_read, page_size)
-                    : read_pages_into_scratch<false>(addr_gen, page_id, scratch_read_addr, amt_to_read, page_size);
+            amt_read = read_pages_into_scratch(
+                single_packet, folded_offset, addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
 
             // Third step - write from DB
             uint32_t npages =

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1212,6 +1212,12 @@ FORCE_INLINE void assert_walker_matches(
 }
 
 // Issues one page read. flags says which of the address registers this read still has to program.
+//
+// noc_read_with_state counts one read per call, which on tt-1xx is exactly the one response a burst draws. Quasar's
+// overlay instead packetizes a page longer than NOC_V2_MAX_BYTES_IN_PACKET and answers each packet separately, so
+// there the count runs low, where noc_async_read would have counted per packet. Nothing depends on the difference:
+// v2 answers ncrisc_noc_reads_flushed() from the hardware's outstanding-transaction count, so the barrier waits on
+// the responses themselves rather than on noc_reads_num_issued.
 template <enum CQNocFlags flags>
 FORCE_INLINE void issue_page_read(uint32_t coord, uint32_t local_addr, uint32_t dst_addr, uint32_t page_size) {
     // Keep the reads visible to watcher and to noc tracing, both of which noc_async_read would have done. Both
@@ -1227,15 +1233,16 @@ FORCE_INLINE void issue_page_read(uint32_t coord, uint32_t local_addr, uint32_t 
 // number of bytes read.
 //
 // noc_async_read reprograms the transaction length on every read, and ahead of that has to test the length against
-// NOC_MAX_BURST_SIZE to decide whether the transfer needs splitting across packets. A page that fits in a single
-// packet needs neither: every page in the command is the same size, so the caller programs the length once and each
-// read then writes only the addresses. single_packet asserts both halves of that.
+// NOC_MAX_BURST_SIZE to decide whether the transfer needs splitting across bursts. A page that one burst covers needs
+// neither: every page in the command is the same size, so the caller programs the length once and each read then
+// writes only the addresses. single_read asserts both halves of that. It is not a claim about packets: a burst is
+// several of them on Quasar, which issue_page_read covers.
 //
 // folded_offset additionally drops the local address from all but the first read of a row, leaving only the
 // coordinate and the destination. It requires the walker to have been built with fold_offset set. The pages sharing
 // an address are consecutive, and how many of them there are is known before the run starts, so they are read by a
 // loop that counts them rather than one that re-tests every page for the row having changed.
-template <bool single_packet, bool folded_offset, bool is_dram, typename AddrGen>
+template <bool single_read, bool folded_offset, bool is_dram, typename AddrGen>
 FORCE_INLINE uint32_t read_pages_into_scratch(
     [[maybe_unused]] const AddrGen& addr_gen,
     InterleavedBankWalker<is_dram>& walker,
@@ -1291,12 +1298,13 @@ FORCE_INLINE uint32_t read_pages_into_scratch(
     }
 
     // Banks whose base offsets differ put consecutive pages at different addresses, so every read programs one. Same
-    // for the multi-packet case, which has to reprogram the length as well and so goes back through noc_async_read.
+    // for a page too long for one burst, which has to reprogram the length as well and so goes back through
+    // noc_async_read.
     while (amt_to_read >= page_size) {
         assert_walker_matches<false>(walker, addr_gen);
         const uint32_t coord = walker.coord();
         const uint32_t local_addr = walker.template local_addr<false>();
-        if constexpr (single_packet) {
+        if constexpr (single_read) {
             issue_page_read<CQ_NOC_SNDl>(coord, local_addr, scratch_read_addr, page_size);
         } else {
             noc_async_read(get_noc_addr_helper(coord, local_addr), scratch_read_addr, page_size);
@@ -1313,14 +1321,14 @@ FORCE_INLINE uint32_t read_pages_into_scratch(
 // per chunk and each loop body is free of it.
 template <bool is_dram, typename AddrGen>
 FORCE_INLINE uint32_t read_pages_into_scratch(
-    bool single_packet,
+    bool single_read,
     bool folded_offset,
     const AddrGen& addr_gen,
     InterleavedBankWalker<is_dram>& walker,
     uint32_t scratch_read_addr,
     uint32_t amt_to_read,
     uint32_t page_size) {
-    if (!single_packet) {
+    if (!single_read) {
         return read_pages_into_scratch<false, false>(addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
     }
     if (folded_offset) {
@@ -1390,13 +1398,13 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
     uint32_t scratch_read_addr = scratch_db_base;
     uint32_t amt_to_read = (scratch_db_buf_size > read_wlength) ? read_wlength : scratch_db_buf_size;
 
-    // Every page in this command is the same size, so when a page fits in one packet the transaction length is
+    // Every page in this command is the same size, so when a page fits in one burst the transaction length is
     // programmed here and left alone for the rest of the command: the only NoC state the reads below share the
     // command buffer with is their own, since the writes to the dispatcher go out on a different one. Programming it
     // with no send is the same thing paged_read_into_cmddat_q and noc_read_64bit_any_len do, and leaves the address
     // registers to the read loop, which has to write them anyway.
-    const bool single_packet = page_size <= NOC_MAX_BURST_SIZE;
-    if (single_packet) {
+    const bool single_read = page_size <= NOC_MAX_BURST_SIZE;
+    if (single_read) {
         noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sndL, CQ_NOC_send, CQ_NOC_WAIT>(
             noc_index, 0, 0, 0, page_size);
     }
@@ -1404,11 +1412,11 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
     // Fold the shared bank offset into the row address whenever the banks have one. No lower bound on the page count:
     // the read loop saves an address write on every page after the first of each contiguous run, and a command too
     // short to finish a row is still one run.
-    const bool folded_offset = single_packet && bank_offsets_uniform<is_dram>();
+    const bool folded_offset = single_read && bank_offsets_uniform<is_dram>();
     InterleavedBankWalker<is_dram> walker(page_id, base_addr, page_size, folded_offset);
 
     uint32_t amt_read = read_pages_into_scratch(
-        single_packet, folded_offset, addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
+        single_read, folded_offset, addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
     // The fences are to prevent any compiler reordering of instructions around the division. The latency of the
     // division is hidden by the latency of the noc_async_read_barrier().
     std::atomic_signal_fence(std::memory_order_acq_rel);
@@ -1457,7 +1465,7 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
             uint32_t amt_to_write = amt_read;
             amt_to_read = (scratch_db_buf_size > read_length) ? read_length : scratch_db_buf_size;
             amt_read = read_pages_into_scratch(
-                single_packet, folded_offset, addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
+                single_read, folded_offset, addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
 
             // Third step - write from DB
             uint32_t npages =

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -296,6 +296,21 @@ static uint32_t downstream_data_ptr_s = dispatch_s_buffer_base;
 static uint32_t ringbuffer_wp = scratch_db_base;
 static uint32_t ringbuffer_offset = 0;
 
+// Whether every interleaved bank carries the same base offset, for DRAM and for L1. That is what lets the relay_paged
+// read loop fold the offset into the row address and stop reprogramming the source address per read. The bank tables
+// are fixed once firmware init has written them, so this is scanned once in kernel_main rather than per command.
+static bool dram_bank_offsets_uniform = false;
+static bool l1_bank_offsets_uniform = false;
+
+template <bool is_dram>
+FORCE_INLINE bool bank_offsets_uniform() {
+    if constexpr (is_dram) {
+        return dram_bank_offsets_uniform;
+    } else {
+        return l1_bank_offsets_uniform;
+    }
+}
+
 // Runtime args
 static uint32_t my_dev_id;
 static uint32_t to_dev_id;
@@ -1091,9 +1106,10 @@ class InterleavedBankWalker {
 public:
     static constexpr uint32_t num_banks = is_dram ? NUM_DRAM_BANKS : NUM_L1_BANKS;
 
-    // Whether all banks share one base offset, which is the precondition for the fold_offset ctor argument. The
-    // table is fixed once firmware init writes it, so this only depends on the arch and its harvesting.
-    static FORCE_INLINE bool offsets_uniform() {
+    // Whether all banks share one base offset, which is the precondition for the fold_offset ctor argument. Scanned
+    // once from kernel_main into bank_offsets_uniform<is_dram>(), not per command -- the table is fixed once firmware
+    // init writes it, so this only depends on the arch and its harvesting.
+    static bool scan_offsets_uniform() {
         const uint32_t first = interleaved_addr_gen::get_bank_offset<is_dram>(0);
         for (uint32_t bank = 1; bank < num_banks; bank++) {
             if (interleaved_addr_gen::get_bank_offset<is_dram>(bank) != first) {
@@ -1385,10 +1401,10 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
             noc_index, 0, 0, 0, page_size);
     }
 
-    // Folding the shared bank offset into the row address is only worth a separate loop when there is at least one
-    // full row of pages to spread the saved address writes over.
-    const bool folded_offset = single_packet && pages >= InterleavedBankWalker<is_dram>::num_banks &&
-                               InterleavedBankWalker<is_dram>::offsets_uniform();
+    // Fold the shared bank offset into the row address whenever the banks have one. No lower bound on the page count:
+    // the read loop saves an address write on every page after the first of each contiguous run, and a command too
+    // short to finish a row is still one run.
+    const bool folded_offset = single_packet && bank_offsets_uniform<is_dram>();
     InterleavedBankWalker<is_dram> walker(page_id, base_addr, page_size, folded_offset);
 
     uint32_t amt_read = read_pages_into_scratch(
@@ -3091,6 +3107,9 @@ void kernel_main() {
     my_dev_id = get_arg_val<uint32_t>(OFFSETOF_MY_DEV_ID);
     to_dev_id = get_arg_val<uint32_t>(OFFSETOF_TO_DEV_ID);
     router_direction = get_arg_val<uint32_t>(OFFSETOF_ROUTER_DIRECTION);
+
+    dram_bank_offsets_uniform = InterleavedBankWalker<true>::scan_offsets_uniform();
+    l1_bank_offsets_uniform = InterleavedBankWalker<false>::scan_offsets_uniform();
 
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1376,10 +1376,13 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
 
     // Every page in this command is the same size, so when a page fits in one packet the transaction length is
     // programmed here and left alone for the rest of the command: the only NoC state the reads below share the
-    // command buffer with is their own, since the writes to the dispatcher go out on a different one.
+    // command buffer with is their own, since the writes to the dispatcher go out on a different one. Programming it
+    // with no send is the same thing paged_read_into_cmddat_q and noc_read_64bit_any_len do, and leaves the address
+    // registers to the read loop, which has to write them anyway.
     const bool single_packet = page_size <= NOC_MAX_BURST_SIZE;
     if (single_packet) {
-        noc_async_read_one_packet_set_state(addr_gen.get_noc_addr(page_id), page_size);
+        noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sndL, CQ_NOC_send, CQ_NOC_WAIT>(
+            noc_index, 0, 0, 0, page_size);
     }
 
     // Folding the shared bank offset into the row address is only worth a separate loop when there is at least one


### PR DESCRIPTION
### PR Category

Performance (plus one new test, covering a branch this change introduces).

### Summary

The scratch-ring work this was stacked on has landed as #51272, so this is now six commits against `main`.

`process_relay_paged_cmd` is read-issue bound at small page sizes: the prefetcher is ~100% busy and neither credit-gated nor source-latency bound (see #51272 for the instrumentation), so whatever the loop spends per page is bandwidth. Three commits take work out of it, a fourth stops Quasar counting a with-state call that issues nothing, and two apply review feedback.

**1. Program the transaction length once per command.** `noc_async_read` writes `NOC_AT_LEN_BE` on every read and, ahead of that, tests the length against `NOC_MAX_BURST_SIZE` to decide whether to split across bursts. Every page in a relay_paged command is the same size, so when it fits in one burst the length is programmed once and each read writes only addresses — one fewer command-buffer register write of five (Wormhole) or six (Blackhole).

**2. Walk the interleaved bank cycle instead of re-deriving it.** Disassembling the loop showed address generation, not NoC programming, was most of it — about 19 of 32 instructions per page. `TensorAccessor::get_noc_addr` recovers the bank and in-bank offset from the page id with a magic-multiply division by the bank count, `get_dram_bank_base_offset` then divides by the bank count *again* to look up the coordinate, and the 64-bit address the two assemble is taken straight back apart by the NoC API. Interleaved layout sends consecutive pages to consecutive banks, so page order steps the bank index by one and only advances the in-bank offset when it wraps: an increment, a compare and two table lookups, with coordinate and local address handed to the command buffer separately so no 64-bit address is built.

**3. Drop the local address where banks share a base offset, and count the run.** A page's local address is `row_addr + bank_offset[bank]`; where every bank carries the same offset it folds into `row_addr`, and then a whole row of pages shares one address and only the coordinate needs reprogramming. The pages sharing an address are consecutive and there are exactly as many as remain in the row, so the run is read by a loop that counts down rather than one retesting each page — which also lets it skip the wrap test, since the run cannot outlast the row. A chunk's last partial run is still inside one row and so still one address, so it folds too — there is no page-count floor, and a one-page command folds with a run of one. Whether the banks are uniform is scanned once in `kernel_main`, not per command.

Which layouts fold, probed on device rather than inferred:

| | banks | uniform offsets? |
|---|---|---|
| L1 (both archs) | 64 on WH | yes — allocator gives every L1 bank offset 0 |
| Blackhole DRAM | 8 | yes — all 8 DRAM views have `address_offset: 0` |
| Wormhole DRAM | 12 | **no** — views alternate a 1 GB offset |

Wormhole n150, 64 MB `EnqueueReadBuffer` from an interleaved buffer, median of 3 (Gi/s). DRAM never folds here, so its whole gain is (1) and (2):

| interleaved DRAM | 32 B | 64 B | 128 B | 256 B | 512 B | 1 KB | 2 KB |
|---|---|---|---|---|---|---|---|
| base (#51272) | 0.646 | 1.251 | 2.352 | 4.223 | 5.812 | 7.601 | 8.668 |
| this PR | 0.970 | 1.838 | 3.324 | 5.575 | 7.617 | 8.927 | 10.097 |
| | **+50%** | **+47%** | **+41%** | **+32%** | **+31%** | **+17%** | **+16%** |

| interleaved L1 | 32 B | 64 B | 128 B | 256 B | 512 B | 1 KB | 2 KB |
|---|---|---|---|---|---|---|---|
| base (#51272) | 0.876 | 1.676 | 3.084 | 5.310 | 7.579 | 9.127 | 10.020 |
| this PR | 1.446 | 2.641 | 4.489 | 6.951 | 7.823 | 9.474 | 10.365 |
| | **+65%** | **+58%** | **+46%** | **+31%** | **+3%** | **+4%** | **+3%** |

L1 is bandwidth bound from 512 B up, which is why it flattens there.

Per-commit at 32 B, to show where it comes from: DRAM 0.646 → 0.781 → 0.959 → 0.970; L1 0.876 → (walk alone 0.988) → 1.178 → 1.446. On L1 the walk is worth less than on DRAM because 64 banks is a power of two, so the division it removes was only a shift — DRAM's 12 is where the magic multiplies were.

### Notes for reviewers

**Correctness of the hand-rolled address generation.** An assert-enabled build compares every page's composed address against `addr_gen.get_noc_addr` for the same page id, so any layout the walk gets wrong is reported rather than silently reading elsewhere. Both members that needs are compiled out of a release build. The 131072-page test alone puts 131072 pages through the comparison. This is the thing to be most skeptical of, and the assert is the argument — please push on it if you think it has a hole.

**A page that fits one burst is not always one packet (6th commit).** The flag gating the program-length-once path was called `single_packet`, but the condition it tests is `page_size <= NOC_MAX_BURST_SIZE` — whether *one `noc_read_with_state` call* covers the page. On Quasar a burst is eight packets, so the name claimed something the condition never checked. Renamed `single_read`, comments corrected to say burst; the bound is unchanged and there is no functional difference. The related counting question is documented rather than changed: `noc_read_with_state` counts one read per call, so on Quasar a multi-packet page undercounts relative to `noc_async_read`, and that is harmless precisely because v2's flush predicate reads hardware acks instead of the counter. Making the count exact would have added an accumulate to the per-page loop this PR exists to tighten, in service of a field with no readers.

**New test.** Pages between `NOC_MAX_BURST_SIZE` and the scratch buffer size still stream through this loop and still need a length per read, so they keep calling `noc_async_read`. Nothing covered that band — the buffer tests topped out at an 8 KB page, which is exactly one burst on Wormhole — so `TestMultiPacketPagesStreamedThroughScratch` reads 32 KB pages. Confirmed it is the only case that takes the branch by temporarily asserting `single_read`: the 32 KB test tripped it, the 128 B test did not. Temporarily forcing `single_read` false then exercised the multi-burst path across every page size in the suite, which still passed. Note the size is chosen for Wormhole and Blackhole: 32 KB does not clear Quasar's 64 KB burst, and it exceeds an eth prefetcher's 19 KB scratch, so on those two the test takes the single-burst and large-page paths instead.

**Blackhole: functionally covered, not measured.** Its eight uniform DRAM banks put it on the folding path, so DRAM there should gain roughly what Wormhole L1 gains. The dispatch buffer suites now pass on a p150b (below), but no bandwidth numbers have been taken on it.

**Left undone: Wormhole DRAM folding.** Its twelve offsets take only two distinct values, so issuing a row grouped by offset would fold there too — reads are independent with per-read destinations, so reordering within a row is legal. It complicates the partial rows at chunk boundaries and changes DRAM issue order, so I would rather agree that is wanted first.

### Verification

Wormhole n150, before the rebase, with `TT_METAL_WATCHER=1` throughout — which is what compiles in both the read sanitizer the new path calls and the per-page address comparison above:

- `unit_tests_dispatch --gtest_filter='UnitMeshCQSingleCard*BufferFixture*'` — 56 passed / 1 skipped of 57, on **both** worker and eth dispatch (`TT_METAL_GTEST_ETH_DISPATCH=1`). Baseline before this PR was 55/55 of 56; the extra test is the new one.
- `test_prefetcher --gtest_filter='PrefetcherTests*'` — 27 passed / 2 skipped, matching baseline.
- No NoC sanitizer hits in any run.

Eth matters here because its prefetcher has a much smaller scratch region and so a different buffer count; it exercises the fallback paths the worker does not.

Blackhole p150b, after the rebase onto `main`, without watcher:

- `unit_tests_dispatch --gtest_filter='UnitMeshCQSingleCardSharedBufferFixture.*:UnitMeshCQSingleCardBufferFixture.*:UnitMeshMultiCQSingleDeviceBufferFixture.*:LargeInterleavedReadback/*:LargeShardedReadback/*'` — 79 passed, 0 failed, 17 skipped of 96. The skips are the multi-CQ fixture and three nightly sharded cases, neither runnable on a single card. Identical results before and after both review commits.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/relay-paged-single-packet-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/relay-paged-single-packet-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/relay-paged-single-packet-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/relay-paged-single-packet-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/relay-paged-single-packet-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/relay-paged-single-packet-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/relay-paged-single-packet-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/relay-paged-single-packet-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/relay-paged-single-packet-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/relay-paged-single-packet-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/relay-paged-single-packet-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/relay-paged-single-packet-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/relay-paged-single-packet-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/relay-paged-single-packet-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/relay-paged-single-packet-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/relay-paged-single-packet-read)
