### PR TITLE
[GLM-5.2] SP-only merged KVPE+indexer KV chunk address table

### DIFF
--- a/models/demos/common/prefill/runners/prefill_producer.py
+++ b/models/demos/common/prefill/runners/prefill_producer.py
@@ -693,6 +693,26 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
     return min_pcc
 
 
+def _full_indexer_layer_indices(num_layers: int):
+    """Global layer indices that own a lightning indexer, over layers [0, num_layers).
+
+    GLM-5.2 reuses one ``full`` layer's top-k across the ``shared`` layers that follow, so only full
+    layers write the index cache and config 1 of the merged table is COMPACTED to that count: its layer
+    axis is the full-indexer RANK, not the global layer index. The golden trace's
+    ``dsa/indexer_k_layer_N`` is numbered by GLOBAL layer, so rank -> global has to be mapped before
+    loading it (GLM-5.2 full layers are {0, 1, 2, 6, 10, ... 74}, so rank 3 is global layer 6).
+
+    Returns None when the model has no ``indexer_types`` map (GLM-5.1 / v3.2: every layer is a full
+    indexer owner, so rank == global index and no mapping is needed).
+    """
+    from models.demos.deepseek_v3_d_p.tt.mla.indexer import indexer_layer_is_reused
+
+    hf_config = ADAPTER.load_hf_config()  # host-only attribute config; no device, no weights
+    if not getattr(hf_config, "indexer_types", None):
+        return None
+    return [layer for layer in range(num_layers) if not indexer_layer_is_reused(hf_config, layer)]
+
+
 def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_len: int, trace_dir):
     """Read slot `slot_id`'s KV over [0, real_len) via the table and validate it. Config 0 (the KVPE
     cache) is PCC'd vs the golden trace. For a sparse/DSA model the merged table also carries config 1
@@ -755,23 +775,38 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
 
         index_head_dim = ADAPTER.model_config.INDEX_HEAD_DIM
         n_index_layers = table.config(1).num_layers
-        index_decode = _decoder_for_config(table, 1, index_head_dim)  # bf8 TILE on GLM-5.1/5.2
+        # Config 1's layer axis is the full-indexer RANK (GLM-5.2 compacts the shared layers out of the
+        # cache); the golden is numbered by GLOBAL layer, so map rank -> global before loading it.
+        full_layers = _full_indexer_layer_indices(NUM_LAYERS)
+        assert full_layers is None or len(full_layers) == n_index_layers, (
+            f"config 1 declares {n_index_layers} index-cache layers but layers [0,{NUM_LAYERS}) own only "
+            f"{len(full_layers)} full indexers. The index cache is sized from the model's WHOLE "
+            f"indexer_types map, so ranks {len(full_layers)}..{n_index_layers - 1} are never written by "
+            f"this run and would PCC against unwritten memory. Run the model's full layer count "
+            f"(PREFILL_NUM_LAYERS)."
+        )
         min_index = 1.0
-        for layer in range(n_index_layers):
+        for rank in range(n_index_layers):
             decoded_rows = []
             for pos in range(0, read_len, tokens_per_block):
-                loc = table.lookup(layer, pos, slot_id, 1)  # config 1 = index cache
+                loc = table.lookup(rank, pos, slot_id, 1)  # config 1 = index cache, keyed by full-layer rank
                 unique_id = _resolve_unique_id(
                     table.get_device_group(loc.device_group_index).fabric_node_ids, device_map
                 )
                 raw = ttnn.experimental.disaggregation.read_dram_umd(unique_id, loc.noc_addr, loc.size_bytes)
-                decoded_rows.append(index_decode(raw, index_head_dim))
+                # Same byte-size-driven dispatch as config 0; a 128-wide bfp8 index chunk is
+                # (128/32) x 1088 = 4352 B, which lands on the bfp8 tile branch.
+                decoded_rows.append(_decode_kv_chunk(raw, index_head_dim))
             dev_ik = torch.cat(decoded_rows, dim=0)[:real_len]
 
-            golden_ik = _load_golden_index_k(trace_dir, layer, real_len)
+            golden_layer = rank if full_layers is None else full_layers[rank]
+            golden_ik = _load_golden_index_k(trace_dir, golden_layer, real_len)
             _, pcc_index = comp_pcc(golden_ik, dev_ik)
             min_index = min(min_index, pcc_index)
-            logger.info(f"[producer] slot {slot_id} layer {layer:>2} index PCC: {pcc_index:.5f}")
+            logger.info(
+                f"[producer] slot {slot_id} layer {golden_layer:>2} (index rank {rank:>2}) "
+                f"index PCC: {pcc_index:.5f}"
+            )
 
         logger.info(
             f"[producer] slot {slot_id} index PCC over [0,{real_len}) across {n_index_layers} layers -> {min_index:.6f}"

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -25,6 +25,10 @@ from models.common.utility_functions import is_blackhole, skip_for_slow_dispatch
 
 CHUNK_SIZE = 5120
 NUM_LAYERS = int(os.environ.get("PREFILL_NUM_LAYERS", "2"))
+# GLM-5.2 golden trace carrying BOTH the 78 kv_cache layers and the 21 dsa/indexer_k_layer_* dirs, at
+# 56320 rows (= 11 x CHUNK_SIZE). The adapter's own prefill_trace_default omits dsa/, which would leave
+# the merged table's index config with no golden to PCC against.
+GLM52_TRACE = "/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k"
 SERVICE_ID = "ci_ds_prefill"
 TABLE_PATH = "/tmp/ci_prefill_kv_table.pb"  # IPC rendezvous files; cleaned up around each scenario
 DEVMAP_PATH = "/tmp/ci_prefill_kv_devmap.json"
@@ -92,6 +96,12 @@ pytestmark = [
 # Each scenario carries its OWN runner config (users / max_seq_len) + the producer schedule. Runners
 # run sequentially (one at a time), so each only needs users*max_seq_len to fit the KV budget on its
 # own. The producer inherits the runner's NUM_USERS (drives all its slots) unless overridden.
+#
+# Optional per-scenario keys:
+#   layers             -- PREFILL_NUM_LAYERS for this scenario (default: the module-level NUM_LAYERS)
+#   env                -- extra env applied to BOTH the runner and the producer (model, trace dir, ...)
+#   ready_timeout_s    -- override the runner startup budget (bigger models load + JIT for longer)
+#   producer_timeout_s -- override the producer budget (the PCC sweep scales with layers x seq_len)
 SCENARIOS = {
     # 1) Full-depth single user: 11 x 5120 = 56320 = the full Kimi golden trace. Deepest correctness gate.
     "single_user_full_depth": {
@@ -124,6 +134,34 @@ SCENARIOS = {
             "PREFILL_PRODUCER_P_BURST": "0.2",
         },
     },
+    # 4) GLM-5.2 (sparse / DSA) full-depth single user over ALL 78 layers. This is the gate for the
+    #    MERGED two-config KV chunk address table: config 0 = the bf16 ROW_MAJOR MLA KVPE cache (all 78
+    #    layers), config 1 = the bfp8 lightning-indexer KEY cache (only the 21 `full` layers, compacted).
+    #    The runner builds that single merged table under PREFILL_MOCK_MIGRATION and the producer reads
+    #    BOTH configs back through it over UMD, so a wrong address in either config shows up as a PCC
+    #    failure. 11 x 5120 = 56320 is exactly the trace depth.
+    #
+    #    ALL layers is mandatory here, not a preference: the index cache is sized from the model's whole
+    #    indexer_types map (21 full layers), so a truncated run leaves the upper index ranks unwritten —
+    #    the producer asserts on exactly that mismatch rather than PCC'ing untouched memory.
+    "glm52_full_depth_kv_table": {
+        "users": 1,
+        "layers": 78,
+        "max_seq_len": 56320,
+        "env": {
+            "PREFILL_MODEL": "glm_5_2",
+            "PREFILL_TRACE_DIR": GLM52_TRACE,
+            # The table describes all 78 layers, so the last layer must still WRITE its KV; the runner's
+            # default headless-last-layer optimization would leave layer 77 empty.
+            "PREFILL_KV_ONLY_LAST_LAYER": "0",
+        },
+        # 78 layers of GLM-5.2 weights + kernel JIT, then a two-config PCC sweep of ~174k sequential
+        # read_dram_umd block reads (78 x 1760 for KVPE + 21 x 1760 for the index cache). Both phases
+        # are far past the Kimi-sized defaults.
+        "ready_timeout_s": 3600,
+        "producer_timeout_s": 7200,
+        "producer": {"PREFILL_PRODUCER_CHUNKS": "11", "PREFILL_PRODUCER_MAX_REQUESTS": "1"},
+    },
 }
 
 # Opt-in prompt-driven scenario: instead of a recorded golden trace, generate the reference KV from a
@@ -146,7 +184,7 @@ if _PROMPT_FILE:
     }
 
 
-def _transport_env(num_users: int, max_seq_len: int, **extra) -> dict:
+def _transport_env(num_users: int, max_seq_len: int, num_layers: int = NUM_LAYERS, **extra) -> dict:
     """Inherit the CI/dev env (weights cache, HF, golden trace) and add the shared orchestration knobs
     for this scenario's runner+producer. `extra` layers on the runner (MOCK_MIGRATION) or producer
     (schedule + CHECK_PCC) knobs.
@@ -158,7 +196,7 @@ def _transport_env(num_users: int, max_seq_len: int, **extra) -> dict:
     env.update(
         PREFILL_CHUNK_SIZE=str(CHUNK_SIZE),
         PREFILL_MAX_SEQ_LEN=str(max_seq_len),
-        PREFILL_NUM_LAYERS=str(NUM_LAYERS),
+        PREFILL_NUM_LAYERS=str(num_layers),
         PREFILL_NUM_USERS=str(num_users),
         PREFILL_H2D_SERVICE_ID=SERVICE_ID,
         PREFILL_MIGRATION_TABLE_PATH=TABLE_PATH,
@@ -171,6 +209,19 @@ def _transport_env(num_users: int, max_seq_len: int, **extra) -> dict:
         for key in _mpi_launcher_keys(env):
             env.pop(key, None)
     return env
+
+
+def _scenario_env(sc: dict, **extra) -> dict:
+    """Child environment for one scenario's runner or producer: the shared transport knobs, the
+    scenario's own layer count, its model-specific `env` (model, trace dir, ...), then the role-specific
+    `extra` (MOCK_MIGRATION for the runner; the schedule + CHECK_PCC for the producer). Both roles must
+    agree on model/layers/seq_len or the producer would validate against a differently-shaped cache."""
+    return _transport_env(
+        sc["users"],
+        sc["max_seq_len"],
+        num_layers=sc.get("layers", NUM_LAYERS),
+        **{**sc.get("env", {}), **extra},
+    )
 
 
 def _cleanup_ipc() -> None:
@@ -329,13 +380,16 @@ def _readiness_gates() -> str:
 
 
 @contextlib.contextmanager
-def _running_runner(tag: str, num_users: int, max_seq_len: int, **extra):
-    """Spin up ONE runner (mock-migration, request mode) for a scenario and tear it down. Yields once
-    it has published the H2D descriptor + KV table + device map (i.e. it is serving)."""
+def _running_runner(tag: str, sc: dict, **extra):
+    """Spin up ONE runner (mock-migration, request mode) for a scenario and tear it down. Yields the
+    live _ChildStream once it has published the H2D descriptor + KV table + device map (i.e. it is
+    serving). `extra` layers additional env on top of the scenario's own (e.g. a generated prompt trace
+    dir) -- same role as `_scenario_env`'s `extra`."""
     os.makedirs(_REPORT_DIR, exist_ok=True)
     log_path = os.path.join(_REPORT_DIR, f"ci_runner_{tag}.log")
     _cleanup_ipc()  # a stale table/descriptor from a prior scenario would make the readiness poll pass early
-    env = _transport_env(num_users, max_seq_len, PREFILL_MOCK_MIGRATION="1", **extra)
+    env = _scenario_env(sc, PREFILL_MOCK_MIGRATION="1", **extra)
+    ready_timeout_s = int(sc.get("ready_timeout_s", _READY_TIMEOUT_S))
     mode = _launch_mode()
     if mode == "ci":
         print(
@@ -349,7 +403,7 @@ def _running_runner(tag: str, num_users: int, max_seq_len: int, **extra):
     proc = _spawn(_RUNNER_MODULE, env, stream)
     print(f"[e2e {_elapsed()}] runner [{tag}] launched (pid={proc.pid}); its output follows, tagged", flush=True)
     try:
-        deadline = time.monotonic() + _READY_TIMEOUT_S
+        deadline = time.monotonic() + ready_timeout_s
         with _heartbeat(lambda: f"runner [{tag}] not ready yet: {_readiness_gates()} | {stream.status()}"):
             while not (os.path.exists(_DESCRIPTOR) and os.path.exists(TABLE_PATH) and os.path.exists(DEVMAP_PATH)):
                 if proc.poll() is not None:
@@ -358,7 +412,7 @@ def _running_runner(tag: str, num_users: int, max_seq_len: int, **extra):
                         f"runner [{tag}] exited early (rc={proc.returncode}) during startup:\n{_tail(log_path)}"
                     )
                 if time.monotonic() > deadline:
-                    raise TimeoutError(f"runner [{tag}] not ready within {_READY_TIMEOUT_S}s:\n{_tail(log_path)}")
+                    raise TimeoutError(f"runner [{tag}] not ready within {ready_timeout_s}s:\n{_tail(log_path)}")
                 time.sleep(2.0)
         print(f"[e2e {_elapsed()}] runner [{tag}] ready ({_readiness_gates()}); starting producer", flush=True)
         yield stream
@@ -394,8 +448,30 @@ def _generate_prompt_trace(out_dir: str, isl: int, prompt_file: str, model: str)
     generate(model, _load_prompt_text(None, prompt_file), isl, NUM_LAYERS, out_dir)
 
 
-@pytest.mark.timeout(_READY_TIMEOUT_S + 2 * _PRODUCER_TIMEOUT_S + 300)
-@pytest.mark.parametrize("scenario", list(SCENARIOS))
+def _scenario_params():
+    """One pytest param per scenario, each carrying a pytest-timeout budget matching its own limits.
+
+    pytest.ini sets a blanket ``timeout = 300``, which is below what this test declares even for the
+    small scenarios (_READY_TIMEOUT_S + _PRODUCER_TIMEOUT_S = 2100s) and nowhere near a full-depth
+    model, which spends longer than that just loading weights. pytest-timeout reads the marker at
+    setup time, so the bound has to be attached at collection rather than inside the test body. The
+    real per-phase enforcement stays in _running_runner/producer.wait(); this only stops SIGALRM from
+    killing the test before those can report a useful failure.
+    """
+    return [
+        pytest.param(
+            name,
+            marks=pytest.mark.timeout(
+                sc.get("ready_timeout_s", _READY_TIMEOUT_S)
+                + sc.get("producer_timeout_s", _PRODUCER_TIMEOUT_S)
+                + 600  # slack for import, table build, teardown and log emission
+            ),
+        )
+        for name, sc in SCENARIOS.items()
+    ]
+
+
+@pytest.mark.parametrize("scenario", _scenario_params())
 def test_producer_runner_pcc(scenario, tmp_path):
     """Spin up a fresh runner for the scenario, drive it with the producer, and require the per-slot
     KV PCC gate to pass (the producer exits non-zero if any resident slot is below threshold)."""
@@ -412,10 +488,8 @@ def test_producer_runner_pcc(scenario, tmp_path):
             trace_dir = str(tmp_path / "prompt_trace")
             _generate_prompt_trace(trace_dir, sc["isl"], sc["prompt_file"], model)
         trace_env["PREFILL_TRACE_DIR"] = trace_dir
-    with _running_runner(scenario, sc["users"], sc["max_seq_len"], **trace_env) as runner_stream:
-        env = _transport_env(
-            sc["users"], sc["max_seq_len"], PREFILL_PRODUCER_CHECK_PCC="1", **trace_env, **sc["producer"]
-        )
+    with _running_runner(scenario, sc, **trace_env) as runner_stream:
+        env = _scenario_env(sc, PREFILL_PRODUCER_CHECK_PCC="1", **trace_env, **sc["producer"])
         producer_stream = _ChildStream("producer", prod_log)
 
         def _both_running() -> str:
@@ -426,7 +500,9 @@ def test_producer_runner_pcc(scenario, tmp_path):
             producer = _spawn(_PRODUCER_MODULE, env, producer_stream)
             print(f"[e2e {_elapsed()}] producer [{scenario}] launched (pid={producer.pid})", flush=True)
             with _heartbeat(_both_running):
-                returncode = producer.wait(timeout=_PRODUCER_TIMEOUT_S)  # raises TimeoutExpired
+                returncode = producer.wait(
+                    timeout=int(sc.get("producer_timeout_s", _PRODUCER_TIMEOUT_S))
+                )  # raises TimeoutExpired
         finally:
             # Reap on EVERY exit where the producer is still alive, not just our own timeout: a
             # pytest-timeout signal or a Ctrl-C would otherwise leave it running, holding the transport

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -606,7 +606,7 @@ def test_glm_kv_cache_table(
         mesh_shape=mesh_shape,
         seq_len=seq_len,
         sp_axis=sp_axis,
-        kvpe_cache=index_kbuf,
+        tt_kvpe_cache=index_kbuf,
         chunk_size_bytes=INDEX_CHUNK_SIZE_BYTES,
         num_users=1,
         config_id=INDEX_CONFIG_ID,
@@ -618,7 +618,7 @@ def test_glm_kv_cache_table(
         mesh_shape=mesh_shape,
         seq_len=seq_len,
         sp_axis=sp_axis,
-        kvpe_cache=tt_kvpe_cache.storage,
+        tt_kvpe_cache=tt_kvpe_cache.storage,
         chunk_size_bytes=KVPE_CHUNK_SIZE_BYTES,
         num_users=1,
         config_id=KVPE_CONFIG_ID,
@@ -662,3 +662,199 @@ def test_glm_kv_cache_table(
     logger.info(
         f"[glm] kvpe-cache (config {KVPE_CONFIG_ID}, bf16 RM) address-table readback verified over {seq_len} tokens"
     )
+
+
+# sp x tp -- STANDARD (SP-only, TP-replicated) GLM-5.2 merged KV chunk address table.
+# main has a model-driven table readback for glm_5_1 (test_glm_kv_cache_table) but none for glm_5.2;
+# this is the missing SP-only baseline. It runs the real GLM-5.2 DSA MLA (layer 0 = a "full" layer, so
+# the indexer runs and fills the index-key cache), fills both the KVPE and indexer caches, builds the
+# merged 2-config kimi table (config 0 = KVPE, config 1 = index), and reads every 32-token chunk back.
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(2, 4), (8, 4)],
+    ids=["2x4", "8x4"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    ids=["line"],
+    indirect=True,
+)
+@pytest.mark.parametrize("seq_len", [5 * 1024], ids=["seq5k"])
+@pytest.mark.parametrize("variant", ["glm_5_2"], indirect=True, ids=["glm52"])
+@pytest.mark.skipif(not is_blackhole(), reason="GLM-5.2 DSA (indexer / sparse SDPA) is Blackhole-only")
+@pytest.mark.timeout(0)
+def test_glm52_kv_cache_table(
+    mesh_device,
+    seq_len,
+    variant,
+    config_only,
+    device_params,
+):
+    """Readback test for the standard (SP-only) GLM-5.2 merged KVPE + indexer KV chunk address table.
+
+    Mirrors test_glm_kv_cache_table (glm_5_1): one sparse GLM-5.2 MLA layer with random weights, a single
+    full-seq block-cyclic forward filling both caller-owned caches, then a merged 2-config table over
+    both, read back chunk-by-chunk. This is the SP-only baseline that main lacks for GLM-5.2.
+    """
+    config = config_only
+    fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
+    topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
+
+    sp_axis = 0
+    tp_axis = 1
+    mesh_shape = list(mesh_device.shape)
+    config.max_seq_len = seq_len
+    logger.info(
+        f"model={variant.name} num_heads={config.num_attention_heads} hidden={config.hidden_size} topology={topology}"
+    )
+
+    # Random GLM-5.2 weights incl. indexer weights (build_weights populates indexer.* for the sparse path).
+    weights, _ = build_weights(variant, config, seed=42)
+
+    chunk_size_global = seq_len
+    sp = mesh_shape[sp_axis]
+    mla_tt = ttMLA(
+        config,
+        weights,
+        mesh_device,
+        layer_idx=0,  # full layer: indexer runs (not a reuse/shared layer), so the index cache is filled
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_chunked=True,
+        slot_num=1,
+        layer_num=1,
+    )
+    rope = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False)
+    rope_tensors = rope.get_rope_tensors_indexed(cache_seq_len_global=seq_len, chunk_size_global=chunk_size_global)
+
+    # KVPE cache: uncompressed bf16 + ROW_MAJOR (the format sparse_sdpa reads natively).
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BF16_RM,
+        hf_config=config,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+    )
+
+    # Indexer key cache: caller-owned, block-cyclic bfp8 TILE, index_head_dim wide. GLM-5.2 cross-layer
+    # reuse COMPACTS this cache to the FULL-layer count (num_full_indexer_layers), NOT all layers: only
+    # `full` layers own an indexer and write their compacted rank slot. Size it to the indexer's own
+    # _index_cache_layers (the same stride write_k passes as num_layers) so the write's
+    # `cache_batch % num_layers == 0` check holds. Our single built layer (idx 0) is `full` -> rank 0.
+    num_index_layers = mla_tt._indexer._index_cache_layers
+    tt_index_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=mla_tt._indexer.index_args.index_head_dim,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=num_index_layers,
+        num_users=1,
+        dtype=ttnn.bfloat8_b,
+    )
+
+    torch.manual_seed(42)
+    hidden = torch.randn(seq_len, config.hidden_size, dtype=torch.bfloat16)
+    # Block-cyclic (device-major) input ordering so an SP-contiguous shard lands each chip's block-cyclic
+    # rows (identity for a single aligned chunk, but keeps the layout correct/general).
+    p = blockcyclic_positions(sp, chunk_size_global, seq_len)
+    chunk_in = hidden[p]
+    shard_dims = [None, None]
+    shard_dims[tp_axis], shard_dims[sp_axis] = -1, -2
+    tt_hidden = ttnn.from_torch(
+        chunk_in.reshape(1, 1, seq_len, config.hidden_size),
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+    )
+
+    tt_out = mla_tt.forward(
+        tt_hidden, rope_tensors, tt_kvpe_cache, actual_start=0, cache_user_id=0, index_kv_cache=tt_index_cache
+    )
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"[glm52] forward complete: out shape {tuple(tt_out.shape)}")
+
+    index_kbuf = tt_index_cache
+    index_head_dim = mla_tt._indexer.index_args.index_head_dim  # 128
+    kvpe_head_dim = config.kv_lora_rank + config.qk_rope_head_dim  # 576
+
+    INDEX_CHUNK_SIZE_BYTES = 4 * 1088  # [1,1,32,128] bfp8 = 4 tiles * 1088 bytes
+    KVPE_CHUNK_SIZE_BYTES = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK * kvpe_head_dim * 2  # bf16 RM contiguous
+    KVPE_CONFIG_ID, INDEX_CONFIG_ID = 0, 1
+
+    def _table_config(chunk_size_bytes, n_layers):
+        c = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
+        c.num_layers = n_layers
+        c.max_sequence_length = seq_len
+        c.num_slots = 1
+        c.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+        c.chunk_size_bytes = chunk_size_bytes
+        return c
+
+    # KVPE keeps all (here: 1) layers; the index config is sized to the COMPACTED full-layer count so it
+    # matches the index cache's batch stride (GLM-5.2 indexer reuse). Readback below checks rank 0.
+    index_config = _table_config(INDEX_CHUNK_SIZE_BYTES, num_index_layers)
+    kvpe_config = _table_config(KVPE_CHUNK_SIZE_BYTES, 1)
+
+    lookup_table = ttnn.experimental.disaggregation.KvChunkAddressTable([kvpe_config, index_config])
+    assert lookup_table.num_configs() == 2, f"expected 2 configs, got {lookup_table.num_configs()}"
+
+    populate_kv_chunk_address_table_kimi(
+        lookup_table=lookup_table,
+        config=index_config,
+        mesh_device=mesh_device,
+        mesh_shape=mesh_shape,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tt_kvpe_cache=index_kbuf,
+        chunk_size_bytes=INDEX_CHUNK_SIZE_BYTES,
+        num_users=1,
+        config_id=INDEX_CONFIG_ID,
+    )
+    populate_kv_chunk_address_table_kimi(
+        lookup_table=lookup_table,
+        config=kvpe_config,
+        mesh_device=mesh_device,
+        mesh_shape=mesh_shape,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tt_kvpe_cache=tt_kvpe_cache.storage,
+        chunk_size_bytes=KVPE_CHUNK_SIZE_BYTES,
+        num_users=1,
+        config_id=KVPE_CONFIG_ID,
+    )
+
+    # --- readback the index cache (config 1, bfp8 TILE) ---
+    index_kbuf_torch = ttnn.to_torch(
+        index_kbuf,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
+    ).to(torch.bfloat16)[:1, :1, :, :]
+    chunk_shape = [1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, index_head_dim]
+    for position in range(0, seq_len, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+        pos_end = position + NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+        raw_bytes = lookup_table.read_device_chunk(layer=0, position=position, slot=0, config_id=INDEX_CONFIG_ID)
+        chunk_tt = ttnn.experimental.disaggregation.tensor_from_bfp8_bytes(raw_bytes, chunk_shape)
+        chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
+        assert_equal(chunk_torch, index_kbuf_torch[:, :, position:pos_end, :])
+    logger.info(f"[glm52] index-cache (config {INDEX_CONFIG_ID}) readback verified over {seq_len} tokens")
+
+    # --- readback the MLA KVPE cache (config 0, bf16 ROW_MAJOR) ---
+    tt_kvpe_cache_torch = ttnn.to_torch(
+        tt_kvpe_cache.storage,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
+    ).to(torch.bfloat16)[:1, :1, :, :]
+    kvpe_chunk_shape = [1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_head_dim]
+    for position in range(0, seq_len, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+        pos_end = position + NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+        raw_bytes = lookup_table.read_device_chunk(layer=0, position=position, slot=0, config_id=KVPE_CONFIG_ID)
+        chunk_tt = ttnn.experimental.disaggregation.tensor_from_bf16_bytes(raw_bytes, kvpe_chunk_shape)
+        chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
+        assert_equal(chunk_torch, tt_kvpe_cache_torch[:, :, position:pos_end, :])
+    logger.info(f"[glm52] kvpe-cache (config {KVPE_CONFIG_ID}, bf16 RM) readback verified over {seq_len} tokens")

--- a/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
@@ -185,7 +185,7 @@ def _build_and_serialize_merged_kv_chunk_table(
             mesh_shape=mesh_shape,
             seq_len=seq_len,
             sp_axis=sp_axis,
-            kvpe_cache=cache,
+            tt_kvpe_cache=cache,
             chunk_size_bytes=cfg.chunk_size_bytes,
             num_users=num_users,
             config_id=config_id,

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -446,7 +446,7 @@ def create_kv_chunk_address_table_kimi(
         mesh_shape=mesh_shape,
         seq_len=seq_len,
         sp_axis=sp_axis,
-        kvpe_cache=kvpe_cache,
+        tt_kvpe_cache=kvpe_cache,
         chunk_size_bytes=chunk_size_bytes,
         num_users=num_users,
         config_id=0,
@@ -461,7 +461,7 @@ def populate_kv_chunk_address_table_kimi(
     mesh_shape,
     seq_len,
     sp_axis,
-    kvpe_cache,
+    tt_kvpe_cache,
     chunk_size_bytes,
     num_users=1,
     config_id=0,
@@ -486,59 +486,133 @@ def populate_kv_chunk_address_table_kimi(
     Returns:
         lookup_table: the same table, with config_id populated.
     """
-    # Per-stage device groups + host tags are built inside the stage loop below (one group per
-    # (stage, SP row)); no rank-local single-stage device-group pass here — the multi-stage merge
-    # supersedes it, and a rank-local set_fabric_node_host(localhost) would fight the per-stage host.
-    rows = mesh_shape[0]
+    if stage_layout is not None:
+        # ---- stage_layout-driven path (PP-capable, #48826). ----
+        # Per-stage device groups + host tags are built inside the stage loop below (one group per
+        # (stage, SP row)); no rank-local single-stage device-group pass here — the multi-stage merge
+        # supersedes it, and a rank-local set_fabric_node_host(localhost) would fight the per-stage host.
+        rows = mesh_shape[0]
 
-    tokens_per_chunk_local = PREFILL_CHUNK_OUTPUT_TOKENS // mesh_shape[sp_axis]  # 640 for 5k chunks
-    num_chunks_per_seq_len = seq_len // PREFILL_CHUNK_OUTPUT_TOKENS  # number of 5k chunks in the seq len
+        tokens_per_chunk_local = PREFILL_CHUNK_OUTPUT_TOKENS // mesh_shape[sp_axis]  # 640 for 5k chunks
+        num_chunks_per_seq_len = seq_len // PREFILL_CHUNK_OUTPUT_TOKENS  # number of 5k chunks in the seq len
+
+        assert (
+            seq_len % PREFILL_CHUNK_OUTPUT_TOKENS == 0
+        ), f"seq_len {seq_len} must be a multiple of {PREFILL_CHUNK_OUTPUT_TOKENS}"
+
+        assert tokens_per_chunk_local % NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK == 0, (
+            f"{PREFILL_CHUNK_OUTPUT_TOKENS} tokens / sp({mesh_shape[sp_axis]}) = {tokens_per_chunk_local}, "
+            f"not a multiple of {NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK}"
+        )
+
+        # tt-blaze-style merge: for every STAGE place its layers' chunks on ITS mesh at ITS base addr.
+        # Within a stage we replay the original single-stage build exactly (one device group per SP row, an
+        # independent bank round-robin per row sequencing slot -> local layer -> chunk), but write to the
+        # GLOBAL layer index (first_layer + local_layer) so every stage lands in one table.
+        for stage in stage_layout:
+            dram_bank_base_addr = stage["base_addr"]
+            num_dram_banks = stage["num_banks"]
+            host_name = f"host-{stage['host_tag']:08x}"  # crc32 tag rebuilt to a string (int-only allgather)
+            first = stage["first_layer"]
+            count = stage["count"]
+            stage_fnids = stage["fnids"]
+            for row in range(rows):
+                # Data is replicated across each TP column, so one device group per (stage, SP row).
+                fnids_row = stage_fnids[row]
+                group_idx = lookup_table.add_device_group(fnids_row)
+                for fid in fnids_row:
+                    lookup_table.set_fabric_node_host(fid, host_name=host_name)
+                curr_bank_id = 0
+                curr_bank_offset = 0
+                for slot in range(num_users):
+                    for local_layer in range(count):
+                        global_layer = first + local_layer
+                        for seq_chunk in range(num_chunks_per_seq_len):
+                            chunk_token_start = seq_chunk * PREFILL_CHUNK_OUTPUT_TOKENS + row * tokens_per_chunk_local
+                            chunk_token_end = chunk_token_start + tokens_per_chunk_local
+                            for position in range(
+                                chunk_token_start, chunk_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+                            ):
+                                location = ttnn.experimental.disaggregation.KvCacheLocation()
+                                location.noc_addr = (curr_bank_id << 32) | (dram_bank_base_addr + curr_bank_offset)
+                                location.size_bytes = chunk_size_bytes
+                                location.device_group_index = group_idx
+                                lookup_table.set(global_layer, position, slot, location, config_id)
+
+                                curr_bank_id = (curr_bank_id + 1) % num_dram_banks
+                                if curr_bank_id == 0:
+                                    curr_bank_offset += chunk_size_bytes
+        return lookup_table
+
+    # ---- Legacy single-stage path (direct call, stage_layout is None). ----
+    # The pre-#48826 behavior, still exercised by direct callers that don't build a stage_layout
+    # (e.g. test_glm52_kv_cache_table and the kv_chunk_table runner): one replicated device group per
+    # SP row, base addr / bank count derived from the cache itself.
+    host_name = socket.gethostname()
+
+    rank = ttnn.distributed_context_get_rank()
+    size = ttnn.distributed_context_get_size()
+    total_rows = mesh_shape[0]
+    rank_row_start = int(rank) * total_rows // int(size)
+    rank_row_end = rank_row_start + total_rows // int(size)
+
+    num_layers = config.num_layers
 
     assert (
         seq_len % PREFILL_CHUNK_OUTPUT_TOKENS == 0
     ), f"seq_len {seq_len} must be a multiple of {PREFILL_CHUNK_OUTPUT_TOKENS}"
+    num_chunks_per_seq_len = seq_len // PREFILL_CHUNK_OUTPUT_TOKENS
 
+    assert (
+        tt_kvpe_cache.shape[0] == num_users * num_layers
+    ), f"cache batch dim {tt_kvpe_cache.shape[0]} != num_users({num_users}) * num_layers({num_layers})"
+
+    tokens_per_chunk_local = PREFILL_CHUNK_OUTPUT_TOKENS // mesh_shape[sp_axis]  # 640 for 5k chunks
     assert tokens_per_chunk_local % NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK == 0, (
         f"{PREFILL_CHUNK_OUTPUT_TOKENS} tokens / sp({mesh_shape[sp_axis]}) = {tokens_per_chunk_local}, "
         f"not a multiple of {NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK}"
     )
 
-    # tt-blaze-style merge: for every STAGE place its layers' chunks on ITS mesh at ITS base addr.
-    # Within a stage we replay the original single-stage build exactly (one device group per SP row, an
-    # independent bank round-robin per row sequencing slot -> local layer -> chunk), but write to the
-    # GLOBAL layer index (first_layer + local_layer) so every stage lands in one table.
-    for stage in stage_layout:
-        dram_bank_base_addr = stage["base_addr"]
-        num_dram_banks = stage["num_banks"]
-        host_name = f"host-{stage['host_tag']:08x}"  # crc32 tag rebuilt to a string (int-only allgather)
-        first = stage["first_layer"]
-        count = stage["count"]
-        stage_fnids = stage["fnids"]
-        for row in range(rows):
-            # Data is replicated across each TP column, so one device group per (stage, SP row).
-            fnids_row = stage_fnids[row]
-            group_idx = lookup_table.add_device_group(fnids_row)
-            for fid in fnids_row:
-                lookup_table.set_fabric_node_host(fid, host_name=host_name)
-            curr_bank_id = 0
-            curr_bank_offset = 0
-            for slot in range(num_users):
-                for local_layer in range(count):
-                    global_layer = first + local_layer
-                    for seq_chunk in range(num_chunks_per_seq_len):
-                        chunk_token_start = seq_chunk * PREFILL_CHUNK_OUTPUT_TOKENS + row * tokens_per_chunk_local
-                        chunk_token_end = chunk_token_start + tokens_per_chunk_local
-                        for position in range(chunk_token_start, chunk_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
-                            location = ttnn.experimental.disaggregation.KvCacheLocation()
-                            location.noc_addr = (curr_bank_id << 32) | (dram_bank_base_addr + curr_bank_offset)
-                            location.size_bytes = chunk_size_bytes
-                            location.device_group_index = group_idx
-                            lookup_table.set(global_layer, position, slot, location, config_id)
-
-                            curr_bank_id = (curr_bank_id + 1) % num_dram_banks
-                            if curr_bank_id == 0:
-                                curr_bank_offset += chunk_size_bytes
+    dram_bank_base_addr = tt_kvpe_cache.buffer_address()
     # Must match the bank count the cache was ND-sharded across (see get_num_dram_banks).
+    num_dram_banks = get_num_dram_banks(mesh_device)
+
+    device_group_idx_per_row = []
+    all_fabric_node_ids = []
+    for row in range(rank_row_start, rank_row_end):
+        fabric_node_ids = []
+        for col in range(mesh_shape[1]):
+            fabric_node_ids.append(mesh_device.get_fabric_node_id(ttnn.MeshCoordinate(row, col)))
+        all_fabric_node_ids.extend(fabric_node_ids)
+        device_group_idx_per_row.append(lookup_table.add_device_group(fabric_node_ids))
+
+    for fid in all_fabric_node_ids:
+        lookup_table.set_fabric_node_host(fid, host_name=host_name)
+        logger.debug(
+            f"Set host name for fabric node id: mesh_id={int(fid.mesh_id)}, chip_id={int(fid.chip_id)} "
+            f"to {host_name}"
+        )
+
+    for local_idx, global_row in enumerate(range(rank_row_start, rank_row_end)):
+        group_idx = device_group_idx_per_row[local_idx]
+        curr_bank_id = 0
+        curr_bank_offset = 0
+
+        for slot in range(num_users):
+            for layer in range(num_layers):
+                for seq_chunk in range(num_chunks_per_seq_len):
+                    chunk_token_start = seq_chunk * PREFILL_CHUNK_OUTPUT_TOKENS + global_row * tokens_per_chunk_local
+                    chunk_token_end = chunk_token_start + tokens_per_chunk_local
+                    for position in range(chunk_token_start, chunk_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+                        location = ttnn.experimental.disaggregation.KvCacheLocation()
+                        location.noc_addr = (curr_bank_id << 32) | (dram_bank_base_addr + curr_bank_offset)
+                        location.size_bytes = chunk_size_bytes
+                        location.device_group_index = group_idx
+                        lookup_table.set(layer, position, slot, location, config_id)
+
+                        curr_bank_id = (curr_bank_id + 1) % num_dram_banks
+                        if curr_bank_id == 0:
+                            curr_bank_offset += chunk_size_bytes
     return lookup_table
 
 

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -88,6 +88,7 @@
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
       python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kv_cache_table -k "line and pretrained and seq5k" -vvv --tb=short
       python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kimi_kv_cache_mock -k "line" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_glm52_kv_cache_table -k "8x4" -vvv --tb=short
     '
   test_type: kv_cache_table
   test_group: module


### PR DESCRIPTION
## Summary

Split out of the GLM-5.2 KV TP-sharding work (`ipotkonjak/glm52-kv-tp-sharding-plan`): the SP-only
(TP-replicated) baseline test coverage, with zero `tp_axis`/`tp_shard_kv` coupling, so it can land
independently.

- `test_glm52_kv_cache_table` (`tests/test_kv_cache_table.py`): main has a model-driven KV chunk
  address table readback for glm_5_1 (`test_glm_kv_cache_table`) but none for GLM-5.2. This fills that
  gap — one sparse GLM-5.2 MLA layer, random weights, single block-cyclic forward filling both the
  KVPE (bf16 ROW_MAJOR) and indexer key (bfp8 TILE) caches, then a merged 2-config table read back
  chunk-by-chunk. Formats match the real `GLM52Adapter.allocate_kv_cache` production path exactly.
- `populate_kv_chunk_address_table_kimi` (`utils/kv_cache_utils.py`): restores the pre-#48826
  single-stage direct-call path (`stage_layout=None`) that this test's calling convention needs — it
  had regressed to iterating over `None` and crashing. Also renames its `kvpe_cache` param to
  `tt_kvpe_cache` (ripples through existing call sites) so a later multi-cache table call isn't
  ambiguous about which cache it configures.
- Cherry-picked from `nbabin/glm_cache_check` (authored by Nenad Babin, preserved as commit author):
  wires the same SP-only `glm52_full_depth_kv_table` scenario into the producer/runner e2e test
  (`models/demos/common/prefill/tests/test_producer_runner_e2e.py`), including the index-cache
  rank↔global-layer mapping needed for GLM-5.2's indexer-reuse compaction.

## Test plan
- [x] `./build_metal.sh` clean build
- [x] `test_glm52_kv_cache_table[2x4]` passes on the 2x4 Blackhole loudbox (the `8x4` variant, and the
  file's other pre-existing 8x4-only tests, are Galaxy-only and were already unrunnable on this box)
- [x] `test_producer_runner_e2e.py --collect-only` collects all 4 scenarios (incl. the new
  `glm52_full_depth_kv_table`) with correct per-scenario timeouts — full run needs a 32-device
  Blackhole galaxy, not available here

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/glm52-kv-cache-table-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/glm52-kv-cache-table-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/glm52-kv-cache-table-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/glm52-kv-cache-table-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/glm52-kv-cache-table-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/glm52-kv-cache-table-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/glm52-kv-cache-table-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/glm52-kv-cache-table-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/glm52-kv-cache-table-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/glm52-kv-cache-table-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/glm52-kv-cache-table-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/glm52-kv-cache-table-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/glm52-kv-cache-table-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/glm52-kv-cache-table-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/glm52-kv-cache-table-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/glm52-kv-cache-table-baseline)