### PR TITLE
Improve runner failure reports with live GitHub jobs [skip ci]

### DIFF
--- a/.github/scripts/runner_failure_common.py
+++ b/.github/scripts/runner_failure_common.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:  # pragma: no cover - handled in load_config
     yaml = None
 
 
-SIGNATURE_VERSION = "runner-failure-signatures-2026-08-01-v1"
+SIGNATURE_VERSION = "runner-failure-signatures-2026-08-01-v2"
 UNKNOWN_RUNNER = "(unknown runner)"
 
 OSC_SEQUENCE_RE = re.compile(r"\x1b\].*?\x1b\\")
@@ -139,6 +139,12 @@ ERROR_SIGNATURES = (
         key="FAILED_RESET_FOUND",
         label="Failed reset",
         needle="Unable to reset board successfully",
+        case_sensitive=False,
+    ),
+    ErrorSignature(
+        key="PHYSICAL_DISCOVERY_FAILURE_FOUND",
+        label="Physical discovery failure",
+        pattern=r"Physical\s+Discovery\s+found\s+[1-9]\d*\s+missing\s+(?:channel|port/cable)\s+connections",
         case_sensitive=False,
     ),
 )

--- a/.github/scripts/runner_failure_common.py
+++ b/.github/scripts/runner_failure_common.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:  # pragma: no cover - handled in load_config
     yaml = None
 
 
-SIGNATURE_VERSION = "runner-failure-signatures-2026-08-01-v4"
+SIGNATURE_VERSION = "runner-failure-signatures-2026-08-01-v5"
 UNKNOWN_RUNNER = "(unknown runner)"
 
 OSC_SEQUENCE_RE = re.compile(r"\x1b\].*?\x1b\\")
@@ -488,24 +488,16 @@ def out_of_disk_signature_found(log_text: str) -> bool:
     if OUT_OF_DISK_HARD_RE.search(plain_log_text):
         return True
 
-    high_positions: list[int] = []
-    usage_reports: list[tuple[int, int]] = []
+    disk_pressure_signals: list[tuple[int, bool]] = []
     for match in DISK_USAGE_RE.finditer(plain_log_text):
         percent = int(match.group("percent"))
-        usage_reports.append((match.start(), percent))
-        if percent >= 90:
-            high_positions.append(match.start())
+        disk_pressure_signals.append((match.start(), percent >= 90))
 
-    high_positions.extend(match.start() for match in DISK_USAGE_HIGH_RE.finditer(plain_log_text))
-    if not high_positions:
+    disk_pressure_signals.extend((match.start(), True) for match in DISK_USAGE_HIGH_RE.finditer(plain_log_text))
+    if not disk_pressure_signals:
         return False
 
-    first_high_position = min(high_positions)
-    later_usage_reports = [(position, percent) for position, percent in usage_reports if position > first_high_position]
-    if later_usage_reports and later_usage_reports[-1][1] < 90:
-        return False
-
-    return True
+    return max(disk_pressure_signals, key=lambda signal: signal[0])[1]
 
 
 def format_fabric_node(mesh: str, device: str) -> str:

--- a/.github/scripts/runner_failure_common.py
+++ b/.github/scripts/runner_failure_common.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:  # pragma: no cover - handled in load_config
     yaml = None
 
 
-SIGNATURE_VERSION = "runner-failure-signatures-2026-07-24-v1"
+SIGNATURE_VERSION = "runner-failure-signatures-2026-08-01-v1"
 UNKNOWN_RUNNER = "(unknown runner)"
 
 OSC_SEQUENCE_RE = re.compile(r"\x1b\].*?\x1b\\")
@@ -35,6 +35,9 @@ FABRIC_LINK_MISMATCH_RE = re.compile(
     r"\S+\s+to\s+\S+\s+only\s+has\s+\d+\s+channels",
     re.IGNORECASE,
 )
+OUT_OF_DISK_HARD_RE = re.compile(r"(no\s+space\s+left\s+on\s+device|enospc)", re.IGNORECASE)
+DISK_USAGE_RE = re.compile(r"disk\s+usage\s+is\s+(?P<percent>\d{1,3})\s*%", re.IGNORECASE)
+DISK_USAGE_HIGH_RE = re.compile(r"disk\s+usage\s+is\s+high", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -453,6 +456,9 @@ def strip_terminal_sequences(value: str) -> str:
 
 
 def signature_found(log_text: str, signature: ErrorSignature) -> bool:
+    if signature.key == "OUT_OF_DISK_FOUND":
+        return out_of_disk_signature_found(log_text)
+
     if signature.pattern:
         flags = 0 if signature.case_sensitive else re.IGNORECASE
         return re.search(signature.pattern, log_text, flags=flags) is not None
@@ -463,6 +469,31 @@ def signature_found(log_text: str, signature: ErrorSignature) -> bool:
     if signature.case_sensitive:
         return signature.needle in log_text
     return signature.needle.lower() in log_text.lower()
+
+
+def out_of_disk_signature_found(log_text: str) -> bool:
+    plain_log_text = strip_terminal_sequences(log_text)
+    if OUT_OF_DISK_HARD_RE.search(plain_log_text):
+        return True
+
+    high_positions: list[int] = []
+    usage_reports: list[tuple[int, int]] = []
+    for match in DISK_USAGE_RE.finditer(plain_log_text):
+        percent = int(match.group("percent"))
+        usage_reports.append((match.start(), percent))
+        if percent >= 90:
+            high_positions.append(match.start())
+
+    high_positions.extend(match.start() for match in DISK_USAGE_HIGH_RE.finditer(plain_log_text))
+    if not high_positions:
+        return False
+
+    first_high_position = min(high_positions)
+    later_usage_reports = [(position, percent) for position, percent in usage_reports if position > first_high_position]
+    if later_usage_reports and later_usage_reports[-1][1] < 90:
+        return False
+
+    return True
 
 
 def format_fabric_node(mesh: str, device: str) -> str:

--- a/.github/scripts/runner_failure_common.py
+++ b/.github/scripts/runner_failure_common.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:  # pragma: no cover - handled in load_config
     yaml = None
 
 
-SIGNATURE_VERSION = "runner-failure-signatures-2026-08-01-v3"
+SIGNATURE_VERSION = "runner-failure-signatures-2026-08-01-v4"
 UNKNOWN_RUNNER = "(unknown runner)"
 
 OSC_SEQUENCE_RE = re.compile(r"\x1b\].*?\x1b\\")
@@ -145,6 +145,12 @@ ERROR_SIGNATURES = (
         key="PHYSICAL_DISCOVERY_FAILURE_FOUND",
         label="Physical discovery failure",
         pattern=r"Physical\s+Discovery\s+found\s+\d+\s+missing\s+channel\s+connections?",
+        case_sensitive=False,
+    ),
+    ErrorSignature(
+        key="PHYSICAL_CHIP_NOT_FOUND",
+        label="Physical chip not found",
+        pattern=r"Physical\s+chip\s+id\s+\d+\s+(?:is\s+)?not\s+found\s+in\s+(?:the\s+)?control\s+plane\s+chip\s+mapping",
         case_sensitive=False,
     ),
 )

--- a/.github/scripts/runner_failure_common.py
+++ b/.github/scripts/runner_failure_common.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:  # pragma: no cover - handled in load_config
     yaml = None
 
 
-SIGNATURE_VERSION = "runner-failure-signatures-2026-08-01-v2"
+SIGNATURE_VERSION = "runner-failure-signatures-2026-08-01-v3"
 UNKNOWN_RUNNER = "(unknown runner)"
 
 OSC_SEQUENCE_RE = re.compile(r"\x1b\].*?\x1b\\")
@@ -144,7 +144,7 @@ ERROR_SIGNATURES = (
     ErrorSignature(
         key="PHYSICAL_DISCOVERY_FAILURE_FOUND",
         label="Physical discovery failure",
-        pattern=r"Physical\s+Discovery\s+found\s+[1-9]\d*\s+missing\s+(?:channel|port/cable)\s+connections",
+        pattern=r"Physical\s+Discovery\s+found\s+\d+\s+missing\s+channel\s+connections?",
         case_sensitive=False,
     ),
 )

--- a/.github/scripts/runner_failure_post_slack.py
+++ b/.github/scripts/runner_failure_post_slack.py
@@ -254,10 +254,10 @@ def workflow_job_label(job: RecentJob) -> str:
 def slack_runner_table_header() -> list[dict[str, str]]:
     return [
         slack_raw_text_cell("Job"),
+        slack_raw_text_cell("Failures"),
         slack_raw_text_cell("Status"),
         slack_raw_text_cell("Started"),
         slack_raw_text_cell("Scanned?"),
-        slack_raw_text_cell("Failures"),
         slack_raw_text_cell("Workflow / job"),
     ]
 
@@ -284,10 +284,10 @@ def slack_runner_table_row(result: JobScanResult) -> list[dict[str, Any]]:
     job = result.job
     return [
         slack_link_cell(job.html_url, job.job_id or "open"),
+        slack_raw_text_cell(failure_summary_for_slack_cell(result)),
         slack_raw_text_cell(job.conclusion or job.status or "unknown"),
         slack_raw_text_cell(compact_started_at(job.started_at)),
         slack_flag_cell("Y" if result.log_checked else "N"),
-        slack_raw_text_cell(failure_summary_for_slack_cell(result)),
         slack_raw_text_cell(workflow_job_label(job)),
     ]
 
@@ -364,10 +364,10 @@ def slack_runner_table_block(rows: list[list[dict[str, Any]]]) -> dict[str, Any]
         "type": "table",
         "column_settings": [
             {"is_wrapped": False},
+            {"is_wrapped": True},
             {"is_wrapped": False},
             {"is_wrapped": False},
             {"align": "center"},
-            {"is_wrapped": True},
             {"is_wrapped": True},
         ],
         "rows": [slack_runner_table_header(), *rows],

--- a/.github/scripts/runner_failure_report.py
+++ b/.github/scripts/runner_failure_report.py
@@ -23,6 +23,7 @@ from runner_failure_common import (
     format_signature_summary,
     format_utc,
     gh_api_json,
+    job_from_dict,
     job_state_key,
     job_to_dict,
     load_triggering_failures_json,
@@ -52,6 +53,7 @@ GITHUB_JOB_LINK_RE = re.compile(
 class LiveGithubPopulationMetrics:
     statuses: tuple[str, ...]
     run_list_api_calls: int = 0
+    run_list_api_failures: int = 0
     job_list_api_calls: int = 0
     job_list_api_failures: int = 0
     workflow_runs_seen: int = 0
@@ -102,6 +104,22 @@ def parse_args() -> argparse.Namespace:
         "--triggering-failures-json",
         type=Path,
         help="Optional JSON array of triggering failures from the scan workflow.",
+    )
+    parser.add_argument(
+        "--live-jobs-json",
+        type=Path,
+        help="Optional JSON cache of live GitHub jobs from the scan workflow.",
+    )
+    parser.add_argument(
+        "--export-live-jobs-json",
+        type=Path,
+        help="Fetch active GitHub jobs once, write the cache JSON, and exit.",
+    )
+    parser.add_argument(
+        "--run-enrichment",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Fetch live GitHub active-run enrichment when no --live-jobs-json is supplied (default: true).",
     )
     parser.add_argument(
         "--api-base-url",
@@ -158,14 +176,20 @@ def parse_args() -> argparse.Namespace:
 def validate_args(args: argparse.Namespace) -> None:
     if args.hours <= 0:
         raise ValueError("--hours must be greater than zero.")
-    if args.api_timeout <= 0:
-        raise ValueError("--api-timeout must be greater than zero.")
     if args.gh_timeout <= 0:
         raise ValueError("--gh-timeout must be greater than zero.")
-    if args.log_workers <= 0:
-        raise ValueError("--log-workers must be greater than zero.")
     if args.live_run_workers <= 0:
         raise ValueError("--live-run-workers must be greater than zero.")
+    if not args.owner_repo or not args.owner_repo.strip():
+        raise ValueError("--owner-repo is required.")
+
+    if args.export_live_jobs_json:
+        return
+
+    if args.api_timeout <= 0:
+        raise ValueError("--api-timeout must be greater than zero.")
+    if args.log_workers <= 0:
+        raise ValueError("--log-workers must be greater than zero.")
     if not args.runner_name or not args.runner_name.strip():
         raise ValueError("--runner-name is required.")
     if not args.api_base_url or not args.api_base_url.strip():
@@ -210,6 +234,7 @@ def build_runner_markdown_report(
             f"`{live_github_metrics.api_calls}` API call(s) "
             f"({live_github_metrics.run_list_api_calls} run-list + "
             f"{live_github_metrics.job_list_api_calls} job-list, "
+            f"{live_github_metrics.run_list_api_failures} run-list failure(s), "
             f"{live_github_metrics.job_list_api_failures} job-list failure(s))."
         ),
         "",
@@ -305,6 +330,38 @@ def response_api_call_count(response: Any) -> int:
     if isinstance(response, list):
         return max(1, len(response))
     return 1
+
+
+def live_github_metrics_from_dict(value: Any) -> LiveGithubPopulationMetrics:
+    if not isinstance(value, dict):
+        return LiveGithubPopulationMetrics(statuses=ACTIVE_RUN_STATUSES)
+
+    raw_statuses = value.get("statuses")
+    statuses = (
+        tuple(str(status) for status in raw_statuses if status)
+        if isinstance(raw_statuses, list)
+        else ACTIVE_RUN_STATUSES
+    )
+    metrics = LiveGithubPopulationMetrics(statuses=statuses)
+    for field_name in (
+        "run_list_api_calls",
+        "run_list_api_failures",
+        "job_list_api_calls",
+        "job_list_api_failures",
+        "workflow_runs_seen",
+        "workflow_runs_inspected",
+        "workflows_inspected",
+        "workflow_runs_skipped_stale",
+        "jobs_seen",
+        "jobs_for_runner",
+        "jobs_in_window",
+        "jobs_added_to_report",
+    ):
+        try:
+            setattr(metrics, field_name, int(value.get(field_name) or 0))
+        except (TypeError, ValueError):
+            setattr(metrics, field_name, 0)
+    return metrics
 
 
 def api_get_json(
@@ -556,6 +613,17 @@ def active_workflow_runs_endpoint(owner_repo: str, status: str) -> str:
     return f"repos/{owner_repo}/actions/runs?{query}"
 
 
+def live_workflow_identity(run: dict[str, Any]) -> str:
+    return str(
+        run.get("workflow_id")
+        or run.get("path")
+        or run.get("workflow_url")
+        or run.get("name")
+        or run.get("display_title")
+        or ""
+    )
+
+
 def job_touched_window(job: RecentJob, *, since: datetime, until: datetime) -> bool:
     started_at = parse_github_time(job.started_at)
     completed_at = parse_github_time(job.completed_at)
@@ -600,14 +668,13 @@ def fetch_live_run_jobs(
     *,
     owner_repo: str,
     run: dict[str, Any],
-    runner_name: str,
     since: datetime,
     until: datetime,
     gh_timeout: int,
-) -> tuple[list[RecentJob], int, int, int]:
+) -> tuple[list[RecentJob], int, int]:
     run_id = str(run.get("id") or "")
     if not run_id:
-        return [], 0, 0, 0
+        return [], 0, 0
 
     response = gh_api_json(
         f"repos/{owner_repo}/actions/runs/{run_id}/jobs?{urlencode({'filter': 'latest', 'per_page': '100'})}",
@@ -617,23 +684,18 @@ def fetch_live_run_jobs(
     api_calls = response_api_call_count(response)
     jobs = paginated_items(response, "jobs")
 
-    expected_runner = runner_name.casefold()
-    runner_jobs: list[RecentJob] = []
-    jobs_for_runner = 0
+    live_jobs: list[RecentJob] = []
     for job in jobs:
         live_job = recent_job_from_live_github_api(owner_repo=owner_repo, run=run, job=job)
-        if live_job.runner_name.casefold() != expected_runner:
+        if not live_job.runner_name or not job_touched_window(live_job, since=since, until=until):
             continue
-        jobs_for_runner += 1
-        if job_touched_window(live_job, since=since, until=until):
-            runner_jobs.append(live_job)
+        live_jobs.append(live_job)
 
-    return runner_jobs, api_calls, len(jobs), jobs_for_runner
+    return live_jobs, api_calls, len(jobs)
 
 
-def list_live_runner_jobs_from_github(
+def list_live_jobs_from_github(
     *,
-    runner_name: str,
     since: datetime,
     until: datetime,
     owner_repo: str,
@@ -645,11 +707,17 @@ def list_live_runner_jobs_from_github(
     seen_run_ids: set[str] = set()
 
     for status in ACTIVE_RUN_STATUSES:
-        response = gh_api_json(
-            active_workflow_runs_endpoint(owner_repo, status),
-            paginate=True,
-            timeout=gh_timeout,
-        )
+        try:
+            response = gh_api_json(
+                active_workflow_runs_endpoint(owner_repo, status),
+                paginate=True,
+                timeout=gh_timeout,
+            )
+        except Exception as exc:
+            metrics.run_list_api_calls += 1
+            metrics.run_list_api_failures += 1
+            print(f"warning: live GitHub run-list lookup failed for status {status!r}: {exc}", file=sys.stderr)
+            continue
         metrics.run_list_api_calls += response_api_call_count(response)
         runs = paginated_items(response, "workflow_runs")
         metrics.workflow_runs_seen += len(runs)
@@ -661,17 +729,15 @@ def list_live_runner_jobs_from_github(
             candidate_runs.append(run)
 
     metrics.workflow_runs_inspected = len(candidate_runs)
-    metrics.workflows_inspected = len(
-        {str(run.get("name") or run.get("display_title") or run.get("path") or "") for run in candidate_runs}
-    )
+    metrics.workflows_inspected = len({identity for run in candidate_runs if (identity := live_workflow_identity(run))})
     if not candidate_runs:
-        print("Live GitHub enrichment: no active workflow run(s) found " "to inspect for runner jobs.")
+        print("Live GitHub enrichment: no active workflow run(s) found to inspect for runner jobs.")
         return [], metrics
 
     print(
         "Live GitHub enrichment: "
-        f"inspecting {len(candidate_runs)} active workflow run(s) for runner "
-        f"{runner_name!r} with {min(live_run_workers, len(candidate_runs))} worker(s)."
+        f"inspecting {len(candidate_runs)} active workflow run(s) with "
+        f"{min(live_run_workers, len(candidate_runs))} worker(s)."
     )
 
     live_jobs: list[RecentJob] = []
@@ -681,7 +747,6 @@ def list_live_runner_jobs_from_github(
                 fetch_live_run_jobs,
                 owner_repo=owner_repo,
                 run=run,
-                runner_name=runner_name,
                 since=since,
                 until=until,
                 gh_timeout=gh_timeout,
@@ -690,7 +755,7 @@ def list_live_runner_jobs_from_github(
         ]
         for future in as_completed(futures):
             try:
-                runner_jobs, api_calls, jobs_seen, jobs_for_runner = future.result()
+                run_jobs, api_calls, jobs_seen = future.result()
             except Exception as exc:
                 metrics.job_list_api_calls += 1
                 metrics.job_list_api_failures += 1
@@ -698,18 +763,110 @@ def list_live_runner_jobs_from_github(
                 continue
             metrics.job_list_api_calls += api_calls
             metrics.jobs_seen += jobs_seen
-            metrics.jobs_for_runner += jobs_for_runner
-            metrics.jobs_in_window += len(runner_jobs)
-            live_jobs.extend(runner_jobs)
+            metrics.jobs_in_window += len(run_jobs)
+            live_jobs.extend(run_jobs)
 
     print(
         "Live GitHub enrichment: "
-        f"{metrics.jobs_in_window} runner job(s) in window from "
+        f"{metrics.jobs_in_window} runner-assigned job(s) in window from "
         f"{metrics.jobs_seen} inspected job(s); "
         f"{metrics.api_calls} API call(s), "
+        f"{metrics.run_list_api_failures} run-list failure(s), "
         f"{metrics.job_list_api_failures} job-list failure(s)."
     )
     return sorted(live_jobs, key=lambda job: parse_github_time(job.started_at), reverse=True), metrics
+
+
+def filter_live_jobs_for_runner(
+    live_jobs: list[RecentJob], *, runner_name: str, since: datetime, until: datetime
+) -> list[RecentJob]:
+    expected_runner = runner_name.casefold()
+    return [
+        job
+        for job in live_jobs
+        if job.runner_name.casefold() == expected_runner and job_touched_window(job, since=since, until=until)
+    ]
+
+
+def load_live_jobs_json(path: Path) -> tuple[list[RecentJob], LiveGithubPopulationMetrics]:
+    try:
+        raw_value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RuntimeError(f"Unable to read live jobs JSON {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Unable to parse live jobs JSON {path}: {exc}") from exc
+
+    metrics = LiveGithubPopulationMetrics(statuses=ACTIVE_RUN_STATUSES)
+    raw_jobs: Any
+    if isinstance(raw_value, list):
+        raw_jobs = raw_value
+    elif isinstance(raw_value, dict):
+        metrics = live_github_metrics_from_dict(raw_value.get("metrics"))
+        raw_jobs = raw_value.get("jobs")
+    else:
+        raise RuntimeError(f"Live jobs JSON {path} must contain a list or object.")
+
+    if not isinstance(raw_jobs, list):
+        raise RuntimeError(f"Live jobs JSON {path} must contain jobs list.")
+
+    jobs = [job_from_dict(value) for value in raw_jobs if isinstance(value, dict)]
+    if not metrics.jobs_seen:
+        metrics.jobs_seen = len(jobs)
+    print(f"Loaded {len(jobs)} precomputed live GitHub job(s) from {path}.")
+    return jobs, metrics
+
+
+def write_live_jobs_json(
+    *,
+    path: Path,
+    generated_at: datetime,
+    since: datetime,
+    until: datetime,
+    owner_repo: str,
+    live_jobs: list[RecentJob],
+    metrics: LiveGithubPopulationMetrics,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "generated_at": format_utc(generated_at),
+                "since": format_utc(since),
+                "until": format_utc(until),
+                "owner_repo": owner_repo,
+                "metrics": metrics.to_dict(),
+                "jobs": [job_to_dict(job) for job in live_jobs],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def export_live_github_jobs(args: argparse.Namespace) -> int:
+    ensure_gh_available()
+    generated_at = datetime.now(timezone.utc)
+    since = generated_at - timedelta(hours=args.hours)
+    live_jobs, metrics = list_live_jobs_from_github(
+        since=since,
+        until=generated_at,
+        owner_repo=args.owner_repo,
+        gh_timeout=args.gh_timeout,
+        live_run_workers=args.live_run_workers,
+    )
+    write_live_jobs_json(
+        path=args.export_live_jobs_json,
+        generated_at=generated_at,
+        since=since,
+        until=generated_at,
+        owner_repo=args.owner_repo,
+        live_jobs=live_jobs,
+        metrics=metrics,
+    )
+    print(f"Wrote {len(live_jobs)} live GitHub job(s) to {args.export_live_jobs_json}.")
+    return 0
 
 
 def triggering_results_for_runner(results: list[JobScanResult], runner_name: str) -> list[JobScanResult]:
@@ -864,14 +1021,36 @@ def build_runner_report(args: argparse.Namespace) -> int:
         timeout=args.api_timeout,
         owner_repo=args.owner_repo,
     )
-    live_runner_jobs, live_github_metrics = list_live_runner_jobs_from_github(
-        runner_name=runner_name,
-        since=since,
-        until=generated_at,
-        owner_repo=args.owner_repo,
-        gh_timeout=args.gh_timeout,
-        live_run_workers=args.live_run_workers,
-    )
+    live_github_metrics = LiveGithubPopulationMetrics(statuses=ACTIVE_RUN_STATUSES)
+    if args.live_jobs_json:
+        live_jobs, live_github_metrics = load_live_jobs_json(args.live_jobs_json)
+        live_runner_jobs = filter_live_jobs_for_runner(
+            live_jobs,
+            runner_name=runner_name,
+            since=since,
+            until=generated_at,
+        )
+        live_github_metrics.jobs_for_runner = len(live_runner_jobs)
+        live_github_metrics.jobs_in_window = len(live_runner_jobs)
+    elif args.run_enrichment:
+        live_jobs, live_github_metrics = list_live_jobs_from_github(
+            since=since,
+            until=generated_at,
+            owner_repo=args.owner_repo,
+            gh_timeout=args.gh_timeout,
+            live_run_workers=args.live_run_workers,
+        )
+        live_runner_jobs = filter_live_jobs_for_runner(
+            live_jobs,
+            runner_name=runner_name,
+            since=since,
+            until=generated_at,
+        )
+        live_github_metrics.jobs_for_runner = len(live_runner_jobs)
+        live_github_metrics.jobs_in_window = len(live_runner_jobs)
+    else:
+        live_runner_jobs = []
+        print("Live GitHub enrichment disabled for this runner report.")
     runner_jobs, live_jobs_added = merge_missing_runner_jobs(runner_jobs, live_runner_jobs)
     live_github_metrics.jobs_added_to_report = live_jobs_added
     if live_runner_jobs:
@@ -939,6 +1118,8 @@ def main() -> int:
     args = parse_args()
     try:
         validate_args(args)
+        if args.export_live_jobs_json:
+            return export_live_github_jobs(args)
         return build_runner_report(args)
     except (RuntimeError, ValueError) as exc:
         print(str(exc), file=sys.stderr)

--- a/.github/scripts/runner_failure_report.py
+++ b/.github/scripts/runner_failure_report.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
 import json
 import os
 import re
@@ -11,6 +13,7 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlencode
 
 from runner_failure_common import (
     JobScanResult,
@@ -19,11 +22,13 @@ from runner_failure_common import (
     ensure_gh_available,
     format_signature_summary,
     format_utc,
+    gh_api_json,
     job_state_key,
     job_to_dict,
     load_triggering_failures_json,
     markdown_escape,
     markdown_link,
+    paginated_items,
     parse_github_time,
     result_to_dict,
     scan_jobs,
@@ -36,10 +41,37 @@ API_BASE_URL = ""
 API_ROUTE = "/api/v1/data_db_main/ci_jobs_by_runner"
 AWS_REGION = "us-east-2"
 DEFAULT_OWNER_REPO = "tenstorrent/tt-metal"
+ACTIVE_RUN_STATUSES = ("in_progress", "queued", "pending", "waiting", "requested")
 
 GITHUB_JOB_LINK_RE = re.compile(
     r"https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/actions/runs/" r"(?P<run_id>\d+)/job/(?P<job_id>\d+)"
 )
+
+
+@dataclass
+class LiveGithubPopulationMetrics:
+    statuses: tuple[str, ...]
+    run_list_api_calls: int = 0
+    job_list_api_calls: int = 0
+    job_list_api_failures: int = 0
+    workflow_runs_seen: int = 0
+    workflow_runs_inspected: int = 0
+    workflows_inspected: int = 0
+    workflow_runs_skipped_stale: int = 0
+    jobs_seen: int = 0
+    jobs_for_runner: int = 0
+    jobs_in_window: int = 0
+    jobs_added_to_report: int = 0
+
+    @property
+    def api_calls(self) -> int:
+        return self.run_list_api_calls + self.job_list_api_calls
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["statuses"] = list(self.statuses)
+        value["api_calls"] = self.api_calls
+        return value
 
 
 def parse_args() -> argparse.Namespace:
@@ -111,6 +143,15 @@ def parse_args() -> argparse.Namespace:
             "Maximum number of GitHub job logs to scan in parallel " "(default: RUNNER_FAILURE_SCAN_LOG_WORKERS or 8)."
         ),
     )
+    parser.add_argument(
+        "--live-run-workers",
+        type=int,
+        default=int(os.environ.get("RUNNER_FAILURE_LIVE_RUN_WORKERS", "8")),
+        help=(
+            "Maximum number of active GitHub workflow runs whose job lists are fetched "
+            "in parallel for live enrichment (default: RUNNER_FAILURE_LIVE_RUN_WORKERS or 8)."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -123,6 +164,8 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("--gh-timeout must be greater than zero.")
     if args.log_workers <= 0:
         raise ValueError("--log-workers must be greater than zero.")
+    if args.live_run_workers <= 0:
+        raise ValueError("--live-run-workers must be greater than zero.")
     if not args.runner_name or not args.runner_name.strip():
         raise ValueError("--runner-name is required.")
     if not args.api_base_url or not args.api_base_url.strip():
@@ -139,8 +182,10 @@ def build_runner_markdown_report(
     runner_jobs: list[RecentJob],
     scan_results: list[JobScanResult],
     triggering_jobs_added: int,
+    live_github_metrics: LiveGithubPopulationMetrics,
 ) -> str:
     failures = [result for result in scan_results if result.signature_labels]
+    failure_summary = format_signature_summary(failures) if failures else "none"
     lines = [
         "# Runner Failure Report",
         "",
@@ -152,6 +197,21 @@ def build_runner_markdown_report(
         f"- Triggering jobs added: `{triggering_jobs_added}`",
         f"- Scanned jobs: `{sum(1 for result in scan_results if result.log_checked)}`",
         f"- Runner-failure jobs: `{len(failures)}`",
+        f"- Failure summary: `{failure_summary}`",
+        (
+            "- Live GitHub active-run enrichment: "
+            f"`{live_github_metrics.workflow_runs_seen}` workflow run(s) listed, "
+            f"`{live_github_metrics.workflow_runs_inspected}` inspected, "
+            f"`{live_github_metrics.workflows_inspected}` distinct workflow(s), "
+            f"`{live_github_metrics.jobs_seen}` job(s) inspected, "
+            f"`{live_github_metrics.jobs_for_runner}` on this runner, "
+            f"`{live_github_metrics.jobs_in_window}` in window, "
+            f"`{live_github_metrics.jobs_added_to_report}` added; "
+            f"`{live_github_metrics.api_calls}` API call(s) "
+            f"({live_github_metrics.run_list_api_calls} run-list + "
+            f"{live_github_metrics.job_list_api_calls} job-list, "
+            f"{live_github_metrics.job_list_api_failures} job-list failure(s))."
+        ),
         "",
     ]
 
@@ -161,7 +221,7 @@ def build_runner_markdown_report(
 
     lines.extend(
         [
-            "| GH job | Workflow | Job name | Status | Started | Log checked | Signatures |",
+            "| GH job | Failure signatures | Workflow | Job name | Status | Started | Log checked |",
             "| --- | --- | --- | --- | --- | --- | --- |",
         ]
     )
@@ -172,12 +232,12 @@ def build_runner_markdown_report(
         lines.append(
             "| "
             f"{markdown_link(result.job.job_id or 'open', result.job.html_url)} | "
+            f"{markdown_escape(signatures)} | "
             f"{markdown_escape(result.job.workflow)} | "
             f"{markdown_escape(result.job.name)} | "
             f"{markdown_escape(result.job.conclusion or result.job.status or 'unknown')} | "
             f"{markdown_escape(result.job.started_at)} | "
-            f"{'YES' if result.log_checked else 'NO'} | "
-            f"{markdown_escape(signatures)} |"
+            f"{'YES' if result.log_checked else 'NO'} |"
         )
     return "\n".join(lines) + "\n"
 
@@ -193,6 +253,7 @@ def build_runner_json_report(
     scan_results: list[JobScanResult],
     triggering_jobs: list[JobScanResult],
     triggering_jobs_added: int,
+    live_github_metrics: LiveGithubPopulationMetrics,
 ) -> dict[str, Any]:
     failures = [result for result in scan_results if result.signature_labels]
     return {
@@ -208,10 +269,12 @@ def build_runner_json_report(
             "runner_jobs": len(runner_jobs),
             "triggering_jobs": len(triggering_jobs),
             "triggering_jobs_added": triggering_jobs_added,
+            "live_github_jobs_added": live_github_metrics.jobs_added_to_report,
             "scanned_jobs": len(scan_results),
             "log_checked_jobs": sum(1 for result in scan_results if result.log_checked),
             "runner_failure_jobs": len(failures),
         },
+        "live_github_population": live_github_metrics.to_dict(),
         "signature_counts": signature_counts(failures),
         "recent_jobs": [job_to_dict(job) for job in runner_jobs],
         "triggering_jobs": [result_to_dict(result) for result in triggering_jobs],
@@ -236,6 +299,12 @@ def log_normalized_jobs(jobs: list[RecentJob]) -> None:
         f"{len(jobs)} total, {with_job_ids} with GitHub job id(s), "
         f"{with_links} with GitHub link(s)."
     )
+
+
+def response_api_call_count(response: Any) -> int:
+    if isinstance(response, list):
+        return max(1, len(response))
+    return 1
 
 
 def api_get_json(
@@ -482,20 +551,180 @@ def recent_job_from_runner_api_row(
     )
 
 
+def active_workflow_runs_endpoint(owner_repo: str, status: str) -> str:
+    query = urlencode({"status": status, "per_page": "100"})
+    return f"repos/{owner_repo}/actions/runs?{query}"
+
+
+def job_touched_window(job: RecentJob, *, since: datetime, until: datetime) -> bool:
+    started_at = parse_github_time(job.started_at)
+    completed_at = parse_github_time(job.completed_at)
+
+    if since <= completed_at <= until:
+        return True
+    if since <= started_at <= until:
+        return True
+    return job.status == "in_progress" and started_at <= until and not job.completed_at
+
+
+def recent_job_from_live_github_api(
+    *,
+    owner_repo: str,
+    run: dict[str, Any],
+    job: dict[str, Any],
+) -> RecentJob:
+    run_id = str(run.get("id") or "")
+    job_id = str(job.get("id") or "")
+    return RecentJob(
+        owner_repo=owner_repo,
+        workflow=str(run.get("name") or run.get("display_title") or run.get("path") or ""),
+        workflow_id=str(run.get("path") or ""),
+        run_id=run_id,
+        run_attempt=str(run.get("run_attempt") or ""),
+        run_url=str(run.get("html_url") or ""),
+        job_id=job_id,
+        name=str(job.get("name") or ""),
+        runner_name=str(job.get("runner_name") or ""),
+        status=str(job.get("status") or ""),
+        conclusion=str(job.get("conclusion") or ""),
+        html_url=str(
+            job.get("html_url")
+            or (f"https://github.com/{owner_repo}/actions/runs/{run_id}/job/{job_id}" if run_id and job_id else "")
+        ),
+        started_at=str(job.get("started_at") or ""),
+        completed_at=str(job.get("completed_at") or ""),
+    )
+
+
+def fetch_live_run_jobs(
+    *,
+    owner_repo: str,
+    run: dict[str, Any],
+    runner_name: str,
+    since: datetime,
+    until: datetime,
+    gh_timeout: int,
+) -> tuple[list[RecentJob], int, int, int]:
+    run_id = str(run.get("id") or "")
+    if not run_id:
+        return [], 0, 0, 0
+
+    response = gh_api_json(
+        f"repos/{owner_repo}/actions/runs/{run_id}/jobs?{urlencode({'filter': 'latest', 'per_page': '100'})}",
+        paginate=True,
+        timeout=gh_timeout,
+    )
+    api_calls = response_api_call_count(response)
+    jobs = paginated_items(response, "jobs")
+
+    expected_runner = runner_name.casefold()
+    runner_jobs: list[RecentJob] = []
+    jobs_for_runner = 0
+    for job in jobs:
+        live_job = recent_job_from_live_github_api(owner_repo=owner_repo, run=run, job=job)
+        if live_job.runner_name.casefold() != expected_runner:
+            continue
+        jobs_for_runner += 1
+        if job_touched_window(live_job, since=since, until=until):
+            runner_jobs.append(live_job)
+
+    return runner_jobs, api_calls, len(jobs), jobs_for_runner
+
+
+def list_live_runner_jobs_from_github(
+    *,
+    runner_name: str,
+    since: datetime,
+    until: datetime,
+    owner_repo: str,
+    gh_timeout: int,
+    live_run_workers: int,
+) -> tuple[list[RecentJob], LiveGithubPopulationMetrics]:
+    metrics = LiveGithubPopulationMetrics(statuses=ACTIVE_RUN_STATUSES)
+    candidate_runs: list[dict[str, Any]] = []
+    seen_run_ids: set[str] = set()
+
+    for status in ACTIVE_RUN_STATUSES:
+        response = gh_api_json(
+            active_workflow_runs_endpoint(owner_repo, status),
+            paginate=True,
+            timeout=gh_timeout,
+        )
+        metrics.run_list_api_calls += response_api_call_count(response)
+        runs = paginated_items(response, "workflow_runs")
+        metrics.workflow_runs_seen += len(runs)
+        for run in runs:
+            run_id = str(run.get("id") or "")
+            if not run_id or run_id in seen_run_ids:
+                continue
+            seen_run_ids.add(run_id)
+            candidate_runs.append(run)
+
+    metrics.workflow_runs_inspected = len(candidate_runs)
+    metrics.workflows_inspected = len(
+        {str(run.get("name") or run.get("display_title") or run.get("path") or "") for run in candidate_runs}
+    )
+    if not candidate_runs:
+        print("Live GitHub enrichment: no active workflow run(s) found " "to inspect for runner jobs.")
+        return [], metrics
+
+    print(
+        "Live GitHub enrichment: "
+        f"inspecting {len(candidate_runs)} active workflow run(s) for runner "
+        f"{runner_name!r} with {min(live_run_workers, len(candidate_runs))} worker(s)."
+    )
+
+    live_jobs: list[RecentJob] = []
+    with ThreadPoolExecutor(max_workers=min(live_run_workers, len(candidate_runs))) as executor:
+        futures = [
+            executor.submit(
+                fetch_live_run_jobs,
+                owner_repo=owner_repo,
+                run=run,
+                runner_name=runner_name,
+                since=since,
+                until=until,
+                gh_timeout=gh_timeout,
+            )
+            for run in candidate_runs
+        ]
+        for future in as_completed(futures):
+            try:
+                runner_jobs, api_calls, jobs_seen, jobs_for_runner = future.result()
+            except Exception as exc:
+                metrics.job_list_api_calls += 1
+                metrics.job_list_api_failures += 1
+                print(f"warning: live GitHub job-list lookup failed: {exc}", file=sys.stderr)
+                continue
+            metrics.job_list_api_calls += api_calls
+            metrics.jobs_seen += jobs_seen
+            metrics.jobs_for_runner += jobs_for_runner
+            metrics.jobs_in_window += len(runner_jobs)
+            live_jobs.extend(runner_jobs)
+
+    print(
+        "Live GitHub enrichment: "
+        f"{metrics.jobs_in_window} runner job(s) in window from "
+        f"{metrics.jobs_seen} inspected job(s); "
+        f"{metrics.api_calls} API call(s), "
+        f"{metrics.job_list_api_failures} job-list failure(s)."
+    )
+    return sorted(live_jobs, key=lambda job: parse_github_time(job.started_at), reverse=True), metrics
+
+
 def triggering_results_for_runner(results: list[JobScanResult], runner_name: str) -> list[JobScanResult]:
     expected_runner = runner_name.casefold()
     return [result for result in results if result.job.runner_name.casefold() == expected_runner]
 
 
-def merge_triggering_jobs(
-    runner_jobs: list[RecentJob], triggering_results: list[JobScanResult]
+def merge_missing_runner_jobs(
+    runner_jobs: list[RecentJob], jobs_to_add: list[RecentJob]
 ) -> tuple[list[RecentJob], int]:
     merged_jobs = list(runner_jobs)
     seen_job_keys = {job_state_key(job) for job in runner_jobs if job.job_id}
     added_jobs = 0
 
-    for result in triggering_results:
-        job = result.job
+    for job in jobs_to_add:
         if not job.job_id:
             continue
 
@@ -515,6 +744,12 @@ def merge_triggering_jobs(
         ),
         added_jobs,
     )
+
+
+def merge_triggering_jobs(
+    runner_jobs: list[RecentJob], triggering_results: list[JobScanResult]
+) -> tuple[list[RecentJob], int]:
+    return merge_missing_runner_jobs(runner_jobs, [result.job for result in triggering_results])
 
 
 def list_runner_jobs_from_api(
@@ -629,6 +864,22 @@ def build_runner_report(args: argparse.Namespace) -> int:
         timeout=args.api_timeout,
         owner_repo=args.owner_repo,
     )
+    live_runner_jobs, live_github_metrics = list_live_runner_jobs_from_github(
+        runner_name=runner_name,
+        since=since,
+        until=generated_at,
+        owner_repo=args.owner_repo,
+        gh_timeout=args.gh_timeout,
+        live_run_workers=args.live_run_workers,
+    )
+    runner_jobs, live_jobs_added = merge_missing_runner_jobs(runner_jobs, live_runner_jobs)
+    live_github_metrics.jobs_added_to_report = live_jobs_added
+    if live_runner_jobs:
+        print(
+            f"Live GitHub enrichment found {len(live_runner_jobs)} runner job(s); "
+            f"added {live_jobs_added} missing job(s) to the runner report."
+        )
+
     triggering_results = triggering_results_for_runner(
         load_triggering_failures_json(args.triggering_failures_json),
         runner_name,
@@ -657,6 +908,7 @@ def build_runner_report(args: argparse.Namespace) -> int:
         scan_results=scan_results,
         triggering_jobs=triggering_results,
         triggering_jobs_added=triggering_jobs_added,
+        live_github_metrics=live_github_metrics,
     )
     report_md = build_runner_markdown_report(
         generated_at=generated_at,
@@ -667,6 +919,7 @@ def build_runner_report(args: argparse.Namespace) -> int:
         runner_jobs=runner_jobs,
         scan_results=scan_results,
         triggering_jobs_added=triggering_jobs_added,
+        live_github_metrics=live_github_metrics,
     )
     write_reports(
         report_json_path=args.report_json,

--- a/.github/workflows/runner-failure-report.yaml
+++ b/.github/workflows/runner-failure-report.yaml
@@ -15,8 +15,16 @@ on:
         required: false
         type: boolean
         default: true
+      run_enrichment:
+        description: "Fetch live GitHub active-run enrichment when no enrichment_jobs_json is supplied"
+        required: false
+        type: boolean
+        default: true
       triggering_failures_json:
         description: "Optional JSON array of triggering failures from the scan workflow."
+        required: false
+      enrichment_jobs_json:
+        description: "Optional JSON array of precomputed live GitHub jobs from the scan workflow."
         required: false
   workflow_call:
     inputs:
@@ -31,7 +39,15 @@ on:
         required: false
         type: boolean
         default: true
+      run_enrichment:
+        required: false
+        type: boolean
+        default: true
       triggering_failures_json:
+        required: false
+        type: string
+        default: ""
+      enrichment_jobs_json:
         required: false
         type: string
         default: ""
@@ -84,6 +100,8 @@ jobs:
           HOURS: ${{ inputs.hours || '24' }}
           RUNNER_FAILURE_API_BASE_URL: ${{ secrets.DATA_API_ROUTE_BASE }}
           TRIGGERING_FAILURES_JSON: ${{ inputs.triggering_failures_json }}
+          ENRICHMENT_JOBS_JSON: ${{ inputs.enrichment_jobs_json }}
+          RUN_ENRICHMENT: ${{ inputs.run_enrichment }}
         run: |
           mkdir -p out
           args=(
@@ -97,6 +115,15 @@ jobs:
             args+=(
               --triggering-failures-json out/triggering_failures.json
             )
+          fi
+          if [[ -n "$ENRICHMENT_JOBS_JSON" && "$ENRICHMENT_JOBS_JSON" != "[]" ]]; then
+            printf '%s' "$ENRICHMENT_JOBS_JSON" > out/enrichment_jobs.json
+            args+=(
+              --live-jobs-json out/enrichment_jobs.json
+            )
+          fi
+          if [[ "$RUN_ENRICHMENT" != "true" ]]; then
+            args+=(--no-run-enrichment)
           fi
           python3 .github/scripts/runner_failure_report.py "${args[@]}"
 

--- a/.github/workflows/runner-failure-scan.yaml
+++ b/.github/workflows/runner-failure-scan.yaml
@@ -124,8 +124,35 @@ jobs:
       - name: Build runner report matrix
         id: runner_matrix
         if: always() && hashFiles('out/runner_failure_report.json') != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          HOURS: ${{ github.event.inputs.hours || '24' }}
         run: |
-          runner_matrix="$(jq -c '(.runner_failures // {}) | to_entries | map({runner_name: .key, triggering_failures: .value})' out/runner_failure_report.json)"
+          runner_count="$(jq '(.runner_failures // {}) | length' out/runner_failure_report.json)"
+          if [[ "$runner_count" -gt 0 ]]; then
+            python3 .github/scripts/runner_failure_report.py \
+              --hours "$HOURS" \
+              --owner-repo tenstorrent/tt-metal \
+              --export-live-jobs-json out/live_github_jobs.json || {
+                echo "warning: live GitHub enrichment export failed; continuing without precomputed enrichment."
+                printf '{"jobs":[]}\n' > out/live_github_jobs.json
+              }
+          else
+            printf '{"jobs":[]}\n' > out/live_github_jobs.json
+          fi
+          runner_matrix="$(
+            jq -c --slurpfile live out/live_github_jobs.json '
+              (($live[0].jobs // []) | group_by(.runner_name | ascii_downcase) |
+                map({key: (.[0].runner_name | ascii_downcase), value: .}) | from_entries) as $live_by_runner |
+              (.runner_failures // {}) | to_entries |
+              map({
+                runner_name: .key,
+                triggering_failures: .value,
+                enrichment_jobs: ($live_by_runner[(.key | ascii_downcase)] // [])
+              })
+            ' out/runner_failure_report.json
+          )"
           echo "runner_matrix=$runner_matrix" >> "$GITHUB_OUTPUT"
           echo "Runner report matrix: $runner_matrix"
 
@@ -160,12 +187,15 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         runner: ${{ fromJson(needs.scan.outputs.runner_matrix) }}
     uses: ./.github/workflows/runner-failure-report.yaml
     with:
       runner_name: ${{ matrix.runner.runner_name }}
       triggering_failures_json: ${{ toJson(matrix.runner.triggering_failures) }}
+      enrichment_jobs_json: ${{ toJson(matrix.runner.enrichment_jobs) }}
+      run_enrichment: false
       hours: ${{ github.event.inputs.hours || '24' }}
       post_to_slack: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event.inputs.post-to-slack == 'true' }}
     secrets: inherit


### PR DESCRIPTION
### What
- Enrich runner failure reports with jobs from currently active GitHub workflow runs, then filter locally by runner and job timestamps so old-created but still-active workflows are represented.
- Add live-enrichment metadata to the report: workflow runs listed/inspected, distinct workflows, jobs inspected, jobs on the runner, jobs in-window, jobs added, and API call counts.
- Move the failure/signature column to the second column in both the workflow summary table and Slack table.
- Add a per-runner failure summary line.
- Avoid flagging recovered disk pressure as Out of disk while still detecting hard ENOSPC/no-space failures.
- Add new failure signatyres

### Validation
- `python3 -m py_compile .github/scripts/runner_failure_report.py .github/scripts/runner_failure_post_slack.py .github/scripts/runner_failure_common.py`
- `/tmp/tt-metal-precommit-venv/bin/pre-commit run --files .github/scripts/runner_failure_report.py .github/scripts/runner_failure_post_slack.py .github/scripts/runner_failure_common.py`
- Live enrichment probe for `OM1-01A01-STGWH03`: 39.2s, 184 active workflow runs inspected, 8,692 jobs inspected, 218 GitHub API calls, and it picked up the old-created TM-Fabric job.
- Signature regression: job `91212049214` -> no signature; job `84062130308` -> Out of disk, Failed reset.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tcheda/runner-report-live-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tcheda/runner-report-live-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tcheda/runner-report-live-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tcheda/runner-report-live-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=tcheda/runner-report-live-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:tcheda/runner-report-live-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tcheda/runner-report-live-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tcheda/runner-report-live-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tcheda/runner-report-live-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tcheda/runner-report-live-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tcheda/runner-report-live-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tcheda/runner-report-live-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tcheda/runner-report-live-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tcheda/runner-report-live-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tcheda/runner-report-live-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tcheda/runner-report-live-jobs)