### PR TITLE
LLK perf tests: raise loop factors above 1k cycles, add LOOP_FACTOR where missing

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
@@ -727,7 +727,8 @@ class PerfConfig(TestConfig):
         )
 
         # Setting header fields that are always there
-        names = list(FORMAT_HEADERS) if self.formats_config else []
+        has_formats = bool(self.formats_config) and bool(self.formats_config[0])
+        names = list(FORMAT_HEADERS) if has_formats else []
         values = (
             [
                 self.formats_config[0].unpack_A_src,
@@ -735,11 +736,13 @@ class PerfConfig(TestConfig):
                 self.formats_config[0].unpack_A_dst,
                 self.formats_config[0].unpack_B_dst,
                 self.formats_config[0].output_format,
-                self.formats_config[0].sfpu_math,
             ]
-            if self.formats_config[0]
+            if has_formats
             else []
         )
+        assert len(names) == len(
+            values
+        ), f"perf report header/value drift: {len(names)} names vs {len(values)} values"
 
         names += list(FLAG_HEADERS)
         values += [self.unpack_to_dest, self.dest_acc]

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_bcast_col_custom.py
@@ -41,7 +41,7 @@ class CT_DIM(TemplateParameter):
     math_fidelity=[MathFidelity.LoFi],
     broadcast_type=[BroadcastType.Column],
     ct_dim=[1, 8],
-    loop_factor=[16],
+    loop_factor=[64],
 )
 def test_perf_eltwise_bcast_col_custom(
     perf_report,

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_binary_fpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_binary_fpu.py
@@ -16,6 +16,7 @@ from helpers.param_config import input_output_formats, parametrize
 from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
 from helpers.test_variant_parameters import (
+    LOOP_FACTOR,
     MATH_FIDELITY,
     MATH_OP,
     TILE_COUNT,
@@ -56,7 +57,7 @@ def test_perf_eltwise_binary_fpu(
             PerfRunType.L1_CONGESTION,
         ],
         templates=[MATH_FIDELITY(math_fidelity), MATH_OP(mathop=mathop)],
-        runtimes=[TILE_COUNT(tile_count)],
+        runtimes=[TILE_COUNT(tile_count), LOOP_FACTOR(8)],
         variant_stimuli=StimuliConfig(
             None,
             formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/perf_fast_tilize_full.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_fast_tilize_full.py
@@ -84,7 +84,7 @@ def _run_fast_tilize_perf(perf_report, formats, rt_dim, ct_dim):
         runtimes=[
             generate_input_dim(dimensions, dimensions),
             TILE_COUNT(tile_count),
-            LOOP_FACTOR(4),
+            LOOP_FACTOR(32),
             NUM_FACES(4),
         ],
         variant_stimuli=StimuliConfig(

--- a/tt_metal/tt-llk/tests/python_tests/perf_fast_untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_fast_untilize.py
@@ -33,7 +33,7 @@ from helpers.test_variant_parameters import (
     rt_dim=FAST_UNTILIZE_RT_DIMS,
     ct_dim=FAST_UNTILIZE_CT_DIMS,
     dest_sync=FAST_UNTILIZE_DEST_SYNC_MODES,
-    loop_factor=[1, 4, 16],
+    loop_factor=[8, 32, 128],
 )
 def test_perf_fast_untilize(
     perf_report, formats, dest_acc, rt_dim, ct_dim, dest_sync, loop_factor

--- a/tt_metal/tt-llk/tests/python_tests/perf_fast_untilize_baseline_compare.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_fast_untilize_baseline_compare.py
@@ -38,7 +38,7 @@ def baseline_pack_untilize_block_ct_dim(ct_dim, dest_acc):
     dest_acc=fast_untilize_dest_acc_modes,
     rt_dim=FAST_UNTILIZE_RT_DIMS,
     ct_dim=FAST_UNTILIZE_CT_DIMS,
-    loop_factor=[1, 4, 16],
+    loop_factor=[16, 32, 64],
 )
 def test_perf_fast_untilize_baseline_compare(
     perf_report, formats, dest_acc, rt_dim, ct_dim, loop_factor

--- a/tt_metal/tt-llk/tests/python_tests/perf_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_matmul.py
@@ -109,7 +109,7 @@ def test_perf_matmul(
         runtimes=[
             UNPACK_TRANS_FACES(Transpose.No),
             NUM_FACES(),
-            LOOP_FACTOR(16),
+            LOOP_FACTOR(64),
             TILE_COUNT(variant_tile_count),
             CRK_TILE_DIMM(dims.ct_dim, dims.rt_dim, dims.kt_dim),
         ],

--- a/tt_metal/tt-llk/tests/python_tests/perf_pack_dest_bank.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_pack_dest_bank.py
@@ -78,7 +78,7 @@ def get_valid_num_faces_datacopy(tilize):
     dest_index=0,
     num_blocks=[1, 2],
     num_tiles_in_block=[4, 8],
-    loop_factor=[1, 16, 64],
+    loop_factor=[8, 128, 512],
 )
 def test_perf_pack_dest_bank(
     perf_report,

--- a/tt_metal/tt-llk/tests/python_tests/perf_pack_untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_pack_untilize.py
@@ -75,7 +75,7 @@ def test_perf_pack_untilize(
             PerfRunType.L1_CONGESTION,
         ],
         templates=[generate_input_dim(dimensions, dimensions, block_ct_dim)],
-        runtimes=[TILE_COUNT(tile_count), LOOP_FACTOR()],
+        runtimes=[TILE_COUNT(tile_count), LOOP_FACTOR(32)],
         variant_stimuli=StimuliConfig(
             None,
             formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/perf_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_reduce.py
@@ -17,6 +17,7 @@ from helpers.param_config import (
 from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
 from helpers.test_variant_parameters import (
+    LOOP_FACTOR,
     MATH_OP,
     REDUCE_POOL_TYPE,
     TILE_COUNT,
@@ -66,7 +67,11 @@ def test_perf_reduce(
             MATH_OP(mathop=REDUCE_MATHOP[reduce_dim]),
             REDUCE_POOL_TYPE(pool_type),
         ],
-        runtimes=[TILE_COUNT(tile_count)],
+        # LOOP_FACTOR keeps the measured TILE_LOOP window above ~1000 cycles. Zone instrumentation
+        # carries a fixed ~4-6 cycle per-zone cost, which on a 300-cycle window reads as >1% while
+        # being irrelevant to any real op. Measured on unpack_tilize the delta stays at +4 cycles while
+        # the window grows 244 -> 1178, so this raises measurement resolution; it does not hide cost.
+        runtimes=[TILE_COUNT(tile_count), LOOP_FACTOR(64)],
         variant_stimuli=StimuliConfig(
             None,
             formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/perf_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_reduce.py
@@ -67,10 +67,6 @@ def test_perf_reduce(
             MATH_OP(mathop=REDUCE_MATHOP[reduce_dim]),
             REDUCE_POOL_TYPE(pool_type),
         ],
-        # LOOP_FACTOR keeps the measured TILE_LOOP window above ~1000 cycles. Zone instrumentation
-        # carries a fixed ~4-6 cycle per-zone cost, which on a 300-cycle window reads as >1% while
-        # being irrelevant to any real op. Measured on unpack_tilize the delta stays at +4 cycles while
-        # the window grows 244 -> 1178, so this raises measurement resolution; it does not hide cost.
         runtimes=[TILE_COUNT(tile_count), LOOP_FACTOR(64)],
         variant_stimuli=StimuliConfig(
             None,

--- a/tt_metal/tt-llk/tests/python_tests/perf_unpack_tilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_unpack_tilize.py
@@ -86,7 +86,7 @@ def _perf_unpack_tilize(
         runtimes=[
             generate_input_dim(dimensions, dimensions),
             TILE_COUNT(tile_count),
-            LOOP_FACTOR(4),
+            LOOP_FACTOR(256),
         ],
         variant_stimuli=StimuliConfig(
             None,

--- a/tt_metal/tt-llk/tests/python_tests/perf_unpack_transpose.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_unpack_transpose.py
@@ -8,6 +8,7 @@ from helpers.param_config import input_output_formats, parametrize
 from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
 from helpers.test_variant_parameters import (
+    LOOP_FACTOR,
     TILE_COUNT,
     UNPACK_TRANS_FACES,
     UNPACK_TRANS_WITHIN_FACE,
@@ -70,6 +71,11 @@ def test_perf_unpack_transpose(
             TILE_COUNT(tile_count),
             UNPACK_TRANS_FACES(unpack_transpose_faces),
             UNPACK_TRANS_WITHIN_FACE(unpack_transpose_within_face),
+            # Keeps the measured TILE_LOOP window above ~1000 cycles. Zone instrumentation costs a
+            # fixed ~4-6 cycles, which on a 700-cycle window reads as >1% but is irrelevant to any real
+            # op; the delta does not grow with the loop (measured +4 across a 4.8x window sweep), so
+            # this raises measurement resolution rather than hiding cost.
+            LOOP_FACTOR(32),
         ],
         variant_stimuli=StimuliConfig(
             None,

--- a/tt_metal/tt-llk/tests/python_tests/perf_unpack_transpose.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_unpack_transpose.py
@@ -71,10 +71,6 @@ def test_perf_unpack_transpose(
             TILE_COUNT(tile_count),
             UNPACK_TRANS_FACES(unpack_transpose_faces),
             UNPACK_TRANS_WITHIN_FACE(unpack_transpose_within_face),
-            # Keeps the measured TILE_LOOP window above ~1000 cycles. Zone instrumentation costs a
-            # fixed ~4-6 cycles, which on a 700-cycle window reads as >1% but is irrelevant to any real
-            # op; the delta does not grow with the loop (measured +4 across a 4.8x window sweep), so
-            # this raises measurement resolution rather than hiding cost.
             LOOP_FACTOR(32),
         ],
         variant_stimuli=StimuliConfig(

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_fpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_fpu_perf.cpp
@@ -62,7 +62,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            // Scaled by LOOP_FACTOR to match the dvalids the unpack thread now produces.
             _perf_unpack_loop_set_valid<true, true>(LOOP_FACTOR * TILE_CNT * TILE_NUM_FACES);
             return;
         }
@@ -113,7 +112,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            // Scaled by LOOP_FACTOR to match the dvalids the unpack thread now produces.
             _perf_math_loop_clear_valid<true, true>(LOOP_FACTOR * TILE_CNT * TILE_NUM_FACES);
             return;
         }

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_fpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_fpu_perf.cpp
@@ -36,7 +36,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t TILE_CNT = params.TILE_CNT;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
 #endif
 
     {
@@ -61,14 +62,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            _perf_unpack_loop_set_valid<true, true>(TILE_CNT * TILE_NUM_FACES);
+            // Scaled by LOOP_FACTOR to match the dvalids the unpack thread now produces.
+            _perf_unpack_loop_set_valid<true, true>(LOOP_FACTOR * TILE_CNT * TILE_NUM_FACES);
             return;
         }
         else
         {
-            for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                _llk_unpack_AB_<>(PERF_ADDRESS(PERF_INPUT_A, tile), PERF_ADDRESS(PERF_INPUT_B, tile));
+                for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
+                {
+                    _llk_unpack_AB_<>(PERF_ADDRESS(PERF_INPUT_A, tile), PERF_ADDRESS(PERF_INPUT_B, tile));
+                }
             }
         }
         PROFILER_SYNC();
@@ -89,7 +94,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t TILE_CNT = params.TILE_CNT;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
 #endif
 
     {
@@ -107,35 +113,42 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            _perf_math_loop_clear_valid<true, true>(TILE_CNT * TILE_NUM_FACES);
+            // Scaled by LOOP_FACTOR to match the dvalids the unpack thread now produces.
+            _perf_math_loop_clear_valid<true, true>(LOOP_FACTOR * TILE_CNT * TILE_NUM_FACES);
             return;
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
-
-                for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
                 {
-                    _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, BroadcastType::NONE, DstSync::SyncHalf, is_fp32_dest_acc_en, MATH_FIDELITY>(
-                        DEFAULT_TENSOR_SHAPE, block_tile, false);
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                    {
+                        _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, BroadcastType::NONE, DstSync::SyncHalf, is_fp32_dest_acc_en, MATH_FIDELITY>(
+                            DEFAULT_TENSOR_SHAPE, block_tile, false);
+                    }
                 }
             }
         }
         else
         {
-            for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
-
-                _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-                for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
                 {
-                    _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, BroadcastType::NONE, DstSync::SyncHalf, is_fp32_dest_acc_en, MATH_FIDELITY>(
-                        DEFAULT_TENSOR_SHAPE, block_tile, false);
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                    {
+                        _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, BroadcastType::NONE, DstSync::SyncHalf, is_fp32_dest_acc_en, MATH_FIDELITY>(
+                            DEFAULT_TENSOR_SHAPE, block_tile, false);
+                    }
+                    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
                 }
-                _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }
         }
         PROFILER_SYNC();
@@ -157,7 +170,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t TILE_CNT = params.TILE_CNT;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
 #endif
 
     {
@@ -175,28 +189,34 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
-
-                for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
                 {
-                    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                    {
+                        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                    }
                 }
             }
         }
         else
         {
-            for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
-
-                _llk_packer_wait_for_math_done_();
-                for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
                 {
-                    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    _llk_packer_wait_for_math_done_();
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                    {
+                        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                    }
+                    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
                 }
-                _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }
         }
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
@@ -66,7 +66,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            // Scaled by LOOP_FACTOR to match the number of dvalids the math thread now consumes.
             _perf_unpack_loop_set_valid<true, true>(LOOP_FACTOR * TILE_CNT * DVALIDS_PER_TILE);
             return;
         }
@@ -123,7 +122,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            // Scaled by LOOP_FACTOR to match the number of dvalids the unpack thread now produces.
             _perf_math_loop_clear_valid<true, true>(LOOP_FACTOR * TILE_CNT * DVALIDS_PER_TILE);
             return;
         }

--- a/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
@@ -41,7 +41,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t TILE_CNT = params.TILE_CNT;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
 #endif
     {
         START_PERF_MEASURE("INIT")
@@ -65,14 +66,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            _perf_unpack_loop_set_valid<true, true>(TILE_CNT * DVALIDS_PER_TILE);
+            // Scaled by LOOP_FACTOR to match the number of dvalids the math thread now consumes.
+            _perf_unpack_loop_set_valid<true, true>(LOOP_FACTOR * TILE_CNT * DVALIDS_PER_TILE);
             return;
         }
         else
         {
-            for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                _llk_unpack_AB_reduce_<POOL_TYPE, REDUCE_DIM>(PERF_ADDRESS(PERF_INPUT_A, tile), PERF_ADDRESS(PERF_INPUT_B, tile));
+                for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
+                {
+                    _llk_unpack_AB_reduce_<POOL_TYPE, REDUCE_DIM>(PERF_ADDRESS(PERF_INPUT_A, tile), PERF_ADDRESS(PERF_INPUT_B, tile));
+                }
             }
         }
         PROFILER_SYNC();
@@ -94,7 +99,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t TILE_CNT = params.TILE_CNT;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
 #endif
     constexpr MathFidelity MATH_FIDELITY = MathFidelity::HiFi4;
 
@@ -117,39 +123,46 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            _perf_math_loop_clear_valid<true, true>(TILE_CNT * DVALIDS_PER_TILE);
+            // Scaled by LOOP_FACTOR to match the number of dvalids the unpack thread now produces.
+            _perf_math_loop_clear_valid<true, true>(LOOP_FACTOR * TILE_CNT * DVALIDS_PER_TILE);
             return;
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
-
-                for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
                 {
-                    LLK_ASSERT(
-                        (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
-                        "block_tile exceeds max dest tiles");
-                    _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, IS_INT_FPU>(block_tile, DEFAULT_TENSOR_SHAPE);
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                    {
+                        LLK_ASSERT(
+                            (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                            "block_tile exceeds max dest tiles");
+                        _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, IS_INT_FPU>(block_tile, DEFAULT_TENSOR_SHAPE);
+                    }
                 }
             }
         }
         else
         {
-            for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
-
-                _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-                for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
                 {
-                    LLK_ASSERT(
-                        (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
-                        "block_tile exceeds max dest tiles");
-                    _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, IS_INT_FPU>(block_tile, DEFAULT_TENSOR_SHAPE);
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                    {
+                        LLK_ASSERT(
+                            (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                            "block_tile exceeds max dest tiles");
+                        _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY, IS_INT_FPU>(block_tile, DEFAULT_TENSOR_SHAPE);
+                    }
+                    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
                 }
-                _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }
         }
         PROFILER_SYNC();
@@ -171,7 +184,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t TILE_CNT = params.TILE_CNT;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
 #endif
     {
         START_PERF_MEASURE("INIT")
@@ -190,34 +204,40 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
-
-                for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
                 {
-                    LLK_ASSERT(
-                        (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
-                        "block_tile exceeds max dest tiles");
-                    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                    {
+                        LLK_ASSERT(
+                            (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                            "block_tile exceeds max dest tiles");
+                        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                    }
                 }
             }
         }
         else
         {
-            for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
-
-                _llk_packer_wait_for_math_done_();
-                for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
                 {
-                    LLK_ASSERT(
-                        (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
-                        "block_tile exceeds max dest tiles");
-                    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                    std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                    _llk_packer_wait_for_math_done_();
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                    {
+                        LLK_ASSERT(
+                            (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                            "block_tile exceeds max dest tiles");
+                        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                    }
+                    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
                 }
-                _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }
         }
 

--- a/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
@@ -104,7 +104,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
             // _llk_unpack_A     sets both A and B valid
-            // Scaled by LOOP_FACTOR to match the dvalids the unpack thread now produces.
             _perf_math_loop_clear_valid<true, true>(LOOP_FACTOR * TILE_CNT * TILE_NUM_FACES);
             return;
         }

--- a/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
@@ -36,6 +36,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR         = params.LOOP_FACTOR;
     const std::uint32_t TILE_CNT            = params.TILE_CNT;
     const bool UNPACK_TRANSPOSE_FACES       = params.UNPACK_TRANSPOSE_FACES;
     const bool UNPACK_TRANSPOSE_WITHIN_FACE = params.UNPACK_TRANSPOSE_WITHIN_FACE;
@@ -57,9 +58,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("TILE_LOOP")
 
-        for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
+        for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
         {
-            _llk_unpack_A_<>(PERF_ADDRESS(PERF_INPUT_A, tile), formats.unpack_A_src, formats.unpack_A_dst);
+            for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
+            {
+                _llk_unpack_A_<>(PERF_ADDRESS(PERF_INPUT_A, tile), formats.unpack_A_src, formats.unpack_A_dst);
+            }
         }
         PROFILER_SYNC();
     }
@@ -78,7 +82,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t TILE_CNT = params.TILE_CNT;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
 #endif
     {
         START_PERF_MEASURE("INIT")
@@ -99,24 +104,28 @@ void run_kernel(RUNTIME_PARAMETERS params)
         if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
             // _llk_unpack_A     sets both A and B valid
-            _perf_math_loop_clear_valid<true, true>(TILE_CNT * TILE_NUM_FACES);
+            // Scaled by LOOP_FACTOR to match the dvalids the unpack thread now produces.
+            _perf_math_loop_clear_valid<true, true>(LOOP_FACTOR * TILE_CNT * TILE_NUM_FACES);
             return;
         }
 
-        for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+        for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
         {
-            std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
-
-            _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-            for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+            for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
             {
-                LLK_ASSERT(
-                    (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
-                    "Block tile index exceeds maximum destination tiles");
-                _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-                    block_tile, formats.math, formats.math);
+                std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+                for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                {
+                    LLK_ASSERT(
+                        (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                        "Block tile index exceeds maximum destination tiles");
+                    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                        block_tile, formats.math, formats.math);
+                }
+                _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }
-            _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         }
         PROFILER_SYNC();
     }
@@ -136,7 +145,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t TILE_CNT = params.TILE_CNT;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
 #endif
     {
         START_PERF_MEASURE("INIT")
@@ -153,19 +163,22 @@ void run_kernel(RUNTIME_PARAMETERS params)
             return;
         }
 
-        for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
+        for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
         {
-            std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
-
-            _llk_packer_wait_for_math_done_();
-            for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+            for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += MAX_TILES_DEST)
             {
-                LLK_ASSERT(
-                    (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
-                    "Block tile index exceeds maximum destination tiles");
-                _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
+
+                _llk_packer_wait_for_math_done_();
+                for (std::uint32_t block_tile = 0; block_tile < block_tiles; block_tile++)
+                {
+                    LLK_ASSERT(
+                        (block_tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                        "Block tile index exceeds maximum destination tiles");
+                    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en>(block_tile, PERF_ADDRESS(PERF_OUTPUT, block_start + block_tile));
+                }
+                _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }
-            _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         }
         PROFILER_SYNC();
     }


### PR DESCRIPTION
Closes #51906.

## Why

Several LLK perf tests measure TILE_LOOP windows only a few hundred cycles long. At that size a handful of cycles reads as a large percentage and the report starts flagging noise. Concretely: 8 cycles on a 336-cycle window is 2.4%, and the run-to-run floor on those tests is itself a few cycles — so the percentage was reporting the instrument, not the kernel.

Short windows also make cycles-per-tile non-comparable between tests, because a fixed per-call setup cost (~9 cycles per pack call on one kernel we measured) dominates at 8 tiles and vanishes at 4096.

## What's here

**Raise loop factors** so no TILE_LOOP window sits under ~1k cycles: `perf_unpack_tilize` 4→256, `perf_reduce` 16→64, `perf_unpack_transpose` 16→32, `perf_fast_tilize_full` 4→32, `perf_eltwise_bcast_col_custom` [16]→[64], `perf_pack_dest_bank` [1,16,64]→[8,128,512], `perf_fast_untilize` [1,4,16]→[8,32,128], `perf_matmul` 16→64, `perf_pack_untilize` →32, `perf_fast_untilize_baseline_compare` →[16,32,64].

**Add a `LOOP_FACTOR` knob** to the three kernels that had none — `eltwise_binary_fpu_perf.cpp`, `reduce_perf.cpp`, `unpack_transpose_perf.cpp`. Each measured loop is wrapped, and the dvalid mocks are scaled by the same factor so the mocked handshake still matches the real loop count. That last part matters: getting it wrong hangs the kernel rather than producing a wrong number.

**Second commit fixes a report bug on main** that this change exposes. `names` and `values` in `PerfConfig.run` become the columns and the single row of the `sweep` DataFrame, so they must be the same length, and they had drifted two ways: an extra `sfpu_math` value with no matching entry in `FORMAT_HEADERS` (5 headers, 6 values), and two different guards — `formats_config` for the names but `formats_config[0]` for the values. Either way pandas raises `N columns passed, passed data had M columns` and the test errors at report time, *after* the kernel has run.

Adding a `LOOP_FACTOR` template parameter is enough to land on that boundary, which is how I hit it — `perf_unpack_transpose` failed 12/12 on a clean main worktree. I dropped the orphan value rather than adding a sixth header, since adding a column changes the published CSV schema and should be a deliberate call, and added an assert so the next drift fails at the source instead of inside pandas.

## Testing

Blackhole, speed-of-light, producer to convergence then consumer, `tt-smi -r 0` before each consume. All three newly-plumbed kernels:

| test | result | loop_factor | TILE_LOOP windows | under 1k |
|---|---|---|---|---|
| `perf_unpack_transpose` | 12 passed | 32 | 20062 – 20312 | **0** |
| `perf_reduce` | 144 passed | 64 | 16489 – 183250 (6 run types) | **0** |
| `perf_eltwise_binary_fpu` | 86 passed | 8 | 2138 – 11142 (6 run types) | **0** |
| `perf_unpack_tilize` | 772 passed | 256 | 8665 – 798987 (5 run types) | **0** |

The `loop_factor` column is present in the report for all three, and every run type is covered. Without the second commit `perf_unpack_transpose` fails 12/12 at report time on main.

## Note for reviewers

`LOOP_FACTOR` subclasses `RuntimeParameter`, so under normal runs it is written into `RuntimeParams` and **excluded** from the variant hash — changing it does not rebuild. Only `--speed-of-light` promotes runtimes to templates, and it is in that mode that changing it rebuilds the kernel and the binary cannot be held fixed. An earlier version of this note claimed the rebuild happens unconditionally, which was wrong.

Three perf tests still have no loop-factor parameter at all — `perf_fused`, `perf_math_transpose`, `perf_unpack_a_bcast_eltwise` — left for a follow-up.