### PR TITLE
Fix MoE compute tilize/matmul chunk overlap

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -539,8 +539,9 @@ void kernel_main() {
              */
 
             // == 1 ==
-            // skip for the first two chunks (2 chunks are allocated, and both are initially empty)
-            if (num_chunks_sent >= 2) {
+            // Two chunks fit in the matmul input double buffer, but the next tilize linked mcast must not overlap the
+            // current chunk's matmul/A2A/writeback traffic on NoC1.
+            if (num_chunks_sent >= 1) {
                 // wait_min as MM may signal twice (once per buffer slot) before we acknowledge the first (empty) buffer
                 // slot
                 matmul_chunk_available_sem.wait_min(matmul_chunk_available_semaphore_wait_value);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
GPT-OSS single-card MoE compute was failing matmul validation on Wormhole in both compute-only and fused-local modes: the tilize writer allowed two chunks to be sent before waiting for matmul to release a buffer, but the next linked multicast can overlap the previous chunk's matmul/A2A/writeback traffic on NoC1 and corrupt the double-buffered matmul input/output path. This change makes the tilize writer wait after one in-flight chunk instead of skipping the first two availability waits, preserving correctness for the GPT-OSS shape. Verified on WH ttsim that `test_moe_compute_single_card_gpt_oss` now passes in both compute-only and fused-local modes, with matmul PCCs around 0.985 and fused-local combine validation passing including the cache-hit rerun.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/moe-corruption)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/moe-corruption)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/moe-corruption)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/moe-corruption)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/moe-corruption)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/moe-corruption)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/moe-corruption)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/moe-corruption)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/moe-corruption)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/moe-corruption)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/moe-corruption)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/moe-corruption)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/moe-corruption)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/moe-corruption)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/moe-corruption)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/moe-corruption)