### PR TITLE
fix(sfpu): Bug fix - softsign returns 0 instead of ±1 for large magnitudes

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -198,6 +198,33 @@ def test_softsign(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.softsign)
 
 
+# softsign(x) = x / (1 + |x|) saturates to +-1 as |x| grows. The kernel evaluates it as
+# v * (1 / (1 + |v|)), and that reciprocal is the intermediate that underflows: once it
+# falls below the smallest normal it is flushed to zero and the product collapses to 0 --
+# the opposite end of the range from the correct answer.
+#
+# run_activation_unary_test draws from a standard normal, so the existing coverage never
+# reaches the affected magnitudes; the first failing input is around 1.06e38.
+@pytest.mark.parametrize(
+    "magnitude",
+    [2.0**120, 2.0**125, 2.0**126, 2.0**127, 3.3895313892515355e38],  # last = largest finite bfloat16
+)
+@pytest.mark.parametrize("sign", [1.0, -1.0])
+def test_softsign_large_magnitude(device, magnitude, sign):
+    torch_input_tensor = torch.full((32, 32), sign * magnitude, dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn.softsign)
+    torch_output_tensor = golden_function(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.softsign(input_tensor)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor))
+
+    # The expected value is exactly +-1, so no tolerance is needed to state the contract:
+    # the magnitude must not collapse towards zero.
+    assert torch.all(output_tensor == torch_output_tensor)
+
+
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_swish(device, h, w):

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
@@ -17,7 +17,22 @@ inline void calculate_softsign() {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat tmp = sfpi::abs(v) + 1.0f;
         tmp = sfpu_reciprocal<APPROXIMATION_MODE>(tmp);
-        sfpi::dst_reg[0] = v * tmp;
+        sfpi::vFloat result = v * tmp;
+
+        // 1/(1+|v|) is the intermediate that underflows. Once it drops below the smallest
+        // normal it is flushed to zero and v * tmp collapses to 0 -- the opposite end of
+        // softsign's range, where the exact result is +-1. ckernel_sfpu_gelu.h names the
+        // same hazard ("Fused multiply avoids intermediate underflow") and restructures to
+        // avoid it; softsign has no equivalent fused form, so guard the saturated region
+        // instead. For |v| >= 2**26 the exact value of v/(1+|v|) already rounds to +-1.0f
+        // in float32, so this is an exact substitution rather than a clamp. Non-finite
+        // inputs skip the guard and keep their current behaviour.
+        v_if(sfpi::is_finite(v) && sfpi::abs(v) >= 0x1.0p26f) {
+            result = sfpi::copysgn(sfpi::vFloat(1.0f), v);
+        }
+        v_endif;
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
@@ -17,7 +17,22 @@ inline void calculate_softsign() {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat tmp = sfpi::abs(v) + 1.0f;
         tmp = sfpu_reciprocal<APPROXIMATION_MODE>(tmp);
-        sfpi::dst_reg[0] = v * tmp;
+        sfpi::vFloat result = v * tmp;
+
+        // 1/(1+|v|) is the intermediate that underflows. Once it drops below the smallest
+        // normal it is flushed to zero and v * tmp collapses to 0 -- the opposite end of
+        // softsign's range, where the exact result is +-1. ckernel_sfpu_gelu.h names the
+        // same hazard ("Fused multiply avoids intermediate underflow") and restructures to
+        // avoid it; softsign has no equivalent fused form, so guard the saturated region
+        // instead. For |v| >= 2**26 the exact value of v/(1+|v|) already rounds to +-1.0f
+        // in float32, so this is an exact substitution rather than a clamp. Non-finite
+        // inputs skip the guard and keep their current behaviour.
+        v_if(sfpi::is_finite(v) && sfpi::abs(v) >= 0x1.0p26f) {
+            result = sfpi::copysgn(sfpi::vFloat(1.0f), v);
+        }
+        v_endif;
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`calculate_softsign()` evaluates `x / (1 + |x|)` as `v * (1 / (1 + |v|))`:

```cpp
sfpi::vFloat v = sfpi::dst_reg[0];
sfpi::vFloat tmp = sfpi::abs(v) + 1.0f;
tmp = sfpu_reciprocal<APPROXIMATION_MODE>(tmp);
sfpi::dst_reg[0] = v * tmp;
```

The reciprocal is the intermediate that underflows. Once `1 / (1 + |v|)` falls below the smallest
normal it is flushed to zero, and the product collapses to `0` — the opposite end of softsign's
range from the correct answer, which is `±1` in that region.

Measured on ttsim, comparing against the registered golden (`torch.nn.functional.softsign`):

| input | Wormhole | Blackhole | golden |
|---:|---:|---:|---:|
| `8.507e37` (`2^126`) | 1.0 | **0.0** | 1.0 |
| `1.063e38` (`1.25·2^126`) | **0.0** | **0.0** | 1.0 |
| `1.701e38` (`2^127`) | **0.0** | **0.0** | 1.0 |
| `3.390e38` (largest finite bf16) | **0.0** | **0.0** | 1.0 |

Both signs behave identically. Wormhole loses the value from about `1.06e38`, Blackhole one binade
earlier at `8.51e37`; the difference is the reciprocal's flush threshold on each architecture.

`run_activation_unary_test` draws inputs from a standard normal, so the existing coverage never
reaches these magnitudes — which is why this has not shown up.

### Notes for reviewers

**The change.** `ckernel_sfpu_gelu.h` names this exact hazard — *"Fused multiply avoids intermediate
underflow"*, with the accompanying note that `exp(t)` alone may underflow while `x * exp(t)` may not —
and restructures its computation to avoid materialising the underflowing term. softsign has no
equivalent fused form available, so this guards the saturated region instead:

```cpp
v_if(sfpi::is_finite(v) && sfpi::abs(v) >= 0x1.0p26f) {
    result = sfpi::copysgn(sfpi::vFloat(1.0f), v);
}
v_endif;
```

For `|v| >= 2^26` the exact value of `v / (1 + |v|)` already rounds to `±1.0f` in float32
(`1 / (1 + 2^26) < 2^-26`, well inside half a ULP of 1.0), so within the guarded region this is an
exact substitution and not a clamp.

One thing I would rather state than have you find: the guard is not bit-identical below the failing
band either. Sweeping `[2^26, 2^126)` with five mantissa values per binade, 200 points, both signs,
40 of them currently return `0.9960938` where the golden is `1.0`. That is `1 - 2^-8`, the next
representable bfloat16 below `1.0`, one step away — a bit-level fact, not a tolerance measurement.
It arises because the reciprocal carries about that much error while `1 + |v|` already equals `|v|`
at those magnitudes. The guard returns `1.0` there: closer to the golden, and well inside the
threshold `tests/ttnn/utils_for_testing.py::assert_with_ulp` applies in the activation tests. It is
still a change, and I would rather you heard it from me.

**Two-way verification**, run on ttsim against the real kernel, both architectures:

| | Wormhole | Blackhole |
|---|---|---|
| defect assertion — failing band must match golden | current **FAIL** → patched **PASS** | current **FAIL** → patched **PASS** |
| regression — ordinary values unchanged (ULP ≤ 2, same tolerance as `run_activation_unary_test`) | PASS both | PASS both |
| non-finite inputs unchanged | PASS both | PASS both |

**Cost, measured — this is the part worth arguing about.** The kernel body carries
`#pragma GCC unroll 8`, so the guard is paid eight times per invocation:

```
Wormhole, kernels/eltwise_sfpu trisc1.elf
  current   .text 1048    262 instructions
  patched   .text 1292    323 instructions      (+61, +23%)
```

That is roughly 7–8 SFPU instructions per element for a correctness case that only bites above
`8.5e37`. If that trade is not acceptable, there are cheaper variants — dropping the `is_finite`
term, or testing the already-computed reciprocal against zero rather than testing `|v|` — and I am
happy to measure whichever shape you prefer. I did not pick one unilaterally because the right
answer depends on how you weigh this path.

**Explicitly out of scope.** Non-finite inputs are left exactly as they are: `softsign(±inf)`
currently returns `inf`/`-inf` on Wormhole and `inf`/`inf` on Blackhole, while the golden gives
`nan`. That is a separate pre-existing deviation and this PR does not touch it — the `is_finite`
term in the guard is there specifically to keep that behaviour unchanged.

**On measurement.** I do not have Tenstorrent hardware. Everything above is ttsim, using the
repository's own release image with the patched header mounted in, so the numbers come from the real
kernel rather than a model of it. The included test has not been run on a device — CI is its first
real execution.

---

*Disclosure: the analysis behind this change and a first draft of the patch were produced with AI
assistance. I have personally reviewed and understand the change, ran the verification myself, and
take responsibility for it. Nothing here rests on taking my word for it — the test included in this
PR fails on current `main`. I will answer review questions here.*