### PR TITLE
[Bug fix] Fix LLK perf report schema

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_schema.py
@@ -19,6 +19,7 @@ FORMAT_HEADERS = (
     "formats.register_A",
     "formats.register_B",
     "formats.output",
+    "formats.sfpu_math",
 )
 FLAG_HEADERS = ("unpack_to_dest", "dest_acc")
 

--- a/tt_metal/tt-llk/tests/python_tests/perf_sfpu_div_wh.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_sfpu_div_wh.py
@@ -73,6 +73,7 @@ def _run(formats, dest_acc, input_dimensions):
         ),
         unpack_to_dest=unpack_to_dest,
         dest_acc=dest_acc,
+        compile_time_formats=True,
     )
     return configuration
 


### PR DESCRIPTION
### Ticket

N/A

### Problem description

The nightly LLK perf workflow failed all Wormhole and Blackhole shards while assembling performance reports. `PerfConfig.run()` emitted an `sfpu_math` value without a corresponding CSV header, causing Pandas to reject every row with a column-count mismatch.

A no-`--speed-of-light` verification also exposed that the dedicated SFPU division probe requires compile-time formats because `formats.math` is used as a C++ template argument.

### What's changed

- Add `formats.sfpu_math` to the centralized performance report format headers.
- Compile formats statically for `perf_sfpu_div_wh` so the probe also builds when runtime parameters remain enabled.
- Verified the complete LLK perf matrix passes: https://github.com/tenstorrent/tt-metal/actions/runs/30809459531

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist

- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Sanity](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml) CI passes (not required for this Python test-harness-only change)
- [x] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (not applicable; no assert changes)

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_llk_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_llk_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_llk_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix_llk_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_llk_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/fix_llk_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_llk_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_llk_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix_llk_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix_llk_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_llk_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_llk_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_llk_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_llk_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_llk_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_llk_perf)