### PR TITLE
fix: guard INT32_MIN in div int32 residual

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -66,6 +66,8 @@ sfpi_inline void calculate_div_int32_body(
     // Compute remainder.
     sfpi::vInt r = a - qb;
     sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
+    v_if(r_f < 0.0f) { r_f = 0x1.0p31f; }
+    v_endif;
 
     // Compute correction value in float32.
     sfpi::vFloat correction_f = r_f * inv_b_f;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -107,6 +107,8 @@ sfpi_inline void calculate_div_int32_body(
     a_s = sfpi::abs(a_s);
     sfpi::vInt r = a_s - qb;
     sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
+    v_if(r_f < 0.0f) { r_f = 0x1.0p31f; }
+    v_endif;
 
     // Compute correction value in float32.
     sfpi::vFloat correction_f = r_f * inv_b_f;


### PR DESCRIPTION
## Fix INT32_MIN guard in div int32 residual (WH/BH)

### Issue
ttnn.div int32 floor/trunc drops residual for INT32_MIN because `r_f` can become -0.0f.
Two conversions already guard INT32_MIN; the residual conversion was missing the same clamp.

### Fix
Add the same INT32_MIN guard after converting `r` to float:

