### PR TITLE
[Feature] Compare-to-history + full-pipeline integration test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_compare.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_compare.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare a run's Parquet batch to historical batches (regression detection).
+
+For every comparable data point — one (test, sweep config, marker, run type) with
+a ``mean(<run_type>)`` value — the current run is compared to a baseline built
+from the same point across the historical batches (median, robust to noise). A
+point that is more than ``threshold`` slower than its baseline is flagged as a
+regression. Points with no matching history (a new config) are reported
+separately, not as regressions.
+
+This is the "compare to history" step of the real use case; full regression
+semantics (noise modelling, approved baselines) is a later milestone. Needs
+pyarrow + pandas; no device libraries.
+"""
+
+from statistics import median
+
+import pyarrow.parquet as pq
+
+from .perf_wide_schema import DB_SCHEMA
+
+_SWEEP_CATEGORIES = {"formats", "flags", "key", "configuration"}
+_SWEEP_COLUMNS = {c.name for c in DB_SCHEMA if c.category in _SWEEP_CATEGORIES}
+
+
+def _load(path):
+    return pq.read_table(path).to_pandas()
+
+
+def _point_key(row, sweep_columns):
+    """Stable identity of a data point across runs: test + arch + marker + config.
+
+    arch is part of the identity so a run is only ever compared to history from
+    the SAME architecture — comparing wormhole cycles to blackhole cycles is
+    meaningless.
+    """
+    config = tuple(
+        sorted((c, row[c]) for c in sweep_columns if row[c] == row[c])  # skip NaN
+    )
+    return (row["test_name"], row["arch"], row["marker"], config)
+
+
+def compare_to_history(current_parquet, history_parquets, *, threshold=0.05):
+    """Compare current to history. Returns a dict:
+
+    {
+      "records":    [ {test, marker, run_type, current, baseline, delta, regression} ],
+      "regressions":[ subset of records where regression is True ],
+      "new_points": [ {test, marker, run_type, current} with no history baseline ],
+    }
+    ``delta`` is the fractional change vs baseline (0.12 = 12% slower).
+    """
+    current = _load(current_parquet)
+    history = [_load(p) for p in history_parquets]
+
+    mean_columns = [c for c in current.columns if c.startswith("mean(")]
+    sweep_columns = [c for c in current.columns if c in _SWEEP_COLUMNS]
+
+    # baseline[(key, mean_col)] = median of the historical values for that point
+    samples = {}
+    for frame in history:
+        frame_sweep = [c for c in frame.columns if c in _SWEEP_COLUMNS]
+        for _, row in frame.iterrows():
+            key = _point_key(row, frame_sweep)
+            for col in mean_columns:
+                val = row.get(col)
+                if val is not None and val == val:
+                    samples.setdefault((key, col), []).append(float(val))
+    baseline = {k: median(v) for k, v in samples.items()}
+
+    records, regressions, new_points = [], [], []
+    for _, row in current.iterrows():
+        key = _point_key(row, sweep_columns)
+        for col in mean_columns:
+            val = row.get(col)
+            if val is None or val != val:
+                continue
+            run_type = col[len("mean(") : -1]
+            base = baseline.get((key, col))
+            point = {
+                "test": row["test_name"],
+                "marker": row["marker"],
+                "run_type": run_type,
+                "current": float(val),
+            }
+            if base is None:
+                new_points.append(point)
+                continue
+            delta = (float(val) - base) / base if base else 0.0
+            record = {
+                **point,
+                "baseline": base,
+                "delta": delta,
+                "regression": delta > threshold,
+            }
+            records.append(record)
+            if record["regression"]:
+                regressions.append(record)
+
+    return {"records": records, "regressions": regressions, "new_points": new_points}
+
+
+def summarize_comparison(result) -> str:
+    """Human summary: regression count + the worst offenders."""
+    regs = result["regressions"]
+    lines = [
+        f"{len(result['records'])} points compared, "
+        f"{len(regs)} regression(s), {len(result['new_points'])} new point(s)."
+    ]
+    for r in sorted(regs, key=lambda x: -x["delta"])[:10]:
+        lines.append(
+            f"  REGRESSION {r['test']} [{r['marker']}] {r['run_type']}: "
+            f"{r['current']:.1f} vs {r['baseline']:.1f} baseline "
+            f"(+{r['delta'] * 100:.1f}%)"
+        )
+    return "\n".join(lines)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_dashboard.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_dashboard.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import plotly.graph_objects as go
 import pyarrow.parquet as pq
 
+from .perf_parquet import safe_stem
 from .perf_wide_schema import DB_SCHEMA
 
 _SWEEP_CATEGORIES = {"formats", "flags", "key", "configuration"}
@@ -71,7 +72,7 @@ def dashboard_from_parquet(parquet_path, out_dir):
             legend_title="Run type / stat",
         )
 
-        path = out_dir / f"{test_name}.html"
+        path = out_dir / f"{safe_stem(test_name)}.html"
         fig.write_html(str(path))
         written[test_name] = path
     return written

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_migrate.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_migrate.py
@@ -102,7 +102,10 @@ def discover_runs(archive_root, *, pipeline="nightly"):
             continue
         arch_match = _ARCH_RE.search(run_dir.name)
         meta_file = run_dir / "run_meta.json"
-        meta = json.loads(meta_file.read_text()) if meta_file.exists() else {}
+        try:
+            meta = json.loads(meta_file.read_text()) if meta_file.exists() else {}
+        except (json.JSONDecodeError, OSError):
+            meta = {}  # a broken sidecar falls back to folder-derived defaults
         runs.append(
             MigrationRun(
                 run_id=run_dir.name,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
@@ -262,7 +262,9 @@ def convert_csvs_to_parquet(
     diagnostics = {"unknown_columns": {}, "coerced_values": {}}
     for path in csv_paths:
         name = _test_name_from_csv(path)
-        df = pd.read_csv(path)
+        # round_trip: the default C float parser is not exact; this preserves
+        # full float64 precision so CSV -> Parquet is lossless.
+        df = pd.read_csv(path, float_precision="round_trip")
         # Drop columns the published table intentionally omits (see
         # perf_wide_schema.DROPPED_COLUMNS), before the unknown-column check so
         # they are not flagged as accidental drift.
@@ -314,6 +316,7 @@ def parquet_to_csvs(parquet_path, out_dir, *, drop_provenance=True, drop_empty=T
         if drop_empty:
             group = group.dropna(axis=1, how="all")
         path = out_dir / f"{safe_stem(test_name)}.csv"
-        group.to_csv(path, index=False)
+        # %.17g round-trips float64 exactly, so Parquet->CSV->Parquet is lossless.
+        group.to_csv(path, index=False, float_format="%.17g")
         written[test_name] = path
     return written

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
@@ -287,6 +287,12 @@ def convert_csvs_to_parquet(
     return diagnostics
 
 
+def safe_stem(name) -> str:
+    """A filesystem-safe file stem: anything but [A-Za-z0-9._-] becomes '_', so a
+    hostile test_name (e.g. containing '/') can never escape the output directory."""
+    return re.sub(r"[^A-Za-z0-9._-]", "_", str(name))
+
+
 def parquet_to_csvs(parquet_path, out_dir, *, drop_provenance=True, drop_empty=True):
     """Split a run-level Parquet batch back into per-test CSVs (the reverse of
     convert_csvs_to_parquet). One CSV per test_name, written to out_dir.
@@ -307,7 +313,7 @@ def parquet_to_csvs(parquet_path, out_dir, *, drop_provenance=True, drop_empty=T
             group = group[[c for c in group.columns if c not in provenance_cols]]
         if drop_empty:
             group = group.dropna(axis=1, how="all")
-        path = out_dir / f"{test_name}.csv"
+        path = out_dir / f"{safe_stem(test_name)}.csv"
         group.to_csv(path, index=False)
         written[test_name] = path
     return written

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_compare.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_compare.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hardware-free tests for compare-to-history (regression detection)."""
+
+import pandas as pd
+from helpers.perf_compare import compare_to_history
+from helpers.perf_parquet import write_run_batch
+
+_RUN_PROV = dict(
+    commit_sha="abc123",
+    arch="wormhole",
+    run_id="run",
+    timestamp="t",
+    pipeline="nightly",
+    pr_number=None,
+)
+
+
+def _batch(tmp_path, name, mean_math, tile_cnt=(4, 4)):
+    df = pd.DataFrame(
+        {
+            "marker": ["INIT", "TILE_LOOP"],
+            "tile_cnt": list(tile_cnt),
+            "mean(MATH_ISOLATE)": list(mean_math),
+        }
+    )
+    path = tmp_path / f"{name}.parquet"
+    write_run_batch({"perf_a": df}, path, **dict(_RUN_PROV, run_id=name))
+    return path
+
+
+def test_detects_regression(tmp_path):
+    history = [
+        _batch(tmp_path, "h1", [100.0, 200.0]),
+        _batch(tmp_path, "h2", [102.0, 198.0]),
+    ]
+    current = _batch(tmp_path, "cur", [130.0, 205.0])  # INIT ~+29%, TILE ~+3%
+
+    result = compare_to_history(current, history, threshold=0.05)
+
+    regs = {(r["marker"], r["run_type"]) for r in result["regressions"]}
+    assert ("INIT", "MATH_ISOLATE") in regs
+    assert ("TILE_LOOP", "MATH_ISOLATE") not in regs  # within threshold
+
+
+def test_no_regression_within_threshold(tmp_path):
+    history = [_batch(tmp_path, "h1", [100.0, 200.0])]
+    current = _batch(tmp_path, "cur", [103.0, 202.0])  # ~3%, ~1%
+
+    result = compare_to_history(current, history, threshold=0.05)
+
+    assert result["regressions"] == []
+    assert len(result["records"]) == 2
+
+
+def test_new_config_has_no_baseline(tmp_path):
+    history = [_batch(tmp_path, "h1", [100.0, 200.0], tile_cnt=(4, 4))]
+    # a config not seen in history -> no baseline, reported as a new point
+    current = _batch(tmp_path, "cur", [100.0, 200.0], tile_cnt=(8, 8))
+
+    result = compare_to_history(current, history, threshold=0.05)
+
+    assert result["regressions"] == []
+    assert result["records"] == []
+    assert len(result["new_points"]) == 2

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -304,3 +304,24 @@ def test_round_trip_parquet_csv_parquet(tmp_path):
     d1 = t1.to_pandas().sort_values(key).reset_index(drop=True)
     d2 = t2.to_pandas().sort_values(key)[d1.columns].reset_index(drop=True)
     pd.testing.assert_frame_equal(d1, d2)
+
+
+def test_round_trip_preserves_float_precision(tmp_path):
+    # a std with many significant digits must survive Parquet -> CSV -> Parquet exactly
+    df = pd.DataFrame(
+        {
+            "marker": ["INIT", "TILE_LOOP"],
+            "tile_cnt": [4, 4],
+            "mean(MATH_ISOLATE)": [1.0, 2.0],
+            "std(L1_TO_L1)": [0.6324555320336759, 0.7071067811865476],
+        }
+    )
+    b1 = tmp_path / "b1.parquet"
+    write_run_batch({"perf_a": df}, b1, **_RUN_PROV)
+    back = parquet_to_csvs(b1, tmp_path / "back")
+    b2 = tmp_path / "b2.parquet"
+    convert_csvs_to_parquet([str(p) for p in back.values()], b2, **_RUN_PROV)
+
+    v1 = sorted(pq.read_table(b1).to_pandas()["std(L1_TO_L1)"].dropna())
+    v2 = sorted(pq.read_table(b2).to_pandas()["std(L1_TO_L1)"].dropna())
+    assert v1 == v2  # bit-exact, not just close

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_pipeline_edge_cases.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_pipeline_edge_cases.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Adversarial edge cases — deliberately trying to break the pipeline.
+
+Degenerate inputs, hostile names, malformed metadata, and numeric corner cases
+across convert / migrate / dashboard / compare. Each asserts either graceful
+handling or a loud, correct failure.
+"""
+
+import pandas as pd
+import pyarrow.parquet as pq
+import pytest
+from helpers.perf_compare import compare_to_history
+from helpers.perf_dashboard import dashboard_from_parquet
+from helpers.perf_migrate import discover_runs, migrate_runs
+from helpers.perf_parquet import (
+    convert_csvs_to_parquet,
+    parquet_to_csvs,
+    write_run_batch,
+)
+
+PROV = dict(
+    commit_sha="c",
+    arch="wormhole",
+    run_id="r",
+    timestamp="t",
+    pipeline="PR",
+    pr_number=None,
+)
+
+
+def _csv(path, df):
+    df.to_csv(path, index=False)
+    return str(path)
+
+
+def _one(mean=1.0):
+    return pd.DataFrame(
+        {"marker": ["INIT"], "tile_cnt": [4], "mean(MATH_ISOLATE)": [mean]}
+    )
+
+
+# ── degenerate inputs ─────────────────────────────────────────────────────────
+
+
+def test_empty_csv_header_only(tmp_path):
+    p = _csv(tmp_path / "perf_x.csv", pd.DataFrame({"marker": [], "tile_cnt": []}))
+    out = tmp_path / "o.parquet"
+    convert_csvs_to_parquet([p], out, **PROV)
+    assert pq.read_table(out).num_rows == 0
+
+
+def test_convert_no_csvs_is_empty_batch(tmp_path):
+    out = tmp_path / "o.parquet"
+    convert_csvs_to_parquet([], out, **PROV)
+    assert pq.read_table(out).num_rows == 0
+
+
+def test_missing_marker_fails_loud(tmp_path):
+    p = _csv(tmp_path / "perf_x.csv", pd.DataFrame({"tile_cnt": [4]}))  # no marker
+    with pytest.raises(ValueError, match="marker"):
+        convert_csvs_to_parquet([p], tmp_path / "o.parquet", **PROV)
+
+
+# ── hostile names (path safety) ───────────────────────────────────────────────
+
+
+def test_dashboard_test_name_with_slash(tmp_path):
+    b = tmp_path / "b.parquet"
+    write_run_batch({"weird/../name": _one()}, b, **PROV)
+    out = tmp_path / "out"
+    written = dashboard_from_parquet(b, out)
+    for path in written.values():
+        assert out.resolve() in path.resolve().parents  # never escapes out_dir
+
+
+def test_parquet_to_csvs_test_name_with_slash(tmp_path):
+    b = tmp_path / "b.parquet"
+    write_run_batch({"a/b": _one()}, b, **PROV)
+    out = tmp_path / "out"
+    written = parquet_to_csvs(b, out)
+    for path in written.values():
+        assert out.resolve() in path.resolve().parents
+
+
+# ── migrate robustness ────────────────────────────────────────────────────────
+
+
+def test_discover_runs_malformed_sidecar(tmp_path):
+    run_dir = tmp_path / "run1" / "perf_data"
+    run_dir.mkdir(parents=True)
+    _csv(run_dir / "perf_a.csv", _one())
+    (tmp_path / "run1" / "run_meta.json").write_text("{ not valid json")
+    runs = discover_runs(tmp_path)  # must not crash
+    assert runs[0].commit_sha == "unknown"
+
+
+def test_migrate_empty_archive(tmp_path):
+    (tmp_path / "empty").mkdir()
+    report = migrate_runs(discover_runs(tmp_path / "empty"), tmp_path / "out")
+    assert report == {}
+
+
+# ── compare robustness ────────────────────────────────────────────────────────
+
+
+def test_compare_empty_history(tmp_path):
+    cur = tmp_path / "c.parquet"
+    write_run_batch({"perf_a": _one()}, cur, **PROV)
+    result = compare_to_history(cur, [], threshold=0.05)
+    assert result["regressions"] == []
+    assert len(result["new_points"]) == 1
+
+
+def test_compare_zero_baseline_no_crash(tmp_path):
+    h = tmp_path / "h.parquet"
+    write_run_batch({"perf_a": _one(0.0)}, h, **PROV)
+    c = tmp_path / "c.parquet"
+    write_run_batch({"perf_a": _one(5.0)}, c, **PROV)
+    result = compare_to_history(c, [h], threshold=0.05)  # baseline 0 -> no div-by-zero
+    assert isinstance(result["records"], list)

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_pipeline_integration.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_pipeline_integration.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end integration test: the full pipeline the way a real run uses it.
+
+Chains every piece together on synthetic data (no chip):
+
+    history runs -> Parquet batches
+    current run  -> CSV  ->  Parquet  ->  CSV (reverse)  ->  dashboard
+                                       ->  compare to history  ->  flag regression
+
+This is the single "everything works together" check on the tip of the stack.
+"""
+
+import pandas as pd
+import pyarrow.parquet as pq
+from helpers.perf_compare import compare_to_history, summarize_comparison
+from helpers.perf_dashboard import dashboard_from_parquet
+from helpers.perf_parquet import (
+    convert_csvs_to_parquet,
+    parquet_to_csvs,
+    write_run_batch,
+)
+from helpers.perf_wide_schema import DB_SCHEMA
+
+_PROV = dict(
+    commit_sha="cur_commit",
+    arch="wormhole",
+    run_id="current",
+    timestamp="t",
+    pipeline="PR",
+    pr_number="7",
+)
+
+
+def _report(mean_math):
+    """What one perf test emits: a config (tile_cnt=4) with MATH_ISOLATE timings."""
+    return pd.DataFrame(
+        {
+            "marker": ["INIT", "TILE_LOOP"],
+            "tile_cnt": [4, 4],
+            "mean(MATH_ISOLATE)": list(mean_math),
+        }
+    )
+
+
+def test_full_pipeline_run_to_regression(tmp_path):
+    # 1. HISTORY: several past runs, published as Parquet batches.
+    history = []
+    for i, vals in enumerate([[100.0, 200.0], [101.0, 199.0], [99.0, 201.0]]):
+        path = tmp_path / f"hist_{i}.parquet"
+        write_run_batch(
+            {"perf_matmul": _report(vals)}, path, **dict(_PROV, run_id=f"h{i}")
+        )
+        history.append(path)
+
+    # 2. CURRENT run: produces a CSV, as a real perf test would. INIT regressed +30%.
+    perf_data = tmp_path / "perf_data"
+    perf_data.mkdir()
+    _report([130.0, 205.0]).to_csv(perf_data / "perf_matmul.csv", index=False)
+
+    # 3. CSV -> Parquet (the live conversion / migration path).
+    current = tmp_path / "current.parquet"
+    convert_csvs_to_parquet([str(perf_data / "perf_matmul.csv")], current, **_PROV)
+    assert pq.read_table(current).schema.names == [c.name for c in DB_SCHEMA]
+
+    # 4. Parquet -> CSV round-trips (reverse converter).
+    back = parquet_to_csvs(current, tmp_path / "back")
+    assert "perf_matmul" in back
+
+    # 5. Dashboard straight from Parquet (no database).
+    html = dashboard_from_parquet(current, tmp_path / "dash")
+    assert (tmp_path / "dash" / "perf_matmul.html").exists()
+    assert "perf_matmul" in html
+
+    # 6. Compare to history: the regressed point is flagged, the stable one is not.
+    result = compare_to_history(current, history, threshold=0.05)
+    flagged = {(r["test"], r["marker"], r["run_type"]) for r in result["regressions"]}
+    assert ("perf_matmul", "INIT", "MATH_ISOLATE") in flagged
+    assert ("perf_matmul", "TILE_LOOP", "MATH_ISOLATE") not in flagged
+    assert "REGRESSION" in summarize_comparison(result)


### PR DESCRIPTION
Flags regressions per (test, config, marker, run-type) beyond a threshold, keyed by arch; integration test chains report→Parquet→reverse CSV→dashboard→compare; plus edge-case hardening and float-exact CSV↔Parquet.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstojictt/perf-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstojictt/perf-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstojictt/perf-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nstojictt/perf-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstojictt/perf-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstojictt/perf-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstojictt/perf-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstojictt/perf-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstojictt/perf-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstojictt/perf-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstojictt/perf-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstojictt/perf-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstojictt/perf-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstojictt/perf-compare)