### PR TITLE
Fix folded FABRIC_2D CCL startup barriers

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_gather_2d_fabric.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_gather_2d_fabric.py
@@ -60,3 +60,30 @@ def test_all_gather_2d_fabric(
         enable_trace=enable_trace,
         num_iters=num_iters,
     )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 4)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D, "trace_region_size": 90112}],
+    indirect=True,
+)
+def test_all_gather_async_fabric_2d_folded_line(mesh_device):
+    """A logical four-device line folded onto QB's physical 2D cycle."""
+    run_all_gather_impl(
+        mesh_device,
+        ag_output_shape=[1, 1, 128, 128],
+        dim=3,
+        ag_input_dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mem_config_input=ttnn.DRAM_MEMORY_CONFIG,
+        mem_config_ag=ttnn.DRAM_MEMORY_CONFIG,
+        num_links=2,
+        all_gather_topology=ttnn.Topology.Linear,
+        num_iters=1,
+        enable_trace=False,
+        cluster_axis=1,
+        use_barrier=True,
+        use_persistent_buffers=False,
+        all_gather_function=ttnn.experimental.all_gather_async,
+    )

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
@@ -306,12 +306,26 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
         ccl::get_forward_backward_line_mcast_distance(ring_size, ring_index, topology, false);
     auto [unicast_forward_args, unicast_backward_args] = ccl::get_forward_backward_line_unicast_configuration(
         sender_device_coord, forward_coord, backward_coord, mesh_device);
+    const bool use_fabric_2d_neighbor_barrier =
+        topology == ccl::Topology::Linear && tt::tt_fabric::is_2d_fabric_config(tt::tt_fabric::GetFabricConfig());
+    // A logical line can turn when it is embedded in a 2D physical mesh (for example QB 1x4 on its
+    // four-chip cycle). A single Fabric multicast range cannot describe that turn: its hop range
+    // continues in the physical direction selected by the first neighbor. The all-gather data path
+    // already store-and-forwards through immediate neighbors, so its startup barrier only needs to
+    // prove that those immediate neighbors have reached their worker kernels. Keep the full-range
+    // barrier for 1D Fabric and use terminal one-hop ranges for Fabric2D.
+    const uint32_t barrier_targets_forward =
+        use_fabric_2d_neighbor_barrier ? std::min(num_targets_forward, 1u) : num_targets_forward;
+    const uint32_t barrier_targets_backward =
+        use_fabric_2d_neighbor_barrier ? std::min(num_targets_backward, 1u) : num_targets_backward;
     auto [barrier_mcast_forward_args, barrier_mcast_backward_args] = ccl::get_forward_backward_line_mcast_configuration(
         sender_device_coord,
         forward_coord,
         backward_coord,
-        topology == ccl::Topology::Linear ? num_targets_forward : ring_size - 1,
-        topology == ccl::Topology::Linear ? num_targets_backward : ring_size - 1,
+        topology == ccl::Topology::Linear ? barrier_targets_forward
+                                          : (use_fabric_2d_neighbor_barrier ? 1u : ring_size - 1),
+        topology == ccl::Topology::Linear ? barrier_targets_backward
+                                          : (use_fabric_2d_neighbor_barrier ? 1u : ring_size - 1),
         mesh_device);
 
     TT_FATAL(
@@ -418,7 +432,6 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
         reader_compute_defines["OUTPUT_IS_SHARDED"] = "1";
         writer_compute_defines["OUTPUT_IS_SHARDED"] = "1";
     }
-
     if (num_mux_cores_per_direction_per_link) {
         writer_compute_defines["USE_WORKER_MUX"] = "1";
     }
@@ -581,6 +594,8 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
         output_tensor_C,                  // output_tensor_C
         fuse_op,                          // fuse_op
         reverse_order,                    // reverse
+        use_fabric_2d_neighbor_barrier ? static_cast<uint32_t>((num_targets_forward != 0) + (num_targets_backward != 0))
+                                       : ring_size - 1,  // barrier_target_count
     };
 
     if (num_mux_cores_per_direction_per_link) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -47,15 +47,16 @@ constexpr uint32_t output_tensor_Ht = get_compile_time_arg_val(14);
 constexpr uint32_t output_tensor_C = get_compile_time_arg_val(15);
 constexpr bool fuse_op = get_compile_time_arg_val(16);
 constexpr uint32_t reverse = get_compile_time_arg_val(17) == 1;
+constexpr uint32_t barrier_target_count = get_compile_time_arg_val(18);
 #ifdef USE_WORKER_MUX
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(18);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(19);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(20);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(21);
-constexpr uint32_t num_mux_clients = get_compile_time_arg_val(22);
-constexpr uint32_t rt_arg_count = 23;
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(19);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(20);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(21);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(22);
+constexpr uint32_t num_mux_clients = get_compile_time_arg_val(23);
+constexpr uint32_t rt_arg_count = 24;
 #else
-constexpr uint32_t rt_arg_count = 18;
+constexpr uint32_t rt_arg_count = 19;
 #endif
 
 constexpr ccl_routing_utils::line_unicast_route_info_t forward_unicast_route_info =
@@ -278,7 +279,7 @@ void kernel_main() {
             }
         }
 
-        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), barrier_target_count);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
@@ -47,8 +47,9 @@ constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val
 constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(13);
 constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(14);
 constexpr uint32_t num_mux_clients = get_compile_time_arg_val(15);
+constexpr uint32_t barrier_target_count = get_compile_time_arg_val(16);
 
-constexpr uint32_t num_ct_args = 16;
+constexpr uint32_t num_ct_args = 17;
 
 constexpr ccl_routing_utils::line_unicast_route_info_t forward_unicast_route_info =
     ccl_routing_utils::get_line_unicast_route_info_from_args<num_ct_args>();
@@ -243,7 +244,7 @@ void kernel_main() {
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{opposite_direction_barrier_sem_noc_addr_in_pkt, 0});
         }
 
-        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), barrier_target_count);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -54,8 +54,9 @@ constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val
 constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(20);
 constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(21);
 constexpr uint32_t num_mux_clients = get_compile_time_arg_val(22);
+constexpr uint32_t barrier_target_count = get_compile_time_arg_val(23);
 
-constexpr uint32_t num_ct_args = 23;
+constexpr uint32_t num_ct_args = 24;
 
 constexpr ccl_routing_utils::line_unicast_route_info_t forward_unicast_route_info =
     ccl_routing_utils::get_line_unicast_route_info_from_args<num_ct_args>();
@@ -248,7 +249,7 @@ void kernel_main() {
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{opposite_direction_barrier_sem_noc_addr_in_pkt, 0});
         }
 
-        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), barrier_target_count);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -1111,8 +1111,23 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
         sender_device_coord, forward_coord, backward_coord, mesh_device);
     auto [num_targets_forward, num_targets_backward] =
         ccl::get_forward_backward_line_mcast_distance(ring_size, ring_index, topology, true);
+    const bool use_fabric_2d_neighbor_barrier =
+        topology == ccl::Topology::Linear && tt::tt_fabric::is_2d_fabric_config(tt::tt_fabric::GetFabricConfig());
+    // A logical line embedded in a 2D fabric can turn at an intermediate device. A single line
+    // multicast range follows the physical direction selected by its first hop, so it cannot
+    // represent such a turn. The reduce-scatter data path already relays through immediate logical
+    // neighbors; use the same one-hop connectivity for its startup barrier on Fabric2D.
+    const uint32_t barrier_targets_forward =
+        use_fabric_2d_neighbor_barrier ? std::min(num_targets_forward, 1u) : num_targets_forward;
+    const uint32_t barrier_targets_backward =
+        use_fabric_2d_neighbor_barrier ? std::min(num_targets_backward, 1u) : num_targets_backward;
     auto [mcast_forward_args, mcast_backward_args] = ccl::get_forward_backward_line_mcast_configuration(
-        sender_device_coord, forward_coord, backward_coord, num_targets_forward, num_targets_backward, mesh_device);
+        sender_device_coord,
+        forward_coord,
+        backward_coord,
+        barrier_targets_forward,
+        barrier_targets_backward,
+        mesh_device);
 
     uint32_t num_cores_per_link = ttnn::experimental::ccl::reduce_scatter_core_count_per_link(
         num_workers_per_direction, num_directions_per_link, num_mux_cores_per_direction_per_link);
@@ -1252,7 +1267,6 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
         reader_compute_defines["OUTPUT_IS_SHARDED"] = "1";
         writer_compute_defines["OUTPUT_IS_SHARDED"] = "1";
     }
-
     // KERNEL CREATION
     if (fuse_op) {
         fused_op_signaler->init_reduce_scatter(program, mesh_device, sender_worker_core_range_set);
@@ -1372,6 +1386,10 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
         mux_kernel_config,
         num_workers_per_direction,
         sender_writer_compile_args);
+
+    sender_writer_compile_args.push_back(
+        use_fabric_2d_neighbor_barrier ? static_cast<uint32_t>((num_targets_forward != 0) + (num_targets_backward != 0))
+                                       : ring_size - 1);  // barrier_target_count
 
     sender_writer_compile_args.insert(
         sender_writer_compile_args.end(), unicast_forward_args.begin(), unicast_forward_args.end());


### PR DESCRIPTION
## Summary
- use one-hop startup barriers for FABRIC_2D linear all-gather and minimal reduce-scatter
- avoid waiting for a multicast range that cannot traverse a physical turn in a folded logical line
- add folded 1×4 FABRIC_2D all-gather coverage

## Validation
- `./build_metal.sh --release`
- GLM 5.2  Sparse MLA, 1×4 FABRIC_2D
- folded-line FABRIC_2D all-gather regression

## Manually dispatched CI

[![TM-Fabric Fabric Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)](https://github.com/tenstorrent/tt-metal/actions/runs/30765144806)
[![Blackhole e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)](https://github.com/tenstorrent/tt-metal/actions/runs/30765172036)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-folded-fabric2d-ccl-startup-barriers)