### PR TITLE
add support fused/virtual concat to matmul variants (except agmm)

### DIFF
--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -482,7 +482,7 @@ class RowParallelLinear(Module):
 
     def forward(
         self,
-        x: ttnn.Tensor,
+        x: ttnn.Tensor | list[ttnn.Tensor],
         *,
         compute_kernel_config=None,
         use_persistent_buffer: bool = True,
@@ -491,6 +491,7 @@ class RowParallelLinear(Module):
     ) -> ttnn.Tensor:
         """
         Expects x to be column fractured.
+        x may be a 2-element list [prefix, suffix] for fused concat over K (concat-free).
         Return output fractured on columns.
         """
         if self.fsdp_mesh_axis is not None and self.mesh_device.shape[self.fsdp_mesh_axis] > 1:
@@ -503,11 +504,19 @@ class RowParallelLinear(Module):
         else:
             weight = self.weight.data
 
-        M, K, N = x.padded_shape[-2], x.padded_shape[-1], weight.padded_shape[-1]
+        if isinstance(x, (list, tuple)):
+            assert len(x) == 2, f"RowParallelLinear.forward: list x must be [prefix, suffix], got {len(x)}"
+            x, x_second = x
+            K = weight.padded_shape[-2]
+        else:
+            x_second = None
+            K = x.padded_shape[-1]
+
+        M, N = x.padded_shape[-2], weight.padded_shape[-1]
         core_grid = get_matmul_core_grid(self.mesh_device)
         matmul_config = get_matmul_config(M, K, N, core_grid, default_block_size)
         output = ttnn.experimental.minimal_matmul(
-            input_tensor=x,
+            input_tensor=[x, x_second] if x_second is not None else x,
             weight_tensor=weight,
             bias_tensor=self.bias.data if self.bias is not None else None,
             config=matmul_config,
@@ -531,7 +540,7 @@ class RowParallelLinear(Module):
 
     def forward_fused_addcmul(
         self,
-        x: ttnn.Tensor,
+        x: ttnn.Tensor | list[ttnn.Tensor],
         addcmul_a: ttnn.Tensor,
         addcmul_b: ttnn.Tensor,
         scalar: float = 1.0,
@@ -542,6 +551,9 @@ class RowParallelLinear(Module):
         """Fused RowParallel matmul + reduce-scatter + addcmul at the RS final write step.
 
         Computes: output = addcmul_a + scalar * rs_result * addcmul_b
+
+        ``x`` may be a single tensor or a 2-element list ``[prefix, suffix]`` for fused concat over K.
+        The weight must be per-segment tile-padded (see ``prepare_weight_for_concatenated_input``).
 
         Both addcmul_a and addcmul_b must already be at their per-TP-device slice size
         [D/tp]. The RS kernel fuses the addcmul at the final ring write, eliminating
@@ -556,14 +568,29 @@ class RowParallelLinear(Module):
         else:
             weight = self.weight.data
 
-        M, K, N = x.padded_shape[-2], x.padded_shape[-1], weight.padded_shape[-1]
+        # x: single tensor, or [prefix, suffix] virtually concatenated over K (concat-free).
+        if isinstance(x, (list, tuple)):
+            assert len(x) == 2, f"forward_fused_addcmul: list x must be exactly [prefix, suffix], got {len(x)}"
+            x, x_second = x
+        else:
+            x_second = None
+
+        # For fused concat the matmul K spans both halves = the weight's K; x is only the prefix half.
+        K = weight.padded_shape[-2] if x_second is not None else x.padded_shape[-1]
+        M, N = x.padded_shape[-2], weight.padded_shape[-1]
         core_grid = self.mesh_device.compute_with_storage_grid_size()
 
         needs_reshape = len(x.shape) <= 3
         if needs_reshape:
             x = ttnn.unsqueeze(x, 0)
+            if x_second is not None:
+                x_second = ttnn.unsqueeze(x_second, 0)
+        pre_rs_shape = tuple(list(x.shape)[:-1] + [N])
+        _, rs_output_buffer = self.ccl_manager.get_rs_ping_pong_buffer(
+            pre_rs_shape, 3, self.mesh_axis, return_intermediate=False
+        )
         _, output = ttnn.experimental.minimal_matmul_strided_reduce_scatter_async(
-            input_tensor=x,
+            input_tensor=[x, x_second] if x_second is not None else x,
             weight_tensor=weight,
             dim=3,
             multi_device_global_semaphore=self.ccl_manager.get_rs_ping_pong_semaphore(self.mesh_axis),

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -375,7 +375,7 @@ class RowParallelLinear(Module):
 
     def forward(
         self,
-        x: ttnn.Tensor,
+        x: ttnn.Tensor | list[ttnn.Tensor],
         *,
         compute_kernel_config=None,
         use_persistent_buffer: bool = True,
@@ -384,6 +384,7 @@ class RowParallelLinear(Module):
     ) -> ttnn.Tensor:
         """
         Expects x to be column fractured.
+        x may be a 2-element list [prefix, suffix] for fused concat over K (concat-free).
         Return output fractured on columns.
         """
         if self.fsdp_mesh_axis is not None and self.mesh_device.shape[self.fsdp_mesh_axis] > 1:
@@ -396,11 +397,19 @@ class RowParallelLinear(Module):
         else:
             weight = self.weight.data
 
-        M, K, N = x.padded_shape[-2], x.padded_shape[-1], weight.padded_shape[-1]
+        if isinstance(x, (list, tuple)):
+            assert len(x) == 2, f"RowParallelLinear.forward: list x must be [prefix, suffix], got {len(x)}"
+            x, x_second = x
+            K = weight.padded_shape[-2]
+        else:
+            x_second = None
+            K = x.padded_shape[-1]
+
+        M, N = x.padded_shape[-2], weight.padded_shape[-1]
         core_grid = get_matmul_core_grid(self.mesh_device)
         matmul_config = get_matmul_config(M, K, N, core_grid, default_block_size)
         output = ttnn.experimental.minimal_matmul(
-            input_tensor=x,
+            input_tensor=[x, x_second] if x_second is not None else x,
             weight_tensor=weight,
             bias_tensor=self.bias.data if self.bias is not None else None,
             config=matmul_config,
@@ -424,7 +433,7 @@ class RowParallelLinear(Module):
 
     def forward_fused_addcmul(
         self,
-        x: ttnn.Tensor,
+        x: ttnn.Tensor | list[ttnn.Tensor],
         addcmul_a: ttnn.Tensor,
         addcmul_b: ttnn.Tensor,
         scalar: float = 1.0,
@@ -435,6 +444,9 @@ class RowParallelLinear(Module):
         """Fused RowParallel matmul + reduce-scatter + addcmul at the RS final write step.
 
         Computes: output = addcmul_a + scalar * rs_result * addcmul_b
+
+        ``x`` may be a single tensor or a 2-element list ``[prefix, suffix]`` for fused concat over K.
+        The weight must be per-segment tile-padded (see ``prepare_weight_for_concatenated_input``).
 
         Both addcmul_a and addcmul_b must already be at their per-TP-device slice size
         [D/tp]. The RS kernel fuses the addcmul at the final ring write, eliminating
@@ -449,14 +461,29 @@ class RowParallelLinear(Module):
         else:
             weight = self.weight.data
 
-        M, K, N = x.padded_shape[-2], x.padded_shape[-1], weight.padded_shape[-1]
+        # x: single tensor, or [prefix, suffix] virtually concatenated over K (concat-free).
+        if isinstance(x, (list, tuple)):
+            assert len(x) == 2, f"forward_fused_addcmul: list x must be exactly [prefix, suffix], got {len(x)}"
+            x, x_second = x
+        else:
+            x_second = None
+
+        # For fused concat the matmul K spans both halves = the weight's K; x is only the prefix half.
+        K = weight.padded_shape[-2] if x_second is not None else x.padded_shape[-1]
+        M, N = x.padded_shape[-2], weight.padded_shape[-1]
         core_grid = self.mesh_device.compute_with_storage_grid_size()
 
         needs_reshape = len(x.shape) <= 3
         if needs_reshape:
             x = ttnn.unsqueeze(x, 0)
+            if x_second is not None:
+                x_second = ttnn.unsqueeze(x_second, 0)
+        pre_rs_shape = tuple(list(x.shape)[:-1] + [N])
+        _, rs_output_buffer = self.ccl_manager.get_rs_ping_pong_buffer(
+            pre_rs_shape, 3, self.mesh_axis, return_intermediate=False
+        )
         _, output = ttnn.experimental.minimal_matmul_strided_reduce_scatter_async(
-            input_tensor=x,
+            input_tensor=[x, x_second] if x_second is not None else x,
             weight_tensor=weight,
             dim=3,
             multi_device_global_semaphore=self.ccl_manager.get_rs_ping_pong_semaphore(self.mesh_axis),

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -131,7 +131,14 @@ class CCLManager:
         self.barrier_fused_semaphores = None
         self.np_region_progress_semaphores = None
 
-    def get_rs_ping_pong_buffer(self, shape, dim, mesh_axis):
+    def get_dim(self, dim, shape):
+        if dim < 0:
+            dim += len(shape)
+        return dim
+
+    def get_rs_ping_pong_buffer(
+        self, shape, dim, mesh_axis, return_output_buffer: bool = True, return_intermediate: bool = True
+    ):
         """
         Get or create ping pong buffers for reduce scatter operations.
         Caches buffers based on shape, dim, and mesh_axis.
@@ -145,6 +152,7 @@ class CCLManager:
             Current ping pong buffer (alternates between two buffers)
         """
         # Create cache key from the parameters
+        dim = self.get_dim(dim, shape)
         cache_key = (tuple(shape), dim, mesh_axis)
 
         # Create buffers if not cached
@@ -164,8 +172,16 @@ class CCLManager:
             if self.topology == ttnn.Topology.Linear:
                 intermediate_buffer_shape[0] *= 2
             for _ in range(2):
-                intermediate_buffer = bf16_tensor(torch.empty(intermediate_buffer_shape), device=self.mesh_device)
-                output_buffer = bf16_tensor(torch.empty(output_buffer_shape), device=self.mesh_device)
+                intermediate_buffer = (
+                    bf16_tensor(torch.empty(intermediate_buffer_shape), device=self.mesh_device)
+                    if return_intermediate
+                    else None
+                )
+                output_buffer = (
+                    bf16_tensor(torch.empty(output_buffer_shape), device=self.mesh_device)
+                    if return_output_buffer
+                    else None
+                )
                 buffers.append([intermediate_buffer, output_buffer])
 
             self._ping_pong_buffer_cache[cache_key] = buffers
@@ -192,6 +208,7 @@ class CCLManager:
             Current ping pong buffer (alternates between two buffers)
         """
         # Create cache key from the parameters (use different namespace than rs)
+        dim = self.get_dim(dim, shape)
         cache_key = ("ag", tuple(shape), dim, mesh_axis, dtype)
 
         # Create buffers if not cached

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -866,3 +866,30 @@ def print_tensor_mem_info(tt: ttnn.Tensor):
         logger.info("  layout:", s.layout)
         logger.info("  dtype:", s.dtype)
         logger.info("  memory_config:", s.memory_config())
+
+
+def prepare_weight_for_concatenated_input(
+    weight: torch.Tensor,
+    sizes: Sequence[int],
+    *,
+    device_count: int,
+    tile_pad_segments: bool = True,
+) -> torch.Tensor:
+    """Shard weight by device_count per segment and stack.
+
+    tile_pad_segments=True (fused concat): zero-pad each per-device segment K to a tile boundary
+    so minimal_matmul([prefix, suffix], weight) works for any channel count.
+    tile_pad_segments=False (materialized concat): contiguous stack, for use with ttnn.concat.
+    """
+    segments = weight.split(sizes, dim=1)
+    padded_segments = []
+    for seg in segments:
+        unf = seg.unflatten(1, [device_count, -1])  # [out, device_count, K_seg/dev]
+        if tile_pad_segments:
+            k_per_dev = unf.shape[2]
+            k_padded = ((k_per_dev + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+            if k_padded != k_per_dev:
+                pad = torch.zeros(*unf.shape[:2], k_padded - k_per_dev, dtype=unf.dtype)
+                unf = torch.cat([unf, pad], dim=2)
+        padded_segments.append(unf)
+    return torch.cat(padded_segments, dim=2).flatten(1, 2)

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -870,3 +870,30 @@ def print_tensor_mem_info(tt: ttnn.Tensor):
         logger.info("  layout:", s.layout)
         logger.info("  dtype:", s.dtype)
         logger.info("  memory_config:", s.memory_config())
+
+
+def prepare_weight_for_concatenated_input(
+    weight: torch.Tensor,
+    sizes: Sequence[int],
+    *,
+    device_count: int,
+    tile_pad_segments: bool = True,
+) -> torch.Tensor:
+    """Shard weight by device_count per segment and stack.
+
+    tile_pad_segments=True (fused concat): zero-pad each per-device segment K to a tile boundary
+    so minimal_matmul([prefix, suffix], weight) works for any channel count.
+    tile_pad_segments=False (materialized concat): contiguous stack, for use with ttnn.concat.
+    """
+    segments = weight.split(sizes, dim=1)
+    padded_segments = []
+    for seg in segments:
+        unf = seg.unflatten(1, [device_count, -1])  # [out, device_count, K_seg/dev]
+        if tile_pad_segments:
+            k_per_dev = unf.shape[2]
+            k_padded = ((k_per_dev + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+            if k_padded != k_per_dev:
+                pad = torch.zeros(*unf.shape[:2], k_padded - k_per_dev, dtype=unf.dtype)
+                unf = torch.cat([unf, pad], dim=2)
+        padded_segments.append(unf)
+    return torch.cat(padded_segments, dim=2).flatten(1, 2)

--- a/tests/nightly/t3000/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
@@ -85,6 +85,8 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
     broadcast_gate=True,
     check_correctness=True,
     mm_window_blocks=None,
+    fused_concat=False,
+    fused_concat_ka=None,
 ):
     torch.manual_seed(0)
 
@@ -156,6 +158,7 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
     logger.info(f"RS output shape per device: [1, 1, {M}, {N // num_devices}]")
 
     input_tensor_mesh_list = []
+    input_b_tensor_mesh_list = []  # fused-concat second in0 source (when fused_concat)
     weight_tensor_mesh_list = []
     torch_mm_output_per_device_list = []  # list of lists, [iter][device]
     torch_rs_output_list = []
@@ -191,13 +194,30 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
             mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
 
+    # For non-aligned virtual concat: compute per-device padded K and build zero-padded weight.
+    if fused_concat and fused_concat_ka is not None:
+        ka_p = ((fused_concat_ka + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+        kb = K - fused_concat_ka
+        kb_p = ((kb + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+        K_weight = ka_p + kb_p  # padded K used for device weight
+    else:
+        K_weight = K
+
     for i in range(num_iters):
         torch_input = torch.randn(input_shape, dtype=torch.float32)
-        torch_weight_global = torch.randn(weight_shape_global, dtype=torch.float32)
+        torch_weight_ref = torch.randn(weight_shape_global, dtype=torch.float32)  # logical weight for golden
 
-        # Golden: per-device MM outputs (each device has different weights)
+        if fused_concat and fused_concat_ka is not None:
+            # Build per-segment tile-padded weight: zero rows fill each segment's tile gap.
+            torch_weight_global = torch.zeros(num_devices, 1, K_weight, N, dtype=torch.float32)
+            torch_weight_global[:, :, :fused_concat_ka, :] = torch_weight_ref[:, :, :fused_concat_ka, :]
+            torch_weight_global[:, :, ka_p : ka_p + kb, :] = torch_weight_ref[:, :, fused_concat_ka:, :]
+        else:
+            torch_weight_global = torch_weight_ref
+
+        # Golden: per-device MM outputs using logical (unpadded) weights
         if check_correctness:
-            torch_weight_chunks = torch.chunk(torch_weight_global, num_devices, dim=0)  # each [1, 1, K, N]
+            torch_weight_chunks = torch.chunk(torch_weight_ref, num_devices, dim=0)  # each [1, 1, K, N]
             mm_outputs = []
             for d in range(num_devices):
                 mm_out_d = torch.matmul(torch_input, torch_weight_chunks[d])
@@ -233,6 +253,31 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
             memory_config=mem_config_input,
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=shard_dims, mesh_shape=tuple(mesh_device.shape)),
         )
+
+        # Fused concat: split the (full) activation on K into two replicated buffers fed as a
+        # [prefix, suffix] list. Split at 1/4 : 3/4 (asymmetric, so prefix/suffix widths differ — this
+        # catches width-confusion bugs; at K=3072 it is exactly the FLUX.2 attn(768) + mlp(2304) split).
+        # The golden uses the full torch_input, so a correct fused concat must match it exactly.
+        if fused_concat:
+            ka = fused_concat_ka if fused_concat_ka is not None else max(1, (K // TILE_SIZE) // 4) * TILE_SIZE
+            input_a_mesh = ttnn.from_torch(
+                torch_input[..., :ka],
+                device=mesh_device,
+                layout=layout,
+                dtype=input_dtype,
+                memory_config=mem_config_input,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            )
+            input_b_mesh = ttnn.from_torch(
+                torch_input[..., ka:],
+                device=mesh_device,
+                layout=layout,
+                dtype=input_dtype,
+                memory_config=mem_config_input,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            )
+            input_tensor_mesh = input_a_mesh
+            input_b_tensor_mesh_list.append(input_b_mesh)
 
         input_tensor_mesh_list.append(input_tensor_mesh)
         weight_tensor_mesh_list.append(weight_tensor_mesh)
@@ -271,12 +316,17 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
 
     def run_op(i):
         if rs_mode == "fused":
+            # input_tensor accepts a single tensor, or [prefix, suffix] to fused-concatenate in0's K
+            # (concat-free); the baseline (fused_concat=False) passes a single tensor.
+            mm_input = (
+                [input_tensor_mesh_list[i], input_b_tensor_mesh_list[i]] if fused_concat else input_tensor_mesh_list[i]
+            )
             # Fused path: matmul and strided reduce-scatter run concurrently
             (
                 tt_mm_out,
                 tt_rs_out,
             ) = ttnn.experimental.minimal_matmul_strided_reduce_scatter_async(
-                input_tensor_mesh_list[i],
+                mm_input,
                 weight_tensor_mesh_list[i],
                 dim,
                 ccl_semaphore_handles[i],
@@ -738,6 +788,51 @@ def test_minimal_matmul_strided_reduce_scatter_addcmul(mesh_device, broadcast_ga
         cluster_axis=1,
         addcmul_scalar=1.0,
         broadcast_gate=broadcast_gate,
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True, ids=["1x8"])
+@pytest.mark.parametrize(
+    "device_params, topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+@skip_for_blackhole("t3000 tests are wormhole_b0 only")
+def test_minimal_matmul_strided_reduce_scatter_fused_concat_non_aligned(mesh_device, topology):
+    """MMRS fused concat with non-tile-aligned Ka and Kb (t3000/WH).
+
+    K=32 per device (logical), Ka=11 (non-aligned prefix), Kb=21 (non-aligned suffix).
+    Weight is per-segment tile-padded: prefix rows [0..11) real, zeros to tile 32,
+    suffix rows [32..53) real, zeros to tile 64.  K_padded=64 (2 tiles), mm_block_k=64.
+    """
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    run_minimal_matmul_strided_reduce_scatter_impl(
+        mesh_device,
+        M=128,
+        K=32,  # logical per-device K: Ka=11 + Kb=21
+        N=512,
+        dim=3,
+        num_links=1,
+        input_dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mem_config_input=mem_config,
+        mem_config_mm=mem_config,
+        mem_config_rs=mem_config,
+        topology=topology,
+        mm_block_m=128,
+        mm_block_k=64,  # K_padded=64=2t, 2 divides 2
+        mm_block_n=64,
+        subblock_h=1,
+        subblock_w=1,
+        mm_core_grid=ttnn.CoreCoord(8, 2),
+        chunk_width_in_mm_blocks=1,
+        rs_mode="fused",
+        cluster_axis=1,
+        fused_concat=True,
+        fused_concat_ka=11,  # Ka=11: non-tile-aligned prefix (padded to 32)
     )
 
 

--- a/tests/nightly/t3000/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
@@ -82,6 +82,8 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
     allowed_pcc=0.99,
     addcmul_scalar=None,
     broadcast_gate=True,
+    fused_concat=False,
+    fused_concat_ka=None,
 ):
     torch.manual_seed(0)
 
@@ -120,6 +122,7 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
     logger.info(f"RS output shape per device: [1, 1, {M}, {N // num_devices}]")
 
     input_tensor_mesh_list = []
+    input_b_tensor_mesh_list = []  # fused-concat second in0 source (when fused_concat)
     weight_tensor_mesh_list = []
     torch_mm_output_per_device_list = []  # list of lists, [iter][device]
     torch_rs_output_list = []
@@ -155,12 +158,29 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
             mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
 
+    # For non-aligned virtual concat: compute per-device padded K and build zero-padded weight.
+    if fused_concat and fused_concat_ka is not None:
+        ka_p = ((fused_concat_ka + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+        kb = K - fused_concat_ka
+        kb_p = ((kb + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+        K_weight = ka_p + kb_p  # padded K used for device weight
+    else:
+        K_weight = K
+
     for i in range(num_iters):
         torch_input = torch.randn(input_shape, dtype=torch.float32)
-        torch_weight_global = torch.randn(weight_shape_global, dtype=torch.float32)
+        torch_weight_ref = torch.randn(weight_shape_global, dtype=torch.float32)  # logical weight for golden
 
-        # Golden: per-device MM outputs (each device has different weights)
-        torch_weight_chunks = torch.chunk(torch_weight_global, num_devices, dim=0)  # each [1, 1, K, N]
+        if fused_concat and fused_concat_ka is not None:
+            # Build per-segment tile-padded weight: zero rows fill each segment's tile gap.
+            torch_weight_global = torch.zeros(num_devices, 1, K_weight, N, dtype=torch.float32)
+            torch_weight_global[:, :, :fused_concat_ka, :] = torch_weight_ref[:, :, :fused_concat_ka, :]
+            torch_weight_global[:, :, ka_p : ka_p + kb, :] = torch_weight_ref[:, :, fused_concat_ka:, :]
+        else:
+            torch_weight_global = torch_weight_ref
+
+        # Golden: per-device MM outputs using logical (unpaddded) weights
+        torch_weight_chunks = torch.chunk(torch_weight_ref, num_devices, dim=0)  # each [1, 1, K, N]
         mm_outputs = []
         for d in range(num_devices):
             mm_out_d = torch.matmul(torch_input, torch_weight_chunks[d])
@@ -196,6 +216,31 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
             memory_config=mem_config_input,
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=shard_dims, mesh_shape=tuple(mesh_device.shape)),
         )
+
+        # Fused concat: split the (full) activation on K into two replicated buffers fed as a
+        # [prefix, suffix] list. Split at 1/4 : 3/4 (asymmetric, so prefix/suffix widths differ — this
+        # catches width-confusion bugs; at K=3072 it is exactly the FLUX.2 attn(768) + mlp(2304) split).
+        # The golden uses the full torch_input, so a correct fused concat must match it exactly.
+        if fused_concat:
+            ka = fused_concat_ka if fused_concat_ka is not None else max(1, (K // TILE_SIZE) // 4) * TILE_SIZE
+            input_a_mesh = ttnn.from_torch(
+                torch_input[..., :ka],
+                device=mesh_device,
+                layout=layout,
+                dtype=input_dtype,
+                memory_config=mem_config_input,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            )
+            input_b_mesh = ttnn.from_torch(
+                torch_input[..., ka:],
+                device=mesh_device,
+                layout=layout,
+                dtype=input_dtype,
+                memory_config=mem_config_input,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            )
+            input_tensor_mesh = input_a_mesh
+            input_b_tensor_mesh_list.append(input_b_mesh)
 
         input_tensor_mesh_list.append(input_tensor_mesh)
         weight_tensor_mesh_list.append(weight_tensor_mesh)
@@ -234,12 +279,17 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
 
     def run_op(i):
         if rs_mode == "fused":
+            # input_tensor accepts a single tensor, or [prefix, suffix] to fused-concatenate in0's K
+            # (concat-free); the baseline (fused_concat=False) passes a single tensor.
+            mm_input = (
+                [input_tensor_mesh_list[i], input_b_tensor_mesh_list[i]] if fused_concat else input_tensor_mesh_list[i]
+            )
             # Fused path: matmul and strided reduce-scatter run concurrently
             (
                 tt_mm_out,
                 tt_rs_out,
             ) = ttnn.experimental.minimal_matmul_strided_reduce_scatter_async(
-                input_tensor_mesh_list[i],
+                mm_input,
                 weight_tensor_mesh_list[i],
                 dim,
                 ccl_semaphore_handles[i],
@@ -691,6 +741,51 @@ def test_minimal_matmul_strided_reduce_scatter_addcmul(mesh_device, broadcast_ga
         cluster_axis=1,
         addcmul_scalar=1.0,
         broadcast_gate=broadcast_gate,
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True, ids=["1x8"])
+@pytest.mark.parametrize(
+    "device_params, topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+@skip_for_blackhole("t3000 tests are wormhole_b0 only")
+def test_minimal_matmul_strided_reduce_scatter_fused_concat_non_aligned(mesh_device, topology):
+    """MMRS fused concat with non-tile-aligned Ka and Kb (t3000/WH).
+
+    K=32 per device (logical), Ka=11 (non-aligned prefix), Kb=21 (non-aligned suffix).
+    Weight is per-segment tile-padded: prefix rows [0..11) real, zeros to tile 32,
+    suffix rows [32..53) real, zeros to tile 64.  K_padded=64 (2 tiles), mm_block_k=64.
+    """
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    run_minimal_matmul_strided_reduce_scatter_impl(
+        mesh_device,
+        M=128,
+        K=32,  # logical per-device K: Ka=11 + Kb=21
+        N=512,
+        dim=3,
+        num_links=1,
+        input_dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mem_config_input=mem_config,
+        mem_config_mm=mem_config,
+        mem_config_rs=mem_config,
+        topology=topology,
+        mm_block_m=128,
+        mm_block_k=64,  # K_padded=64=2t, 2 divides 2
+        mm_block_n=64,
+        subblock_h=1,
+        subblock_w=1,
+        mm_core_grid=ttnn.CoreCoord(8, 2),
+        chunk_width_in_mm_blocks=1,
+        rs_mode="fused",
+        cluster_axis=1,
+        fused_concat=True,
+        fused_concat_ka=11,  # Ka=11: non-tile-aligned prefix (padded to 32)
     )
 
 

--- a/tests/nightly/t3000/ccl/test_strided_all_gather_minimal_matmul_async.py
+++ b/tests/nightly/t3000/ccl/test_strided_all_gather_minimal_matmul_async.py
@@ -62,6 +62,7 @@ def run_strided_all_gather_minimal_matmul_impl(
     shard_weights=False,
     ag_core_grid_offset=(0, 6),
     read_local_slice_from_input=False,
+    mm_signal_aggregator_mode=ttnn.MMSignalAggregatorMode.Auto,
 ):
     torch.manual_seed(0)
 
@@ -305,6 +306,7 @@ def run_strided_all_gather_minimal_matmul_impl(
                 fused_ternary_input_b=ternary_b_tensor_mesh_list[i] if use_ternary else None,
                 fused_ternary_scalar=ternary_scalar if use_ternary else None,
                 chunks=chunks,
+                mm_signal_aggregator_mode=mm_signal_aggregator_mode,
             )
             # Op returns [all_gather_output, matmul_chunk_0, ..., matmul_chunk_{chunks-1}].
             tt_all_gather_out_tensor = fused_outputs[0]

--- a/tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
@@ -705,3 +705,52 @@ def test_minimal_matmul_strided_reduce_scatter_block_sweep(
 
     if skipped:
         logger.warning(f"[block sweep] {len(skipped)}/{len(configs)} configs failed on device: {skipped}")
+
+
+@pytest.mark.parametrize("mesh_device", [(4, 8)], indirect=True, ids=["4x8"])
+@pytest.mark.parametrize("num_links", [2], ids=["2link"])
+@pytest.mark.parametrize("cluster_axis", [0, 1], ids=["axis_0", "axis_1"])
+@pytest.mark.parametrize(
+    "device_params, topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+def test_minimal_matmul_strided_reduce_scatter_fused_concat_non_aligned(mesh_device, num_links, cluster_axis, topology):
+    """MMRS fused concat with non-tile-aligned Ka and Kb (TG/galaxy).
+
+    K=32 per device (logical), Ka=11 (non-aligned prefix), Kb=21 (non-aligned suffix).
+    Weight is per-segment tile-padded: prefix rows [0..11) real, zeros to tile 32,
+    suffix rows [32..53) real, zeros to tile 64.  K_padded=64 (2 tiles), mm_block_k=64.
+    """
+    if mesh_device.shape[cluster_axis] == 1:
+        pytest.skip(f"cluster_axis={cluster_axis} has only 1 device in this mesh, reduce-scatter ring size must be > 1")
+
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    run_minimal_matmul_strided_reduce_scatter_impl(
+        mesh_device,
+        M=128,
+        K=32,  # logical per-device K: Ka=11 + Kb=21
+        N=512,
+        dim=3,
+        num_links=num_links,
+        input_dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mem_config_input=mem_config,
+        mem_config_mm=mem_config,
+        mem_config_rs=mem_config,
+        topology=topology,
+        mm_block_m=128,
+        mm_block_k=64,  # K_padded=64=2t, 2 divides 2
+        mm_block_n=64,
+        subblock_h=1,
+        subblock_w=1,
+        mm_core_grid=ttnn.CoreCoord(8, 2),
+        chunk_width_in_mm_blocks=1,
+        rs_mode="fused",
+        cluster_axis=cluster_axis,
+        fused_concat=True,
+        fused_concat_ka=11,  # Ka=11: non-tile-aligned prefix (padded to 32)
+    )

--- a/tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
@@ -362,3 +362,52 @@ def test_minimal_matmul_strided_reduce_scatter_async_bh_large_packet(
         math_fidelity=ttnn.MathFidelity.HiFi2,
         fp32_acc=True,
     )
+
+
+@pytest.mark.parametrize("mesh_device", [(4, 8)], indirect=True, ids=["4x8"])
+@pytest.mark.parametrize("num_links", [2], ids=["2link"])
+@pytest.mark.parametrize("cluster_axis", [0, 1], ids=["axis_0", "axis_1"])
+@pytest.mark.parametrize(
+    "device_params, topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+def test_minimal_matmul_strided_reduce_scatter_fused_concat_non_aligned(mesh_device, num_links, cluster_axis, topology):
+    """MMRS fused concat with non-tile-aligned Ka and Kb (TG/galaxy).
+
+    K=32 per device (logical), Ka=11 (non-aligned prefix), Kb=21 (non-aligned suffix).
+    Weight is per-segment tile-padded: prefix rows [0..11) real, zeros to tile 32,
+    suffix rows [32..53) real, zeros to tile 64.  K_padded=64 (2 tiles), mm_block_k=64.
+    """
+    if mesh_device.shape[cluster_axis] == 1:
+        pytest.skip(f"cluster_axis={cluster_axis} has only 1 device in this mesh, reduce-scatter ring size must be > 1")
+
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    run_minimal_matmul_strided_reduce_scatter_impl(
+        mesh_device,
+        M=128,
+        K=32,  # logical per-device K: Ka=11 + Kb=21
+        N=512,
+        dim=3,
+        num_links=num_links,
+        input_dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mem_config_input=mem_config,
+        mem_config_mm=mem_config,
+        mem_config_rs=mem_config,
+        topology=topology,
+        mm_block_m=128,
+        mm_block_k=64,  # K_padded=64=2t, 2 divides 2
+        mm_block_n=64,
+        subblock_h=1,
+        subblock_w=1,
+        mm_core_grid=ttnn.CoreCoord(8, 2),
+        chunk_width_in_mm_blocks=1,
+        rs_mode="fused",
+        cluster_axis=cluster_axis,
+        fused_concat=True,
+        fused_concat_ka=11,  # Ka=11: non-tile-aligned prefix (padded to 32)
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
@@ -202,6 +202,137 @@ def test_linear_granular_write_ordering(
 
 
 @pytest.mark.parametrize(
+    "M, Ka, Kb, N, M_block_size, K_block_size, N_block_size, subblock_h, subblock_w",
+    [
+        # Realistic FLUX.2 proj_out shape (per device): in0 = [attn 768 | mlp 2304] -> 96 K-tiles.
+        # k_split (Ka/32 = 24) aligns to K_block (8) -> no K-block straddles the seam.
+        (1152, 768, 2304, 768, 8, 8, 8, 2, 2),
+        # Seam falls INSIDE a K-block: k_split=3 tiles, K_block=4 -> block [0,4) is part x_a (0..2),
+        # part x_b (3). Exercises the per-tile source switch across the boundary.
+        (256, 96, 160, 128, 4, 4, 4, 2, 2),
+        # M < N -> transpose_core_grid=False, so in0 is the output-writer + mcaster AND the two-source
+        # reader in the same kernel (the config MMRS uses). M=256, Ka=768(24t), Kb=2304(72t), N=768.
+        (256, 768, 2304, 768, 8, 8, 8, 2, 2),
+    ],
+    ids=["proj_out_aligned", "seam_in_block", "transpose_false_in0_writer"],
+)
+def test_linear_fused_concat(device, M, Ka, Kb, N, M_block_size, K_block_size, N_block_size, subblock_h, subblock_w):
+    """Fused concatenation of in0 over K: minimal_matmul([x_a, x_b], weight) (a 2-element input list)
+    must equal matmul(concat([x_a, x_b], -1), weight) without materializing the concat. The split point
+    is x_a's K width; weight is [Ka+Kb, N] in matching K order."""
+    torch_dtype = torch.float32
+    torch.manual_seed(0)
+    x_a = torch.randn((M, Ka), dtype=torch_dtype)
+    x_b = torch.randn((M, Kb), dtype=torch_dtype)
+    weight = torch.randn((Ka + Kb, N), dtype=torch_dtype)
+
+    with torch.no_grad():
+        torch_output = torch.cat([x_a, x_b], dim=-1) @ weight
+
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+    matmul_config = ttnn.MinimalMatmulConfig(
+        M_block_size=M_block_size,
+        K_block_size=K_block_size,
+        N_block_size=N_block_size,
+        subblock_h=subblock_h,
+        subblock_w=subblock_w,
+        compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+    )
+
+    tt_x_a = ttnn.from_torch(x_a, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_x_b = ttnn.from_torch(x_b, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_weight = ttnn.from_torch(weight, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+
+    tt_output = ttnn.experimental.minimal_matmul(
+        [tt_x_a, tt_x_b],  # 2-element list -> virtual concat of in0 over K (concat-free)
+        tt_weight,
+        compute_kernel_config=compute_config,
+        config=matmul_config,
+    )
+    tt_output_torch = ttnn.to_torch(tt_output)
+
+    result = assert_quality(torch_output, tt_output_torch)
+    assert result["pcc"] > 0.999_000
+    assert result["relative_rmse"] < 0.02
+
+
+@pytest.mark.parametrize(
+    "M, Ka, Kb, N, M_block_size, K_block_size, N_block_size, subblock_h, subblock_w",
+    [
+        # Ka=94 (Ka%32=30 != 0, padded to 96=3t), Kb=20 (Kb%32=20 != 0, padded to 32=1t).
+        # Total K_padded=128=4t. Weight is per-segment tile-padded (device_count=1).
+        (256, 94, 20, 128, 4, 4, 4, 2, 2),
+        # Ka=752 (Ka%32=16 != 0, padded to 768=24t), Kb=100 (Kb%32=4 != 0, padded to 128=4t).
+        # K_tiles=28, K_block_size=4 (divides 28).
+        (256, 752, 100, 128, 4, 4, 4, 2, 2),
+    ],
+    ids=["small_non_aligned", "large_non_aligned"],
+)
+def test_linear_fused_concat_non_aligned(
+    device, M, Ka, Kb, N, M_block_size, K_block_size, N_block_size, subblock_h, subblock_w
+):
+    """Fused concat with non-tile-aligned segment K (Ka % 32 != 0 and/or Kb % 32 != 0).
+
+    The weight is built via prepare_weight_for_concatenated_input (device_count=1) which inserts
+    zero-padding rows at each segment's tile boundary.  The golden is exact matmul of the
+    concatenated logical activations against the original (un-padded) weight; the padding rows
+    must contribute zero to the contraction to match.
+    """
+    from models.tt_dit.utils.tensor import prepare_weight_for_concatenated_input
+
+    torch_dtype = torch.float32
+    torch.manual_seed(42)
+    x_a = torch.randn((M, Ka), dtype=torch_dtype)
+    x_b = torch.randn((M, Kb), dtype=torch_dtype)
+    # Reference weight in [K, N] form (un-padded); golden uses the logical entries only.
+    weight_ref = torch.randn((Ka + Kb, N), dtype=torch_dtype)
+
+    with torch.no_grad():
+        torch_output = torch.cat([x_a, x_b], dim=-1) @ weight_ref
+
+    # Build per-segment tile-padded weight: transpose to [N, K], prep, transpose back to [K_padded, N].
+    weight_padded = prepare_weight_for_concatenated_input(weight_ref.T, [Ka, Kb], device_count=1).T
+
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+    matmul_config = ttnn.MinimalMatmulConfig(
+        M_block_size=M_block_size,
+        K_block_size=K_block_size,
+        N_block_size=N_block_size,
+        subblock_h=subblock_h,
+        subblock_w=subblock_w,
+        compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+    )
+
+    tt_x_a = ttnn.from_torch(x_a, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_x_b = ttnn.from_torch(x_b, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_weight = ttnn.from_torch(weight_padded, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+
+    tt_output = ttnn.experimental.minimal_matmul(
+        [tt_x_a, tt_x_b],
+        tt_weight,
+        compute_kernel_config=compute_config,
+        config=matmul_config,
+    )
+    tt_output_torch = ttnn.to_torch(tt_output)
+
+    result = assert_quality(torch_output, tt_output_torch)
+    assert result["pcc"] > 0.999_000
+    assert result["relative_rmse"] < 0.02
+
+
+@pytest.mark.parametrize(
     "M, K, N, M_block_size, K_block_size, N_block_size, subblock_h, subblock_w",
     [(512, 512, 512, 1, 1, 1, 1, 1)],
 )

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_strided_all_gather_minimal_matmul_async_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_strided_all_gather_minimal_matmul_async_bh.py
@@ -182,6 +182,9 @@ def test_strided_all_gather_minimal_matmul_async(
         shard_weights=shard_weights,
         ag_core_grid_offset=ag_offset,
         read_local_slice_from_input=read_local_slice_from_input,
+        # Blackhole has the cores for the aggregators; require them so a config change cannot silently
+        # drop back to reader-signaled matmul and lose the overlap.
+        mm_signal_aggregator_mode=ttnn.MMSignalAggregatorMode.On,
     )
 
 
@@ -309,4 +312,5 @@ def test_strided_all_gather_minimal_matmul_ltx_configs(
         shard_weights=False,
         ag_core_grid_offset=ag_offset,
         read_local_slice_from_input=True,
+        mm_signal_aggregator_mode=ttnn.MMSignalAggregatorMode.On,
     )

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -403,7 +403,7 @@ std::vector<IDevice*> get_active_physical_devices(const std::vector<Tensor>& ten
     return devices;
 }
 
-std::tuple<CoreRangeSet, std::vector<CoreCoord>> choose_worker_cores(
+WorkerCoreSelection try_choose_worker_cores(
     size_t num_links,
     size_t num_workers_per_link,
     IDevice* device,
@@ -411,12 +411,12 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> choose_worker_cores(
     const CoreCoord core_grid_offset,
     const std::optional<CoreRangeSet>& sub_core_grid,
     CoreAllocationStrategy strategy) {
-    std::tuple<CoreRangeSet, std::vector<CoreCoord>> result;
     CoreRangeSet sender_worker_core_range;
     const size_t num_workers_preferred = num_workers_per_link * num_links;
-    auto available_cores = device->worker_cores(
+    const auto worker_cores = device->worker_cores(
         tt::tt_metal::HalProgrammableCoreType::TENSIX,
         sub_device_id.has_value() ? *sub_device_id : device->get_sub_device_ids().at(0));
+    auto available_cores = worker_cores;
     if (sub_core_grid.has_value()) {
         available_cores = available_cores.intersection(sub_core_grid.value());
     }
@@ -471,7 +471,38 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> choose_worker_cores(
             break;
         }
     }
-    return {sender_worker_core_range, corerange_to_cores(sender_worker_core_range, std::nullopt, true)};
+
+    // The loops above shift each candidate by core_grid_offset without re-checking it, so an offset near the grid
+    // edge can push cores off the worker grid entirely (onto dispatch cores).
+    WorkerCoreSelection selection{
+        sender_worker_core_range, corerange_to_cores(sender_worker_core_range, std::nullopt, true), {}};
+    for (const auto& core : selection.cores) {
+        if (!worker_cores.contains(core)) {
+            selection.unplaceable_cores.push_back(core);
+        }
+    }
+    return selection;
+}
+
+std::tuple<CoreRangeSet, std::vector<CoreCoord>> choose_worker_cores(
+    size_t num_links,
+    size_t num_workers_per_link,
+    IDevice* device,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    const CoreCoord core_grid_offset,
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    CoreAllocationStrategy strategy) {
+    auto selection = try_choose_worker_cores(
+        num_links, num_workers_per_link, device, sub_device_id, core_grid_offset, sub_core_grid, strategy);
+    TT_FATAL(
+        selection.all_placeable(),
+        "Core grid offset {} pushed {} of the {} selected worker cores (first: {}) off the worker grid; kernels "
+        "cannot be placed there. Request fewer cores or use a smaller offset.",
+        core_grid_offset.str(),
+        selection.unplaceable_cores.size(),
+        selection.cores.size(),
+        selection.unplaceable_cores.front().str());
+    return {std::move(selection.core_range_set), std::move(selection.cores)};
 }
 
 std::vector<ttnn::Tensor> unpad_output_tensor(

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -97,6 +97,26 @@ enum class CoreAllocationStrategy {
     COL_MAJOR,
 };
 
+struct WorkerCoreSelection {
+    CoreRangeSet core_range_set;
+    std::vector<CoreCoord> cores;
+    // Selected cores that core_grid_offset shifted off the device's worker grid. Kernels cannot be placed on these.
+    std::vector<CoreCoord> unplaceable_cores;
+
+    bool all_placeable() const { return unplaceable_cores.empty(); }
+};
+
+// Selects worker cores without asserting on the result. Callers that can adapt to a selection which does not fit at
+// core_grid_offset use this; everyone else should use choose_worker_cores(), which rejects such a selection.
+WorkerCoreSelection try_choose_worker_cores(
+    size_t num_links,
+    size_t num_workers_per_link,
+    IDevice* device,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    CoreCoord core_grid_offset = CoreCoord(0, 0),
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+    CoreAllocationStrategy strategy = CoreAllocationStrategy::ROW_MAJOR);
+
 std::tuple<CoreRangeSet, std::vector<CoreCoord>> choose_worker_cores(
     size_t num_links,
     size_t num_workers_per_link,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_device_operation_types.hpp
@@ -110,6 +110,9 @@ struct MinimalMatmulStridedReduceScatterAsyncInputs {
     // Caller-owned RS->MM credit array for the rolling window; see mm_window_blocks. Allocated per
     // compiled program when absent, which permanently lowers the device's L1 floor.
     const std::optional<const Tensor> mm_credit_counters = std::nullopt;
+
+    /* Fused concatenation: the second in0 source (suffix K-tiles). */
+    const std::optional<const Tensor> mm_optional_input_tensor = std::nullopt;
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_device_operation_types.hpp
@@ -89,6 +89,9 @@ struct MinimalMatmulStridedReduceScatterAsyncInputs {
     /* Fused addcmul inputs: output = addcmul_a + scalar * mm_output * addcmul_b */
     const std::optional<const Tensor> addcmul_input_tensor1 = std::nullopt;  // residual/base
     const std::optional<const Tensor> addcmul_input_tensor2 = std::nullopt;  // gate/multiplier
+
+    /* Fused concatenation: the second in0 source (suffix K-tiles). */
+    const std::optional<const Tensor> mm_optional_input_tensor = std::nullopt;
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.cpp
@@ -43,13 +43,15 @@ void MinimalMatmulStridedReduceScatterAsync::validate_on_program_cache_miss(
         return opt.has_value() ? std::optional<Tensor>(opt.value()) : std::nullopt;
     };
 
+    // Delegate to the matmul validator. The fused-concat checks (two sources concatenable on K,
+    // K's sum to the weight K) are driven by the presence of optional_input_tensor below.
     matmul_device_operation_t::validate_on_program_cache_miss(
         attributes.matmul_struct,
         matmul_device_operation_t::tensor_args_t{
             .input_tensor = tensor_args.input_tensor,
             .weight_tensor = tensor_args.weight_tensor,
             .bias_tensor = to_mutable_opt(tensor_args.bias),
-            .optional_input_tensor = std::nullopt,
+            .optional_input_tensor = to_mutable_opt(tensor_args.mm_optional_input_tensor),
             .fused_ternary_input_a = std::nullopt,
             .fused_ternary_input_b = std::nullopt,
         });
@@ -262,7 +264,8 @@ std::vector<Tensor> minimal_matmul_strided_reduce_scatter_async(
     std::optional<tt::tt_metal::DataType> dtype,
     const std::optional<const Tensor>& mm_progress_counters,
     std::optional<uint32_t> mm_window_blocks,
-    const std::optional<const Tensor>& mm_credit_counters) {
+    const std::optional<const Tensor>& mm_credit_counters,
+    const std::optional<const Tensor>& mm_optional_input_tensor) {
     using OperationType = ttnn::experimental::prim::MinimalMatmulStridedReduceScatterAsync;
 
     uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
@@ -310,7 +313,8 @@ std::vector<Tensor> minimal_matmul_strided_reduce_scatter_async(
         addcmul_input_tensor1,
         addcmul_input_tensor2,
         mm_progress_counters,
-        mm_credit_counters};
+        mm_credit_counters,
+        mm_optional_input_tensor};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.cpp
@@ -43,13 +43,15 @@ void MinimalMatmulStridedReduceScatterAsync::validate_on_program_cache_miss(
         return opt.has_value() ? std::optional<Tensor>(opt.value()) : std::nullopt;
     };
 
+    // Delegate to the matmul validator. The fused-concat checks (two sources concatenable on K,
+    // K's sum to the weight K) are driven by the presence of optional_input_tensor below.
     matmul_device_operation_t::validate_on_program_cache_miss(
         attributes.matmul_struct,
         matmul_device_operation_t::tensor_args_t{
             .input_tensor = tensor_args.input_tensor,
             .weight_tensor = tensor_args.weight_tensor,
             .bias_tensor = to_mutable_opt(tensor_args.bias),
-            .optional_input_tensor = std::nullopt,
+            .optional_input_tensor = to_mutable_opt(tensor_args.mm_optional_input_tensor),
             .fused_ternary_input_a = std::nullopt,
             .fused_ternary_input_b = std::nullopt,
         });
@@ -228,7 +230,8 @@ std::vector<Tensor> minimal_matmul_strided_reduce_scatter_async(
     const std::optional<float> fused_ternary_scalar,
     const std::optional<const Tensor>& addcmul_input_tensor1,
     const std::optional<const Tensor>& addcmul_input_tensor2,
-    std::optional<tt::tt_metal::DataType> dtype) {
+    std::optional<tt::tt_metal::DataType> dtype,
+    const std::optional<const Tensor>& mm_optional_input_tensor) {
     using OperationType = ttnn::experimental::prim::MinimalMatmulStridedReduceScatterAsync;
 
     uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
@@ -273,7 +276,8 @@ std::vector<Tensor> minimal_matmul_strided_reduce_scatter_async(
         optional_rs_output_tensor,
         bias,
         addcmul_input_tensor1,
-        addcmul_input_tensor2};
+        addcmul_input_tensor2,
+        mm_optional_input_tensor};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.hpp
@@ -80,6 +80,8 @@ std::vector<Tensor> minimal_matmul_strided_reduce_scatter_async(
     // Shared per-MM-core progress counter scratch; see MinimalMatmulStridedReduceScatterAsyncInputs.
     const std::optional<const Tensor>& mm_progress_counters = std::nullopt,
     std::optional<uint32_t> mm_window_blocks = std::nullopt,
-    const std::optional<const Tensor>& mm_credit_counters = std::nullopt);
+    const std::optional<const Tensor>& mm_credit_counters = std::nullopt,
+    // Fused concat: second in0 source (suffix half of K; input_tensor is the prefix half).
+    const std::optional<const Tensor>& mm_optional_input_tensor = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.hpp
@@ -76,6 +76,8 @@ std::vector<Tensor> minimal_matmul_strided_reduce_scatter_async(
     std::optional<float> fused_ternary_scalar = std::nullopt,
     const std::optional<const Tensor>& addcmul_input_tensor1 = std::nullopt,
     const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt,
-    std::optional<tt::tt_metal::DataType> dtype = std::nullopt);
+    std::optional<tt::tt_metal::DataType> dtype = std::nullopt,
+    // Fused concat: second in0 source (suffix half of K; input_tensor is the prefix half).
+    const std::optional<const Tensor>& mm_optional_input_tensor = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_program.cpp
@@ -168,8 +168,8 @@ void MinimalMatmulStridedReduceScatterAsyncProgramFactory::override_runtime_argu
             {tensor_args.input_tensor,
              tensor_args.weight_tensor,
              tensor_args.bias,
-             std::nullopt,
-             std::nullopt,  // addcmul fused in RS, not MM
+             tensor_args.mm_optional_input_tensor,  // fused-concat 2nd in0 source; must re-point on cached reuse
+             std::nullopt,                          // addcmul fused in RS, not MM
              std::nullopt},
             mm_output_vec);
     }
@@ -215,7 +215,9 @@ minimal_matmul_strided_reduce_scatter_async_program(
     const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt,
 
     /* Caller-owned per-MM-core progress counter scratch shared across MMRS programs. */
-    const std::optional<const Tensor>& mm_progress_counters = std::nullopt) {
+    const std::optional<const Tensor>& mm_progress_counters = std::nullopt,
+    /* Fused concat (concat-free): second in0 source (suffix half of K; input_tensor is the prefix). */
+    const std::optional<const Tensor>& mm_optional_input_tensor = std::nullopt) {
     tt::tt_metal::Program program{};
 
     // Derive matmul geometry parameters for the RS factory.
@@ -311,7 +313,9 @@ minimal_matmul_strided_reduce_scatter_async_program(
         std::nullopt,                // ternary fused in RS, not MM
         std::nullopt,
         std::nullopt,
-        srs_fused_op_signaler);  // MM -> RS signaling (populated from step 1)
+        srs_fused_op_signaler,  // MM -> RS signaling (populated from step 1)
+        false,                  // fuse_swiglu
+        mm_optional_input_tensor);
 
     return {std::move(program), {rs_shared_variables, mm_shared_variables}};
 }
@@ -373,7 +377,9 @@ MinimalMatmulStridedReduceScatterAsyncProgramFactory::create_at(
         tensor_args.addcmul_input_tensor2,
 
         /* Shared MM->RS progress counter scratch */
-        tensor_args.mm_progress_counters);
+        tensor_args.mm_progress_counters,
+        /* Fused concat: second in0 source */
+        tensor_args.mm_optional_input_tensor);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_program.cpp
@@ -141,8 +141,8 @@ void MinimalMatmulStridedReduceScatterAsyncProgramFactory::override_runtime_argu
             {tensor_args.input_tensor,
              tensor_args.weight_tensor,
              tensor_args.bias,
-             std::nullopt,
-             std::nullopt,  // addcmul fused in RS, not MM
+             tensor_args.mm_optional_input_tensor,  // fused-concat 2nd in0 source; must re-point on cached reuse
+             std::nullopt,                          // addcmul fused in RS, not MM
              std::nullopt},
             mm_output_vec);
     }
@@ -183,7 +183,10 @@ minimal_matmul_strided_reduce_scatter_async_program(
     /* Fused addcmul params */
     const std::optional<float> fused_ternary_scalar = std::nullopt,
     const std::optional<const Tensor>& addcmul_input_tensor1 = std::nullopt,
-    const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt) {
+    const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt,
+
+    /* Fused concat (concat-free): second in0 source (suffix half of K; input_tensor is the prefix). */
+    const std::optional<const Tensor>& mm_optional_input_tensor = std::nullopt) {
     tt::tt_metal::Program program{};
 
     // Derive matmul geometry parameters for the RS factory.
@@ -268,7 +271,9 @@ minimal_matmul_strided_reduce_scatter_async_program(
         std::nullopt,                // ternary fused in RS, not MM
         std::nullopt,
         std::nullopt,
-        srs_fused_op_signaler);  // MM -> RS signaling (populated from step 1)
+        srs_fused_op_signaler,  // MM -> RS signaling (populated from step 1)
+        false,                  // fuse_swiglu
+        mm_optional_input_tensor);
 
     return {std::move(program), {rs_shared_variables, mm_shared_variables}};
 }
@@ -325,7 +330,10 @@ MinimalMatmulStridedReduceScatterAsyncProgramFactory::create_at(
         /* Fused addcmul params */
         attributes.fused_ternary_scalar,
         tensor_args.addcmul_input_tensor1,
-        tensor_args.addcmul_input_tensor2);
+        tensor_args.addcmul_input_tensor2,
+
+        /* Fused concat: second in0 source */
+        tensor_args.mm_optional_input_tensor);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.cpp
@@ -8,7 +8,7 @@
 namespace ttnn::experimental {
 
 std::vector<ttnn::Tensor> minimal_matmul_strided_reduce_scatter_async(
-    const ttnn::Tensor& input_tensor,
+    const std::variant<ttnn::Tensor, std::vector<ttnn::Tensor>>& input_tensor,
     const ttnn::Tensor& weight_tensor,
     const uint32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
@@ -37,15 +37,30 @@ std::vector<ttnn::Tensor> minimal_matmul_strided_reduce_scatter_async(
     const std::optional<const Tensor>& mm_progress_counters,
     std::optional<uint32_t> mm_window_blocks,
     const std::optional<const Tensor>& mm_credit_counters) {
+    // Unpack: single Tensor, or [prefix, suffix] virtually concatenated over K (concat-free).
+    ttnn::Tensor main_input;
+    std::optional<ttnn::Tensor> second_input;
+    if (const auto* inputs = std::get_if<std::vector<ttnn::Tensor>>(&input_tensor)) {
+        TT_FATAL(
+            inputs->size() == 2,
+            "minimal_matmul_strided_reduce_scatter_async: list input must be exactly 2 tensors "
+            "[prefix, suffix] for fused concat over K, got {}",
+            inputs->size());
+        main_input = (*inputs)[0];
+        second_input = (*inputs)[1];
+    } else {
+        main_input = std::get<ttnn::Tensor>(input_tensor);
+    }
+
     auto all_outputs = ttnn::prim::minimal_matmul_strided_reduce_scatter_async(
-        input_tensor,
+        main_input,
         weight_tensor,
         dim,
         multi_device_global_semaphore,
         reduce_scatter_core_grid_offset,
         num_links,
         memory_config_mm,
-        rs_output_mem_config.value_or(input_tensor.memory_config()),
+        rs_output_mem_config.value_or(main_input.memory_config()),
         rs_intermediate_mem_config,
         topology,
         cluster_axis,
@@ -67,7 +82,8 @@ std::vector<ttnn::Tensor> minimal_matmul_strided_reduce_scatter_async(
         dtype,
         mm_progress_counters,
         mm_window_blocks,
-        mm_credit_counters);
+        mm_credit_counters,
+        second_input);
 
     return {std::move(all_outputs[0]), std::move(all_outputs[2])};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.cpp
@@ -8,7 +8,7 @@
 namespace ttnn::experimental {
 
 std::vector<ttnn::Tensor> minimal_matmul_strided_reduce_scatter_async(
-    const ttnn::Tensor& input_tensor,
+    const std::variant<ttnn::Tensor, std::vector<ttnn::Tensor>>& input_tensor,
     const ttnn::Tensor& weight_tensor,
     const uint32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
@@ -34,15 +34,30 @@ std::vector<ttnn::Tensor> minimal_matmul_strided_reduce_scatter_async(
     const std::optional<const Tensor>& addcmul_input_tensor1,
     const std::optional<const Tensor>& addcmul_input_tensor2,
     std::optional<tt::tt_metal::DataType> dtype) {
+    // Unpack: single Tensor, or [prefix, suffix] virtually concatenated over K (concat-free).
+    ttnn::Tensor main_input;
+    std::optional<ttnn::Tensor> second_input;
+    if (const auto* inputs = std::get_if<std::vector<ttnn::Tensor>>(&input_tensor)) {
+        TT_FATAL(
+            inputs->size() == 2,
+            "minimal_matmul_strided_reduce_scatter_async: list input must be exactly 2 tensors "
+            "[prefix, suffix] for fused concat over K, got {}",
+            inputs->size());
+        main_input = (*inputs)[0];
+        second_input = (*inputs)[1];
+    } else {
+        main_input = std::get<ttnn::Tensor>(input_tensor);
+    }
+
     auto all_outputs = ttnn::prim::minimal_matmul_strided_reduce_scatter_async(
-        input_tensor,
+        main_input,
         weight_tensor,
         dim,
         multi_device_global_semaphore,
         reduce_scatter_core_grid_offset,
         num_links,
         memory_config_mm,
-        rs_output_mem_config.value_or(input_tensor.memory_config()),
+        rs_output_mem_config.value_or(main_input.memory_config()),
         rs_intermediate_mem_config,
         topology,
         cluster_axis,
@@ -61,7 +76,8 @@ std::vector<ttnn::Tensor> minimal_matmul_strided_reduce_scatter_async(
         fused_ternary_scalar,
         addcmul_input_tensor1,
         addcmul_input_tensor2,
-        dtype);
+        dtype,
+        second_input);
 
     return {std::move(all_outputs[0]), std::move(all_outputs[2])};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <variant>
+#include <vector>
+
 #include <tt-metalium/core_coord.hpp>
 #include "ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.hpp"
 #include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.hpp"
@@ -12,8 +15,13 @@
 
 namespace ttnn::experimental {
 
+// input_tensor: a single activation, or a 2-element list [prefix, suffix] virtually concatenated
+// (concat-free) on the channel (K, last) axis ONLY — the two must be identical on every other axis.
+// Any per-segment channel count is allowed; the weight must be per-segment tile-padded
+// (see prepare_weight_for_concatenated_input in models/tt_dit/layers/linear.py) so that
+// prefix_padded_K + suffix_padded_K == weight_padded_K.
 std::vector<ttnn::Tensor> minimal_matmul_strided_reduce_scatter_async(
-    const ttnn::Tensor& input_tensor,
+    const std::variant<ttnn::Tensor, std::vector<ttnn::Tensor>>& input_tensor,
     const ttnn::Tensor& weight_tensor,
     uint32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <variant>
+#include <vector>
+
 #include <tt-metalium/core_coord.hpp>
 #include "ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.hpp"
 #include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.hpp"
@@ -12,8 +15,13 @@
 
 namespace ttnn::experimental {
 
+// input_tensor: a single activation, or a 2-element list [prefix, suffix] virtually concatenated
+// (concat-free) on the channel (K, last) axis ONLY — the two must be identical on every other axis.
+// Any per-segment channel count is allowed; the weight must be per-segment tile-padded
+// (see prepare_weight_for_concatenated_input in models/tt_dit/utils/tensor.py) so that
+// prefix_padded_K + suffix_padded_K == weight_padded_K.
 std::vector<ttnn::Tensor> minimal_matmul_strided_reduce_scatter_async(
-    const ttnn::Tensor& input_tensor,
+    const std::variant<ttnn::Tensor, std::vector<ttnn::Tensor>>& input_tensor,
     const ttnn::Tensor& weight_tensor,
     uint32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_nanobind.cpp
@@ -36,7 +36,13 @@ void bind_minimal_matmul_strided_reduce_scatter_async(nb::module_& mod) {
             [1] reduce-scatter output (final result)
 
         Args:
-            * :attr:`input_tensor` (ttnn.Tensor): multi-device input activations tensor
+            * :attr:`input_tensor` (ttnn.Tensor | list[ttnn.Tensor]): input activations. Pass a single
+              tensor for a standard matmul, or exactly 2 tensors [prefix, suffix] for fused concat over
+              in0's K (concat-free, no host concat). Concatenation is on the channel (K, last) axis ONLY —
+              the two must be identical on every other axis. Any per-segment channel count is allowed
+              (the seam lands on the prefix's padded-K tile boundary); the weight must be per-segment
+              tile-padded (see prepare_weight_for_concatenated_input in models/tt_dit/utils/tensor.py)
+              so that prefix_padded_K + suffix_padded_K == weight_padded_K.
             * :attr:`weight_tensor` (ttnn.Tensor): multi-device weight tensor
             * :attr:`dim` (int): scatter dimension for reduce-scatter
             * :attr:`multi_device_global_semaphore`: global semaphores for reduce-scatter

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_device_operation_types.hpp
@@ -12,6 +12,11 @@
 
 namespace ttnn::experimental::prim {
 
+// Matmul-signal aggregators (fused all-gather only) need one extra worker core per direction on top of the
+// mux/worker cores. Auto falls back to reader-signaled matmul when those cores do not fit at the requested
+// core_grid_offset; On requires them, Off never uses them.
+enum class MMSignalAggregatorMode : uint8_t { Auto, On, Off };
+
 struct StridedAllGatherAsyncParams {
     const std::vector<tt::tt_metal::IDevice*> devices;
     const uint32_t dim;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
@@ -31,6 +31,7 @@
 #include <type_traits>
 #include <ranges>
 #include <optional>
+#include <tuple>
 #include <cstdlib>
 
 using namespace tt::constants;
@@ -265,7 +266,8 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     std::optional<uint32_t> mm_cores_y,
     std::optional<uint32_t> mm_block_ht,
     std::optional<uint32_t> mm_block_wt,
-    const CoreCoord core_grid_offset) {
+    const CoreCoord core_grid_offset,
+    const MMSignalAggregatorMode mm_signal_aggregator_mode) {
     // Tensor Info
     const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
     const auto& input_tensor_shape = input_tensor.padded_shape();
@@ -296,8 +298,51 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     /* All gather fusion */
     bool fuse_op = fused_op_signaler.has_value();
 
-    // Experimental (env-gated): have the AG writer signal the *remote* device's matmul directly over fabric
-    const bool writer_signals_mm = fuse_op;
+    // Option W: the AG writer signals the remote device's matmul through per-direction aggregator cores, which cost
+    // num_directions_per_link worker cores on top of the mux/workers. Without them the reader signals the matmul.
+    const uint32_t num_mux_worker_cores = num_links * num_cores_per_link;
+    bool writer_signals_mm = false;
+    std::optional<ttnn::ccl::WorkerCoreSelection> aggregator_core_selection;
+    if (fuse_op) {
+        // Ask for the aggregator-inclusive set and check what comes back: core_grid_offset can shift the trailing
+        // cores off the worker grid, where kernels cannot be placed.
+        auto selection = ttnn::ccl::try_choose_worker_cores(
+            1, num_mux_worker_cores + num_directions_per_link, mesh_device, std::nullopt, core_grid_offset);
+        const bool aggregators_fit = selection.all_placeable();
+        switch (mm_signal_aggregator_mode) {
+            case MMSignalAggregatorMode::On:
+                TT_FATAL(
+                    aggregators_fit,
+                    "strided AG: matmul-signal aggregators need {} worker cores ({} mux/worker + {} aggregator), but "
+                    "at core grid offset {} the last {} of them fall outside the worker grid",
+                    num_mux_worker_cores + num_directions_per_link,
+                    num_mux_worker_cores,
+                    num_directions_per_link,
+                    core_grid_offset.str(),
+                    selection.unplaceable_cores.size());
+                writer_signals_mm = true;
+                break;
+            case MMSignalAggregatorMode::Off: break;
+            case MMSignalAggregatorMode::Auto:
+                writer_signals_mm = aggregators_fit;
+                if (!aggregators_fit) {
+                    log_warning(
+                        tt::LogOp,
+                        "strided AG: matmul-signal aggregators need {} worker cores ({} mux/worker + {} aggregator), "
+                        "but at core grid offset {} the last {} of them fall outside the worker grid; falling back to "
+                        "reader-signaled matmul. Pass mm_signal_aggregator_mode=On to require the aggregators instead.",
+                        num_mux_worker_cores + num_directions_per_link,
+                        num_mux_worker_cores,
+                        num_directions_per_link,
+                        core_grid_offset.str(),
+                        selection.unplaceable_cores.size());
+                }
+                break;
+        }
+        if (writer_signals_mm) {
+            aggregator_core_selection = std::move(selection);
+        }
+    }
     const uint32_t num_ag_workers = num_links * num_workers_per_direction;
 
     // Need a separate signaler for the sender workers, to handle the first tensor slice that is locally available
@@ -319,9 +364,16 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
 
     // Option W: carve `num_directions_per_link` extra trailing cores as per-direction matmul-signal aggregators
     const uint32_t num_agg_cores = writer_signals_mm ? num_directions_per_link : 0;
-    const uint32_t total_worker_cores = num_links * num_cores_per_link + num_agg_cores;
-    const auto [all_core_range, all_cores] =
-        ttnn::ccl::choose_worker_cores(1, total_worker_cores, mesh_device, std::nullopt, core_grid_offset);
+    const uint32_t total_worker_cores = num_mux_worker_cores + num_agg_cores;
+    CoreRangeSet all_core_range;
+    std::vector<CoreCoord> all_cores;
+    if (aggregator_core_selection.has_value()) {
+        all_core_range = std::move(aggregator_core_selection->core_range_set);
+        all_cores = std::move(aggregator_core_selection->cores);
+    } else {
+        std::tie(all_core_range, all_cores) =
+            ttnn::ccl::choose_worker_cores(1, total_worker_cores, mesh_device, std::nullopt, core_grid_offset);
+    }
     std::set<CoreRange> sender_worker_core_ranges;
     std::set<CoreRange> sender_forward_core_ranges;
     std::set<CoreRange> sender_backward_core_ranges;
@@ -426,6 +478,12 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     // Streaming matmul signal: deliver each chunk's M-rows as IN0_SUB_CHUNKS row-bands, one aggregator inc per band
     const char* in0_sub_chunks_env = std::getenv("IN0_SUB_CHUNKS");
     const std::string in0_sub_chunks_str = (in0_sub_chunks_env != nullptr) ? in0_sub_chunks_env : "1";
+    // Only the aggregator emits one matmul signal per band; the reader-signaled path emits one per chunk, which the
+    // matmul's per-band waits would outrun.
+    TT_FATAL(
+        !fuse_op || writer_signals_mm || in0_sub_chunks_str == "1",
+        "strided AG: IN0_SUB_CHUNKS={} requires the matmul-signal aggregators, which are not in use",
+        in0_sub_chunks_str);
     reader_compute_defines["IN0_SUB_CHUNKS"] = in0_sub_chunks_str;
     writer_compute_defines["IN0_SUB_CHUNKS"] = in0_sub_chunks_str;
     agg_defines["IN0_SUB_CHUNKS"] = in0_sub_chunks_str;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.hpp
@@ -55,7 +55,8 @@ struct StridedAllGatherAsyncProgramFactory {
         std::optional<uint32_t> mm_cores_y,
         std::optional<uint32_t> mm_block_ht,
         std::optional<uint32_t> mm_block_wt,
-        CoreCoord core_grid_offset = CoreCoord(0, 0));
+        CoreCoord core_grid_offset = CoreCoord(0, 0),
+        MMSignalAggregatorMode mm_signal_aggregator_mode = MMSignalAggregatorMode::Auto);
 
     static void override_runtime_arguments_per_program(
         const shared_variables_t& shared_variables,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_device_operation_types.hpp
@@ -25,6 +25,7 @@ struct StridedAllGatherMinimalMatmulAsyncParams {
     const bool read_local_slice_from_input;
     const std::vector<tt::tt_metal::IDevice*> devices;
     const StridedAllGatherAsync ag_op;
+    const MMSignalAggregatorMode mm_signal_aggregator_mode = MMSignalAggregatorMode::Auto;
 
     // Compile-time attributes select exactly the program-structure-affecting fields for the default
     // program-cache reflection hash + canonical key
@@ -42,7 +43,8 @@ struct StridedAllGatherMinimalMatmulAsyncParams {
         "mm_block_wt",
         "matmul_struct",
         "all_gather_core_grid_offset",
-        "read_local_slice_from_input");
+        "read_local_slice_from_input",
+        "mm_signal_aggregator_mode");
     auto attribute_values() const {
         return std::make_tuple(
             strided_all_gather_async_struct.dim,
@@ -58,7 +60,8 @@ struct StridedAllGatherMinimalMatmulAsyncParams {
             std::cref(strided_all_gather_async_struct.mm_block_wt),
             std::cref(matmul_struct),
             std::cref(all_gather_core_grid_offset),
-            read_local_slice_from_input);
+            read_local_slice_from_input,
+            mm_signal_aggregator_mode);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.cpp
@@ -125,7 +125,8 @@ std::vector<Tensor> strided_all_gather_minimal_matmul_async(
     const std::optional<const Tensor>& fused_ternary_input_a,
     const std::optional<const Tensor>& fused_ternary_input_b,
     std::optional<float> fused_ternary_scalar,
-    int32_t chunks) {
+    int32_t chunks,
+    ttnn::experimental::prim::MMSignalAggregatorMode mm_signal_aggregator_mode) {
     using OperationType = ttnn::experimental::prim::StridedAllGatherMinimalMatmulAsync;
 
     // addcmul uses value=1 (torch default) when ternary inputs are given without an explicit scalar
@@ -177,7 +178,8 @@ std::vector<Tensor> strided_all_gather_minimal_matmul_async(
         strided_all_gather_core_grid_offset,
         read_local_from_input,
         devices,
-        ag_op};
+        ag_op,
+        mm_signal_aggregator_mode};
     auto tensor_args = OperationType::tensor_args_t{
         input_tensor, weight_tensor, persistent_output_buffer, bias, fused_ternary_input_a, fused_ternary_input_b};
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.hpp
@@ -70,6 +70,7 @@ std::vector<Tensor> strided_all_gather_minimal_matmul_async(
     const std::optional<const Tensor>& fused_ternary_input_a,
     const std::optional<const Tensor>& fused_ternary_input_b,
     std::optional<float> fused_ternary_scalar,
-    int32_t chunks);
+    int32_t chunks,
+    ttnn::experimental::prim::MMSignalAggregatorMode mm_signal_aggregator_mode);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.cpp
@@ -96,6 +96,7 @@ strided_all_gather_minimal_matmul_async_program(
     std::optional<uint32_t> num_workers_per_direction_opt,
     std::optional<uint32_t> num_buffers_per_channel,
     const CoreCoord core_grid_offset,
+    const MMSignalAggregatorMode mm_signal_aggregator_mode,
 
     /* Matmul Params */
     const std::optional<const Tensor>& bias,
@@ -169,7 +170,8 @@ strided_all_gather_minimal_matmul_async_program(
             matmul_fused_op_signaler->num_fused_op_cores_to_signal,
             config.M_block_size,
             config.K_block_size,
-            core_grid_offset);
+            core_grid_offset,
+            mm_signal_aggregator_mode);
 
     return {std::move(program), {ag_shared_variables, mm_shared_variables}};
 }
@@ -225,6 +227,7 @@ StridedAllGatherMinimalMatmulAsyncProgramFactory::create_at(
         attributes.strided_all_gather_async_struct.num_workers_per_link,
         attributes.strided_all_gather_async_struct.num_buffers_per_channel,
         attributes.all_gather_core_grid_offset,
+        attributes.mm_signal_aggregator_mode,
 
         /* Matmul Params */
         tensor_args.bias,  // Bias

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async.cpp
@@ -29,7 +29,8 @@ std::vector<ttnn::Tensor> strided_all_gather_minimal_matmul_async(
     const std::optional<const Tensor>& fused_ternary_input_a,
     const std::optional<const Tensor>& fused_ternary_input_b,
     std::optional<float> fused_ternary_scalar,
-    int32_t chunks) {
+    int32_t chunks,
+    ttnn::experimental::prim::MMSignalAggregatorMode mm_signal_aggregator_mode) {
     return ttnn::prim::strided_all_gather_minimal_matmul_async(
         input_tensor,
         weight_tensor,
@@ -53,7 +54,8 @@ std::vector<ttnn::Tensor> strided_all_gather_minimal_matmul_async(
         fused_ternary_input_a,
         fused_ternary_input_b,
         fused_ternary_scalar,
-        chunks);
+        chunks,
+        mm_signal_aggregator_mode);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async.hpp
@@ -34,6 +34,8 @@ std::vector<ttnn::Tensor> strided_all_gather_minimal_matmul_async(
     const std::optional<const Tensor>& fused_ternary_input_a = std::nullopt,
     const std::optional<const Tensor>& fused_ternary_input_b = std::nullopt,
     std::optional<float> fused_ternary_scalar = std::nullopt,
-    int32_t chunks = 1);
+    int32_t chunks = 1,
+    ttnn::experimental::prim::MMSignalAggregatorMode mm_signal_aggregator_mode =
+        ttnn::experimental::prim::MMSignalAggregatorMode::Auto);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async_nanobind.cpp
@@ -23,6 +23,11 @@
 namespace ttnn::operations::experimental::ccl {
 
 void bind_strided_all_gather_minimal_matmul_async(nb::module_& mod) {
+    nb::enum_<ttnn::experimental::prim::MMSignalAggregatorMode>(mod, "MMSignalAggregatorMode")
+        .value("Auto", ttnn::experimental::prim::MMSignalAggregatorMode::Auto)
+        .value("On", ttnn::experimental::prim::MMSignalAggregatorMode::On)
+        .value("Off", ttnn::experimental::prim::MMSignalAggregatorMode::Off);
+
     ttnn::bind_function<"strided_all_gather_minimal_matmul_async", "ttnn.experimental.">(
         mod,
         R"doc(strided_all_gather_minimal_matmul_async(input_tensor: ttnn.Tensor, weight_tensor: ttnn.Tensor, dim: int, *, num_links: int = 1, memory_config: Optional[ttnn.MemoryConfig] = None) -> (ttnn.Tensor, ttnn.Tensor)
@@ -51,6 +56,7 @@ void bind_strided_all_gather_minimal_matmul_async(nb::module_& mod) {
             * :attr:`fused_ternary_input_b` (Optional[ttnn.Tensor]): addcmul multiplier/gate tensor; a single tile-row broadcasts across M.
             * :attr:`fused_ternary_scalar` (Optional[float]): addcmul scale; output = a + scalar * matmul_out * b. Requires both a and b.
             * :attr:`chunks` (int): split the matmul output into this many tensors along N (default 1). Returns [all_gather_output, matmul_chunk_0, ..., matmul_chunk_{chunks-1}]. N must be divisible by chunks.
+            * :attr:`mm_signal_aggregator_mode` (ttnn.MMSignalAggregatorMode): whether the all-gather signals the matmul through per-direction aggregator cores. These cost one worker core per direction on top of `num_links * (num_workers_per_link + 1) * 2` mux/worker cores, all placed from `strided_all_gather_core_grid_offset`. `Auto` (default) uses them when they fit and otherwise falls back to reader-signaled matmul with a warning, `On` requires them, `Off` never uses them.
 
         Example:
 
@@ -82,7 +88,8 @@ void bind_strided_all_gather_minimal_matmul_async(nb::module_& mod) {
         nb::arg("fused_ternary_input_a") = nb::none(),
         nb::arg("fused_ternary_input_b") = nb::none(),
         nb::arg("fused_ternary_scalar") = nb::none(),
-        nb::arg("chunks") = 1);
+        nb::arg("chunks") = 1,
+        nb::arg("mm_signal_aggregator_mode") = nb::cast(ttnn::experimental::prim::MMSignalAggregatorMode::Auto));
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
@@ -207,10 +207,6 @@ void kernel_main() {
     const uint32_t effective_worker_id = worker_id + (direction ? num_workers : 0);
     const uint32_t effective_advance_by_tiles = 2 * num_workers;
 
-    // This reader owns credit slot effective_worker_id on every MM core — the same index that
-    // identifies its tile stripe, so slots and stripes cannot disagree.
-    const uint32_t rs_credit_slot_addr = rs_credit_counters + effective_worker_id * sizeof(uint32_t);
-
     // Snapshot the semaphore's value at startup
     uint32_t out_ready_sem_target = 0;
 
@@ -439,6 +435,7 @@ void kernel_main() {
                     slice_idx += direction ? -1 : 1;
                 }
             }
+#ifdef FUSE_MM_OP_SIGNALER
             if constexpr (mm_window_blocks > 0) {
                 // Every tile of this M block is now read: the ring loop above covered all ring_size
                 // slices, i.e. the block's full width. Bump this reader's counter on every matmul
@@ -446,6 +443,7 @@ void kernel_main() {
                 // reached at least this block. One increment per M block, so the counter is the
                 // number of blocks this reader has released. Walking the cores individually mirrors
                 // OpSignaler::signal_op_per_core, the signalling path in the other direction.
+                const uint32_t rs_credit_slot_addr = rs_credit_counters + effective_worker_id * sizeof(uint32_t);
                 for (uint32_t i = 0; i < num_mm_cores; i++) {
                     const uint64_t dst = get_noc_addr(
                         get_arg_val<uint32_t>(rs_credit_mm_coords_arg_base + i * 2),
@@ -454,6 +452,7 @@ void kernel_main() {
                     noc_semaphore_inc(dst, 1);
                 }
             }
+#endif
         }
         // No per-batch reset: a local reset races the writer's monotonic fabric atomic-inc
         // (lost signal). Target grows across batches; reset once at kernel exit. See #50793.

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
@@ -80,9 +80,11 @@ void kernel_main() {
 #endif
 
 #ifdef FUSE_TERNARY
-// Calculate offset for ternary_a_args - must account for FUSE_BIAS and potentially FUSE_AG
-#if defined(FUSE_AG) && defined(READ_FROM_LOCAL_INPUT)
-// If we have FUSE_AG with READ_FROM_LOCAL_INPUT, in3 is defined
+// Calculate offset for ternary_a_args - must account for FUSE_BIAS and an optional in3 accessor.
+// in3 is present whenever in0 has a second source (AG local slice OR fused concat), so the
+// ternary args sit one accessor-block later in the CTA list in both cases.
+#ifdef IN0_HAS_SECOND_SOURCE
+// in3 is defined (AG local slice or fused-concat second half)
 #ifdef FUSE_BIAS
     // After in2, then in3, then ternary
     constexpr uint32_t ternary_a_args_cta_offset =
@@ -176,8 +178,12 @@ void kernel_main() {
             device_k_block_start_ids,
             forward_k_block_schedule);
     }
+#endif  // FUSE_AG
 
-#ifdef READ_FROM_LOCAL_INPUT
+// in3 is the second in0 source buffer. AG path: this device's local pre-gather slice. Virtual
+// concat: the second concat half (e.g. mlp output) supplied via optional_input_tensor. Set up
+// whenever in0 has a second source, independent of FUSE_AG.
+#ifdef IN0_HAS_SECOND_SOURCE
 #ifdef FUSE_BIAS
     // in3 (local input) sits right after in2 (bias); advance by in2's real arg count, not a fixed constant.
     constexpr auto in3_args = TensorAccessorArgs<in2_args.next_compile_time_args_offset()>();
@@ -187,7 +193,6 @@ void kernel_main() {
     constexpr auto in3_args = TensorAccessorArgs<in3_args_cta_offset>();
 #endif
     const auto in3_reader = TensorAccessor(in3_args, in3_addr);
-#endif
 #endif
 
 #ifdef SRS_FUSE_OP_SIGNALER
@@ -364,11 +369,23 @@ void kernel_main() {
                         in0_shape,
                         cb_in0_id,
                         in0_tile_size,
-#ifdef READ_FROM_LOCAL_INPUT
+#ifdef IN0_HAS_SECOND_SOURCE
+#ifdef IN0_VIRTUAL_CONCAT
+                        // Fused concatenation (concat-free): in0 (main) holds K-tiles [0, k_split);
+                        // in3 holds K-tiles [k_split, K). main_Wt = k_split is the main buffer width.
+                        in3_reader,
+                        /*local_k_start=*/IN0_K_SPLIT_TILES,
+                        /*local_k_end=*/K_tiles - 1,
+                        /*input_tensor_Wt=*/K_tiles - IN0_K_SPLIT_TILES,
+                        /*main_Wt=*/IN0_K_SPLIT_TILES,
+#else
+                        // AG: in0 is the full gathered K; in3 is this device's local pre-gather slice.
                         in3_reader,
                         fused_op_receiver.local_k_start,
                         fused_op_receiver.local_k_end,
                         fused_op_receiver.input_tensor_Wt,
+                        /*main_Wt=*/K_tiles,
+#endif
 #endif
                         m_tile,
                         m_tile_end,

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
@@ -83,9 +83,11 @@ void kernel_main() {
 #endif
 
 #ifdef FUSE_TERNARY
-// Calculate offset for ternary_a_args - must account for FUSE_BIAS and potentially FUSE_AG
-#if defined(FUSE_AG) && defined(READ_FROM_LOCAL_INPUT)
-// If we have FUSE_AG with READ_FROM_LOCAL_INPUT, in3 is defined
+// Calculate offset for ternary_a_args - must account for FUSE_BIAS and an optional in3 accessor.
+// in3 is present whenever in0 has a second source (AG local slice OR fused concat), so the
+// ternary args sit one accessor-block later in the CTA list in both cases.
+#ifdef IN0_HAS_SECOND_SOURCE
+// in3 is defined (AG local slice or fused-concat second half)
 #ifdef FUSE_BIAS
     // After in2, then in3, then ternary
     constexpr uint32_t ternary_a_args_cta_offset =
@@ -173,8 +175,12 @@ void kernel_main() {
             device_k_block_start_ids,
             forward_k_block_schedule);
     }
+#endif  // FUSE_AG
 
-#ifdef READ_FROM_LOCAL_INPUT
+// in3 is the second in0 source buffer. AG path: this device's local pre-gather slice. Virtual
+// concat: the second concat half (e.g. mlp output) supplied via optional_input_tensor. Set up
+// whenever in0 has a second source, independent of FUSE_AG.
+#ifdef IN0_HAS_SECOND_SOURCE
 #ifdef FUSE_BIAS
     constexpr auto in3_args =
         TensorAccessorArgs<in2_args_cta_offset + tensor_accessor::detail::NUM_TENSOR_ACCESSOR_ARGS>();
@@ -184,7 +190,6 @@ void kernel_main() {
     constexpr auto in3_args = TensorAccessorArgs<in3_args_cta_offset>();
 #endif
     const auto in3_reader = TensorAccessor(in3_args, in3_addr);
-#endif
 #endif
 
 #ifdef SRS_FUSE_OP_SIGNALER
@@ -322,11 +327,23 @@ void kernel_main() {
                         in0_shape,
                         cb_in0_id,
                         in0_tile_size,
-#ifdef READ_FROM_LOCAL_INPUT
+#ifdef IN0_HAS_SECOND_SOURCE
+#ifdef IN0_VIRTUAL_CONCAT
+                        // Fused concatenation (concat-free): in0 (main) holds K-tiles [0, k_split);
+                        // in3 holds K-tiles [k_split, K). main_Wt = k_split is the main buffer width.
+                        in3_reader,
+                        /*local_k_start=*/IN0_K_SPLIT_TILES,
+                        /*local_k_end=*/K_tiles - 1,
+                        /*input_tensor_Wt=*/K_tiles - IN0_K_SPLIT_TILES,
+                        /*main_Wt=*/IN0_K_SPLIT_TILES,
+#else
+                        // AG: in0 is the full gathered K; in3 is this device's local pre-gather slice.
                         in3_reader,
                         fused_op_receiver.local_k_start,
                         fused_op_receiver.local_k_end,
                         fused_op_receiver.input_tensor_Wt,
+                        /*main_Wt=*/K_tiles,
+#endif
 #endif
                         m_tile,
                         m_tile_end,

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_compute.cpp
@@ -21,7 +21,8 @@
 #define IN0_SUB_CHUNKS 1
 #endif
 
-void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+// Named apart from the ckernel copy_block() compute API, whose signature this would otherwise be ambiguous with
+void copy_block_to_cb(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
     CircularBuffer cb_out(out_cb);
     copy_tile_to_dst_init_short(in_cb);
     reconfig_data_format_srca(in_cb);
@@ -672,7 +673,7 @@ void kernel_main() {
             cb_out.reserve_back(out_block_num_tiles);
             cb_intermediate.wait_front(out_block_num_tiles);
 #ifndef FUSE_BIAS
-            copy_block(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
+            copy_block_to_cb(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
 #else
             cb_in2.wait_front(N_block_tiles);
             add_bias_block(intermediate_cb, in2_cb, out_cb, M_block_tiles, N_block_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
@@ -13,6 +13,14 @@
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
+// in0's K is read from TWO source buffers via the in3 path: either the AG local pre-gather slice
+// (READ_FROM_LOCAL_INPUT) or a plain fused concatenation of two operands (IN0_VIRTUAL_CONCAT).
+// IN0_HAS_SECOND_SOURCE gates the shared read plumbing; the two cases differ only in how the
+// local K-range / widths are derived (see dm_in0_sender.cpp).
+#if defined(READ_FROM_LOCAL_INPUT) || defined(IN0_VIRTUAL_CONCAT)
+#define IN0_HAS_SECOND_SOURCE 1
+#endif
+
 namespace detail {
 template <typename... Args, uint32_t... Indexes>
 auto make_tensor_accessor_tuple_impl(
@@ -65,7 +73,7 @@ template <
     uint32_t M_block_tiles,
     uint32_t K_block_tiles,
     typename TensorAccessorType
-#ifdef READ_FROM_LOCAL_INPUT
+#ifdef IN0_HAS_SECOND_SOURCE
     ,
     typename LocalTensorAccessorType
 #endif
@@ -75,11 +83,15 @@ void read_in0_block_sync(
     const TensorShape2D& shape,
     uint32_t cb_id,
     uint32_t tile_size_bytes,
-#ifdef READ_FROM_LOCAL_INPUT
+#ifdef IN0_HAS_SECOND_SOURCE
     const LocalTensorAccessorType& in3_accessor,
     uint32_t local_k_start,
     uint32_t local_k_end,
     uint32_t input_tensor_Wt,
+    // Row width (in tiles) of the MAIN (tensor_accessor) buffer. AG path: full logical K (in0 is the
+    // full gathered tensor). Two-input K-split: the main tensor's own (narrow) width so its tile_id
+    // indexes the narrow buffer correctly.
+    uint32_t main_Wt,
 #endif
     uint32_t d0_start,
     uint32_t d0_end,
@@ -98,18 +110,26 @@ void read_in0_block_sync(
         }
         for (uint32_t j = d1_start; j < d1_end; j++) {
             if (j < shape.logical_d1) {
-#ifdef READ_FROM_LOCAL_INPUT
+#ifdef IN0_HAS_SECOND_SOURCE
                 if (local_k_start <= j && j <= local_k_end) {
                     // read from self_tensor_accessor
                     uint32_t tile_id = i * input_tensor_Wt + (j - local_k_start);
                     noc.async_read(
                         in3_accessor, CoreLocalMem<uint32_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
                 } else {
-#endif
+                    // Non-local K-tile: read from the main buffer. main_Wt generalizes the row
+                    // stride so the main tensor can be either the full gathered K (AG) or a narrow
+                    // K-split half (two-input). j is the logical K index; main covers a prefix so no
+                    // offset is needed (local range is the suffix for the two-input case).
+                    uint32_t tile_id = i * main_Wt + j;
+                    noc.async_read(
+                        tensor_accessor, CoreLocalMem<uint32_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
+                }
+#else
+                {
                     uint32_t tile_id = i * shape.logical_d1 + j;
                     noc.async_read(
                         tensor_accessor, CoreLocalMem<uint32_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
-#ifdef READ_FROM_LOCAL_INPUT
                 }
 #endif
             } else {

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
@@ -11,6 +11,14 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/circular_buffer.h"
 
+// in0's K is read from TWO source buffers via the in3 path: either the AG local pre-gather slice
+// (READ_FROM_LOCAL_INPUT) or a plain fused concatenation of two operands (IN0_VIRTUAL_CONCAT).
+// IN0_HAS_SECOND_SOURCE gates the shared read plumbing; the two cases differ only in how the
+// local K-range / widths are derived (see dm_in0_sender.cpp).
+#if defined(READ_FROM_LOCAL_INPUT) || defined(IN0_VIRTUAL_CONCAT)
+#define IN0_HAS_SECOND_SOURCE 1
+#endif
+
 namespace detail {
 template <typename... Args, uint32_t... Indexes>
 auto make_tensor_accessor_tuple_impl(
@@ -63,7 +71,7 @@ template <
     uint32_t M_block_tiles,
     uint32_t K_block_tiles,
     typename TensorAccessorType
-#ifdef READ_FROM_LOCAL_INPUT
+#ifdef IN0_HAS_SECOND_SOURCE
     ,
     typename LocalTensorAccessorType
 #endif
@@ -73,11 +81,15 @@ void read_in0_block_sync(
     const TensorShape2D& shape,
     uint32_t cb_id,
     uint32_t tile_size_bytes,
-#ifdef READ_FROM_LOCAL_INPUT
+#ifdef IN0_HAS_SECOND_SOURCE
     const LocalTensorAccessorType& in3_accessor,
     uint32_t local_k_start,
     uint32_t local_k_end,
     uint32_t input_tensor_Wt,
+    // Row width (in tiles) of the MAIN (tensor_accessor) buffer. AG path: full logical K (in0 is the
+    // full gathered tensor). Two-input K-split: the main tensor's own (narrow) width so its tile_id
+    // indexes the narrow buffer correctly.
+    uint32_t main_Wt,
 #endif
     uint32_t d0_start,
     uint32_t d0_end,
@@ -96,16 +108,23 @@ void read_in0_block_sync(
         }
         for (uint32_t j = d1_start; j < d1_end; j++) {
             if (j < shape.logical_d1) {
-#ifdef READ_FROM_LOCAL_INPUT
+#ifdef IN0_HAS_SECOND_SOURCE
                 if (local_k_start <= j && j <= local_k_end) {
                     // read from self_tensor_accessor
                     uint32_t tile_id = i * input_tensor_Wt + (j - local_k_start);
                     noc_async_read_page(tile_id, in3_accessor, write_ptr);
                 } else {
-#endif
+                    // Non-local K-tile: read from the main buffer. main_Wt generalizes the row
+                    // stride so the main tensor can be either the full gathered K (AG) or a narrow
+                    // K-split half (two-input). j is the logical K index; main covers a prefix so no
+                    // offset is needed (local range is the suffix for the two-input case).
+                    uint32_t tile_id = i * main_Wt + j;
+                    noc_async_read_page(tile_id, tensor_accessor, write_ptr);
+                }
+#else
+                {
                     uint32_t tile_id = i * shape.logical_d1 + j;
                     noc_async_read_page(tile_id, tensor_accessor, write_ptr);
-#ifdef READ_FROM_LOCAL_INPUT
                 }
 #endif
             } else {

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
@@ -77,7 +77,56 @@ void MinimalMatmulDeviceOperation::validate_on_program_cache_miss(
     const uint32_t K_w = w_logical[-2];
     const uint32_t N = w_logical[-1];
 
-    TT_FATAL(K == K_w, "minimal_matmul inner dimensions must match, got K={} and K_w={}", K, K_w);
+    if (tensor_args.optional_input_tensor.has_value()) {
+        // Fused concat: in0's K = input_tensor (prefix) + optional_input_tensor (suffix); the split
+        // point is input_tensor's K width. The two sources must be concatenable on K (differ only on
+        // the last axis) and their K's must sum to the weight's K (weight stacked [W_prefix; W_suffix]).
+        const auto& second_input = tensor_args.optional_input_tensor.value();
+        TT_FATAL(
+            second_input.device() == act_tensor.device(),
+            "minimal_matmul fused concat: second input must be on the same device as activation");
+        // The suffix is read tile-by-tile through the same in0 path (in3), so it must be TILE layout
+        // and share the activation's dtype (the in0 reads use the activation's tile size for both
+        // sources — a differing dtype would read the wrong number of bytes per tile).
+        TT_FATAL(
+            second_input.layout() == Layout::TILE, "minimal_matmul fused concat requires TILE layout for second input");
+        TT_FATAL(
+            dtype_supported(second_input.dtype()),
+            "minimal_matmul fused concat supports only BFLOAT16, BFLOAT8_B, BFLOAT4_B, and FLOAT32 for second input");
+        TT_FATAL(
+            second_input.dtype() == act_tensor.dtype(),
+            "minimal_matmul fused concat: second-input dtype ({}) must match activation dtype ({})",
+            second_input.dtype(),
+            act_tensor.dtype());
+        const auto& opt_logical = second_input.logical_shape();
+        TT_FATAL(
+            opt_logical.rank() == a_logical.rank(),
+            "minimal_matmul fused concat: second-input rank ({}) must match input rank ({})",
+            opt_logical.rank(),
+            a_logical.rank());
+        for (int i = 0; i < static_cast<int>(a_logical.rank()) - 1; ++i) {
+            TT_FATAL(
+                opt_logical[i] == a_logical[i],
+                "minimal_matmul fused concat: inputs must differ only on the K (last) axis; dim {} "
+                "differs (input={}, second={})",
+                i,
+                a_logical[i],
+                opt_logical[i]);
+        }
+        // Seam lands at prefix's padded-K tile boundary: weight must be per-segment tile-padded.
+        const uint32_t prefix_padded_K = act_tensor.padded_shape()[-1];
+        const uint32_t suffix_padded_K = second_input.padded_shape()[-1];
+        const uint32_t weight_padded_K = weight_tensor.padded_shape()[-2];
+        TT_FATAL(
+            prefix_padded_K + suffix_padded_K == weight_padded_K,
+            "minimal_matmul fused concat: prefix_padded_K({}) + suffix_padded_K({}) must equal "
+            "weight_padded_K({}) — use prepare_weight_for_concatenated_input to build the weight.",
+            prefix_padded_K,
+            suffix_padded_K,
+            weight_padded_K);
+    } else {
+        TT_FATAL(K == K_w, "minimal_matmul inner dimensions must match, got K={} and K_w={}", K, K_w);
+    }
     TT_FATAL(M > 0 && K > 0 && N > 0, "minimal_matmul dimensions must be positive");
 
     // Validate chunks and dim parameters
@@ -296,7 +345,8 @@ std::vector<Tensor> minimal_matmul(
     std::optional<float> fused_ternary_scalar,
     const std::optional<Tensor>& fused_ternary_input_a,
     const std::optional<Tensor>& fused_ternary_input_b,
-    bool fuse_swiglu) {
+    bool fuse_swiglu,
+    const std::optional<Tensor>& optional_input_tensor) {
     using OperationType = experimental::prim::MinimalMatmulDeviceOperation;
     const auto arch = input_tensor.device()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -323,7 +373,7 @@ std::vector<Tensor> minimal_matmul(
             .input_tensor = input_tensor,
             .weight_tensor = weight_tensor,
             .bias_tensor = bias_tensor,
-            .optional_input_tensor = std::nullopt,
+            .optional_input_tensor = optional_input_tensor,
             .fused_ternary_input_a = fused_ternary_input_a,
             .fused_ternary_input_b = fused_ternary_input_b});
 }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
@@ -77,7 +77,39 @@ void MinimalMatmulDeviceOperation::validate_on_program_cache_miss(
     const uint32_t K_w = w_logical[-2];
     const uint32_t N = w_logical[-1];
 
-    TT_FATAL(K == K_w, "minimal_matmul inner dimensions must match, got K={} and K_w={}", K, K_w);
+    if (tensor_args.optional_input_tensor.has_value()) {
+        // Fused concat: in0's K = input_tensor (prefix) + optional_input_tensor (suffix); the split
+        // point is input_tensor's K width. The two sources must be concatenable on K (differ only on
+        // the last axis) and their K's must sum to the weight's K (weight stacked [W_prefix; W_suffix]).
+        const auto& opt_logical = tensor_args.optional_input_tensor.value().logical_shape();
+        TT_FATAL(
+            opt_logical.rank() == a_logical.rank(),
+            "minimal_matmul fused concat: second-input rank ({}) must match input rank ({})",
+            opt_logical.rank(),
+            a_logical.rank());
+        for (int i = 0; i < static_cast<int>(a_logical.rank()) - 1; ++i) {
+            TT_FATAL(
+                opt_logical[i] == a_logical[i],
+                "minimal_matmul fused concat: inputs must differ only on the K (last) axis; dim {} "
+                "differs (input={}, second={})",
+                i,
+                a_logical[i],
+                opt_logical[i]);
+        }
+        // Seam lands at prefix's padded-K tile boundary: weight must be per-segment tile-padded.
+        const uint32_t prefix_padded_K = act_tensor.padded_shape()[-1];
+        const uint32_t suffix_padded_K = tensor_args.optional_input_tensor.value().padded_shape()[-1];
+        const uint32_t weight_padded_K = weight_tensor.padded_shape()[-2];
+        TT_FATAL(
+            prefix_padded_K + suffix_padded_K == weight_padded_K,
+            "minimal_matmul fused concat: prefix_padded_K({}) + suffix_padded_K({}) must equal "
+            "weight_padded_K({}) — use prepare_weight_for_concatenated_input to build the weight.",
+            prefix_padded_K,
+            suffix_padded_K,
+            weight_padded_K);
+    } else {
+        TT_FATAL(K == K_w, "minimal_matmul inner dimensions must match, got K={} and K_w={}", K, K_w);
+    }
     TT_FATAL(M > 0 && K > 0 && N > 0, "minimal_matmul dimensions must be positive");
 
     // Validate chunks and dim parameters
@@ -296,7 +328,8 @@ std::vector<Tensor> minimal_matmul(
     std::optional<float> fused_ternary_scalar,
     const std::optional<Tensor>& fused_ternary_input_a,
     const std::optional<Tensor>& fused_ternary_input_b,
-    bool fuse_swiglu) {
+    bool fuse_swiglu,
+    const std::optional<Tensor>& optional_input_tensor) {
     using OperationType = experimental::prim::MinimalMatmulDeviceOperation;
     const auto arch = input_tensor.device()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -323,7 +356,7 @@ std::vector<Tensor> minimal_matmul(
             .input_tensor = input_tensor,
             .weight_tensor = weight_tensor,
             .bias_tensor = bias_tensor,
-            .optional_input_tensor = std::nullopt,
+            .optional_input_tensor = optional_input_tensor,
             .fused_ternary_input_a = fused_ternary_input_a,
             .fused_ternary_input_b = fused_ternary_input_b});
 }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.hpp
@@ -66,6 +66,9 @@ std::vector<Tensor> minimal_matmul(
     std::optional<float> fused_ternary_scalar = std::nullopt,
     const std::optional<Tensor>& fused_ternary_input_a = std::nullopt,
     const std::optional<Tensor>& fused_ternary_input_b = std::nullopt,
-    bool fuse_swiglu = false);
+    bool fuse_swiglu = false,
+    // Fused concat (concat-free): when set, in0's K is input_tensor (prefix) then optional_input_tensor
+    // (suffix); the split point is input_tensor's K width and the weight is stacked [W_prefix; W_suffix].
+    const std::optional<Tensor>& optional_input_tensor = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation_types.hpp
@@ -44,7 +44,9 @@ struct MinimalMatmulInputs {
     Tensor input_tensor;
     Tensor weight_tensor;
     std::optional<Tensor> bias_tensor;
-    std::optional<Tensor> optional_input_tensor;  // for StridedAllGatherMinimalMatmul
+    // Second in0 source. AG-fused matmul: this device's local pre-gather slice. Fused concat: the
+    // suffix half of in0's K (input_tensor is the prefix half; the weight is stacked [W_prefix; W_suffix]).
+    std::optional<Tensor> optional_input_tensor;
 
     // Fused addcmul: ternary_a + scalar * matmul_output * ternary_b
     std::optional<Tensor> fused_ternary_input_a;  // residual/base (broadcast like bias)

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -130,11 +130,18 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
     const std::optional<const Tensor>& fused_ternary_input_a,
     const std::optional<const Tensor>& fused_ternary_input_b,
     std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> srs_fused_op_signaler,
-    bool fuse_swiglu) {
+    bool fuse_swiglu,
+    const std::optional<const Tensor>& optional_input_tensor) {
     (void)fused_ternary_scalar;  // Scalar not needed in dataflow kernel, only in compute kernel
     auto* device = input_tensor.device();
 
     bool fuse_op = fused_op_signaler.has_value();
+
+    // Fused concat (concat-free): in0's K is sourced from input_tensor (prefix K-tiles) then
+    // optional_input_tensor (suffix), via the in0 second-source (in3) read path, instead of a
+    // materialized concat. The split point is input_tensor's own K width. Mutually exclusive with AG.
+    const bool two_input_split = optional_input_tensor.has_value();
+    TT_FATAL(!(two_input_split && fuse_op), "Fused concat is not supported together with the AG-fused matmul path");
 
     if (!config.has_value()) {
         log_debug(tt::LogOp, "No config provided, using default block sizes and core grid");
@@ -185,9 +192,12 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
 
     auto in0_tensor_shape = input_tensor.padded_shape();
     auto in1_tensor_shape = weight_tensor.padded_shape();
-    // Fold activation (LHS) upper dimensions into rows: M_total = prod(upper dims) * M
-    uint32_t K = in0_tensor_shape[-1];
-    uint32_t M = input_tensor.physical_volume() / K;
+    // Fold activation (LHS) upper dimensions into rows: M_total = prod(upper dims) * M.
+    // M is derived from input_tensor's OWN K width (K_in); for fused concat that's only the prefix
+    // half, so the matmul contraction K must instead span the full weight K (both concat halves).
+    uint32_t K_in = in0_tensor_shape[-1];
+    uint32_t M = input_tensor.physical_volume() / K_in;
+    uint32_t K = two_input_split ? static_cast<uint32_t>(in1_tensor_shape[-2]) : K_in;
     uint32_t N = in1_tensor_shape[-1];
 
     uint32_t M_tiles = M / tt::constants::TILE_HEIGHT;
@@ -449,6 +459,17 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
         }
     }
 
+    // Fused concatenation of in0: only the in0 SENDER reads from the two source buffers; the
+    // receiver gets the assembled block by mcast and needs no split. Copy AFTER all base defines are
+    // finalized (incl. SRS_FUSE_OP_SIGNALER) so the sender still signals the fused reduce-scatter.
+    std::map<std::string, std::string> in0_concat_defines;
+    if (two_input_split) {
+        in0_concat_defines = defines;
+        in0_concat_defines["IN0_VIRTUAL_CONCAT"] = "1";
+        // Split point = input_tensor's own K width (prefix half), in tiles.
+        in0_concat_defines["IN0_K_SPLIT_TILES"] = std::to_string(K_in / tt::constants::TILE_WIDTH);
+    }
+
     std::vector<CoreCoord> all_worker_cores_noc;
     if (fuse_srs) {
         all_worker_cores_noc.reserve(num_cores);
@@ -465,13 +486,17 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
     // They are appended as a variable-length array at the end of the runtime-args:
     //   - for in0 output-writer cores the first output address is at index 13
     //   - for in1 output-writer cores the first output address is at index 12
+    // in3 is the second in0 source buffer: AG local pre-gather slice, or (fused concat) the second
+    // concat half supplied via optional_input_tensor.
     uint32_t in3_addr = (fuse_op && fused_op_signaler->read_local_slice_from_input)
                             ? fused_op_signaler->ag_input.value().buffer()->address()
-                            : 0;
+                        : two_input_split ? optional_input_tensor.value().buffer()->address()
+                                          : 0;
     auto in3_data_format =
         (fuse_op && fused_op_signaler->read_local_slice_from_input)
             ? tt::tt_metal::datatype_to_dataformat_converter(fused_op_signaler->ag_input.value().dtype())
-            : in1_data_format;
+        : two_input_split ? tt::tt_metal::datatype_to_dataformat_converter(optional_input_tensor.value().dtype())
+                          : in1_data_format;
 
     auto in3_tile_size = tt::tile_size(in3_data_format);
 
@@ -506,12 +531,19 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
         N_tiles_per_chunk,  // N_tiles_per_chunk
         in3_tile_size,
     };
+    // The in0 sender's second source: AG local slice, or (fused concat) optional_input_tensor.
+    std::optional<Tensor> in0_sender_in3_tensor;
+    if (fuse_op && fused_op_signaler->read_local_slice_from_input) {
+        in0_sender_in3_tensor = fused_op_signaler->ag_input.value();
+    } else if (two_input_split) {
+        in0_sender_in3_tensor = optional_input_tensor.value();
+    }
     append_accessors(
         in0_sender_compile_time_args,
         input_tensor,
         output_tensors,
         bias_tensor,
-        (fuse_op && fused_op_signaler->read_local_slice_from_input) ? fused_op_signaler->ag_input : std::nullopt,
+        in0_sender_in3_tensor,
         fused_ternary_input_a,
         fused_ternary_input_b);
     auto in0_sender_kernels_id = CreateKernel(
@@ -522,7 +554,9 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
             .processor = in0_risc,
             .noc = in0_noc,
             .compile_args = in0_sender_compile_time_args,
-            .defines = (fuse_op && fused_op_signaler->read_local_slice_from_input) ? in0_injector_defines : defines});
+            .defines = (fuse_op && fused_op_signaler->read_local_slice_from_input) ? in0_injector_defines
+                       : two_input_split                                           ? in0_concat_defines
+                                                                                   : defines});
 
     std::vector<uint32_t> in0_receiver_compile_time_args = {
         M_tiles,
@@ -903,7 +937,8 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
         in1_receiver_kernels_id,
         compute_kernels_id,
         transpose_core_grid,
-        fuse_op && fused_op_signaler->read_local_slice_from_input};
+        fuse_op && fused_op_signaler->read_local_slice_from_input,
+        two_input_split};
 }
 
 MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper(
@@ -960,7 +995,8 @@ MinimalMatmulProgramFactory::cached_program_t MinimalMatmulProgramFactory::creat
         tensor_args.fused_ternary_input_a,
         tensor_args.fused_ternary_input_b,
         empty_srs_fused_op_signaler,
-        operation_attributes.fuse_swiglu);
+        operation_attributes.fuse_swiglu,
+        tensor_args.optional_input_tensor);
 
     return {std::move(program), std::move(shared_vars)};
 }
@@ -1016,7 +1052,8 @@ void MinimalMatmulProgramFactory::override_runtime_arguments(
             in0_sender_args[in0_in2_addr_idx] =
                 tensor_args.bias_tensor.has_value() ? tensor_args.bias_tensor.value().buffer()->address() : 0;
             in0_sender_args[in0_in3_addr_idx] = tensor_args.optional_input_tensor.has_value() &&
-                                                        cached_program.shared_variables.read_local_slice_from_input
+                                                        (cached_program.shared_variables.read_local_slice_from_input ||
+                                                         cached_program.shared_variables.two_input_split)
                                                     ? tensor_args.optional_input_tensor.value().buffer()->address()
                                                     : 0;
             // Update ternary addresses if present

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -130,11 +130,18 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
     const std::optional<const Tensor>& fused_ternary_input_a,
     const std::optional<const Tensor>& fused_ternary_input_b,
     std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> srs_fused_op_signaler,
-    bool fuse_swiglu) {
+    bool fuse_swiglu,
+    const std::optional<const Tensor>& optional_input_tensor) {
     (void)fused_ternary_scalar;  // Scalar not needed in dataflow kernel, only in compute kernel
     auto* device = input_tensor.device();
 
     bool fuse_op = fused_op_signaler.has_value();
+
+    // Fused concat (concat-free): in0's K is sourced from input_tensor (prefix K-tiles) then
+    // optional_input_tensor (suffix), via the in0 second-source (in3) read path, instead of a
+    // materialized concat. The split point is input_tensor's own K width. Mutually exclusive with AG.
+    const bool two_input_split = optional_input_tensor.has_value();
+    TT_FATAL(!(two_input_split && fuse_op), "Fused concat is not supported together with the AG-fused matmul path");
 
     if (!config.has_value()) {
         log_debug(tt::LogOp, "No config provided, using default block sizes and core grid");
@@ -185,9 +192,12 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
 
     auto in0_tensor_shape = input_tensor.padded_shape();
     auto in1_tensor_shape = weight_tensor.padded_shape();
-    // Fold activation (LHS) upper dimensions into rows: M_total = prod(upper dims) * M
-    uint32_t K = in0_tensor_shape[-1];
-    uint32_t M = input_tensor.physical_volume() / K;
+    // Fold activation (LHS) upper dimensions into rows: M_total = prod(upper dims) * M.
+    // M is derived from input_tensor's OWN K width (K_in); for fused concat that's only the prefix
+    // half, so the matmul contraction K must instead span the full weight K (both concat halves).
+    uint32_t K_in = in0_tensor_shape[-1];
+    uint32_t M = input_tensor.physical_volume() / K_in;
+    uint32_t K = two_input_split ? static_cast<uint32_t>(in1_tensor_shape[-2]) : K_in;
     uint32_t N = in1_tensor_shape[-1];
 
     uint32_t M_tiles = M / tt::constants::TILE_HEIGHT;
@@ -442,6 +452,17 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
         srs_fuse_signaler_sync_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, 0);
     }
 
+    // Fused concatenation of in0: only the in0 SENDER reads from the two source buffers; the
+    // receiver gets the assembled block by mcast and needs no split. Copy AFTER all base defines are
+    // finalized (incl. SRS_FUSE_OP_SIGNALER) so the sender still signals the fused reduce-scatter.
+    std::map<std::string, std::string> in0_concat_defines;
+    if (two_input_split) {
+        in0_concat_defines = defines;
+        in0_concat_defines["IN0_VIRTUAL_CONCAT"] = "1";
+        // Split point = input_tensor's own K width (prefix half), in tiles.
+        in0_concat_defines["IN0_K_SPLIT_TILES"] = std::to_string(K_in / tt::constants::TILE_WIDTH);
+    }
+
     std::vector<CoreCoord> all_worker_cores_noc;
     if (fuse_srs) {
         all_worker_cores_noc.reserve(num_cores);
@@ -458,13 +479,17 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
     // They are appended as a variable-length array at the end of the runtime-args:
     //   - for in0 output-writer cores the first output address is at index 13
     //   - for in1 output-writer cores the first output address is at index 12
+    // in3 is the second in0 source buffer: AG local pre-gather slice, or (fused concat) the second
+    // concat half supplied via optional_input_tensor.
     uint32_t in3_addr = (fuse_op && fused_op_signaler->read_local_slice_from_input)
                             ? fused_op_signaler->ag_input.value().buffer()->address()
-                            : 0;
+                        : two_input_split ? optional_input_tensor.value().buffer()->address()
+                                          : 0;
     auto in3_data_format =
         (fuse_op && fused_op_signaler->read_local_slice_from_input)
             ? tt::tt_metal::datatype_to_dataformat_converter(fused_op_signaler->ag_input.value().dtype())
-            : in1_data_format;
+        : two_input_split ? tt::tt_metal::datatype_to_dataformat_converter(optional_input_tensor.value().dtype())
+                          : in1_data_format;
 
     auto in3_tile_size = tt::tile_size(in3_data_format);
 
@@ -499,12 +524,19 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
         N_tiles_per_chunk,  // N_tiles_per_chunk
         in3_tile_size,
     };
+    // The in0 sender's second source: AG local slice, or (fused concat) optional_input_tensor.
+    std::optional<Tensor> in0_sender_in3_tensor;
+    if (fuse_op && fused_op_signaler->read_local_slice_from_input) {
+        in0_sender_in3_tensor = fused_op_signaler->ag_input.value();
+    } else if (two_input_split) {
+        in0_sender_in3_tensor = optional_input_tensor.value();
+    }
     append_accessors(
         in0_sender_compile_time_args,
         input_tensor,
         output_tensors,
         bias_tensor,
-        (fuse_op && fused_op_signaler->read_local_slice_from_input) ? fused_op_signaler->ag_input : std::nullopt,
+        in0_sender_in3_tensor,
         fused_ternary_input_a,
         fused_ternary_input_b);
     auto in0_sender_kernels_id = CreateKernel(
@@ -515,7 +547,9 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
             .processor = in0_risc,
             .noc = in0_noc,
             .compile_args = in0_sender_compile_time_args,
-            .defines = (fuse_op && fused_op_signaler->read_local_slice_from_input) ? in0_injector_defines : defines});
+            .defines = (fuse_op && fused_op_signaler->read_local_slice_from_input) ? in0_injector_defines
+                       : two_input_split                                           ? in0_concat_defines
+                                                                                   : defines});
 
     std::vector<uint32_t> in0_receiver_compile_time_args = {
         M_tiles,
@@ -873,7 +907,8 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
         in1_receiver_kernels_id,
         compute_kernels_id,
         transpose_core_grid,
-        fuse_op && fused_op_signaler->read_local_slice_from_input};
+        fuse_op && fused_op_signaler->read_local_slice_from_input,
+        two_input_split};
 }
 
 MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper(
@@ -930,7 +965,8 @@ MinimalMatmulProgramFactory::cached_program_t MinimalMatmulProgramFactory::creat
         tensor_args.fused_ternary_input_a,
         tensor_args.fused_ternary_input_b,
         empty_srs_fused_op_signaler,
-        operation_attributes.fuse_swiglu);
+        operation_attributes.fuse_swiglu,
+        tensor_args.optional_input_tensor);
 
     return {std::move(program), std::move(shared_vars)};
 }
@@ -986,7 +1022,8 @@ void MinimalMatmulProgramFactory::override_runtime_arguments(
             in0_sender_args[in0_in2_addr_idx] =
                 tensor_args.bias_tensor.has_value() ? tensor_args.bias_tensor.value().buffer()->address() : 0;
             in0_sender_args[in0_in3_addr_idx] = tensor_args.optional_input_tensor.has_value() &&
-                                                        cached_program.shared_variables.read_local_slice_from_input
+                                                        (cached_program.shared_variables.read_local_slice_from_input ||
+                                                         cached_program.shared_variables.two_input_split)
                                                     ? tensor_args.optional_input_tensor.value().buffer()->address()
                                                     : 0;
             // Update ternary addresses if present

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp
@@ -21,6 +21,9 @@ struct MinimalMatmulProgramFactory {
         tt::tt_metal::KernelHandle compute_kernels_id{};
         bool transpose_core_grid{};
         bool read_local_slice_from_input{};
+        // Fused concatenation: in0's K is sourced from input_tensor + optional_input_tensor (no
+        // materialized concat). When set, optional_input_tensor feeds the in3 address on re-runs.
+        bool two_input_split{};
     };
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
@@ -67,6 +70,9 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
     const std::optional<const Tensor>& fused_ternary_input_a = std::nullopt,
     const std::optional<const Tensor>& fused_ternary_input_b = std::nullopt,
     std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> srs_fused_op_signaler = std::nullopt,
-    bool fuse_swiglu = false);
+    bool fuse_swiglu = false,
+    // Fused concat (concat-free): when set, in0's K is sourced from input_tensor (prefix tiles) then
+    // optional_input_tensor (suffix tiles). The split point is input_tensor's own K width.
+    const std::optional<const Tensor>& optional_input_tensor = std::nullopt);
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul.cpp
@@ -12,7 +12,7 @@ using namespace tt::tt_metal;
 namespace ttnn::experimental {
 
 ttnn::Tensor minimal_matmul(
-    const ttnn::Tensor& input_tensor,
+    const std::variant<ttnn::Tensor, std::vector<ttnn::Tensor>>& input_tensor,
     const ttnn::Tensor& weight_tensor,
     const std::optional<ttnn::Tensor>& bias_tensor,
     std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation,
@@ -21,9 +21,23 @@ ttnn::Tensor minimal_matmul(
     std::optional<const DataType> dtype,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config,
     bool fuse_swiglu) {
+    // Unpack: single Tensor, or [prefix, suffix] virtually concatenated over K (concat-free).
+    ttnn::Tensor main_input;
+    std::optional<ttnn::Tensor> second_input;
+    if (const auto* inputs = std::get_if<std::vector<ttnn::Tensor>>(&input_tensor)) {
+        TT_FATAL(
+            inputs->size() == 2,
+            "minimal_matmul: list input must be exactly 2 tensors [prefix, suffix] for fused concat over K, got {}",
+            inputs->size());
+        main_input = (*inputs)[0];
+        second_input = (*inputs)[1];
+    } else {
+        main_input = std::get<ttnn::Tensor>(input_tensor);
+    }
+
     // Call device operation with chunks=1 (default), which returns a vector with 1 element
     auto outputs = ttnn::prim::minimal_matmul(
-        input_tensor,
+        main_input,
         weight_tensor,
         bias_tensor,
         std::move(fused_activation),
@@ -36,7 +50,8 @@ ttnn::Tensor minimal_matmul(
         /*fused_ternary_scalar=*/std::nullopt,
         /*fused_ternary_input_a=*/std::nullopt,
         /*fused_ternary_input_b=*/std::nullopt,
-        fuse_swiglu);
+        fuse_swiglu,
+        second_input);
 
     // Extract and return the single output
     TT_FATAL(outputs.size() == 1, "Expected single output from minimal_matmul, got {}", outputs.size());

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <optional>
+#include <variant>
+#include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
@@ -21,8 +23,15 @@ using MinimalMatmulConfig = ttnn::experimental::prim::MinimalMatmulConfig;
 
 namespace ttnn::experimental {
 
+// input_tensor: a single activation, or a 2-element list [prefix, suffix] virtually concatenated
+// (concat-free) on the channel (K, last) axis ONLY — the two must be identical on every other axis.
+// Any per-segment channel count is allowed; segments are joined at tile boundaries with zero-filled
+// gaps on both the activation (zero from tilization) and the weight (the stacked weight must be
+// per-segment tile-padded, i.e. zero rows between segments, via prepare_weight_for_concatenated_input).
+// The op size-checks prefix_padded_K + suffix_padded_K == weight_padded_K but trusts the weight
+// layout for gap content.
 ttnn::Tensor minimal_matmul(
-    const ttnn::Tensor& input_tensor,
+    const std::variant<ttnn::Tensor, std::vector<ttnn::Tensor>>& input_tensor,
     const ttnn::Tensor& weight_tensor,
     const std::optional<ttnn::Tensor>& bias_tensor,
     std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation,

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
@@ -45,7 +45,7 @@ void bind_minimal_matmul(nb::module_& mod) {
             Activation/input matrix A, or a 2-element [prefix, suffix] list for fused concat over K.
             - Layout: TILE (required).
             - Device: must be on device and allocated in a device buffer.
-            - DType: one of {DataType::BFLOAT16, DataType::BFLOAT8_B, DataType::BFLOAT4_B}.
+            - DType: one of {DataType::BFLOAT16, DataType::BFLOAT8_B, DataType::BFLOAT4_B, DataType::FLOAT32}.
             - Shape: [..., M, K]. Upper (leading) dimensions are broadcast over rows (folded into M).
               With fused concat, each list element carries its own K; the contraction K is taken from
               the weight and spans both padded segments.

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
@@ -9,6 +9,8 @@
 #include <fmt/format.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/variant.h>
+#include <nanobind/stl/vector.h>
 
 #include "minimal_matmul.hpp"
 #include "ttnn-nanobind/bind_function.hpp"
@@ -27,14 +29,26 @@ void bind_minimal_matmul(nb::module_& mod) {
         This op expects TILE layout tensors on device and operates in tile units internally. It is designed
         to be minimal and fast, with a small set of required constraints explicitly validated at runtime.
 
+        input_tensor may be either a single tensor or a 2-element list [prefix, suffix] for fused concat
+        over the K (inner/last) axis:
+            - Single tensor: standard matmul; input_tensor is the full activation matrix A.
+            - Fused concat: pass exactly 2 tensors [prefix, suffix] to source in0's K from both (no host
+              concat). Concatenation is on the channel (K, last) axis ONLY — the two must be identical on
+              every other axis. Any per-segment channel count is allowed: the seam lands on the prefix's
+              padded-K tile boundary, so the weight must be the per-segment tile-padded stack
+              [W_prefix; W_suffix] in that K order (see prepare_weight_for_concatenated_input in
+              models/tt_dit/utils/tensor.py), such that prefix_padded_K + suffix_padded_K == weight_padded_K.
+
         Parameters
         ----------
-        input_tensor : ttnn.Tensor
-            Activation/input matrix A.
+        input_tensor : ttnn.Tensor or List[ttnn.Tensor]
+            Activation/input matrix A, or a 2-element [prefix, suffix] list for fused concat over K.
             - Layout: TILE (required).
             - Device: must be on device and allocated in a device buffer.
             - DType: one of {DataType::BFLOAT16, DataType::BFLOAT8_B, DataType::BFLOAT4_B}.
             - Shape: [..., M, K]. Upper (leading) dimensions are broadcast over rows (folded into M).
+              With fused concat, each list element carries its own K; the contraction K is taken from
+              the weight and spans both padded segments.
 
         weight_tensor : ttnn.Tensor
             Weight matrix B.

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -530,7 +530,13 @@ from ttnn.operations.reduction import (
     ReduceType,
 )
 
-from ttnn.operations.ccl import Topology, get_usable_topology, DispatchAlgorithm, WorkerMode
+from ttnn.operations.ccl import (
+    Topology,
+    get_usable_topology,
+    DispatchAlgorithm,
+    WorkerMode,
+    MMSignalAggregatorMode,
+)
 
 from ttnn.operations.conv2d import (
     Conv2dConfig,

--- a/ttnn/ttnn/operations/ccl.py
+++ b/ttnn/ttnn/operations/ccl.py
@@ -15,6 +15,16 @@ WorkerMode = ttnn._ttnn.operations.experimental.ccl_experimental.WorkerMode
 # Experimental CCL enum for moe_compute operation
 MoEActivationFunction = ttnn._ttnn.operations.experimental.ccl_experimental.MoEActivationFunction
 
+# Experimental CCL enum for strided_all_gather_minimal_matmul_async operation
+MMSignalAggregatorMode = ttnn._ttnn.operations.experimental.ccl_experimental.MMSignalAggregatorMode
+
 # TODO: Add golden functions (#12747)
 
-__all__ = ["Topology", "get_usable_topology", "DispatchAlgorithm", "WorkerMode", "MoEActivationFunction"]
+__all__ = [
+    "Topology",
+    "get_usable_topology",
+    "DispatchAlgorithm",
+    "WorkerMode",
+    "MoEActivationFunction",
+    "MMSignalAggregatorMode",
+]


### PR DESCRIPTION
### PR Category
Feature

### Summary
This PR adds support for fusing concatenation into matmul variants so instead of `y = Mul(ttnn.cat([a,b]),W)`, we now have `Mul(([a,b]),W)`. Older single tensor behaviour is preserved. With this new feature we eliminate the new buffer overhead and data movement cost. 

Closes [#48507 ](https://github.com/tenstorrent/tt-metal/issues/48507)

### Notes for reviewers
Only 2 tensor concatenation currently supported.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sadesoye/fused_concat_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sadesoye/fused_concat_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sadesoye/fused_concat_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sadesoye/fused_concat_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sadesoye/fused_concat_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sadesoye/fused_concat_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/fused_concat_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/fused_concat_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sadesoye/fused_concat_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sadesoye/fused_concat_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sadesoye/fused_concat_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sadesoye/fused_concat_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/fused_concat_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/fused_concat_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sadesoye/fused_concat_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sadesoye/fused_concat_mm)