### PR TITLE
[Bug fix] fix(sfpu): add asymptotic branch to i0 for large |x|

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -6,52 +6,123 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu_exp.h"
 #include "cmath_common.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 
-using namespace sfpi;
+namespace ckernel::sfpu {
 
-namespace ckernel {
-namespace sfpu {
+// ======================================================================
+// i0(x) — modified Bessel function of the first kind, order 0.
+//
+// Two-region implementation, exploiting that i0 is even: i0(-x) = i0(x).
+//   |x| ≤ 7:   Maclaurin polynomial (12 terms, same as before)
+//              max rel err ~3.2e-07 over [0, 7]
+//   |x| >  7:  asymptotic expansion (Abramowitz & Stegun 9.7.1)
+//                i0(x) = exp(|x|) / sqrt(2π|x|) · P(1/|x|)
+//              degree-5 asymptotic series in 1/|x|, max rel err ~6e-06
+//
+// Code shape (chosen to relieve SFPI LRA budget):
+//   1. Compute polynomial result unconditionally.
+//      Polynomial-path intermediates die at the store, freeing LRegs.
+//   2. v_if (|x|>7): overwrite with asymptotic result.
+// This is semantically identical to a v_if/v_else split but lets the
+// register allocator schedule the two paths sequentially.
+//
+// Inputs are clamped to [-88.5, 88.5] to avoid exp() overflow.
+// Overall worst-case rel err ~6e-06 over [0, 88.5], well within
+// 1 BF16 ULP (~4e-3).
+//
+// APPROXIMATION_MODE: used by the templated calculate_i0() for
+// SFPI approximation flags.
+// ======================================================================
 
-#define POLYVAL10(coef10, coef9, coef8, coef7, coef6, coef5, coef4, coef3, coef2, coef1, coef0, t4)               \
-    ((coef0 +                                                                                                     \
-      (coef1 +                                                                                                    \
-       (coef2 +                                                                                                   \
-        (coef3 +                                                                                                  \
-         (coef4 + (coef5 + (coef6 + (coef7 + (coef8 + (coef9 + coef10 * t4) * t4) * t4) * t4) * t4) * t4) * t4) * \
-            t4) *                                                                                                 \
-           t4) *                                                                                                  \
-          t4) *                                                                                                   \
-     t4)
-inline void i0_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+// Asymptotic path outlined to keep register pressure within SFPI's LRA budget.
+// Returns exp(|x|) / sqrt(2π|x|) · P(1/|x|).
+// Note: i0 is even — no sign handling needed.
+inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
+    // exp(|x|) — unsafe variants: |x|∈[7,88.5] precludes overflow/underflow.
+#ifdef INP_FLOAT32
+    const sfpi::vFloat exp_abs = _sfpu_exp_fp32_accurate_unsafe_(abs_x);
+#else
+    const sfpi::vFloat exp_abs = _sfpu_exp_21f_bf16_unsafe_<true>(abs_x);
+#endif
+
+    // 1/sqrt(|x|) via Quake-style magic constant + two Newton refinements.
+    // Computed first so that 1/|x| can be derived as rsqrt_y².
+    const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
+    sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
+    sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
+    c0 = 1.0f + (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = c0 * sfpi::addexp(rsqrt_y, -1) + rsqrt_y;
+
+    // 1/|x| = (1/√|x|)² — reuses the refined rsqrt.
+    const sfpi::vFloat inv_abs_x = rsqrt_y * rsqrt_y;
+
+    // P(y), degree-5 asymptotic series on y ∈ [1/88.5, 1/7]; max rel err ~6e-06.
+    // Abramowitz & Stegun 9.7.1 for nu=0: S(y) = 1 + 1/8*y + 9/128*y^2 + 75/1024*y^3 + ...
+    // P(y) = S(y) / sqrt(2π), so all coefficients are positive.
+    const sfpi::vFloat correction = PolynomialEvaluator::eval(
+        inv_abs_x,
+        3.9894228040e-01f,
+        4.9867785050e-02f,
+        2.8050629091e-02f,
+        2.9219405303e-02f,
+        4.4742214370e-02f,
+        9.0602984099e-02f);
+
+    return exp_abs * rsqrt_y * correction;
+}
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_i0() {
-#pragma GCC unroll 0
+    constexpr float I0_MAX_INPUT = 88.5f;
+    constexpr float I0_THRESHOLD = 7.0f;
 
+#pragma GCC unroll 1
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat result = 0.0f;
-        vFloat input = dst_reg[0];
-        vFloat x = input * input;
+        sfpi::vFloat x = sfpi::dst_reg[0];
 
-        result = 1.0f + POLYVAL10(
-                            1.50E-22f,
-                            7.24E-20f,
-                            2.90E-17f,
-                            9.39E-15f,
-                            2.40E-12f,
-                            4.71E-10f,
-                            6.78E-08f,
-                            0.000006781684028f,
-                            0.0004340277778f,
-                            0.015625f,
-                            0.25f,
-                            x);
+        // Clamp to [-88.5, 88.5] — exp() saturates near ±88.7 in FP32.
+        x = sfpi::symmetric_clamp(x, I0_MAX_INPUT);
 
-        dst_reg[0] = result;
-        dst_reg++;
+        const sfpi::vFloat abs_x = sfpi::abs(x);
+
+        sfpi::vFloat val;
+        // ─── Polynomial path (always; valid for |x| ≤ 7) ─────────────────
+        // Maclaurin series: i0(x) = sum_{k=0}^{11} (x²/4)^k / (k!)²
+        // Computed unconditionally — intermediates die after the store.
+        {
+            val = PolynomialEvaluator::eval(
+                x * x,
+                1.0f,
+                2.5000000000e-01f,
+                1.5625000000e-02f,
+                4.3402777780e-04f,
+                6.7816840280e-06f,
+                6.7816840280e-08f,
+                4.7100000000e-10f,
+                2.4000000000e-12f,
+                9.3900000000e-15f,
+                2.9000000000e-17f,
+                7.2400000000e-20f,
+                1.5000000000e-22f);
+        }
+
+        // ─── Asymptotic overwrite for OOD lanes (|x| > 7) ─────────────────
+        v_if(abs_x > I0_THRESHOLD) { val = calculate_i0_asymptotic_(abs_x); }
+        v_endif;
+#ifndef INP_FLOAT32
+        val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);
+#endif
+        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+void i0_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -6,52 +6,123 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu_exp.h"
 #include "cmath_common.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 
-using namespace sfpi;
+namespace ckernel::sfpu {
 
-namespace ckernel {
-namespace sfpu {
+// ======================================================================
+// i0(x) — modified Bessel function of the first kind, order 0.
+//
+// Two-region implementation, exploiting that i0 is even: i0(-x) = i0(x).
+//   |x| ≤ 7:   Maclaurin polynomial (12 terms, same as before)
+//              max rel err ~3.2e-07 over [0, 7]
+//   |x| >  7:  asymptotic expansion (Abramowitz & Stegun 9.7.1)
+//                i0(x) = exp(|x|) / sqrt(2π|x|) · P(1/|x|)
+//              degree-5 asymptotic series in 1/|x|, max rel err ~6e-06
+//
+// Code shape (chosen to relieve SFPI LRA budget):
+//   1. Compute polynomial result unconditionally.
+//      Polynomial-path intermediates die at the store, freeing LRegs.
+//   2. v_if (|x|>7): overwrite with asymptotic result.
+// This is semantically identical to a v_if/v_else split but lets the
+// register allocator schedule the two paths sequentially.
+//
+// Inputs are clamped to [-88.5, 88.5] to avoid exp() overflow.
+// Overall worst-case rel err ~6e-06 over [0, 88.5], well within
+// 1 BF16 ULP (~4e-3).
+//
+// APPROXIMATION_MODE: used by the templated calculate_i0() for
+// SFPI approximation flags.
+// ======================================================================
 
-#define POLYVAL10(coef10, coef9, coef8, coef7, coef6, coef5, coef4, coef3, coef2, coef1, coef0, t4)               \
-    ((coef0 +                                                                                                     \
-      (coef1 +                                                                                                    \
-       (coef2 +                                                                                                   \
-        (coef3 +                                                                                                  \
-         (coef4 + (coef5 + (coef6 + (coef7 + (coef8 + (coef9 + coef10 * t4) * t4) * t4) * t4) * t4) * t4) * t4) * \
-            t4) *                                                                                                 \
-           t4) *                                                                                                  \
-          t4) *                                                                                                   \
-     t4)
-inline void i0_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+// Asymptotic path outlined to keep register pressure within SFPI's LRA budget.
+// Returns exp(|x|) / sqrt(2π|x|) · P(1/|x|).
+// Note: i0 is even — no sign handling needed.
+inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
+    // exp(|x|) — unsafe variants: |x|∈[7,88.5] precludes overflow/underflow.
+#ifdef INP_FLOAT32
+    const sfpi::vFloat exp_abs = _sfpu_exp_fp32_accurate_unsafe_(abs_x);
+#else
+    const sfpi::vFloat exp_abs = _sfpu_exp_21f_bf16_unsafe_<true>(abs_x);
+#endif
+
+    // 1/sqrt(|x|) via Quake-style magic constant + two Newton refinements.
+    // Computed first so that 1/|x| can be derived as rsqrt_y².
+    const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
+    sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
+    sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
+    c0 = 1.0f + (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = c0 * sfpi::addexp(rsqrt_y, -1) + rsqrt_y;
+
+    // 1/|x| = (1/√|x|)² — reuses the refined rsqrt.
+    const sfpi::vFloat inv_abs_x = rsqrt_y * rsqrt_y;
+
+    // P(y), degree-5 asymptotic series on y ∈ [1/88.5, 1/7]; max rel err ~6e-06.
+    // Abramowitz & Stegun 9.7.1 for nu=0: S(y) = 1 + 1/8*y + 9/128*y^2 + 75/1024*y^3 + ...
+    // P(y) = S(y) / sqrt(2π), so all coefficients are positive.
+    const sfpi::vFloat correction = PolynomialEvaluator::eval(
+        inv_abs_x,
+        3.9894228040e-01f,
+        4.9867785050e-02f,
+        2.8050629091e-02f,
+        2.9219405303e-02f,
+        4.4742214370e-02f,
+        9.0602984099e-02f);
+
+    return exp_abs * rsqrt_y * correction;
+}
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_i0() {
-#pragma GCC unroll 0
+    constexpr float I0_MAX_INPUT = 88.5f;
+    constexpr float I0_THRESHOLD = 7.0f;
 
+#pragma GCC unroll 1
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat result = 0.0f;
-        vFloat input = dst_reg[0];
-        vFloat x = input * input;
+        sfpi::vFloat x = sfpi::dst_reg[0];
 
-        result = 1.0f + POLYVAL10(
-                            1.50E-22f,
-                            7.24E-20f,
-                            2.90E-17f,
-                            9.39E-15f,
-                            2.40E-12f,
-                            4.71E-10f,
-                            6.78E-08f,
-                            0.000006781684028f,
-                            0.0004340277778f,
-                            0.015625f,
-                            0.25f,
-                            x);
+        // Clamp to [-88.5, 88.5] — exp() saturates near ±88.7 in FP32.
+        x = sfpi::symmetric_clamp(x, I0_MAX_INPUT);
 
-        dst_reg[0] = result;
-        dst_reg++;
+        const sfpi::vFloat abs_x = sfpi::abs(x);
+
+        sfpi::vFloat val;
+        // ─── Polynomial path (always; valid for |x| ≤ 7) ─────────────────
+        // Maclaurin series: i0(x) = sum_{k=0}^{11} (x²/4)^k / (k!)²
+        // Computed unconditionally — intermediates die after the store.
+        {
+            val = PolynomialEvaluator::eval(
+                x * x,
+                1.0f,
+                2.5000000000e-01f,
+                1.5625000000e-02f,
+                4.3402777780e-04f,
+                6.7816840280e-06f,
+                6.7816840280e-08f,
+                4.7100000000e-10f,
+                2.4000000000e-12f,
+                9.3900000000e-15f,
+                2.9000000000e-17f,
+                7.2400000000e-20f,
+                1.5000000000e-22f);
+        }
+
+        // ─── Asymptotic overwrite for OOD lanes (|x| > 7) ─────────────────
+        v_if(abs_x > I0_THRESHOLD) { val = calculate_i0_asymptotic_(abs_x); }
+        v_endif;
+#ifndef INP_FLOAT32
+        val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);
+#endif
+        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+void i0_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -317,9 +317,9 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.Selu: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
     ),
-    # i0: modified Bessel I0; kernel poly approx is only valid on |x| <= 3.75
+    # i0: modified Bessel I0; two-region kernel (poly + asymptotic) accurate over |x| ≤ 88.5
     MathOperation.I0: OperandSpecs(
-        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-3.75, high=3.75)
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-30.0, high=30.0)
     ),
     # i1: modified Bessel I1; poly path valid on |x| <= ~3.75 (asymptotic beyond)
     MathOperation.I1: OperandSpecs(

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -81,6 +81,7 @@ ALL_MATHOPS = [
     MathOperation.Threshold,
     MathOperation.ReluMax,
     MathOperation.ReluMin,
+    MathOperation.I0,
 ]
 
 FORMATS = input_output_formats(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
@@ -1731,9 +1731,10 @@ void py_module(nb::module_& mod) {
     bind_unary_operation_subcoregrids<"i0">(
         mod,
         &ttnn::i0,
-        R"doc(\mathrm{{output\_tensor}}_i = \verb|i0|(\mathrm{{input\_tensor}}_i))doc",
-        "",
-        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+        R"doc(\mathrm{{output\_tensor}}_i = I_0(\mathrm{{input\_tensor}}_i))doc",
+        "[Validated range: -88.5 to 88.5]",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc",
+        R"doc(Computes the modified Bessel function of the first kind of order 0.)doc");
     bind_unary_operation_subcoregrids<"i1">(
         mod,
         &ttnn::i1,


### PR DESCRIPTION
### Ticket

#50465

## Problem

`ttnn.i0` used a fixed 12-term Maclaurin series with no domain split, causing silent finite errors past |x|≈13:

- 21% relative error at x=20
- 89% relative error at x=30

The sibling `ttnn.i1` already carries the two-region fix (PR #43246). This brings `i0` to parity.

## Fix

Mirror `ckernel_sfpu_i1.h` with two regions:

```
|x| ≤ 7:   Maclaurin polynomial (12 terms)
|x| >  7:  asymptotic exp(|x|)/sqrt(2π|x|) · P(1/|x|)
```

- Threshold 7 selected from an independent host-side threshold sweep.
- Degree-5 Abramowitz & Stegun 9.7.1 asymptotic series for ν=0, with coefficients in the kernel's `PolynomialEvaluator::eval` ordering.
- Inputs clamped to ±88.5.
- BF16 output rounded via `sfpi::convert<vFloat16b>`.
- `i0_init()` is non-templated, matching the existing LLK declaration and call site.
- Wormhole and Blackhole kernel files are byte-identical.

## Validation

Host-side validation against `scipy.special.i0` (float64), with no hardware:

| Metric | Result |
|--------|--------|
| Max relative error over [0, 88.5] on a dense 0.5-step grid | 5.94e-06 |
| BF16 ULP threshold | ~4e-3 |
| Discontinuity at threshold | 9.3e-06 |
| Even symmetry | Exact |

Pinned SFPI 7.67.0 was downloaded with checksum verification and reports `tenstorrent/sfpi:7.67.0[761]`.

The LLK unary sweep now includes `MathOperation.I0` in `ALL_MATHOPS` so the kernel is exercised by the existing test infrastructure.

TTSIM validation using the repository-pinned v1.9.7 simulator:

- Wormhole: focused FP32 i0 variant passed end-to-end.
- Blackhole: 113 i0 variants passed; 23 unsupported format combinations were skipped; 0 simulator crashes.
- The broader Wormhole sweep reaches an unsupported `tensix_unpacr` format combination in TTSIM; this is an emulator limitation, not an i0 numerical failure.
- Generated `math.elf` was inspected with the pinned `riscv-tt-elf-objdump`: it contains `i0_init`, templated `calculate_i0`, `sfpexexp`, `sfpsetexp`, and the generated branch loop.

Additional checks passed:

- Python syntax checks for modified Python files.
- `git diff --check`.
- WH/BH kernel files byte-identical.
- SPDX and header-style checks.

Unavailable:

- Silicon validation: no Tenstorrent hardware.
- clang-tidy 20 is installed (`Ubuntu LLVM 20.1.2`), but a clean project pass is not claimable locally because there is no `compile_commands.json` and host Clang rejects the SFPI target headers; CI or a maintainer build should run the authoritative clang-tidy check.

## Additional changes

- Widen i0 stimulus domain from ±3.75 to ±30 in `sfpu_domains.py`.
- Add validated-range documentation to the i0 Python binding.
- Add `MathOperation.I0` to the LLK unary SFPU sweep.
- Fix the `i0_init()` template mismatch.
- Correct the I₀ LaTeX notation.

## Known limitations

The host approximation error is approximately 6e-06, comfortably below the BF16 ULP threshold. Device-side accuracy was exercised through TTSIM, but silicon confirmation and performance measurement still require Tenstorrent hardware. Some unsupported TTSIM format combinations remain skipped.

## References

Prior work: commit 25aa8cb / PR #51132 (closed without merge).

Template: `ckernel_sfpu_i1.h` (PR #43246).