### PR TITLE
cleanup(llk): remove dead llk_pack_untilize_hw_configure

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include "llk_pack_common_api.h"
 #include "llk_pack_untilize.h"
-#include "llk_param_structs.h"
 
 /*************************************************************************
  * LLK PACK UNTILIZE

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_pack_common_api.h"
 #include "llk_pack_untilize.h"
 #include "llk_param_structs.h"
@@ -10,40 +11,6 @@
 /*************************************************************************
  * LLK PACK UNTILIZE
  *************************************************************************/
-
-/**
- * Configure the packer hardware for an untilize output operand.
- *
- * Face geometry (face_r_dim, num_faces), tile column dimension, partial-face flag
- * and tile size are all derived from the output CB metadata associated with the
- * operand id. Callers no longer thread face geometry through the API, since per-CB
- * face geometry is recorded in the CB descriptor at program creation time. The relu
- * configuration is taken from the supplied pack params.
- *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @tparam pack_mode           Packer program mode (e.g. Default, Untilize).
- * @param  pack_params         Pack parameters carrying the output operand and relu config.
- */
-template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
-inline void llk_pack_untilize_hw_configure(const llk_pack_params_t* pack_params) {
-    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
-    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
-    const bool partial_face = get_output_partial_face(output_id);
-
-    const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
-
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, pack_mode>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        tile_size,
-        face_r_dim,
-        tile_c_dim,
-        num_faces,
-        partial_face,
-        pack_params->relu_config.val);
-}
 
 /**
  * Initialize the packer for an untilize operation on the given output operand.
@@ -115,7 +82,7 @@ template <
     bool diagonal = false /* unused */,
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM /* unused */,
-    uint32_t tile_dst_ct_offset = 0,
+    std::uint32_t tile_dst_ct_offset = 0,
     bool dense = false>
 inline void llk_pack_untilize(
     std::uint32_t block_rt_dim,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_pack_common_api.h"
 #include "llk_pack_untilize.h"
 #include "llk_param_structs.h"
@@ -10,40 +11,6 @@
 /*************************************************************************
  * LLK PACK UNTILIZE
  *************************************************************************/
-
-/**
- * Configure the packer hardware for an untilize output operand.
- *
- * Face geometry (face_r_dim, num_faces), partial-face flag, narrow-tile flag and tile
- * size are all derived from the output CB metadata associated with the operand id.
- * Callers no longer thread face geometry through the API, since per-CB face geometry
- * is recorded in the CB descriptor at program creation time. The relu configuration is
- * taken from the supplied pack params.
- *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @tparam pack_mode           Packer program mode (e.g. Default, Untilize).
- * @param  pack_params         Pack parameters carrying the output operand and relu config.
- */
-template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
-inline void llk_pack_untilize_hw_configure(const llk_pack_params_t* pack_params) {
-    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
-    const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
-
-    const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
-
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, pack_mode>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        tile_size,
-        face_r_dim,
-        num_faces,
-        partial_face,
-        narrow_tile,
-        pack_params->relu_config.val);
-}
 
 /**
  * Initialize the packer for an untilize operation on the given output operand.
@@ -104,7 +71,7 @@ template <
     bool diagonal = false,
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM,
-    uint32_t tile_dst_ct_offset = 0,
+    std::uint32_t tile_dst_ct_offset = 0,
     bool dense = false>
 inline void llk_pack_untilize(
     std::uint32_t block_rt_dim,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include "llk_pack_common_api.h"
 #include "llk_pack_untilize.h"
-#include "llk_param_structs.h"
 
 /*************************************************************************
  * LLK PACK UNTILIZE


### PR DESCRIPTION
## What

Removes `llk_pack_untilize_hw_configure` from the Wormhole B0 and Blackhole `llk_api` headers (Quasar never defined it), and drops the now-dead `llk_param_structs.h` include those headers no longer need.

## Why

The function has **zero call sites**. The untilize compute path (`tt_metal/hw/inc/api/compute/pack_untilize.h`) configures the packer via `llk_pack_reconfig_data_format` + `llk_pack_untilize_init`, never through this function. It was a near-duplicate of `llk_pack_hw_configure` left over after the #17641 / #44417 rework — its only functional delta was forwarding `relu_config` from `pack_params` instead of hardcoding `0`. Removal is safe purely on the zero-call-sites evidence.

> Correction: an earlier revision of this description claimed pack HW-configure is entirely pack-mode agnostic. That holds on Wormhole, but **not** on Blackhole, where `configure_pack` calls `set_packer_strides<pack_mode>` and selects a different Z-stride for Untilize (`cpack_common.h:599` / `:309`). This does not change the conclusion, since nothing called the removed helper. (Thanks @Copilot for the catch.)

With the helper gone, `llk_pack_params_t` has no references left anywhere in the repo, so the `#include "llk_param_structs.h"` in these two headers is dead and is dropped; `std::uint32_t` now comes from an explicit `<cstdint>`. The `llk_param_structs.h` file itself stays — `chlkc_list.h` / `llk_unpack_common_api.h` still use it for other structs.

## Testing

Dead-code removal — no call sites, no behavioral change. `grep` confirms no remaining references in `tt_metal/` or `ttnn/`.

Closes #17641

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/remove-dead-pack-untilize-hw-configure)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/remove-dead-pack-untilize-hw-configure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/remove-dead-pack-untilize-hw-configure)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/remove-dead-pack-untilize-hw-configure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/remove-dead-pack-untilize-hw-configure)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/remove-dead-pack-untilize-hw-configure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/remove-dead-pack-untilize-hw-configure)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/remove-dead-pack-untilize-hw-configure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/remove-dead-pack-untilize-hw-configure)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/remove-dead-pack-untilize-hw-configure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/remove-dead-pack-untilize-hw-configure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/remove-dead-pack-untilize-hw-configure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/remove-dead-pack-untilize-hw-configure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/remove-dead-pack-untilize-hw-configure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/remove-dead-pack-untilize-hw-configure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/remove-dead-pack-untilize-hw-configure)
