### PR TITLE
[Bug fix]: Workaround upper 16 TCs corrupting mirrored TCs by remapping upper TCs to an unused shadow

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -46,8 +46,46 @@
 #include <tt-metalium/bfloat16.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
+#include "impl/context/metal_context.hpp"
+#include <llrt/tt_cluster.hpp>
 
 namespace tt::tt_metal {
+
+// Host readback of NEO-local tile-counter mirror fields used by isolation tests.
+// NEO mirror: tiles_available@0x8, space_available@0xC, capacity@0x10.
+struct LiveTcSnapshot {
+    std::vector<uint32_t> capacity;
+    std::vector<uint32_t> tiles_available;
+    std::vector<uint32_t> space_available;
+};
+
+inline LiveTcSnapshot read_live_tcs(IDevice* device, const CoreCoord& logical_core, uint32_t neo_id) {
+    const auto& hal = MetalContext::instance().hal();
+    const uint32_t base = hal.get_neo_tile_counters_base_addr() + neo_id * hal.get_neo_tile_counters_stride();
+    const uint32_t size = hal.get_neo_tile_counters_size();
+    const uint32_t cap_offset = hal.get_neo_tile_counters_buffer_capacity_offset();
+    const uint32_t tiles_available_offset = hal.get_neo_tile_counters_tiles_available_offset();
+    // Same offset as NEO_REGS_*_SPACE_AVAILABLE.
+    constexpr uint32_t space_available_offset = 0x0000000Cu;
+    const uint32_t num_counters = size != 0 ? static_cast<uint32_t>(::dfb::NUM_TILE_COUNTERS_PER_TENSIX) : 0u;
+    const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
+
+    LiveTcSnapshot snap;
+    snap.capacity.reserve(num_counters);
+    snap.tiles_available.reserve(num_counters);
+    snap.space_available.reserve(num_counters);
+    auto& cluster = MetalContext::instance().get_cluster();
+    for (uint32_t i = 0; i < num_counters; i++) {
+        const uint32_t tc_base = base + i * size;
+        snap.capacity.push_back(
+            cluster.read_core(device->id(), virtual_core, tc_base + cap_offset, sizeof(uint32_t))[0]);
+        snap.tiles_available.push_back(
+            cluster.read_core(device->id(), virtual_core, tc_base + tiles_available_offset, sizeof(uint32_t))[0]);
+        snap.space_available.push_back(
+            cluster.read_core(device->id(), virtual_core, tc_base + space_available_offset, sizeof(uint32_t))[0]);
+    }
+    return snap;
+}
 
 namespace m2 = experimental;
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -1082,12 +1082,17 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_HomogeneousGrid_SingleGroup) {
 
 // Validates an intra-tensix DFB (pack TRISC producer → unpack TRISC consumer, same Neo):
 //   - Exactly one per-risc config entry (shared Neo bit) marked is_producer=true.
-//   - The tensix-only TC (id ≥ TC_TENSIX_POOL_START) is assigned to Neo tensix_id derived from producer_risc_mask.
+//   - STRIDED producer → STRIDED consumer (INTRA never uses ALL / remapper fan-out patterns).
+//   - RemapperProgrammer::TENSIX_PACKER with Tensix-only ClientL + distinct shadow TC.
+//   - Remapper pair drawn from the top-down 1-to-1 pool.
 void validate_intra_tensix_dfb(
     Program& program,
     const CoreCoord& logical_core,
     const experimental::dfb::DataflowBufferConfig& config) {
     program.impl().finalize_dataflow_buffer_configs();
+
+    ASSERT_EQ(config.pap, dfb::AccessPattern::STRIDED);
+    ASSERT_EQ(config.cap, dfb::AccessPattern::STRIDED);
 
     auto dfbs = program.impl().dataflow_buffers_on_core(logical_core);
     ASSERT_EQ(dfbs.size(), 1u) << "Expected exactly 1 DFB on core";
@@ -1095,7 +1100,10 @@ void validate_intra_tensix_dfb(
 
     ASSERT_EQ(dfb->risc_mask, config.producer_risc_mask)
         << "Intra-tensix risc_mask should equal producer_risc_mask (same Neo bit)";
-    ASSERT_FALSE(dfb->use_remapper) << "Intra-tensix DFB must not use the remapper";
+    ASSERT_TRUE(dfb->use_remapper) << "Intra-tensix DFB must use remapper for the Tensix-only TC alias workaround";
+    ASSERT_EQ(dfb->remapper_programmer, experimental::dfb::detail::RemapperProgrammer::TENSIX_PACKER)
+        << "Intra-tensix remapper pairs are programmed by the Neo packer, not DM1";
+    EXPECT_EQ(dfb->dm1_remapper_slot_count(), 0u) << "Packer-programmed pairs must not appear in the DM1 blob";
     ASSERT_FALSE(dfb->groups.empty()) << "DFB has no groups (configs not finalized?)";
 
     const auto& hw_risc_configs = dfb->groups[0].hw_risc_configs;
@@ -1117,11 +1125,20 @@ void validate_intra_tensix_dfb(
     EXPECT_EQ(actual_tensix_id, expected_tensix_id) << "TC tensix_id must match Neo";
     EXPECT_GE(tc_id, ::dfb::TC_TENSIX_POOL_START)
         << "Intra-tensix DFB must use a Tensix-only TC (id ≥ " << (int)::dfb::TC_TENSIX_POOL_START << ")";
+    EXPECT_GE(rc.config.intra_shadow_tc_id, ::dfb::TC_TENSIX_POOL_START);
+    EXPECT_NE(rc.config.intra_shadow_tc_id, tc_id)
+        << "Shadow TC must be a distinct Tensix-only id that absorbs the remapper HW update copy";
+    EXPECT_GE(rc.config.remapper_pair_index, ::dfb::REMAPPER_ONE_TO_ONE_PAIR_START)
+        << "Packer pairs must come from the 1-to-1 remapper pool";
+    EXPECT_LT(rc.config.remapper_pair_index, ::dfb::NUM_REMAPPER_PAIRINGS);
 
     log_info(
         tt::LogTest,
-        "Intra-tensix DFB: Neo{} Tensix-only TC (tensix_id={}, tc_id={})",
-        expected_tensix_id, (int)actual_tensix_id, (int)tc_id);
+        "Intra-tensix DFB: Neo{} ClientL tc_id={} shadow={} remapper_pair={}",
+        expected_tensix_id,
+        (int)tc_id,
+        (int)rc.config.intra_shadow_tc_id,
+        (int)rc.config.remapper_pair_index);
 }
 
 TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1SConfig) {
@@ -1546,7 +1563,11 @@ static inline void validate_intra_tensix_dfb_2_0(Program& program, const CoreCoo
     auto dfbs = program.impl().dataflow_buffers_on_core(logical_core);
     ASSERT_EQ(dfbs.size(), 1u);
     const auto& dfb = dfbs[0];
-    ASSERT_FALSE(dfb->use_remapper) << "INTRA DFB must not use the remapper";
+    ASSERT_EQ(dfb->config.pap, dfb::AccessPattern::STRIDED);
+    ASSERT_EQ(dfb->config.cap, dfb::AccessPattern::STRIDED);
+    ASSERT_TRUE(dfb->use_remapper) << "INTRA DFB must use remapper for the Tensix-only TC alias workaround";
+    ASSERT_EQ(dfb->remapper_programmer, experimental::dfb::detail::RemapperProgrammer::TENSIX_PACKER);
+    EXPECT_EQ(dfb->dm1_remapper_slot_count(), 0u);
     ASSERT_FALSE(dfb->groups.empty());
     const auto& hw_risc_configs = dfb->groups[0].hw_risc_configs;
     ASSERT_EQ(hw_risc_configs.size(), 1u) << "INTRA DFB should have exactly 1 per-risc entry (shared Neo)";
@@ -1556,6 +1577,10 @@ static inline void validate_intra_tensix_dfb_2_0(Program& program, const CoreCoo
     uint8_t tc_id = ::dfb::get_counter_id(rc.config.packed_tile_counter[0]);
     EXPECT_GE(tc_id, ::dfb::TC_TENSIX_POOL_START)
         << "INTRA DFB must use Tensix-only TC (id >= " << (int)::dfb::TC_TENSIX_POOL_START << ")";
+    EXPECT_GE(rc.config.intra_shadow_tc_id, ::dfb::TC_TENSIX_POOL_START);
+    EXPECT_NE(rc.config.intra_shadow_tc_id, tc_id);
+    EXPECT_GE(rc.config.remapper_pair_index, ::dfb::REMAPPER_ONE_TO_ONE_PAIR_START);
+    EXPECT_LT(rc.config.remapper_pair_index, ::dfb::NUM_REMAPPER_PAIRINGS);
 }
 
 // Multicore-group probe.
@@ -1960,13 +1985,15 @@ TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1SConfig_2_0) {
 
     auto compute = make_compute_kernel(
         COMPUTE, "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra_2_0.cpp", /*num_threads=*/1);
+    // Accessor names must be distinct and match what dfb_t6_intra_2_0.cpp references (dfb::out);
+    // both bindings still resolve to the same DFB, which is what makes M2 infer INTRA scope.
     compute.dfb_bindings = {
         {.dfb_spec_name = DFB,
-         .accessor_name = "self",
+         .accessor_name = "out",
          .endpoint_type = m2::DFBEndpointType::PRODUCER,
          .access_pattern = m2::DFBAccessPattern::STRIDED},
         {.dfb_spec_name = DFB,
-         .accessor_name = "self",
+         .accessor_name = "in",
          .endpoint_type = m2::DFBEndpointType::CONSUMER,
          .access_pattern = m2::DFBAccessPattern::STRIDED},
     };
@@ -2056,6 +2083,113 @@ TEST_F(MeshDeviceFixture, B8_FiveAllConsumers_Rejected_2_0) {
 // direct equivalent.
 TEST_F(MeshDeviceFixture, B9_InterTensixScope_Rejected_2_0) {
     GTEST_SKIP() << "Not applicable: M2 DataflowBufferSpec has no tensix_scope field";
+}
+
+// Host-only: packer INTRA pairs allocate top-down from 63; DM1 1:m pairs stay in [0,16).
+TEST_F(MeshDeviceFixture, IntraPackerRemapperPairsTopDownConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Quasar-only remapper pool split";
+    }
+
+    Program program = CreateProgram();
+    CoreCoord logical_core(0, 0);
+
+    // Two INTRA DFBs on Neo0 → ClientL 16 then 18; contiguous packer remapper block [62,64).
+    for (int i = 0; i < 2; i++) {
+        experimental::dfb::DataflowBufferConfig intra{
+            .entry_size = 1024,
+            .num_entries = 4,
+            .producer_risc_mask = 0x100,
+            .num_producers = 1,
+            .pap = dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask = 0x100,
+            .num_consumers = 1,
+            .cap = dfb::AccessPattern::STRIDED,
+            .enable_producer_implicit_sync = false,
+            .enable_consumer_implicit_sync = false,
+            .tensix_scope = experimental::dfb::TensixScope::INTRA};
+        experimental::dfb::CreateDataflowBuffer(program, logical_core, intra);
+    }
+
+    // DM→Tensix ALL remapper on same core (producer STRIDED, consumer ALL).
+    experimental::dfb::DataflowBufferConfig remapper{
+        .entry_size = 1024,
+        .num_entries = 8,
+        .producer_risc_mask = 0x4,  // DM2
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0xF00,  // Neo0-3
+        .num_consumers = 4,
+        .cap = dfb::AccessPattern::ALL,
+        .enable_producer_implicit_sync = true,
+        .enable_consumer_implicit_sync = true};
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, remapper);
+
+    program.impl().finalize_dataflow_buffer_configs();
+    auto dfbs = program.impl().dataflow_buffers_on_core(logical_core);
+    ASSERT_EQ(dfbs.size(), 3u);
+
+    std::vector<uint8_t> packer_pairs;
+    std::vector<uint8_t> packer_tcs;
+    uint8_t dm1_pair = 0xFF;
+    for (const auto& dfb : dfbs) {
+        if (dfb->remapper_programmer == experimental::dfb::detail::RemapperProgrammer::TENSIX_PACKER) {
+            ASSERT_FALSE(dfb->groups.empty());
+            const auto& rc = dfb->groups[0].hw_risc_configs[0];
+            packer_pairs.push_back(rc.config.remapper_pair_index);
+            packer_tcs.push_back(::dfb::get_counter_id(rc.config.packed_tile_counter[0]));
+            EXPECT_EQ(dfb->dm1_remapper_slot_count(), 0u);
+        } else if (dfb->remapper_programmer == experimental::dfb::detail::RemapperProgrammer::DM1) {
+            ASSERT_FALSE(dfb->groups.empty());
+            for (const auto& rc : dfb->groups[0].hw_risc_configs) {
+                if (rc.is_producer) {
+                    dm1_pair = rc.config.remapper_pair_index;
+                }
+            }
+        }
+    }
+    ASSERT_EQ(packer_pairs.size(), 2u);
+    ASSERT_EQ(packer_tcs.size(), 2u);
+    EXPECT_EQ(packer_tcs[0], 16);
+    EXPECT_EQ(packer_tcs[1], 18);
+    // Contiguous top-down block of size 2 starts at 62: [62, 64).
+    EXPECT_EQ(packer_pairs[0], 62);
+    EXPECT_EQ(packer_pairs[1], 63);
+    EXPECT_NE(dm1_pair, 0xFF);
+    EXPECT_LT(dm1_pair, ::dfb::NUM_REMAPPER_ONE_TO_MANY_PAIRINGS);
+    EXPECT_LT(dm1_pair, packer_pairs[0]);
+}
+
+// T7: one INTRA DFB past what a Neo's Tensix-only TC pool can back must fail. The limit is per Neo:
+// each INTRA DFB spends a ClientL + shadow pair out of that Neo's 16 Tensix-only TCs, so 8 fit and the
+// 9th exhausts the pool (and its packer remapper pair).
+TEST_F(MeshDeviceFixture, MaxEightIntraPerNeoConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Quasar-only INTRA TC pool limit";
+    }
+
+    constexpr uint32_t max_intra_dfbs_per_neo =
+        ::dfb::NUM_TENSIX_ONLY_TILE_COUNTERS / ::dfb::TILE_COUNTERS_PER_INTRA_TENSIX_DFB;
+
+    Program program = CreateProgram();
+    CoreCoord logical_core(0, 0);
+    for (uint32_t i = 0; i < max_intra_dfbs_per_neo + 1; i++) {
+        experimental::dfb::DataflowBufferConfig intra{
+            .entry_size = 1024,
+            .num_entries = 4,
+            .producer_risc_mask = 0x100,
+            .num_producers = 1,
+            .pap = dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask = 0x100,
+            .num_consumers = 1,
+            .cap = dfb::AccessPattern::STRIDED,
+            .enable_producer_implicit_sync = false,
+            .enable_consumer_implicit_sync = false,
+            .tensix_scope = experimental::dfb::TensixScope::INTRA};
+        experimental::dfb::CreateDataflowBuffer(program, logical_core, intra);
+    }
+
+    EXPECT_THROW(program.impl().finalize_dataflow_buffer_configs(), std::exception);
 }
 
 }  // end namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
@@ -6,6 +6,10 @@
 
 #include "dfb_test_common.hpp"
 
+#include <array>
+#include <map>
+#include <string_view>
+
 namespace tt::tt_metal {
 
 // legacy intra-Tensix self-loop harness + test
@@ -244,6 +248,20 @@ TEST_F(MeshDeviceFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input);
     m2_writeshard_barrier_uint32(device, in_tensor, input);
 
+    // Finalize early so host can assert INTRA remapper assignment before launch.
+    program.impl().finalize_dataflow_buffer_configs();
+    auto self_dfb = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle(*DFB_SELF));
+    ASSERT_NE(self_dfb, nullptr);
+    EXPECT_EQ(self_dfb->remapper_programmer, experimental::dfb::detail::RemapperProgrammer::TENSIX_PACKER);
+    EXPECT_EQ(self_dfb->dm1_remapper_slot_count(), 0u);
+    ASSERT_FALSE(self_dfb->groups.empty());
+    const auto& self_rc = self_dfb->groups[0].hw_risc_configs[0];
+    const uint8_t self_tc = ::dfb::get_counter_id(self_rc.config.packed_tile_counter[0]);
+    EXPECT_GE(self_tc, ::dfb::TC_TENSIX_POOL_START);
+    EXPECT_GE(self_rc.config.intra_shadow_tc_id, ::dfb::TC_TENSIX_POOL_START);
+    EXPECT_NE(self_rc.config.intra_shadow_tc_id, self_tc);
+    EXPECT_GE(self_rc.config.remapper_pair_index, ::dfb::REMAPPER_ONE_TO_ONE_PAIR_START);
+
     detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
@@ -251,6 +269,13 @@ TEST_F(MeshDeviceFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     EXPECT_TRUE(packed_uint32_t_vector_comparison(output, input, [](float a, float b) {
         return std::abs(a - b) < 0.01f;
     })) << "M2 C2 double-relu identity mismatch";
+
+    // Capacity is shared (all DFBs use num_entries=4), so only assert the INTRA ClientL/shadow
+    // programming — not overlay isolation by capacity fingerprint.
+    const auto live = read_live_tcs(device, CoreCoord(0, 0), /*neo_id=*/0);
+    ASSERT_GT(live.capacity.size(), self_rc.config.intra_shadow_tc_id);
+    EXPECT_EQ(live.capacity[self_tc], num_entries);
+    EXPECT_EQ(live.capacity[self_rc.config.intra_shadow_tc_id], 0u);
 }
 
 // Metal 2.0 intra-Tensix self-loop harness + test
@@ -431,6 +456,81 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
     params.tensor_args = {{IN_TENSOR, std::cref(in_tensor)}};
     m2::SetProgramRunArgs(program, params);
 
+    // Finalize before launch so the counters each DFB owns are known while the pre-launch snapshot is taken.
+    program.impl().finalize_dataflow_buffer_configs();
+
+    // Remapper (DM1) vs packer (INTRA) pool split + live TC integrity.
+    auto remapper_dfb = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle(*DFB_REMAPPER));
+    auto intra_dfb = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle(*DFB_INTRA));
+    ASSERT_NE(remapper_dfb, nullptr);
+    ASSERT_NE(intra_dfb, nullptr);
+    EXPECT_EQ(remapper_dfb->remapper_programmer, experimental::dfb::detail::RemapperProgrammer::DM1);
+    EXPECT_EQ(intra_dfb->remapper_programmer, experimental::dfb::detail::RemapperProgrammer::TENSIX_PACKER);
+    EXPECT_EQ(intra_dfb->dm1_remapper_slot_count(), 0u);
+
+    uint8_t packer_lo = ::dfb::NUM_REMAPPER_PAIRINGS;
+    for (const auto& rc : intra_dfb->groups[0].hw_risc_configs) {
+        ASSERT_TRUE(rc.is_producer);
+        const uint8_t tc_id = ::dfb::get_counter_id(rc.config.packed_tile_counter[0]);
+        EXPECT_GE(tc_id, ::dfb::TC_TENSIX_POOL_START);
+        EXPECT_GE(rc.config.intra_shadow_tc_id, ::dfb::TC_TENSIX_POOL_START);
+        EXPECT_NE(rc.config.intra_shadow_tc_id, tc_id);
+        EXPECT_GE(rc.config.remapper_pair_index, ::dfb::REMAPPER_ONE_TO_ONE_PAIR_START);
+        packer_lo = std::min(packer_lo, rc.config.remapper_pair_index);
+    }
+    for (const auto& rc : remapper_dfb->groups[0].hw_risc_configs) {
+        if (!rc.is_producer) {
+            continue;
+        }
+        EXPECT_LT(rc.config.remapper_pair_index, ::dfb::NUM_REMAPPER_ONE_TO_MANY_PAIRINGS)
+            << "DM1 1:m pairs must stay in [0,16)";
+        EXPECT_LT(rc.config.remapper_pair_index, packer_lo) << "DM1 pairs must stay below packer-owned top-down range";
+    }
+
+    // Record which Neo0 counter each DFB claims so a collision shows up as two owners of one tc id instead of
+    // being inferred from counter values. Distinct capacities (remapper consumers hold num_entries, INTRA
+    // ClientL holds entries_per_neo, shadow stays unprogrammed) then let the live readback confirm the owner
+    // of every counter this program touched.
+    static_assert(num_entries != entries_per_neo, "capacities must differ so a counter names its owner");
+    struct TcClaim {
+        uint32_t capacity;
+        std::string_view owner;
+    };
+    std::map<uint8_t, TcClaim> claims;  // Neo0 tc id -> expected state after init
+    auto claim = [&](uint8_t tc_id, uint32_t capacity, std::string_view owner) {
+        const auto [it, inserted] = claims.emplace(tc_id, TcClaim{capacity, owner});
+        if (!inserted) {
+            EXPECT_EQ(it->second.owner, owner)
+                << "Neo0 TC" << (int)tc_id << " claimed by both " << it->second.owner << " and " << owner;
+        }
+    };
+
+    for (const auto& rc : remapper_dfb->groups[0].hw_risc_configs) {
+        if (rc.is_producer) {
+            continue;
+        }
+        const uint8_t tc_id = ::dfb::get_counter_id(rc.config.packed_tile_counter[0]);
+        if (::dfb::get_tensix_id(rc.config.packed_tile_counter[0]) != 0) {
+            continue;  // host live readback is Neo0-local
+        }
+        EXPECT_LT(tc_id, ::dfb::TC_TENSIX_POOL_START) << "DM->Tensix consumer must use a DM-visible TC";
+        claim(tc_id, num_entries, "remapper consumer");
+    }
+    for (const auto& rc : intra_dfb->groups[0].hw_risc_configs) {
+        if (::dfb::get_tensix_id(rc.config.packed_tile_counter[0]) != 0) {
+            continue;
+        }
+        claim(::dfb::get_counter_id(rc.config.packed_tile_counter[0]), entries_per_neo, "INTRA ClientL");
+        claim(rc.config.intra_shadow_tc_id, 0u, "INTRA shadow");
+    }
+
+    // DFB init only resets and sizes the counters named in this program's config, so counters it does not
+    // claim must come out of the run bit-identical to this snapshot no matter what earlier programs left in
+    // them. Comparing against the snapshot is what makes the isolation check exact instead of a guess about
+    // which values look like INTRA state.
+    const auto before = read_live_tcs(device, CoreCoord(0, 0), /*neo_id=*/0);
+    ASSERT_GE(before.capacity.size(), ::dfb::NUM_TILE_COUNTERS_PER_TENSIX);
+
     // Fill DRAM input; DM NOC-reads this into the remapper ring's L1.
     auto input_remapper =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, num_entries * entry_size / sizeof(uint32_t));
@@ -446,6 +546,217 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
     std::vector<uint32_t> l1_remapper;
     detail::ReadFromDeviceL1(device, CoreCoord(0, 0), remapper_l1_addr, num_entries * entry_size, l1_remapper);
     EXPECT_EQ(input_remapper, l1_remapper) << "M2 DM->Tensix strided x ALL remapper ring L1 mismatch";
+
+    // space_available is the free-space view (capacity - tiles_available), so a fully drained counter reads
+    // tiles_available == 0 and space_available == capacity.
+    const auto live = read_live_tcs(device, CoreCoord(0, 0), /*neo_id=*/0);
+    ASSERT_GE(live.capacity.size(), ::dfb::NUM_TILE_COUNTERS_PER_TENSIX);
+    for (const auto& [tc_id, expected] : claims) {
+        EXPECT_EQ(live.capacity[tc_id], expected.capacity) << expected.owner << " TC" << (int)tc_id << " capacity";
+        EXPECT_EQ(live.tiles_available[tc_id], 0u) << expected.owner << " TC" << (int)tc_id << " not drained";
+        EXPECT_EQ(live.space_available[tc_id], expected.capacity)
+            << expected.owner << " TC" << (int)tc_id << " space_available after drain";
+    }
+    for (uint32_t tc = 0; tc < ::dfb::TC_TENSIX_POOL_START; tc++) {
+        if (claims.contains(static_cast<uint8_t>(tc))) {
+            continue;
+        }
+        EXPECT_EQ(live.capacity[tc], before.capacity[tc]) << "unclaimed DM-visible TC" << tc << " capacity changed";
+        EXPECT_EQ(live.tiles_available[tc], before.tiles_available[tc])
+            << "unclaimed DM-visible TC" << tc << " tiles_available changed";
+        EXPECT_EQ(live.space_available[tc], before.space_available[tc])
+            << "unclaimed DM-visible TC" << tc << " space_available changed";
+    }
+}
+
+// T1: pure INTRA must not corrupt DM-visible overlay tile counters 0-15.
+TEST_F(MeshDeviceFixture, TensixIntraIsolatesOverlayTCs) {
+    auto& mesh_device = this->devices_.at(0);
+    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Overlay TC isolation is Quasar-only";
+    }
+    IDevice* device = mesh_device->get_devices()[0];
+
+    constexpr uint32_t entry_size = 1024;
+    constexpr uint32_t num_entries = 8;
+    constexpr uint32_t num_threads = 1;
+    constexpr uint32_t entries_per_neo = num_entries / num_threads;
+    constexpr uint32_t total_bytes = num_entries * entry_size;
+    constexpr uint32_t scratch_magic = 0x000A11A5u;
+    constexpr uint32_t scratch_done = 0x000D0EEu;
+    constexpr uint32_t handshake_ready = 0x000BEE71u;
+    constexpr uint32_t handshake_pushes_done = 0x000BEE72u;
+    constexpr uint32_t settle_reads = 256;
+    constexpr uint32_t num_mirrored_dm_tcs = ::dfb::NUM_TENSIX_TILE_COUNTERS_FOR_DM;  // 16
+    constexpr uint32_t words_per_tc = 3;
+
+    // Uneven pushes so a doubled credit cannot be mistaken for the next step's push. Pack issues the
+    // whole series before unpack pops, so the sum must fit in the ClientL capacity.
+    constexpr std::array<uint32_t, 4> steps = {1, 3, 2, 2};
+    constexpr uint32_t num_steps = 4;
+    static_assert(steps[0] + steps[1] + steps[2] + steps[3] == entries_per_neo);
+
+    // Intra-tensix allocation is deterministic for the first INTRA DFB on Neo0; the kernel needs the
+    // ClientL id at compile time and the host asserts the finalized config still matches.
+    constexpr uint32_t client_l_tc_arg = ::dfb::TC_TENSIX_POOL_START;  // 16
+
+    constexpr uint32_t ready_idx = 2;
+    constexpr uint32_t pushes_done_idx = 3;
+    constexpr uint32_t num_steps_idx = 4;
+    constexpr uint32_t posted_base = 5;
+    constexpr uint32_t acked_base = posted_base + num_steps;
+    constexpr uint32_t baseline_base = acked_base + num_steps;
+    constexpr uint32_t final_base = baseline_base + num_mirrored_dm_tcs * words_per_tc;
+    constexpr uint32_t done_idx = final_base + num_mirrored_dm_tcs * words_per_tc;
+    constexpr uint32_t scratch_words = done_idx + 1;
+
+    const uint32_t dfb_l1_addr = static_cast<uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+    const uint32_t scratch_l1_addr = dfb_l1_addr + total_bytes;
+
+    const m2::DFBSpecName DFB{"intra_dfb"};
+    const m2::KernelSpecName COMPUTE{"compute"};
+
+    m2::DataflowBufferSpec dfb_spec{
+        .unique_id = DFB,
+        .entry_size = entry_size,
+        .num_entries = num_entries,
+        .data_format_metadata = tt::DataFormat::Float16_b,
+    };
+
+    auto compute = make_compute_kernel(
+        COMPUTE, "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra_overlay_check.cpp", num_threads);
+    compute.dfb_bindings = {
+        {.dfb_spec_name = DFB,
+         .accessor_name = "out",
+         .endpoint_type = m2::DFBEndpointType::PRODUCER,
+         .access_pattern = m2::DFBAccessPattern::STRIDED},
+        {.dfb_spec_name = DFB,
+         .accessor_name = "in",
+         .endpoint_type = m2::DFBEndpointType::CONSUMER,
+         .access_pattern = m2::DFBAccessPattern::STRIDED},
+    };
+    compute.compile_time_args = {
+        {"scratch_l1_address", scratch_l1_addr},
+        {"scratch_magic", scratch_magic},
+        {"scratch_done", scratch_done},
+        {"handshake_ready", handshake_ready},
+        {"handshake_pushes_done", handshake_pushes_done},
+        {"settle_reads", settle_reads},
+        {"client_l_tc", client_l_tc_arg},
+        {"num_overlay_tcs", num_mirrored_dm_tcs},
+        {"words_per_tc", words_per_tc},
+        {"ready_idx", ready_idx},
+        {"pushes_done_idx", pushes_done_idx},
+        {"num_steps_idx", num_steps_idx},
+        {"posted_base", posted_base},
+        {"acked_base", acked_base},
+        {"baseline_base", baseline_base},
+        {"final_base", final_base},
+        {"done_idx", done_idx},
+        {"step0", steps[0]},
+        {"step1", steps[1]},
+        {"step2", steps[2]},
+        {"step3", steps[3]},
+    };
+
+    const m2::NodeRangeSet node_set{m2::NodeRange{m2::NodeCoord{0, 0}, m2::NodeCoord{0, 0}}};
+    m2::ProgramSpec spec{
+        .name = "intra_overlay_isolation_2_0",
+        .kernels = {compute},
+        .dataflow_buffers = {dfb_spec},
+        .tensor_parameters = {},
+        .work_units = {m2::WorkUnitSpec{.name = "main", .kernels = {COMPUTE}, .target_nodes = node_set}},
+    };
+
+    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    program.impl().finalize_dataflow_buffer_configs();
+
+    auto intra_dfb = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle(*DFB));
+    ASSERT_NE(intra_dfb, nullptr);
+    ASSERT_EQ(intra_dfb->remapper_programmer, experimental::dfb::detail::RemapperProgrammer::TENSIX_PACKER);
+    const auto& rc = intra_dfb->groups[0].hw_risc_configs[0];
+    const uint8_t client_l_tc = ::dfb::get_counter_id(rc.config.packed_tile_counter[0]);
+    EXPECT_GE(client_l_tc, ::dfb::TC_TENSIX_POOL_START);
+    EXPECT_GE(rc.config.intra_shadow_tc_id, ::dfb::TC_TENSIX_POOL_START);
+    EXPECT_NE(rc.config.intra_shadow_tc_id, client_l_tc);
+    EXPECT_GE(rc.config.remapper_pair_index, ::dfb::REMAPPER_ONE_TO_ONE_PAIR_START);
+    // The kernel samples ClientL as a compile-time arg, so a reallocation must fail loudly here
+    // rather than silently sampling the wrong counter.
+    ASSERT_EQ(client_l_tc, client_l_tc_arg);
+
+    m2::ProgramRunArgs params;
+    params.kernel_run_args = {{.kernel = COMPUTE}};
+    m2::SetProgramRunArgs(program, params);
+
+    // Kernel only exercises TC push/pop credits; L1 payload is untouched.
+    std::vector<uint32_t> scratch_zero(scratch_words, 0);
+    detail::WriteToDeviceL1(device, CoreCoord(0, 0), scratch_l1_addr, scratch_zero);
+
+    // This program owns only Tensix-only counters (ClientL + shadow), so every DM-visible counter must survive
+    // the run untouched. The kernel's own baseline is sampled after DFB init; snapshotting here additionally
+    // covers init-time aliasing, and comparing exact values avoids inferring corruption from a magic capacity.
+    const auto before = read_live_tcs(device, CoreCoord(0, 0), /*neo_id=*/0);
+    ASSERT_GE(before.capacity.size(), ::dfb::NUM_TILE_COUNTERS_PER_TENSIX);
+
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+
+    std::vector<uint32_t> scratch;
+    detail::ReadFromDeviceL1(device, CoreCoord(0, 0), scratch_l1_addr, scratch_words * sizeof(uint32_t), scratch);
+    ASSERT_EQ(scratch.size(), scratch_words);
+    EXPECT_EQ(scratch[0], scratch_magic) << "Pack never wrote overlay isolation scratch";
+    EXPECT_EQ(scratch[done_idx], scratch_done) << "Pack never finished overlay isolation scratch";
+    EXPECT_EQ(scratch[1], entries_per_neo) << "ClientL capacity mismatch";
+    EXPECT_EQ(scratch[ready_idx], handshake_ready) << "Pack never published the baseline handshake";
+    EXPECT_EQ(scratch[pushes_done_idx], handshake_pushes_done) << "Pack never finished the push series";
+    EXPECT_EQ(scratch[num_steps_idx], num_steps) << "Kernel decoded a different step count";
+
+    // Double-count check on ClientL: nothing is popped until every push has been issued, so
+    // tiles-available after push step s is the running push total and space-available after pop
+    // step s is the running pop total. A doubled credit shows up as 2x the expected value.
+    uint32_t tiles_pushed = 0;
+    for (uint32_t step = 0; step < num_steps; step++) {
+        tiles_pushed += steps[step];
+        EXPECT_EQ(scratch[posted_base + step], tiles_pushed)
+            << "ClientL TC" << (uint32_t)client_l_tc << " tiles-available after push step " << step << " (pushed "
+            << steps[step] << ", expected running total " << tiles_pushed << ") — possible double-counted push";
+    }
+    uint32_t tiles_popped = 0;
+    for (uint32_t step = 0; step < num_steps; step++) {
+        tiles_popped += steps[step];
+        EXPECT_EQ(scratch[acked_base + step], tiles_popped)
+            << "ClientL TC" << (uint32_t)client_l_tc << " space-available after pop step " << step << " (popped "
+            << steps[step] << ", expected running total " << tiles_popped << ") — possible double-counted pop";
+    }
+    EXPECT_EQ(tiles_pushed, entries_per_neo);
+    EXPECT_EQ(tiles_popped, tiles_pushed) << "Tiles popped must equal tiles pushed (no lost/double credits)";
+
+    // Mirrored DM TCs (overlay 0-15) must be unchanged by the INTRA push/pop series. The remapper
+    // routes ClientL updates to a sacrificial shadow; nothing should leak into the DM-visible pool.
+    for (uint32_t tc = 0; tc < num_mirrored_dm_tcs; tc++) {
+        for (uint32_t f = 0; f < words_per_tc; f++) {
+            const uint32_t baseline = scratch[baseline_base + tc * words_per_tc + f];
+            const uint32_t final_v = scratch[final_base + tc * words_per_tc + f];
+            EXPECT_EQ(final_v, baseline) << "Mirrored DM TC" << tc << " field " << f
+                                         << " changed during INTRA push/pop (baseline=" << baseline
+                                         << " final=" << final_v << ")";
+        }
+    }
+
+    // Host-side NEO mirror readback after the drained series: ClientL must be empty, and every DM-visible
+    // counter must match the pre-launch snapshot — init sized and reset only ClientL, so anything else moving
+    // means a T6 update aliased into the overlay pool.
+    const auto live = read_live_tcs(device, CoreCoord(0, 0), /*neo_id=*/0);
+    ASSERT_GT(live.capacity.size(), client_l_tc);
+    EXPECT_EQ(live.capacity[client_l_tc], entries_per_neo);
+    EXPECT_EQ(live.tiles_available[client_l_tc], 0u)
+        << "ClientL tiles_available not drained after equal push/pop — possible double-count or missed pop";
+    for (uint32_t tc = 0; tc < ::dfb::NUM_TENSIX_TILE_COUNTERS_FOR_DM; tc++) {
+        EXPECT_EQ(live.capacity[tc], before.capacity[tc]) << "Mirrored DM TC" << tc << " capacity changed";
+        EXPECT_EQ(live.tiles_available[tc], before.tiles_available[tc])
+            << "Mirrored DM TC" << tc << " tiles_available changed — T6->overlay alias leaked a push";
+        EXPECT_EQ(live.space_available[tc], before.space_available[tc])
+            << "Mirrored DM TC" << tc << " space_available changed — T6->overlay alias leaked a credit";
+    }
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra_overlay_check.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra_overlay_check.cpp
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// INTRA self-loop that samples the mirrored DM-visible overlay tile counters (0-15) so the host can
+// detect the Quasar T6→overlay alias bug. Pack only pushes, unpack only pops, no L1 payload
+// modification. Firmware has already programmed the ClientL capacity and the remapper alias before
+// this kernel runs.
+//
+// Pack issues every push before unpack is allowed to pop, so the ClientL counter is a deterministic
+// function of the tiles pushed/popped so far and the host can tell a single count from a double
+// count. Steps carry uneven tile counts for the same reason: a doubled event on a series of 1s is
+// indistinguishable from the next step's push.
+//
+// Two handshakes through uncached L1, one writer per word:
+//   ready       — pack has taken the baseline overlay sample; unpack may start
+//   pushes_done — pack has issued the whole push series; unpack may start popping
+//
+// Scratch layout (uncached L1 words) is defined by host CTAs:
+//   [0]                    scratch_magic
+//   [1]                    ClientL capacity after DataflowBuffer ctor (get_local_num_entries)
+//   [ready_idx]            handshake_ready once pack's baseline sample is in L1
+//   [pushes_done_idx]      handshake_pushes_done once every push has been issued
+//   [num_steps_idx]        step count decoded from the step CTAs
+//   [posted_base ..)       pack: ClientL tiles-available after each push
+//   [acked_base ..)        unpack: ClientL space-available after each pop
+//   [baseline_base ..)     mirrored DM TC0..N-1 baseline {cap, posted, acked}
+//   [final_base ..)        mirrored DM TC0..N-1 after the INTRA series {cap, posted, acked}
+//   [done_idx]             scratch_done
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/debug/dprint.h"
+#include "ckernel_trisc_common.h"
+#include "dev_mem_map.h"
+#include "experimental/kernel_args.h"
+
+namespace {
+// Host may pass fewer steps; a zero tile count ends the series.
+constexpr uint32_t max_steps = 4;
+
+volatile uint32_t* scratch_ptr(uint32_t l1_address, uint32_t word_idx) {
+    return reinterpret_cast<volatile uint32_t*>(l1_address + MEM_L1_UNCACHED_BASE + word_idx * sizeof(uint32_t));
+}
+
+// A counter reads back a derived view rather than the credit total that was written:
+// tile_counters[].f.posted sits at the TILES_AVAILABLE offset and .f.acked at SPACE_AVAILABLE.
+// Sampling right after a push/pop returns the pre-update value, so each sample re-reads until the
+// value settles.
+uint32_t settled_capacity(uint32_t tc, uint32_t settle_reads) {
+    uint32_t value = 0;
+    for (uint32_t i = 0; i < settle_reads; i++) {
+        value = ckernel::trisc::tile_counters[tc].f.buf_capacity;
+    }
+    return value;
+}
+
+uint32_t settled_posted(uint32_t tc, uint32_t settle_reads) {
+    uint32_t value = 0;
+    for (uint32_t i = 0; i < settle_reads; i++) {
+        value = ckernel::trisc::tile_counters[tc].f.posted;
+    }
+    return value;
+}
+
+uint32_t settled_acked(uint32_t tc, uint32_t settle_reads) {
+    uint32_t value = 0;
+    for (uint32_t i = 0; i < settle_reads; i++) {
+        value = ckernel::trisc::tile_counters[tc].f.acked;
+    }
+    return value;
+}
+
+void write_tc_triple(uint32_t l1_address, uint32_t tc, uint32_t base_idx, uint32_t settle_reads) {
+    *scratch_ptr(l1_address, base_idx + 0) = settled_capacity(tc, settle_reads);
+    *scratch_ptr(l1_address, base_idx + 1) = settled_posted(tc, settle_reads);
+    *scratch_ptr(l1_address, base_idx + 2) = settled_acked(tc, settle_reads);
+}
+
+void sample_mirrored_dm_tc_block(
+    uint32_t l1_address, uint32_t base_idx, uint32_t num_overlay_tcs, uint32_t words_per_tc, uint32_t settle_reads) {
+    for (uint32_t tc = 0; tc < num_overlay_tcs; tc++) {
+        write_tc_triple(l1_address, tc, base_idx + tc * words_per_tc, settle_reads);
+    }
+}
+}  // namespace
+
+void kernel_main() {
+    constexpr uint32_t scratch_l1_address = get_arg(args::scratch_l1_address);
+    constexpr uint32_t scratch_magic = get_arg(args::scratch_magic);
+    constexpr uint32_t scratch_done = get_arg(args::scratch_done);
+    constexpr uint32_t handshake_ready = get_arg(args::handshake_ready);
+    constexpr uint32_t handshake_pushes_done = get_arg(args::handshake_pushes_done);
+    constexpr uint32_t settle_reads = get_arg(args::settle_reads);
+    constexpr uint32_t client_l_tc = get_arg(args::client_l_tc);
+    constexpr uint32_t num_overlay_tcs = get_arg(args::num_overlay_tcs);
+    constexpr uint32_t words_per_tc = get_arg(args::words_per_tc);
+    constexpr uint32_t ready_idx = get_arg(args::ready_idx);
+    constexpr uint32_t pushes_done_idx = get_arg(args::pushes_done_idx);
+    constexpr uint32_t num_steps_idx = get_arg(args::num_steps_idx);
+    constexpr uint32_t posted_base = get_arg(args::posted_base);
+    constexpr uint32_t acked_base = get_arg(args::acked_base);
+    constexpr uint32_t baseline_base = get_arg(args::baseline_base);
+    constexpr uint32_t final_base = get_arg(args::final_base);
+    constexpr uint32_t done_idx = get_arg(args::done_idx);
+
+    const uint32_t step_tiles[max_steps] = {
+        get_arg(args::step0), get_arg(args::step1), get_arg(args::step2), get_arg(args::step3)};
+    uint32_t num_steps = 0;
+    while (num_steps < max_steps && step_tiles[num_steps] != 0) {
+        num_steps++;
+    }
+
+    DataflowBuffer dfb(dfb::out);
+
+#ifdef UCK_CHLKC_PACK
+    // Firmware already programmed ClientL capacity + remapper alias. Snapshot mirrored DM TCs before
+    // any INTRA push so a leaked capacity/credit write would already show up here.
+    *scratch_ptr(scratch_l1_address, 0) = scratch_magic;
+    *scratch_ptr(scratch_l1_address, 1) = dfb.get_local_num_entries();
+    *scratch_ptr(scratch_l1_address, num_steps_idx) = num_steps;
+    sample_mirrored_dm_tc_block(scratch_l1_address, baseline_base, num_overlay_tcs, words_per_tc, settle_reads);
+    *scratch_ptr(scratch_l1_address, ready_idx) = handshake_ready;
+    DPRINT(
+        "PACK baseline: ClientL TC{} capacity={} mirrored_dm_tc0={}/{}/{}\n",
+        client_l_tc,
+        *scratch_ptr(scratch_l1_address, 1),
+        *scratch_ptr(scratch_l1_address, baseline_base + 0),
+        *scratch_ptr(scratch_l1_address, baseline_base + 1),
+        *scratch_ptr(scratch_l1_address, baseline_base + 2));
+
+    // Whole series is issued before unpack pops, so ClientL tiles-available after step s must equal
+    // the tiles pushed through step s. Twice that means the update was counted twice.
+    for (uint32_t step = 0; step < num_steps; step++) {
+        const uint32_t num_tiles = step_tiles[step];
+        WAYPOINT("PW");
+        dfb.reserve_back(num_tiles);
+        WAYPOINT("PWD");
+        dfb.push_back(num_tiles);
+        WAYPOINT("PPD");
+        const uint32_t posted = settled_posted(client_l_tc, settle_reads);
+        *scratch_ptr(scratch_l1_address, posted_base + step) = posted;
+        DPRINT("PACK step{} push={} TC{} posted={}\n", step, num_tiles, client_l_tc, posted);
+    }
+    *scratch_ptr(scratch_l1_address, pushes_done_idx) = handshake_pushes_done;
+#endif
+
+#ifdef UCK_CHLKC_UNPACK
+    WAYPOINT("URW");
+    while (*scratch_ptr(scratch_l1_address, ready_idx) != handshake_ready) {
+    }
+    WAYPOINT("URD");
+
+    // Wait for the full push series so the pop arithmetic is a deterministic function of tiles popped.
+    WAYPOINT("UPW");
+    while (*scratch_ptr(scratch_l1_address, pushes_done_idx) != handshake_pushes_done) {
+    }
+    WAYPOINT("UPR");
+
+    for (uint32_t step = 0; step < num_steps; step++) {
+        const uint32_t num_tiles = step_tiles[step];
+        WAYPOINT("WT");
+        dfb.wait_front(num_tiles);
+        WAYPOINT("WTD");
+        dfb.pop_front(num_tiles);
+        WAYPOINT("UPD");
+        const uint32_t acked = settled_acked(client_l_tc, settle_reads);
+        *scratch_ptr(scratch_l1_address, acked_base + step) = acked;
+        DPRINT("UNPACK step{} pop={} TC{} acked={}\n", step, num_tiles, client_l_tc, acked);
+    }
+#endif
+
+    dfb.finish();
+
+#ifdef UCK_CHLKC_PACK
+    sample_mirrored_dm_tc_block(scratch_l1_address, final_base, num_overlay_tcs, words_per_tc, settle_reads);
+    *scratch_ptr(scratch_l1_address, done_idx) = scratch_done;
+    DPRINT(
+        "PACK final: mirrored_dm_tc0={}/{}/{}\n",
+        *scratch_ptr(scratch_l1_address, final_base + 0),
+        *scratch_ptr(scratch_l1_address, final_base + 1),
+        *scratch_ptr(scratch_l1_address, final_base + 2));
+#endif
+}

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -165,7 +165,11 @@ extern "C" uint32_t _start1() {
             uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base +
                                                                     launch_msg->kernel_config.local_cb_offset);
             uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
+#if defined(UCK_CHLKC_PACK)
+            const DfbPackerRemapperRange packer_rmp = setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
+#else
             setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
+#endif
 #endif
 
             // TODO: Remove MEM_L1_UNCACHED_BASE here and invalidate cache lines when PR #38124 is merged
@@ -213,6 +217,11 @@ extern "C" uint32_t _start1() {
             record_stack_usage(stack_free);
             WAYPOINT("D");
             DEVICE_PRINT_KERNEL_FINISHED();
+
+#if defined(UCK_CHLKC_PACK)
+            // Tear down packer remapper pairs programmed this launch so they cannot leak into the next.
+            dfb_clear_packer_remapper_window(packer_rmp.lo, packer_rmp.hi);
+#endif
 
             // Signal completion
             DPRINT("SIGNALING COMPLETION {:x}\n", (uint32_t)*trisc_run);

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
@@ -35,7 +35,24 @@ constexpr uint8_t NUM_TENSIX_TILE_COUNTERS_FOR_DM = 16;
 // First TC ID in the default Tensix-only pool (not accessible by DM); used for intra/inter-tensix DFBs.
 // Note: The Remapper can be programmed to expose these TCs to DMs.
 constexpr uint8_t TC_TENSIX_POOL_START = NUM_TENSIX_TILE_COUNTERS_FOR_DM;  // = 16
+// Size of the Tensix-only pool [TC_TENSIX_POOL_START, NUM_TILE_COUNTERS_PER_TENSIX), per Neo. This is a
+// counter budget, not a DFB budget: how many TCs a DFB draws depends on its access pattern and endpoint
+// count, so only the intra-tensix cost below is fixed.
+constexpr uint8_t NUM_TENSIX_ONLY_TILE_COUNTERS = NUM_TILE_COUNTERS_PER_TENSIX - TC_TENSIX_POOL_START;  // = 16
+// Intra-tensix HW workaround: a T6 update to a Tensix-only TC aliases into overlay TCs 0-15 unless the
+// remapper routes that TC somewhere. Each intra-tensix DFB therefore burns two Tensix-only TCs on its
+// Neo — the ClientL TC that packer and unpacker both drive, plus a sacrificial ClientR shadow that
+// absorbs the HW update copy. ClientL and ClientR need not be adjacent; remapper maps any pair.
+constexpr uint8_t TILE_COUNTERS_PER_INTRA_TENSIX_DFB = 2;
+
 constexpr uint8_t NUM_REMAPPER_PAIRINGS = 64;
+// Only pairs [0, 16) can express a 1-to-many (grouped fan-out) mapping; [16, 64) are 1-to-1 only.
+// Allocate by fan-out so single-consumer mappings don't consume the scarce fan-out pairs.
+// Packer (intra-tensix) and DM1 1-to-1 share [16, 64): before finalizing a core, host reserves an
+// exact contiguous block per Neo from pair 63 downward; DM1 allocates from pair 16 upward. This
+// keeps packer pairs above DM1's high-watermark clear while leaving unused capacity available.
+constexpr uint8_t NUM_REMAPPER_ONE_TO_MANY_PAIRINGS = 16;
+constexpr uint8_t REMAPPER_ONE_TO_ONE_PAIR_START = NUM_REMAPPER_ONE_TO_MANY_PAIRINGS;
 // Max txn ids assigned to one DFB producer or consumer side
 constexpr uint8_t NUM_TXN_IDS = 4;
 static_assert(NUM_DFB_POOL_TXN_IDS >= NUM_TXN_IDS);
@@ -150,8 +167,13 @@ inline uint8_t dfb_hart_participation_count(uint32_t participation_mask) {
 
 // Flag bits for dfb_hart_init_entry_t::flags
 constexpr uint8_t DFB_HART_FLAG_IS_PRODUCER  = (1u << 7);
-constexpr uint8_t DFB_HART_FLAG_REMAPPER_EN  = (1u << 6);
+// DM1 owns this producer's remapper pair; the producer must wait for it before touching its TCs.
+constexpr uint8_t DFB_HART_FLAG_REMAPPER_WAIT_DM1 = (1u << 6);
 constexpr uint8_t DFB_HART_FLAG_BROADCAST_TC = (1u << 5);
+// This Neo's packer programs its own remapper pair (intra-tensix alias). DM1 cannot do it: the
+// Tensix-only TC pool is invisible to DM, and one Neo cannot see another Neo's TCs.
+// Mutually exclusive with DFB_HART_FLAG_REMAPPER_WAIT_DM1.
+constexpr uint8_t DFB_HART_FLAG_REMAPPER_SELF_PROG = (1u << 4);
 constexpr uint8_t DFB_HART_FLAG_TRISC_MASK   = 0x0Fu;  // bits 3:0 = tensix_trisc_mask (which TRISC(s) run DFB ops)
 
 // Layout: dfb_blob_tc_pair_t[num_tcs] immediately after the 28B header, followed by
@@ -186,7 +208,9 @@ struct dfb_hart_init_entry_t {
     uint8_t  producer_signal_bit;            // TRISC layout byte 17; DM pack byte 13 (transport)
     uint8_t  txn_ids[dfb::NUM_TXN_IDS];     // TRISC layout bytes 18-21; DM pack bytes 14-17
     uint8_t  remapper_pair_index;            // TRISC layout byte 22; DM pack remapper at byte 23
-    uint8_t  _pad;                           // byte 23; DM pack p[11] overwrites with remapper_pair_index
+    uint8_t intra_shadow_tc_id;              // TRISC byte 23: intra-tensix ClientR shadow TC id, 0xFF if unused.
+                                             // Intra-tensix never targets a DM hart, so DM pack p[11]
+                                             // reclaims this byte for remapper_pair_index.
     uint16_t num_entries;                    // bytes 24-25; ring entry count (main update_size path)
     uint8_t  _pad2[2];                       // pad header to 28B → 4B-aligned TC arrays follow
 } __attribute__((packed));

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -74,6 +74,7 @@ struct dfb_init_entry_hdr_t {
     uint8_t txn_ids[dfb::NUM_TXN_IDS];  // bytes 18–21 (DM only; 0 elsewhere)
     uint8_t broadcast_tc;         // DM pack byte 22 → iface.broadcast_tc (DM unpack only)
     uint8_t remapper_pair_index;  // TRISC byte 22; DM pack byte 23
+    uint8_t intra_shadow_tc_id;   // TRISC byte 23: intra-tensix ClientR shadow TC; 0xFF / unused on DM
     uint16_t num_entries;         // bytes 24–25
 };
 
@@ -88,7 +89,8 @@ struct dfb_init_entry_hdr_t {
 //   w2 = stride_size_precomp (u32): host pre-computed per hart type — DM=raw bytes, TRISC=tile units
 //   w3 [7:0]=stride_size_tiles  [15:8]=num_txn_ids  [23:16]=threshold  [31:24]=num_entries_per_txn_id
 //   w4 [7:0]=num_entries_per_txn_id_per_tc  [15:8]=producer_signal_bit  [23:16]=txn_ids[0]  [31:24]=txn_ids[1]
-//   w5 [7:0]=txn_ids[2]  [15:8]=txn_ids[3]  [23:16]=remapper_pair_index  [31:24]=_pad (TRISC) / remapper (DM pack)
+//   w5 [7:0]=txn_ids[2]  [15:8]=txn_ids[3]  [23:16]=remapper_pair_index
+//      [31:24]=intra_shadow_tc_id (TRISC) / remapper_pair_index (DM pack)
 //   w6 [15:0]=num_entries  [31:16]=_pad2
 
 // Shared unpack helper: TRISC blob w3–w6 (legacy SoA byte layout).
@@ -114,6 +116,7 @@ FORCE_INLINE dfb_init_entry_hdr_t dfb_unpack_entry_header(PtrT s) {
     h.txn_ids[3]                 = static_cast<uint8_t>(w5 >> 8);
     h.broadcast_tc               = 0;
     h.remapper_pair_index        = static_cast<uint8_t>(w5 >> 16);
+    h.intra_shadow_tc_id = static_cast<uint8_t>(w5 >> 24);
     h.num_entries                = static_cast<uint16_t>(w6);
     return h;
 }
@@ -142,6 +145,7 @@ FORCE_INLINE dfb_init_entry_hdr_t dfb_unpack_entry_header_dm(PtrT s) {
     h.num_txn_ids                = static_cast<uint8_t>(w5 >> 8);
     h.broadcast_tc               = static_cast<uint8_t>(w5 >> 16);
     h.remapper_pair_index        = static_cast<uint8_t>(w5 >> 24);
+    h.intra_shadow_tc_id = 0xFFu;  // intra-tensix never targets a DM hart
     h.num_entries                = static_cast<uint16_t>(w6);
     return h;
 }
@@ -622,11 +626,56 @@ FORCE_INLINE void setup_dfb_remapper(uint32_t tt_l1_ptr* dfb_config_base, uint32
 
 #endif  // !COMPILE_FOR_TRISC
 
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+
+// Intra-tensix alias (HW workaround): route this Neo's ClientL tile counter to a sacrificial
+// ClientR shadow counter, so the T6 counter update copy lands there instead of aliasing into
+// overlay counters 0-15. Packer and unpacker both keep driving the ClientL counter; nothing reads
+// the shadow. ClientL and ClientR need not be adjacent — remapper maps any (id, cnt_sel) pair.
+//
+// This cannot be done by DM1 like every other remapper pair: the Tensix-only counter pool is
+// invisible to DM, and one Neo cannot see another Neo's counters. So each Neo's packer programs
+// its own pair.
+FORCE_INLINE void dfb_program_intra_tensix_alias(
+    uint32_t pair_idx, uint32_t client_tc_id, uint32_t shadow_tc_id, uint32_t neo_id) {
+    const uint32_t client_id = static_cast<uint32_t>(overlay::NEO_0) + neo_id;
+    const uint32_t clientR_val = (client_id & 0x7u) | ((shadow_tc_id & 0x1Fu) << 3);
+    const uint32_t clientL_val = (client_id & 0x7u) | ((client_tc_id & 0x1Fu) << 3) |
+                                 (0x1u << 8) |  // valid: ClientR slot 0 only
+                                 (0x1u << 12);  // clientl_is_producer=1; clientr_group=0, distribute=0
+
+    // Publish ClientR first, then ClientL (which carries the valid bits)
+    WRITE_REG32(REMAP_CLIENT_R_CONFIG_REG_ADDR32(pair_idx), clientR_val);
+    WRITE_REG32(REMAP_CLIENT_L_CONFIG_REG_ADDR32(pair_idx), clientL_val);
+}
+
+// Clear ClientL valid for packer remapper pairs in [lo, hi). Called from trisc.cc after the kernel
+// so pairs from launch N cannot leak into launch N+1. lo==0xFF means nothing was programmed.
+FORCE_INLINE void dfb_clear_packer_remapper_window(uint8_t lo, uint8_t hi) {
+    if (lo == 0xFFu) {
+        return;
+    }
+    for (uint32_t i = lo; i < hi; i++) {
+        WRITE_REG32(REMAP_CLIENT_L_CONFIG_REG_ADDR32(i), 0u);
+    }
+    asm volatile("fence" ::: "memory");
+}
+
+#endif  // COMPILE_FOR_TRISC && UCK_CHLKC_PACK
+
+// Contiguous packer remapper pairs programmed this launch ([lo, hi); lo==0xFF if none).
+// Pack trisc.cc tears this range down after the kernel. DM/unpack ignore the return.
+struct DfbPackerRemapperRange {
+    uint8_t lo = 0xFFu;
+    uint8_t hi = 0;
+};
+
 // DM2-7 + TRISC: walk this hart's pre-computed sequential init blob; TC readiness is published
 // via store to dfb_publish_producer_ready and consumers poll in DataflowBuffer::DataflowBuffer().
-FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base, uint32_t num_dfbs) {
+FORCE_INLINE DfbPackerRemapperRange setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base, uint32_t num_dfbs) {
+    DfbPackerRemapperRange packer_rmp{};
     if (num_dfbs == 0) {
-        return;
+        return packer_rmp;
     }
 
     const uint32_t start_time = rdcycle();
@@ -818,9 +867,29 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
         // --- Producer-only: wait for remapper pair + TC HW init + publish ready ---
 #if !defined(COMPILE_FOR_TRISC) || defined(UCK_CHLKC_PACK)
         if (eh.flags & DFB_HART_FLAG_IS_PRODUCER) {
+            // A producer's remapper pair is programmed one of two ways; host sets at most one flag.
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+            // Intra-tensix: this packer owns the pair, so it programs rather than waits. Must happen
+            // before the TC reset/capacity writes below so the alias is live for the first update.
+            if (eh.flags & DFB_HART_FLAG_REMAPPER_SELF_PROG) {
+                const uint32_t spin_start = rdcycle();
+                dfb_program_intra_tensix_alias(
+                    eh.remapper_pair_index,
+                    dfb::get_counter_id(iface.tc_slots[0].packed_tile_counter),
+                    eh.intra_shadow_tc_id,
+                    neo_id);
+                // Contiguous [lo, hi) over this Neo's packer-owned pairs (host assigns ascending
+                // indices within the reserved block). Teardown clears exactly this window.
+                if (packer_rmp.lo == 0xFFu) {
+                    packer_rmp.lo = eh.remapper_pair_index;
+                }
+                packer_rmp.hi = static_cast<uint8_t>(eh.remapper_pair_index + 1u);
+                total_remapper_spin += rdcycle() - spin_start;
+            }
+#endif
             // Remapped producers: spin until DM1 has written this pair's ClientL config with
             // non-zero valid bits (bits [11:8]). No global remapper-enable wait is needed.
-            if (eh.flags & DFB_HART_FLAG_REMAPPER_EN) {
+            if (eh.flags & DFB_HART_FLAG_REMAPPER_WAIT_DM1) {
                 const uint32_t spin_start = rdcycle();
                 const uint32_t pair_idx = eh.remapper_pair_index;
                 WAYPOINT("RMSW");
@@ -908,4 +977,5 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
         total_entry_hdr,                     // METRIC_H: entry_hdr (6 u32 bulk reads × N entries)
         total_tc_slots,                      // METRIC_I: tc_slots (base/limit/ptc reads + iface writes)
         total_sig_write);                    // METRIC_J: sig_write (uncached store to signal region)
+    return packer_rmp;
 }

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -606,8 +606,12 @@ size_t serialize_dfb_config_for_core(
             if (rc.is_producer) {
                 flags |= DFB_HART_FLAG_IS_PRODUCER;
             }
+            // Exactly one of these can be set: either DM1 programs this producer's pair and the
+            // producer waits on it, or the producer programs the pair itself (intra-tensix dfb case).
             if (dfb->use_remapper) {
-                flags |= DFB_HART_FLAG_REMAPPER_EN;
+                flags |= (dfb->remapper_programmer == RemapperProgrammer::TENSIX_PACKER)
+                             ? DFB_HART_FLAG_REMAPPER_SELF_PROG
+                             : DFB_HART_FLAG_REMAPPER_WAIT_DM1;
             }
             if (rc.config.broadcast_tc) {
                 flags |= DFB_HART_FLAG_BROADCAST_TC;
@@ -631,6 +635,10 @@ size_t serialize_dfb_config_for_core(
             entry.remapper_pair_index = (dfb->use_remapper && rc.is_producer)
                 ? rc.config.remapper_pair_index
                 : 0xFFu;
+            // Only meaningful for self-programming (intra-tensix) producers; DM harts reclaim this byte.
+            entry.intra_shadow_tc_id = (dfb->remapper_programmer == RemapperProgrammer::TENSIX_PACKER && rc.is_producer)
+                                           ? rc.config.intra_shadow_tc_id
+                                           : 0xFFu;
 
             // Zero the full entry region first (covers padding between packed_tc and next 4B boundary).
             std::memset(out.data() + offset, 0, entry_sz);
@@ -841,14 +849,87 @@ namespace detail {
         (tensix_id << ::dfb::PACKED_TC_COUNTER_ID_BITS) | tc_id);
 }
 
-uint8_t RemapperIndexAllocator::allocate(const CoreCoord& core_coord) {
-    uint8_t idx = next_index_[core_coord]++;
+std::pair<::dfb::PackedTileCounter, ::dfb::PackedTileCounter> TileCounterAllocator::allocate_intra_tensix_pair(
+    const CoreCoord& core, uint8_t tensix_id) {
+    // ClientL + sacrificial ClientR shadow. Remapper can map any two Tensix-only TCs; adjacency is
+    // not required — these just happen to come out consecutive because the Tensix-only pool is
+    // allocated monotonically.
+    auto client_l = allocate(core, tensix_id, /*use_t6_only=*/true);
+    auto shadow = allocate(core, tensix_id, /*use_t6_only=*/true);
+    return {client_l, shadow};
+}
+
+void RemapperIndexAllocator::reserve_packer_ranges(
+    const CoreCoord& core_coord, const std::array<uint8_t, ::dfb::NUM_TENSIX>& counts) {
+    auto& pools = next_index_[core_coord];
+    uint8_t packer_floor = ::dfb::NUM_REMAPPER_PAIRINGS;
+    for (uint8_t neo = 0; neo < ::dfb::NUM_TENSIX; neo++) {
+        pools.packer_base[neo] = 0xFFu;
+        pools.packer_count[neo] = 0;
+        pools.packer_next[neo] = 0;
+        if (counts[neo] == 0) {
+            continue;
+        }
+        TT_FATAL(
+            counts[neo] * ::dfb::TILE_COUNTERS_PER_INTRA_TENSIX_DFB <= ::dfb::NUM_TENSIX_ONLY_TILE_COUNTERS,
+            "Neo {} on core ({}, {}) needs {} packer remapper pairs, which would need {} of the {} Tensix-only tile "
+            "counters ({} per intra-tensix DFB: ClientL + shadow)",
+            neo,
+            core_coord.x,
+            core_coord.y,
+            counts[neo],
+            counts[neo] * ::dfb::TILE_COUNTERS_PER_INTRA_TENSIX_DFB,
+            ::dfb::NUM_TENSIX_ONLY_TILE_COUNTERS,
+            ::dfb::TILE_COUNTERS_PER_INTRA_TENSIX_DFB);
+        TT_FATAL(
+            packer_floor >= ::dfb::REMAPPER_ONE_TO_ONE_PAIR_START + counts[neo],
+            "Out of 1-to-1 remapper pairs on core ({}, {}) while reserving {} packer pairs for Neo {}",
+            core_coord.x,
+            core_coord.y,
+            counts[neo],
+            neo);
+        packer_floor = static_cast<uint8_t>(packer_floor - counts[neo]);
+        pools.packer_base[neo] = packer_floor;
+        pools.packer_count[neo] = counts[neo];
+    }
+    pools.packer_floor = packer_floor;
+}
+
+uint8_t RemapperIndexAllocator::allocate(const CoreCoord& core_coord, bool one_to_many) {
+    auto& pools = next_index_[core_coord];
+    if (one_to_many) {
+        TT_FATAL(
+            pools.next_one_to_many < ::dfb::NUM_REMAPPER_ONE_TO_MANY_PAIRINGS,
+            "Out of 1-to-many remapper pairs for core ({}, {}): only {} of the {} pairs support fan-out",
+            core_coord.x,
+            core_coord.y,
+            ::dfb::NUM_REMAPPER_ONE_TO_MANY_PAIRINGS,
+            ::dfb::NUM_REMAPPER_PAIRINGS);
+        return pools.next_one_to_many++;
+    }
+    const uint8_t pair_index = static_cast<uint8_t>(::dfb::REMAPPER_ONE_TO_ONE_PAIR_START + pools.next_one_to_one);
     TT_FATAL(
-        idx < ::dfb::NUM_REMAPPER_PAIRINGS,
-        "Out of remapper pairs for core ({}, {})",
+        pair_index < pools.packer_floor,
+        "Out of DM1 1-to-1 remapper pairs for core ({}, {}): bottom-up allocation reached "
+        "packer-owned range [{}, {})",
+        core_coord.x,
+        core_coord.y,
+        pools.packer_floor,
+        ::dfb::NUM_REMAPPER_PAIRINGS);
+    pools.next_one_to_one++;
+    return pair_index;
+}
+
+uint8_t RemapperIndexAllocator::allocate_for_packer(const CoreCoord& core_coord, uint8_t tensix_id) {
+    TT_FATAL(tensix_id < ::dfb::NUM_TENSIX, "Invalid tensix_id: {}", tensix_id);
+    auto& pools = next_index_[core_coord];
+    TT_FATAL(
+        pools.packer_base[tensix_id] != 0xFFu && pools.packer_next[tensix_id] < pools.packer_count[tensix_id],
+        "No reserved packer remapper pair left for Neo {} on core ({}, {}): call reserve_packer_ranges first",
+        tensix_id,
         core_coord.x,
         core_coord.y);
-    return idx;
+    return static_cast<uint8_t>(pools.packer_base[tensix_id] + pools.packer_next[tensix_id]++);
 }
 
 void RemapperIndexAllocator::reset() { next_index_.clear(); }
@@ -1188,7 +1269,8 @@ uint16_t DataflowBufferImpl::dm1_remapper_slot_count() const {
     if (!MetalContext::instance().hal().has_tile_counter_registers()) {
         return 0;
     }
-    return use_remapper ? static_cast<uint16_t>(config.num_producers) : 0;
+    // Intra-tensix pairs are programmed by each Neo's packer, so they contribute no DM1 slots.
+    return remapper_programmer == RemapperProgrammer::DM1 ? static_cast<uint16_t>(config.num_producers) : 0;
 }
 
 void DataflowBufferImpl::append_dm1_remapper_slots_for_core(const CoreCoord& core, std::vector<uint8_t>& data) const {
@@ -1604,8 +1686,10 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
         TT_FATAL(
             *config.tensix_scope != TensixScope::INTER,
             "Inter-tensix DFBs are not yet supported. Use TensixScope::INTRA for same-Neo packer→unpacker DFBs.");
-        // INTRA: each Neo has an independent packer (TRISC2) → unpacker (TRISC0) credit flow, one Tensix-only TC per Neo.
-        // Always STRIDED for both producer and consumer — blocked access and remapper are never used.
+        // INTRA: each Neo has an independent packer (TRISC2) → unpacker (TRISC0) credit flow, one Tensix-only TC per
+        // Neo. Access pattern is always STRIDED producer → STRIDED consumer (no ALL / BLOCKED). The remapper may still
+        // be enabled as a HW workaround to alias the Tensix-only ClientL TC away from overlay TCs 0-15; that is
+        // not an ALL fan-out remapper path.
         // num_producers == num_consumers == number of Neos (one packer-unpacker pair per Neo).
         TT_FATAL(
             config.num_producers == config.num_consumers,
@@ -1613,7 +1697,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
             config.num_producers, config.num_consumers);
         TT_FATAL(
             config.pap == dfb::AccessPattern::STRIDED && config.cap == dfb::AccessPattern::STRIDED,
-            "Intra-tensix DFBs require STRIDED access for both producer (packer) and consumer (unpacker)");
+            "Intra-tensix DFBs require STRIDED producer → STRIDED consumer access patterns");
         TT_FATAL(
             !config.enable_producer_implicit_sync && !config.enable_consumer_implicit_sync,
             "Intra-tensix DFBs do not support implicit sync (ISR-based credits)");
@@ -1747,16 +1831,32 @@ void ProgramImpl::finalize_dataflow_buffer_configs() {
     // Process each core's DFBs together
     for (auto& [core, core_dfbs] : dfbs_by_core) {
         bool core_needs_remapper = false;
+        std::array<uint8_t, ::dfb::NUM_TENSIX> packer_pair_counts{};
         for (const auto& dfb : core_dfbs) {
-            if (dfb->config.cap == dfb::AccessPattern::ALL) {
+            const bool is_intra =
+                dfb->config.tensix_scope.has_value() && *dfb->config.tensix_scope == TensixScope::INTRA;
+            if (is_intra) {
+                // Intra DFBs need remapper HW for the Tensix-only TC alias workaround.
+                core_needs_remapper = true;
+                for (uint8_t risc_id = ::dfb::TENSIX_RISC_OFFSET;
+                     risc_id < ::dfb::TENSIX_RISC_OFFSET + ::dfb::NUM_TENSIX;
+                     risc_id++) {
+                    if (dfb->config.producer_risc_mask & (1u << risc_id)) {
+                        packer_pair_counts[risc_id - ::dfb::TENSIX_RISC_OFFSET]++;
+                    }
+                }
+            } else if (dfb->config.cap == dfb::AccessPattern::ALL) {
                 bool dm_dm_all = !has_tensix_risc(dfb->config.producer_risc_mask) &&
                                      !has_tensix_risc(dfb->config.consumer_risc_mask);
                 if (!dm_dm_all) {
                     core_needs_remapper = true;
-                    break;
                 }
             }
         }
+        // Count every INTRA DFB on this core first, then reserve exact contiguous packer remapper
+        // blocks per Neo from pair 63 downward. Finalize sees the full core DFB set in one pass —
+        // there is no incremental reassignment if more INTRA DFBs are added later in the same program.
+        remapper_index_allocator_.reserve_packer_ranges(core, packer_pair_counts);
 
         log_debug(
             tt::LogMetal,
@@ -1798,12 +1898,11 @@ void ProgramImpl::finalize_single_dfb_config(
                 }
                 const auto& ca = a[i].config;
                 const auto& cb = b[i].config;
-                if (ca.num_tcs_to_rr != cb.num_tcs_to_rr ||
-                    ca.broadcast_tc != cb.broadcast_tc ||
-                    ca.remapper_pair_index != cb.remapper_pair_index ||
-                    ca.consumer_tcs != cb.consumer_tcs ||
+                if (ca.num_tcs_to_rr != cb.num_tcs_to_rr || ca.broadcast_tc != cb.broadcast_tc ||
+                    ca.remapper_pair_index != cb.remapper_pair_index || ca.consumer_tcs != cb.consumer_tcs ||
                     ca.remapper_consumer_ids_mask != cb.remapper_consumer_ids_mask ||
-                    ca.producer_client_type != cb.producer_client_type) {
+                    ca.producer_client_type != cb.producer_client_type ||
+                    ca.intra_shadow_tc_id != cb.intra_shadow_tc_id) {
                     return false;
                 }
                 for (int j = 0; j < ca.num_tcs_to_rr; j++) {
@@ -1879,14 +1978,22 @@ void ProgramImpl::finalize_single_dfb_config(
 
     // ---------------------------------------------------------------------------
     // Intra-tensix: packer TRISC2 (producer) → unpacker TRISC0 (consumer) within the same Neo.
-    // No DM RISC, no remapper, no strided/blocked access pattern — each Neo is a fully
-    // independent packer→unpacker credit flow backed by one Tensix-only TC on that Neo.
-    // For N Neos (num_producers == num_consumers == N): N Tensix-only TCs, one per Neo.
+    // Each Neo is a fully independent packer→unpacker credit flow backed by one Tensix-only TC on that Neo.
+    //
+    // HW workaround: a T6 update to a Tensix-only TC aliases into overlay TCs 0-15 unless the
+    // remapper routes that TC elsewhere, so each Neo also burns a sacrificial ClientR shadow TC as
+    // the remapper target and needs its own 1-to-1 remapper pair. Both packer and unpacker keep using
+    // the ClientL TC; nothing ever reads the shadow. ClientL/ClientR need not be adjacent. The pair
+    // must be programmed by that Neo's packer — DM1 cannot see the Tensix-only pool, and no Neo can
+    // see another Neo's TCs.
     // ---------------------------------------------------------------------------
     if (is_intra_tensix) {
-        // Iterate over every Neo bit in producer_risc_mask and allocate a separate Tensix-only
-        // TC for each, giving each Neo its own independent credit counter.
-        dfb->use_remapper = false;
+        TT_FATAL(
+            core_has_remapper,
+            "Intra-tensix DFBs require the remapper to alias the Tensix-only tile counter away from "
+            "overlay counters 0-15");
+        dfb->use_remapper = true;
+        dfb->remapper_programmer = RemapperProgrammer::TENSIX_PACKER;
 
         for (uint8_t risc_id = ::dfb::TENSIX_RISC_OFFSET;
              risc_id < ::dfb::TENSIX_RISC_OFFSET + ::dfb::NUM_TENSIX;
@@ -1896,16 +2003,20 @@ void ProgramImpl::finalize_single_dfb_config(
             }
             uint8_t tensix_id = risc_id - ::dfb::TENSIX_RISC_OFFSET;
 
-            ::dfb::PackedTileCounter t6_only_tc =
-                tile_counter_allocator_.allocate(core, tensix_id, /*use_t6_only=*/true);
+            auto [t6_only_tc, shadow_tc] = tile_counter_allocator_.allocate_intra_tensix_pair(core, tensix_id);
+            // Contiguous within this Neo's exact reserved block (see reserve_packer_ranges).
+            const uint8_t pair_index = remapper_index_allocator_.allocate_for_packer(core, tensix_id);
 
             log_info(
                 tt::LogMetal,
-                "Intra-tensix DFB {}: Neo{} Tensix-only TC (tensix_id={}, tc_id={})",
+                "Intra-tensix DFB {}: Neo{} Tensix-only TC (tensix_id={}, tc_id={}) aliased to shadow tc_id={} "
+                "via remapper pair {}",
                 dfb->id,
                 tensix_id,
                 (uint32_t)::dfb::get_tensix_id(t6_only_tc),
-                (uint32_t)::dfb::get_counter_id(t6_only_tc));
+                (uint32_t)::dfb::get_counter_id(t6_only_tc),
+                (uint32_t)::dfb::get_counter_id(shadow_tc),
+                (uint32_t)pair_index);
 
             DFBRiscConfig risc_config;
             risc_config.risc_id = risc_id;
@@ -1913,6 +2024,8 @@ void ProgramImpl::finalize_single_dfb_config(
             risc_config.config.packed_tile_counter[0] = t6_only_tc;
             risc_config.config.num_tcs_to_rr = 1;
             risc_config.config.broadcast_tc = false;
+            risc_config.config.remapper_pair_index = pair_index;
+            risc_config.config.intra_shadow_tc_id = ::dfb::get_counter_id(shadow_tc);
             new_hw_risc_configs.push_back(risc_config);
         }
 
@@ -2121,7 +2234,6 @@ void ProgramImpl::finalize_single_dfb_config(
         risc_config.config.broadcast_tc = dm_dm_all;
 
         if (use_remapper) {
-            risc_config.config.remapper_pair_index = remapper_index_allocator_.allocate(core);
             risc_config.config.producer_client_type = producer_client_types[producer_idx];
 
             // Build consumer_tcs packed and consumer_ids_mask for this producer
@@ -2147,6 +2259,11 @@ void ProgramImpl::finalize_single_dfb_config(
             }
             risc_config.config.consumer_tcs = packed;
             risc_config.config.remapper_consumer_ids_mask = consumer_ids_mask;
+
+            // The ClientR valid mask decides which pool this pair must come from: fan-out needs one
+            // of the 16 grouped-capable pairs, a single consumer can use the plentiful 1-to-1 pairs.
+            const bool one_to_many = __builtin_popcount(consumer_ids_mask) > 1;
+            risc_config.config.remapper_pair_index = remapper_index_allocator_.allocate(core, one_to_many);
 
             log_debug(
                 tt::LogMetal,
@@ -2281,6 +2398,7 @@ void ProgramImpl::finalize_single_dfb_config(
     }
 
     dfb->use_remapper = use_remapper;
+    dfb->remapper_programmer = use_remapper ? RemapperProgrammer::DM1 : RemapperProgrammer::NONE;
     log_debug(
         tt::LogMetal, "DFB {} finalized risc_mask: 0x{:x} use_remapper: {}", dfb->id, dfb->risc_mask, use_remapper);
 

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -25,6 +25,13 @@ struct KernelGroup;
 
 namespace tt::tt_metal::experimental::dfb::detail {
 
+// Who writes this DFB's remapper ClientL/ClientR registers on device.
+enum class RemapperProgrammer : uint8_t {
+    NONE,           // DFB does not use the remapper
+    DM1,            // DM1 programs the pairs during DFB init; producers wait on ClientL valid
+    TENSIX_PACKER,  // each Neo's packer programs its own pair; DM1 cannot see Tensix-only TCs
+};
+
 struct LocalDFBInterfaceHost {
     std::array<uint32_t, ::dfb::MAX_NUM_TILE_COUNTERS_TO_RR> base_addr = {0};
     std::array<uint32_t, ::dfb::MAX_NUM_TILE_COUNTERS_TO_RR> limit = {0};
@@ -35,6 +42,8 @@ struct LocalDFBInterfaceHost {
     uint32_t consumer_tcs = 0;
     uint8_t remapper_consumer_ids_mask = 0;
     uint8_t producer_client_type = 0;
+    // Intra-tensix only: sacrificial ClientR shadow TC paired with packed_tile_counter[0]. 0xFF if unused.
+    uint8_t intra_shadow_tc_id = 0xFF;
 };
 
 struct DFBRiscConfig {
@@ -75,6 +84,8 @@ struct DataflowBufferImpl {
     bool configs_finalized = false;
     // Flag to track if this DFB uses remapper (set during finalization)
     bool use_remapper = false;
+    // Signals who programs the remapper pairs on device
+    RemapperProgrammer remapper_programmer = RemapperProgrammer::NONE;
 
     // Set by set_borrowed_memory_base_addr()
     uint32_t borrowed_addr_ = 0;
@@ -165,6 +176,14 @@ public:
     // use_t6_only=true  → Tensix-only pool [TC_TENSIX_POOL_START, NUM_TILE_COUNTERS_PER_TENSIX)
     // The remapper can reference any of the 32 TCs, so both pools live in one allocator.
     ::dfb::PackedTileCounter allocate(const CoreCoord& core, uint8_t tensix_id, bool use_t6_only = false);
+
+    // Allocate ClientL + sacrificial ClientR shadow from the Tensix-only pool for one intra-tensix
+    // DFB on (core, tensix_id). Only ClientL is used for credits; ClientR exists solely to absorb
+    // the remapper's HW update copy. The two TCs need not be adjacent. Each call spends
+    // TILE_COUNTERS_PER_INTRA_TENSIX_DFB of that Neo's NUM_TENSIX_ONLY_TILE_COUNTERS.
+    std::pair<::dfb::PackedTileCounter, ::dfb::PackedTileCounter> allocate_intra_tensix_pair(
+        const CoreCoord& core, uint8_t tensix_id);
+
     void reset() { next_tc_id_.clear(); }
 
 private:
@@ -175,13 +194,33 @@ private:
     std::unordered_map<CoreCoord, PerCoreCounters> next_tc_id_;
 };
 
+// Remapper pairs are split by fan-out and programmer:
+//   DM1 1-to-many → [0, 16)
+//   1-to-1 pool [16, 64) shared by DM1 (bottom-up) and packer/intra (top-down):
+//     reserve_packer_ranges() claims an exact contiguous block per Neo from pair 63 downward;
+//     allocate() gives DM1 pairs from pair 16 upward. The two frontiers are collision-checked.
+// This keeps packer-owned pairs above DM1's high watermark while leaving unused capacity available.
 class RemapperIndexAllocator {
 public:
-    uint8_t allocate(const CoreCoord& core_coord);
+    // Claim exact contiguous 1-to-1 blocks for each Neo's packer pairs on this core.
+    // Must run before any allocate()/allocate_for_packer() for the core.
+    void reserve_packer_ranges(const CoreCoord& core_coord, const std::array<uint8_t, ::dfb::NUM_TENSIX>& counts);
+    // DM1-programmed pairs. one_to_many selects the fan-out pool vs the shared 1-to-1 frontier.
+    uint8_t allocate(const CoreCoord& core_coord, bool one_to_many);
+    // Next pair from Neo `tensix_id`'s reserved contiguous block (ascending).
+    uint8_t allocate_for_packer(const CoreCoord& core_coord, uint8_t tensix_id);
     void reset();
 
 private:
-    std::unordered_map<CoreCoord, uint8_t> next_index_;
+    struct PerCorePools {
+        uint8_t next_one_to_many = 0;  // offset into [0, NUM_REMAPPER_ONE_TO_MANY_PAIRINGS)
+        uint8_t next_one_to_one = 0;   // DM1 offset from REMAPPER_ONE_TO_ONE_PAIR_START (bottom-up)
+        uint8_t packer_floor = ::dfb::NUM_REMAPPER_PAIRINGS;       // first packer-owned pair (top-down)
+        std::array<uint8_t, ::dfb::NUM_TENSIX> packer_base = {};   // absolute pair index, or 0xFF if unused
+        std::array<uint8_t, ::dfb::NUM_TENSIX> packer_count = {};  // exact reserved count
+        std::array<uint8_t, ::dfb::NUM_TENSIX> packer_next = {};   // offset within [base, base+count)
+    };
+    std::unordered_map<CoreCoord, PerCorePools> next_index_;
 };
 
 // Allocates DFB implicit-sync transaction IDs from the runtime pool


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Resnet on Quasar debug helped surface a HW issue with the upper 16 tile counters of each Tensix that by default do not get mirrored to the Overlay. 

The bug is that when tile counter A (>= 16) is programmed/used, tile counter A % 16 gets corrupted because TCs >= 16 are represented by 5 bits in remapper but overlay tensix are represented by 4 bits. The workaround is to remap tile counter A to another tile counter B (>= 16) and have both producer and consumer of the intra-tensix DFB use tile counter A. This means we can only have a total of 8 fully parallelized intra-tensix DFBs. 

Why was it not caught earlier?
Our intra-t6 DFB + DM->Tensix/Tensix->DM DFB tests were only testing that the host side config for both were set up correctly and both being able to push/pop credits (and the tests were only pushing/popping one credit at a time). Since the capacities didn't conflict with each other, this issue was never caught. We are planning to add randomized testing.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/tc-workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/tc-workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/tc-workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/tc-workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abhullar/tc-workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abhullar/tc-workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/tc-workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/tc-workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/tc-workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/tc-workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/tc-workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/tc-workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/tc-workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/tc-workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/tc-workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/tc-workaround)