### PR TITLE
[Bug fix] Fix DeepSeek Ring reduce-scatter intermediate shape

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -486,9 +486,8 @@ class TtSharedExpert(LightweightModule):
             # which run sequentially). This keeps it alive across the overlap (so dispatch can't reuse
             # its slot) AND fixes its DRAM address every iteration, so the op's fabric reduction order
             # is identical each iteration — giving bit-exact determinism. The op overwrites the
-            # intermediate before reading it (the line-reduction compute skips the first slice), so no
-            # per-iteration re-zeroing is needed.
-            rs_intermediate = self.tt_ccl.get_shared_rs_intermediate(output_full)
+            # intermediate before reading it, so no per-iteration re-zeroing is needed.
+            rs_intermediate = self.tt_ccl.get_shared_rs_intermediate(output_full, self.topology)
             output = ttnn.experimental.reduce_scatter_minimal_async(
                 output_full,
                 persistent_output_buffers=[rs_intermediate],

--- a/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
@@ -217,18 +217,21 @@ class TT_CCL:
             )
         return self.mla_chunked_kv_buffers[key]
 
-    def get_shared_rs_intermediate(self, input_tensor):
+    def get_shared_rs_intermediate(self, input_tensor, topology):
         """Lazily allocate (once per mesh) and return the shared reduce_scatter intermediate
-        accumulator. Line (Linear) topology needs a double-sized leading dim for the
-        forward/backward halves: shape = [2, *input_shape]. Interleaved DRAM, input dtype/layout,
-        replicated across the mesh. A single buffer is reused at a stable address by every
-        shared-expert reduce_scatter — all layers share the same shape and run sequentially, so one
-        buffer for the whole model is safe."""
+        accumulator. The Ring tiled path requires the persistent intermediate to have the same
+        shape, dtype, and layout as its input. The Linear path retains its double-sized leading
+        dimension for forward/backward halves. Interleaved DRAM, replicated across the mesh. A
+        single buffer is reused at a stable address by every shared-expert reduce_scatter — all
+        layers share the same shape and run sequentially, so one buffer for the whole model is safe."""
         import torch
 
         if self.shared_rs_intermediate is None:
+            intermediate_shape = list(input_tensor.shape)
+            if topology == ttnn.Topology.Linear:
+                intermediate_shape = [2] + intermediate_shape
             self.shared_rs_intermediate = ttnn.from_torch(
-                torch.zeros([2] + list(input_tensor.shape)),
+                torch.zeros(intermediate_shape),
                 device=self.mesh_device,
                 layout=input_tensor.layout,
                 dtype=input_tensor.dtype,


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes the Blackhole E2E DeepSeek shared-expert PCC failure for the Ring topology.

Causal chain:

1. [#46190](https://github.com/tenstorrent/tt-metal/pull/46190) added a stable, persistent shared-expert reduce-scatter intermediate to prevent a use-after-free during the shared-expert/dispatch overlap. It allocated `torch.zeros([2] + input_tensor.shape)` for the legacy Linear forward/backward halves. That buffer was also passed on Ring, where the old operator accepted it without validating its shape.
2. [#50933](https://github.com/tenstorrent/tt-metal/pull/50933) added contiguous Ring reduce-scatter staging and validates a caller-provided intermediate against either the contiguous staging spec or the input-shaped tiled spec. The old Ring buffer (`[2, 1, seq_len, 7168]`) matches neither and fails before the operation runs.

This change uses an input-shaped persistent intermediate for Ring (`[1, seq_len, 7168]`) and preserves the existing double-leading-dimension allocation for Linear. It retains the stable-address/lifetime protection that #46190 added.

Affected failing pipeline jobs on `main`:

- https://github.com/tenstorrent/tt-metal/actions/runs/30774240262/job/91567605070
- https://github.com/tenstorrent/tt-metal/actions/runs/30756293443/job/91519906990
- https://github.com/tenstorrent/tt-metal/actions/runs/30740348742/job/91477369840

### Validation

- `./build_metal.sh --release`
- `scripts/run_safe_pytest.sh --run-all models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py -vvv --tb=short -k ring-4`
  - Ring 4K and 3.2K cases passed locally; no hang or `tt-triage` invocation.

### Notes for reviewers

The scope is intentionally limited to the Ring configuration that violates the newer reduce-scatter validation. The existing Linear allocation is preserved.

### Targeted CI

[![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-reduce-scatter-intermediate)](https://github.com/tenstorrent/tt-metal/actions/runs/30807225726)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-reduce-scatter-intermediate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-deepseek-reduce-scatter-intermediate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-reduce-scatter-intermediate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-deepseek-reduce-scatter-intermediate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-reduce-scatter-intermediate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/fix-deepseek-reduce-scatter-intermediate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-deepseek-reduce-scatter-intermediate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-deepseek-reduce-scatter-intermediate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-reduce-scatter-intermediate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-deepseek-reduce-scatter-intermediate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-deepseek-reduce-scatter-intermediate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-deepseek-reduce-scatter-intermediate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-deepseek-reduce-scatter-intermediate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-deepseek-reduce-scatter-intermediate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-deepseek-reduce-scatter-intermediate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-deepseek-reduce-scatter-intermediate)