### PR TITLE
fix(ci): use manylinux wheel for ubuntu 24.04 sanity tests [Bug Fix]

### DIFF
--- a/.github/workflows/blackhole-sanity-tests.yaml
+++ b/.github/workflows/blackhole-sanity-tests.yaml
@@ -150,7 +150,9 @@ jobs:
     with:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
       build-type: ${{ inputs.build-type || 'Release' }}
-      build-inplace-wheel: true
+      # In-place wheel is cp310; only valid for 22.04 tests. 24.04 (cp312) needs the manylinux wheel.
+      build-inplace-wheel: ${{ (inputs.platform || 'Ubuntu 22.04') == 'Ubuntu 22.04' }}
+      build-wheel: ${{ (inputs.platform || 'Ubuntu 22.04') != 'Ubuntu 22.04' }}
       tracy: true
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       build-umd-tests: true

--- a/.github/workflows/sanity-tests-debug.yaml
+++ b/.github/workflows/sanity-tests-debug.yaml
@@ -98,7 +98,8 @@ jobs:
     with:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
       build-type: RelWithDebInfo
-      build-inplace-wheel: true
+      # Manylinux wheel: in-place is cp310, but this leg tests on 24.04 (cp312 venv).
+      build-wheel: true
       tracy: true
       platform: "Ubuntu 24.04"
       skip-tt-train: false


### PR DESCRIPTION
### PR Category

Bug Fix

### Summary

The sanity-tests-debug workflow was building an in-place wheel (cp310) but testing on Ubuntu 24.04 which uses cp312. This mismatch caused test failures.

Switch from `build-inplace-wheel` to `build-wheel` to generate a proper manylinux wheel that is compatible with the Ubuntu 24.04 test environment.

### Notes for reviewers

- Fixes #51969
- Partly reverts #51330

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/wheel-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/wheel-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/wheel-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/wheel-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix/wheel-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix/wheel-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/wheel-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/wheel-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/wheel-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/wheel-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/wheel-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/wheel-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/wheel-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/wheel-nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/wheel-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/wheel-nightly)