### PR TITLE
Fix Ring SDPA LLK assert program size and FP32 hangs

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -546,7 +546,12 @@ class RingJointSDPARuntime:
 
 
 def open_ring_joint_sdpa_runtime(
-    mesh_config, *, fp32_dest_acc_en: bool = False, trace_region_size: int = 0, topology: Topology = None
+    mesh_config,
+    *,
+    fp32_dest_acc_en: bool = False,
+    trace_region_size: int = 0,
+    topology: Topology = None,
+    reserve_llk_kernel_config: bool = True,
 ):
     use_ring = mesh_config.sp_size > 2 if topology is None else topology == Topology.Ring
     fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
@@ -574,7 +579,7 @@ def open_ring_joint_sdpa_runtime(
         # trace_region_size defaults to 0 (no trace region), leaving every existing caller unchanged; only
         # the trace-replay test asks for one.
         mesh_device_kwargs = {"mesh_shape": mesh_shape, "trace_region_size": trace_region_size}
-        if os.getenv("TT_METAL_LLK_ASSERTS"):
+        if reserve_llk_kernel_config and os.getenv("TT_METAL_LLK_ASSERTS"):
             mesh_device_kwargs["worker_l1_size"] = LLK_ASSERT_WORKER_L1_SIZE
         mesh_device = ttnn.open_mesh_device(**mesh_device_kwargs)
 
@@ -1621,6 +1626,7 @@ def run_ring_joint_sdpa_chunked(
     sliding_window_size: int = None,
     use_attention_sink: bool = False,
     runtime: RingJointSDPARuntime = None,
+    reserve_llk_kernel_config: bool = True,
 ):
     """
     Validate ring joint SDPA chunked-prefill, or verify deterministic replay.
@@ -1705,7 +1711,11 @@ def run_ring_joint_sdpa_chunked(
 
     owns_runtime = runtime is None
     if runtime is None:
-        runtime = open_ring_joint_sdpa_runtime(mesh_config, fp32_dest_acc_en=fp32_dest_acc_en)
+        runtime = open_ring_joint_sdpa_runtime(
+            mesh_config,
+            fp32_dest_acc_en=fp32_dest_acc_en,
+            reserve_llk_kernel_config=reserve_llk_kernel_config,
+        )
     mesh_device = runtime.mesh_device
     topology = runtime.topology
     sp_axis = runtime.sp_axis
@@ -5324,6 +5334,7 @@ def test_ring_mla_chunked_accuracy(model_name, qk_configs, chunk_size):
         qk_configs=qk_configs,
         persistent_buffer_mode="reuse_max",
         use_ring_mla=True,
+        reserve_llk_kernel_config=False,
     )
 
 
@@ -5416,6 +5427,7 @@ def test_ring_mla_chunked_determinism(model_name, qk_configs, chunk_size):
         qk_configs=qk_configs,
         num_iterations=3,
         use_ring_mla=True,
+        reserve_llk_kernel_config=False,
     )
 
 

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -59,6 +59,10 @@ MESH_CONFIG = MeshConfig.detect()
 
 BATCH_SIZE = 1
 
+# Experimental LLK-assert override: shrink user-allocatable worker L1 by 16 KiB so the
+# kernel-config staging region grows from 69 KiB to 85 KiB on Blackhole.
+LLK_ASSERT_WORKER_L1_SIZE = 1_444_992
+
 
 @dataclass(frozen=True)
 class GPTOSSRingSinkConfig:
@@ -569,7 +573,10 @@ def open_ring_joint_sdpa_runtime(
         mesh_shape = ttnn.MeshShape(mesh_config.tp_size, mesh_config.sp_size)
         # trace_region_size defaults to 0 (no trace region), leaving every existing caller unchanged; only
         # the trace-replay test asks for one.
-        mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, trace_region_size=trace_region_size)
+        mesh_device_kwargs = {"mesh_shape": mesh_shape, "trace_region_size": trace_region_size}
+        if os.getenv("TT_METAL_LLK_ASSERTS"):
+            mesh_device_kwargs["worker_l1_size"] = LLK_ASSERT_WORKER_L1_SIZE
+        mesh_device = ttnn.open_mesh_device(**mesh_device_kwargs)
 
         full_compute_grid = mesh_device.compute_with_storage_grid_size()
         ccl_sub_device_crs = ttnn.CoreRangeSet(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -262,9 +262,9 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
     CircularBuffer cb_in(in_cb);
     // Precondition: in_cb has num_tiles produced
     // Postcondition: in_cb has num_tiles produced
+    reconfig_data_format_srca(in_cb);
     copy_tile_to_dst_init_short(in_cb);
     recip_tile_init();
-    reconfig_data_format_srca(in_cb);
     pack_reconfig_data_format(in_cb);
 
     cb_in.wait_front(num_tiles);
@@ -300,8 +300,11 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, uint3
     // Precondition: in1_cb has rows produced
     // Postcondition: in0_cb has rows*cols produced
     // Postcondition: in1_cb has rows produced
-    sub_bcast_cols_init_short(in0_cb, in1_cb);
+    // llk_unpack_AB_init (inside sub_bcast_cols_init_short) validates the live
+    // unpacker configuration.  Reconfigure first: qk_im can be FP32 while the
+    // row maximum is BF16, notably after applying a windowed BF16 mask.
     reconfig_data_format(in0_cb, in1_cb);
+    sub_bcast_cols_init_short(in0_cb, in1_cb);
 
     // The exponential function uses InputClamping::None for better performance. This version
     // produces incorrect outputs for inputs <~ -88, but those outputs are guaranteed to be negative.
@@ -488,8 +491,8 @@ void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb) {
     constexpr uint32_t granularity = cols;
 #endif
 
-    mul_bcast_cols_init_short(in0_cb, in1_cb);
     reconfig_data_format(in0_cb, in1_cb);
+    mul_bcast_cols_init_short(in0_cb, in1_cb);
     pack_reconfig_data_format(in0_cb);
     cb_in0.wait_front(num_tiles);
     cb_in1.wait_front(rows);
@@ -598,8 +601,8 @@ void mul_tiles_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_cb has num_tiles produced
 
-    mul_bcast_cols_init_short(in0_cb, in1_cb);
     reconfig_data_format(in0_cb, in1_cb);
+    mul_bcast_cols_init_short(in0_cb, in1_cb);
     pack_reconfig_data_format(in0_cb);
     cb_in0.wait_front(num_tiles);
     cb_in1.wait_front(num_tiles);
@@ -1085,13 +1088,15 @@ void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
      * Use matmul on Mx1 input to reduce rows within tile to produce Mx1 output.
      */
 
+    // matmul_block_init validates the live reverse-order unpacker setup
+    // (in1_cb -> SrcA, out_cb -> SrcB), so establish it before init.
+    reconfig_data_format(in1_cb, out_cb);
     matmul_block_init(
         out_cb, in1_cb, 0 /*transpose*/, subblock_w /*ct_dim*/, subblock_h /*rt_dim*/, in0_block_w /*kt_dim*/);
 
     constexpr uint32_t output_num_tiles = M * N;
     constexpr uint32_t out_subblock_num_tiles = subblock_h * subblock_w;
 
-    reconfig_data_format(in1_cb, out_cb);
     pack_reconfig_data_format(out_cb);
     cb_in1.wait_front(N);
     cb_out.wait_front(M);


### PR DESCRIPTION
## Summary

- reserve 16 KiB of worker L1 for Ring SDPA tests when LLK asserts are enabled
- reconfigure live unpacker formats before LLK initialization in FP32 SDPA paths
- incorporate the fix developed in [#51609](https://github.com/tenstorrent/tt-metal/pull/51609)

## Related issues

| Hardware | Ubuntu | Issue |
|---|---:|---|
| Wormhole N300 | 22.04 | Closes #51526 |
| Wormhole N300 | 24.04 | Closes #51527 |
| Blackhole P150B | 22.04 | Closes #51528 |
| Blackhole P150B | 24.04 | Closes #51529 |
| Wormhole N300 | 22.04 | Closes #52065 (windowed SDPA hang) |
| Blackhole P150B | 22.04 | Closes #52066 (windowed SDPA hang) |

## Validation

Local Ubuntu 22.04, 8x Blackhole P150B; each node ran independently through `scripts/run_safe_pytest.sh`:

| Configuration | Pass | Hang | Kernel-buffer overflow |
|---|---:|---:|---:|
| LLK asserts + this PR | 14 | 0 | 0 |
| No LLK asserts | 14 | 0 | 0 |

Release rebuild passed on latest `origin/main`. The run-633 `chunk2560` parameter is unavailable at current HEAD; its current `chunk5120` replacement passed.

## Test plan

[![Wormhole sanity](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=momcilo/program_size&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/30916236586) — failed in unrelated reduce `test_tiebreak_input_adjust.py`.
[![Blackhole sanity](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=momcilo/program_size&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/30916238043) — failed in the same unrelated reduce test.
[![LLK-assert sanity](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests-debug.yaml/badge.svg?branch=momcilo/program_size&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/30916241178) — affected Ring-SDPA nightly jobs passed on Ubuntu 22.04 and 24.04 (116 passed each); top-level failure is unrelated reduce plus setup infrastructure.

All PR-relevant LLK SDPA tests pass; remaining failures are either a baseline reduce-test issue already reverted on newer `main` or transient CI setup timeouts.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=momcilo/program_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:momcilo/program_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=momcilo/program_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:momcilo/program_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=momcilo/program_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:momcilo/program_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=momcilo/program_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:momcilo/program_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=momcilo/program_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:momcilo/program_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=momcilo/program_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:momcilo/program_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=momcilo/program_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:momcilo/program_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=momcilo/program_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:momcilo/program_size)