### PR TITLE
[Minimax M3] Intra-galaxy pipeline-parallel prefill

### DIFF
--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml
@@ -1,18 +1,12 @@
 # REQUEST mode (unbounded, H2D-driven) 2-stage INTRA-galaxy pipeline prefill on ONE BH galaxy.
 #
 # One 8x4 galaxy carved into 2 Z-connected [4,4] sub-meshes (16 chips each); hidden state hops stage->stage
-# over the Z-link MeshSocket. Per-stage SP4 x TP4 x EP16. REQUEST mode (no PREFILL_STANDALONE): rank 0
+# over the Z-link MeshSocket. Per-stage EP16. REQUEST mode (no PREFILL_STANDALONE): rank 0
 # builds the H2D service and waits for an external prefill_producer.
 #
 # TT_VISIBLE_DEVICES order is authoritative from the Generate2x4SliceToPCIeDeviceMapping discovery gtest
 # (slice_to_pcie_device_mapping.yaml): mesh0 = slices {0,1} (top), mesh1 = slices {2,3}
 # (bottom). Two 2x4 slices concatenate into a contiguous 4x4; the blitz/diagonal split fails topology_mapper.
-#
-# Launch (2 ranks on the single host), then run prefill_producer.py on this host:
-#   PREFILL_MANIFEST=models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json \
-#     ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
-#     models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml \
-#     <galaxy-host>:2
 
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "28,29,24,25,0,4,5,1,31,26,27,30,6,7,2,3"}}

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml
@@ -29,4 +29,8 @@ global_env:
   PREFILL_H2D_SERVICE_ID: "ds_prefill"
   PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"
   PREFILL_PP_FILE_BARRIER: "1"
+  # Vestigial socket L1 buffer: the activation bypasses it DRAM->DRAM, only ~12B metadata transits, so its
+  # size is L1 footprint only. 32KB (half the 64KB default) is the minimal reduction that keeps it clear of
+  # the routed-expert MoE static CBs (see 4rank).
+  PREFILL_PP_D2D_FIFO_BYTES: "32768"
   LOGURU_LEVEL: "INFO"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml
@@ -1,0 +1,32 @@
+# REQUEST mode (unbounded, H2D-driven) 2-stage INTRA-galaxy pipeline prefill on ONE BH galaxy.
+#
+# One 8x4 galaxy carved into 2 Z-connected [4,4] sub-meshes (16 chips each); hidden state hops stage->stage
+# over the Z-link MeshSocket. Per-stage SP4 x TP4 x EP16. REQUEST mode (no PREFILL_STANDALONE): rank 0
+# builds the H2D service and waits for an external prefill_producer.
+#
+# TT_VISIBLE_DEVICES order is authoritative from the Generate2x4SliceToPCIeDeviceMapping discovery gtest
+# (slice_to_pcie_device_mapping.yaml): mesh0 = slices {0,1} (top), mesh1 = slices {2,3}
+# (bottom). Two 2x4 slices concatenate into a contiguous 4x4; the blitz/diagonal split fails topology_mapper.
+#
+# Launch (2 ranks on the single host), then run prefill_producer.py on this host:
+#   PREFILL_MANIFEST=models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json \
+#     ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
+#     models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml \
+#     <galaxy-host>:2
+
+rank_bindings:
+  - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "28,29,24,25,0,4,5,1,31,26,27,30,6,7,2,3"}}
+  - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "18,22,23,19,14,15,10,11,20,16,17,21,9,8,13,12"}}
+
+mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto
+
+global_env:
+  PREFILL_FABRIC_MODE: "2d"
+  PREFILL_SP: "4"
+  PREFILL_TP: "4"
+  PREFILL_NUM_LAYERS: "60"
+  PREFILL_MAX_SEQ_LEN: "56320"
+  PREFILL_H2D_SERVICE_ID: "ds_prefill"
+  PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"
+  PREFILL_PP_FILE_BARRIER: "1"
+  LOGURU_LEVEL: "INFO"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml
@@ -1,12 +1,9 @@
-# REQUEST mode (unbounded, H2D-driven) 2-stage INTRA-galaxy pipeline prefill on ONE BH galaxy.
+# 2-stage intra-galaxy pipeline prefill: one 8x4 galaxy carved into 2 Z-connected [4,4] sub-meshes; the
+# hidden state hops stage->stage over the Z-link MeshSocket. Request mode — rank 0 serves an external
+# prefill_producer. Model selected by PREFILL_MANIFEST.
 #
-# One 8x4 galaxy carved into 2 Z-connected [4,4] sub-meshes (16 chips each); hidden state hops stage->stage
-# over the Z-link MeshSocket. Per-stage EP16. REQUEST mode (no PREFILL_STANDALONE): rank 0
-# builds the H2D service and waits for an external prefill_producer.
-#
-# TT_VISIBLE_DEVICES order is authoritative from the Generate2x4SliceToPCIeDeviceMapping discovery gtest
-# (slice_to_pcie_device_mapping.yaml): mesh0 = slices {0,1} (top), mesh1 = slices {2,3}
-# (bottom). Two 2x4 slices concatenate into a contiguous 4x4; the blitz/diagonal split fails topology_mapper.
+# TT_VISIBLE_DEVICES: two 2x4 slices per mesh (mesh0 = {0,1}, mesh1 = {2,3}), ordered by the
+# Generate2x4SliceToPCIeDeviceMapping discovery gtest into a contiguous 4x4; other splits fail topology_mapper.
 
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "28,29,24,25,0,4,5,1,31,26,27,30,6,7,2,3"}}
@@ -21,10 +18,7 @@ global_env:
   PREFILL_NUM_LAYERS: "60"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"
-  PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"
-  PREFILL_PP_FILE_BARRIER: "1"
-  # Vestigial socket L1 buffer: the activation bypasses it DRAM->DRAM, only ~12B metadata transits, so its
-  # size is L1 footprint only. 32KB (half the 64KB default) is the minimal reduction that keeps it clear of
-  # the routed-expert MoE static CBs (see 4rank).
+  # Only 12B of metadata transits the queue, so reducing it's size has no effect on transfer speed
+  # Keeping it default (64KB) clashes with the MoE FFN L1 allocation
   PREFILL_PP_D2D_FIFO_BYTES: "32768"
   LOGURU_LEVEL: "INFO"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml
@@ -18,7 +18,7 @@ global_env:
   PREFILL_NUM_LAYERS: "60"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"
-  # Only 12B of metadata transits the queue, so reducing it's size has no effect on transfer speed
+  # Only 12B of metadata transits the queue, so reducing its size has no effect on transfer speed
   # Keeping it default (64KB) clashes with the MoE FFN L1 allocation
   PREFILL_PP_D2D_FIFO_BYTES: "32768"
   LOGURU_LEVEL: "INFO"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml
@@ -29,4 +29,10 @@ global_env:
   # Hold all stages until every one has compiled before creating sockets (asymmetric per-stage load races
   # the D2D socket setup).
   PREFILL_PP_FILE_BARRIER: "1"
+  # The D2D socket's L1 buffer is vestigial: the sender fabric-writes the activation shard straight
+  # DRAM->DRAM (persistent_d2d_receiver.cpp), so only ~12B of metadata transits it and its size has no
+  # effect on transfer speed -- only L1 footprint. The default 64KB, x2 on a middle stage's two sockets,
+  # overflows main L1 into the routed-expert MoE static CBs; 32KB (half the default) is the minimal
+  # reduction that clears the clash.
+  PREFILL_PP_D2D_FIFO_BYTES: "32768"
   LOGURU_LEVEL: "INFO"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml
@@ -1,9 +1,7 @@
-# REQUEST mode (unbounded, H2D-driven) 4-stage INTRA-galaxy pipeline prefill on ONE BH galaxy.
-#
-# One 8x4 galaxy carved into 4 Z-connected [2,4] sub-meshes; hidden state hops stage->stage over the
-# Z-link MeshSocket, per-stage EP8. REQUEST mode: no PREFILL_STANDALONE, so rank 0 builds the
-# H2D service and waits for an external prefill_producer to drive concurrent prompts. Tray pins from
-# test_physical_discovery (QUAD rank->tray {0:1,1:3,2:4,3:2}).
+# 4-stage intra-galaxy pipeline prefill: one 8x4 galaxy carved into 4 Z-connected [2,4] sub-meshes; the
+# hidden state hops stage->stage over the Z-link MeshSocket. Request mode — rank 0 serves an external
+# prefill_producer. Model selected by PREFILL_MANIFEST.
+# Tray pins from test_physical_discovery (QUAD rank->tray {0:1,1:3,2:4,3:2}).
 
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"}}
@@ -20,13 +18,7 @@ global_env:
   PREFILL_NUM_LAYERS: "60"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"
-  # Hold all stages until every one has compiled before creating sockets (asymmetric per-stage load races
-  # the D2D socket setup).
-  PREFILL_PP_FILE_BARRIER: "1"
-  # The D2D socket's L1 buffer is vestigial: the sender fabric-writes the activation shard straight
-  # DRAM->DRAM (persistent_d2d_receiver.cpp), so only ~12B of metadata transits it and its size has no
-  # effect on transfer speed -- only L1 footprint. The default 64KB, x2 on a middle stage's two sockets,
-  # overflows main L1 into the routed-expert MoE static CBs; 32KB (half the default) is the minimal
-  # reduction that clears the clash.
+  # Only 12B of metadata transits the queue, so reducing it's size has no effect on transfer speed
+  # Keeping it default (64KB) clashes with the MoE FFN L1 allocation
   PREFILL_PP_D2D_FIFO_BYTES: "32768"
   LOGURU_LEVEL: "INFO"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml
@@ -18,7 +18,7 @@ global_env:
   PREFILL_NUM_LAYERS: "60"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"
-  # Only 12B of metadata transits the queue, so reducing it's size has no effect on transfer speed
+  # Only 12B of metadata transits the queue, so reducing its size has no effect on transfer speed
   # Keeping it default (64KB) clashes with the MoE FFN L1 allocation
   PREFILL_PP_D2D_FIFO_BYTES: "32768"
   LOGURU_LEVEL: "INFO"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml
@@ -1,0 +1,32 @@
+# REQUEST mode (unbounded, H2D-driven) 4-stage INTRA-galaxy pipeline prefill on ONE BH galaxy.
+#
+# One 8x4 galaxy carved into 4 Z-connected [2,4] sub-meshes; hidden state hops stage->stage over the
+# Z-link MeshSocket, per-stage SP2 x TP4 x EP8. REQUEST mode: no PREFILL_STANDALONE, so rank 0 builds the
+# H2D service and waits for an external prefill_producer to drive concurrent prompts. Tray pins from
+# test_physical_discovery (QUAD rank->tray {0:1,1:3,2:4,3:2}).
+#
+# Launch (4 ranks on the single host), then run prefill_producer.py on this host:
+#   PREFILL_MANIFEST=models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json \
+#     ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
+#     models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml \
+#     <galaxy-host>:4
+
+rank_bindings:
+  - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"}}
+  - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "24,25,26,27,28,29,30,31"}}
+  - {rank: 2, mesh_id: 2, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "16,17,18,19,20,21,22,23"}}
+  - {rank: 3, mesh_id: 3, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "8,9,10,11,12,13,14,15"}}
+
+mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2_z_chain_graph_descriptor.textproto
+
+global_env:
+  PREFILL_FABRIC_MODE: "2d"
+  PREFILL_SP: "2"
+  PREFILL_TP: "4"
+  PREFILL_NUM_LAYERS: "60"
+  PREFILL_MAX_SEQ_LEN: "56320"
+  PREFILL_H2D_SERVICE_ID: "ds_prefill"
+  # Hold all stages until every one has compiled before creating sockets (asymmetric per-stage load races
+  # the D2D socket setup).
+  PREFILL_PP_FILE_BARRIER: "1"
+  LOGURU_LEVEL: "INFO"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml
@@ -1,15 +1,9 @@
 # REQUEST mode (unbounded, H2D-driven) 4-stage INTRA-galaxy pipeline prefill on ONE BH galaxy.
 #
 # One 8x4 galaxy carved into 4 Z-connected [2,4] sub-meshes; hidden state hops stage->stage over the
-# Z-link MeshSocket, per-stage SP2 x TP4 x EP8. REQUEST mode: no PREFILL_STANDALONE, so rank 0 builds the
+# Z-link MeshSocket, per-stage EP8. REQUEST mode: no PREFILL_STANDALONE, so rank 0 builds the
 # H2D service and waits for an external prefill_producer to drive concurrent prompts. Tray pins from
 # test_physical_discovery (QUAD rank->tray {0:1,1:3,2:4,3:2}).
-#
-# Launch (4 ranks on the single host), then run prefill_producer.py on this host:
-#   PREFILL_MANIFEST=models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json \
-#     ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
-#     models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml \
-#     <galaxy-host>:4
 
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"}}

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -93,6 +93,8 @@ class TtPrefillRuntime:
         self.compiled = False
         # Per-layer LayerAck callback, registered via set_layer_ack_channel() after compile.
         self._on_layer_complete = None
+        # Per-layer completion sink for pipelined prefill, registered via set_layer_completion_sink().
+        self._layer_completion_sink = None
 
         # The Model builds `hf_config.num_hidden_layers` decoder layers, but the KV cache (and gather /
         # PCC) is sized to `config.num_layers`. Pin them equal so a partial-model run (PREFILL_NUM_LAYERS
@@ -252,6 +254,7 @@ class TtPrefillRuntime:
         slot_id: int,
         actual_start: int,
         actual_end: int,
+        request_id: int = 0,
         *,
         skip_lm_head: bool = True,
         get_last_token: int = -1,
@@ -305,6 +308,16 @@ class TtPrefillRuntime:
         # per-chunk host reshard, and the tensors are persistent (do NOT deallocate them here). The KV
         # cache is engine-owned and passed in. If a LayerAck channel is registered, the model bumps it
         # once per layer via on_layer_complete.
+        # Pipelined mode registers a completion sink keyed by (layer_idx, request_id); bind request_id per
+        # call so the synchronous per-layer callback reads no mutable state. Single-host mode uses the ack.
+        if self._layer_completion_sink is not None:
+            sink = self._layer_completion_sink
+
+            def on_layer_complete(layer_idx: int) -> None:
+                sink(layer_idx, request_id)
+
+        else:
+            on_layer_complete = self._on_layer_complete
         out = self.model.prefill_forward(
             x_embd,
             rot_mats_global=self.rope_indexed,
@@ -314,7 +327,7 @@ class TtPrefillRuntime:
             get_last_token=get_last_token,
             skip_lm_head=skip_lm_head,  # default: cache-fill only (skip final norm + lm_head)
             indexed_rope=True,
-            on_layer_complete=self._on_layer_complete,
+            on_layer_complete=on_layer_complete,
         )
         if not self.config.is_last_rank:
             # Middle rank: hand the slice's output hidden state to the next rank.
@@ -335,6 +348,15 @@ class TtPrefillRuntime:
             layer_ack_channel.inject(1)
 
         self._on_layer_complete = on_layer_complete
+
+    def set_layer_completion_sink(self, sink) -> None:
+        """Register a per-layer completion sink for pipelined (multi-rank) prefill. ``sink`` is called once
+        per layer as ``sink(layer_idx, request_id)`` — the global layer index plus the current request/chunk
+        id (bound per ``prefill_chunk`` call, so the sink reads no mutable runtime state). Replaces the
+        single-host ack-counter inject: the runner pushes a full completion into the host-local
+        LayerCompletionQueue and the LayerCompletionRouter re-emits it in seq order to the scheduler channel."""
+        assert self.compiled, "Call compile() before set_layer_completion_sink()"
+        self._layer_completion_sink = sink
 
     def gather_layer(self, kv_cache, slot_id: int, layer_idx: int, n_tokens: int):
         """Read one layer's device cache back to NATURAL token order (un-rotating the block-cyclic SP

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -107,6 +107,8 @@ class TtPrefillRuntime:
         self.compiled = False
         # Per-layer LayerAck callback, registered via set_layer_ack_channel() after compile.
         self._on_layer_complete = None
+        # Per-layer completion sink for pipelined prefill, registered via set_layer_completion_sink().
+        self._layer_completion_sink = None
 
         # The Model builds `hf_config.num_hidden_layers` decoder layers, but the KV cache (and gather /
         # PCC) is sized to `config.num_layers`. Pin them equal so a partial-model run (PREFILL_NUM_LAYERS
@@ -337,6 +339,16 @@ class TtPrefillRuntime:
         # per-chunk host reshard, and the tensors are persistent (do NOT deallocate them here). The KV
         # cache is engine-owned and passed in. If a LayerAck channel is registered, the model bumps it
         # once per layer via on_layer_complete.
+        # Pipelined mode registers a completion sink keyed by (layer_idx, request_id); bind request_id per
+        # call so the synchronous per-layer callback reads no mutable state. Single-host mode uses the ack.
+        if self._layer_completion_sink is not None:
+            sink = self._layer_completion_sink
+
+            def on_layer_complete(layer_idx: int) -> None:
+                sink(layer_idx, request_id)
+
+        else:
+            on_layer_complete = self._on_layer_complete
         out = self.model.prefill_forward(
             x_embd,
             rot_mats_global=self.rope_indexed,
@@ -346,7 +358,7 @@ class TtPrefillRuntime:
             get_last_token=get_last_token,
             skip_lm_head=skip_lm_head,  # default: cache-fill only (skip final norm + lm_head)
             indexed_rope=True,
-            on_layer_complete=self._on_layer_complete,
+            on_layer_complete=on_layer_complete,
         )
         if not self.config.is_last_rank:
             # Middle rank: hand the slice's output hidden state to the next rank.
@@ -367,6 +379,15 @@ class TtPrefillRuntime:
             layer_ack_channel.inject(1)
 
         self._on_layer_complete = on_layer_complete
+
+    def set_layer_completion_sink(self, sink) -> None:
+        """Register a per-layer completion sink for pipelined (multi-rank) prefill. ``sink`` is called once
+        per layer as ``sink(layer_idx, request_id)`` — the global layer index plus the current request/chunk
+        id (bound per ``prefill_chunk`` call, so the sink reads no mutable runtime state). Replaces the
+        single-host ack-counter inject: the runner pushes a full completion into the host-local
+        LayerCompletionQueue and the LayerCompletionRouter re-emits it in seq order to the scheduler channel."""
+        assert self.compiled, "Call compile() before set_layer_completion_sink()"
+        self._layer_completion_sink = sink
 
     def gather_layer(self, kv_cache, slot_id: int, layer_idx: int, n_tokens: int):
         """Read one layer's device cache back to NATURAL token order (un-rotating the block-cyclic SP

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -247,19 +247,23 @@ class TtPrefillRuntime:
         return x
 
     def compile(self, kv_cache) -> None:
-        """Warm up one zero-token chunk so the per-chunk loop hits no first-run cost (JIT-compiles all
-        ops). The engine passes the cache it owns; the warm-up writes slot 0 and is harmless."""
+        """Warm up every KV-length the served loop can reach so no served chunk pays a first-run JIT. The
+        cache-read attention (RingJointSDPA) keys its program per KV-length bucket, so warming only the
+        first chunk just relocates the ~6s compile to the first un-warmed depth. Sweep the full per-user
+        cache in chunk steps (actual_start = 0, chunk, 2*chunk, ... max_seq_len-chunk); each warm-up writes
+        slot 0, which the real run overwrites in order."""
         assert self.model_built
         chunk = self.config.chunk_size
-        logger.info(f"TtPrefillRuntime.compile() — warming up one {chunk}-token chunk")
+        starts = list(range(0, self.config.max_seq_len - chunk + 1, chunk))
+        logger.info(f"TtPrefillRuntime.compile() — warming {len(starts)} KV-length buckets ({chunk}-token chunks)")
         t0 = time.perf_counter()
-        tt_input = self.make_chunk_input([0] * chunk)
-        self.prefill_chunk(tt_input, kv_cache, slot_id=0, actual_start=0, actual_end=chunk)
+        for start in starts:
+            self.prefill_chunk(
+                self.make_chunk_input([0] * chunk), kv_cache, slot_id=0, actual_start=start, actual_end=start + chunk
+            )
         ttnn.synchronize_device(self.mesh_device)
         warmup_ms = (time.perf_counter() - t0) * 1000.0
-        logger.info(
-            f"[prefill timing] task_id=WARMUP num_tokens={chunk} runtime.prefill_chunk(chunk) = {warmup_ms:.2f} ms"
-        )
+        logger.info(f"[prefill timing] task_id=WARMUP buckets={len(starts)} runtime.compile() = {warmup_ms:.2f} ms")
         self.compiled = True
 
     def prefill_chunk(

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -247,11 +247,8 @@ class TtPrefillRuntime:
         return x
 
     def compile(self, kv_cache) -> None:
-        """Warm up every KV-length the served loop can reach so no served chunk pays a first-run JIT. The
-        cache-read attention (RingJointSDPA) keys its program per KV-length bucket, so warming only the
-        first chunk just relocates the ~6s compile to the first un-warmed depth. Sweep the full per-user
-        cache in chunk steps (actual_start = 0, chunk, 2*chunk, ... max_seq_len-chunk); each warm-up writes
-        slot 0, which the real run overwrites in order."""
+        """Warm up every KV-length the served loop can reach so no served chunk pays a first-run JIT.
+        Sweep the full per-user cache in chunk steps; each warm-up writes slot 0, which the real run overwrites."""
         assert self.model_built
         chunk = self.config.chunk_size
         starts = list(range(0, self.config.max_seq_len - chunk + 1, chunk))

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -339,13 +339,16 @@ class TtPrefillRuntime:
         # per-chunk host reshard, and the tensors are persistent (do NOT deallocate them here). The KV
         # cache is engine-owned and passed in. If a LayerAck channel is registered, the model bumps it
         # once per layer via on_layer_complete.
-        # Pipelined mode registers a completion sink keyed by (layer_idx, request_id); bind request_id per
-        # call so the synchronous per-layer callback reads no mutable state. Single-host mode uses the ack.
+        # Pipelined mode registers a completion sink keyed by (global_layer_idx, request_id); bind request_id
+        # per call so the synchronous per-layer callback reads no mutable state. Single-host mode uses the ack.
         if self._layer_completion_sink is not None:
             sink = self._layer_completion_sink
 
             def on_layer_complete(layer_idx: int) -> None:
-                sink(layer_idx, request_id)
+                # The model reports a rank-local index; the sink's seq = request_id * total_layers +
+                # layer_idx needs the GLOBAL index, else every rank's local layer k collides at one seq
+                # and all but the first rank's completion is dropped.
+                sink(self.config.first_layer_idx + layer_idx, request_id)
 
         else:
             on_layer_complete = self._on_layer_complete

--- a/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2_z_chain_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2_z_chain_graph_descriptor.textproto
@@ -1,0 +1,47 @@
+# Single BH galaxy carved into 4 Z-connected [2,4] meshes, wired as a Z-CHAIN 0->1->2->3
+# (NOT a ring). Derived from single_bh_galaxy_4x4x2_z_graph_descriptor.textproto by DROPPING the
+# ring-closing 0<->3 connection: a 4-cycle cannot carry a consistent assign_z_direction, so the
+# control plane drops the wraparound link ("Z/non-Z direction mismatch") and aborts. Pipeline-parallel
+# prefill only needs the forward chain (rank 0 -> 1 -> 2 -> 3; the last rank never sends back), so the
+# chain topology matches what PP uses and resolves cleanly.
+#
+# Each mesh is [2,4] (8 chips) -> per-stage SP2 x TP4 x EP8. Same tray layout / rank->tray order as the
+# ring MGD (QUAD {0:tr1, 1:tr3, 2:tr4, 3:tr2}), so the same rank binding + TT_VISIBLE_DEVICES apply.
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 2, 4 ] dim_types: [ LINE, LINE ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: STRICT }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 4 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 4 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 4 policy: RELAXED }
+    assign_z_direction: true
+  }
+}
+
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2_z_chain_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2_z_chain_graph_descriptor.textproto
@@ -1,12 +1,4 @@
-# Single BH galaxy carved into 4 Z-connected [2,4] meshes, wired as a Z-CHAIN 0->1->2->3
-# (NOT a ring). Derived from single_bh_galaxy_4x4x2_z_graph_descriptor.textproto by DROPPING the
-# ring-closing 0<->3 connection: a 4-cycle cannot carry a consistent assign_z_direction, so the
-# control plane drops the wraparound link ("Z/non-Z direction mismatch") and aborts. Pipeline-parallel
-# prefill only needs the forward chain (rank 0 -> 1 -> 2 -> 3; the last rank never sends back), so the
-# chain topology matches what PP uses and resolves cleanly.
-#
-# Each mesh is [2,4] (8 chips) -> per-stage SP2 x TP4 x EP8. Same tray layout / rank->tray order as the
-# ring MGD (QUAD {0:tr1, 1:tr3, 2:tr4, 3:tr2}), so the same rank binding + TT_VISIBLE_DEVICES apply.
+# Single BH galaxy carved into 4 Z-connected [2,4] meshes, wired as a Z-CHAIN 0->1->2->3 (no wraparound)
 
 mesh_descriptors {
   name: "M0"


### PR DESCRIPTION
### PR Category

Performance  
MiniMax-M3 intra-galaxy pipeline-parallel prefill. Splits one 8×4 Blackhole galaxy into N pipeline stages (sub-meshes), to raise 5k@50k prefill throughput. 
Enabled by new request-mode bindings - `pipeline_prefill_request_intragalaxy_{2,4}rank.yaml`

## Summary

The default M3 prefill runs the whole 60-layer model on one galaxy `(8,4)`/EP32. This PR adds **intra-galaxy
pipeline parallelism**: carve the galaxy into N contiguous sub-meshes that pass the hidden state stage→stage over the existing D2D MeshSocket on a **Z-chain** fabric descriptor, and drive it with the existing request-mode runner + producer. Smaller per-stage EP (EP8/EP16 vs EP32) so the pipelined version beats single-galaxy path in throughput at 5k@50k.

The change is mostly **configuration**. The base request-loop / D2D / producer infra already exists.
This PR adds:
- the `(2,4)` 4-stage Z-chain mesh descriptor (`single_bh_galaxy_4x4x2_z_chain_graph_descriptor.textproto`);
  the `(4,4)` 2-stage descriptor is already upstream;
- request-mode rank bindings for the 2- and 4-stage pipelines - (`pipeline_prefill_request_intragalaxy_{2,4}rank.yaml`);
  the single-stage `(8,4)` uses the existing `pipeline_prefill_request_1rank.yaml`;
- **Brings the M3 runtime up to main's current pipeline contract** -  add `TtPrefillRuntime.set_layer_completion_sink()` `+` `prefill_chunk(request_id=)`. Since each stage owns a disjoint slice of layers, the runtime reports each finished layer to the sink by its global index (first_layer_idx + local) so stages don't collide on the same per-layer id.
- a **32 KB D2D FIFO** (`PREFILL_PP_D2D_FIFO_BYTES`) in the two intra-galaxy bindings - a **workaround, not a
  tuning knob**.  A middle stage builds two sockets (inbound and outbound), so the default 2x64kB causes CB/L1 allocation clash: (`TT_THROW: statically allocated circular buffers … clash with L1 buffers`) inside `unified_routed_expert_ffn`
*Root cause*: the FFN program factory sizes its CBs against total per-core L1 minus a hardcoded 48 KB margin (`L1_SCRATCH_MARGIN`).
Only 12B of metadata is transported through the socket buffer, so shrinking it doesn't affect perf. Dropping the default 64 KB to 32 KB frees enough L1 that the clash disappears. Needs a proper fix, out of scope for this PR.
- **KV sweep prefill warmup** - pre-compiles every `RingJointSDPA` KV-length bucket (JIT times were polluting throughput). Brings total compilation to `146–240 s`.

## Results

### Performance

**Expert precision:** all runs use **bf4** (`bfloat4_b`) routed-expert weights.
Single request is chunked prefill, 10×5120-token chunks, 6 requests, **2 concurrent users** (round-robined). 
Measured on `bh-glx` (parsed from the runner log, script below), warm cache:

```
  ┌────────┬────────┬─────┬───────────────────────────────────┬──────────┐
  │ config │ stages │ EP  │ throughput (59-chunk output-span) │ vs (8,4) │
  ├────────┼────────┼─────┼───────────────────────────────────┼──────────┤
  │ (8,4)  │ 1      │ 32  │ 4148 tok/s                        │ 1.0×     │
  ├────────┼────────┼─────┼───────────────────────────────────┼──────────┤
  │ (4,4)  │ 2      │ 16  │ 8967 tok/s                        │ 2.16×    │
  ├────────┼────────┼─────┼───────────────────────────────────┼──────────┤
  │ (2,4)  │ 4      │ 8   │ 10071 tok/s                       │ 2.43×    │
  └────────┴────────┴─────┴───────────────────────────────────┴──────────┘
```

### Correctness

Measured manually on request path, single golden prompt fed as 1 user (11×5120)
Per-layer KV-cache PCC vs the golden trace, 5k@50k (11×5120), **bf4 routed experts**.

| config | grouping                | K     | V     | index_k | overall min |
|--------|-------------------------|-------|-------|---------|-------------|
| (8,4)  | whole model (60 layers) | 0.968 | 0.886 | 0.979   | 0.886       |
| (2,4)  | min across 4 stages     | 0.963 | 0.880 | 0.975   | **0.880**   |

(2,4)'s floor (0.880) matches single-galaxy (8,4) (0.886) within ~0.006 V.

`(2,4)` per-stage (each rank's 15-layer slice):

| stage (rank) | layers | K     | V     | index_k |
|--------------|--------|-------|-------|---------|
| 0            | 0–14   | 0.995 | 0.985 | 0.997   |
| 1            | 15–29  | 0.987 | 0.968 | 0.989   |
| 2            | 30–44  | 0.971 | 0.933 | 0.979   |
| 3            | 45–59  | 0.963 | 0.880 | 0.975   |

## How to run
**Build cache has to be populated before running!**

```bash=

export TT_METAL_HOME=$PWD
export PREFILL_MANIFEST=models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json
export TT_CACHE_PATH=${TT_CACHE_PATH:?set to a prepopulated weight cache keyed to this carve's MeshShape} # NEEDS TO BE PREPOPULATED!

# 1) runner
HOST=$(hostname)
PREFILL_H2D_SERVICE_ID=ds_prefill \
  ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
  models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml \
  "$HOST,$HOST,$HOST,$HOST" > /tmp/runner_2x4.log 2>&1 &
    
# wait until background runner is ready
until [ "$(grep -c 'entering request loop' /tmp/runner_2x4.log)" -ge 4 ]; do
  sleep 5; kill -0 %1 2>/dev/null || { echo "runner died:"; tail -30 /tmp/runner_2x4.log; break; }
done
  
# 2) producer
PREFILL_CHUNK_SIZE=5120 PREFILL_MAX_SEQ_LEN=56320 PREFILL_NUM_LAYERS=60 PREFILL_NUM_USERS=2 \
PREFILL_SP=2 PREFILL_TP=4 PREFILL_H2D_SERVICE_ID=ds_prefill PREFILL_H2D_CONNECT_TIMEOUT=60 \
PREFILL_PRODUCER_CHUNKS=10 PREFILL_PRODUCER_MAX_REQUESTS=6 PREFILL_PRODUCER_INTERLEAVE=round_robin \
PREFILL_SEND_SHUTDOWN=1 \
python3 -m models.demos.common.prefill.runners.prefill_producer
  
# 3) parse results
gawk 'match($0, /rank ([0-9]+)\] CHUNK_START.*compute_start=([0-9.]+)/, m) {
    rank = m[1] + 0; start_epoch = m[2] + 0
    if (last_stage == "" || rank > last_stage) last_stage = rank   # highest rank = final stage
    if (!(rank in count)) first_start[rank] = start_epoch          # first chunk-start for this rank
    last_start[rank] = start_epoch                                 # overwritten each time -> ends on the last
    count[rank]++
}
END {
    n = count[last_stage]
    if (n < 2) { print "need >=2 chunks on the last stage"; exit }
    emit_span_s = last_start[last_stage] - first_start[last_stage]
    printf "last stage = rank %d: %d chunks over %.2fs => %.0f tok/s\n",
        last_stage, n-1, emit_span_s, (n-1)*5120/emit_span_s
}' /tmp/runner_2x4.log
```

### Follow-ups
+ Cold-build tooling for the sharded cache
+ Automated pipeline PCC tests
+ FIFO size fix - come up with a better solution than just lowering the size of the buffer

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=zbaczewski/perf/m3-intragalaxy-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:zbaczewski/perf/m3-intragalaxy-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=zbaczewski/perf/m3-intragalaxy-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:zbaczewski/perf/m3-intragalaxy-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=zbaczewski/perf/m3-intragalaxy-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:zbaczewski/perf/m3-intragalaxy-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=zbaczewski/perf/m3-intragalaxy-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:zbaczewski/perf/m3-intragalaxy-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=zbaczewski/perf/m3-intragalaxy-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:zbaczewski/perf/m3-intragalaxy-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=zbaczewski/perf/m3-intragalaxy-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:zbaczewski/perf/m3-intragalaxy-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=zbaczewski/perf/m3-intragalaxy-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:zbaczewski/perf/m3-intragalaxy-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=zbaczewski/perf/m3-intragalaxy-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:zbaczewski/perf/m3-intragalaxy-pp)