### PR TITLE
Performance: walk the interleaved bank cycle in the dispatcher's paged write loop

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer_blackhole_golden.json
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer_blackhole_golden.json
@@ -1,11 +1,11 @@
 {
   "context": {
-    "date": "2026-05-15T17:48:36+00:00",
-    "host_name": "e6f5436f6b39",
+    "date": "2026-08-01T05:10:01+00:00",
+    "host_name": "6cf1919c015d",
     "executable": "./build/test/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer",
-    "num_cpus": 32,
-    "mhz_per_cpu": 400,
-    "cpu_scaling_enabled": false,
+    "num_cpus": 12,
+    "mhz_per_cpu": 5453,
+    "cpu_scaling_enabled": true,
     "caches": [
       {
         "type": "Data",
@@ -28,14 +28,14 @@
       {
         "type": "Unified",
         "level": 3,
-        "size": 100663296,
-        "num_sharing": 16
+        "size": 33554432,
+        "num_sharing": 12
       }
     ],
     "load_avg": [
-      0.827637,
-      0.336426,
-      0.125
+      0.666992,
+      0.299805,
+      0.224121
     ],
     "library_version": "v1.9.1",
     "library_build_type": "release",
@@ -47,308 +47,308 @@
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 915087238.7249177
+      "bytes_per_second": 1316138686.414627
     },
     {
       "name": "Write/page_size:64/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 1829739034.7646437
+      "bytes_per_second": 2627446650.445785
     },
     {
       "name": "Write/page_size:128/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 3642504597.2446823
+      "bytes_per_second": 5223644759.10701
     },
     {
       "name": "Write/page_size:256/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 7218128535.620046
+      "bytes_per_second": 10234034576.7531
     },
     {
       "name": "Write/page_size:512/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 14167016366.682096
+      "bytes_per_second": 19800357977.837353
     },
     {
       "name": "Write/page_size:1024/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 22704981575.925365
+      "bytes_per_second": 21481735063.050835
     },
     {
       "name": "Write/page_size:2048/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 22669504651.83079
+      "bytes_per_second": 21479735275.470493
     },
     {
       "name": "Write/page_size:32/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 845155122.1138369
+      "bytes_per_second": 1375218753.351641
     },
     {
       "name": "Write/page_size:64/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 1686535971.067312
+      "bytes_per_second": 2732492477.5702043
     },
     {
       "name": "Write/page_size:128/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 3358116495.7644606
+      "bytes_per_second": 5395462305.320002
     },
     {
       "name": "Write/page_size:256/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 6656410309.137891
+      "bytes_per_second": 10531969704.661175
     },
     {
       "name": "Write/page_size:512/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 13031140132.47672
+      "bytes_per_second": 20535240660.22773
     },
     {
       "name": "Write/page_size:1024/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 22603103634.966278
+      "bytes_per_second": 21448133696.34343
     },
     {
       "name": "Write/page_size:2048/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 22643011949.53998
+      "bytes_per_second": 21466503694.588814
     },
     {
       "name": "Read/page_size:32/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 1100174721.0784
+      "bytes_per_second": 1097463107.6661196
     },
     {
       "name": "Read/page_size:64/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 2199537706.8732033
+      "bytes_per_second": 2187960074.984833
     },
     {
       "name": "Read/page_size:128/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 4260169567.9850526
+      "bytes_per_second": 4210652132.8758063
     },
     {
       "name": "Read/page_size:256/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 8011339194.797826
+      "bytes_per_second": 7855570403.504386
     },
     {
       "name": "Read/page_size:512/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 13490662673.186476
+      "bytes_per_second": 13639788269.000965
     },
     {
       "name": "Read/page_size:1024/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 14368525591.70974
+      "bytes_per_second": 14389222182.801176
     },
     {
       "name": "Read/page_size:2048/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 14658990171.84644
+      "bytes_per_second": 14548937618.289997
     },
     {
       "name": "Read/page_size:32/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 989826875.0890255
+      "bytes_per_second": 987959269.915374
     },
     {
       "name": "Read/page_size:64/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 1951143482.2538536
+      "bytes_per_second": 1951135182.1861637
     },
     {
       "name": "Read/page_size:128/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 3792258876.048175
+      "bytes_per_second": 3751458430.2339354
     },
     {
       "name": "Read/page_size:256/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 7180655418.663877
+      "bytes_per_second": 7046063567.566767
     },
     {
       "name": "Read/page_size:512/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 12859566871.22672
+      "bytes_per_second": 12519681855.399189
     },
     {
       "name": "Read/page_size:1024/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 14445942322.33753
+      "bytes_per_second": 14544828712.726818
     },
     {
       "name": "Read/page_size:2048/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 14577116792.772358
+      "bytes_per_second": 14586349429.814745
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:1/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 10767802654.09666
+      "bytes_per_second": 10934631196.96694
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:2/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 11722785202.920542
+      "bytes_per_second": 11469360965.683254
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:4/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 13857250880.647783
+      "bytes_per_second": 13608939974.235361
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:8/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 14205821350.235512
+      "bytes_per_second": 13829851487.409443
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:16/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 16272002225.348337
+      "bytes_per_second": 16295722840.073313
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:32/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 19698484979.185265
+      "bytes_per_second": 19601038128.50214
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:64/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 20704031609.281914
+      "bytes_per_second": 20057077539.2085
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:128/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 21252525508.72159
+      "bytes_per_second": 20006330955.05304
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:1/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 10907228199.338032
+      "bytes_per_second": 11056805167.581146
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:2/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 12864921829.408455
+      "bytes_per_second": 12237681925.457663
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:4/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 13933205598.103354
+      "bytes_per_second": 13491602782.596375
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:8/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 14168249648.95961
+      "bytes_per_second": 13602792627.128883
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:16/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 18090939569.90725
+      "bytes_per_second": 16215195606.22946
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:32/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 20218994851.002907
+      "bytes_per_second": 18701153095.98964
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:64/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 20885489893.941273
+      "bytes_per_second": 19658295589.36407
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:128/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 11,
       "aggregate_name": "median",
-      "bytes_per_second": 20244933207.487553
+      "bytes_per_second": 17881351835.517895
     }
   ]
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer_n300_iommu_golden.json
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer_n300_iommu_golden.json
@@ -1,7 +1,7 @@
 {
   "context": {
-    "date": "2026-05-15T17:54:52+00:00",
-    "host_name": "78d1cc04d751",
+    "date": "2026-08-01T05:24:10+00:00",
+    "host_name": "f413ad15a398",
     "executable": "./build/test/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer",
     "num_cpus": 16,
     "mhz_per_cpu": 2300,
@@ -33,9 +33,9 @@
       }
     ],
     "load_avg": [
-      1.26953,
-      1.0542,
-      0.475586
+      1.84082,
+      0.919922,
+      0.364746
     ],
     "library_version": "v1.9.1",
     "library_build_type": "release",
@@ -47,1260 +47,1260 @@
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 578223648.6449913
+      "bytes_per_second": 983555493.0559863
     },
     {
       "name": "Write/page_size:64/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1148848717.2464046
+      "bytes_per_second": 1950102398.7451522
     },
     {
       "name": "Write/page_size:128/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2277946107.61841
+      "bytes_per_second": 3835654543.987552
     },
     {
       "name": "Write/page_size:256/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4474336026.165982
+      "bytes_per_second": 7054265286.559948
     },
     {
       "name": "Write/page_size:512/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 7686772079.512948
+      "bytes_per_second": 11420909368.391123
     },
     {
       "name": "Write/page_size:1024/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 12071994940.248747
+      "bytes_per_second": 11846536162.678474
     },
     {
       "name": "Write/page_size:2048/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 12344516194.497185
+      "bytes_per_second": 11723370336.31356
     },
     {
       "name": "Write/page_size:32/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 579212678.6413003
+      "bytes_per_second": 996706187.4810686
     },
     {
       "name": "Write/page_size:64/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1152225323.1156673
+      "bytes_per_second": 1975650217.2297387
     },
     {
       "name": "Write/page_size:128/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2287040162.126993
+      "bytes_per_second": 3878621919.5854545
     },
     {
       "name": "Write/page_size:256/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4491908056.452183
+      "bytes_per_second": 7530021358.267712
     },
     {
       "name": "Write/page_size:512/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 8708721002.546768
+      "bytes_per_second": 11839101226.881613
     },
     {
       "name": "Write/page_size:1024/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 12419222354.388039
+      "bytes_per_second": 11835749456.410322
     },
     {
       "name": "Write/page_size:2048/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 12369688391.908857
+      "bytes_per_second": 12157233768.990088
     },
     {
       "name": "Read/page_size:32/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 646494019.0831584
+      "bytes_per_second": 703710042.9098417
     },
     {
       "name": "Read/page_size:64/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1251260797.504409
+      "bytes_per_second": 1356283341.7088702
     },
     {
       "name": "Read/page_size:128/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2349105626.407627
+      "bytes_per_second": 2528131805.519171
     },
     {
       "name": "Read/page_size:256/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4194483069.870364
+      "bytes_per_second": 4444115689.159622
     },
     {
       "name": "Read/page_size:512/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 6824156968.735048
+      "bytes_per_second": 7010714511.035926
     },
     {
       "name": "Read/page_size:1024/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 8235696715.324194
+      "bytes_per_second": 8395656928.590978
     },
     {
       "name": "Read/page_size:2048/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9420770919.46506
+      "bytes_per_second": 9589971950.616884
     },
     {
       "name": "Read/page_size:32/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 704817811.136502
+      "bytes_per_second": 648300740.2463837
     },
     {
       "name": "Read/page_size:64/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1360628642.56526
+      "bytes_per_second": 1256013291.878444
     },
     {
       "name": "Read/page_size:128/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2543405125.7284317
+      "bytes_per_second": 2365222781.52859
     },
     {
       "name": "Read/page_size:256/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4464078150.26184
+      "bytes_per_second": 4229031327.5032563
     },
     {
       "name": "Read/page_size:512/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 6765244263.378261
+      "bytes_per_second": 6975014917.673583
     },
     {
       "name": "Read/page_size:1024/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 8500360627.172953
+      "bytes_per_second": 8566086164.606341
     },
     {
       "name": "Read/page_size:2048/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9562299366.069975
+      "bytes_per_second": 10033230455.458412
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:1/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5033451886.310372
+      "bytes_per_second": 5371804138.724663
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:2/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 6822378589.912113
+      "bytes_per_second": 7217481131.870883
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:4/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9050253044.953856
+      "bytes_per_second": 9208407912.221806
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:8/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10174314640.589241
+      "bytes_per_second": 10442886011.154657
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:16/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 11205593092.505167
+      "bytes_per_second": 11142189729.770702
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:32/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 11260052646.539255
+      "bytes_per_second": 11242290283.093468
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:64/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 11387437263.599735
+      "bytes_per_second": 11582359983.334822
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:128/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 11749780530.85122
+      "bytes_per_second": 11914587745.755196
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:1/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5392858553.853558
+      "bytes_per_second": 6438757440.758148
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:2/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 7287877119.542074
+      "bytes_per_second": 8083136828.783657
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:4/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9370879778.417435
+      "bytes_per_second": 10051819768.386595
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:8/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10030147431.797255
+      "bytes_per_second": 10817255170.195745
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:16/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10456364848.296234
+      "bytes_per_second": 11208773821.109793
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:32/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10600461044.803202
+      "bytes_per_second": 11270970000.875784
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:64/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 11283727733.078516
+      "bytes_per_second": 12121920997.779669
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:128/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 11702527594.637354
+      "bytes_per_second": 12349585073.69762
     },
     {
       "name": "ReadPinnedMemory/page_size:32/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 644831361.2189522
+      "bytes_per_second": 702765818.2952228
     },
     {
       "name": "ReadPinnedMemory/page_size:64/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1246288299.250014
+      "bytes_per_second": 1352509807.6579547
     },
     {
       "name": "ReadPinnedMemory/page_size:128/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2332581811.810506
+      "bytes_per_second": 2515040258.326723
     },
     {
       "name": "ReadPinnedMemory/page_size:256/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4145437802.126435
+      "bytes_per_second": 4407171471.910325
     },
     {
       "name": "ReadPinnedMemory/page_size:512/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 6768807813.004294
+      "bytes_per_second": 7087242549.234335
     },
     {
       "name": "ReadPinnedMemory/page_size:1024/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9716189860.138245
+      "bytes_per_second": 10116845428.678707
     },
     {
       "name": "ReadPinnedMemory/page_size:2048/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 12258718118.809235
+      "bytes_per_second": 12676323812.027445
     },
     {
       "name": "ReadPinnedMemory/page_size:32/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 703337208.6630394
+      "bytes_per_second": 647747663.6730927
     },
     {
       "name": "ReadPinnedMemory/page_size:64/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1355327775.6393628
+      "bytes_per_second": 1253414504.6332633
     },
     {
       "name": "ReadPinnedMemory/page_size:128/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2530680959.8946834
+      "bytes_per_second": 2357434388.9471107
     },
     {
       "name": "ReadPinnedMemory/page_size:256/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4481985272.936653
+      "bytes_per_second": 4212113461.893155
     },
     {
       "name": "ReadPinnedMemory/page_size:512/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 7283578321.648742
+      "bytes_per_second": 6891510065.572343
     },
     {
       "name": "ReadPinnedMemory/page_size:1024/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10385817837.710192
+      "bytes_per_second": 10228662522.681799
     },
     {
       "name": "ReadPinnedMemory/page_size:2048/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 12560245712.630938
+      "bytes_per_second": 13207916739.544163
     },
     {
       "name": "WritePinnedMemory/page_size:32/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 578716095.0146126
+      "bytes_per_second": 985180421.8414583
     },
     {
       "name": "WritePinnedMemory/page_size:64/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1152387915.5528738
+      "bytes_per_second": 1958173808.2318656
     },
     {
       "name": "WritePinnedMemory/page_size:128/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2279301707.4086227
+      "bytes_per_second": 3865540092.9319468
     },
     {
       "name": "WritePinnedMemory/page_size:256/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4504399873.371808
+      "bytes_per_second": 7599946006.210968
     },
     {
       "name": "WritePinnedMemory/page_size:512/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 8894138777.495977
+      "bytes_per_second": 14704236135.043526
     },
     {
       "name": "WritePinnedMemory/page_size:1024/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 16529903630.597042
+      "bytes_per_second": 20998354956.783867
     },
     {
       "name": "WritePinnedMemory/page_size:2048/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 18793341175.92867
+      "bytes_per_second": 21046126194.32127
     },
     {
       "name": "WritePinnedMemory/page_size:4096/size:67108864/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 19154668287.317783
+      "bytes_per_second": 20173319553.257046
     },
     {
       "name": "WritePinnedMemory/page_size:32/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 579854591.993781
+      "bytes_per_second": 998507265.1411841
     },
     {
       "name": "WritePinnedMemory/page_size:64/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1153898544.9383132
+      "bytes_per_second": 1982009912.4871607
     },
     {
       "name": "WritePinnedMemory/page_size:128/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2292545125.524367
+      "bytes_per_second": 3919895793.6407766
     },
     {
       "name": "WritePinnedMemory/page_size:256/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4537423996.588416
+      "bytes_per_second": 7679087459.515502
     },
     {
       "name": "WritePinnedMemory/page_size:512/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 8773990516.411095
+      "bytes_per_second": 14650918590.911844
     },
     {
       "name": "WritePinnedMemory/page_size:1024/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 17069836694.992094
+      "bytes_per_second": 20685122572.018555
     },
     {
       "name": "WritePinnedMemory/page_size:2048/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 18843073466.029964
+      "bytes_per_second": 20582565456.760593
     },
     {
       "name": "WritePinnedMemory/page_size:4096/size:67108864/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 18477763381.438465
+      "bytes_per_second": 20609282440.869568
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:1/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5057817391.433721
+      "bytes_per_second": 5004880289.8959255
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:2/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 6867479959.928608
+      "bytes_per_second": 7146394648.688222
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:4/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9114518925.51749
+      "bytes_per_second": 8992049451.124954
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:8/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10138805217.067915
+      "bytes_per_second": 10092805313.952856
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:16/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 12387075571.974113
+      "bytes_per_second": 12692803401.406086
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:32/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 12926991927.859531
+      "bytes_per_second": 13094148146.676023
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:64/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 12886710532.45953
+      "bytes_per_second": 13238095351.397684
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:128/type:0/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 13274412826.81224
+      "bytes_per_second": 13288232179.125841
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:1/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 6070191643.559272
+      "bytes_per_second": 6604845747.873909
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:2/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 7310170970.478466
+      "bytes_per_second": 7942121227.598246
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:4/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9219699372.917992
+      "bytes_per_second": 9384163804.135145
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:8/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9968551702.484652
+      "bytes_per_second": 10081978453.706112
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:16/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 12606268133.768421
+      "bytes_per_second": 13424193366.545185
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:32/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 12982102064.666355
+      "bytes_per_second": 14026842837.977623
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:64/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 13703462988.360163
+      "bytes_per_second": 14685189382.122395
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:128/type:1/device:0/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 13633383508.66456
+      "bytes_per_second": 14697371515.828447
     },
     {
       "name": "Write/page_size:32/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 538652170.0882246
+      "bytes_per_second": 992540030.9958777
     },
     {
       "name": "Write/page_size:64/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1071377851.7559209
+      "bytes_per_second": 1967846751.6465092
     },
     {
       "name": "Write/page_size:128/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2115480640.7486928
+      "bytes_per_second": 3867169090.795445
     },
     {
       "name": "Write/page_size:256/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4121456259.520796
+      "bytes_per_second": 7491631044.057185
     },
     {
       "name": "Write/page_size:512/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 8022547667.969274
+      "bytes_per_second": 10292905294.25191
     },
     {
       "name": "Write/page_size:1024/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10040499522.488674
+      "bytes_per_second": 10282775847.646555
     },
     {
       "name": "Write/page_size:2048/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10243364120.897964
+      "bytes_per_second": 10302062461.972588
     },
     {
       "name": "Write/page_size:32/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 539116348.844632
+      "bytes_per_second": 999026988.4064482
     },
     {
       "name": "Write/page_size:64/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1072737680.6774771
+      "bytes_per_second": 1982764465.0696597
     },
     {
       "name": "Write/page_size:128/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2128309320.8156364
+      "bytes_per_second": 3901797683.268368
     },
     {
       "name": "Write/page_size:256/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4194365151.93715
+      "bytes_per_second": 7559445873.36632
     },
     {
       "name": "Write/page_size:512/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 8190498745.756775
+      "bytes_per_second": 10282359861.760931
     },
     {
       "name": "Write/page_size:1024/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10327870590.85752
+      "bytes_per_second": 10270454687.205353
     },
     {
       "name": "Write/page_size:2048/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10328419690.5658
+      "bytes_per_second": 10280095179.320686
     },
     {
       "name": "Read/page_size:32/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 710985153.4185438
+      "bytes_per_second": 711543329.2531935
     },
     {
       "name": "Read/page_size:64/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1380738584.6698208
+      "bytes_per_second": 1382900619.3721256
     },
     {
       "name": "Read/page_size:128/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2591288061.536151
+      "bytes_per_second": 2615803450.6783037
     },
     {
       "name": "Read/page_size:256/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4654202686.4218445
+      "bytes_per_second": 4728660454.282238
     },
     {
       "name": "Read/page_size:512/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5212421753.9737835
+      "bytes_per_second": 5338803112.692886
     },
     {
       "name": "Read/page_size:1024/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5241406107.668027
+      "bytes_per_second": 5342347975.5243
     },
     {
       "name": "Read/page_size:2048/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5254634363.29553
+      "bytes_per_second": 5348890251.374484
     },
     {
       "name": "Read/page_size:32/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 711272195.364817
+      "bytes_per_second": 711639577.1401987
     },
     {
       "name": "Read/page_size:64/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1382633804.843721
+      "bytes_per_second": 1383179950.2910674
     },
     {
       "name": "Read/page_size:128/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2611485630.3553224
+      "bytes_per_second": 2617612449.9712386
     },
     {
       "name": "Read/page_size:256/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4605527716.172176
+      "bytes_per_second": 4726628983.730568
     },
     {
       "name": "Read/page_size:512/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5127198815.502052
+      "bytes_per_second": 5339773829.302453
     },
     {
       "name": "Read/page_size:1024/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5233710519.48345
+      "bytes_per_second": 5339357959.92195
     },
     {
       "name": "Read/page_size:2048/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5242275686.244991
+      "bytes_per_second": 5347460671.812174
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:1/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4950889460.177423
+      "bytes_per_second": 5302605676.938025
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:2/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 7019564090.882265
+      "bytes_per_second": 7665315863.844464
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:4/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9128024841.39495
+      "bytes_per_second": 9706083341.111965
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:8/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9681304333.53845
+      "bytes_per_second": 10165371459.953012
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:16/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9812332885.305094
+      "bytes_per_second": 10215608484.234526
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:32/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10106684441.587301
+      "bytes_per_second": 10248702427.153456
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:64/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10291008970.342567
+      "bytes_per_second": 10218812605.30451
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:128/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10053884778.312002
+      "bytes_per_second": 10113137642.431498
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:1/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5289667282.767461
+      "bytes_per_second": 6265270065.454204
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:2/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 7657228562.286262
+      "bytes_per_second": 8107340028.072414
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:4/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9107720400.511892
+      "bytes_per_second": 9569907771.662281
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:8/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9273560811.301008
+      "bytes_per_second": 9629829548.824192
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:16/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9333889042.963158
+      "bytes_per_second": 9580324938.760687
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:32/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9394551341.804075
+      "bytes_per_second": 9499937943.645123
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:64/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9428157399.427069
+      "bytes_per_second": 9450526700.054935
     },
     {
       "name": "WriteSharded/size:67108864/contiguity:128/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9467793837.340206
+      "bytes_per_second": 9523937182.833435
     },
     {
       "name": "ReadPinnedMemory/page_size:32/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 712071880.092951
+      "bytes_per_second": 712318290.1795677
     },
     {
       "name": "ReadPinnedMemory/page_size:64/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1385320312.4703076
+      "bytes_per_second": 1385799477.9463658
     },
     {
       "name": "ReadPinnedMemory/page_size:128/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2607714867.0078707
+      "bytes_per_second": 2628580638.941875
     },
     {
       "name": "ReadPinnedMemory/page_size:256/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4750286753.151874
+      "bytes_per_second": 4763138735.544518
     },
     {
       "name": "ReadPinnedMemory/page_size:512/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5281340809.302482
+      "bytes_per_second": 5405603750.187987
     },
     {
       "name": "ReadPinnedMemory/page_size:1024/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5289408856.018021
+      "bytes_per_second": 5412201380.39095
     },
     {
       "name": "ReadPinnedMemory/page_size:2048/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5313392430.895387
+      "bytes_per_second": 5410437114.345695
     },
     {
       "name": "ReadPinnedMemory/page_size:32/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 712404299.3727921
+      "bytes_per_second": 712668268.3064463
     },
     {
       "name": "ReadPinnedMemory/page_size:64/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1385996906.723055
+      "bytes_per_second": 1386479417.204097
     },
     {
       "name": "ReadPinnedMemory/page_size:128/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2623210993.8044443
+      "bytes_per_second": 2628551048.204681
     },
     {
       "name": "ReadPinnedMemory/page_size:256/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4753377504.005402
+      "bytes_per_second": 4761549931.215551
     },
     {
       "name": "ReadPinnedMemory/page_size:512/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5304274452.739601
+      "bytes_per_second": 5405727347.815862
     },
     {
       "name": "ReadPinnedMemory/page_size:1024/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5300622382.630438
+      "bytes_per_second": 5403592435.535646
     },
     {
       "name": "ReadPinnedMemory/page_size:2048/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5314596195.292243
+      "bytes_per_second": 5408441750.560829
     },
     {
       "name": "WritePinnedMemory/page_size:32/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 539294188.0093454
+      "bytes_per_second": 995699478.7508074
     },
     {
       "name": "WritePinnedMemory/page_size:64/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1074179287.616292
+      "bytes_per_second": 1978461034.1594386
     },
     {
       "name": "WritePinnedMemory/page_size:128/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2135517951.090954
+      "bytes_per_second": 3910233787.897436
     },
     {
       "name": "WritePinnedMemory/page_size:256/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4154459861.9305253
+      "bytes_per_second": 7649310900.587465
     },
     {
       "name": "WritePinnedMemory/page_size:512/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 7968251915.551379
+      "bytes_per_second": 10268668911.088217
     },
     {
       "name": "WritePinnedMemory/page_size:1024/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10068218184.019196
+      "bytes_per_second": 10267578356.910715
     },
     {
       "name": "WritePinnedMemory/page_size:2048/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10190323694.636906
+      "bytes_per_second": 10282538023.657183
     },
     {
       "name": "WritePinnedMemory/page_size:4096/size:67108864/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10211746487.686602
+      "bytes_per_second": 10250798920.57281
     },
     {
       "name": "WritePinnedMemory/page_size:32/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 539940329.5090977
+      "bytes_per_second": 1003263656.5220197
     },
     {
       "name": "WritePinnedMemory/page_size:64/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 1074861399.6338224
+      "bytes_per_second": 1994382691.5542593
     },
     {
       "name": "WritePinnedMemory/page_size:128/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 2136655429.4719336
+      "bytes_per_second": 3940269898.3420987
     },
     {
       "name": "WritePinnedMemory/page_size:256/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4220014805.858941
+      "bytes_per_second": 7719301748.679024
     },
     {
       "name": "WritePinnedMemory/page_size:512/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 8280295453.041072
+      "bytes_per_second": 10241637032.498661
     },
     {
       "name": "WritePinnedMemory/page_size:1024/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10151138507.976215
+      "bytes_per_second": 10256481376.243021
     },
     {
       "name": "WritePinnedMemory/page_size:2048/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10177424710.67694
+      "bytes_per_second": 10278923008.140415
     },
     {
       "name": "WritePinnedMemory/page_size:4096/size:67108864/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10174121506.982864
+      "bytes_per_second": 10253570999.940708
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:1/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 4807610175.603838
+      "bytes_per_second": 5428000387.293559
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:2/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 6381465862.402367
+      "bytes_per_second": 7391316608.271447
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:4/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 8624686408.851229
+      "bytes_per_second": 9226063138.529509
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:8/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9200432205.78496
+      "bytes_per_second": 9968971840.857601
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:16/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9757473285.164036
+      "bytes_per_second": 9899203032.897568
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:32/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9979336153.523489
+      "bytes_per_second": 10037042016.28746
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:64/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10111138726.304766
+      "bytes_per_second": 10131817767.696636
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:128/type:0/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10152200382.555445
+      "bytes_per_second": 10150058455.02577
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:1/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 5816422286.931014
+      "bytes_per_second": 6757771244.313977
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:2/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 7301887439.291234
+      "bytes_per_second": 7838707501.637142
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:4/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 8898162786.399559
+      "bytes_per_second": 9217926786.51479
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:8/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9444367166.099297
+      "bytes_per_second": 9558948042.622314
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:16/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9634108551.418997
+      "bytes_per_second": 9715020100.56874
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:32/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 9887367792.442162
+      "bytes_per_second": 9804368240.91128
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:64/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10070331291.439236
+      "bytes_per_second": 10160753870.078562
     },
     {
       "name": "WritePinnedMemorySharded/size:67108864/contiguity:128/type:1/device:1/real_time_median",
       "run_type": "aggregate",
       "repetitions": 5,
       "aggregate_name": "median",
-      "bytes_per_second": 10089788246.79845
+      "bytes_per_second": 10118182128.625776
     }
   ]
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -625,9 +625,41 @@ __attribute__((noinline)) void process_write_paged() {
     // DPRINT("process_write_paged - pages: {} page_size: {} dispatch_cb_page_size: {}\n", pages, page_size,
     // dispatch_cb_page_size);
 
+    // A page that fits in one packet and starts on a page boundary is written whole, and every such page in a row of
+    // available data is the same length. Count them up front and write the run with the transfer length programmed
+    // once, which also drops the availability check, both clamps and the partial-page branch from the inner loop.
+    // Anything else -- a page larger than a packet, or a page split across the command buffer's data -- falls through
+    // to the general path below.
+    const bool single_packet_pages = page_size <= NOC_MAX_BURST_SIZE;
+    cq_noc_async_write_init_state<CQ_NOC_sndl>(0, 0, 0);
+
     while (write_length != 0) {
         // Transfer size is min(remaining_length, data_available_in_cb)
         uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
+
+        if (single_packet_pages && dst_addr_offset == 0 && available_data >= page_size) {
+            uint32_t run = available_data < write_length ? available_data : write_length;
+            noc_write_with_state<DM_DEDICATED_NOC, NCRISC_WR_CMD_BUF, CQ_NOC_sndL, CQ_NOC_send, CQ_NOC_WAIT, false>(
+                noc_index, 0, 0, page_size);
+            do {
+                uint64_t dst = get_noc_addr_helper(
+                    interleaved_addr_gen::get_noc_xy<is_dram>(walk_bank, noc_index),
+                    walk_row_addr + interleaved_addr_gen::get_bank_offset<is_dram>(walk_bank));
+                ASSERT(dst == addr_gen.get_noc_addr(page_id, 0));
+                cq_noc_async_write_with_state<CQ_NOC_SNDl, CQ_NOC_WAIT, CQ_NOC_SEND, NCRISC_WR_CMD_BUF, true>(
+                    static_cast<uint32_t>(data_ptr), dst, page_size);
+                page_id++;
+                if (++walk_bank == num_banks) {
+                    walk_bank = 0;
+                    walk_row_addr += page_size;
+                }
+                data_ptr += page_size;
+                write_length -= page_size;
+                run -= page_size;
+            } while (run >= page_size);
+            continue;
+        }
+
         uint32_t remaining_page_size = page_size - dst_addr_offset;
         uint32_t xfer_size = remaining_page_size > available_data ? available_data : remaining_page_size;
         // Cap the transfer size to the NOC packet size - use of One Packet NOC API (better performance
@@ -638,7 +670,8 @@ __attribute__((noinline)) void process_write_paged() {
             walk_row_addr + interleaved_addr_gen::get_bank_offset<is_dram>(walk_bank) + dst_addr_offset);
         ASSERT(dst == addr_gen.get_noc_addr(page_id, dst_addr_offset));
 
-        noc_async_write<NOC_MAX_BURST_SIZE>(static_cast<uint32_t>(data_ptr), dst, xfer_size);
+        cq_noc_async_write_with_state<CQ_NOC_SNDL, CQ_NOC_WAIT, CQ_NOC_SEND, NCRISC_WR_CMD_BUF, true>(
+            static_cast<uint32_t>(data_ptr), dst, xfer_size);
         // If paged write is not completed for a page (dispatch_cb_page_size < page_size) then add offset, otherwise
         // incr page_id.
         if (xfer_size < remaining_page_size) {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -594,8 +594,13 @@ void process_write() {
     process_write_linear(num_mcast_dests);
 }
 
+// Deliberately out of line. kernel_main inlines every command handler into one ~11 KB function, so this loop's
+// register allocation and placement depend on everything else in it: a couple hundred bytes added anywhere -- a cold
+// handler, a telemetry counter -- swings small-page write bandwidth by ~9% in either direction. Isolating the loop
+// makes it independent of that. It is free here only because the bank walk below removes enough register pressure
+// that the standalone function no longer spills; on its own the isolation cost ~5%.
 template <bool is_dram>
-void process_write_paged() {
+__attribute__((noinline)) void process_write_paged() {
     volatile tt_l1_ptr CQDispatchCmd* cmd =
         reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>(l1_uncached_addr(cmd_ptr));
 
@@ -605,8 +610,17 @@ void process_write_paged() {
     uint32_t pages = cmd->write_paged.pages;
     uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd);
     uint32_t write_length = pages * page_size;
-    auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec<is_dram>(), base_addr, page_size);
+    [[maybe_unused]] auto addr_gen =
+        TensorAccessor(tensor_accessor::make_interleaved_dspec<is_dram>(), base_addr, page_size);
     uint32_t dst_addr_offset = 0;  // Offset into page.
+
+    // Interleaved pages round-robin the banks, so walking them in page order steps the bank index by one and only
+    // advances the in-bank offset when it wraps. TensorAccessor::get_noc_addr instead recovers both from the page id
+    // every page, at the cost of two magic-multiply divisions by the bank count.
+    constexpr uint32_t num_banks = is_dram ? NUM_DRAM_BANKS : NUM_L1_BANKS;
+    uint32_t walk_row = interleaved_addr_gen::get_bank_offset_index<is_dram>(page_id);
+    uint32_t walk_bank = interleaved_addr_gen::get_bank_index<is_dram>(page_id, walk_row);
+    uint32_t walk_row_addr = base_addr + walk_row * page_size;
 
     // DPRINT("process_write_paged - pages: {} page_size: {} dispatch_cb_page_size: {}\n", pages, page_size,
     // dispatch_cb_page_size);
@@ -619,7 +633,10 @@ void process_write_paged() {
         // Cap the transfer size to the NOC packet size - use of One Packet NOC API (better performance
         // than writing a generic amount of data)
         xfer_size = xfer_size > NOC_MAX_BURST_SIZE ? NOC_MAX_BURST_SIZE : xfer_size;
-        uint64_t dst = addr_gen.get_noc_addr(page_id, dst_addr_offset);
+        uint64_t dst = get_noc_addr_helper(
+            interleaved_addr_gen::get_noc_xy<is_dram>(walk_bank, noc_index),
+            walk_row_addr + interleaved_addr_gen::get_bank_offset<is_dram>(walk_bank) + dst_addr_offset);
+        ASSERT(dst == addr_gen.get_noc_addr(page_id, dst_addr_offset));
 
         noc_async_write<NOC_MAX_BURST_SIZE>(static_cast<uint32_t>(data_ptr), dst, xfer_size);
         // If paged write is not completed for a page (dispatch_cb_page_size < page_size) then add offset, otherwise
@@ -630,6 +647,10 @@ void process_write_paged() {
         } else {
             page_id++;
             dst_addr_offset = 0;
+            if (++walk_bank == num_banks) {
+                walk_bank = 0;
+                walk_row_addr += page_size;
+            }
         }
 
         write_length -= xfer_size;


### PR DESCRIPTION
### PR Category

Performance.

### Summary

Fixes the write half of #51803. Three changes to `process_write_paged` in `cq_dispatch.cpp`; small-page `EnqueueWriteBuffer` gains **+87% on DRAM** and **+70% on L1**, and stops depending on unrelated edits to the file. A fourth commit refreshes the buffer goldens, which these numbers move well past.

**1. Walk the interleaved bank cycle.** The loop asked `TensorAccessor::get_noc_addr` for a fresh address every page. For an interleaved buffer that recovers the bank and in-bank offset from the page id with a magic-multiply division by the bank count, then `get_dram_bank_base_offset` divides by the bank count *again* to look up the coordinate. Consecutive pages round-robin the banks, so walking the cycle costs an increment and a compare instead, and hands the coordinate and local address to the NoC separately rather than composing a 64-bit address the API immediately takes apart.

The loop goes 79 → 75 instructions per page but loses **all three multiplies**, which is where the time was — the magic-multiply sequence is a serial dependency chain the loop can't hide.

**2. Take the loop out of line.** `kernel_main` inlines every command handler into one ~11 KB function, so this loop's register allocation and placement depend on everything else in it. A couple hundred bytes added anywhere swings small-page write bandwidth ~9% *in either direction*. That is the whole of the apparent "dispatch telemetry costs 9%" in #51803: telemetry's 192 bytes land in cold handlers and knocked this loop into worse codegen, with no telemetry code running in the write path at all.

**3. Write a counted run of whole pages.** The loop re-derived per page how much data the command buffer had, the bytes left in the page, both clamps, and a branch for whether the page finished. None of it varies across a run of whole pages, and whole pages are the normal case when a page fits in one packet -- exactly where dispatch rather than bandwidth is the limit. Counting the run up front programs the length once and leaves the inner loop carrying only the address walk and the write: **~73 instructions per page down to 26, no spills**. Pages larger than a packet, and pages split across the command buffer's data, take the general path unchanged.

**The first two unlock each other**, which is why neither landed alone. Isolation by itself costs ~5% because the standalone function spills 22 times; the bank walk removes enough register pressure that it spills 10 and the isolation becomes free. At 32 B pages, DRAM:

| | telemetry ON | telemetry OFF | spread |
|---|---|---|---|
| before | 508.1 | 555.2 | 9.2% |
| isolation only | 525.2 | 525.5 | 0.1%, but below the good state |
| bank walk only | 593.1 | 553.4 | 7.2% |
| **both (this PR)** | **643.9** | **644.4** | **0.07%** |

The spread collapsing matters as much as the throughput: the benchmark stops being a lottery on unrelated dispatcher changes.

Re-confirmed on an n300 with IOMMU (5 reps, pinned, same binary): before this PR, enabling telemetry cost **-8.4%** at 32 B and -8.3% at 256 B on interleaved DRAM writes. With it, the same comparison is -0.7% worst case and -0.41% median, and across all 68 benchmarks measured (including all 64 sharded) nothing is more than 1.7% slower with telemetry on.

### Measurements

Wormhole n150, 64 MB `EnqueueWriteBuffer`, median of 3 reps, pinned to the device-local NUMA node. MiB/s below 1 Gi/s, else Gi/s.

| interleaved DRAM | 32 B | 64 B | 128 B | 256 B | 512 B | 1 KB |
|---|---|---|---|---|---|---|
| main | 508.1 | 1012.8 | 1.970 | 3.893 | 7.112 | 11.80 |
| bank walk + outline | 643.8 | 1282.5 | 2.494 | 4.910 | 8.519 | 13.04 |
| + counted run | **950.8** | **1893.1** | **3.653** | **6.766** | **11.069** | **13.39** |
| | **+87.1%** | +86.9% | +85.4% | +73.8% | +55.6% | +13.5% |

| interleaved L1 | 32 B | 64 B | 128 B | 256 B | 512 B | 1 KB |
|---|---|---|---|---|---|---|
| main | 564.2 | 1124.9 | 2.189 | 4.327 | 8.463 | 13.11 |
| bank walk + outline | 647.7 | 1291.9 | 2.508 | 4.944 | 9.632 | 13.17 |
| + counted run | **958.2** | **1907.3** | **3.684** | **7.188** | **13.412** | **13.22** |
| | **+69.8%** | +69.6% | +68.3% | +66.1% | +58.5% | +0.8% |

L1 now saturates at 512 B rather than 1 KB. Both cap near 13.2-13.4 Gi/s, so the gains stop exactly where bandwidth takes over. L1 starts higher than DRAM because its instantiation was not the one sitting in the bad codegen state.

### Notes for reviewers

**Correctness of the hand-rolled address generation** is the thing to be skeptical of. An assert-enabled build compares every computed address against `addr_gen.get_noc_addr` for the same page id, so any layout the walk gets wrong is reported rather than silently writing elsewhere. `Sending131072Pages` alone puts 131072 pages through that comparison, on DRAM and L1. The accessor is `[[maybe_unused]]` because a release build drops it. Please push on this if you think it has a hole.

**Why `noinline` on a hot function** reads backwards, so it carries a comment explaining it. It is not a micro-optimization — it is what makes the number reproducible. Without it, this PR's own gain would be at the mercy of the next edit to `cq_dispatch.cpp`.

**Goldens are updated in the last commit**, regenerated from this branch's run 30684977726 so they land with the code that moves them. The previous values dated from 2026-05-18, predating dispatch telemetry, and every CI run since had been reporting deviations against them in both directions.

Against the old goldens: WH n300 median +4.0% (84 raised >5%, 10 lowered), BH p150 median -0.6% (10 raised, 9 lowered). By family, `Write/` +68.0% WH / +43.5% BH, `Read` +1.8% / -0.4%, `Sharded` +3.7% / -3.1%. Both new goldens validate the run they came from at the 5% gate, 180/180 and 44/44.

Two caveats recorded in that commit rather than left to be found later: the sharded entries measured ~11% below the median of five recent main runs (untouched `Read` was flat at -0.0% on the same run, so it is not machine state) — still above the old golden, but accepting these values means CI will not flag that gap, tracked in #51803; and the entries this lowers are mostly large-page and sharded cases whose run-to-run spread on the CI hosts is 26-54%, far wider than the 5% gate, so their new values are arbitrary points in a wide distribution rather than measurements.

**A negative result worth knowing.** Simply keeping the length register programmed across writes -- testing it per iteration and choosing between two write forms -- measured **20% slower** than reprogramming it every time. The two inlined issue sequences add 14 instructions to a loop that is issue-bound, to save one store. Hoisting the test out of the loop entirely, as the counted run does, is what pays. Worth knowing before anyone tries the obvious stateful-write refactor here.

**Same pattern as #51793**, which does this to the prefetcher's `relay_paged` read loop (+50% at 32 B there). The `TensorAccessor` per-page cost is worth auditing anywhere it appears in a per-page loop; these are the two I have measured.

### Verification

`TT_METAL_WATCHER=1` throughout, which is what compiles in the address comparison:

- `unit_tests_dispatch --gtest_filter='UnitMeshCQSingleCard*BufferFixture*'` — 55 passed / 1 skipped of 56, on **both** worker and eth dispatch (`TT_METAL_GTEST_ETH_DISPATCH=1`).
- `test_prefetcher --gtest_filter='PrefetcherTests*'` — 27 passed / 2 skipped.
- No NoC sanitizer hits in any run.

**Blackhole is now measured** (run 30684977726, `bh_p150_perf`): `Write/` +44.7% median, +44.8% DRAM and +63.0% L1 at 32 B, and flat at 1-2 KB where it saturates. No large-page downside.

**The sharded question is resolved: there is no regression.** CI showed WH sharded writes ~11% below recent main runs, which looked real because the untouched `Read` family was flat on that same run. Re-measured directly on an n300 with a working IOMMU (so the pinned families actually register), same binary swapped back to back, 5 repetitions, pinned to the device-local NUMA node:

| family | n | median | worst case | worse than -5% |
|---|---|---|---|---|
| `Write/` interleaved (control) | 4 | **+84.5%** | — | 0 |
| `WriteSharded` | 32 | **+0.1%** | -1.9% | **0** |
| `WritePinnedMemorySharded` | 32 | **+0.0%** | -1.7% | **0** |

Median CV was 0.34-0.55%, against the ~2x run-to-run spread these have on the CI host. All 64 sharded benchmarks land within ±5%, and the interleaved win reproduces at +84.5% (32 B: 506 -> 941 DRAM, 506 -> 952 L1 MiB/s).

The CI signal was a false positive from treating one run as many samples: those 64 benchmarks share a process, a host and an allocation, so a family median across them is close to a single sample rather than 64 independent ones. The flat `Read` control did not rule that out, since reads are not sensitive to whatever the sharded write path was contending with on that host.

