### PR TITLE
Fix MX float encoding in metal.

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -71,6 +71,7 @@ set(UNIT_TESTS_API_SOURCES
     test_tilize_untilize.cpp
     test_worker_config_buffer.cpp
     test_blockfloat_common.cpp
+    test_mx_common.cpp
     test_descriptor_patching.cpp
     test_duplicate_kernel.cpp
     test_core_local_mem_api.cpp

--- a/tests/tt_metal/tt_metal/api/test_mx_common.cpp
+++ b/tests/tt_metal/tt_metal/api/test_mx_common.cpp
@@ -20,9 +20,6 @@ using tt::tt_metal::mx::convert_to_mxfp_elem_bits;
 using tt::tt_metal::mx::FormatParams;
 using tt::tt_metal::mx::InfNanRepresentation;
 
-// Mirrors of the per-format descriptors in mxfp4.cpp / mxfp6.cpp / mxfp8.cpp,
-// which live in anonymous namespaces and so cannot be included here. Keep in
-// sync with those definitions.
 constexpr FormatParams kMxFp4Params = {
     .elem_exp_bits = 2,
     .elem_man_bits = 1,

--- a/tests/tt_metal/tt_metal/api/test_mx_common.cpp
+++ b/tests/tt_metal/tt_metal/api/test_mx_common.cpp
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "impl/data_format/mx_common.hpp"
+
+namespace {
+
+using tt::tt_metal::mx::convert_from_mxfp_elem_bits;
+using tt::tt_metal::mx::convert_to_mxfp_elem_bits;
+using tt::tt_metal::mx::FormatParams;
+using tt::tt_metal::mx::InfNanRepresentation;
+
+// Mirrors of the per-format descriptors in mxfp4.cpp / mxfp6.cpp / mxfp8.cpp,
+// which live in anonymous namespaces and so cannot be included here. Keep in
+// sync with those definitions.
+constexpr FormatParams kMxFp4Params = {
+    .elem_exp_bits = 2,
+    .elem_man_bits = 1,
+    .elem_exp_bias = 1,
+    .elem_exp_max_unbiased = 2,
+    .elem_exp_min_unbiased = 0,
+    .elem_man_max = 0x1,
+    .elem_width_bits = 4,
+    .elem_width_storage_bits = 4,
+    .sat_supported = true,
+    .elem_sat_pos_bits = 0x7,
+    .elem_sat_neg_bits = 0xF,
+};
+
+constexpr FormatParams kMxFp6RParams = {
+    .elem_exp_bits = 3,
+    .elem_man_bits = 2,
+    .elem_exp_bias = 3,
+    .elem_exp_max_unbiased = 4,
+    .elem_exp_min_unbiased = -2,
+    .elem_man_max = 0x3,
+    .elem_width_bits = 6,
+    .elem_width_storage_bits = 8,
+    .sat_supported = true,
+    .elem_sat_pos_bits = 0x1F,
+    .elem_sat_neg_bits = 0x3F,
+};
+
+constexpr FormatParams kMxFp6PParams = {
+    .elem_exp_bits = 2,
+    .elem_man_bits = 3,
+    .elem_exp_bias = 1,
+    .elem_exp_max_unbiased = 2,
+    .elem_exp_min_unbiased = 0,
+    .elem_man_max = 0x7,
+    .elem_width_bits = 6,
+    .elem_width_storage_bits = 8,
+    .sat_supported = true,
+    .elem_sat_pos_bits = 0x1F,
+    .elem_sat_neg_bits = 0x3F,
+};
+
+constexpr FormatParams kMxFp8E5M2Params = {
+    .elem_exp_bits = 5,
+    .elem_man_bits = 2,
+    .elem_exp_bias = 15,
+    .elem_exp_max_unbiased = 15,
+    .elem_exp_min_unbiased = -14,
+    .elem_man_max = 0x3,
+    .elem_width_bits = 8,
+    .elem_width_storage_bits = 8,
+    .sat_supported = true,
+    .elem_sat_pos_bits = 0x7B,
+    .elem_sat_neg_bits = 0xFB,
+    .inf_rep = InfNanRepresentation::ExpAllOnesManZero,
+    .nan_rep = InfNanRepresentation::ExpAllOnesManNonZero,
+};
+
+constexpr FormatParams kMxFp8E4M3Params = {
+    .elem_exp_bits = 4,
+    .elem_man_bits = 3,
+    .elem_exp_bias = 7,
+    .elem_exp_max_unbiased = 8,
+    .elem_exp_min_unbiased = -6,
+    .elem_man_max = 0x6,  // mant 0b111 at max exp is reserved for NaN
+    .elem_width_bits = 8,
+    .elem_width_storage_bits = 8,
+    .sat_supported = true,
+    .elem_sat_pos_bits = 0x7E,
+    .elem_sat_neg_bits = 0xFE,
+    .nan_rep = InfNanRepresentation::ExpAllOnesManAllOnes,
+};
+
+struct NamedFormat {
+    const char* name;
+    const FormatParams* params;
+};
+
+const std::vector<NamedFormat>& all_formats() {
+    static const std::vector<NamedFormat> formats = {
+        {"MxFp4_E2M1", &kMxFp4Params},
+        {"MxFp6R_E3M2", &kMxFp6RParams},
+        {"MxFp6P_E2M3", &kMxFp6PParams},
+        {"MxFp8_E5M2", &kMxFp8E5M2Params},
+        {"MxFp8_E4M3", &kMxFp8E4M3Params},
+    };
+    return formats;
+}
+
+// Shared exponent that leaves the decoded element unscaled, so these tests
+// exercise the element quantizer in isolation from block scaling.
+constexpr std::uint8_t kUnityScale = 0x7F;
+
+}  // namespace
+
+// Every representable element encoding must survive decode -> encode. This is the
+// property that catches whole-binade errors in the element quantizer: it fails if
+// the subnormal branch rounds at the wrong bit position (every subnormal encoded
+// a binade too small) or if the mantissa field is masked with elem_man_max rather
+// than the full field width (E4M3 losing mantissa bit 0).
+TEST(MxCommonTests, EveryRepresentableCodeRoundTrips) {
+    for (const auto& [name, params] : all_formats()) {
+        const std::uint32_t code_count = 1u << params->elem_width_bits;
+        for (std::uint32_t code = 0; code < code_count; ++code) {
+            const float value = convert_from_mxfp_elem_bits(code, kUnityScale, *params);
+            if (std::isnan(value) || std::isinf(value)) {
+                continue;  // Inf/NaN encodings are canonicalized, not round-tripped.
+            }
+            const std::uint32_t reencoded = convert_to_mxfp_elem_bits(value, *params);
+            EXPECT_EQ(reencoded, code) << name << ": code 0x" << std::hex << code << " decoded to " << std::dec << value
+                                       << " but re-encoded as 0x" << std::hex << reencoded;
+        }
+    }
+}
+
+struct MxEncodeCase {
+    float input = 0.0f;
+    std::uint32_t expected_bits = 0;
+    float expected_decoded = 0.0f;
+};
+
+class MxFp4EncodeTests : public ::testing::TestWithParam<MxEncodeCase> {};
+
+TEST_P(MxFp4EncodeTests, EncodesToExpectedBits) {
+    const auto& p = GetParam();
+    const std::uint32_t bits = convert_to_mxfp_elem_bits(p.input, kMxFp4Params);
+    EXPECT_EQ(bits, p.expected_bits);
+    EXPECT_EQ(convert_from_mxfp_elem_bits(bits, kUnityScale, kMxFp4Params), p.expected_decoded);
+}
+
+// MxFp4 (E2M1) lattice: 0, 0.5, 1, 1.5, 2, 3, 4, 6. Everything below 1.0 goes
+// through the subnormal branch, so 0.5 is the case that regressed to zero.
+INSTANTIATE_TEST_SUITE_P(
+    MxCommonTests,
+    MxFp4EncodeTests,
+    ::testing::Values(
+        MxEncodeCase{0.5f, 0x1u, 0.5f},    // smallest subnormal, must not collapse to 0
+        MxEncodeCase{0.375f, 0x1u, 0.5f},  // above the 0.25 midpoint -> up
+        MxEncodeCase{0.25f, 0x0u, 0.0f},   // exact midpoint, ties to even -> 0
+        MxEncodeCase{0.125f, 0x0u, 0.0f},  // below midpoint -> 0
+        MxEncodeCase{0.75f, 0x2u, 1.0f},   // subnormal rounding overflows into exp 1
+        MxEncodeCase{1.0f, 0x2u, 1.0f},
+        MxEncodeCase{1.5f, 0x3u, 1.5f},
+        MxEncodeCase{2.0f, 0x4u, 2.0f},
+        MxEncodeCase{3.0f, 0x5u, 3.0f},
+        MxEncodeCase{4.0f, 0x6u, 4.0f},
+        MxEncodeCase{6.0f, 0x7u, 6.0f}));
+
+class MxFp6PEncodeTests : public ::testing::TestWithParam<MxEncodeCase> {};
+
+TEST_P(MxFp6PEncodeTests, EncodesToExpectedBits) {
+    const auto& p = GetParam();
+    const std::uint32_t bits = convert_to_mxfp_elem_bits(p.input, kMxFp6PParams);
+    EXPECT_EQ(bits, p.expected_bits);
+    EXPECT_EQ(convert_from_mxfp_elem_bits(bits, kUnityScale, kMxFp6PParams), p.expected_decoded);
+}
+
+// MxFp6P (E2M3) subnormals step by 0.125 up to 1.0; these are the encodings that
+// were each shifted one step down.
+INSTANTIATE_TEST_SUITE_P(
+    MxCommonTests,
+    MxFp6PEncodeTests,
+    ::testing::Values(
+        MxEncodeCase{0.125f, 0x01u, 0.125f},
+        MxEncodeCase{0.25f, 0x02u, 0.25f},
+        MxEncodeCase{0.375f, 0x03u, 0.375f},
+        MxEncodeCase{0.5f, 0x04u, 0.5f},
+        MxEncodeCase{0.625f, 0x05u, 0.625f},
+        MxEncodeCase{0.75f, 0x06u, 0.75f},
+        MxEncodeCase{0.875f, 0x07u, 0.875f},
+        MxEncodeCase{0.09375f, 0x01u, 0.125f},  // above the 0.0625 midpoint -> up
+        MxEncodeCase{0.0625f, 0x00u, 0.0f}));   // exact midpoint, ties to even -> 0
+
+// E4M3 reserves mantissa 0b111 at the top exponent for NaN, so its elem_man_max
+// is 0x6 rather than the full 3-bit field. Masking the mantissa field with that
+// value clears bit 0 of every element; these normal-range values all carry an odd
+// mantissa and would each decode one step low.
+TEST(MxCommonTests, MxFp8E4M3PreservesOddNormalMantissas) {
+    const std::vector<MxEncodeCase> cases = {
+        {9.0f, 0x51u, 9.0f},
+        {1.875f, 0x3Fu, 1.875f},
+        {240.0f, 0x77u, 240.0f},
+        {0.140625f, 0x21u, 0.140625f},
+        {0.001953125f, 0x01u, 0.001953125f},  // smallest subnormal
+    };
+    for (const auto& c : cases) {
+        const std::uint32_t bits = convert_to_mxfp_elem_bits(c.input, kMxFp8E4M3Params);
+        EXPECT_EQ(bits, c.expected_bits) << "input " << c.input;
+        EXPECT_EQ(convert_from_mxfp_elem_bits(bits, kUnityScale, kMxFp8E4M3Params), c.expected_decoded)
+            << "input " << c.input;
+    }
+}
+
+// Widening the mantissa mask must not disturb the reserved encodings: NaN is
+// S.1111.111 and overflow saturates to the largest normal (S.1111.110).
+TEST(MxCommonTests, MxFp8E4M3ReservedEncodings) {
+    EXPECT_EQ(convert_to_mxfp_elem_bits(std::numeric_limits<float>::quiet_NaN(), kMxFp8E4M3Params), 0x7Fu);
+    EXPECT_EQ(convert_to_mxfp_elem_bits(std::numeric_limits<float>::infinity(), kMxFp8E4M3Params), 0x7Eu);
+    EXPECT_EQ(convert_to_mxfp_elem_bits(-std::numeric_limits<float>::infinity(), kMxFp8E4M3Params), 0xFEu);
+    EXPECT_EQ(convert_to_mxfp_elem_bits(448.0f, kMxFp8E4M3Params), 0x7Eu);  // largest normal
+    EXPECT_EQ(convert_to_mxfp_elem_bits(500.0f, kMxFp8E4M3Params), 0x7Eu);  // saturates, never NaN
+    EXPECT_TRUE(std::isnan(convert_from_mxfp_elem_bits(0x7Fu, kUnityScale, kMxFp8E4M3Params)));
+    EXPECT_EQ(convert_from_mxfp_elem_bits(0x7Eu, kUnityScale, kMxFp8E4M3Params), 448.0f);
+}
+
+// The subnormal branch pre-shifts the significand with a truncating >> before
+// rounding, so the dropped bits must be folded into a sticky bit. Without it, a
+// value just above a rounding midpoint is indistinguishable from an exact tie and
+// rounds down instead of up. Each input below is one fp32 ULP above the midpoint
+// between zero and the format's smallest subnormal, so correct round-to-nearest
+// (the OCP MX spec's rounding, which this host-side packer implements) must round
+// away from zero rather than tie to even.
+TEST(MxCommonTests, SubnormalRoundingKeepsStickyBitsAboveMidpoint) {
+    EXPECT_EQ(convert_to_mxfp_elem_bits(0.25000006f, kMxFp4Params), 0x1u);         // -> 0.5, not 0
+    EXPECT_EQ(convert_to_mxfp_elem_bits(0.062500015f, kMxFp6PParams), 0x01u);      // -> 0.125, not 0
+    EXPECT_EQ(convert_to_mxfp_elem_bits(0.031250007f, kMxFp6RParams), 0x01u);      // -> 0.0625, not 0
+    EXPECT_EQ(convert_to_mxfp_elem_bits(7.629396e-06f, kMxFp8E5M2Params), 0x01u);  // -> 2^-16, not 0
+    EXPECT_EQ(convert_to_mxfp_elem_bits(0.0009765627f, kMxFp8E4M3Params), 0x01u);  // -> 2^-9, not 0
+
+    // Exactly on the midpoint (no dropped bits) still ties to even, i.e. to zero.
+    EXPECT_EQ(convert_to_mxfp_elem_bits(0.25f, kMxFp4Params), 0x0u);
+    EXPECT_EQ(convert_to_mxfp_elem_bits(0.0625f, kMxFp6PParams), 0x0u);
+}

--- a/tests/tt_metal/tt_metal/api/test_mx_common.cpp
+++ b/tests/tt_metal/tt_metal/api/test_mx_common.cpp
@@ -233,13 +233,19 @@ TEST(MxCommonTests, MxFp8E4M3ReservedEncodings) {
 // (the OCP MX spec's rounding, which this host-side packer implements) must round
 // away from zero rather than tie to even.
 TEST(MxCommonTests, SubnormalRoundingKeepsStickyBitsAboveMidpoint) {
-    EXPECT_EQ(convert_to_mxfp_elem_bits(0.25000006f, kMxFp4Params), 0x1u);         // -> 0.5, not 0
-    EXPECT_EQ(convert_to_mxfp_elem_bits(0.062500015f, kMxFp6PParams), 0x01u);      // -> 0.125, not 0
-    EXPECT_EQ(convert_to_mxfp_elem_bits(0.031250007f, kMxFp6RParams), 0x01u);      // -> 0.0625, not 0
-    EXPECT_EQ(convert_to_mxfp_elem_bits(7.629396e-06f, kMxFp8E5M2Params), 0x01u);  // -> 2^-16, not 0
-    EXPECT_EQ(convert_to_mxfp_elem_bits(0.0009765627f, kMxFp8E4M3Params), 0x01u);  // -> 2^-9, not 0
+    // Stepped up with nextafter rather than written as a decimal literal, so the
+    // one-ULP claim cannot drift: the nearest decimals land two ULPs up.
+    constexpr float kUp = std::numeric_limits<float>::infinity();
+    EXPECT_EQ(convert_to_mxfp_elem_bits(std::nextafter(0.25f, kUp), kMxFp4Params), 0x1u);          // -> 0.5
+    EXPECT_EQ(convert_to_mxfp_elem_bits(std::nextafter(0.0625f, kUp), kMxFp6PParams), 0x01u);      // -> 0.125
+    EXPECT_EQ(convert_to_mxfp_elem_bits(std::nextafter(0.03125f, kUp), kMxFp6RParams), 0x01u);     // -> 0.0625
+    EXPECT_EQ(convert_to_mxfp_elem_bits(std::nextafter(0x1p-17f, kUp), kMxFp8E5M2Params), 0x01u);  // -> 2^-16
+    EXPECT_EQ(convert_to_mxfp_elem_bits(std::nextafter(0x1p-10f, kUp), kMxFp8E4M3Params), 0x01u);  // -> 2^-9
 
     // Exactly on the midpoint (no dropped bits) still ties to even, i.e. to zero.
     EXPECT_EQ(convert_to_mxfp_elem_bits(0.25f, kMxFp4Params), 0x0u);
     EXPECT_EQ(convert_to_mxfp_elem_bits(0.0625f, kMxFp6PParams), 0x0u);
+    EXPECT_EQ(convert_to_mxfp_elem_bits(0.03125f, kMxFp6RParams), 0x0u);
+    EXPECT_EQ(convert_to_mxfp_elem_bits(0x1p-17f, kMxFp8E5M2Params), 0x0u);
+    EXPECT_EQ(convert_to_mxfp_elem_bits(0x1p-10f, kMxFp8E4M3Params), 0x0u);
 }

--- a/tt_metal/impl/data_format/mx_common.hpp
+++ b/tt_metal/impl/data_format/mx_common.hpp
@@ -218,29 +218,10 @@ inline std::uint32_t convert_to_mxfp_elem_bits(float datum, const FormatParams& 
             // significant bits of mant_with_hb, in which case the result is
             // unconditionally zero.
             std::uint32_t mant_exp_adjusted_pre = (shift >= 24) ? 0u : (mant_with_hb >> shift);
-            // The shift above is truncating, so fold the bits it drops into a sticky
-            // bit before rounding. Without this, a value just above a rounding
-            // midpoint looks like an exact tie and rounds the wrong way (e.g. MxFp4
-            // 0.25000006 -> 0 instead of 0.5). OR-ing into bit 0 is safe because the
-            // round position is bit 23 - mant_width, well above bit 0 for every MX
-            // format (mant_width <= 3). This packer converts host data into MX, so
-            // its reference is the OCP MX spec's round-to-nearest-even; no hardware
-            // performs this conversion. Note the tt-llk golden
-            // _quantize_fp4_storage_model omits this sticky bit -- that model targets
-            // the hardware packer (device MX output), which is a separate question.
             const std::uint32_t discarded = (shift >= 32) ? mant_with_hb : (mant_with_hb & ((1u << shift) - 1u));
             if (discarded != 0u) {
                 mant_exp_adjusted_pre |= 1u;
             }
-            // input_width is 23, not 24: mant_with_hb is the significand scaled by
-            // 2^23 (value = mant_with_hb / 2^23), so it carries 23 fraction bits --
-            // the same fixed-point scale the normal path passes as 23 above. The
-            // right-shift by `shift` changes the value, not the number of fraction
-            // bits. Passing 24 would round off one extra bit and encode every
-            // subnormal element a binade too small (halved), collapsing the
-            // smallest subnormal to zero. Matches the tt-llk golden
-            // _quantize_fp4_storage_model, which applies the same rounder with
-            // shift_out hard-coded to 23 - mant_width in its subnormal branch.
             auto [mant_round_sub, exp_inc_sub] = round_ties_even(mant_exp_adjusted_pre, mant_width, 23);
             mant_exp_adjusted = mant_round_sub;
             elem_exp_unbiased_adj =

--- a/tt_metal/impl/data_format/mx_common.hpp
+++ b/tt_metal/impl/data_format/mx_common.hpp
@@ -14,7 +14,7 @@
 
 namespace tt::tt_metal::mx {
 
-enum class InfNanRepresentation : uint8_t {
+enum class InfNanRepresentation : std::uint8_t {
     NotRepresentable = 0,
     ExpAllOnesManZero,
     ExpAllOnesManNonZero,
@@ -22,20 +22,20 @@ enum class InfNanRepresentation : uint8_t {
 };
 
 struct FormatParams {
-    uint32_t block_size = 32;
+    std::uint32_t block_size = 32;
     int scale_bias = 0x7F;
-    uint32_t elem_exp_bits = 0;
-    uint32_t elem_man_bits = 0;
+    std::uint32_t elem_exp_bits = 0;
+    std::uint32_t elem_man_bits = 0;
     int elem_exp_bias = 0;
     int elem_exp_max_unbiased = 0;
     int elem_exp_min_unbiased = 0;
     int elem_exp_subnorm_encoding = 0;
-    uint32_t elem_man_max = 0;
-    uint32_t elem_width_bits = 0;
-    uint32_t elem_width_storage_bits = 0;
+    std::uint32_t elem_man_max = 0;
+    std::uint32_t elem_width_bits = 0;
+    std::uint32_t elem_width_storage_bits = 0;
     bool sat_supported = false;
-    uint32_t elem_sat_pos_bits = 0;
-    uint32_t elem_sat_neg_bits = 0;
+    std::uint32_t elem_sat_pos_bits = 0;
+    std::uint32_t elem_sat_neg_bits = 0;
     InfNanRepresentation inf_rep = InfNanRepresentation::NotRepresentable;
     InfNanRepresentation nan_rep = InfNanRepresentation::NotRepresentable;
     // MX integer-format (MxInt2/4/8) parameters. Unused by the floating-point MX
@@ -44,17 +44,17 @@ struct FormatParams {
     // implicit scale of 1/elem_int_scale; the shared block scale (E8M0) is applied
     // on top. elem_int_max is the symmetric clamp magnitude.
     bool is_integer = false;
-    uint32_t elem_int_scale = 0;  // round(scaled * elem_int_scale): 64 (MxInt8), 4 (MxInt4), 1 (MxInt2)
-    int elem_int_max = 0;         // symmetric clamp: 127 (MxInt8), 7 (MxInt4), 1 (MxInt2)
+    std::uint32_t elem_int_scale = 0;  // round(scaled * elem_int_scale): 64 (MxInt8), 4 (MxInt4), 1 (MxInt2)
+    int elem_int_max = 0;              // symmetric clamp: 127 (MxInt8), 7 (MxInt4), 1 (MxInt2)
 };
 
 struct RoundResult {
-    uint32_t mantissa = 0;
-    uint32_t overflow = 0;
+    std::uint32_t mantissa = 0;
+    std::uint32_t overflow = 0;
 };
 
 struct BlockScaleResult {
-    uint8_t shared_exp_biased = 0;
+    std::uint8_t shared_exp_biased = 0;
     // Unbiased shared exponent. Effective scale is 2^shared_exp_adj — kept as
     // an int so callers can ldexp directly and avoid building/dividing by a
     // float power of two.
@@ -62,10 +62,10 @@ struct BlockScaleResult {
 };
 
 struct TileWordCounts {
-    uint32_t exp_count = 0;
-    uint32_t exp_bytes = 0;
-    uint32_t exp_words = 0;
-    uint32_t elem_words = 0;
+    std::uint32_t exp_count = 0;
+    std::uint32_t exp_bytes = 0;
+    std::uint32_t exp_words = 0;
+    std::uint32_t elem_words = 0;
 };
 
 // 2^k for integer k, avoiding the libm overhead of std::ldexp on the hot
@@ -74,7 +74,7 @@ struct TileWordCounts {
 // defer to std::ldexp so behavior matches at boundaries.
 inline float pow2_f32(int k) {
     if (k >= -126 && k <= 127) {
-        return std::bit_cast<float>(static_cast<uint32_t>(127 + k) << 23);
+        return std::bit_cast<float>(static_cast<std::uint32_t>(127 + k) << 23);
     }
     return std::ldexp(1.0f, k);
 }
@@ -83,23 +83,23 @@ inline float pow2_f32(int k) {
 // kMxFp6RParams) can constant-propagate field accesses, mask widths, and
 // inf/nan/sat branches. convert_to_mxfp_elem_bits inlines this on the per-
 // element hot path.
-constexpr RoundResult round_ties_even(uint32_t input_mantissa, int output_width, int input_width = 23) {
+constexpr RoundResult round_ties_even(std::uint32_t input_mantissa, int output_width, int input_width = 23) {
     if (output_width < 0) {
         return {0, 0};
     }
-    auto mask_of = [](int w) -> uint32_t { return (w >= 32) ? 0xFFFFFFFFu : ((1u << w) - 1u); };
+    auto mask_of = [](int w) -> std::uint32_t { return (w >= 32) ? 0xFFFFFFFFu : ((1u << w) - 1u); };
     // No rounding needed: output is at least as wide as input.
     if (output_width >= input_width) {
         return {input_mantissa & mask_of(output_width), 0};
     }
     const int shift_out = input_width - output_width;  // 1..32
-    const uint32_t shifted = (shift_out >= 32) ? 0u : (input_mantissa >> shift_out);
-    const uint32_t round_bit = (input_mantissa >> (shift_out - 1)) & 1u;
-    const uint32_t sticky = input_mantissa & mask_of(shift_out - 1);  // 0 when shift_out == 1
-    const uint32_t lsb = shifted & 1u;                                // 0 when output_width == 0
+    const std::uint32_t shifted = (shift_out >= 32) ? 0u : (input_mantissa >> shift_out);
+    const std::uint32_t round_bit = (input_mantissa >> (shift_out - 1)) & 1u;
+    const std::uint32_t sticky = input_mantissa & mask_of(shift_out - 1);  // 0 when shift_out == 1
+    const std::uint32_t lsb = shifted & 1u;                                // 0 when output_width == 0
     // Round up iff round bit is set AND (any sticky bit OR kept LSB is 1).
-    const uint32_t round_inc = round_bit & ((sticky != 0 ? 1u : 0u) | lsb);
-    const uint32_t new_mantissa = shifted + round_inc;
+    const std::uint32_t round_inc = round_bit & ((sticky != 0 ? 1u : 0u) | lsb);
+    const std::uint32_t new_mantissa = shifted + round_inc;
     if (output_width == 0) {
         // Whole rounded value is overflow; mantissa field is empty.
         return {0, new_mantissa};
@@ -111,7 +111,7 @@ constexpr RoundResult round_ties_even(uint32_t input_mantissa, int output_width,
 // shared exponent can be obtained from a single pass over the values (see
 // update_block_stats in mx_tile_pack.hpp).
 inline BlockScaleResult finalize_block_scale(
-    uint32_t max_abs_bits,
+    std::uint32_t max_abs_bits,
     bool all_nan,
     bool all_inf_or_zero,
     bool any_inf,
@@ -119,7 +119,7 @@ inline BlockScaleResult finalize_block_scale(
     bool exp_rnd_en = false) {
     int max_abs_exp = 0;
     if (max_abs_bits != 0) {
-        uint32_t exp_field = max_abs_bits >> 23;
+        std::uint32_t exp_field = max_abs_bits >> 23;
         if (exp_field != 0) {
             max_abs_exp = static_cast<int>(exp_field) - 127;
         } else {
@@ -146,20 +146,20 @@ inline BlockScaleResult finalize_block_scale(
         shared_exp_biased = 0xFE;
     }
 
-    return {static_cast<uint8_t>(shared_exp_biased), shared_exp_adj_for_elem_max};
+    return {static_cast<std::uint8_t>(shared_exp_biased), shared_exp_adj_for_elem_max};
 }
 
-TileWordCounts compute_tile_word_counts(uint32_t elem_count, const FormatParams& params);
+TileWordCounts compute_tile_word_counts(std::uint32_t elem_count, const FormatParams& params);
 
-inline uint32_t convert_to_mxfp_elem_bits(float datum, const FormatParams& params) {
-    uint32_t ui32 = std::bit_cast<uint32_t>(datum);
-    uint8_t sign = static_cast<uint8_t>((ui32 >> 31) & 0x1u);
-    uint32_t fp32_exp_biased = (ui32 >> 23) & 0xFFu;
-    uint32_t fp32_mant = ui32 & 0x7FFFFFu;
+inline std::uint32_t convert_to_mxfp_elem_bits(float datum, const FormatParams& params) {
+    std::uint32_t ui32 = std::bit_cast<std::uint32_t>(datum);
+    std::uint8_t sign = static_cast<std::uint8_t>((ui32 >> 31) & 0x1u);
+    std::uint32_t fp32_exp_biased = (ui32 >> 23) & 0xFFu;
+    std::uint32_t fp32_mant = ui32 & 0x7FFFFFu;
 
     bool fp32_is_zero = (fp32_exp_biased == 0) && (fp32_mant == 0);
     if (fp32_is_zero) {
-        uint32_t elem_sign_bit = static_cast<uint32_t>(sign) << (params.elem_man_bits + params.elem_exp_bits);
+        std::uint32_t elem_sign_bit = static_cast<std::uint32_t>(sign) << (params.elem_man_bits + params.elem_exp_bits);
         return elem_sign_bit;
     }
 
@@ -171,9 +171,9 @@ inline uint32_t convert_to_mxfp_elem_bits(float datum, const FormatParams& param
 
     if (fp32_is_inf) {
         if (params.inf_rep != InfNanRepresentation::NotRepresentable) {
-            uint32_t exp_all_ones = (1u << params.elem_exp_bits) - 1u;
-            uint32_t man = 0;
-            uint32_t sign_bit = static_cast<uint32_t>(sign) << (params.elem_man_bits + params.elem_exp_bits);
+            std::uint32_t exp_all_ones = (1u << params.elem_exp_bits) - 1u;
+            std::uint32_t man = 0;
+            std::uint32_t sign_bit = static_cast<std::uint32_t>(sign) << (params.elem_man_bits + params.elem_exp_bits);
             return sign_bit | (exp_all_ones << params.elem_man_bits) | man;
         }
         if (params.sat_supported) {
@@ -184,20 +184,20 @@ inline uint32_t convert_to_mxfp_elem_bits(float datum, const FormatParams& param
 
     if (fp32_is_nan) {
         if (params.nan_rep == InfNanRepresentation::ExpAllOnesManNonZero) {
-            uint32_t exp_all_ones = (1u << params.elem_exp_bits) - 1u;
-            uint32_t man = 1u;
+            std::uint32_t exp_all_ones = (1u << params.elem_exp_bits) - 1u;
+            std::uint32_t man = 1u;
             return (exp_all_ones << params.elem_man_bits) | man;
         }
         if (params.nan_rep == InfNanRepresentation::ExpAllOnesManAllOnes) {
-            uint32_t exp_all_ones = (1u << params.elem_exp_bits) - 1u;
-            uint32_t man = (1u << params.elem_man_bits) - 1u;
+            std::uint32_t exp_all_ones = (1u << params.elem_exp_bits) - 1u;
+            std::uint32_t man = (1u << params.elem_man_bits) - 1u;
             return (exp_all_ones << params.elem_man_bits) | man;
         }
         return 0;
     }
 
-    uint32_t mant_exp_adjusted = 0;
-    uint32_t elem_exp_biased = 0;
+    std::uint32_t mant_exp_adjusted = 0;
+    std::uint32_t elem_exp_biased = 0;
 
     if (fp32_exp_biased != 0) {
         int elem_exp_unbiased = static_cast<int>(fp32_exp_biased) - 127;
@@ -205,20 +205,43 @@ inline uint32_t convert_to_mxfp_elem_bits(float datum, const FormatParams& param
 
         int mant_width = static_cast<int>(params.elem_man_bits);
         auto [mant_round, exp_inc] = round_ties_even(fp32_mant, mant_width, 23);
-        uint32_t elem_mant_shifted = mant_round;
+        std::uint32_t elem_mant_shifted = mant_round;
         int elem_exp_unbiased_adj = elem_exp_unbiased + static_cast<int>(exp_inc);
         mant_exp_adjusted = elem_mant_shifted;
 
         if (elem_exp_unbiased_adj < params.elem_exp_min_unbiased) {
             elem_exp_unbiased_adj -= static_cast<int>(exp_inc);
-            uint32_t mant_with_hb = fp32_mant | (1u << 23);
+            std::uint32_t mant_with_hb = fp32_mant | (1u << 23);
             int shift = std::abs(params.elem_exp_min_unbiased - elem_exp_unbiased_adj);
             // Right-shifting a uint32_t by >= 32 is undefined behaviour.
             // For very small inputs (|v| << block max) shift can exceed the 24
             // significant bits of mant_with_hb, in which case the result is
             // unconditionally zero.
-            uint32_t mant_exp_adjusted_pre = (shift >= 24) ? 0u : (mant_with_hb >> shift);
-            auto [mant_round_sub, exp_inc_sub] = round_ties_even(mant_exp_adjusted_pre, mant_width, 24);
+            std::uint32_t mant_exp_adjusted_pre = (shift >= 24) ? 0u : (mant_with_hb >> shift);
+            // The shift above is truncating, so fold the bits it drops into a sticky
+            // bit before rounding. Without this, a value just above a rounding
+            // midpoint looks like an exact tie and rounds the wrong way (e.g. MxFp4
+            // 0.25000006 -> 0 instead of 0.5). OR-ing into bit 0 is safe because the
+            // round position is bit 23 - mant_width, well above bit 0 for every MX
+            // format (mant_width <= 3). This packer converts host data into MX, so
+            // its reference is the OCP MX spec's round-to-nearest-even; no hardware
+            // performs this conversion. Note the tt-llk golden
+            // _quantize_fp4_storage_model omits this sticky bit -- that model targets
+            // the hardware packer (device MX output), which is a separate question.
+            const std::uint32_t discarded = (shift >= 32) ? mant_with_hb : (mant_with_hb & ((1u << shift) - 1u));
+            if (discarded != 0u) {
+                mant_exp_adjusted_pre |= 1u;
+            }
+            // input_width is 23, not 24: mant_with_hb is the significand scaled by
+            // 2^23 (value = mant_with_hb / 2^23), so it carries 23 fraction bits --
+            // the same fixed-point scale the normal path passes as 23 above. The
+            // right-shift by `shift` changes the value, not the number of fraction
+            // bits. Passing 24 would round off one extra bit and encode every
+            // subnormal element a binade too small (halved), collapsing the
+            // smallest subnormal to zero. Matches the tt-llk golden
+            // _quantize_fp4_storage_model, which applies the same rounder with
+            // shift_out hard-coded to 23 - mant_width in its subnormal branch.
+            auto [mant_round_sub, exp_inc_sub] = round_ties_even(mant_exp_adjusted_pre, mant_width, 23);
             mant_exp_adjusted = mant_round_sub;
             elem_exp_unbiased_adj =
                 -params.elem_exp_bias + params.elem_exp_subnorm_encoding + static_cast<int>(exp_inc_sub);
@@ -230,31 +253,38 @@ inline uint32_t convert_to_mxfp_elem_bits(float datum, const FormatParams& param
             mant_exp_adjusted = params.elem_man_max;
         }
 
-        elem_exp_biased = static_cast<uint32_t>(elem_exp_unbiased_adj + params.elem_exp_bias);
+        elem_exp_biased = static_cast<std::uint32_t>(elem_exp_unbiased_adj + params.elem_exp_bias);
     } else {
         mant_exp_adjusted = 0;
         elem_exp_biased = 0;
     }
 
-    uint32_t elem_bits = (elem_exp_biased << params.elem_man_bits) | (mant_exp_adjusted & params.elem_man_max);
+    // Mask with the full mantissa field width, not elem_man_max: the latter is the
+    // largest *usable* mantissa at the top exponent, which for E4M3FN is 0x6 because
+    // S.1111.111 is reserved for NaN. Using it as a field mask would clear mantissa
+    // bit 0 of every E4M3 element, not just the saturating ones (every odd mantissa
+    // would decode one step too small). Saturation is already clamped above.
+    std::uint32_t elem_man_field_mask = (1u << params.elem_man_bits) - 1u;
+    std::uint32_t elem_bits = (elem_exp_biased << params.elem_man_bits) | (mant_exp_adjusted & elem_man_field_mask);
     if (sign) {
-        elem_bits |= static_cast<uint32_t>(1u << (params.elem_man_bits + params.elem_exp_bits));
+        elem_bits |= static_cast<std::uint32_t>(1u << (params.elem_man_bits + params.elem_exp_bits));
     }
     return elem_bits;
 }
 
-inline float convert_from_mxfp_elem_bits(uint32_t elem_bits, uint8_t scale_exp_biased, const FormatParams& params) {
+inline float convert_from_mxfp_elem_bits(
+    std::uint32_t elem_bits, std::uint8_t scale_exp_biased, const FormatParams& params) {
     if (scale_exp_biased == 0xFF) {
         return std::numeric_limits<float>::quiet_NaN();
     }
 
-    uint32_t elem_man_mask = (1u << params.elem_man_bits) - 1u;
-    uint32_t elem_man = elem_bits & elem_man_mask;
-    uint32_t sign_bit = elem_bits >> (params.elem_man_bits + params.elem_exp_bits);
-    uint32_t elem_exp_biased = (elem_bits >> params.elem_man_bits) & ((1u << params.elem_exp_bits) - 1u);
+    std::uint32_t elem_man_mask = (1u << params.elem_man_bits) - 1u;
+    std::uint32_t elem_man = elem_bits & elem_man_mask;
+    std::uint32_t sign_bit = elem_bits >> (params.elem_man_bits + params.elem_exp_bits);
+    std::uint32_t elem_exp_biased = (elem_bits >> params.elem_man_bits) & ((1u << params.elem_exp_bits) - 1u);
 
-    uint32_t exp_all_ones = (params.elem_exp_bits == 0) ? 0 : ((1u << params.elem_exp_bits) - 1u);
-    uint32_t man_all_ones = elem_man_mask;
+    std::uint32_t exp_all_ones = (params.elem_exp_bits == 0) ? 0 : ((1u << params.elem_exp_bits) - 1u);
+    std::uint32_t man_all_ones = elem_man_mask;
 
     if (params.inf_rep == InfNanRepresentation::ExpAllOnesManZero) {
         if (elem_exp_biased == exp_all_ones && elem_man == 0) {
@@ -272,9 +302,9 @@ inline float convert_from_mxfp_elem_bits(uint32_t elem_bits, uint8_t scale_exp_b
         }
     }
 
-    uint32_t elem_man_one = 1u << params.elem_man_bits;
-    bool include_hidden_bit = (elem_exp_biased == static_cast<uint32_t>(params.elem_exp_subnorm_encoding));
-    uint32_t elem_man_with_int_bit = include_hidden_bit ? elem_man : (elem_man | elem_man_one);
+    std::uint32_t elem_man_one = 1u << params.elem_man_bits;
+    bool include_hidden_bit = (elem_exp_biased == static_cast<std::uint32_t>(params.elem_exp_subnorm_encoding));
+    std::uint32_t elem_man_with_int_bit = include_hidden_bit ? elem_man : (elem_man | elem_man_one);
 
     int elem_exp_unbiased = 0;
     if (!(elem_exp_biased == 0 && elem_man_with_int_bit == 0)) {
@@ -282,7 +312,7 @@ inline float convert_from_mxfp_elem_bits(uint32_t elem_bits, uint8_t scale_exp_b
     }
 
     float sign_f = (sign_bit != 0) ? -1.0f : 1.0f;
-    float exp_f = (elem_exp_biased != static_cast<uint32_t>(params.elem_exp_subnorm_encoding))
+    float exp_f = (elem_exp_biased != static_cast<std::uint32_t>(params.elem_exp_subnorm_encoding))
                       ? pow2_f32(elem_exp_unbiased)
                       : pow2_f32(params.elem_exp_min_unbiased);
     float man_f = static_cast<float>(elem_man_with_int_bit) / static_cast<float>(elem_man_one);
@@ -320,14 +350,15 @@ inline float rint_ties_even(float x) {
 //   - +/-Inf element -> saturate to +/-elem_int_max
 //   - otherwise int = clamp(rint_ties_even(scaled * elem_int_scale), +/-elem_int_max)
 // `scaled` is the input value already divided by the block scale (2^shared_exp).
-inline uint32_t convert_to_mxint_elem_bits(float scaled, const FormatParams& params) {
-    const uint32_t elem_mask = (params.elem_width_bits >= 32) ? 0xFFFFFFFFu : ((1u << params.elem_width_bits) - 1u);
+inline std::uint32_t convert_to_mxint_elem_bits(float scaled, const FormatParams& params) {
+    const std::uint32_t elem_mask =
+        (params.elem_width_bits >= 32) ? 0xFFFFFFFFu : ((1u << params.elem_width_bits) - 1u);
     const int elem_max = params.elem_int_max;
 
-    uint32_t bits = std::bit_cast<uint32_t>(scaled);
-    uint32_t abs_bits = bits & 0x7FFFFFFFu;
-    uint32_t exp_field = abs_bits >> 23;
-    uint32_t mant_field = abs_bits & 0x7FFFFFu;
+    std::uint32_t bits = std::bit_cast<std::uint32_t>(scaled);
+    std::uint32_t abs_bits = bits & 0x7FFFFFFFu;
+    std::uint32_t exp_field = abs_bits >> 23;
+    std::uint32_t mant_field = abs_bits & 0x7FFFFFu;
     bool is_nan = (exp_field == 0xFFu) && (mant_field != 0);
     bool is_inf = (exp_field == 0xFFu) && (mant_field == 0);
 
@@ -347,7 +378,7 @@ inline uint32_t convert_to_mxint_elem_bits(float scaled, const FormatParams& par
         }
     }
 
-    return static_cast<uint32_t>(int_val) & elem_mask;
+    return static_cast<std::uint32_t>(int_val) & elem_mask;
 }
 
 // Decode a single MxInt element field (width `params.elem_width_bits`, two's
@@ -356,9 +387,9 @@ inline uint32_t convert_to_mxint_elem_bits(float scaled, const FormatParams& par
 // 2^(scale-bias). Unlike the floating-point decoder this takes no scale byte:
 // the NaN block scale (0xFF) is handled by the caller (zeros the block), so a
 // 0 * 2^(0xFF-bias) = 0 * inf = NaN trap never reaches here.
-inline float convert_from_mxint_elem_bits(uint32_t elem_bits, const FormatParams& params) {
-    const uint32_t width = params.elem_width_bits;
-    const uint32_t sign_bit = 1u << (width - 1);
+inline float convert_from_mxint_elem_bits(std::uint32_t elem_bits, const FormatParams& params) {
+    const std::uint32_t width = params.elem_width_bits;
+    const std::uint32_t sign_bit = 1u << (width - 1);
     int int_val = static_cast<int>(elem_bits & ((1u << width) - 1u));
     if (elem_bits & sign_bit) {
         int_val -= static_cast<int>(1u << width);  // sign-extend two's complement


### PR DESCRIPTION
### Summary
Three defects in `convert_to_mxfp_elem_bits`
(`tt_metal/impl/data_format/mx_common.hpp`), the host-side float -> MX element
quantizer. All five MX floating-point formats are affected. They share one
reproduction, so they are reported together; happy to split if preferred.

Affected public APIs — everything routing through `pack_as_mx_tiles_impl`:
`pack_as_mxfp4_tiles`, `pack_as_mxfp6r_tiles`, `pack_as_mxfp6p_tiles`,
`pack_as_mxfp8_e5m2_tiles`, `pack_as_mxfp8_e4m3_tiles`. The MxInt formats use a
separate path and are not affected.

Issue: https://github.com/tenstorrent/tt-metal/issues/51971

Decoding every representable element encoding and re-encoding it does not return
the original code:

```
MXFP4  (E2M1) :   2 / 16  codes fail to round-trip
MXFP6R (E3M2) :   6 / 64  codes fail to round-trip
MXFP6P (E2M3) :  14 / 64  codes fail to round-trip
MXFP8  (E5M2) :   6 / 256 codes fail to round-trip
MXFP8  (E4M3) : 132 / 256 codes fail to round-trip

MXFP4 0.25000006 -> 0x0 = 0   (expected 0x1 = 0.5)
```

Three distinct root causes:

**1. https://github.com/tenstorrent/tt-metal/blob/7307161406c7ce4f40f02ddef7584ede9b525ce8/tt_metal/impl/data_format/mx_common.hpp#L221 — subnormal branch rounds at the wrong bit position.**
`round_ties_even(mant_exp_adjusted_pre, mant_width, 24)` passes `input_width = 24`,
but `mant_with_hb = fp32_mant | (1u << 23)` carries 23 fraction bits (its value is
`mant_with_hb / 2^23`) — exactly what the normal path two lines above passes as
`23`. The extra bit halves the result: **every subnormal element is encoded one
binade too small, and the smallest subnormal collapses to zero.**
Sample: MXFP4 `0.5 -> 0`; MXFP6P `0.5 -> 0.25`, `0.875 -> 0.5`;
MXFP6R `0.125 -> 0.0625`; MXFP8 E5M2 `2^-16 -> 0`.

**2. https://github.com/tenstorrent/tt-metal/blob/7307161406c7ce4f40f02ddef7584ede9b525ce8/tt_metal/impl/data_format/mx_common.hpp#L239 — `elem_man_max` used as the mantissa field mask.**
`elem_man_max` is the largest *usable* mantissa at the top exponent, not the field
width. For every format except E4M3 the two coincide, so this looks correct — but
`kMxFp8E4M3Params` sets `.elem_man_max = 0x6` because `S.1111.111` is reserved for
NaN in E4M3FN. `0x6 == 0b110`, so **mantissa bit 0 of every E4M3 element is
cleared**, not just saturating ones: `9 -> 8`, `1.875 -> 1.75`, `240 -> 224`,
`0.140625 -> 0.125`. This spans the entire normal range, not just subnormals, and
fixing defect 1 alone still leaves 126/256 codes wrong.

**3. https://github.com/tenstorrent/tt-metal/blob/7307161406c7ce4f40f02ddef7584ede9b525ce8/tt_metal/impl/data_format/mx_common.hpp#L220 — truncating pre-shift drops sticky bits.**
`mant_with_hb >> shift` discards the shifted-out bits before the rounder runs, so a
value just above a rounding midpoint is indistinguishable from an exact tie and
rounds to even instead of away from zero: MXFP4 `0.25000006` (one fp32 ULP above the
0.25 midpoint) encodes to 0 rather than 0.5.

### Expected

Every representable encoding round-trips, and the quantizer implements the OCP MX
spec's round-to-nearest-even:

```
MXFP4  (E2M1) : 0 / 16  codes fail to round-trip
MXFP6R (E3M2) : 0 / 64  codes fail to round-trip
MXFP6P (E2M3) : 0 / 64  codes fail to round-trip
MXFP8  (E5M2) : 0 / 256 codes fail to round-trip
MXFP8  (E4M3) : 0 / 256 codes fail to round-trip

MXFP4 0.25000006 -> 0x1 = 0.5   (expected 0x1 = 0.5)
```

Fixes (all three verified, see Frequency for measured effect):

```cpp
// 1. mx_common.hpp:221 — 24 -> 23
auto [mant_round_sub, exp_inc_sub] = round_ties_even(mant_exp_adjusted_pre, mant_width, 23);

// 2. mx_common.hpp:239 — mask with the field width, not elem_man_max
uint32_t elem_man_field_mask = (1u << params.elem_man_bits) - 1u;
uint32_t elem_bits = (elem_exp_biased << params.elem_man_bits) | (mant_exp_adjusted & elem_man_field_mask);

// 3. mx_common.hpp:220 — fold the dropped bits into a sticky bit
const uint32_t discarded = (shift >= 32) ? mant_with_hb : (mant_with_hb & ((1u << shift) - 1u));
if (discarded != 0u) { mant_exp_adjusted_pre |= 1u; }
```

Verified these preserve the reserved E4M3 encodings: NaN -> `0x7F`, `+/-Inf` and
overflow saturate to `0x7E`/`0xFE`, max normal 448 -> `0x7E`.

Note on the reference for defect 3: this is the *host* packer, converting user fp32
into MX to send to the device. Both in-tree call sites
(https://github.com/tenstorrent/tt-metal/blob/7307161406c7ce4f40f02ddef7584ede9b525ce8/tests/tt_metal/tt_metal/llk/test_reduce.cpp#L548,
https://github.com/tenstorrent/tt-metal/blob/7307161406c7ce4f40f02ddef7584ede9b525ce8/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp#L280) pack the
input, write it, then unpack to recover exactly what the device received and build
the golden from that. No hardware performs this conversion and nothing bit-compares
its output against device-produced MX, so the reference is the OCP MX spec's RNE.
tt-llk's https://github.com/tenstorrent/tt-metal/blob/7307161406c7ce4f40f02ddef7584ede9b525ce8/tt_metal/tt-llk/tests/python_tests/helpers/pack.py#L701 omits the same sticky bit,
but that model targets the *hardware* packer (device MX output) — the opposite
direction. It is also not self-consistent on this point: only MXFP4 uses that
hand-written model, while `pack_mxfp8r` / `pack_mxfp8p` use `ml_dtypes` (true RNE).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=uvelimirovic/fix_mx_float_encoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:uvelimirovic/fix_mx_float_encoder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=uvelimirovic/fix_mx_float_encoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:uvelimirovic/fix_mx_float_encoder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=uvelimirovic/fix_mx_float_encoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:uvelimirovic/fix_mx_float_encoder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=uvelimirovic/fix_mx_float_encoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:uvelimirovic/fix_mx_float_encoder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=uvelimirovic/fix_mx_float_encoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:uvelimirovic/fix_mx_float_encoder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=uvelimirovic/fix_mx_float_encoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:uvelimirovic/fix_mx_float_encoder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=uvelimirovic/fix_mx_float_encoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:uvelimirovic/fix_mx_float_encoder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=uvelimirovic/fix_mx_float_encoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:uvelimirovic/fix_mx_float_encoder)