### PR TITLE
Reservation of memory for vector beforehand

### DIFF
--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2076,6 +2076,7 @@ std::vector<KernelCouplingGroup> BuildDMKernelCouplingGroups(
     // Iterate dm_kernels in given order to preserve a deterministic per-class member order.
     std::unordered_map<size_t, size_t> root_to_group_idx;
     std::vector<KernelCouplingGroup> groups;
+    groups.reserve(dm_kernels.size());
     for (size_t i = 0; i < dm_kernels.size(); ++i) {
         const size_t r = find(i);
         auto [it, inserted] = root_to_group_idx.try_emplace(r, groups.size());
@@ -2115,6 +2116,7 @@ KernelRiscMaskMap SolveGen2KernelRiscMasks(const ProgramSpec& spec, const Collec
     // num_threads uniformity is enforced upstream, so same-role compute kernels get identical masks
     // without any coupling-group machinery).
     std::vector<const KernelSpec*> dm_kernels;
+    dm_kernels.reserve(spec.kernels.size());
     for (const KernelSpec& kernel : spec.kernels) {
         if (kernel.is_data_movement_kernel()) {
             dm_kernels.push_back(&kernel);


### PR DESCRIPTION
PR Cathegory:
memory work optimization
Summary:
Preallocate memory for further usage to avoid possible sequential reallocation.
Notes for reviewers:
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_51)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_51)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_51)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_51)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_51)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_51)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_51)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_51)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_51)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_51)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_51)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_51)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_51)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_51)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_51)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_51)