### PR TITLE
Reservation of memory for vector beforehand

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/chunk/chunk.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/chunk/chunk.cpp
@@ -24,6 +24,7 @@ std::vector<ttnn::Tensor> chunk(const ttnn::Tensor& input_tensor, const uint32_t
     int chunk_size = tt::div_up(size_along_dim, num_chunks);
 
     std::vector<ttnn::Tensor> chunks;
+    chunks.reserve(num_chunks);
     int start = 0;
 
     while (start < size_along_dim) {
@@ -40,7 +41,7 @@ std::vector<ttnn::Tensor> chunk(const ttnn::Tensor& input_tensor, const uint32_t
 
         ttnn::Tensor chunk_tensor = ttnn::slice(input_tensor, slice_start, slice_end, slice_step);
 
-        chunks.push_back(chunk_tensor);
+        chunks.push_back(std::move(chunk_tensor));
 
         start = end;
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/chunk/chunk.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/chunk/chunk.cpp
@@ -24,7 +24,8 @@ std::vector<ttnn::Tensor> chunk(const ttnn::Tensor& input_tensor, const uint32_t
     int chunk_size = tt::div_up(size_along_dim, num_chunks);
 
     std::vector<ttnn::Tensor> chunks;
-    chunks.reserve(num_chunks);
+    // A chunk holds at least one element, so fewer than num_chunks are produced for a small dim.
+    chunks.reserve(std::min(num_chunks, static_cast<uint32_t>(size_along_dim)));
     int start = 0;
 
     while (start < size_along_dim) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
@@ -123,6 +123,8 @@ tt::tt_metal::ProgramDescriptor ConcatS2SMultiProgramFactory::create_descriptor(
 
     std::vector<uint32_t> runtime_args_0;
     std::vector<uint32_t> runtime_args_1;
+    runtime_args_0.reserve(num_input_tensors * 4);
+    runtime_args_1.reserve(num_input_tensors * 4);
     for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
         const auto input_num_sticks_per_risc = tt::div_up(input_num_sticks[input_id], 2);
         runtime_args_0.push_back(input_num_pages_per_stick[input_id]);

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -376,6 +376,7 @@ tt::tt_metal::ProgramDescriptor FillPadL1ShardedProgramFactory::create_descripto
     };
 
     std::vector<ShardCoreInfo> active;
+    active.reserve(all_shard_cores.size());
 
     for (uint32_t i = 0; i < static_cast<uint32_t>(all_shard_cores.size()); ++i) {
         uint32_t row, col;

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.cpp
@@ -27,6 +27,7 @@ std::vector<CoreRange> get_multicast_regions(const CoreRangeSet& all_cores, cons
     TT_ASSERT(logical_controller == logical_zero);
 
     std::vector<CoreRange> logical_core_ranges;
+    logical_core_ranges.reserve(3);
     auto split_core_range_containing_controller = [&](const CoreRange& controller_core_range) {
         TT_ASSERT(controller_core_range.start_coord == logical_controller);
         CoreRange right_block(

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
@@ -180,6 +180,7 @@ ProgramDescriptor NonZeroIndicesProgramFactory::create_descriptor(
     // Buffer* slots are auto-patched by the framework on program cache hits.
     // Geometry uint32_t args are fixed by the tensor spec (part of the program cache key).
     std::vector<std::variant<uint32_t, Buffer*>> runtime_args_list;
+    runtime_args_list.reserve(3 + geom_args.size());
     runtime_args_list.push_back(input.buffer());
     runtime_args_list.push_back(out_num_indices.buffer());
     runtime_args_list.push_back(out_indices.buffer());

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -21,9 +21,11 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_and_repeated_values(s
     if (values.empty()) {
         return chunks;
     }
+    chunks.reserve(values.size());
 
     // Initialize the first chunk
     std::vector<uint32_t> current_chunk;
+    current_chunk.reserve(values.size());
     current_chunk.push_back(values[0]);
 
     for (size_t i = 1; i < values.size(); ++i) {
@@ -36,7 +38,7 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_and_repeated_values(s
         }
     }
     // Add the last chunk
-    chunks.push_back(current_chunk);
+    chunks.push_back(std::move(current_chunk));
     return chunks;
 }
 
@@ -83,6 +85,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // figure out the start read stick id for each core, and the start id for each dim
         std::vector<int> stick_ids_per_core;
+        stick_ids_per_core.reserve(num_sticks_per_core_padded);
         int front_pad_stick_id = -2;
         int pad_stick_id = -1;
         for (uint32_t j = 0; j < num_sticks_per_core_padded; ++j) {
@@ -153,6 +156,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // reader rt args
         std::vector<uint32_t> reader_kernel_args;
+        reader_kernel_args.reserve(1 + 3 * core_stick_map.size() + 2 * num_sticks_per_core_padded);
         reader_kernel_args.push_back(core_stick_map.size());  // num_cores
 
         for (const auto& core_stick_pair : core_stick_map) {
@@ -168,10 +172,11 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // coalesce the sticks into chunks
         std::vector<std::vector<std::vector<uint32_t>>> stick_chunks_per_core;
+        stick_chunks_per_core.reserve(core_stick_map.size());
         for (auto core_stick_pair : core_stick_map) {
             auto stick_chunks = group_contiguous_and_repeated_values(core_stick_pair.second);
-            stick_chunks_per_core.push_back(stick_chunks);
             reader_kernel_args.push_back(stick_chunks.size());  // num_chunks for current core
+            stick_chunks_per_core.push_back(std::move(stick_chunks));
         }
         for (const auto& stick_chunks : stick_chunks_per_core) {
             for (auto chunk : stick_chunks) {
@@ -180,7 +185,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             }
         }
 
-        ret_val[i] = {reader_kernel_args, writer_kernel_args};
+        ret_val[i] = {std::move(reader_kernel_args), std::move(writer_kernel_args)};
     }
 
     return ret_val;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -209,6 +209,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileInvariant::
     // Constant reader tail shared by every core: output shape, inverse permutation, input strides.
     // The src buffer binding and per-core scalar slots are prepended per core in the loop below.
     std::vector<uint32_t> reader_common_args;
+    reader_common_args.reserve(output_shape_view.size() + inv_perm.size() + input_tile_strides.size());
     reader_common_args.insert(reader_common_args.end(), output_shape_view.begin(), output_shape_view.end());
     reader_common_args.insert(reader_common_args.end(), inv_perm.begin(), inv_perm.end());
     reader_common_args.insert(reader_common_args.end(), input_tile_strides.begin(), input_tile_strides.end());

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
@@ -438,6 +438,7 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
     auto build_runtime_args_dram_rm = [&](uint32_t dst_core_idx, const std::vector<RollTransferDesc>& descs) {
         // Collect unique source shards (at most 2) and assign them to staging slots 0/1.
         std::vector<uint32_t> src_shards;
+        src_shards.reserve(descs.size());
         std::unordered_map<uint32_t, uint32_t> src_to_slot;
         for (const auto& td : descs) {
             if (!src_to_slot.contains(td.src_dram_shard_idx)) {

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
@@ -438,7 +438,7 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
     auto build_runtime_args_dram_rm = [&](uint32_t dst_core_idx, const std::vector<RollTransferDesc>& descs) {
         // Collect unique source shards (at most 2) and assign them to staging slots 0/1.
         std::vector<uint32_t> src_shards;
-        src_shards.reserve(descs.size());
+        src_shards.reserve(2);
         std::unordered_map<uint32_t, uint32_t> src_to_slot;
         for (const auto& td : descs) {
             if (!src_to_slot.contains(td.src_dram_shard_idx)) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
@@ -270,6 +270,7 @@ std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> create
             continue;
         }
         std::vector<detail::CompressedStrideBlock> compressed_blocks;
+        compressed_blocks.reserve(page_strides.size());
         auto it = page_strides.cbegin();
         while (it != page_strides.cend()) {
             size_t best_pattern_len = 0;


### PR DESCRIPTION
PR Cathegory:
memory work optimization
Summary:
Preallocate memory for further usage to avoid possible sequential reallocation.
Notes for reviewers:
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_56)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_56)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_56)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_56)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_56)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_56)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_56)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_56)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_56)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_56)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_56)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_56)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_56)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_56)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_56)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_56)