### PR TITLE
[Cleanup] `MeshDevice` used for buffer creation in tests

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
@@ -71,7 +71,7 @@ TEST_F(PerCoreAllocationTest, BasicPerCoreAllocation) {
     auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
     experimental::per_core_allocation::set_per_core_allocation(shard_args, true);
 
-    auto buf = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+    auto buf = Buffer::create(this->devices_[0].get(), total_size, PAGE_SIZE, BufferType::L1, shard_args);
 
     ASSERT_TRUE(per_core::is_per_core_allocation(*buf));
 
@@ -103,11 +103,11 @@ TEST_F(PerCoreAllocationTest, PerCoreAndLockstepCoexist) {
     // Create per-core buffer
     auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
     experimental::per_core_allocation::set_per_core_allocation(shard_args, true);
-    auto per_core_buf = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+    auto per_core_buf = Buffer::create(this->devices_[0].get(), total_size, PAGE_SIZE, BufferType::L1, shard_args);
 
     // Create lockstep buffer on same cores
     auto lockstep_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
-    auto lockstep_buf = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, lockstep_args);
+    auto lockstep_buf = Buffer::create(this->devices_[0].get(), total_size, PAGE_SIZE, BufferType::L1, lockstep_args);
 
     // Both should be allocated successfully
     EXPECT_TRUE(per_core_buf->is_allocated());
@@ -143,13 +143,13 @@ TEST_F(PerCoreAllocationTest, DeallocationFreesPerCoreSpace) {
 
     // Create and destroy a buffer
     {
-        auto buf1 = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+        auto buf1 = Buffer::create(this->devices_[0].get(), total_size, PAGE_SIZE, BufferType::L1, shard_args);
         EXPECT_TRUE(per_core::is_per_core_allocation(*buf1));
         // buf1 destroyed here, freeing per-core allocations
     }
 
     // Create another buffer on same cores — should succeed (space was freed)
-    auto buf2 = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+    auto buf2 = Buffer::create(this->devices_[0].get(), total_size, PAGE_SIZE, BufferType::L1, shard_args);
     EXPECT_TRUE(per_core::is_per_core_allocation(*buf2));
     EXPECT_TRUE(buf2->is_allocated());
 }

--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
@@ -53,7 +53,8 @@ protected:
 static constexpr DeviceAddr PAGE_SIZE = 1024;
 
 TEST_F(PerCoreAllocationTest, BasicPerCoreAllocation) {
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     auto compute_grid = device->compute_with_storage_grid_size();
     uint32_t num_cores = static_cast<uint32_t>(std::min<size_t>(4, compute_grid.x));
     ASSERT_GE(num_cores, 2u) << "Need at least 2 compute cores";
@@ -71,7 +72,7 @@ TEST_F(PerCoreAllocationTest, BasicPerCoreAllocation) {
     auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
     experimental::per_core_allocation::set_per_core_allocation(shard_args, true);
 
-    auto buf = Buffer::create(this->devices_[0].get(), total_size, PAGE_SIZE, BufferType::L1, shard_args);
+    auto buf = Buffer::create(&mesh_device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
 
     ASSERT_TRUE(per_core::is_per_core_allocation(*buf));
 
@@ -85,7 +86,8 @@ TEST_F(PerCoreAllocationTest, BasicPerCoreAllocation) {
 }
 
 TEST_F(PerCoreAllocationTest, PerCoreAndLockstepCoexist) {
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     auto compute_grid = device->compute_with_storage_grid_size();
     uint32_t num_cores = static_cast<uint32_t>(std::min<size_t>(4, compute_grid.x));
     ASSERT_GE(num_cores, 2u);
@@ -103,11 +105,11 @@ TEST_F(PerCoreAllocationTest, PerCoreAndLockstepCoexist) {
     // Create per-core buffer
     auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
     experimental::per_core_allocation::set_per_core_allocation(shard_args, true);
-    auto per_core_buf = Buffer::create(this->devices_[0].get(), total_size, PAGE_SIZE, BufferType::L1, shard_args);
+    auto per_core_buf = Buffer::create(&mesh_device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
 
     // Create lockstep buffer on same cores
     auto lockstep_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
-    auto lockstep_buf = Buffer::create(this->devices_[0].get(), total_size, PAGE_SIZE, BufferType::L1, lockstep_args);
+    auto lockstep_buf = Buffer::create(&mesh_device, total_size, PAGE_SIZE, BufferType::L1, lockstep_args);
 
     // Both should be allocated successfully
     EXPECT_TRUE(per_core_buf->is_allocated());
@@ -123,7 +125,8 @@ TEST_F(PerCoreAllocationTest, PerCoreAndLockstepCoexist) {
 }
 
 TEST_F(PerCoreAllocationTest, DeallocationFreesPerCoreSpace) {
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     auto compute_grid = device->compute_with_storage_grid_size();
     uint32_t num_cores = static_cast<uint32_t>(std::min<size_t>(4, compute_grid.x));
     ASSERT_GE(num_cores, 2u);
@@ -143,13 +146,13 @@ TEST_F(PerCoreAllocationTest, DeallocationFreesPerCoreSpace) {
 
     // Create and destroy a buffer
     {
-        auto buf1 = Buffer::create(this->devices_[0].get(), total_size, PAGE_SIZE, BufferType::L1, shard_args);
+        auto buf1 = Buffer::create(&mesh_device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
         EXPECT_TRUE(per_core::is_per_core_allocation(*buf1));
         // buf1 destroyed here, freeing per-core allocations
     }
 
     // Create another buffer on same cores — should succeed (space was freed)
-    auto buf2 = Buffer::create(this->devices_[0].get(), total_size, PAGE_SIZE, BufferType::L1, shard_args);
+    auto buf2 = Buffer::create(&mesh_device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
     EXPECT_TRUE(per_core::is_per_core_allocation(*buf2));
     EXPECT_TRUE(buf2->is_allocated());
 }

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -180,7 +180,7 @@ TEST_F(MeshDeviceFixture, TensixTestValidCircularBufferAddress) {
 
         auto buffer_size = cb_config.page_size;
         tt::tt_metal::InterleavedBufferConfig buff_config{
-            .device = device->get_devices()[0],
+            .device = device.get(),
             .size = buffer_size,
             .page_size = buffer_size,
             .buffer_type = tt::tt_metal::BufferType::L1};
@@ -358,7 +358,7 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddress) {
 
         auto buffer_size = cb_config.page_size;
         tt::tt_metal::InterleavedBufferConfig buff_config{
-            .device = device->get_devices()[0],
+            .device = device.get(),
             .size = buffer_size,
             .page_size = buffer_size,
             .buffer_type = tt::tt_metal::BufferType::L1};
@@ -608,13 +608,13 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
         uint32_t buffer_size = single_tile_size * num_tiles;
 
         tt::tt_metal::InterleavedBufferConfig dram_config{
-            .device = device->get_devices()[0],
+            .device = device.get(),
             .size = buffer_size,
             .page_size = buffer_size,
             .buffer_type = tt::tt_metal::BufferType::DRAM};
 
         tt::tt_metal::InterleavedBufferConfig l1_config{
-            .device = device->get_devices()[0],
+            .device = device.get(),
             .size = buffer_size,
             .page_size = buffer_size,
             .buffer_type = tt::tt_metal::BufferType::L1};

--- a/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
@@ -493,7 +493,7 @@ TEST_F(MeshDeviceFixture, NocRead_L1_Aligned_NoViolation) {
     // fire for the wrong reason. The allocator aligns buffer starts to >=16 B, so
     // base and base+16 are both 16-byte aligned.
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::L1);
+    auto buf = Buffer::create(this->devices_[0].get(), buffer_size, buffer_size, BufferType::L1);
     uint32_t base = static_cast<uint32_t>(buf->address());
     ASSERT_EQ(base & 0xF, 0u);
 

--- a/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
@@ -358,7 +358,7 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_WH) {
     // bits (0x20) differ from the DRAM source's (0x40) — that divergence is
     // exactly what the broken 0xFF mask used to reject.
     constexpr uint32_t buf_size = 8192;
-    auto l1_buf = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto l1_buf = Buffer::create(mesh.get(), buf_size, buf_size, BufferType::L1);
     uint32_t base = static_cast<uint32_t>(l1_buf->address());
     uint32_t l1_dst = ((base + 0xFFu) & ~0xFFu) + 0x20u;  // 256-align, +0x20 -> low5=0, low8=0x20
     ASSERT_GE(l1_dst, base);
@@ -429,7 +429,7 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_BH) {
     // (0x80) differ from the DRAM source's (0x40) — that divergence is exactly
     // what an over-strict relative mask would wrongly reject.
     constexpr uint32_t buf_size = 8192;
-    auto l1_buf = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto l1_buf = Buffer::create(mesh.get(), buf_size, buf_size, BufferType::L1);
     uint32_t base = static_cast<uint32_t>(l1_buf->address());
     uint32_t l1_dst = ((base + 0xFFu) & ~0xFFu) + 0x80u;  // 256-align, +0x80 -> low6=0, low8=0x80
     ASSERT_GE(l1_dst, base);
@@ -493,7 +493,7 @@ TEST_F(MeshDeviceFixture, NocRead_L1_Aligned_NoViolation) {
     // fire for the wrong reason. The allocator aligns buffer starts to >=16 B, so
     // base and base+16 are both 16-byte aligned.
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(device, buffer_size, buffer_size, BufferType::L1);
+    auto buf = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::L1);
     uint32_t base = static_cast<uint32_t>(buf->address());
     ASSERT_EQ(base & 0xF, 0u);
 

--- a/tests/tt_metal/tt_metal/api/emule/test_host_alignment.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_host_alignment.cpp
@@ -40,12 +40,13 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, Host_Alignment_L1_Unaligned_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     // Allocate an L1 buffer so the poke targets a valid, non-reserved address.
     constexpr uint32_t buf_size = 256;
-    auto buf = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buf = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
 
     // Deliberately unaligned: buffer base + 1 byte. On a DMA-backed build with a
     // real alignment > 1 this would be rejected; on emule it must be accepted.
@@ -70,11 +71,12 @@ TEST_F(MeshDeviceFixture, Host_Alignment_L1_Unaligned_NoViolation) {
 TEST_F(MeshDeviceFixture, Host_Alignment_DRAM_Unaligned_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
 
     // Allocate a DRAM buffer to obtain a valid, non-reserved DRAM address.
     constexpr uint32_t buf_size = 256;
-    auto buf = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::DRAM);
+    auto buf = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::DRAM);
 
     uint32_t unaligned_addr = static_cast<uint32_t>(buf->address()) + 1;
     std::vector<uint8_t> payload = {0x01, 0x23, 0x45, 0x67};

--- a/tests/tt_metal/tt_metal/api/emule/test_host_alignment.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_host_alignment.cpp
@@ -45,7 +45,7 @@ TEST_F(MeshDeviceFixture, Host_Alignment_L1_Unaligned_NoViolation) {
 
     // Allocate an L1 buffer so the poke targets a valid, non-reserved address.
     constexpr uint32_t buf_size = 256;
-    auto buf = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto buf = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
 
     // Deliberately unaligned: buffer base + 1 byte. On a DMA-backed build with a
     // real alignment > 1 this would be rejected; on emule it must be accepted.
@@ -74,7 +74,7 @@ TEST_F(MeshDeviceFixture, Host_Alignment_DRAM_Unaligned_NoViolation) {
 
     // Allocate a DRAM buffer to obtain a valid, non-reserved DRAM address.
     constexpr uint32_t buf_size = 256;
-    auto buf = Buffer::create(device, buf_size, buf_size, BufferType::DRAM);
+    auto buf = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::DRAM);
 
     uint32_t unaligned_addr = static_cast<uint32_t>(buf->address()) + 1;
     std::vector<uint8_t> payload = {0x01, 0x23, 0x45, 0x67};

--- a/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
@@ -23,7 +23,8 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -36,7 +37,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_SanityCheck) {
     // Allocate a real L1 buffer as the noc_async_read destination so the
     // tensor-area sanitizer doesn't fire before cb_pop_front triggers the
     // barrier check.
-    auto dst_buf = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
+    auto dst_buf = Buffer::create(&mesh_device, 1024, 1024, BufferType::L1);
 
     // 2. Kernel that reads then pops WITHOUT a barrier. Popping frees the page
     //    for the producer to refill while the read is still in flight — a race.
@@ -75,7 +76,8 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_SanityCheck) {
 TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -86,8 +88,8 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
 
     // DRAM source for the page-accessor read + a real L1 destination (so the
     // tensor/OOB check doesn't pre-empt the pop-time race check).
-    auto src_buf = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::DRAM);
-    auto dst_buf = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
+    auto src_buf = Buffer::create(&mesh_device, 1024, 1024, BufferType::DRAM);
+    auto dst_buf = Buffer::create(&mesh_device, 1024, 1024, BufferType::L1);
 
     // The TensorAccessor reads its bank layout from compile-time args.
     std::vector<uint32_t> reader_ct_args;
@@ -128,7 +130,8 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
 TEST_F(MeshDeviceFixture, NoC_Barrier_Present_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -137,7 +140,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Present_NoViolation) {
         CircularBufferConfig(2048, {{cb_id, tt::DataFormat::Float16_b}}).set_page_size(cb_id, 1024);
     CreateCircularBuffer(program, logical_core, cb_config);
 
-    auto dst_buf = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
+    auto dst_buf = Buffer::create(&mesh_device, 1024, 1024, BufferType::L1);
 
     std::string kernel_src = R"(
         #include "api/dataflow/dataflow_api.h"
@@ -179,7 +182,8 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Present_NoViolation) {
 TEST_F(MeshDeviceFixture, NoC_Barrier_MultiRead_SingleBarrier_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -188,7 +192,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_MultiRead_SingleBarrier_NoViolation) {
         CircularBufferConfig(2048, {{cb_id, tt::DataFormat::Float16_b}}).set_page_size(cb_id, 1024);
     CreateCircularBuffer(program, logical_core, cb_config);
 
-    auto dst_buf = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
+    auto dst_buf = Buffer::create(&mesh_device, 1024, 1024, BufferType::L1);
 
     std::string kernel_src = R"(
         #include "api/dataflow/dataflow_api.h"

--- a/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
@@ -36,7 +36,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_SanityCheck) {
     // Allocate a real L1 buffer as the noc_async_read destination so the
     // tensor-area sanitizer doesn't fire before cb_pop_front triggers the
     // barrier check.
-    auto dst_buf = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto dst_buf = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
 
     // 2. Kernel that reads then pops WITHOUT a barrier. Popping frees the page
     //    for the producer to refill while the read is still in flight — a race.
@@ -86,8 +86,8 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
 
     // DRAM source for the page-accessor read + a real L1 destination (so the
     // tensor/OOB check doesn't pre-empt the pop-time race check).
-    auto src_buf = Buffer::create(device, 1024, 1024, BufferType::DRAM);
-    auto dst_buf = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto src_buf = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::DRAM);
+    auto dst_buf = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
 
     // The TensorAccessor reads its bank layout from compile-time args.
     std::vector<uint32_t> reader_ct_args;
@@ -137,7 +137,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Present_NoViolation) {
         CircularBufferConfig(2048, {{cb_id, tt::DataFormat::Float16_b}}).set_page_size(cb_id, 1024);
     CreateCircularBuffer(program, logical_core, cb_config);
 
-    auto dst_buf = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto dst_buf = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
 
     std::string kernel_src = R"(
         #include "api/dataflow/dataflow_api.h"
@@ -188,7 +188,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_MultiRead_SingleBarrier_NoViolation) {
         CircularBufferConfig(2048, {{cb_id, tt::DataFormat::Float16_b}}).set_page_size(cb_id, 1024);
     CreateCircularBuffer(program, logical_core, cb_config);
 
-    auto dst_buf = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto dst_buf = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
 
     std::string kernel_src = R"(
         #include "api/dataflow/dataflow_api.h"

--- a/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
@@ -24,7 +24,8 @@ TEST_F(MeshDeviceFixture, Tensor_Padding_Violation_SanityCheck) {
     GTEST_SKIP() << "Temporarily disabled. See SANITIZER_CHECKS.md for details.";
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -36,7 +37,7 @@ TEST_F(MeshDeviceFixture, Tensor_Padding_Violation_SanityCheck) {
     // in __emule_local_l1_to_ptr will fire on accesses into that region.
     uint32_t logical_size = 1024;
     uint32_t physical_size = 2048;
-    auto buffer = Buffer::create(this->devices_.at(0).get(), physical_size, physical_size, BufferType::L1);
+    auto buffer = Buffer::create(&mesh_device, physical_size, physical_size, BufferType::L1);
     tt::tt_metal::emule::register_logical_size(*buffer, logical_size);
 
     // 2. Add an inline kernel that attempts to modify a padded datum at byte

--- a/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
@@ -36,7 +36,7 @@ TEST_F(MeshDeviceFixture, Tensor_Padding_Violation_SanityCheck) {
     // in __emule_local_l1_to_ptr will fire on accesses into that region.
     uint32_t logical_size = 1024;
     uint32_t physical_size = 2048;
-    auto buffer = Buffer::create(device, physical_size, physical_size, BufferType::L1);
+    auto buffer = Buffer::create(this->devices_.at(0).get(), physical_size, physical_size, BufferType::L1);
     tt::tt_metal::emule::register_logical_size(*buffer, logical_size);
 
     // 2. Add an inline kernel that attempts to modify a padded datum at byte

--- a/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
@@ -55,13 +55,14 @@ TEST_F(MeshDeviceFixture, Semaphore_Direct_Write_SanityCheck) {
 TEST_F(MeshDeviceFixture, Semaphore_OutsideRegion_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     // A normal L1 buffer is allocated well away from the reserved semaphore
     // region (which lives in the low system area near EMULE_SEM_BASE).
-    auto buf = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
+    auto buf = Buffer::create(&mesh_device, 1024, 1024, BufferType::L1);
     uint32_t addr = static_cast<uint32_t>(buf->address());
 
     std::string kernel_src = R"(

--- a/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
@@ -61,7 +61,7 @@ TEST_F(MeshDeviceFixture, Semaphore_OutsideRegion_NoViolation) {
 
     // A normal L1 buffer is allocated well away from the reserved semaphore
     // region (which lives in the low system area near EMULE_SEM_BASE).
-    auto buf = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto buf = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
     uint32_t addr = static_cast<uint32_t>(buf->address());
 
     std::string kernel_src = R"(

--- a/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
@@ -30,9 +30,7 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
-
-    auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto buffer = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
@@ -42,9 +40,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SanityCheck) {
 TEST_F(MeshDeviceFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
-
-    auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto buffer = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
 
     std::vector<uint32_t> out;
@@ -52,11 +48,9 @@ TEST_F(MeshDeviceFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
 }
 
 TEST_F(MeshDeviceFixture, Host_UAF_ReadShard_SanityCheck) {
-    auto* device = this->devices_.at(0)->get_devices()[0];
-
     // ReadShard's sanitizer check runs before its is_sharded() assertion, so a
     // plain interleaved buffer still drives the UAF path under test here.
-    auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto buffer = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
 
     std::vector<uint8_t> out(1024);
@@ -66,9 +60,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_ReadShard_SanityCheck) {
 TEST_F(MeshDeviceFixture, Host_UAF_CoreSubsetWriteToBuffer_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
-
-    auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto buffer = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
@@ -88,9 +80,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_CoreSubsetWriteToBuffer_SanityCheck) {
 TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
-
-    auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto buffer = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
@@ -103,9 +93,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) 
 TEST_F(MeshDeviceFixture, Host_UAF_Allocated_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
-
-    auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);  // left allocated
+    auto buffer = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);  // left allocated
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     detail::WriteToBuffer(*buffer, data);  // must NOT abort

--- a/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
@@ -30,7 +30,7 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto buffer = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
+    auto buffer = Buffer::create(this->devices_[0].get(), 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
@@ -40,7 +40,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SanityCheck) {
 TEST_F(MeshDeviceFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto buffer = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
+    auto buffer = Buffer::create(this->devices_[0].get(), 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
 
     std::vector<uint32_t> out;
@@ -50,7 +50,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
 TEST_F(MeshDeviceFixture, Host_UAF_ReadShard_SanityCheck) {
     // ReadShard's sanitizer check runs before its is_sharded() assertion, so a
     // plain interleaved buffer still drives the UAF path under test here.
-    auto buffer = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
+    auto buffer = Buffer::create(this->devices_[0].get(), 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
 
     std::vector<uint8_t> out(1024);
@@ -60,7 +60,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_ReadShard_SanityCheck) {
 TEST_F(MeshDeviceFixture, Host_UAF_CoreSubsetWriteToBuffer_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto buffer = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
+    auto buffer = Buffer::create(this->devices_[0].get(), 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
@@ -80,7 +80,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_CoreSubsetWriteToBuffer_SanityCheck) {
 TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto buffer = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);
+    auto buffer = Buffer::create(this->devices_[0].get(), 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
@@ -93,7 +93,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) 
 TEST_F(MeshDeviceFixture, Host_UAF_Allocated_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto buffer = Buffer::create(this->devices_.at(0).get(), 1024, 1024, BufferType::L1);  // left allocated
+    auto buffer = Buffer::create(this->devices_[0].get(), 1024, 1024, BufferType::L1);  // left allocated
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     detail::WriteToBuffer(*buffer, data);  // must NOT abort

--- a/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
@@ -42,8 +42,8 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_Violation_SanityCheck) {
     // That arrangement matches the narrative the kernel computes below
     // (overshoot Buffer A upward to stomp Buffer B).
     uint32_t buf_size = 1024;  // 1 KB each
-    auto buffer_b = Buffer::create(device, buf_size, buf_size, BufferType::L1);
-    auto buffer_a = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto buffer_b = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buffer_a = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
 
     uint32_t addr_a = buffer_a->address();
     uint32_t addr_b = buffer_b->address();
@@ -118,9 +118,9 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NonAdjacent_Violation) {
 
     // Top-down: first allocated lands highest. Order so addr_a < addr_b < addr_c.
     uint32_t buf_size = 1024;
-    auto buffer_c = Buffer::create(device, buf_size, buf_size, BufferType::L1);
-    auto buffer_b = Buffer::create(device, buf_size, buf_size, BufferType::L1);
-    auto buffer_a = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto buffer_c = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buffer_b = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buffer_a = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
     uint32_t addr_a = buffer_a->address();
     uint32_t addr_b = buffer_b->address();
     uint32_t addr_c = buffer_c->address();
@@ -178,8 +178,8 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NoViolation_Control) {
     Program program = CreateProgram();
 
     uint32_t buf_size = 1024;
-    auto buffer_b = Buffer::create(device, buf_size, buf_size, BufferType::L1);
-    auto buffer_a = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto buffer_b = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buffer_a = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
 
     // Resolve both buffers, write only within bounds of each — the
     // "intended write set" covers every buffer whose bytes change.
@@ -225,8 +225,8 @@ TEST_F(MeshDeviceFixture, Object_Intent_IOArg_Exempt_NoViolation) {
     Program program = CreateProgram();
 
     uint32_t buf_size = 1024;
-    auto buffer_b = Buffer::create(device, buf_size, buf_size, BufferType::L1);
-    auto buffer_a = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto buffer_b = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buffer_a = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
     uint32_t addr_a = buffer_a->address();
     uint32_t addr_b = buffer_b->address();
     ASSERT_LT(addr_a, addr_b);
@@ -277,7 +277,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) 
     // Non-exempt L1 buffer, left untouched — makes Object Intent active (snapshots_
     // non-empty) without itself changing (so it never flags).
     uint32_t buf_size = 1024;
-    auto buffer_a = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto buffer_a = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
     (void)buffer_a;
 
     // Globally-allocated CB backing — exempt from the Object Intent snapshot.
@@ -286,7 +286,8 @@ TEST_F(MeshDeviceFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) 
     constexpr uint32_t num_pages = 2;
     // Single-bank backing (bank size == CB total_size), required for a
     // globally-allocated CB.
-    auto backing = Buffer::create(device, num_pages * page_size, num_pages * page_size, BufferType::L1);
+    auto backing =
+        Buffer::create(this->devices_.at(0).get(), num_pages * page_size, num_pages * page_size, BufferType::L1);
     CircularBufferConfig cb_config = CircularBufferConfig(num_pages * page_size, {{cb_id, tt::DataFormat::Float16_b}})
                                          .set_page_size(cb_id, page_size)
                                          .set_globally_allocated_address(*backing);
@@ -336,8 +337,8 @@ TEST_F(MeshDeviceFixture, Object_Intent_MultiKernel_Core_NoViolation) {
     Program program = CreateProgram();
 
     uint32_t buf_size = 1024;
-    auto buffer_1 = Buffer::create(device, buf_size, buf_size, BufferType::L1);
-    auto buffer_2 = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto buffer_1 = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buffer_2 = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
 
     // Two kernels on the same core (RISCV_0 + RISCV_1), each resolving and writing
     // only its own buffer within bounds.

--- a/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
@@ -29,7 +29,8 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, Object_Intent_Provenance_Violation_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -42,8 +43,8 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_Violation_SanityCheck) {
     // That arrangement matches the narrative the kernel computes below
     // (overshoot Buffer A upward to stomp Buffer B).
     uint32_t buf_size = 1024;  // 1 KB each
-    auto buffer_b = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
-    auto buffer_a = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buffer_b = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
+    auto buffer_a = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
 
     uint32_t addr_a = buffer_a->address();
     uint32_t addr_b = buffer_b->address();
@@ -112,15 +113,16 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_Violation_SanityCheck) {
 TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NonAdjacent_Violation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     // Top-down: first allocated lands highest. Order so addr_a < addr_b < addr_c.
     uint32_t buf_size = 1024;
-    auto buffer_c = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
-    auto buffer_b = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
-    auto buffer_a = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buffer_c = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
+    auto buffer_b = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
+    auto buffer_a = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
     uint32_t addr_a = buffer_a->address();
     uint32_t addr_b = buffer_b->address();
     uint32_t addr_c = buffer_c->address();
@@ -173,13 +175,14 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NonAdjacent_Violation) {
 TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NoViolation_Control) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     uint32_t buf_size = 1024;
-    auto buffer_b = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
-    auto buffer_a = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buffer_b = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
+    auto buffer_a = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
 
     // Resolve both buffers, write only within bounds of each — the
     // "intended write set" covers every buffer whose bytes change.
@@ -220,13 +223,14 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NoViolation_Control) {
 TEST_F(MeshDeviceFixture, Object_Intent_IOArg_Exempt_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     uint32_t buf_size = 1024;
-    auto buffer_b = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
-    auto buffer_a = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buffer_b = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
+    auto buffer_a = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
     uint32_t addr_a = buffer_a->address();
     uint32_t addr_b = buffer_b->address();
     ASSERT_LT(addr_a, addr_b);
@@ -277,7 +281,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) 
     // Non-exempt L1 buffer, left untouched — makes Object Intent active (snapshots_
     // non-empty) without itself changing (so it never flags).
     uint32_t buf_size = 1024;
-    auto buffer_a = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buffer_a = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
     (void)buffer_a;
 
     // Globally-allocated CB backing — exempt from the Object Intent snapshot.
@@ -286,8 +290,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) 
     constexpr uint32_t num_pages = 2;
     // Single-bank backing (bank size == CB total_size), required for a
     // globally-allocated CB.
-    auto backing =
-        Buffer::create(this->devices_.at(0).get(), num_pages * page_size, num_pages * page_size, BufferType::L1);
+    auto backing = Buffer::create(&mesh_device, num_pages * page_size, num_pages * page_size, BufferType::L1);
     CircularBufferConfig cb_config = CircularBufferConfig(num_pages * page_size, {{cb_id, tt::DataFormat::Float16_b}})
                                          .set_page_size(cb_id, page_size)
                                          .set_globally_allocated_address(*backing);
@@ -332,13 +335,14 @@ TEST_F(MeshDeviceFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) 
 TEST_F(MeshDeviceFixture, Object_Intent_MultiKernel_Core_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     uint32_t buf_size = 1024;
-    auto buffer_1 = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
-    auto buffer_2 = Buffer::create(this->devices_.at(0).get(), buf_size, buf_size, BufferType::L1);
+    auto buffer_1 = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
+    auto buffer_2 = Buffer::create(&mesh_device, buf_size, buf_size, BufferType::L1);
 
     // Two kernels on the same core (RISCV_0 + RISCV_1), each resolving and writing
     // only its own buffer within bounds.

--- a/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
@@ -335,7 +335,8 @@ TEST_F(MeshDeviceFixture, CB_Boundary_ProducedRegionReuse_NoViolation) {
 TEST_F(MeshDeviceFixture, CB_Boundary_GloballyAllocated_Exempt_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -346,8 +347,7 @@ TEST_F(MeshDeviceFixture, CB_Boundary_GloballyAllocated_Exempt_NoViolation) {
     // Backing L1 buffer makes the CB globally allocated (sharded-style addressing).
     // Single-bank (one buffer page spanning the whole CB) so its bank size equals
     // the CB total_size — a globally-allocated CB must fit inside its backing bank.
-    auto backing =
-        Buffer::create(this->devices_.at(0).get(), num_pages * page_size, num_pages * page_size, BufferType::L1);
+    auto backing = Buffer::create(&mesh_device, num_pages * page_size, num_pages * page_size, BufferType::L1);
     CircularBufferConfig cb_config = CircularBufferConfig(num_pages * page_size, {{cb_id, tt::DataFormat::Float16_b}})
                                          .set_page_size(cb_id, page_size)
                                          .set_globally_allocated_address(*backing);

--- a/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
@@ -346,7 +346,8 @@ TEST_F(MeshDeviceFixture, CB_Boundary_GloballyAllocated_Exempt_NoViolation) {
     // Backing L1 buffer makes the CB globally allocated (sharded-style addressing).
     // Single-bank (one buffer page spanning the whole CB) so its bank size equals
     // the CB total_size — a globally-allocated CB must fit inside its backing bank.
-    auto backing = Buffer::create(device, num_pages * page_size, num_pages * page_size, BufferType::L1);
+    auto backing =
+        Buffer::create(this->devices_.at(0).get(), num_pages * page_size, num_pages * page_size, BufferType::L1);
     CircularBufferConfig cb_config = CircularBufferConfig(num_pages * page_size, {{cb_id, tt::DataFormat::Float16_b}})
                                          .set_page_size(cb_id, page_size)
                                          .set_globally_allocated_address(*backing);

--- a/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
@@ -28,13 +28,14 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_L1_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     // One small L1 buffer near the top of L1 (allocator is top-down for L1).
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::L1);
+    auto buf = Buffer::create(&mesh_device, buffer_size, buffer_size, BufferType::L1);
 
     // Pick a target that sits 64 KB below the buffer's start. That lands in
     // user-allocatable L1 (above l1_unreserved_base on a fresh device with a
@@ -72,14 +73,15 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_L1_SanityCheck) {
 TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_DRAM_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     // One small DRAM buffer. DRAM allocates bottom-up from dram_unreserved_base
     // by default, so the buffer's address is close to that base.
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::DRAM);
+    auto buf = Buffer::create(&mesh_device, buffer_size, buffer_size, BufferType::DRAM);
 
     // Target a DRAM offset 1 MB above the buffer — well above the buffer's
     // end and above dram_unreserved_base, but not inside any allocated DRAM
@@ -117,12 +119,13 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_DRAM_SanityCheck) {
 TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_JustPast_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     constexpr uint32_t buffer_size = 1024;
-    auto anchor = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::L1);
+    auto anchor = Buffer::create(&mesh_device, buffer_size, buffer_size, BufferType::L1);
     constexpr uint32_t gap_distance = 64 * 1024;
     uint32_t poke_addr = static_cast<uint32_t>(anchor->address()) - gap_distance;
 
@@ -159,12 +162,13 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_JustPast_SanityCheck) {
 TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_L1_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::L1);
+    auto buf = Buffer::create(&mesh_device, buffer_size, buffer_size, BufferType::L1);
     // A word comfortably inside the buffer.
     uint32_t in_addr = static_cast<uint32_t>(buf->address()) + 64;
 
@@ -195,12 +199,13 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_L1_NoViolation) {
 TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::DRAM);
+    auto buf = Buffer::create(&mesh_device, buffer_size, buffer_size, BufferType::DRAM);
     uint32_t in_addr = static_cast<uint32_t>(buf->address()) + 64;
 
     std::string kernel_src = R"(
@@ -236,7 +241,8 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
 TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_Accept_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* device = mesh_device.get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -244,7 +250,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_Accept_NoViolation) {
     // gap: above l1_unreserved_base, inside no allocated tensor) via
     // WriteToDeviceL1 — which registers the host-poke extent when ASAN is on.
     constexpr uint32_t buffer_size = 1024;
-    auto anchor = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::L1);
+    auto anchor = Buffer::create(&mesh_device, buffer_size, buffer_size, BufferType::L1);
     constexpr uint32_t gap_distance = 64 * 1024;
     uint32_t poke_addr = static_cast<uint32_t>(anchor->address()) - gap_distance;
 

--- a/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
@@ -34,7 +34,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_L1_SanityCheck) {
 
     // One small L1 buffer near the top of L1 (allocator is top-down for L1).
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(device, buffer_size, buffer_size, BufferType::L1);
+    auto buf = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::L1);
 
     // Pick a target that sits 64 KB below the buffer's start. That lands in
     // user-allocatable L1 (above l1_unreserved_base on a fresh device with a
@@ -79,7 +79,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_DRAM_SanityCheck) {
     // One small DRAM buffer. DRAM allocates bottom-up from dram_unreserved_base
     // by default, so the buffer's address is close to that base.
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(device, buffer_size, buffer_size, BufferType::DRAM);
+    auto buf = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::DRAM);
 
     // Target a DRAM offset 1 MB above the buffer — well above the buffer's
     // end and above dram_unreserved_base, but not inside any allocated DRAM
@@ -122,7 +122,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_JustPast_SanityCheck) {
     Program program = CreateProgram();
 
     constexpr uint32_t buffer_size = 1024;
-    auto anchor = Buffer::create(device, buffer_size, buffer_size, BufferType::L1);
+    auto anchor = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::L1);
     constexpr uint32_t gap_distance = 64 * 1024;
     uint32_t poke_addr = static_cast<uint32_t>(anchor->address()) - gap_distance;
 
@@ -164,7 +164,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_L1_NoViolation) {
     Program program = CreateProgram();
 
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(device, buffer_size, buffer_size, BufferType::L1);
+    auto buf = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::L1);
     // A word comfortably inside the buffer.
     uint32_t in_addr = static_cast<uint32_t>(buf->address()) + 64;
 
@@ -200,7 +200,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
     Program program = CreateProgram();
 
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(device, buffer_size, buffer_size, BufferType::DRAM);
+    auto buf = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::DRAM);
     uint32_t in_addr = static_cast<uint32_t>(buf->address()) + 64;
 
     std::string kernel_src = R"(
@@ -244,7 +244,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_Accept_NoViolation) {
     // gap: above l1_unreserved_base, inside no allocated tensor) via
     // WriteToDeviceL1 — which registers the host-poke extent when ASAN is on.
     constexpr uint32_t buffer_size = 1024;
-    auto anchor = Buffer::create(device, buffer_size, buffer_size, BufferType::L1);
+    auto anchor = Buffer::create(this->devices_.at(0).get(), buffer_size, buffer_size, BufferType::L1);
     constexpr uint32_t gap_distance = 64 * 1024;
     uint32_t poke_addr = static_cast<uint32_t>(anchor->address()) - gap_distance;
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
@@ -265,13 +265,12 @@ TEST_F(MeshWorkloadFactorySlowDispatchHWTest, FactoryMethodsSupportSlowDispatch)
 
 TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecSupportsDfbResizeBetweenEnqueues) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
 
     // Build a workload with a producer-consumer DFB loopback.
     distributed::MeshWorkload workload = MakeMeshWorkloadFromSpec(*mesh_device, MakeLoopbackSpec());
 
     InterleavedBufferConfig dram_config{
-        .device = device, .size = kBufferBytes, .page_size = kBufferBytes, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(), .size = kBufferBytes, .page_size = kBufferBytes, .buffer_type = BufferType::DRAM};
     auto input_buffer = CreateBuffer(dram_config);
     auto output_buffer = CreateBuffer(dram_config);
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -91,7 +91,7 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     // Create DRAM buffers (single-page so all data is on one bank)
     // -------------------------------------------------------
     InterleavedBufferConfig dram_config{
-        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(), .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
     auto input_buffer = CreateBuffer(dram_config);
     auto output_buffer = CreateBuffer(dram_config);
 
@@ -228,7 +228,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     const NodeCoord node{0, 0};
 
     InterleavedBufferConfig dram_config{
-        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(), .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
     auto input_buffer = CreateBuffer(dram_config);
     auto output_buffer = CreateBuffer(dram_config);
 
@@ -422,7 +422,7 @@ TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopback) {
     const NodeCoord node{0, 0};
 
     InterleavedBufferConfig dram_config{
-        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(), .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
     auto input_buffer = CreateBuffer(dram_config);
     auto output_buffer = CreateBuffer(dram_config);
 
@@ -1018,7 +1018,7 @@ TEST_F(ProgramSpecHWTest, CrtaAllFourSectionsSetAndPartialUpdate) {
 
     // Output buffer holds one DFB entry (single page → single bank).
     InterleavedBufferConfig dram_config{
-        .device = device, .size = entry_size, .page_size = entry_size, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(), .size = entry_size, .page_size = entry_size, .buffer_type = BufferType::DRAM};
     auto output_buffer = CreateBuffer(dram_config);
 
     // Input tensor for the tensor-binding section (interleaved DRAM; only its base address is read here).
@@ -1227,7 +1227,7 @@ TEST_F(ProgramSpecHWTest, ScratchpadBaseReDeliveredAfterDfbResize) {
 
     // Output buffer holds one DFB entry (single page → single bank).
     InterleavedBufferConfig dram_config{
-        .device = device, .size = entry_size, .page_size = entry_size, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(), .size = entry_size, .page_size = entry_size, .buffer_type = BufferType::DRAM};
     auto output_buffer = CreateBuffer(dram_config);
 
     ProgramSpec spec;

--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -58,13 +58,17 @@ KernelDescriptor MakeBlankReaderKernel(CoreCoord core = {0, 0}) {
     return kd;
 }
 
-std::shared_ptr<Buffer> MakeDramBuffer(IDevice* device, uint32_t size = 2048) {
-    InterleavedBufferConfig cfg{.device = device, .size = size, .page_size = size, .buffer_type = BufferType::DRAM};
+std::shared_ptr<Buffer> MakeDramBuffer(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t size = 2048) {
+    InterleavedBufferConfig cfg{
+        .device = mesh_device.get(), .size = size, .page_size = size, .buffer_type = BufferType::DRAM};
     return CreateBuffer(cfg);
 }
 
-std::shared_ptr<Buffer> MakeL1Buffer(IDevice* device, uint32_t size = 2048) {
-    InterleavedBufferConfig cfg{.device = device, .size = size, .page_size = size, .buffer_type = BufferType::L1};
+std::shared_ptr<Buffer> MakeL1Buffer(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t size = 2048) {
+    InterleavedBufferConfig cfg{
+        .device = mesh_device.get(), .size = size, .page_size = size, .buffer_type = BufferType::L1};
     return CreateBuffer(cfg);
 }
 
@@ -174,17 +178,14 @@ TEST(DescriptorPatching, ResolvedBindings_EmptyAfterAddingCb_IsFalse) {
 // SECTION 2: Device integration tests
 // ============================================================================
 
-class DescriptorPatchingDeviceTest : public GenericMeshDeviceFixture {
-protected:
-    IDevice* device() { return get_mesh_device().get(); }
-};
+using DescriptorPatchingDeviceTest = GenericMeshDeviceFixture;
 
 // resolve_bindings correctly maps a single per-core buffer arg.
 // Layout: args = [buf_a, 42u] at core {0,0}.
 // Expected: one ResolvedRtArgBinding with kernel_idx=0, core={0,0}, arg_idx=0,
 //           tensor_buffer_idx=0, is_common=false.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_PerCoreBuffer_CorrectTuples) {
-    auto buf_a = MakeDramBuffer(device());
+    auto buf_a = MakeDramBuffer(get_mesh_device());
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_runtime_args({0, 0}, {buf_a.get(), 42u});
@@ -210,7 +211,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_PerCoreBuffer_Correc
 // resolve_bindings with a buffer at arg index 1 (non-zero position).
 // Layout: args = [99u, buf_a] at core {0,0}. arg_idx should be 1.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_BufferAtNonZeroArgIdx) {
-    auto buf_a = MakeDramBuffer(device());
+    auto buf_a = MakeDramBuffer(get_mesh_device());
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_runtime_args({0, 0}, {99u, buf_a.get()});
@@ -230,8 +231,8 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_BufferAtNonZeroArgId
 // Layout: args = [buf_a, buf_b] at core {0,0}.
 // Expected: two entries with arg_idx 0 and 1, tensor_buffer_idx 0 and 1.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_TwoBuffers_CorrectIndices) {
-    auto buf_a = MakeDramBuffer(device(), 2048);
-    auto buf_b = MakeDramBuffer(device(), 4096);
+    auto buf_a = MakeDramBuffer(get_mesh_device(), 2048);
+    auto buf_b = MakeDramBuffer(get_mesh_device(), 4096);
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_runtime_args({0, 0}, {buf_a.get(), buf_b.get()});
@@ -253,7 +254,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_TwoBuffers_CorrectIn
 // resolve_bindings for a common (non-per-core) buffer arg.
 // is_common should be true; core field is irrelevant / unused.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CommonBuffer_IsCommonTrue) {
-    auto buf_a = MakeDramBuffer(device());
+    auto buf_a = MakeDramBuffer(get_mesh_device());
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_common_runtime_args({50u, buf_a.get()});
@@ -460,8 +461,8 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_NoBufferArgs_Returns
 
 // apply_resolved_bindings patches per-core runtime args with the new buffer's address.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyResolvedBindings_PatchesPerCoreAddress) {
-    auto buf_a = MakeDramBuffer(device(), 2048);
-    auto buf_b = MakeDramBuffer(device(), 4096);
+    auto buf_a = MakeDramBuffer(get_mesh_device(), 2048);
+    auto buf_b = MakeDramBuffer(get_mesh_device(), 4096);
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_runtime_args({0, 0}, {buf_a.get(), 42u});
@@ -487,8 +488,8 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyResolvedBindings_PatchesPerCore
 
 // apply_resolved_bindings patches common runtime args with the new buffer's address.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyResolvedBindings_PatchesCommonAddress) {
-    auto buf_a = MakeDramBuffer(device(), 2048);
-    auto buf_b = MakeDramBuffer(device(), 4096);
+    auto buf_a = MakeDramBuffer(get_mesh_device(), 2048);
+    auto buf_b = MakeDramBuffer(get_mesh_device(), 4096);
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_common_runtime_args({77u, buf_a.get()});
@@ -514,9 +515,9 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyResolvedBindings_PatchesCommonA
 // apply_resolved_bindings can be called repeatedly with different buffer sets.
 // Each call should update the runtime arg to the current buffer's address.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyResolvedBindings_RepeatedApplication) {
-    auto buf_a = MakeDramBuffer(device(), 2048);
-    auto buf_b = MakeDramBuffer(device(), 4096);
-    auto buf_c = MakeDramBuffer(device(), 8192);
+    auto buf_a = MakeDramBuffer(get_mesh_device(), 2048);
+    auto buf_b = MakeDramBuffer(get_mesh_device(), 4096);
+    auto buf_c = MakeDramBuffer(get_mesh_device(), 8192);
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_runtime_args({0, 0}, {buf_a.get()});
@@ -543,8 +544,8 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyResolvedBindings_RepeatedApplic
 // to the slow path.  Before the fix, CB-only bindings made empty() return false,
 // causing the fast path to activate for factories that never opted in.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CbOnly_PopulatesCbs_RtArgsEmpty) {
-    auto buf_dram = MakeDramBuffer(device());
-    auto buf_l1 = MakeL1Buffer(device());
+    auto buf_dram = MakeDramBuffer(get_mesh_device());
+    auto buf_l1 = MakeL1Buffer(get_mesh_device());
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     // Old-style: push buffer address as plain uint32_t (no Buffer* binding).
@@ -590,7 +591,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CbOnly_PopulatesCbs_
 // The fix bails out and returns an empty ResolvedBindings, forcing the
 // adapter onto the slow path (rebuild the descriptor) for that cache hit.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_DuplicateBuffer_ReturnsEmpty) {
-    auto buf_a = MakeDramBuffer(device());
+    auto buf_a = MakeDramBuffer(get_mesh_device());
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     // Two bindings for the same Buffer*, simulating an op that takes the same
@@ -615,7 +616,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_DuplicateBuffer_Retu
 // same-buffer-by-construction alias, not the ambiguous matmul(X, X) case.  With num_input_buffers
 // marking the input/output boundary, resolve_bindings must KEEP the fast path (non-empty bindings).
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_OutputAliasesInput_KeepsFastPath) {
-    auto buf_a = MakeDramBuffer(device());
+    auto buf_a = MakeDramBuffer(get_mesh_device());
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_runtime_args({0, 0}, {buf_a.get()});
@@ -636,7 +637,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_OutputAliasesInput_K
 // #48928: a duplicate purely WITHIN the input region (two distinct input operands that coincide,
 // matmul(X, X)) must still bail even when num_input_buffers is given.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_InputRegionDuplicate_ReturnsEmpty) {
-    auto buf_a = MakeDramBuffer(device());
+    auto buf_a = MakeDramBuffer(get_mesh_device());
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_runtime_args({0, 0}, {buf_a.get(), buf_a.get()});
@@ -656,7 +657,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_InputRegionDuplicate
 // Even with the in-place opt-in ON, the output-alias skip is granted ONCE; the extra input
 // occurrence still bails, so a later same-shape op(X, Y, out=X) cache hit can't patch input-b to X.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_OutputAliasRepeatedInInputs_ReturnsEmpty) {
-    auto buf_a = MakeDramBuffer(device());
+    auto buf_a = MakeDramBuffer(get_mesh_device());
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_runtime_args({0, 0}, {buf_a.get()});
@@ -681,7 +682,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_OutputAliasRepeatedI
 //   - Default (opt-out): treated as an ambiguous input-region duplicate → BAIL to slow-path rebuild.
 //     This is the safe behavior for ops whose get_dynamic_runtime_args is incomplete.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_InplaceOutputTensorInInputs_Default_ReturnsEmpty) {
-    auto buf_a = MakeDramBuffer(device());
+    auto buf_a = MakeDramBuffer(get_mesh_device());
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_runtime_args({0, 0}, {buf_a.get()});
@@ -700,7 +701,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_InplaceOutputTensorI
 //   - Opt-in (allow_inplace_output_tensor_alias=true): the op re-applies every cache-hit-varying arg
 //     itself (binary_ng), so the output_tensor is a safe in-place alias → KEEP the fast path.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_InplaceOutputTensorInInputs_OptIn_KeepsFastPath) {
-    auto buf_a = MakeDramBuffer(device());
+    auto buf_a = MakeDramBuffer(get_mesh_device());
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_runtime_args({0, 0}, {buf_a.get()});
@@ -726,8 +727,8 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_InplaceOutputTensorI
 // path patch a changing input/output address on cache hits, so a missing
 // buffer is genuinely unrecoverable.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_RtArgBufferNotInTensorList_Throws) {
-    auto buf_a = MakeDramBuffer(device());
-    auto buf_other = MakeDramBuffer(device());
+    auto buf_a = MakeDramBuffer(get_mesh_device());
+    auto buf_other = MakeDramBuffer(get_mesh_device());
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     kd.emplace_runtime_args({0, 0}, {buf_a.get()});
@@ -749,8 +750,8 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_RtArgBufferNotInTens
 // buffers have stable addresses across dispatches, so the fast path doesn't
 // need a binding for them.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CbBufferNotInTensorList_SkipsBindingNoThrow) {
-    auto buf_l1_pegged = MakeL1Buffer(device());   // simulates GlobalCircularBuffer's backing buffer
-    auto buf_l1_in_args = MakeL1Buffer(device());  // a CB buffer that IS in tensor_args
+    auto buf_l1_pegged = MakeL1Buffer(get_mesh_device());   // simulates GlobalCircularBuffer's backing buffer
+    auto buf_l1_in_args = MakeL1Buffer(get_mesh_device());  // a CB buffer that IS in tensor_args
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
     ProgramDescriptor desc;
@@ -805,7 +806,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CbBufferNotInTensorL
 // The check was removed; this test pins that behavior so it is not silently
 // reintroduced.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_ScalarMatchingBufferAddress_DoesNotThrow) {
-    auto buf_a = MakeDramBuffer(device());
+    auto buf_a = MakeDramBuffer(get_mesh_device());
     const uint32_t collision_value = buf_a->address();
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
@@ -823,7 +824,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_ScalarMatchingBuffer
 
 // Regression: same idea for common runtime args.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CommonScalarMatchingBufferAddress_DoesNotThrow) {
-    auto buf_a = MakeDramBuffer(device());
+    auto buf_a = MakeDramBuffer(get_mesh_device());
     const uint32_t collision_value = buf_a->address();
 
     KernelDescriptor kd = MakeBlankReaderKernel({0, 0});

--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -176,7 +176,7 @@ TEST(DescriptorPatching, ResolvedBindings_EmptyAfterAddingCb_IsFalse) {
 
 class DescriptorPatchingDeviceTest : public GenericMeshDeviceFixture {
 protected:
-    IDevice* device() { return get_mesh_device()->get_devices()[0]; }
+    IDevice* device() { return get_mesh_device().get(); }
 };
 
 // resolve_bindings correctly maps a single per-core buffer arg.

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -66,7 +66,10 @@ bool reader_only(
     auto* device = mesh_device->get_devices()[0];
 
     tt::tt_metal::InterleavedBufferConfig dram_config{
-        .device = device, .size = byte_size, .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM};
+        .device = mesh_device.get(),
+        .size = byte_size,
+        .page_size = byte_size,
+        .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     auto input_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_byte_address = input_dram_buffer->address();
@@ -136,7 +139,10 @@ bool writer_only(
     auto* device = mesh_device->get_devices()[0];
 
     tt_metal::InterleavedBufferConfig dram_config{
-        .device = device, .size = byte_size, .page_size = byte_size, .buffer_type = tt_metal::BufferType::DRAM};
+        .device = mesh_device.get(),
+        .size = byte_size,
+        .page_size = byte_size,
+        .buffer_type = tt_metal::BufferType::DRAM};
 
     auto output_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_byte_address = output_dram_buffer->address();
@@ -200,7 +206,10 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
     auto* device = mesh_device->get_devices()[0];
 
     tt::tt_metal::InterleavedBufferConfig dram_config{
-        .device = device, .size = byte_size, .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM};
+        .device = mesh_device.get(),
+        .size = byte_size,
+        .page_size = byte_size,
+        .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     auto input_dram_buffer = tt_metal::CreateBuffer(dram_config);
     uint32_t input_dram_byte_address = input_dram_buffer->address();
@@ -344,9 +353,8 @@ static ReaderDatacopyWriterContext setup_reader_datacopy_writer_context(
     ReaderDatacopyWriterContext ctx;
     ctx.byte_size = test_config.num_tiles * test_config.tile_byte_size;
 
-    auto* device = mesh_device->get_devices()[0];
     tt::tt_metal::InterleavedBufferConfig dram_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = ctx.byte_size,
         .page_size = ctx.byte_size,
         .buffer_type = tt::tt_metal::BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -277,7 +277,7 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCWriteToDRAM) {
     // One page per bank: interleaved allocation gives every bank the same bank-relative
     // base address, so each DRISC DMA can write into its own bank at that address.
     auto dram_buffer = CreateBuffer(InterleavedBufferConfig{
-        .device = device_,
+        .device = mesh_device_,
         .size = num_banks * num_endpoints * total_bytes_per_core,
         .page_size = num_endpoints * total_bytes_per_core,
         .buffer_type = BufferType::DRAM,
@@ -379,7 +379,7 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCReadFromDRAM) {
     // One page per bank: interleaved allocation gives every bank the same bank-relative
     // base address, so each DRISC DMA reads from its own bank at that address.
     auto dram_buffer = CreateBuffer(InterleavedBufferConfig{
-        .device = device_,
+        .device = mesh_device_,
         .size = num_banks * num_endpoints * bytes_per_iter,
         .page_size = num_endpoints * bytes_per_iter,
         .buffer_type = BufferType::DRAM,
@@ -490,7 +490,7 @@ TEST_F(DramKernelFixture, DramKernelDRISCReadFromDRAMMcastToTensix) {
 
     // Allocate a single-page DRAM buffer. Page_size == size pins it to bank 0 (logical_core x==0)
     auto dram_buffer = CreateBuffer(InterleavedBufferConfig{
-        .device = device_,
+        .device = mesh_device_,
         .size = total_bytes,
         .page_size = total_bytes,
         .buffer_type = BufferType::DRAM,
@@ -570,7 +570,7 @@ TEST_F(DramKernelFixture, DramKernelDRISCRTensixParallelDRAMReads) {
 
     // Allocate a single-page DRAM buffer. Page_size == size pins it to bank 0 (logical_core x==0)
     auto dram_buffer = CreateBuffer(InterleavedBufferConfig{
-        .device = device_,
+        .device = mesh_device_,
         .size = total_bytes,
         .page_size = total_bytes,
         .buffer_type = BufferType::DRAM,
@@ -655,7 +655,7 @@ TEST_P(DramKernelDRISCGDDRBWSweepFixture, DRISCDMAUcastToTensix) {
 
     // Allocate a single-page DRAM buffer. Page_size == size pins it to bank 0 (logical_core x==0)
     auto dram_buffer = CreateBuffer(InterleavedBufferConfig{
-        .device = device_,
+        .device = mesh_device_,
         .size = total_bytes,
         .page_size = total_bytes,
         .buffer_type = BufferType::DRAM,
@@ -768,7 +768,7 @@ TEST_P(DramKernelDRISCNocModeFixture, DramKernelDRISCNocModeStress) {
     // Fill GDDR with iters random distinct chunks. DRISC and the Tensix reader both walk the same region
     // Only the final chunk remains in L1 after the run, so verification compares against it
     auto dram_buffer = CreateBuffer(InterleavedBufferConfig{
-        .device = device_,
+        .device = mesh_device_,
         .size = total_bytes,
         .page_size = total_bytes,  // single bank (bank 0)
         .buffer_type = BufferType::DRAM,

--- a/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
@@ -90,14 +90,14 @@ std::pair<std::shared_ptr<Buffer>, std::vector<uint32_t>> l1_buffer_write_wait(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const L1Config<T>& test_config) {
     auto* device = mesh_device->get_devices()[0];
     auto buffer = test_config.sharded ? CreateBuffer(tt::tt_metal::ShardedBufferConfig{
-                                            .device = device,
+                                            .device = mesh_device.get(),
                                             .size = test_config.size_bytes,
                                             .page_size = test_config.page_size_bytes,
                                             .buffer_type = test_config.buffer_type,
                                             .buffer_layout = test_config.buffer_layout,
                                             .shard_parameters = test_config.shard_spec()})
                                       : CreateBuffer(tt::tt_metal::BufferConfig{
-                                            .device = device,
+                                            .device = mesh_device.get(),
                                             .size = test_config.size_bytes,
                                             .page_size = test_config.page_size_bytes,
                                             .buffer_type = test_config.buffer_type});
@@ -150,9 +150,8 @@ bool l1_buffer_read_write(const std::shared_ptr<distributed::MeshDevice>& mesh_d
 template <typename T>
 std::shared_ptr<Buffer> make_height_sharded_l1_buffer(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const L1Config<T>& test_config) {
-    auto* device = mesh_device->get_devices()[0];
     return CreateBuffer(tt::tt_metal::ShardedBufferConfig{
-        .device = device,
+        .device = mesh_device.get(),
         .size = test_config.size_bytes,
         .page_size = test_config.page_size_bytes,
         .buffer_type = test_config.buffer_type,
@@ -340,7 +339,7 @@ TEST_F(MeshDeviceFixture, TestUnorderedHeightShardReadWrite) {
         uint32_t page_size = tt::constants::TILE_HW * sizeof(uint32_t);
         uint32_t total_size = cores.size() * page_size;
         auto buffer = CreateBuffer(tt::tt_metal::ShardedBufferConfig{
-            .device = device,
+            .device = mesh_device.get(),
             .size = total_size,
             .page_size = page_size,
             .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,

--- a/tests/tt_metal/tt_metal/api/test_tensor_accessor_default_page_size.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tensor_accessor_default_page_size.cpp
@@ -187,13 +187,13 @@ void verify_runtime_page_size(
 }
 
 std::shared_ptr<Buffer> create_interleaved_buffer(
-    IDevice* device, uint32_t page_size, uint32_t num_pages, BufferType buffer_type) {
+    distributed::MeshDevice* mesh_device, uint32_t page_size, uint32_t num_pages, BufferType buffer_type) {
     return CreateBuffer(InterleavedBufferConfig{
-        .device = device, .size = num_pages * page_size, .page_size = page_size, .buffer_type = buffer_type});
+        .device = mesh_device, .size = num_pages * page_size, .page_size = page_size, .buffer_type = buffer_type});
 }
 
 std::shared_ptr<Buffer> create_legacy_sharded_buffer(
-    IDevice* device,
+    distributed::MeshDevice* mesh_device,
     uint32_t page_size,
     uint32_t num_pages,
     BufferType buffer_type,
@@ -205,7 +205,7 @@ std::shared_ptr<Buffer> create_legacy_sharded_buffer(
         shard_grid, shard_shape, ShardOrientation::ROW_MAJOR, page_shape, tensor2d_shape_in_pages);
 
     return CreateBuffer(tt_metal::ShardedBufferConfig{
-        .device = device,
+        .device = mesh_device,
         .size = num_pages * page_size,
         .page_size = page_size,
         .buffer_type = buffer_type,
@@ -252,32 +252,28 @@ namespace tt::tt_metal {
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedDramRowMajor) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        auto buffer = create_interleaved_buffer(device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::DRAM);
+        auto buffer = create_interleaved_buffer(mesh_device.get(), RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::DRAM);
         verify_default_page_size(mesh_device, buffer.get());
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedDramTilized) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        auto buffer = create_interleaved_buffer(device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::DRAM);
+        auto buffer = create_interleaved_buffer(mesh_device.get(), TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::DRAM);
         verify_default_page_size(mesh_device, buffer.get());
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedL1RowMajor) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        auto buffer = create_interleaved_buffer(device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::L1);
+        auto buffer = create_interleaved_buffer(mesh_device.get(), RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::L1);
         verify_default_page_size(mesh_device, buffer.get());
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedL1Tilized) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        auto buffer = create_interleaved_buffer(device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::L1);
+        auto buffer = create_interleaved_buffer(mesh_device.get(), TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::L1);
         verify_default_page_size(mesh_device, buffer.get());
     }
 }
@@ -286,10 +282,9 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedL1Tili
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorRuntimePageSizeInterleavedDram) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
         // Input is a real interleaved row-major DRAM buffer; its address is passed to the kernel but
         // its page size is NOT -- the accessor must read the page size from the runtime sentinel.
-        auto input = create_interleaved_buffer(device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::DRAM);
+        auto input = create_interleaved_buffer(mesh_device.get(), RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::DRAM);
         verify_runtime_page_size(mesh_device, input.get(), RUNTIME_PAGE_SIZE_SENTINEL);
     }
 }
@@ -298,9 +293,8 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorRuntimePageSizeInterleavedDram) 
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedDramRowMajor) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
         auto buffer = create_legacy_sharded_buffer(
-            device,
+            mesh_device.get(),
             RM_PAGE_SIZE,
             RM_NUM_PAGES,
             BufferType::DRAM,
@@ -313,18 +307,22 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedDram
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedDramTilized) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
         auto buffer = create_legacy_sharded_buffer(
-            device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::DRAM, {TILE_H, TILE_W}, {TILE_H, TILE_W}, {1, 1});
+            mesh_device.get(),
+            TILE_PAGE_SIZE,
+            TILE_NUM_PAGES,
+            BufferType::DRAM,
+            {TILE_H, TILE_W},
+            {TILE_H, TILE_W},
+            {1, 1});
         verify_default_page_size(mesh_device, buffer.get());
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedL1RowMajor) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
         auto buffer = create_legacy_sharded_buffer(
-            device,
+            mesh_device.get(),
             RM_PAGE_SIZE,
             RM_NUM_PAGES,
             BufferType::L1,
@@ -337,9 +335,14 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedL1Ro
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedL1Tilized) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
         auto buffer = create_legacy_sharded_buffer(
-            device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::L1, {TILE_H, TILE_W}, {TILE_H, TILE_W}, {1, 1});
+            mesh_device.get(),
+            TILE_PAGE_SIZE,
+            TILE_NUM_PAGES,
+            BufferType::L1,
+            {TILE_H, TILE_W},
+            {TILE_H, TILE_W},
+            {1, 1});
         verify_default_page_size(mesh_device, buffer.get());
     }
 }

--- a/tests/tt_metal/tt_metal/api/test_tensor_accessor_default_page_size.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tensor_accessor_default_page_size.cpp
@@ -69,7 +69,6 @@ constexpr uint32_t TILE_NUM_PAGES = 1;
 constexpr uint32_t TILE_TOTAL_SIZE = TILE_NUM_PAGES * TILE_PAGE_SIZE;
 
 void verify_default_page_size(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const Buffer* input_buffer) {
-    auto* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
 
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -80,7 +79,10 @@ void verify_default_page_size(const std::shared_ptr<distributed::MeshDevice>& me
     auto& prog = workload.get_programs().at(device_range);
 
     auto output_buffer = CreateBuffer(InterleavedBufferConfig{
-        .device = device, .size = OUTPUT_PAGE_SIZE, .page_size = OUTPUT_PAGE_SIZE, .buffer_type = BufferType::DRAM});
+        .device = mesh_device.get(),
+        .size = OUTPUT_PAGE_SIZE,
+        .page_size = OUTPUT_PAGE_SIZE,
+        .buffer_type = BufferType::DRAM});
 
     CircularBufferConfig cb_config =
         CircularBufferConfig(OUTPUT_PAGE_SIZE, {{0, tt::DataFormat::RawUInt32}}).set_page_size(0, OUTPUT_PAGE_SIZE);
@@ -122,7 +124,6 @@ void verify_runtime_page_size(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const Buffer* input_buffer,
     uint32_t sentinel_page_size) {
-    auto* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
 
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -133,7 +134,10 @@ void verify_runtime_page_size(
     auto& prog = workload.get_programs().at(device_range);
 
     auto output_buffer = CreateBuffer(InterleavedBufferConfig{
-        .device = device, .size = OUTPUT_PAGE_SIZE, .page_size = OUTPUT_PAGE_SIZE, .buffer_type = BufferType::DRAM});
+        .device = mesh_device.get(),
+        .size = OUTPUT_PAGE_SIZE,
+        .page_size = OUTPUT_PAGE_SIZE,
+        .buffer_type = BufferType::DRAM});
 
     CircularBufferConfig cb_config =
         CircularBufferConfig(OUTPUT_PAGE_SIZE, {{0, tt::DataFormat::RawUInt32}}).set_page_size(0, OUTPUT_PAGE_SIZE);

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
@@ -47,7 +47,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Interl
     const size_t total_size_bytes = test_config.num_pages * test_config.page_size_bytes;
 
     InterleavedBufferConfig interleaved_buffer_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = total_size_bytes,
         .page_size = test_config.page_size_bytes,
         .buffer_type = test_config.is_dram ? BufferType::DRAM : BufferType::L1};

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -55,7 +55,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
     const size_t total_buffer_size_bytes = num_cores * per_core_size_bytes;
 
     InterleavedBufferConfig interleaved_buffer_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = total_buffer_size_bytes,
         .page_size = test_config.page_size_bytes,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -634,7 +634,7 @@ static bool run_dram_accessor(
     uint32_t num_pages = num_dram_banks;
 
     InterleavedBufferConfig buf_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = (size_t)num_pages * bytes_per_txn,
         .page_size = (uint32_t)bytes_per_txn,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -50,7 +50,7 @@ void RunTest(
 
     // Allocate L1 buffer for sync flag
     tt_metal::InterleavedBufferConfig sync_buffer_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = sizeof(uint32_t),
         .page_size = sizeof(uint32_t),
         .buffer_type = tt_metal::BufferType::L1};

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -234,12 +234,13 @@ void WriteToUnitMeshBuffer(
     const std::vector<uint32_t>& src,
     const std::shared_ptr<distributed::MeshBuffer>& buf,
     const std::optional<BufferShardingArgs>& sharding_args) {
-    auto* device = mesh_device->get_devices()[0];
     std::shared_ptr<Buffer> slow_dispatch_buffer;
     if (sharding_args.has_value()) {
-        slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype, sharding_args.value());
+        slow_dispatch_buffer = Buffer::create(
+            mesh_device.get(), buf->address(), buf->size(), config.page_size, config.buftype, sharding_args.value());
     } else {
-        slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype);
+        slow_dispatch_buffer =
+            Buffer::create(mesh_device.get(), buf->address(), buf->size(), config.page_size, config.buftype);
     }
     detail::WriteToBuffer(*slow_dispatch_buffer, src);
 }
@@ -250,12 +251,13 @@ void ReadFromUnitMeshBuffer(
     std::vector<uint32_t>& dst,
     const std::shared_ptr<distributed::MeshBuffer>& buf,
     const std::optional<BufferShardingArgs>& sharding_args) {
-    auto* device = mesh_device->get_devices()[0];
     std::shared_ptr<Buffer> slow_dispatch_buffer;
     if (sharding_args.has_value()) {
-        slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype, sharding_args.value());
+        slow_dispatch_buffer = Buffer::create(
+            mesh_device.get(), buf->address(), buf->size(), config.page_size, config.buftype, sharding_args.value());
     } else {
-        slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype);
+        slow_dispatch_buffer =
+            Buffer::create(mesh_device.get(), buf->address(), buf->size(), config.page_size, config.buftype);
     }
     detail::ReadFromBuffer(*slow_dispatch_buffer, dst);
 }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
@@ -52,7 +52,10 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
     const uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(),
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = BufferType::DRAM};
 
     auto src_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();
@@ -119,7 +122,6 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
 
 TEST_F(MeshDispatchFixture, DataflowDfb) {
     auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -141,7 +143,10 @@ TEST_F(MeshDispatchFixture, DataflowDfb) {
     const uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(),
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = BufferType::DRAM};
 
     auto src_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -415,14 +415,11 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
 
         auto& program = programs[device->get_devices()[0]->id()];
 
-        auto input_buffer = CreateBuffer(
-            tt_metal::InterleavedBufferConfig{device->get_devices()[0], cfg.size_bytes, cfg.page_size_bytes, cfg.input_buffer_type});
+        auto input_buffer = CreateBuffer(tt_metal::InterleavedBufferConfig{
+            device.get(), cfg.size_bytes, cfg.page_size_bytes, cfg.input_buffer_type});
         tt_metal::detail::WriteToBuffer(input_buffer, inputs[i]);
         output_buffers.emplace_back(CreateBuffer(tt_metal::InterleavedBufferConfig{
-            device->get_devices()[0],
-            cfg.size_bytes * sender_receivers.size(),
-            cfg.page_size_bytes,
-            cfg.output_buffer_type}));
+            device.get(), cfg.size_bytes * sender_receivers.size(), cfg.page_size_bytes, cfg.output_buffer_type}));
         tt_metal::detail::WriteToBuffer(output_buffers[i], all_zeros);
 
         auto eth_sender_kernel = tt_metal::CreateKernel(

--- a/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
@@ -87,7 +87,6 @@ void run_single_core_cumsum(
     Program program = tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
 
     CoreCoord core = {0, 0};
 
@@ -101,7 +100,7 @@ void run_single_core_cumsum(
     uint32_t dram_buffer_size = single_tile_size * test_config.N * test_config.Wt * test_config.Ht;
 
     tt_metal::InterleavedBufferConfig dram_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = dram_buffer_size,
         .page_size = dram_buffer_size,
         .buffer_type = tt_metal::BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
@@ -115,7 +115,6 @@ bool test_dropout_standalone(
         Program program = CreateProgram();
         workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
-        auto* const device = mesh_device->get_devices()[0];
 
         constexpr CoreCoord core = {0, 0};
         constexpr uint32_t single_tile_size = 2 * 1024;
@@ -123,7 +122,7 @@ bool test_dropout_standalone(
         constexpr uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
         tt_metal::InterleavedBufferConfig dram_config{
-            .device = device,
+            .device = mesh_device.get(),
             .size = dram_buffer_size,
             .page_size = dram_buffer_size,
             .buffer_type = tt_metal::BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -39,7 +39,6 @@ static vector<uint32_t> run_fp8_typecast(
     const vector<uint32_t>& src_vec,
     uint32_t num_tiles,
     bool fp32_dest_acc_en) {
-    IDevice* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
     CoreCoord core = {0, 0};
 
@@ -47,14 +46,14 @@ static vector<uint32_t> run_fp8_typecast(
     uint32_t output_tile_size = tt::tile_size(output_fmt);
 
     InterleavedBufferConfig src_config{
-        .device = dev,
+        .device = &mesh_device,
         .size = num_tiles * input_tile_size,
         .page_size = num_tiles * input_tile_size,
         .buffer_type = BufferType::DRAM};
     auto src_buffer = CreateBuffer(src_config);
 
     InterleavedBufferConfig dst_config{
-        .device = dev,
+        .device = &mesh_device,
         .size = num_tiles * output_tile_size,
         .page_size = num_tiles * output_tile_size,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
@@ -50,7 +50,6 @@ struct MulReduceScalarConfig {
 };
 
 bool run_mul_reduce_scalar_test(distributed::MeshDevice& mesh_device, const MulReduceScalarConfig& config) {
-    IDevice* device = mesh_device.get_devices()[0];
     tt_metal::Program program = tt_metal::CreateProgram();
     CoreCoord core = {0, 0};
 
@@ -61,7 +60,7 @@ bool run_mul_reduce_scalar_test(distributed::MeshDevice& mesh_device, const MulR
 
     uint32_t input_buffer_size = config.num_tiles * tile_byte_size;
     tt_metal::InterleavedBufferConfig dram_config = {
-        .device = device,
+        .device = &mesh_device,
         .size = input_buffer_size,
         .page_size = tile_byte_size,
         .buffer_type = tt_metal::BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -58,14 +58,14 @@ static vector<uint32_t> run_mxfp4_typecast(
     uint32_t output_tile_size = tt::tile_size(output_fmt);
 
     InterleavedBufferConfig src_config{
-        .device = dev,
+        .device = &mesh_device,
         .size = num_tiles * input_tile_size,
         .page_size = input_tile_size,
         .buffer_type = BufferType::DRAM};
     auto src_buffer = CreateBuffer(src_config);
 
     InterleavedBufferConfig dst_config{
-        .device = dev,
+        .device = &mesh_device,
         .size = num_tiles * output_tile_size,
         .page_size = output_tile_size,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
@@ -59,14 +59,14 @@ static vector<uint32_t> run_mxfp6_typecast(
     uint32_t output_tile_size = tt::tile_size(output_fmt);
 
     InterleavedBufferConfig src_config{
-        .device = dev,
+        .device = &mesh_device,
         .size = num_tiles * input_tile_size,
         .page_size = input_tile_size,
         .buffer_type = BufferType::DRAM};
     auto src_buffer = CreateBuffer(src_config);
 
     InterleavedBufferConfig dst_config{
-        .device = dev,
+        .device = &mesh_device,
         .size = num_tiles * output_tile_size,
         .page_size = output_tile_size,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
@@ -58,14 +58,14 @@ static vector<uint32_t> run_mxfp8_typecast(
     uint32_t output_tile_size = tt::tile_size(output_fmt);
 
     InterleavedBufferConfig src_config{
-        .device = dev,
+        .device = &mesh_device,
         .size = num_tiles * input_tile_size,
         .page_size = input_tile_size,
         .buffer_type = BufferType::DRAM};
     auto src_buffer = CreateBuffer(src_config);
 
     InterleavedBufferConfig dst_config{
-        .device = dev,
+        .device = &mesh_device,
         .size = num_tiles * output_tile_size,
         .page_size = output_tile_size,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
@@ -52,14 +52,14 @@ static vector<uint32_t> run_mxint_typecast(
     uint32_t output_tile_size = tt::tile_size(output_fmt);
 
     InterleavedBufferConfig src_config{
-        .device = dev,
+        .device = &mesh_device,
         .size = num_tiles * input_tile_size,
         .page_size = num_tiles * input_tile_size,
         .buffer_type = BufferType::DRAM};
     auto src_buffer = CreateBuffer(src_config);
 
     InterleavedBufferConfig dst_config{
-        .device = dev,
+        .device = &mesh_device,
         .size = num_tiles * output_tile_size,
         .page_size = num_tiles * output_tile_size,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
@@ -56,7 +56,6 @@ void run_single_core_pack_rows_program(
     Program program = tt::tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
 
     CoreCoord core = {0, 0};
 
@@ -66,13 +65,16 @@ void run_single_core_pack_rows_program(
     uint32_t output_size = test_config.num_rows * 16 * 2;
 
     tt_metal::InterleavedBufferConfig input_dram_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = input_single_tile_size,
         .page_size = input_single_tile_size,
         .buffer_type = tt_metal::BufferType::DRAM};
 
     tt_metal::InterleavedBufferConfig output_dram_config{
-        .device = device, .size = output_size, .page_size = output_size, .buffer_type = tt_metal::BufferType::DRAM};
+        .device = mesh_device.get(),
+        .size = output_size,
+        .page_size = output_size,
+        .buffer_type = tt_metal::BufferType::DRAM};
 
     std::shared_ptr<tt_metal::Buffer> src0_dram_buffer = CreateBuffer(input_dram_config);
     uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -116,22 +116,21 @@ bool single_core_reconfig(
     tt_metal::Program program = tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
 
     tt::tt_metal::InterleavedBufferConfig dram_config_bfp16b{
-        .device = device,
+        .device = mesh_device.get(),
         .size = dram_buffer_size_bfp16b,
         .page_size = dram_buffer_size_bfp16b,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt::tt_metal::InterleavedBufferConfig dram_config_bfp8b{
-        .device = device,
+        .device = mesh_device.get(),
         .size = dram_buffer_size_bfp8b,
         .page_size = dram_buffer_size_bfp8b,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt::tt_metal::InterleavedBufferConfig dram_config_out0{
-        .device = device,
+        .device = mesh_device.get(),
         .size = dram_buffer_size_out0,
         .page_size = dram_buffer_size_out0,
         .buffer_type = tt::tt_metal::BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -681,12 +681,12 @@ std::vector<uint32_t> run_sfpu_pipeline(
     const size_t out_bytes = test_config.num_tiles * tt::tile_size(test_config.l1_output_data_format);
 
     tt::tt_metal::InterleavedBufferConfig in_dram{
-        .device = mesh_device->get_devices()[0],
+        .device = mesh_device.get(),
         .size = in_bytes,
         .page_size = in_bytes,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
     tt::tt_metal::InterleavedBufferConfig out_dram{
-        .device = mesh_device->get_devices()[0],
+        .device = mesh_device.get(),
         .size = out_bytes,
         .page_size = out_bytes,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
@@ -993,17 +993,16 @@ std::vector<uint32_t> sfpu_quasar_run(
 /// @return
 bool run_sfpu_binary_two_input_buffer(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const SfpuConfig& test_config) {
-    auto* device = mesh_device->get_devices()[0];
     const size_t per_buffer_byte_size_input = test_config.num_tiles * tt::tile_size(test_config.l1_input_data_format);
     const size_t per_buffer_byte_size_output = test_config.num_tiles * tt::tile_size(test_config.l1_output_data_format);
 
     tt::tt_metal::InterleavedBufferConfig dram_config_input{
-        .device = device,
+        .device = mesh_device.get(),
         .size = per_buffer_byte_size_input,
         .page_size = per_buffer_byte_size_input,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
     tt::tt_metal::InterleavedBufferConfig dram_config_output{
-        .device = device,
+        .device = mesh_device.get(),
         .size = per_buffer_byte_size_output,
         .page_size = per_buffer_byte_size_output,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
@@ -1180,7 +1179,7 @@ bool run_sfpu_ternary_three_input_buffer(
     auto* device = mesh_device->get_devices()[0];
 
     tt::tt_metal::InterleavedBufferConfig dram_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = per_buffer_byte_size,
         .page_size = per_buffer_byte_size,
         .buffer_type = tt::tt_metal::BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -364,7 +364,6 @@ bool single_tile_matmul(
     const uint32_t in1_tile_size = tt::tile_size(in1_fmt);
     const uint32_t out_tile_size = tt::tile_size(out_fmt);
 
-    auto* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -373,17 +372,17 @@ bool single_tile_matmul(
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
     tt::tt_metal::InterleavedBufferConfig dram_in0_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = in0_tile_size,
         .page_size = in0_tile_size,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
     tt::tt_metal::InterleavedBufferConfig dram_in1_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = in1_tile_size,
         .page_size = in1_tile_size,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
     tt::tt_metal::InterleavedBufferConfig dram_out_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = out_tile_size,
         .page_size = out_tile_size,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
@@ -525,20 +524,19 @@ bool single_block_matmul(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
-    auto* device = mesh_device->get_devices()[0];
 
     tt::tt_metal::InterleavedBufferConfig dram_config_0{
-        .device = device,
+        .device = mesh_device.get(),
         .size = in0_byte_size,
         .page_size = in0_byte_size,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
     tt::tt_metal::InterleavedBufferConfig dram_config_1{
-        .device = device,
+        .device = mesh_device.get(),
         .size = in1_byte_size,
         .page_size = in1_byte_size,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
     tt::tt_metal::InterleavedBufferConfig dram_config_out{
-        .device = device,
+        .device = mesh_device.get(),
         .size = out_byte_size,
         .page_size = out_byte_size,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
@@ -691,22 +689,21 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
-    auto* device = mesh_device->get_devices()[0];
 
     tt::tt_metal::InterleavedBufferConfig dram_config_0{
-        .device = device,
+        .device = mesh_device.get(),
         .size = in0_total_size_bytes,
         .page_size = in0_total_size_bytes,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt::tt_metal::InterleavedBufferConfig dram_config_1{
-        .device = device,
+        .device = mesh_device.get(),
         .size = in1_total_size_bytes,
         .page_size = in1_total_size_bytes,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt::tt_metal::InterleavedBufferConfig dram_config_out{
-        .device = device,
+        .device = mesh_device.get(),
         .size = out_byte_size,
         .page_size = out_byte_size,
         .buffer_type = tt::tt_metal::BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/llk/test_top32_rm_dev.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_top32_rm_dev.cpp
@@ -164,7 +164,6 @@ bool verify_top32_outputs(
 
 bool run_top32_rm_dev(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t row_elements, uint32_t seed) {
-    auto* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -183,13 +182,13 @@ bool run_top32_rm_dev(
     const uint32_t out1_bytes = kOutputTiles * tile_u32;
 
     InterleavedBufferConfig dram_in0{
-        .device = device, .size = in0_bytes, .page_size = in0_bytes, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(), .size = in0_bytes, .page_size = in0_bytes, .buffer_type = BufferType::DRAM};
     InterleavedBufferConfig dram_in1{
-        .device = device, .size = in1_bytes, .page_size = in1_bytes, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(), .size = in1_bytes, .page_size = in1_bytes, .buffer_type = BufferType::DRAM};
     InterleavedBufferConfig dram_out0{
-        .device = device, .size = out0_bytes, .page_size = out0_bytes, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(), .size = out0_bytes, .page_size = out0_bytes, .buffer_type = BufferType::DRAM};
     InterleavedBufferConfig dram_out1{
-        .device = device, .size = out1_bytes, .page_size = out1_bytes, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(), .size = out1_bytes, .page_size = out1_bytes, .buffer_type = BufferType::DRAM};
 
     auto buf_in0 = CreateBuffer(dram_in0);
     auto buf_in1 = CreateBuffer(dram_in1);

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -206,7 +206,6 @@ static void validate_result(
 void run_single_core_tilize_program(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const TestConfig& test_config) {
     auto& cq = mesh_device->mesh_command_queue();
-    auto* dev = mesh_device->get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const std::uint32_t num_tiles = test_config.num_tiles_r * test_config.num_tiles_c;
@@ -214,12 +213,12 @@ void run_single_core_tilize_program(
     const std::uint32_t output_dram_buffer_size = test_config.output_single_tile_size * num_tiles;
 
     tt_metal::InterleavedBufferConfig input_dram_config{
-        .device = dev,
+        .device = mesh_device.get(),
         .size = input_dram_buffer_size,
         .page_size = input_dram_buffer_size,
         .buffer_type = tt_metal::BufferType::DRAM};
     tt_metal::InterleavedBufferConfig output_dram_config{
-        .device = dev,
+        .device = mesh_device.get(),
         .size = output_dram_buffer_size,
         .page_size = output_dram_buffer_size,
         .buffer_type = tt_metal::BufferType::DRAM};
@@ -455,7 +454,6 @@ void run_single_core_unpack_tilizeA_B_program(
     Program program = tt::tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
 
     CoreCoord core = {0, 0};
 
@@ -464,12 +462,12 @@ void run_single_core_unpack_tilizeA_B_program(
     std::uint32_t output_dram_buffer_size = test_config.output_single_tile_size * num_tiles;
 
     tt_metal::InterleavedBufferConfig input_dram_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = input_dram_buffer_size,
         .page_size = input_dram_buffer_size,
         .buffer_type = tt_metal::BufferType::DRAM};
     tt_metal::InterleavedBufferConfig output_dram_config{
-        .device = device,
+        .device = mesh_device.get(),
         .size = output_dram_buffer_size,
         .page_size = output_dram_buffer_size,
         .buffer_type = tt_metal::BufferType::DRAM};
@@ -958,7 +956,6 @@ static void run_quasar_tilize_untilize_test(
     std::uint32_t face_r_dim = tt::constants::FACE_HEIGHT) {
     bool is_tilize = (mode == QuasarTestMode::TILIZE);
 
-    IDevice* dev = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
@@ -977,12 +974,12 @@ static void run_quasar_tilize_untilize_test(
     std::uint32_t dst_dram_buffer_size = output_single_tile_size * num_tiles;
 
     InterleavedBufferConfig src_config{
-        .device = dev,
+        .device = mesh_device.get(),
         .size = src_dram_buffer_size,
         .page_size = src_dram_buffer_size,
         .buffer_type = BufferType::DRAM};
     InterleavedBufferConfig dst_config{
-        .device = dev,
+        .device = mesh_device.get(),
         .size = dst_dram_buffer_size,
         .page_size = dst_dram_buffer_size,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -65,7 +65,7 @@ const char* op_id_to_llkop_define[] = {
 const char* bdim_to_llkdim_define[] = {"", "BroadcastType::ROW", "BroadcastType::COL", "", "BroadcastType::SCALAR"};
 const char* op_id_to_op_name[] = {"ADD", "SUB", "MUL"};
 
-void run_bcast_test(IDevice* dev, BcastDim::Enum bcast_dim, BcastOp::Enum bcast_op) {
+void run_bcast_test(distributed::MeshDevice* dev, BcastDim::Enum bcast_dim, BcastOp::Enum bcast_op) {
     bool multibank = true;
 
     log_info(LogTest, "=============================================================");

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -285,32 +285,14 @@ void run_bcast_test(IDevice* dev, BcastDim::Enum bcast_dim, BcastOp::Enum bcast_
 
 }  // namespace
 
-TEST_F(MeshDeviceSingleCardFixture, BcastHAdd) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::H, BcastOp::ADD);
-}
-TEST_F(MeshDeviceSingleCardFixture, BcastHSub) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::H, BcastOp::SUB);
-}
-TEST_F(MeshDeviceSingleCardFixture, BcastHMul) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::H, BcastOp::MUL);
-}
+TEST_F(MeshDeviceSingleCardFixture, BcastHAdd) { run_bcast_test(devices_[0].get(), BcastDim::H, BcastOp::ADD); }
+TEST_F(MeshDeviceSingleCardFixture, BcastHSub) { run_bcast_test(devices_[0].get(), BcastDim::H, BcastOp::SUB); }
+TEST_F(MeshDeviceSingleCardFixture, BcastHMul) { run_bcast_test(devices_[0].get(), BcastDim::H, BcastOp::MUL); }
 
-TEST_F(MeshDeviceSingleCardFixture, BcastWAdd) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::W, BcastOp::ADD);
-}
-TEST_F(MeshDeviceSingleCardFixture, BcastWSub) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::W, BcastOp::SUB);
-}
-TEST_F(MeshDeviceSingleCardFixture, BcastWMul) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::W, BcastOp::MUL);
-}
+TEST_F(MeshDeviceSingleCardFixture, BcastWAdd) { run_bcast_test(devices_[0].get(), BcastDim::W, BcastOp::ADD); }
+TEST_F(MeshDeviceSingleCardFixture, BcastWSub) { run_bcast_test(devices_[0].get(), BcastDim::W, BcastOp::SUB); }
+TEST_F(MeshDeviceSingleCardFixture, BcastWMul) { run_bcast_test(devices_[0].get(), BcastDim::W, BcastOp::MUL); }
 
-TEST_F(MeshDeviceSingleCardFixture, BcastHWAdd) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::HW, BcastOp::ADD);
-}
-TEST_F(MeshDeviceSingleCardFixture, BcastHWSub) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::HW, BcastOp::SUB);
-}
-TEST_F(MeshDeviceSingleCardFixture, BcastHWMul) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::HW, BcastOp::MUL);
-}
+TEST_F(MeshDeviceSingleCardFixture, BcastHWAdd) { run_bcast_test(devices_[0].get(), BcastDim::HW, BcastOp::ADD); }
+TEST_F(MeshDeviceSingleCardFixture, BcastHWSub) { run_bcast_test(devices_[0].get(), BcastDim::HW, BcastOp::SUB); }
+TEST_F(MeshDeviceSingleCardFixture, BcastHWMul) { run_bcast_test(devices_[0].get(), BcastDim::HW, BcastOp::MUL); }

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -103,7 +103,7 @@ TEST_F(MeshDeviceSingleCardFixture, CoreRangeSet) {
     uint32_t buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = dev, .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::DRAM};
+        .device = devices_[0].get(), .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::DRAM};
 
     auto src_dram_buffer = CreateBuffer(dram_config);
 
@@ -115,7 +115,10 @@ TEST_F(MeshDeviceSingleCardFixture, CoreRangeSet) {
             for (auto y = start.y; y <= end.y; y++) {
                 CoreCoord logical_core(x, y);
                 InterleavedBufferConfig l1_config{
-                    .device = dev, .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::L1};
+                    .device = devices_[0].get(),
+                    .size = buffer_size,
+                    .page_size = buffer_size,
+                    .buffer_type = BufferType::L1};
                 auto dst_l1_buffer = CreateBuffer(l1_config);
                 core_to_l1_buffer.emplace(logical_core, dst_l1_buffer);
             }

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -91,7 +91,8 @@ void check_semaphores_are_initialized(
 }  // namespace
 
 TEST_F(MeshDeviceSingleCardFixture, CoreRangeSet) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    IDevice* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
 
     CoreRange core_range_one({0, 0}, {1, 1});
@@ -103,7 +104,7 @@ TEST_F(MeshDeviceSingleCardFixture, CoreRangeSet) {
     uint32_t buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = devices_[0].get(), .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::DRAM};
+        .device = &mesh_device, .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::DRAM};
 
     auto src_dram_buffer = CreateBuffer(dram_config);
 
@@ -115,7 +116,7 @@ TEST_F(MeshDeviceSingleCardFixture, CoreRangeSet) {
             for (auto y = start.y; y <= end.y; y++) {
                 CoreCoord logical_core(x, y);
                 InterleavedBufferConfig l1_config{
-                    .device = devices_[0].get(),
+                    .device = &mesh_device,
                     .size = buffer_size,
                     .page_size = buffer_size,
                     .buffer_type = BufferType::L1};

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -18,7 +18,8 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, Datacopy) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -28,7 +29,7 @@ TEST_F(MeshDeviceSingleCardFixture, Datacopy) {
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = devices_[0].get(),
+        .device = &mesh_device,
         .size = dram_buffer_size,
         .page_size = dram_buffer_size,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -28,7 +28,10 @@ TEST_F(MeshDeviceSingleCardFixture, Datacopy) {
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+        .device = devices_[0].get(),
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = BufferType::DRAM};
     auto src_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();
     auto dst_dram_buffer = CreateBuffer(dram_config);

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -20,7 +20,8 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, DatacopyBfp8b) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -31,7 +32,7 @@ TEST_F(MeshDeviceSingleCardFixture, DatacopyBfp8b) {
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = devices_[0].get(),
+        .device = &mesh_device,
         .size = dram_buffer_size,
         .page_size = dram_buffer_size,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -31,7 +31,10 @@ TEST_F(MeshDeviceSingleCardFixture, DatacopyBfp8b) {
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+        .device = devices_[0].get(),
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = BufferType::DRAM};
     auto src_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();
     auto dst_dram_buffer = CreateBuffer(dram_config);

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -21,7 +21,8 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, DatacopyOutputInL1) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -31,10 +32,10 @@ TEST_F(MeshDeviceSingleCardFixture, DatacopyOutputInL1) {
     uint32_t buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = devices_[0].get(), .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::DRAM};
+        .device = &mesh_device, .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::DRAM};
 
     InterleavedBufferConfig l1_config{
-        .device = devices_[0].get(), .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::L1};
+        .device = &mesh_device, .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::L1};
 
     auto src_dram_buffer = CreateBuffer(dram_config);
     auto dst_l1_buffer = CreateBuffer(l1_config);

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -31,10 +31,10 @@ TEST_F(MeshDeviceSingleCardFixture, DatacopyOutputInL1) {
     uint32_t buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = dev, .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::DRAM};
+        .device = devices_[0].get(), .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::DRAM};
 
     InterleavedBufferConfig l1_config{
-        .device = dev, .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::L1};
+        .device = devices_[0].get(), .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::L1};
 
     auto src_dram_buffer = CreateBuffer(dram_config);
     auto dst_l1_buffer = CreateBuffer(l1_config);

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -62,7 +62,7 @@ TEST_F(MeshDeviceSingleCardFixture, DramCopySticksMultiCore) {
         uint32_t dram_buffer_size =
             num_sticks * stick_size;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
         tt_metal::InterleavedBufferConfig dram_config{
-            .device = dev,
+            .device = devices_[0].get(),
             .size = dram_buffer_size,
             .page_size = dram_buffer_size,
             .buffer_type = tt_metal::BufferType::DRAM};
@@ -78,7 +78,7 @@ TEST_F(MeshDeviceSingleCardFixture, DramCopySticksMultiCore) {
             for (int j = start_core.x; j < start_core.x + num_cores_c; j++) {
                 CoreCoord core = {(std::size_t)j, (std::size_t)i};
                 tt_metal::InterleavedBufferConfig l1_config{
-                    .device = dev,
+                    .device = devices_[0].get(),
                     .size = per_core_l1_size,
                     .page_size = per_core_l1_size,
                     .buffer_type = tt_metal::BufferType::L1};

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -46,7 +46,8 @@ struct hlk_args_t {
 
 TEST_F(MeshDeviceSingleCardFixture, DramCopySticksMultiCore) {
     bool pass = true;
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* dev = mesh_device.get_devices()[0];
 
     try {
         tt_metal::Program program = tt_metal::CreateProgram();
@@ -62,7 +63,7 @@ TEST_F(MeshDeviceSingleCardFixture, DramCopySticksMultiCore) {
         uint32_t dram_buffer_size =
             num_sticks * stick_size;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
         tt_metal::InterleavedBufferConfig dram_config{
-            .device = devices_[0].get(),
+            .device = &mesh_device,
             .size = dram_buffer_size,
             .page_size = dram_buffer_size,
             .buffer_type = tt_metal::BufferType::DRAM};
@@ -78,7 +79,7 @@ TEST_F(MeshDeviceSingleCardFixture, DramCopySticksMultiCore) {
             for (int j = start_core.x; j < start_core.x + num_cores_c; j++) {
                 CoreCoord core = {(std::size_t)j, (std::size_t)i};
                 tt_metal::InterleavedBufferConfig l1_config{
-                    .device = devices_[0].get(),
+                    .device = &mesh_device,
                     .size = per_core_l1_size,
                     .page_size = per_core_l1_size,
                     .buffer_type = tt_metal::BufferType::L1};

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -33,7 +33,10 @@ TEST_F(MeshDeviceSingleCardFixture, DramLoopbackSingleCore) {
     uint32_t l1_buffer_addr = 400 * 1024;
 
     InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+        .device = devices_[0].get(),
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = BufferType::DRAM};
     auto input_dram_buffer = CreateBuffer(dram_config);
     uint32_t input_dram_buffer_addr = input_dram_buffer->address();
 

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -22,7 +22,8 @@ using namespace tt::tt_metal;
 // 4. Host reads from buffer written to in step 2.
 //////////////////////////////////////////////////////////////////////////////////////////
 TEST_F(MeshDeviceSingleCardFixture, DramLoopbackSingleCore) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -33,7 +34,7 @@ TEST_F(MeshDeviceSingleCardFixture, DramLoopbackSingleCore) {
     uint32_t l1_buffer_addr = 400 * 1024;
 
     InterleavedBufferConfig dram_config{
-        .device = devices_[0].get(),
+        .device = &mesh_device,
         .size = dram_buffer_size,
         .page_size = dram_buffer_size,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -125,19 +125,19 @@ TEST_F(MeshDeviceSingleCardFixture, GenericBinaryReaderMatmulLargeBlock) {
             single_tile_size * M * N;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
         tt_metal::InterleavedBufferConfig act_config{
-            .device = dev,
+            .device = devices_[0].get(),
             .size = dram_buffer_size_act,
             .page_size = dram_buffer_size_act,
             .buffer_type = tt_metal::BufferType::DRAM};
 
         tt_metal::InterleavedBufferConfig weights_config{
-            .device = dev,
+            .device = devices_[0].get(),
             .size = dram_buffer_size_weights,
             .page_size = dram_buffer_size_weights,
             .buffer_type = tt_metal::BufferType::DRAM};
 
         tt_metal::InterleavedBufferConfig dst_config{
-            .device = dev,
+            .device = devices_[0].get(),
             .size = dram_buffer_size_out,
             .page_size = dram_buffer_size_out,
             .buffer_type = tt_metal::BufferType::DRAM};
@@ -193,7 +193,7 @@ TEST_F(MeshDeviceSingleCardFixture, GenericBinaryReaderMatmulLargeBlock) {
         TT_FATAL(source_addresses.size() == num_blocks * src0_num_reads_per_block, "Error");
 
         tt_metal::InterleavedBufferConfig l1_config{
-            .device = dev,
+            .device = devices_[0].get(),
             .size = source_addresses.size() * sizeof(uint32_t),
             .page_size = source_addresses.size() * sizeof(uint32_t),
             .buffer_type = tt_metal::BufferType::L1};

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -99,7 +99,8 @@ std::vector<std::uint32_t> transpose_tiles(
 }  // namespace
 
 TEST_F(MeshDeviceSingleCardFixture, GenericBinaryReaderMatmulLargeBlock) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* dev = mesh_device.get_devices()[0];
     bool pass = true;
 
     try {
@@ -125,19 +126,19 @@ TEST_F(MeshDeviceSingleCardFixture, GenericBinaryReaderMatmulLargeBlock) {
             single_tile_size * M * N;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
         tt_metal::InterleavedBufferConfig act_config{
-            .device = devices_[0].get(),
+            .device = &mesh_device,
             .size = dram_buffer_size_act,
             .page_size = dram_buffer_size_act,
             .buffer_type = tt_metal::BufferType::DRAM};
 
         tt_metal::InterleavedBufferConfig weights_config{
-            .device = devices_[0].get(),
+            .device = &mesh_device,
             .size = dram_buffer_size_weights,
             .page_size = dram_buffer_size_weights,
             .buffer_type = tt_metal::BufferType::DRAM};
 
         tt_metal::InterleavedBufferConfig dst_config{
-            .device = devices_[0].get(),
+            .device = &mesh_device,
             .size = dram_buffer_size_out,
             .page_size = dram_buffer_size_out,
             .buffer_type = tt_metal::BufferType::DRAM};
@@ -193,7 +194,7 @@ TEST_F(MeshDeviceSingleCardFixture, GenericBinaryReaderMatmulLargeBlock) {
         TT_FATAL(source_addresses.size() == num_blocks * src0_num_reads_per_block, "Error");
 
         tt_metal::InterleavedBufferConfig l1_config{
-            .device = devices_[0].get(),
+            .device = &mesh_device,
             .size = source_addresses.size() * sizeof(uint32_t),
             .page_size = source_addresses.size() * sizeof(uint32_t),
             .buffer_type = tt_metal::BufferType::L1};

--- a/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
@@ -59,5 +59,5 @@ TEST_F(MeshDeviceSingleCardFixture, InterleavedL1Buffer) {
     int num_bank_pages_one = 258;
     int num_bank_pages_two = 378;
 
-    test_interleaved_l1_buffer_impl(devices_[0]->get_devices()[0], num_bank_pages_one, num_bank_pages_two, page_size);
+    test_interleaved_l1_buffer_impl(devices_[0].get(), num_bank_pages_one, num_bank_pages_two, page_size);
 }

--- a/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
@@ -17,7 +17,8 @@ using namespace tt::tt_metal;
 
 namespace {
 
-void test_interleaved_l1_buffer_impl(IDevice* dev, int num_pages_one, int num_pages_two, uint32_t page_size) {
+void test_interleaved_l1_buffer_impl(
+    distributed::MeshDevice* dev, int num_pages_one, int num_pages_two, uint32_t page_size) {
     uint32_t buffer_size = num_pages_one * page_size;
 
     InterleavedBufferConfig buff_config_0{

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -31,7 +31,10 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileBfp8b) {
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+        .device = devices_[0].get(),
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = BufferType::DRAM};
 
     auto src0_dram_buffer = CreateBuffer(dram_config);
     auto src1_dram_buffer = CreateBuffer(dram_config);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -20,7 +20,8 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileBfp8b) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -31,7 +32,7 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileBfp8b) {
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = devices_[0].get(),
+        .device = &mesh_device,
         .size = dram_buffer_size,
         .page_size = dram_buffer_size,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -23,7 +23,8 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileOutputInL1) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -33,15 +34,12 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileOutputInL1) {
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = devices_[0].get(),
+        .device = &mesh_device,
         .size = dram_buffer_size,
         .page_size = dram_buffer_size,
         .buffer_type = BufferType::DRAM};
     InterleavedBufferConfig l1_config{
-        .device = devices_[0].get(),
-        .size = dram_buffer_size,
-        .page_size = dram_buffer_size,
-        .buffer_type = BufferType::L1};
+        .device = &mesh_device, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::L1};
 
     auto src0_dram_buffer = CreateBuffer(dram_config);
     auto src1_dram_buffer = CreateBuffer(dram_config);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -33,9 +33,15 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileOutputInL1) {
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+        .device = devices_[0].get(),
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = BufferType::DRAM};
     InterleavedBufferConfig l1_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::L1};
+        .device = devices_[0].get(),
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = BufferType::L1};
 
     auto src0_dram_buffer = CreateBuffer(dram_config);
     auto src1_dram_buffer = CreateBuffer(dram_config);

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -84,7 +84,8 @@ void set_rt_args(
 }  // namespace
 
 TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelSameRuntimeArgs) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* dev = mesh_device.get_devices()[0];
 
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {2, 2};
@@ -94,7 +95,7 @@ TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelSameRuntimeArgs) {
     int32_t num_tiles = 2048;
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
     InterleavedBufferConfig dram_config{
-        .device = devices_[0].get(),
+        .device = &mesh_device,
         .size = dram_buffer_size,
         .page_size = dram_buffer_size,
         .buffer_type = BufferType::DRAM};
@@ -127,7 +128,8 @@ TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelSameRuntimeArgs) {
 }
 
 TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelUniqueRuntimeArgs) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* dev = mesh_device.get_devices()[0];
 
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {1, 1};
@@ -142,7 +144,7 @@ TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelUniqueRuntimeArgs) {
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = devices_[0].get(),
+        .device = &mesh_device,
         .size = dram_buffer_size,
         .page_size = dram_buffer_size,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -94,7 +94,10 @@ TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelSameRuntimeArgs) {
     int32_t num_tiles = 2048;
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
     InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+        .device = devices_[0].get(),
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = BufferType::DRAM};
 
     auto src_dram_buffer = CreateBuffer(dram_config);
     auto dst_dram_buffer = CreateBuffer(dram_config);
@@ -139,7 +142,10 @@ TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelUniqueRuntimeArgs) {
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+        .device = devices_[0].get(),
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = BufferType::DRAM};
 
     auto src_dram_buffer = CreateBuffer(dram_config);
     auto dst_dram_buffer_1 = CreateBuffer(dram_config);

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -176,14 +176,15 @@ void write_program_runtime_args_to_device(
 // 3. Second program runs matmul, using results from step 2 as input activation
 //////////////////////////////////////////////////////////////////////////////////////////
 TEST_F(MeshDeviceSingleCardFixture, MultiplePrograms) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* dev = mesh_device.get_devices()[0];
     CoreCoord core = {0, 0};
     uint32_t single_tile_size = 2 * 1024;
     uint32_t num_tiles = 1;
 
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
     InterleavedBufferConfig dram_config{
-        .device = devices_[0].get(),
+        .device = &mesh_device,
         .size = dram_buffer_size,
         .page_size = dram_buffer_size,
         .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -183,7 +183,10 @@ TEST_F(MeshDeviceSingleCardFixture, MultiplePrograms) {
 
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
     InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+        .device = devices_[0].get(),
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = BufferType::DRAM};
 
     auto src0_dram_buffer = CreateBuffer(dram_config);
     auto src1_dram_buffer = CreateBuffer(dram_config);

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -48,12 +48,18 @@ static void run_pack_relu_test(
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig src_config{
-        .device = dev, .size = dram_buffer_size, .page_size = single_tile_size, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(),
+        .size = dram_buffer_size,
+        .page_size = single_tile_size,
+        .buffer_type = BufferType::DRAM};
     auto src_dram_buffer = CreateBuffer(src_config);
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();
 
     InterleavedBufferConfig dst_config{
-        .device = dev, .size = dram_buffer_size, .page_size = single_tile_size, .buffer_type = BufferType::DRAM};
+        .device = mesh_device.get(),
+        .size = dram_buffer_size,
+        .page_size = single_tile_size,
+        .buffer_type = BufferType::DRAM};
     auto dst_dram_buffer = CreateBuffer(dst_config);
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -25,7 +25,8 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, TransposeHC) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    auto& mesh_device = *this->devices_[0];
+    auto* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
     constexpr bool multibank = true;
 
@@ -48,10 +49,7 @@ TEST_F(MeshDeviceSingleCardFixture, TransposeHC) {
     const uint32_t page_size = (!multibank) ? dram_buffer_bytes : single_tile_bytes;
 
     const InterleavedBufferConfig dram_config = {
-        .device = devices_[0].get(),
-        .size = dram_buffer_bytes,
-        .page_size = page_size,
-        .buffer_type = BufferType::DRAM};
+        .device = &mesh_device, .size = dram_buffer_bytes, .page_size = page_size, .buffer_type = BufferType::DRAM};
 
     auto src0_dram_buffer = CreateBuffer(dram_config);
     const uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -48,7 +48,10 @@ TEST_F(MeshDeviceSingleCardFixture, TransposeHC) {
     const uint32_t page_size = (!multibank) ? dram_buffer_bytes : single_tile_bytes;
 
     const InterleavedBufferConfig dram_config = {
-        .device = dev, .size = dram_buffer_bytes, .page_size = page_size, .buffer_type = BufferType::DRAM};
+        .device = devices_[0].get(),
+        .size = dram_buffer_bytes,
+        .page_size = page_size,
+        .buffer_type = BufferType::DRAM};
 
     auto src0_dram_buffer = CreateBuffer(dram_config);
     const uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();

--- a/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
@@ -41,6 +41,7 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
+    auto& mesh_device = *this->devices_[0];
     bool pass = true;
 
     try {
@@ -54,7 +55,7 @@ TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
             2; /*** Non 4-byte aligned buffer size for BFLOAT16s. This is the point of this unaligned test. ***/
 
         tt_metal::InterleavedBufferConfig dram_interleaved_buffer_config{
-            .device = devices_[0].get(),
+            .device = &mesh_device,
             .size = dram_buffer_size,
             .page_size = dram_buffer_size,
             .buffer_type = tt_metal::BufferType::DRAM};
@@ -82,7 +83,7 @@ TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
             {1, dram_buffer_size / sizeof(uint16_t)},
             {1, 1});
         auto device_dram_sharded_buffer = CreateBuffer(tt_metal::ShardedBufferConfig{
-            .device = devices_[0].get(),
+            .device = &mesh_device,
             .size = dram_buffer_size,
             .page_size = dram_buffer_size,
             .buffer_type = tt_metal::BufferType::DRAM,
@@ -109,7 +110,7 @@ TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
             (single_tile_size * 4) +
             2; /*** Non 4-byte aligned buffer size for BFLOAT16s. This is the point of this unaligned test. ***/
         tt_metal::InterleavedBufferConfig l1_interleaved_buffer_config{
-            .device = devices_[0].get(),
+            .device = &mesh_device,
             .size = l1_buffer_size,
             .page_size = l1_buffer_size,
             .buffer_type = tt_metal::BufferType::L1};
@@ -139,7 +140,7 @@ TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
             {1, l1_buffer_size / sizeof(uint16_t)},
             {1, 1});
         auto device_l1_sharded_buffer = CreateBuffer(tt_metal::ShardedBufferConfig{
-            .device = devices_[0].get(),
+            .device = &mesh_device,
             .size = l1_buffer_size,
             .page_size = l1_buffer_size,
             .buffer_type = tt_metal::BufferType::L1,

--- a/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
@@ -41,7 +41,6 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
-    IDevice* dev = devices_[0]->get_devices()[0];
     bool pass = true;
 
     try {
@@ -55,7 +54,7 @@ TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
             2; /*** Non 4-byte aligned buffer size for BFLOAT16s. This is the point of this unaligned test. ***/
 
         tt_metal::InterleavedBufferConfig dram_interleaved_buffer_config{
-            .device = dev,
+            .device = devices_[0].get(),
             .size = dram_buffer_size,
             .page_size = dram_buffer_size,
             .buffer_type = tt_metal::BufferType::DRAM};
@@ -83,7 +82,7 @@ TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
             {1, dram_buffer_size / sizeof(uint16_t)},
             {1, 1});
         auto device_dram_sharded_buffer = CreateBuffer(tt_metal::ShardedBufferConfig{
-            .device = dev,
+            .device = devices_[0].get(),
             .size = dram_buffer_size,
             .page_size = dram_buffer_size,
             .buffer_type = tt_metal::BufferType::DRAM,
@@ -110,7 +109,7 @@ TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
             (single_tile_size * 4) +
             2; /*** Non 4-byte aligned buffer size for BFLOAT16s. This is the point of this unaligned test. ***/
         tt_metal::InterleavedBufferConfig l1_interleaved_buffer_config{
-            .device = dev,
+            .device = devices_[0].get(),
             .size = l1_buffer_size,
             .page_size = l1_buffer_size,
             .buffer_type = tt_metal::BufferType::L1};
@@ -140,7 +139,7 @@ TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
             {1, l1_buffer_size / sizeof(uint16_t)},
             {1, 1});
         auto device_l1_sharded_buffer = CreateBuffer(tt_metal::ShardedBufferConfig{
-            .device = dev,
+            .device = devices_[0].get(),
             .size = l1_buffer_size,
             .page_size = l1_buffer_size,
             .buffer_type = tt_metal::BufferType::L1,


### PR DESCRIPTION
### PR Category

Cleanup, Test Only

### Summary

Advances #51835

`MeshDevice` is used instead of individual `Device` for buffer creation in tests, specifically:
- as `Buffer::create` argument;
- when creating `InterleavedBufferConfig` for `CreateBuffer` call.

The behavior should be the same, because `MeshDevice` is a unit mesh in all these tests.

As a side effect, 50+ calls to `MeshDevice::get_devices()` (which we're planning to hide in the implementation) are removed.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-buffer-create-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-buffer-create-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-buffer-create-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-buffer-create-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=obacherikov-buffer-create-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:obacherikov-buffer-create-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-buffer-create-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-buffer-create-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-buffer-create-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-buffer-create-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-buffer-create-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-buffer-create-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-buffer-create-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-buffer-create-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-buffer-create-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-buffer-create-device)