### PR TITLE
Add CircularBuffer bcast scalar overloads

### DIFF
--- a/ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_api.h"
 
 // W-bcast scalar
@@ -22,6 +23,10 @@ FORCE_INLINE void generate_bcast_col_scalar(const uint32_t cb_id, const uint32_t
     cb_push_back(cb_id, 1);
 }
 
+FORCE_INLINE void generate_bcast_col_scalar(CircularBuffer cb, const uint32_t scalar) {
+    generate_bcast_col_scalar(cb.get_cb_id(), scalar);
+}
+
 // H-bcast scalar
 // Tile is assumed to have 16-bit elements
 // Scalar is assumed to be a 16-bit value double packed into a u32
@@ -37,6 +42,10 @@ FORCE_INLINE void generate_bcast_row_scalar(const uint32_t cb_id, const uint32_t
     cb_push_back(cb_id, 1);
 }
 
+FORCE_INLINE void generate_bcast_row_scalar(CircularBuffer cb, const uint32_t scalar) {
+    generate_bcast_row_scalar(cb.get_cb_id(), scalar);
+}
+
 // HW-bcast scalar
 // Tile is assumed to have 16-bit elements
 // Scalar is assumed to be a 16-bit value double packed into a u32
@@ -46,4 +55,8 @@ FORCE_INLINE void generate_bcast_unary_scalar(const uint32_t cb_id, const uint32
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
     ptr[0] = scalar >> 16;
     cb_push_back(cb_id, 1);
+}
+
+FORCE_INLINE void generate_bcast_unary_scalar(CircularBuffer cb, const uint32_t scalar) {
+    generate_bcast_unary_scalar(cb.get_cb_id(), scalar);
 }


### PR DESCRIPTION
## Summary
- add CircularBuffer overloads for generate_bcast_{col,row,unary}_scalar
- keep existing uint32_t cb_id overloads intact
- unblock tt-blaze softmax_top_p kernels that already use CircularBuffer call sites

## Validation
- git diff --check -- ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp
- clang-format pre-commit hook passed

Note: full pre-commit could not complete in this worktree because infra/fix_cstdint.py and .codespellignore are missing from the checkout.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=codex/bcast-scalar-circularbuffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:codex/bcast-scalar-circularbuffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=codex/bcast-scalar-circularbuffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:codex/bcast-scalar-circularbuffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=codex/bcast-scalar-circularbuffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:codex/bcast-scalar-circularbuffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=codex/bcast-scalar-circularbuffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:codex/bcast-scalar-circularbuffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=codex/bcast-scalar-circularbuffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:codex/bcast-scalar-circularbuffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=codex/bcast-scalar-circularbuffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:codex/bcast-scalar-circularbuffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=codex/bcast-scalar-circularbuffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:codex/bcast-scalar-circularbuffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=codex/bcast-scalar-circularbuffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:codex/bcast-scalar-circularbuffer)