### PR TITLE
Preallocate vector capacity and move vectors into structured return values

### DIFF
--- a/tt-train/sources/examples/rng_simd/main.cpp
+++ b/tt-train/sources/examples/rng_simd/main.cpp
@@ -214,6 +214,7 @@ void benchmark_distribution(
     uint32_t seed = 42;
 
     std::vector<BenchmarkResult> results;
+    results.reserve(4);
 
     auto func_seq = [&](std::vector<T>& data) { ttml::core::sequential_generate(std::span{data}, dist_factory, seed); };
     results.push_back(run_benchmark<T>("MT19937 (Sequential)", type_name, params.name, func_seq, size));

--- a/tt-train/sources/ttml/datasets/dataset_base.hpp
+++ b/tt-train/sources/ttml/datasets/dataset_base.hpp
@@ -34,6 +34,7 @@ public:
 
     [[nodiscard]] std::vector<Sample> get_batch(std::span<size_t> indices) const {
         std::vector<Sample> batch;
+        batch.reserve(indices.size());
         [[maybe_unused]] auto size = get_size();
         for (size_t index : indices) {
             assert(index < size);

--- a/tt-train/sources/ttml/datasets/utils.hpp
+++ b/tt-train/sources/ttml/datasets/utils.hpp
@@ -45,6 +45,7 @@ std::vector<DatasetSubset<DatasetType>> random_split(
 
     // Create the subsets
     std::vector<DatasetSubset<DatasetType>> subsets;
+    subsets.reserve(split_sizes.size());
     auto current_iter = indices.begin();
     for (size_t size : split_sizes) {
         std::vector<size_t> subset_indices(current_iter, current_iter + (long)size);

--- a/tt-train/sources/ttml/models/llama.cpp
+++ b/tt-train/sources/ttml/models/llama.cpp
@@ -647,6 +647,7 @@ void load_model_from_safetensors(
 
     // Report unused parameters
     std::vector<std::string> unused_parameters;
+    unused_parameters.reserve(parameters.size());
     for (const auto& [param_name, _] : parameters) {
         if (used_parameters.find(param_name) == used_parameters.end())
             unused_parameters.push_back(param_name);

--- a/tt-train/sources/ttml/nanobind/nb_util.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_util.cpp
@@ -488,6 +488,7 @@ ttnn::Tensor make_metal_tensor(
     nb::object shape_obj = numpy_data_obj.attr("shape");
     nb::tuple shape_tuple = nb::cast<nb::tuple>(shape_obj);
     std::vector<size_t> shape_from_python;
+    shape_from_python.reserve(rank);
     for (size_t i = 0; i < rank; ++i) {
         shape_from_python.push_back(nb::cast<size_t>(shape_tuple[i]));
     }

--- a/tt-train/sources/ttml/ops/newton_schulz_op.cpp
+++ b/tt-train/sources/ttml/ops/newton_schulz_op.cpp
@@ -39,6 +39,7 @@ ttnn::Tensor newtonschulz(const ttnn::Tensor& G, int steps, float eps, float a, 
     // Preallocate buffers: square shape [batch..., m_eff, m_eff] and X shape [batch..., m_eff, n_eff]
     const auto rank = shape.rank();
     std::vector<uint32_t> mm_dims;
+    mm_dims.reserve(rank);
     for (uint32_t i = 0; i < rank; ++i) {
         mm_dims.push_back(shape[i]);
     }

--- a/tt-train/sources/ttml/tokenizers/char_tokenizer.cpp
+++ b/tt-train/sources/ttml/tokenizers/char_tokenizer.cpp
@@ -17,6 +17,7 @@ CharTokenizer::CharTokenizer(Vocabulary vocabulary) : m_vocabulary(std::move(voc
 
 std::vector<uint32_t> CharTokenizer::encode(const std::string& text) const {
     std::vector<uint32_t> tokens;
+    tokens.reserve(text.size());
     for (char chr : text) {
         auto chr_str = std::string(1, chr);
         auto it = m_vocabulary.find(chr_str);

--- a/tt-train/sources/ttml/utils/memory_utils.cpp
+++ b/tt-train/sources/ttml/utils/memory_utils.cpp
@@ -76,6 +76,7 @@ DRAMUsage get_dram_usage(const std::string& name) {
 
 std::vector<std::pair<std::string, DRAMUsage>> get_dram_usage_all() {
     std::vector<std::pair<std::string, DRAMUsage>> result;
+    result.reserve(trace_order.size());
     for (const auto& name : trace_order) {
         result.push_back(std::make_pair(name, get_dram_usage(name)));
     }
@@ -92,6 +93,7 @@ L1UsagePerCore get_l1_usage(const std::string& name) {
 
 std::vector<std::pair<std::string, L1UsagePerCore>> get_l1_usage_all() {
     std::vector<std::pair<std::string, L1UsagePerCore>> result;
+    result.reserve(trace_order.size());
     for (const auto& name : trace_order) {
         result.push_back(std::make_pair(name, get_l1_usage(name)));
     }

--- a/tt-train/tests/benchmark/gram_matmul_benchmark.cpp
+++ b/tt-train/tests/benchmark/gram_matmul_benchmark.cpp
@@ -76,6 +76,7 @@ void BM_GramMatmul(benchmark::State& state) {
         double gram_tf, minimal_tf, ttnn_tf;
     };
     std::vector<Result> results;
+    results.reserve(shapes.size());
 
     for (const auto& s : shapes) {
         const uint32_t seed = static_cast<uint32_t>(std::hash<std::string>{}(s.name));

--- a/tt-train/tests/benchmark/matmuls_benchmark.cpp
+++ b/tt-train/tests/benchmark/matmuls_benchmark.cpp
@@ -256,6 +256,7 @@ void BM_TTTrainMatmulComparison(benchmark::State& state) {
     device->enable_program_cache();
 
     std::vector<BenchmarkResult> results;
+    results.reserve(core_grid_configs.size());
 
     for ([[maybe_unused]] auto _ : state) {
         results.clear();

--- a/tt-train/tests/core/clip_grad_norm_test.cpp
+++ b/tt-train/tests/core/clip_grad_norm_test.cpp
@@ -34,6 +34,7 @@ TEST_F(ClipGradNormTest, ClipGradNorm_GENEROUS_TOLERANCE) {
     const uint32_t num_tensors = 3U;
     const uint32_t tensor_size = 4U;
     std::vector<autograd::TensorPtr> tensors;
+    tensors.reserve(num_tensors);
     std::vector<xt::xarray<float>> expected_grads = {
         {1.0F, 2.0F, 3.0F, 4.0F}, {-2.0F, -3.0F, -4.0F, 5.0F}, {0.5F, -1.5F, 2.5F, -3.5F}};
 

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -79,6 +79,7 @@ TYPED_TEST(TtmlFromVectorIntUintTest, ToFromTensorLargeWithBatch) {
     std::vector<scalar_t> test_data;
     uint32_t batch_size = 16;
     uint32_t vec_size = 256 * batch_size;
+    test_data.reserve(vec_size);
     for (size_t i = 0; i < vec_size; i++) {
         test_data.push_back(static_cast<scalar_t>(i));
     }
@@ -160,6 +161,7 @@ TYPED_TEST(TtmlFromVectorBf16Test, ToFromTensorLargeWithBatch) {
     std::vector<scalar_t> test_data;
     uint32_t batch_size = 16;
     uint32_t vec_size = 256 * batch_size;
+    test_data.reserve(vec_size);
     for (size_t i = 0; i < vec_size; i++) {
         test_data.push_back(static_cast<scalar_t>((float)i / 100.0F));
     }
@@ -183,6 +185,7 @@ TYPED_TEST(TtmlFromVectorBf16Test, ToFromTensorLarge) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<scalar_t> test_data;
     uint32_t vec_size = 1337;
+    test_data.reserve(vec_size);
     for (size_t i = 0; i < vec_size; i++) {
         test_data.push_back(static_cast<scalar_t>((float)i / 100.0F));
     }
@@ -302,6 +305,7 @@ TYPED_TEST(TtmlFromVectorBf16Test, VeryLargeTileLayout) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<scalar_t> test_data;
     uint32_t vec_size = 1048576;
+    test_data.reserve(vec_size);
     for (size_t i = 0; i < vec_size; i++) {
         test_data.push_back(0);
     }
@@ -336,6 +340,7 @@ TEST_F(TtmlFromVectorFloat32Test, TestFloat32ToFromTensorLarge) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data;
     uint32_t vec_size = 50304;
+    test_data.reserve(vec_size);
     for (size_t i = 0; i < vec_size; i++) {
         test_data.push_back(1.0005F);
     }
@@ -356,6 +361,7 @@ TEST_F(TtmlFromVectorFloat32Test, TestFloat32ToFromTensorLargeWithBatch) {
     std::vector<float> test_data;
     uint32_t batch_size = 256;
     uint32_t vec_size = 256 * batch_size;
+    test_data.reserve(vec_size);
     for (size_t i = 0; i < vec_size; i++) {
         test_data.push_back(i / 100.f);
     }

--- a/tt-train/tests/datasets/dataloader_test.cpp
+++ b/tt-train/tests/datasets/dataloader_test.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "datasets/in_memory_dataset.hpp"
@@ -112,12 +113,13 @@ TEST_F(DataLoaderTest, TestCollateFn) {
     // Custom collate function that sums all elements in the vectors and returns the sum as a new batch
     auto custom_collate_fn = [](const std::vector<std::pair<std::vector<float>, int>>& batch) {
         std::vector<std::pair<std::vector<float>, int>> collated_batch;
+        collated_batch.reserve(batch.size());
         for (const auto& sample : batch) {
             std::vector<float> summed_data(sample.first.size(), 0.0F);
             for (size_t i = 0; i < sample.first.size(); ++i) {
                 summed_data[i] += sample.first[i];
             }
-            collated_batch.emplace_back(summed_data, sample.second);
+            collated_batch.emplace_back(std::move(summed_data), sample.second);
         }
         return collated_batch;
     };

--- a/tt-train/tests/model/linear_regression_full_test.cpp
+++ b/tt-train/tests/model/linear_regression_full_test.cpp
@@ -38,6 +38,7 @@ TEST_F(LinearRegressionFullTest, TestLinearRegressionFull) {
     }
 
     std::vector<float> targets;
+    targets.reserve(batch_size);
     for (size_t i = 0; i < batch_size; ++i) {
         targets.push_back(static_cast<float>(i) * 0.1F);
     }

--- a/tt-train/tests/model/nano_gpt_test.cpp
+++ b/tt-train/tests/model/nano_gpt_test.cpp
@@ -264,7 +264,9 @@ void train_test(bool use_tensor_parallel = false, bool use_ddp = false) {
     };
 
     std::vector<double> steps_time;
+    steps_time.reserve(config.max_steps);
     std::vector<float> losses;
+    losses.reserve(config.max_steps);
 
     for (auto [features, target, masks] : train_dataloader) {
         auto start_timer = std::chrono::high_resolution_clock::now();

--- a/tt-train/tests/model/weight_tying_test.cpp
+++ b/tt-train/tests/model/weight_tying_test.cpp
@@ -103,6 +103,7 @@ TEST_F(WeightTyingTest, ModelFC) {
     }
 
     std::vector<float> targets;
+    targets.reserve(batch_size * output_features);
     for (size_t i = 0; i < batch_size; ++i) {
         for (int j = 0; j < output_features; ++j) {
             targets.push_back(static_cast<float>(i) * 0.1F);

--- a/tt-train/tests/optimizers/adamw_composite_test.cpp
+++ b/tt-train/tests/optimizers/adamw_composite_test.cpp
@@ -43,6 +43,7 @@ TEST_F(AdamWCompositeFullTest, AdamWCompositeTest) {
     }
 
     std::vector<float> targets;
+    targets.reserve(batch_size);
     for (size_t i = 0; i < batch_size; ++i) {
         targets.push_back(static_cast<float>(i) * 0.1F);
     }

--- a/tt-train/tests/optimizers/no_op_test.cpp
+++ b/tt-train/tests/optimizers/no_op_test.cpp
@@ -39,6 +39,7 @@ TEST_F(NoOpFullTest, NIGHTLY_NoOpTest) {
     }
 
     std::vector<float> targets;
+    targets.reserve(batch_size);
     for (size_t i = 0; i < batch_size; ++i) {
         targets.push_back(static_cast<float>(i) * 0.1F);
     }

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -199,6 +199,8 @@ std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
     uint32_t min_worker_y_physical = std::numeric_limits<uint32_t>::max();
     // For WH, rows are harvested. Track non-worker rows and non-worker columns (e.g. dispatch columns).
     if (arch == ARCH::WORMHOLE_B0) {
+        non_worker_rows.reserve(full_grid_size_y);
+        non_worker_cols.reserve(full_grid_size_x);
         for (int y_coord = 0; y_coord < full_grid_size_y; ++y_coord) {
             if (std::find(worker_phy_y.begin(), worker_phy_y.end(), y_coord) == worker_phy_y.end()) {
                 non_worker_rows.push_back(y_coord);
@@ -214,6 +216,7 @@ std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
     }
     std::vector<CoreCoord> dram_interface_workers;
     uint32_t num_dram_banks = dram_phy_coords.size();
+    dram_interface_workers.reserve(num_dram_banks);
     // Get the optimal dram -> worker configuration here.
     // For WH and BH, worker cores are placed to the right of the DRAM Controller.
     // Need to shift down if the row is a non-tensix row (0 or 6 on WH and 0 or 1 on BH)
@@ -264,6 +267,7 @@ std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
     if (arch == ARCH::BLACKHOLE) {
         // Reassign worker cores based on harvesting for BH.
         // Need to account for column harvesting here.
+        non_worker_cols.reserve(full_grid_size_x);
         for (int x_coord = 0; x_coord < full_grid_size_x; ++x_coord) {
             if (std::find(worker_phy_x.begin(), worker_phy_x.end(), x_coord) == worker_phy_x.end()) {
                 non_worker_cols.push_back(x_coord);

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -217,9 +217,11 @@ CoreRangeSet CoreRangeSet::merge(const T& other) const {
     }
 
     crs.clear();
+    std::vector<CoreRange> ranges;
+    ranges.reserve(max_x - min_x + 1);
     for (unsigned y = min_y; y <= max_y; y++) {
         std::set<CoreRange> filter_set, tmp, new_crs;
-        std::vector<CoreRange> ranges;
+        ranges.clear();
         for (unsigned x = min_x; x <= max_x + 1; x++) {
             if (grid[y][x]) {
                 unsigned x_start = x;
@@ -286,6 +288,9 @@ bool CoreRangeSet::intersects(const CoreRangeSet& other) const {
 
 CoreRangeSet CoreRangeSet::intersection(const CoreRangeSet& other) const {
     std::vector<CoreRange> intersection;
+    // Only estimate the likely result size: the Cartesian-product upper bound would over-allocate
+    // heavily for sparse or disjoint range sets.
+    intersection.reserve(std::max(this->ranges_.size(), other.ranges().size()));
     for (const auto& local_cr : this->ranges_) {
         for (const auto& other_cr : other.ranges()) {
             if (auto intersect = local_cr.intersection(other_cr); intersect.has_value()) {
@@ -420,12 +425,14 @@ CoreRangeSet CoreRangeSet::subtract(const CoreRangeSet& other) const {
     }
 
     std::vector<CoreRange> result_ranges;
+    result_ranges.reserve(this_merged.ranges_.size());
 
     for (const auto& current_range : this_merged.ranges_) {
         std::vector<CoreRange> current_remaining = {current_range};
 
         for (const auto& subtract_range : other_merged.ranges_) {
             std::vector<CoreRange> new_remaining;
+            new_remaining.reserve(current_remaining.size());
 
             for (const auto& remaining : current_remaining) {
                 auto intersection_opt = remaining.intersection(subtract_range);
@@ -466,7 +473,7 @@ CoreRangeSet CoreRangeSet::subtract(const CoreRangeSet& other) const {
                     new_remaining.push_back(top);
                 }
             }
-            current_remaining = new_remaining;
+            current_remaining = std::move(new_remaining);
         }
         result_ranges.insert(result_ranges.end(), current_remaining.begin(), current_remaining.end());
     }
@@ -624,10 +631,11 @@ CoreRangeSet select_from_corerangeset(
     const CoreRangeSet& crs, uint32_t start_index, uint32_t end_index, bool row_wise) {
     auto all_cores = corerange_to_cores(crs, end_index + 1, row_wise);
     std::vector<CoreRange> selected_cores;
+    selected_cores.reserve(end_index - start_index + 1);
     for (uint32_t i = start_index; i <= end_index; i++) {
         selected_cores.push_back(CoreRange(all_cores[i], all_cores[i]));
     }
-    return CoreRangeSet(selected_cores);
+    return CoreRangeSet(std::move(selected_cores));
 }
 std::optional<CoreRange> select_contiguous_range_from_corerangeset(const CoreRangeSet& crs, uint32_t x, uint32_t y) {
     for (const auto& core_range : crs.ranges()) {

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -40,6 +40,7 @@ std::vector<size_t> find_diff_dimensions(const MeshCoordinateRange& a, const Mes
     TT_ASSERT(a.dims() == b.dims(), "Cannot compare ranges with different dimensions: {} != {}", a.dims(), b.dims());
 
     std::vector<size_t> diff_dims;
+    diff_dims.reserve(a.dims());
     for (size_t i = 0; i < a.dims(); ++i) {
         if (a.start_coord()[i] != b.start_coord()[i] || a.end_coord()[i] != b.end_coord()[i]) {
             diff_dims.push_back(i);
@@ -634,6 +635,11 @@ MeshCoordinateRangeSet subtract(const MeshCoordinateRange& parent, const MeshCoo
 
 std::vector<MeshCoordinate> MeshCoordinateRangeSet::coords() const {
     std::vector<MeshCoordinate> coords;
+    size_t num_coords = 0;
+    for (const auto& range : ranges_) {
+        num_coords += range.shape().mesh_size();
+    }
+    coords.reserve(num_coords);
     for (const auto& range : ranges_) {
         for (const auto& coord : range) {
             coords.push_back(coord);

--- a/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
+++ b/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
@@ -304,6 +304,7 @@ ResolvedBlitzDecodePipelineAllocation build_pipeline_allocation_from_topology(bo
     // Collect ALL unclaimed nodes; the directly-connected pair may not be the first ones found.
     auto mesh_0_coord_range = mesh_graph.get_coord_range(mesh_ids[0]);
     std::vector<tt::tt_fabric::FabricNodeId> unclaimed_mesh_0_nodes;
+    unclaimed_mesh_0_nodes.reserve(mesh_0_coord_range.shape().mesh_size());
     for (const auto& coord : mesh_0_coord_range) {
         auto chip_id = mesh_graph.coordinate_to_chip(mesh_ids[0], coord);
         tt::tt_fabric::FabricNodeId fn(mesh_ids[0], chip_id);

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -1377,7 +1377,9 @@ void FDMeshCommandQueue::record_end() {
         // safe because allocate_trace_programs() reinitializes dispatch_metadata at the start of
         // each range's processing, overwriting any stale mutations from a previous range.
         std::vector<TraceNode*> trace_nodes;
+        trace_nodes.reserve(trace_nodes_.size());
         std::vector<MeshTraceNode*> mesh_trace_nodes;
+        mesh_trace_nodes.reserve(trace_nodes_.size());
         // Records the number of MeshTraceNodes that had no relevant program.
         struct UnusedNodeData {
             uint32_t unused_nodes_both_multicast_and_unicast = 0;

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -135,6 +135,7 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
         bool is_hybrid = mesh_allocator->get_config().allocator_mode == AllocatorMode::HYBRID;
         if (is_hybrid) {
             std::vector<AllocatorImpl*> device_allocators;
+            device_allocators.reserve(mesh_device->get_view().num_devices());
             for (auto* device : mesh_device->get_view().get_devices()) {
                 device_allocators.push_back(device->allocator_impl().get());
             }

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -306,6 +306,7 @@ void MeshCommandQueueBase::enqueue_write_with_core_filter(
     auto lock = lock_api_function_();
     // Iterate over global coordinates; skip host-remote coordinates, as per `host_buffer` configuration.
     std::vector<distributed::ShardDataTransfer> shard_data_transfers;
+    shard_data_transfers.reserve(host_buffer.shard_coords().size());
     for (const auto& host_buffer_coord : host_buffer.shard_coords()) {
         auto buf = host_buffer.get_shard(host_buffer_coord);
         if (buf.has_value()) {
@@ -373,11 +374,15 @@ void MeshCommandQueueBase::enqueue_read(
     bool blocking) {
     auto lock = lock_api_function_();
     std::vector<distributed::ShardDataTransfer> shard_data_transfers;
+    shard_data_transfers.reserve(buffer->device()->shape().mesh_size());
     // For non-blocking reads, capture a MemoryPin for each shard so the host
     // buffer stays alive until the async reader thread finishes the memcpy
     // (fixes use-after-free, issue #43638). For blocking reads finish_nolock()
     // ensures the copy is complete before we return, so no pin is needed.
     std::vector<MemoryPin> memory_pins;
+    if (!blocking) {
+        memory_pins.reserve(buffer->device()->shape().mesh_size());
+    }
     for (const auto& coord : MeshCoordinateRange(buffer->device()->shape())) {
         if (shards.has_value() && !shards->contains(coord)) {
             continue;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -367,13 +367,14 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
                     worker_l1_size,
                     dispatch_core_config,
                     context_id),
-                mapped_devices.fabric_node_ids,
+                std::move(mapped_devices.fabric_node_ids),
                 mapped_devices.mesh_shape);
         }  // Initialize fabric node ids manually.
         // TODO: #22087 - Remove this code path.
         std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
         TT_FATAL(config.mesh_shape().has_value(), "Mesh shape must be provided when physical device ids are supplied");
         const auto& supplied_ids = config.physical_device_ids();
+        fabric_node_ids.reserve(supplied_ids.size());
         for (int supplied_id : supplied_ids) {
             auto fabric_node_id = ctx.get_control_plane().get_fabric_node_id_from_physical_chip_id(supplied_id);
             TT_FATAL(
@@ -398,7 +399,7 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
                 worker_l1_size,
                 dispatch_core_config,
                 context_id),
-            fabric_node_ids,
+            std::move(fabric_node_ids),
             config.mesh_shape().value());
     }();
 
@@ -649,6 +650,8 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create_submesh(
     std::vector<MaybeRemote<IDevice*>> submesh_devices;
     std::vector<tt::tt_fabric::FabricNodeId> submesh_fabric_node_ids;
     const MeshCoordinateRange submesh_range(offset_coord, end_coordinate);
+    submesh_devices.reserve(submesh_range.shape().mesh_size());
+    submesh_fabric_node_ids.reserve(submesh_range.shape().mesh_size());
     for (const auto& coord : submesh_range) {
         if (view_->impl().is_local(coord)) {
             submesh_devices.push_back(MaybeRemote<IDevice*>::local(view_->impl().get_device(coord)));
@@ -717,6 +720,7 @@ std::vector<std::shared_ptr<MeshDevice>> MeshDeviceImpl::create_submeshes(
 
     // Stamp `submesh_shape` along each dimension, `steps` number of times.
     std::vector<std::shared_ptr<MeshDevice>> submeshes;
+    submeshes.reserve(MeshShape(steps).mesh_size());
     for (const auto& step_position : MeshCoordinateRange(MeshShape(steps))) {
         ttsl::SmallVector<uint32_t> offset_coords;
         for (size_t dim = 0; dim < submesh_shape.dims(); dim++) {

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -32,6 +32,7 @@ namespace {
 std::vector<IDevice*> get_devices_from_coordinates(
     const MeshDeviceViewImpl& mesh, const std::vector<MeshCoordinate>& coords) {
     std::vector<IDevice*> devices;
+    devices.reserve(coords.size());
     for (const auto& coord : coords) {
         if (auto* device = mesh.get_device(coord)) {
             devices.push_back(device);
@@ -92,6 +93,7 @@ MeshDeviceViewImpl::MeshDeviceViewImpl(
 
 std::vector<IDevice*> MeshDeviceViewImpl::get_devices(const MeshCoordinateRange& range) const {
     std::vector<IDevice*> devices_in_region;
+    devices_in_region.reserve(range.shape().mesh_size());
     for (const auto& coord : range) {
         devices_.at(coord).if_local([&devices_in_region](const auto& device) { devices_in_region.push_back(device); });
     }
@@ -257,6 +259,7 @@ std::vector<MeshCoordinate> MeshDeviceViewImpl::get_line_coordinates(
     // Lambda to get valid neighbors (not checking visited - that's done in DFS)
     auto get_neighbors = [&](const MeshCoordinate& coord) -> std::vector<MeshCoordinate> {
         std::vector<MeshCoordinate> neighbors;
+        neighbors.reserve(4);
         const size_t row = coord[0];
         const size_t col = coord[1];
 
@@ -356,6 +359,7 @@ std::vector<MeshCoordinate> MeshDeviceViewImpl::get_ring_coordinates(
     const auto end_col = ring_cols - 1;
 
     std::vector<MeshCoordinate> boundary_coords;
+    boundary_coords.reserve(2 * (ring_rows + ring_cols));
 
     // Traverse the top row from left to right
     for (size_t col = 0; col <= end_col; ++col) {

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -713,6 +713,7 @@ std::vector<multihost::Rank> get_ranks_for_mesh_id(
     const auto& global_logical_bindings =
         tt::tt_metal::MetalContext::instance().get_control_plane().get_global_logical_bindings();
     std::vector<multihost::Rank> ranks;
+    ranks.reserve(global_logical_bindings.size());
 
     for (const auto& [rank, mesh_id_and_host_rank] : global_logical_bindings) {
         if (std::get<0>(mesh_id_and_host_rank) == mesh_id && rank_translation_table.contains(rank)) {

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -1260,6 +1260,7 @@ void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samp
         uint64_t device_time;  // Device wall clock cycles
     };
     std::vector<SyncSample> samples;
+    samples.reserve(num_samples);
 
     // Discard pre-existing pages before sync (their PCIe-mapped bytes can be undefined on a fresh MeshDevice);
     // discard_pending_pages rebases bytes_acked and notifies the device.

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -171,6 +171,7 @@ void SDMeshCommandQueue::dispatch_program(const MeshCoordinateRange& coord_range
 
     // Collect local devices for this program, handling async idle checks
     std::vector<IDevice*> local_devices;
+    local_devices.reserve(coord_range.shape().mesh_size());
     for (const auto& coord : coord_range) {
         if (!mesh_device_->impl().is_local(coord)) {
             continue;

--- a/tt_metal/fabric/builder/connection_registry.cpp
+++ b/tt_metal/fabric/builder/connection_registry.cpp
@@ -19,6 +19,7 @@ std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_from_sou
     FabricNodeId source_node,
     RoutingDirection source_direction) const {
     std::vector<RouterConnectionRecord> result;
+    result.reserve(connections_.size());
     std::copy_if(
         connections_.begin(),
         connections_.end(),
@@ -33,6 +34,7 @@ std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_to_dest(
     FabricNodeId dest_node,
     RoutingDirection dest_direction) const {
     std::vector<RouterConnectionRecord> result;
+    result.reserve(connections_.size());
     std::copy_if(
         connections_.begin(),
         connections_.end(),
@@ -45,6 +47,7 @@ std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_to_dest(
 
 std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_by_type(ConnectionType type) const {
     std::vector<RouterConnectionRecord> result;
+    result.reserve(connections_.size());
     std::copy_if(
         connections_.begin(),
         connections_.end(),
@@ -57,6 +60,7 @@ std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_by_type(
 
 std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_by_source_node(FabricNodeId source_node) const {
     std::vector<RouterConnectionRecord> result;
+    result.reserve(connections_.size());
     std::copy_if(
         connections_.begin(),
         connections_.end(),
@@ -69,6 +73,7 @@ std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_by_sourc
 
 std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_by_dest_node(FabricNodeId dest_node) const {
     std::vector<RouterConnectionRecord> result;
+    result.reserve(connections_.size());
     std::copy_if(
         connections_.begin(),
         connections_.end(),

--- a/tt_metal/fabric/builder/fabric_builder_helpers.cpp
+++ b/tt_metal/fabric/builder/fabric_builder_helpers.cpp
@@ -62,6 +62,7 @@ std::vector<eth_chan_directions> get_all_other_directions(eth_chan_directions di
     }
 
     std::vector<eth_chan_directions> dirs;
+    dirs.reserve(all_directions.size());
     for (auto dir : all_directions) {
         if (dir != direction) {
             dirs.push_back(dir);

--- a/tt_metal/fabric/channel_trimming_export.cpp
+++ b/tt_metal/fabric/channel_trimming_export.cpp
@@ -94,6 +94,8 @@ void emit_sender_channels(
             << fmt::format("0x{:04X}", used_bitfield);
 
     emitter << YAML::Key << "sender_channels" << YAML::Value << YAML::BeginSeq;
+    std::vector<size_t> forwarded_from_vcs;
+    forwarded_from_vcs.reserve(builder_config::MAX_NUM_VCS);
     for (size_t ch = 0; ch < builder_config::num_max_sender_channels; ch++) {
         if (!(used_bitfield & (1u << ch))) {
             continue;
@@ -106,7 +108,7 @@ void emit_sender_channels(
                 << capture.sender_channel_max_packet_size_seen_bytes_by_vc[ch];
 
         // Collect VCs that forward to this sender channel
-        std::vector<size_t> forwarded_from_vcs;
+        forwarded_from_vcs.clear();
         for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; vc++) {
             if (capture.sender_channel_forwarded_to_bitfield_by_vc[vc] & (1u << ch)) {
                 forwarded_from_vcs.push_back(vc);

--- a/tt_metal/fabric/channel_trimming_import.cpp
+++ b/tt_metal/fabric/channel_trimming_import.cpp
@@ -245,6 +245,7 @@ ChannelTrimmingGlobalOverrides load_channel_trimming_global_overrides(const std:
         }
         if (vc_node["force_enable_sender_channels"]) {
             std::vector<size_t> indices;
+            indices.reserve(vc_node["force_enable_sender_channels"].size());
             for (const auto& idx_node : vc_node["force_enable_sender_channels"]) {
                 indices.push_back(idx_node.as<size_t>());
             }
@@ -252,6 +253,7 @@ ChannelTrimmingGlobalOverrides load_channel_trimming_global_overrides(const std:
         }
         if (vc_node["force_enable_receiver_channels"]) {
             std::vector<size_t> indices;
+            indices.reserve(vc_node["force_enable_receiver_channels"].size());
             for (const auto& idx_node : vc_node["force_enable_receiver_channels"]) {
                 indices.push_back(idx_node.as<size_t>());
             }

--- a/tt_metal/fabric/channel_trimming_io.cpp
+++ b/tt_metal/fabric/channel_trimming_io.cpp
@@ -30,6 +30,7 @@ uint16_t parse_hex_bitfield(const std::string& str) { return static_cast<uint16_
 
 std::vector<std::string> collect_map_keys(const YAML::Node& map_node) {
     std::vector<std::string> keys;
+    keys.reserve(map_node.size());
     for (auto it = map_node.begin(); it != map_node.end(); ++it) {
         if (it->first.IsScalar()) {
             keys.push_back(it->first.as<std::string>());

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -285,8 +285,10 @@ LocalMeshBinding ControlPlane::initialize_local_mesh_binding() {
         TT_FATAL(
             *ctx.size() == 1 && *ctx.rank() == 0,
             "Not specifying both TT_MESH_ID and TT_MESH_HOST_RANK is only supported for single host systems.");
+        const auto all_mesh_ids = this->mesh_graph_->get_all_mesh_ids();
         std::vector<MeshId> local_mesh_ids;
-        for (const auto& mesh_id : this->mesh_graph_->get_all_mesh_ids()) {
+        local_mesh_ids.reserve(all_mesh_ids.size());
+        for (const auto& mesh_id : all_mesh_ids) {
             // TODO: #24528 - Move this to use TopologyMapper once Topology mapper works for multi-mesh systems
             const auto& host_ranks = this->mesh_graph_->get_host_ranks(mesh_id);
             TT_FATAL(
@@ -365,6 +367,7 @@ void ControlPlane::initialize_distributed_contexts() {
             distributed_contexts_.emplace(local_mesh_id, host_local_context_);
         } else {
             std::vector<int> mpi_neighbors;
+            mpi_neighbors.reserve(mesh_host_ranks->second.size());
             // Sort mesh_host_ranks->second for deterministic iteration across hosts
             std::vector<std::pair<MeshHostRankId, tt::tt_metal::distributed::multihost::Rank>> sorted_host_ranks(
                 mesh_host_ranks->second.begin(), mesh_host_ranks->second.end());
@@ -1359,9 +1362,14 @@ std::pair<FabricNodeId, chan_id_t> ControlPlane::get_connected_mesh_chip_chan_id
 
 std::vector<chan_id_t> ControlPlane::get_valid_eth_chans_on_routing_plane(
     FabricNodeId fabric_node_id, routing_plane_id_t routing_plane_id) const {
+    const auto& eth_chans_by_direction = this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id);
+    size_t total_eth_chans = 0;
+    for (const auto& [direction, eth_chans] : eth_chans_by_direction) {
+        total_eth_chans += eth_chans.size();
+    }
     std::vector<chan_id_t> valid_eth_chans;
-    for (const auto& [direction, eth_chans] :
-         this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
+    valid_eth_chans.reserve(total_eth_chans);
+    for (const auto& [direction, eth_chans] : eth_chans_by_direction) {
         for (const auto& eth_chan : eth_chans) {
             if (this->get_routing_plane_id(eth_chan, eth_chans) == routing_plane_id) {
                 valid_eth_chans.push_back(eth_chan);
@@ -1543,6 +1551,7 @@ std::vector<chan_id_t> ControlPlane::get_forwarding_eth_chans_to_chip(
     std::vector<chan_id_t> forwarding_channels;
     const auto& active_channels =
         this->get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction);
+    forwarding_channels.reserve(active_channels.size());
     for (const auto& src_chan_id : active_channels) {
         // check for end-to-end route before accepting this channel
         if (this->get_fabric_route(src_fabric_node_id, dst_fabric_node_id, src_chan_id).empty()) {
@@ -2369,6 +2378,7 @@ std::vector<MeshId> ControlPlane::get_local_mesh_id_bindings() const {
     const auto& mesh_id_bindings = this->local_mesh_binding_.mesh_ids;
     const auto& user_mesh_ids = this->get_user_physical_mesh_ids();
     std::vector<MeshId> local_mesh_ids;
+    local_mesh_ids.reserve(mesh_id_bindings.size());
     for (const auto& mesh_id : mesh_id_bindings) {
         if (std::find(user_mesh_ids.begin(), user_mesh_ids.end(), mesh_id) != user_mesh_ids.end()) {
             local_mesh_ids.push_back(mesh_id);
@@ -2800,6 +2810,7 @@ std::vector<PortDescriptor> ControlPlane::gather_intermesh_cables_for_exit_nodes
     // and assigns the port_id on each side. This avoids the per-host greedy port exhaustion where a
     // host that processed a shared exit chip first could strand a later ring-closing boundary.
     std::vector<PortDescriptor> gathered_cables;
+    gathered_cables.reserve(exit_nodes.size());
     for (const auto& exit_node : exit_nodes) {
         FabricNodeId exit_node_fabric_node_id = this->get_fabric_node_id_from_asic_id(*exit_node.src_exit_node);
 
@@ -2846,8 +2857,10 @@ PortDescriptorTable ControlPlane::generate_port_descriptor_table() {
 
     // Iterate neighbors in a stable (neighbor mesh_id, hostname) order rather than get_host_neighbors()'s
     // hostname-keyed unordered_map order, so the gathered record order is host-independent.
+    const auto neighbor_hosts = physical_system_descriptor_->get_host_neighbors(my_host);
     std::vector<std::pair<MeshId, std::string>> sorted_neighbors;
-    for (const auto& neighbor_host : physical_system_descriptor_->get_host_neighbors(my_host)) {
+    sorted_neighbors.reserve(neighbor_hosts.size());
+    for (const auto& neighbor_host : neighbor_hosts) {
         auto neighbor_host_rank = physical_system_descriptor_->get_rank_for_hostname(neighbor_host);
         auto neighbor_rank = tt::tt_metal::distributed::multihost::Rank{static_cast<int>(neighbor_host_rank)};
         // Skip if neighbor host is not in our global logical bindings.
@@ -3924,6 +3937,7 @@ bool ControlPlane::is_local_host_on_switch_mesh() const {
 
     std::optional<MeshId> local_switch_mesh_id = std::nullopt;
     std::vector<MeshId> local_compute_mesh_ids;
+    local_compute_mesh_ids.reserve(local_mesh_ids.size());
     for (const auto& mesh_id : local_mesh_ids) {
         if (mesh_graph.is_switch_mesh(mesh_id)) {
             if (local_switch_mesh_id.has_value()) {
@@ -3952,6 +3966,7 @@ std::vector<ChipId> ControlPlane::get_switch_mesh_device_ids() const {
     for (const auto& mesh_id : local_mesh_ids) {
         if (mesh_graph.is_switch_mesh(mesh_id)) {
             const auto& chip_ids = mesh_graph.get_chip_ids(mesh_id);
+            switch_device_ids.reserve(switch_device_ids.size() + chip_ids.values().size());
             for (const auto& chip_id : chip_ids.values()) {
                 auto fabric_node_id = FabricNodeId(mesh_id, chip_id);
                 auto physical_chip_id = this->get_physical_chip_id_from_fabric_node_id(fabric_node_id);

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -283,6 +283,7 @@ std::vector<eth_chan_directions> get_neighbor_eth_directions(
     const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     std::vector<eth_chan_directions> directions;
+    directions.reserve(FabricContext::routing_directions.size());
     for (const auto& direction : FabricContext::routing_directions) {
         auto neighbors = control_plane.get_intra_chip_neighbors(src_fabric_node_id, direction);
         if (std::find(neighbors.begin(), neighbors.end(), dst_fabric_node_id.chip_id) != neighbors.end()) {
@@ -308,6 +309,7 @@ uint32_t append_routing_plane_connection_manager_rt_args(
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     std::vector<FabricNodeId> dst_nodes;
+    dst_nodes.reserve(attempted_directionss.size());
     std::unordered_set<RoutingDirection> used_directions;
     for (auto dir : attempted_directionss) {
         auto routing_direction = control_plane.eth_direction_to_routing_direction(dir);
@@ -657,6 +659,7 @@ std::vector<std::pair<std::string, std::string>> get_fabric_kernel_defines(tt::t
     const auto& fabric_context = control_plane.get_fabric_context();
 
     std::vector<std::pair<std::string, std::string>> defines;
+    defines.reserve(2);
     switch (api_type) {
         case tt::tt_fabric::FabricApiType::Linear: defines.push_back({"API_TYPE_Linear", "1"}); break;
         case tt::tt_fabric::FabricApiType::Mesh: defines.push_back({"API_TYPE_Mesh", "1"}); break;
@@ -696,6 +699,7 @@ std::vector<uint32_t> compute_fabric_connection_rt_args(
     const auto& fabric_context = control_plane.get_fabric_context();
 
     std::vector<uint32_t> worker_args;
+    worker_args.reserve(dst_nodes.size() * 4 + (fabric_context.is_2D_routing_enabled() ? 3 + dst_nodes.size() * 2 : 0));
 
     for (size_t i = 0; i < dst_nodes.size(); i++) {
         const auto& dst_node = dst_nodes[i];

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -169,6 +169,7 @@ std::vector<uint32_t> get_forwarding_link_indices_in_direction(
         control_plane.get_forwarding_eth_chans_to_chip(src_fabric_node_id, dst_fabric_node_id, direction);
 
     std::vector<uint32_t> link_indices;
+    link_indices.reserve(forwarding_channels.size());
     for (uint32_t i = 0; i < fabric_channels.size(); i++) {
         if (std::find(forwarding_channels.begin(), forwarding_channels.end(), fabric_channels[i]) !=
             forwarding_channels.end()) {
@@ -374,6 +375,7 @@ std::vector<std::filesystem::path> build_physical_grouping_descriptor_search_pat
     const std::string tt_metal_home = tt_metal_home_env != nullptr ? tt_metal_home_env : ".";
 
     std::vector<std::filesystem::path> search_paths;
+    search_paths.reserve(3);
     if (!cluster_name.empty()) {
         search_paths.push_back(
             std::filesystem::path("/data/scaleout_configs") / cluster_name /

--- a/tt_metal/fabric/fabric_router_channel_mapping.cpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.cpp
@@ -281,6 +281,12 @@ uint32_t FabricRouterChannelMapping::get_num_receiver_channels_for_vc(uint32_t v
 std::vector<InternalSenderChannelMapping> FabricRouterChannelMapping::get_all_sender_mappings() const {
     std::vector<InternalSenderChannelMapping> result;
 
+    uint32_t total_sender_channels = 0;
+    for (uint32_t vc = 0; vc < get_num_virtual_channels(); ++vc) {
+        total_sender_channels += get_num_sender_channels_for_vc(vc);
+    }
+    result.reserve(total_sender_channels);
+
     // Iterate through VCs in order and flatten
     for (uint32_t vc = 0; vc < get_num_virtual_channels(); ++vc) {
         for (uint32_t ch_idx = 0; ch_idx < get_num_sender_channels_for_vc(vc); ++ch_idx) {

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -74,7 +74,13 @@ void FabricTensixDatamoverConfig::find_min_max_eth_channels(const std::vector<tt
             active_fabric_eth_channels.insert({direction, active_eth_chans});
         }
 
+        size_t total_active_channels = 0;
+        for (const auto& [direction, eth_chans] : active_fabric_eth_channels) {
+            total_active_channels += eth_chans.size();
+        }
+
         std::vector<chan_id_t> non_dispatch_active_channels;
+        non_dispatch_active_channels.reserve(total_active_channels);
         std::set<routing_plane_id_t> non_dispatch_routing_planes;
         for (const auto& [direction, remote_fabric_node_id] : chip_neighbors) {
             dispatch_link_idx_ = tt_metal::RelayMux::get_dispatch_link_index(

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -276,6 +276,7 @@ void FabricTensixDatamoverBaseConfig::set_fabric_endpoint_status_address(size_t 
 
 std::vector<std::pair<size_t, size_t>> FabricTensixDatamoverBaseConfig::get_memory_regions_to_clear() const {
     std::vector<std::pair<size_t, size_t>> regions;
+    regions.reserve(1 + 3 * channel_configs_.size());
 
     // Always clear termination signal region
     regions.push_back({termination_signal_region_.get_address(), termination_signal_region_.get_total_size()});
@@ -431,6 +432,7 @@ std::vector<MuxConnectionInfo> FabricTensixDatamoverMuxConfig::get_all_mux_conne
     auto downstream_dirs = builder::get_all_other_directions(direction, /*exclude_z=*/true);
 
     std::vector<MuxConnectionInfo> mux_infos;
+    mux_infos.reserve(downstream_dirs.size());
 
     // Collect connection info for each downstream mux
     for (uint32_t i = 0; i < downstream_dirs.size(); i++) {
@@ -1118,19 +1120,20 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_compile_time_args() c
 }
 
 std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_runtime_args(tt::tt_metal::Program& program) const {
-    std::vector<uint32_t> runtime_args;
     const auto& fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
     if (fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::UDM) {
         TT_FATAL(
             upstream_routers_noc_x_.empty() && upstream_routers_noc_y_.empty(),
             "In UDM mode there should NOT be any upstream routers being set");
     }
-    runtime_args.insert(runtime_args.end(), upstream_routers_noc_x_.begin(), upstream_routers_noc_x_.end());
-    runtime_args.insert(runtime_args.end(), upstream_routers_noc_y_.begin(), upstream_routers_noc_y_.end());
 
     auto config_runtime_args =
         config_->get_run_time_args(local_fabric_node_id_, remote_fabric_node_id_, link_idx_, program, my_core_logical_);
 
+    std::vector<uint32_t> runtime_args;
+    runtime_args.reserve(upstream_routers_noc_x_.size() + upstream_routers_noc_y_.size() + config_runtime_args.size());
+    runtime_args.insert(runtime_args.end(), upstream_routers_noc_x_.begin(), upstream_routers_noc_x_.end());
+    runtime_args.insert(runtime_args.end(), upstream_routers_noc_y_.begin(), upstream_routers_noc_y_.end());
     runtime_args.insert(runtime_args.end(), config_runtime_args.begin(), config_runtime_args.end());
     return runtime_args;
 }
@@ -1232,6 +1235,7 @@ std::vector<uint32_t> FabricTensixDatamoverRelayBuilder::get_runtime_args(tt::tt
     std::vector<uint32_t> runtime_args;
     // Memory regions to clear at startup
     auto regions_to_clear = config_->get_memory_regions_to_clear();
+    runtime_args.reserve(1 + 2 * regions_to_clear.size());
     runtime_args.push_back(static_cast<uint32_t>(regions_to_clear.size()));
     for (const auto& [address, size] : regions_to_clear) {
         runtime_args.push_back(static_cast<uint32_t>(address));

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -437,6 +437,7 @@ void MeshGraph::initialize_from_mgd(
             host_shape[1]);
 
         std::vector<MeshHostRankId> mesh_host_ranks_values;
+        mesh_host_ranks_values.reserve(host_shape.mesh_size());
         uint32_t next_rank = 0;
         for (const auto& host_coord : MeshCoordinateRange(host_shape)) {
             mesh_host_ranks_values.push_back(MeshHostRankId{next_rank++});

--- a/tt_metal/fabric/physical_grouping_descriptor_core.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor_core.cpp
@@ -158,7 +158,12 @@ uint32_t PhysicalGroupingDescriptor::get_grouping_asic_count(const std::string& 
 std::vector<GroupingInfo> PhysicalGroupingDescriptor::get_groupings_by_name(const std::string& grouping_name) const {
     auto name_it = resolved_groupings_cache_.find(grouping_name);
     if (name_it != resolved_groupings_cache_.end()) {
+        size_t total_groupings = 0;
+        for (const auto& [type, groupings] : name_it->second) {
+            total_groupings += groupings.size();
+        }
         std::vector<GroupingInfo> result;
+        result.reserve(total_groupings);
         for (const auto& [type, groupings] : name_it->second) {
             result.insert(result.end(), groupings.begin(), groupings.end());
         }
@@ -168,7 +173,15 @@ std::vector<GroupingInfo> PhysicalGroupingDescriptor::get_groupings_by_name(cons
 }
 
 std::vector<GroupingInfo> PhysicalGroupingDescriptor::get_groupings_by_type(const std::string& grouping_type) const {
+    size_t total_groupings = 0;
+    for (const auto& [name, type_map] : resolved_groupings_cache_) {
+        auto type_it = type_map.find(grouping_type);
+        if (type_it != type_map.end()) {
+            total_groupings += type_it->second.size();
+        }
+    }
     std::vector<GroupingInfo> result;
+    result.reserve(total_groupings);
     for (const auto& [name, type_map] : resolved_groupings_cache_) {
         auto type_it = type_map.find(grouping_type);
         if (type_it != type_map.end()) {
@@ -179,7 +192,14 @@ std::vector<GroupingInfo> PhysicalGroupingDescriptor::get_groupings_by_type(cons
 }
 
 std::vector<GroupingInfo> PhysicalGroupingDescriptor::get_all_groupings() const {
+    size_t total_groupings = 0;
+    for (const auto& [name, type_map] : resolved_groupings_cache_) {
+        for (const auto& [type, groupings] : type_map) {
+            total_groupings += groupings.size();
+        }
+    }
     std::vector<GroupingInfo> result;
+    result.reserve(total_groupings);
     for (const auto& [name, type_map] : resolved_groupings_cache_) {
         for (const auto& [type, groupings] : type_map) {
             for (const auto& grouping : groupings) {
@@ -192,6 +212,7 @@ std::vector<GroupingInfo> PhysicalGroupingDescriptor::get_all_groupings() const 
 
 std::vector<std::string> PhysicalGroupingDescriptor::get_all_grouping_names() const {
     std::vector<std::string> names;
+    names.reserve(proto_->groupings().size());
     for (const auto& grouping : proto_->groupings()) {
         names.push_back(PhysicalGroupingDescriptor::get_grouping_name(grouping));
     }
@@ -384,6 +405,7 @@ void PhysicalGroupingDescriptor::populate() {
     }
 
     std::vector<std::string> processed;
+    processed.reserve(dependencies.size());
     while (!to_process.empty()) {
         std::string current = to_process.front();
         to_process.pop();

--- a/tt_metal/fabric/physical_grouping_descriptor_graph_building.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor_graph_building.cpp
@@ -392,7 +392,9 @@ GroupingInfo PhysicalGroupingDescriptor::convert_grouping_to_info(const proto::G
 
     // Collect instance IDs and build items list
     std::vector<uint32_t> instance_ids;
+    instance_ids.reserve(grouping.instances().size());
     std::vector<uint32_t> asic_locations;  // For tray groupings, use ASIC locations as node IDs
+    asic_locations.reserve(grouping.instances().size());
     bool has_asic_locations = false;
 
     for (const auto& instance : grouping.instances()) {
@@ -935,12 +937,25 @@ std::vector<FlattenedMesh> build_flattened_meshes_for_item(
     std::vector<tt::tt_fabric::GroupingInfo> possible_groupings;
     auto name_it = cache.find(item.grouping_name);
     if (name_it != cache.end()) {
+        size_t total_groupings = 0;
+        for (const auto& [type, groupings] : name_it->second) {
+            total_groupings += groupings.size();
+        }
+        possible_groupings.reserve(total_groupings);
         for (const auto& [type, groupings] : name_it->second) {
             possible_groupings.insert(possible_groupings.end(), groupings.begin(), groupings.end());
         }
     }
     if (possible_groupings.empty()) {
         // Fallback: search by type (handles refs like custom_type "tray" where cache key is grouping name)
+        size_t total_groupings = 0;
+        for (const auto& [name, type_map] : cache) {
+            auto type_it = type_map.find(item.grouping_name);
+            if (type_it != type_map.end()) {
+                total_groupings += type_it->second.size();
+            }
+        }
+        possible_groupings.reserve(total_groupings);
         for (const auto& [name, type_map] : cache) {
             auto type_it = type_map.find(item.grouping_name);
             if (type_it != type_map.end()) {

--- a/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
@@ -990,6 +990,7 @@ ValidGroupingsMap PhysicalGroupingDescriptor::get_valid_groupings_for_mgd(
         for (const auto& [node_diff, name_idx_pairs] : candidates_by_diff) {
             best_matches_topology.clear();
             best_matches_psd_placed.clear();
+            best_matches_topology.reserve(name_idx_pairs.size());
 
             for (const auto& [name, idx] : name_idx_pairs) {
                 const auto& grouping_info = mesh_flat_groupings.at(name)[idx];
@@ -1626,7 +1627,7 @@ std::vector<MappingResult<uint32_t, AsicID>> solve_for_many_groupings_to_psd(
             used_asic_ids.insert(asic_id);
         }
 
-        results.push_back(result);
+        results.push_back(std::move(result));
 
         std::set<uint32_t> all_target_nodes(flat_mesh.get_nodes().begin(), flat_mesh.get_nodes().end());
         TT_FATAL(

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -259,6 +259,7 @@ std::vector<AsicID> PhysicalSystemDescriptor::get_asic_neighbors(AsicID asic_id)
     for (const auto& [host, asic_group] : system_graph_.asic_connectivity_graph) {
         if (asic_group.contains(asic_id)) {
             std::vector<AsicID> neighbors;
+            neighbors.reserve(asic_group.at(asic_id).size());
             for (const auto& edge : asic_group.at(asic_id)) {
                 neighbors.push_back(edge.first);
             }
@@ -341,6 +342,7 @@ ChipId PhysicalSystemDescriptor::get_umd_unique_id(AsicID asic_id) const {
 std::vector<AsicID> PhysicalSystemDescriptor::get_asics_connected_to_host(const std::string& hostname) const {
     std::vector<AsicID> asics;
     if (system_graph_.asic_connectivity_graph.contains(hostname)) {
+        asics.reserve(system_graph_.asic_connectivity_graph.at(hostname).size());
         for (const auto& [asic_id, _] : system_graph_.asic_connectivity_graph.at(hostname)) {
             asics.push_back(asic_id);
         }
@@ -376,6 +378,7 @@ std::vector<std::string> PhysicalSystemDescriptor::get_host_neighbors(const std:
     TT_FATAL(
         system_graph_.host_connectivity_graph.contains(hostname), "No Host connectivity found for host {}", hostname);
     std::vector<std::string> neighbors;
+    neighbors.reserve(system_graph_.host_connectivity_graph.at(hostname).size());
     for (const auto& edge : system_graph_.host_connectivity_graph.at(hostname)) {
         neighbors.push_back(edge.first);
     }

--- a/tt_metal/fabric/pipeline_builder.cpp
+++ b/tt_metal/fabric/pipeline_builder.cpp
@@ -139,6 +139,7 @@ std::vector<std::string> topological_sort(
     }
 
     std::vector<std::string> order;
+    order.reserve(all_nodes.size());
     while (!q.empty()) {
         auto node = q.front();
         q.pop();
@@ -292,6 +293,7 @@ GraphLayoutResult resolve_graph_layout(
     // 2. Collect unique node names and separate loopback edges
     // ------------------------------------------------------------------
     std::vector<std::string> all_nodes;
+    all_nodes.reserve(edges.size() * 2);
     {
         std::set<std::string> seen;
         for (const auto& [src, dst, is_lb] : edges) {
@@ -439,6 +441,7 @@ GraphLayoutResult resolve_graph_layout(
     }
 
     std::vector<std::pair<uint32_t, uint32_t>> unclaimed;
+    unclaimed.reserve(chips[stage0_sub].size());
     for (const auto& [fid, row, col] : chips[stage0_sub]) {
         if (!used_coords.contains({row, col})) {
             unclaimed.push_back({row, col});

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -96,6 +96,7 @@ AsicTopology proto_to_asic_topology(const tt::fabric::proto::HostAsicConnectivit
         for (const auto& edge : asic_graph.topology().asic_connections()) {
             AsicID dst_asic_id{edge.dst_asic_id()};
             std::vector<EthConnection> eth_connections;
+            eth_connections.reserve(edge.eth_connections().size());
 
             for (const auto& proto_eth_conn : edge.eth_connections()) {
                 eth_connections.push_back(proto_to_eth_connection(proto_eth_conn));
@@ -136,6 +137,7 @@ HostTopology proto_to_host_topology(const tt::fabric::proto::PhysicalConnectivit
         for (const auto& edge : host_conn.host_connections()) {
             std::string dst_host = edge.dst_host_name();
             std::vector<ExitNodeConnection> exit_connections;
+            exit_connections.reserve(edge.exit_node_connections().size());
 
             for (const auto& proto_exit_conn : edge.exit_node_connections()) {
                 exit_connections.push_back(proto_to_exit_node_connection(proto_exit_conn));
@@ -302,6 +304,7 @@ std::unique_ptr<PhysicalSystemDescriptor> proto_to_physical_system_descriptor(
     auto& exit_node_connection_table = descriptor->get_exit_node_connection_table();
     for (const auto& proto_table : proto_desc.exit_node_connection_table()) {
         std::vector<ExitNodeConnection> exit_connections;
+        exit_connections.reserve(proto_table.exit_connections().size());
 
         for (const auto& proto_exit_conn : proto_table.exit_connections()) {
             exit_connections.push_back(proto_to_exit_node_connection(proto_exit_conn));

--- a/tt_metal/fabric/serialization/port_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/port_descriptor_serialization.cpp
@@ -71,6 +71,7 @@ PortDescriptorTable deserialize_port_descriptors_from_bytes(const std::vector<ui
 
             // Extract port descriptors (dst mesh comes from the entry key)
             std::vector<PortDescriptor> port_descriptors;
+            port_descriptors.reserve(entry.port_descriptors().size());
             for (const auto& proto_port_desc : entry.port_descriptors()) {
                 PortDescriptor port_desc;
                 port_desc.connection_hash = proto_port_desc.connection_hash();

--- a/tt_metal/fabric/serialization/router_port_directions.cpp
+++ b/tt_metal/fabric/serialization/router_port_directions.cpp
@@ -84,6 +84,7 @@ RouterPortDirectionsData deserialize_router_port_directions_from_bytes(const std
             RoutingDirection direction = static_cast<RoutingDirection>(direction_entry.direction());
 
             std::vector<chan_id_t> channels;
+            channels.reserve(direction_entry.channels().size());
             for (const auto& channel : direction_entry.channels()) {
                 channels.push_back(channel);
             }

--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -714,6 +714,7 @@ void TopologyMapper::broadcast_chip_info_to_hosts(const std::vector<std::size_t>
     std::vector<int> target_ranks;
     if (target_rank == -1) {
         // Broadcast to all peers (excluding self)
+        target_ranks.reserve(world_size - 1);
         for (std::size_t peer = 0; peer < world_size; ++peer) {
             if (peer != my_rank) {
                 target_ranks.push_back(peer);
@@ -750,6 +751,7 @@ void TopologyMapper::broadcast_chip_info_to_hosts(const std::vector<std::size_t>
 
     // Collect entries to broadcast based on host ranks filter
     std::vector<const MappedChipInfo*> entries_to_broadcast;
+    entries_to_broadcast.reserve(chip_topology_mapping_.size());
     std::unordered_set<std::size_t> host_rank_set(host_ranks.begin(), host_ranks.end());
     const auto& host_to_rank_map = physical_system_descriptor_.get_host_to_rank_map();
     for (const auto& info : chip_topology_mapping_) {
@@ -1635,6 +1637,7 @@ MeshGraph TopologyMapper::generate_mesh_graph_from_physical_system_descriptor(
 
     // Extract ASIC IDs from the descriptors map
     std::vector<tt::tt_metal::AsicID> all_asic_ids;
+    all_asic_ids.reserve(total_number_of_chips);
     for (const auto& [asic_id, _] : physical_system_descriptor.get_asic_descriptors()) {
         all_asic_ids.push_back(asic_id);
     }

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -58,6 +58,7 @@ std::vector<PinningConstraint> get_galaxy_fixed_asic_position_pinnings_for_mesh(
 
     // Get all 4 possible corner ASIC positions
     std::vector<AsicPosition> corner_asic_positions;
+    corner_asic_positions.reserve(4);
     corner_asic_positions.emplace_back(AsicPosition{1, 1});  // Top left corner
     corner_asic_positions.emplace_back(AsicPosition{2, 1});  // Top right corner
     corner_asic_positions.emplace_back(AsicPosition{3, 1});  // Bottom left corner
@@ -65,6 +66,7 @@ std::vector<PinningConstraint> get_galaxy_fixed_asic_position_pinnings_for_mesh(
 
     // Generate corner fabric node IDs for this mesh
     std::vector<FabricNodeId> corner_fabric_node_ids;
+    corner_fabric_node_ids.reserve(4);
     corner_fabric_node_ids.emplace_back(FabricNodeId{mesh_id, 0});
     corner_fabric_node_ids.emplace_back(FabricNodeId{mesh_id, mesh_shape[1] - 1});
     corner_fabric_node_ids.emplace_back(FabricNodeId{mesh_id, mesh_shape[1] * (mesh_shape[0] - 1)});
@@ -1627,6 +1629,7 @@ void add_inter_mesh_minimal_host_cover_from_hostname_map(
 
     // Build global_mesh_groups in one pass: one group per host for single-host meshes, singleton for multi-host.
     std::vector<std::set<MeshId>> global_mesh_groups;
+    global_mesh_groups.reserve(physical_graph.mesh_adjacency_graphs_.size());
     std::map<std::string, std::size_t> host_group_index;
     for (const auto& [phys_mesh_id, adj] : physical_graph.mesh_adjacency_graphs_) {
         if (adj.get_nodes().empty()) {
@@ -1838,6 +1841,7 @@ void add_rank_binding_constraints(
         // Per-host: classify as explicitly bound (has rank) or UNSET (all ASICs have MESH_HOST_RANK_UNSET).
         std::set<MeshHostRankId> claimed_ranks;
         std::vector<std::set<tt::tt_metal::AsicID>> unset_hosts;
+        unset_hosts.reserve(config.hostname_to_asics.size());
 
         for (const auto& [hostname, asic_set] : config.hostname_to_asics) {
             std::set<tt::tt_metal::AsicID> host_asics_in_mesh;
@@ -1884,6 +1888,7 @@ void add_rank_binding_constraints(
         // -----------------------------------------------------------------------
         if (!unset_hosts.empty()) {
             std::vector<MeshHostRankId> unclaimed_ranks;
+            unclaimed_ranks.reserve(rank_to_fabric_nodes.size());
             for (const auto& [r, fn_set] : rank_to_fabric_nodes) {
                 if (!fn_set.empty() && !claimed_ranks.contains(r)) {
                     unclaimed_ranks.push_back(r);
@@ -1907,6 +1912,7 @@ void add_rank_binding_constraints(
             // are not part of this host↔rank matching. Solver assigns target groups to distinct UNSET partitions
             // (not index-aligned).
             std::vector<std::set<FabricNodeId>> target_groups;
+            target_groups.reserve(unclaimed_ranks.size());
             for (const auto& r : unclaimed_ranks) {
                 auto it = rank_to_fabric_nodes.find(r);
                 if (it != rank_to_fabric_nodes.end() && !it->second.empty()) {
@@ -2443,9 +2449,11 @@ TopologyMappingResult map_multi_mesh_to_physical(
     std::vector<MeshId> physical_meshes;
 
     // Collect logical and physical mesh IDs for error reporting
+    logical_meshes.reserve(mesh_logical_graph.get_nodes().size());
     for (const auto& mesh_id : mesh_logical_graph.get_nodes()) {
         logical_meshes.push_back(mesh_id);
     }
+    physical_meshes.reserve(mesh_physical_graph.get_nodes().size());
     for (const auto& mesh_id : mesh_physical_graph.get_nodes()) {
         physical_meshes.push_back(mesh_id);
     }

--- a/tt_metal/fabric/topology_solver.cpp
+++ b/tt_metal/fabric/topology_solver.cpp
@@ -20,6 +20,7 @@ std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_graph_logical(con
 
     // Collect all mesh and switch instances (same order as MeshGraph: meshes then switches)
     std::vector<GlobalNodeId> mesh_and_switch_instances;
+    mesh_and_switch_instances.reserve(mgd.all_meshes().size() + mgd.all_switches().size());
     for (GlobalNodeId id : mgd.all_meshes()) {
         mesh_and_switch_instances.push_back(id);
     }
@@ -99,6 +100,7 @@ std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_graph_logical(con
             if (neighbor_chip_id == fabric_node_id.chip_id) {
                 continue;
             }
+            adjacents.reserve(adjacents.size() + edge.connected_chip_ids.size());
             for (size_t i = 0; i < edge.connected_chip_ids.size(); ++i) {
                 adjacents.push_back(FabricNodeId(mesh_id, neighbor_chip_id));
             }
@@ -136,9 +138,11 @@ std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> build_adjacency_graph_phy
     for (const auto& [mesh_id, mesh_asics] : mesh_asic_ids) {
         auto get_local_adjacents = [&](tt::tt_metal::AsicID asic_id,
                                        const std::unordered_set<tt::tt_metal::AsicID>& mesh_asics) {
+            const auto neighbors = physical_system_descriptor.get_asic_neighbors(asic_id);
             std::vector<tt::tt_metal::AsicID> adjacents;
+            adjacents.reserve(neighbors.size());
 
-            for (const auto& neighbor : physical_system_descriptor.get_asic_neighbors(asic_id)) {
+            for (const auto& neighbor : neighbors) {
                 // Skip self-connections
                 if (neighbor == asic_id) {
                     continue;

--- a/tt_metal/fabric/topology_solver_sat.cpp
+++ b/tt_metal/fabric/topology_solver_sat.cpp
@@ -1137,6 +1137,7 @@ void topology_sat_append_preferred_hit_indicators(
         const auto& globs = enc.allowed_global_idx[t];
         const auto& row_lits = enc.assign_lit[t];
         std::vector<int> row_pref_lits;
+        row_pref_lits.reserve(globs.size());
         for (size_t k = 0; k < globs.size(); ++k) {
             if (std::binary_search(preferred_globals.begin(), preferred_globals.end(), globs[k])) {
                 row_pref_lits.push_back(row_lits[k]);
@@ -1281,6 +1282,7 @@ bool topology_sat_append_relaxed_channel_threshold_literals(
             const size_t k_hi = std::min(required, kMaxKPerEdge);
             for (size_t k = 1; k <= k_hi; ++k) {
                 std::vector<std::pair<int, int>> pair_lits;
+                pair_lits.reserve(std::min(gidx1.size() * gidx2.size(), kMaxPairsPerIndicator + 1));
                 for (size_t i1 = 0; i1 < gidx1.size(); ++i1) {
                     const size_t glob1 = gidx1[i1];
                     for (size_t i2 = 0; i2 < gidx2.size(); ++i2) {

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -342,6 +342,12 @@ std::vector<std::pair<DeviceAddr, DeviceAddr>> FreeListOpt::available_addresses(
     size_t size_segregated_index = get_size_segregated_index(alloc_size);
     std::vector<std::pair<DeviceAddr, DeviceAddr>> addresses;
 
+    size_t max_candidate_blocks = 0;
+    for (size_t i = size_segregated_index; i < size_segregated_count; i++) {
+        max_candidate_blocks += free_blocks_segregated_by_size_[i].size();
+    }
+    addresses.reserve(max_candidate_blocks);
+
     for (size_t i = size_segregated_index; i < size_segregated_count; i++) {
         for (size_t block_index : free_blocks_segregated_by_size_[i]) {
             if (block_size_[block_index] >= alloc_size) {

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -66,6 +66,7 @@ void AllocatorImpl::init_compute_and_storage_l1_bank_manager() {
 
     // Define the bank assignment here.
     std::vector<uint32_t> shuffled_bank_id = {};
+    shuffled_bank_id.reserve(num_l1_banks);
     if (not config_->l1_bank_remap.empty()) {
         TT_ASSERT(
             num_l1_banks == config_->l1_bank_remap.size(),

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -698,7 +698,9 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
 
     // Build sub-commands on the fly with coalescing
     std::vector<CQDispatchWritePackedLargeUnicastSubCmd> write_sub_cmds;
+    write_sub_cmds.reserve(CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
     std::vector<CQPrefetchRelayLinearPackedSubCmd> relay_sub_cmds;
+    relay_sub_cmds.reserve(CQ_PREFETCH_CMD_RELAY_LINEAR_PACKED_MAX_SUB_CMDS);
     uint32_t relay_stream_offset = 0;
 
     const CoreCoord virtual_core = buffer.device()->virtual_core_from_logical_core(core, buffer.core_type());

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -1141,6 +1141,7 @@ void TensorPrefetcherManager::worker_loop() {
         std::vector<TargetSocket> still_pending = std::move(remaining_target_sockets);
         while (!still_pending.empty()) {
             std::vector<TargetSocket> next_pending;
+            next_pending.reserve(still_pending.size());
             for (const TargetSocket& target : still_pending) {
                 std::vector<uint8_t>& page = req.sender_pages[target.page_index];
                 if (experimental::detail::try_write(*sockets_[target.socket_index], page.data(), 1)) {

--- a/tt_metal/impl/data_format/bfloat16.cpp
+++ b/tt_metal/impl/data_format/bfloat16.cpp
@@ -168,6 +168,7 @@ bfloat16 bfloat16_identity_transform(const bfloat16& input) { return input; }
 std::vector<bfloat16> unpack_uint32_vec_into_bfloat16_vec(
     const std::vector<std::uint32_t>& data, const std::function<bfloat16(const bfloat16&)>& transform) {
     std::vector<bfloat16> result;
+    result.reserve(data.size() * 2);
     for (unsigned int packed : data) {
         auto unpacked = unpack_two_bfloat16_from_uint32(packed);
         result.push_back(transform(unpacked.first));

--- a/tt_metal/impl/data_format/blockfloat_common.cpp
+++ b/tt_metal/impl/data_format/blockfloat_common.cpp
@@ -381,15 +381,24 @@ std::vector<uint32_t> pack_as_bfp_tiles(
     } else {
         num_mantissas_in_dword = 4;
     }
+    const size_t exponents_per_tile = static_cast<size_t>(subtiles_in_tile_row) * subtiles_in_tile_col * subtile_rows;
+    packed_result.reserve(
+        static_cast<size_t>(num_tiles) * (static_cast<size_t>(num_float_in_tile) / num_mantissas_in_dword +
+                                          tt::round_up(exponents_per_tile, l1_alignment) / num_exponents_in_dword));
+    exponents.reserve(num_exponents_in_dword);
+    data.reserve(num_mantissas_in_dword);
+
     int fp32_element_index = 0;
     for (int tile_index = 0; tile_index < num_tiles; ++tile_index) {
         std::vector<uint32_t> packed_data;
+        packed_data.reserve(static_cast<size_t>(num_float_in_tile) / num_mantissas_in_dword);
         std::vector<uint8_t> exponents_with_padding;
         exponents_with_padding.reserve(l1_alignment * subtiles_in_tile_row * subtiles_in_tile_col);
         for (int tr = 0; tr < subtiles_in_tile_row; ++tr) {
             for (int tc = 0; tc < subtiles_in_tile_col; ++tc) {
                 for (int i = 0; i < subtile_rows; ++i) {
                     std::vector<uint32_t> single_row;
+                    single_row.reserve(subtile_cols);
                     // populate a single row
                     for (int j = 0; j < subtile_cols; ++j) {
                         int data_index;

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -323,6 +323,7 @@ uint8_t calculate_num_tile_counters(const DataflowBufferConfig& config, bool is_
 // Returns vector of tensix_ids (0-3) that are being used
 std::vector<uint8_t> extract_tensix_ids(uint16_t risc_mask) {
     std::vector<uint8_t> tensix_ids;
+    tensix_ids.reserve(::dfb::NUM_TENSIX);
     uint16_t tensix_mask = (risc_mask >> 8) & 0x0F;  // bits 8-11
     for (uint8_t i = 0; i < ::dfb::NUM_TENSIX; i++) {
         if (tensix_mask & (1 << i)) {
@@ -1201,9 +1202,13 @@ void ProgramImpl::finalize_single_dfb_config(
     uint8_t num_producer_tcs = calculate_num_tile_counters(config, true);
     uint8_t num_consumer_tcs = calculate_num_tile_counters(config, false);
 
+    // One risc id per bit of the risc masks: bits 0-7 are DM riscs, bits 8-15 are Tensix riscs.
+    constexpr uint8_t num_risc_ids = std::numeric_limits<decltype(config.producer_risc_mask)>::digits;
     std::vector<uint8_t> producer_risc_ids;
+    producer_risc_ids.reserve(num_risc_ids);
     std::vector<uint8_t> consumer_risc_ids;
-    for (uint8_t risc_id = 0; risc_id < 16; risc_id++) {
+    consumer_risc_ids.reserve(num_risc_ids);
+    for (uint8_t risc_id = 0; risc_id < num_risc_ids; risc_id++) {
         if (config.producer_risc_mask & (1 << risc_id)) {
             producer_risc_ids.push_back(risc_id);
         }
@@ -1211,6 +1216,7 @@ void ProgramImpl::finalize_single_dfb_config(
             consumer_risc_ids.push_back(risc_id);
         }
     }
+    new_hw_risc_configs.reserve(producer_risc_ids.size() + consumer_risc_ids.size());
 
     // Determine tensix_id based on which RISC in the pair is Tensix
     // Without remapper,Tensix RISCs can only access TCs from their own tensix_id
@@ -1235,7 +1241,9 @@ void ProgramImpl::finalize_single_dfb_config(
     // For remapper mode, pre-allocate clientTypes for each consumer
     // Also allocate producer clientTypes (clientL)
     std::vector<uint8_t> consumer_client_types;
+    consumer_client_types.reserve(consumer_risc_ids.size());
     std::vector<uint8_t> producer_client_types;
+    producer_client_types.reserve(producer_risc_ids.size());
     ClientTypeAllocator client_type_allocator;
 
     if (use_remapper) {
@@ -1744,6 +1752,7 @@ void ProgramImpl::apply_dfb_size_overrides(const std::vector<DfbSizeOverride>& o
 std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>
 ProgramImpl::dataflow_buffers_on_core(const CoreCoord& core) const {
     std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dfbs_on_core;
+    dfbs_on_core.reserve(dataflow_buffers_.size());
     for (const auto& dfb : dataflow_buffers_) {
         if (dfb->core_ranges.intersects(core)) {
             dfbs_on_core.push_back(dfb);
@@ -1754,6 +1763,7 @@ ProgramImpl::dataflow_buffers_on_core(const CoreCoord& core) const {
 
 std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> ProgramImpl::dataflow_buffers_on_corerange(const CoreRange& cr) const {
     std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dfbs_on_core;
+    dfbs_on_core.reserve(dataflow_buffers_.size());
     for (const auto& dfb : dataflow_buffers_) {
         if (dfb->core_ranges.intersects(cr)) {
             dfbs_on_core.push_back(dfb);
@@ -1764,6 +1774,12 @@ std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBuf
 
 std::vector<CoreRange> ProgramImpl::dataflow_buffers_unique_coreranges() const {
     std::vector<CoreRange> core_ranges;
+    size_t max_core_ranges = 0;
+    for (const auto& dfb : dataflow_buffers_) {
+        max_core_ranges += dfb->core_ranges.ranges().size();
+    }
+    core_ranges.reserve(max_core_ranges);
+
     for (const auto& dfb : dataflow_buffers_) {
         for (const CoreRange& core_range : dfb->core_ranges.ranges()) {
             if (std::find(core_ranges.begin(), core_ranges.end(), core_range) == core_ranges.end()) {

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -297,8 +297,22 @@ void DevicePrintParserImpl<PointerSize>::read_arguments_from_payload(
 template <uint8_t PointerSize>
 std::pair<std::vector<std::string>, std::vector<typename DevicePrintParserImpl<PointerSize>::FormatPlaceholderInfo>>
 DevicePrintParserImpl<PointerSize>::parse_format_string(std::string_view format_str) {
+    // Upper bound on the placeholder count: every unescaped '{' starts at most one placeholder.
+    size_t placeholder_count = 0;
+    for (size_t i = 0; i < format_str.size(); i++) {
+        if (format_str[i] == '{') {
+            if (i + 1 < format_str.size() && format_str[i + 1] == '{') {
+                i++;  // Escaped '{', not a placeholder.
+                continue;
+            }
+            placeholder_count++;
+        }
+    }
+
     std::vector<std::string> plain_text_parts;
+    plain_text_parts.reserve(placeholder_count + 1);
     std::vector<FormatPlaceholderInfo> placeholders;
+    placeholders.reserve(placeholder_count);
     fmt::memory_buffer current_text;
     for (size_t i = 0; i < format_str.size(); i++) {
         if (format_str[i] == '{' && i + 1 < format_str.size() && format_str[i + 1] == '{') {

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -1086,6 +1086,7 @@ void DPrintServer::Impl::attach_device(ChipId device_id) {
 
     // Core range depends on whether dprint_all_cores flag is set.
     std::vector<umd::CoreDescriptor> print_cores_sanitized;
+    print_cores_sanitized.reserve(all_cores.size() + dispatch_cores.size());
     const auto& hal = env_.get_hal();
     std::vector<CoreType> core_types_to_check = {CoreType::WORKER, CoreType::ETH};
     if (hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {

--- a/tt_metal/impl/debug/inspector/data.cpp
+++ b/tt_metal/impl/debug/inspector/data.cpp
@@ -376,11 +376,15 @@ void Data::rpc_get_blocks_by_type(rpc::Inspector::GetBlocksByTypeResults::Builde
         std::vector<std::pair<uint32_t, uint32_t>> active_eth_xy;
         std::vector<std::pair<uint32_t, uint32_t>> idle_eth_xy;
 
-        for (const CoreCoord& logical_core : control_plane.get_active_ethernet_cores(device_id)) {
+        const auto active_eth_cores = control_plane.get_active_ethernet_cores(device_id);
+        active_eth_xy.reserve(active_eth_cores.size());
+        for (const CoreCoord& logical_core : active_eth_cores) {
             active_eth_xy.emplace_back(logical_core.x, logical_core.y);
         }
 
-        for (const CoreCoord& logical_core : control_plane.get_inactive_ethernet_cores(device_id)) {
+        const auto idle_eth_cores = control_plane.get_inactive_ethernet_cores(device_id);
+        idle_eth_xy.reserve(idle_eth_cores.size());
+        for (const CoreCoord& logical_core : idle_eth_cores) {
             idle_eth_xy.emplace_back(logical_core.x, logical_core.y);
         }
 

--- a/tt_metal/impl/debug/noc_debugging.hpp
+++ b/tt_metal/impl/debug/noc_debugging.hpp
@@ -144,6 +144,7 @@ struct NOCDebugIssue {
     // Get all issues with a specific base type
     std::vector<NOCDebugIssueType> get_issues_by_base(NOCDebugIssueBaseType base_type) const {
         std::vector<NOCDebugIssueType> result;
+        result.reserve(issues.size());
         for (const auto& issue : issues) {
             if (issue.base_type == base_type) {
                 result.push_back(issue);

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -1093,6 +1093,7 @@ void WatcherDeviceReader::Core::DumpLaunchMessage() const {
 void WatcherDeviceReader::Core::DumpWaypoints(bool to_stdout) const {
     auto debug_waypoint = mbox_data_.watcher().debug_waypoint();
     std::vector<std::string> risc_status;
+    risc_status.reserve(debug_waypoint.size());
 
     for (auto cpu : debug_waypoint) {
         auto& status = risc_status.emplace_back();

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1007,6 +1007,7 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
         noc_translation_enabled && (hal.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM));
     const metal_SocDescriptor& soc_d = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id());
     std::vector<CoreCoord> dram_phy_coords;
+    dram_phy_coords.reserve(num_dram_banks);
     for (int i = 0; i < num_dram_banks; ++i) {
         auto dram_core = this->dram_core_from_dram_channel(i, noc);
         if (dram_is_virtualized) {

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -132,8 +132,10 @@ std::unordered_map<uint32_t, uint32_t> get_device_id_to_core_map(
     ContextId context_id,
     const uint8_t num_hw_cqs,
     std::unordered_map<uint32_t, uint32_t>& completion_queue_reader_to_cpu_core_map) {
+    const auto chip_ids = tt::tt_metal::MetalContext::instance(context_id).get_cluster().all_chip_ids();
     std::vector<ChipId> device_ids;
-    for (ChipId device_id : tt::tt_metal::MetalContext::instance(context_id).get_cluster().all_chip_ids()) {
+    device_ids.reserve(chip_ids.size());
+    for (ChipId device_id : chip_ids) {
         device_ids.emplace_back(device_id);
     }
     bool use_numa_node_based_thread_binding =
@@ -242,6 +244,7 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
     }
 
     std::vector<ChipId> target_mmio_ids;
+    target_mmio_ids.reserve(device_ids_to_open.size());
     for (const auto& device_id : device_ids_to_open) {
         TT_FATAL(
             ctx_.get_cluster().all_chip_ids().contains(device_id),
@@ -409,6 +412,7 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
     }
 
     std::vector<Device*> activated_devices;
+    activated_devices.reserve(devices_to_activate.size());
     for (const auto& device_id : devices_to_activate) {
         if (not this->is_device_active(device_id)) {
             this->activate_device(device_id);
@@ -581,6 +585,7 @@ IDevice* DeviceManager::get_active_device(ChipId device_id) const { return get_a
 
 std::vector<IDevice*> DeviceManager::get_all_active_devices() const {
     std::vector<IDevice*> user_devices;
+    user_devices.reserve(this->devices_.size());
     for (const auto& device : this->devices_) {
         if (device && device->is_initialized()) {
             user_devices.push_back(device.get());
@@ -591,6 +596,7 @@ std::vector<IDevice*> DeviceManager::get_all_active_devices() const {
 
 std::vector<Device*> DeviceManager::get_all_active_devices_impl() const {
     std::vector<Device*> user_devices;
+    user_devices.reserve(this->devices_.size());
     for (const auto& device : this->devices_) {
         if (device && device->is_initialized()) {
             user_devices.push_back(device.get());

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -173,6 +173,7 @@ void DispatchKernelInitializer::init_device_command_queues() {
     }
 
     std::vector<std::shared_future<void>> events;
+    events.reserve(devices_.size());
     for (auto* dev : devices_) {
         if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
             continue;

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -1014,6 +1014,7 @@ dev_msgs::core_info_msg_t RiscFirmwareInitializer::populate_core_info_msg(
         cluster_.get_soc_desc(device_id).arch, cluster_.get_harvesting_mask(device_id));
     uint32_t max_along_axis =
         hal_.get_tensix_harvest_axis() == HalTensixHarvestAxis::ROW ? soc_d.grid_size.y : soc_d.grid_size.x;
+    harvested_axis_coord.reserve(max_along_axis);
     for (uint32_t idx = 0; idx < max_along_axis; idx++) {
         bool harvested_axis = (harvested_noc_coords >> idx) & 0x1;
         if (harvested_axis) {

--- a/tt_metal/impl/dispatch/dispatch_telemetry.cpp
+++ b/tt_metal/impl/dispatch/dispatch_telemetry.cpp
@@ -267,6 +267,7 @@ private:
 
         std::vector<std::vector<CoreEntry>> entries_per_active_cq;
         const uint8_t num_cqs = control->num_hw_cqs;
+        entries_per_active_cq.reserve(num_cqs);
 
         for (uint8_t cq = 0; cq < num_cqs; ++cq) {
             const auto core_coords = control->cq_dispatch_core_coords[cq];
@@ -277,6 +278,7 @@ private:
             }
 
             std::vector<CoreEntry> cq_entries;
+            cq_entries.reserve(3);
 
             auto smc_xy_to_virtual_core = [](uint32_t xy) {
                 return CoreCoord{

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -487,6 +487,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
     if (remote_devices.empty()) {
         // MMIO devices only, just replicate a single chip arch for each
         std::vector<DispatchKernelNode> nodes_for_one_mmio = populate_single_device();
+        nodes.reserve(mmio_devices.size() * nodes_for_one_mmio.size());
         uint32_t index_offset = 0;
         for (auto id : mmio_devices) {
             for (auto node : nodes_for_one_mmio) {
@@ -507,6 +508,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
             // For Galaxy, we always init all remote devices associated with an mmio device.
             std::vector<DispatchKernelNode> nodes_for_one_mmio =
                 (num_hw_cqs == 1) ? galaxy_nine_chip_arch_1cq_fabric : galaxy_nine_chip_arch_2cq_fabric;
+            nodes.reserve(mmio_devices.size() * nodes_for_one_mmio.size());
             uint32_t index_offset = 0;
             for (auto mmio_device_id : mmio_devices) {
                 // Need a mapping from templated device id (1-8) to actual device id (from the tunnel)
@@ -548,6 +550,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
                 "N300/T3K expects devices in mmio/remote pairs.");
             std::vector<DispatchKernelNode> nodes_for_one_mmio =
                 (num_hw_cqs == 1) ? two_chip_arch_1cq_fabric : two_chip_arch_2cq_fabric;
+            nodes.reserve(mmio_devices.size() * nodes_for_one_mmio.size());
 
             uint32_t index_offset = 0;
             for (auto mmio_device_id : mmio_devices) {

--- a/tt_metal/impl/dispatch/worker_config_buffer.cpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.cpp
@@ -218,6 +218,7 @@ void WorkerConfigBufferMgr::mark_completely_full(uint32_t sync) {
 
 std::vector<size_t> WorkerConfigBufferMgr::get_queued_entry_indices(size_t buffer_type) const {
     std::vector<size_t> indices;
+    indices.reserve(this->entries_.size());
     // Walk the ring buffer from the oldest freeable entry (free_index_) up to, but not including,
     // the alloc entry (alloc_index_). Starting from alloc_index_ here would make the loop empty.
     size_t free_index = this->free_index_[buffer_type];

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2133,6 +2133,9 @@ static int __emule_fabric_dir_neighbor(
     return -1;
 }
 
+// Chip-count backstop for a single-direction walk (loudbox = 8).
+static constexpr int kMaxFabricWalkHops = 64;
+
 // Ordered chips reachable from `src` at distance 1,2,... in `dir` (line or ring), cached.
 static const std::vector<uint32_t>& __emule_fabric_walk(uint32_t src, tt::tt_fabric::RoutingDirection dir) {
     std::lock_guard<std::mutex> lock(g_fabric_route_mutex);
@@ -2142,9 +2145,10 @@ static const std::vector<uint32_t>& __emule_fabric_walk(uint32_t src, tt::tt_fab
         return it->second;
     }
     std::vector<uint32_t> walk;
+    walk.reserve(kMaxFabricWalkHops);
     auto& cp = MetalContext::instance().get_control_plane();
     uint32_t cur = src;
-    for (int hop = 0; hop < 64; ++hop) {  // 64 = chip-count backstop (loudbox = 8)
+    for (int hop = 0; hop < kMaxFabricWalkHops; ++hop) {
         int nxt = __emule_fabric_dir_neighbor(cp, cur, dir);
         if (nxt < 0 || static_cast<uint32_t>(nxt) == src) {
             break;  // line end, or ring wrapped back to the source
@@ -2514,6 +2518,7 @@ static std::vector<uint32_t> __emule_fabric_resolve_targets(const uint8_t* h, ui
             std::vector<uint32_t> tgts;
             if (r.kind == emule_route_kind::MCAST_1D) {
                 const uint32_t start = r.a ? r.a : 1, range = r.b ? r.b : 1;
+                tgts.reserve(std::min<size_t>(range, walk.size()));
                 for (uint32_t hop = start; hop < start + range && hop - 1 < walk.size(); ++hop) {
                     tgts.push_back(walk[hop - 1]);
                 }
@@ -2781,6 +2786,7 @@ static std::vector<DFBAllocInfo> allocate_dfbs_on_core(
     }
 
     std::vector<DFBAllocInfo> dfb_allocs;
+    dfb_allocs.reserve(dfb_impls.size());
     // Compute bridge sharing: a compute-consumer input DFB and a compute-producer
     // output DFB with matching dimensions share L1 (real HW routes through the
     // register file). Independent compute-consumer inputs (e.g. matmul in0/in1)
@@ -3223,6 +3229,9 @@ static void launch_cores(
     // Empty (no snapshot/verify cost) when ASAN is off. See tt-emule #241 / docs/ASAN.md.
     std::vector<std::unique_ptr<tt::tt_metal::emule::ObjectIntentTracker>> intent_trackers;
     const bool object_intent_active = !defer_run && oob_state.object_intent_strict;
+    if (object_intent_active) {
+        intent_trackers.reserve(core_setups.size());
+    }
 
     for (size_t core_idx = 0; core_idx < core_setups.size(); ++core_idx) {
         auto& cs = core_setups[core_idx];

--- a/tt_metal/impl/experimental/udm/mesh_builder.cpp
+++ b/tt_metal/impl/experimental/udm/mesh_builder.cpp
@@ -187,6 +187,7 @@ public:
         // 9. fabric_chip_ids[num_grids]
 
         auto dims = get_aligned_mesh_grid_dimensions();
+        compile_time_args.reserve(3 + 2 * (dims.mesh_num_dims + dims.grid_num_dims + grids_.size()));
 
         compile_time_args.push_back(dims.mesh_num_dims);
         for (uint32_t i = 0; i < dims.mesh_num_dims; ++i) {
@@ -224,6 +225,7 @@ public:
         // 2. fabric_mesh_ids[num_grids]
         // 3. fabric_chip_ids[num_grids]
 
+        compile_time_args.reserve(1 + 2 * grids_.size());
         compile_time_args.push_back(static_cast<uint32_t>(grids_.size()));
         for (size_t i = 0; i < grids_.size(); ++i) {
             compile_time_args.push_back(*grid_to_fabric_node_id_[i].mesh_id);
@@ -639,6 +641,7 @@ MeshBuilder::MeshBuilder(const tt::tt_metal::distributed::MeshBuffer& mesh_buffe
 
     // Collect all mesh coordinates in row-major order
     std::vector<tt::tt_metal::distributed::MeshCoordinate> mesh_coords;
+    mesh_coords.reserve(mesh_shape.mesh_size());
     for (const auto& coord : tt::tt_metal::distributed::MeshCoordinateRange(mesh_shape)) {
         mesh_coords.push_back(coord);
     }

--- a/tt_metal/impl/experimental/udm/mesh_utils.cpp
+++ b/tt_metal/impl/experimental/udm/mesh_utils.cpp
@@ -231,7 +231,9 @@ GlobalCoresInfo map_tensor_to_gcores_nd(
 
     // Validate and normalize partition dimensions
     std::vector<int> normalized_dims;
+    normalized_dims.reserve(partition_dims.size());
     std::vector<uint32_t> dim_sizes;
+    dim_sizes.reserve(partition_dims.size());
     for (int dim : partition_dims) {
         if (dim < 0) {
             dim = tensor_rank + dim;

--- a/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
@@ -139,6 +139,7 @@ CoreRangeSet from_flatbuffer(const flatbuffer::CoreRangeSet* fb_core_range_set) 
     TT_FATAL(fb_core_range_set, "Invalid CoreRangeSet data from flatbuffer.");
 
     std::vector<CoreRange> ranges;
+    ranges.reserve(fb_core_range_set->ranges()->size());
     for (const auto* range : *fb_core_range_set->ranges()) {
         ranges.emplace_back(from_flatbuffer(range));  // Reuse CoreRange deserialization
     }

--- a/tt_metal/impl/flatbuffer/program_types_to_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/program_types_to_flatbuffer.cpp
@@ -26,6 +26,7 @@ flatbuffers::Offset<flatbuffer::CoreRange> to_flatbuffer(
 flatbuffers::Offset<flatbuffer::CoreRangeSet> to_flatbuffer(
     flatbuffers::FlatBufferBuilder& builder, const CoreRangeSet& range_set) {
     std::vector<flatbuffers::Offset<flatbuffer::CoreRange>> range_offsets;
+    range_offsets.reserve(range_set.ranges().size());
     for (const auto& range : range_set.ranges()) {
         range_offsets.push_back(to_flatbuffer(builder, range));
     }
@@ -62,6 +63,7 @@ FlatbufferCoreCoordVector to_flatbuffer(
 FlatbufferUInt32VecOfVec to_flatbuffer(
     flatbuffers::FlatBufferBuilder& builder, const std::vector<std::vector<uint32_t>>& vec_of_vec) {
     std::vector<flatbuffers::Offset<flatbuffer::UInt32Vector>> vec_offsets;
+    vec_offsets.reserve(vec_of_vec.size());
 
     for (const auto& sub_vector : vec_of_vec) {
         auto values_offset = builder.CreateVector(sub_vector);
@@ -76,6 +78,7 @@ std::pair<flatbuffer::KernelConfig, flatbuffers::Offset<void>> to_flatbuffer(
     flatbuffers::FlatBufferBuilder& builder, const DataMovementConfig& config) {
     // Convert defines (map) to FlatBuffer format
     std::vector<flatbuffers::Offset<flatbuffer::DefineEntry>> defines_vector;
+    defines_vector.reserve(config.defines.size());
     for (const auto& [key, value] : config.defines) {
         auto key_offset = builder.CreateString(key);
         auto value_offset = builder.CreateString(value);
@@ -99,6 +102,7 @@ std::pair<flatbuffer::KernelConfig, flatbuffers::Offset<void>> to_flatbuffer(
     flatbuffers::FlatBufferBuilder& builder, const ComputeConfig& config) {
     // Convert defines (map) to FlatBuffer format
     std::vector<flatbuffers::Offset<flatbuffer::DefineEntry>> defines_vector;
+    defines_vector.reserve(config.defines.size());
     for (const auto& [key, value] : config.defines) {
         auto key_offset = builder.CreateString(key);
         auto value_offset = builder.CreateString(value);
@@ -133,6 +137,7 @@ std::pair<flatbuffer::KernelConfig, flatbuffers::Offset<void>> to_flatbuffer(
     flatbuffers::FlatBufferBuilder& builder, const EthernetConfig& config) {
     // Convert defines (map) to FlatBuffer format
     std::vector<flatbuffers::Offset<flatbuffer::DefineEntry>> defines_vector;
+    defines_vector.reserve(config.defines.size());
     for (const auto& [key, value] : config.defines) {
         auto key_offset = builder.CreateString(key);
         auto value_offset = builder.CreateString(value);
@@ -204,6 +209,7 @@ flatbuffers::Offset<flatbuffer::RuntimeArg> create_runtime_arg(
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffer::RuntimeArg>>> to_flatbuffer(
     flatbuffers::FlatBufferBuilder& builder, const std::shared_ptr<RuntimeArgs>& runtime_args) {
     std::vector<flatbuffers::Offset<flatbuffer::RuntimeArg>> arg_offsets;
+    arg_offsets.reserve(runtime_args->size());
 
     for (const auto& arg : *runtime_args) {
         arg_offsets.push_back(create_runtime_arg(builder, arg));

--- a/tt_metal/impl/host_api/temp_quasar_api.cpp
+++ b/tt_metal/impl/host_api/temp_quasar_api.cpp
@@ -84,6 +84,9 @@ std::set<ProcessorClassType> GetProcessorsPerClusterQuasar(
         }
     }
 
+    if constexpr (std::is_same_v<ProcessorClassType, DataMovementProcessor>) {
+        dm_processors_in_use_per_kernel_group.reserve(kernel_groups.size());
+    }
     // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (const KernelGroup* kernel_group : kernel_groups) {
         if constexpr (std::is_same_v<ProcessorClassType, DataMovementProcessor>) {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -1038,11 +1038,13 @@ void EthernetKernel::read_binaries(IDevice* device, const std::string& binary_ro
 
 void ComputeKernel::read_binaries(IDevice* device, const std::string& binary_root) {
     TT_ASSERT(this->binaries_exist_on_disk(device, binary_root));
+    constexpr int num_trisc_binaries = 3;
     std::vector<const ll_api::memory*> binaries;
+    binaries.reserve(num_trisc_binaries);
     uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
-    for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
+    for (int trisc_id = 0; trisc_id < num_trisc_binaries; trisc_id++) {
         auto load_type = MetalContext::instance()
                              .hal()
                              .get_jit_build_config(tensix_core_type, compute_class_idx, trisc_id)
@@ -1307,6 +1309,7 @@ void QuasarDataMovementKernel::generate_binaries(IDevice* device, JitBuildOption
 void QuasarDataMovementKernel::read_binaries(IDevice* device, const std::string& binary_root) {
     TT_ASSERT(this->binaries_exist_on_disk(device, binary_root));
     std::vector<const ll_api::memory*> binaries;
+    binaries.reserve(this->dm_processors_.size());
     const uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
@@ -1433,6 +1436,7 @@ void QuasarComputeKernel::generate_binaries(IDevice* device, JitBuildOptions&) c
 void QuasarComputeKernel::read_binaries(IDevice* device, const std::string& binary_root) {
     TT_ASSERT(this->binaries_exist_on_disk(device, binary_root));
     std::vector<const ll_api::memory*> binaries;
+    binaries.reserve(this->trisc_binary_groups_.size());
     const uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.cpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.cpp
@@ -491,6 +491,7 @@ std::vector<SharedMemoryStatsProvider::ProcessInfo> SharedMemoryStatsProvider::g
         return result;
     }
 
+    result.reserve(MAX_PROCESSES);
     for (auto & processe : region_->processes) {
         if (processe.pid.load(std::memory_order_relaxed) != 0) {
             ProcessInfo info;
@@ -618,6 +619,7 @@ std::vector<SharedMemoryStatsProvider::ChipInfo> SharedMemoryStatsProvider::get_
         return result;
     }
 
+    result.reserve(MAX_CHIPS_PER_DEVICE);
     for (auto & chip_stat : region_->chip_stats) {
         if (chip_stat.chip_id.load(std::memory_order_relaxed) != CHIP_STATS_UNUSED) {
             ChipInfo info{};

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2076,6 +2076,7 @@ std::vector<KernelCouplingGroup> BuildDMKernelCouplingGroups(
     // Iterate dm_kernels in given order to preserve a deterministic per-class member order.
     std::unordered_map<size_t, size_t> root_to_group_idx;
     std::vector<KernelCouplingGroup> groups;
+    groups.reserve(dm_kernels.size());
     for (size_t i = 0; i < dm_kernels.size(); ++i) {
         const size_t r = find(i);
         auto [it, inserted] = root_to_group_idx.try_emplace(r, groups.size());
@@ -2115,6 +2116,7 @@ KernelRiscMaskMap SolveGen2KernelRiscMasks(const ProgramSpec& spec, const Collec
     // num_threads uniformity is enforced upstream, so same-role compute kernels get identical masks
     // without any coupling-group machinery).
     std::vector<const KernelSpec*> dm_kernels;
+    dm_kernels.reserve(spec.kernels.size());
     for (const KernelSpec& kernel : spec.kernels) {
         if (kernel.is_data_movement_kernel()) {
             dm_kernels.push_back(&kernel);

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -497,6 +497,7 @@ bool doAllDispatchCoresComeAfterNonDispatchCores(
     const CoreType dispatch_core_type =
         resolve_dispatch_core_type(env, device->id(), dispatch_core_config);
     std::vector<CoreCoord> virtual_dispatch_cores;
+    virtual_dispatch_cores.reserve(logical_dispatch_cores.size());
     for (const CoreCoord& core : logical_dispatch_cores) {
         const CoreCoord virtual_dispatch_core =
             device->virtual_core_from_logical_core(core, dispatch_core_type);
@@ -587,6 +588,7 @@ void removeFabricMuxEvents(
     std::vector<std::variant<FabricEventMarkers, tracy::TTDeviceMarker>>& coalesced_events,
     const CoreCoord& fabric_mux_core) {
     std::vector<std::variant<FabricEventMarkers, tracy::TTDeviceMarker>> filtered_events;
+    filtered_events.reserve(coalesced_events.size());
     for (const auto& coalesced_event : coalesced_events) {
         if (std::holds_alternative<tracy::TTDeviceMarker>(coalesced_event)) {
             auto event = std::get<tracy::TTDeviceMarker>(coalesced_event);
@@ -2936,6 +2938,7 @@ void DeviceProfiler::pollDebugDumpResults(
     // Figure out which DRAM profiler addresses need to be read
     std::set<uint8_t> stalled_dram_buffer_indices;
     std::vector<CoreCoord> virtual_cores_with_data;
+    virtual_cores_with_data.reserve(stalled_cores_with_data.size());
     for (const auto& [virtual_core, risc_types] : stalled_cores_with_data) {
         virtual_cores_with_data.push_back(virtual_core);
         for (const auto& risc_type : risc_types) {
@@ -2972,6 +2975,7 @@ void DeviceProfiler::pollDebugDumpResults(
     // Remaining L1 data not flushed to DRAM yet
     if (is_final_poll) {
         std::vector<CoreCoord> cores_with_l1_data;
+        cores_with_l1_data.reserve(virtual_cores.size());
         std::map<CoreCoord, std::set<tracy::RiscType>> riscs_with_l1_data;
 
         for (const auto& virtual_core : virtual_cores) {

--- a/tt_metal/impl/profiler/profiler_analysis.cpp
+++ b/tt_metal/impl/profiler/profiler_analysis.cpp
@@ -824,6 +824,7 @@ std::vector<AnalysisConfig> loadAnalysisConfigsFromJSON(const std::filesystem::p
     const nlohmann::json configs_json = nlohmann::json::parse(json_ifs);
 
     std::vector<AnalysisConfig> configs;
+    configs.reserve(configs_json.size());
     for (const auto& config_json : configs_json) {
         configs.push_back(config_json.get<AnalysisConfig>());
     }

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -538,6 +538,7 @@ void syncAllDevices(ChipId host_connected_device) {
     for (auto& sender : profiler_state_manager->device_device_time_pair) {
         for (auto& receiver : sender.second) {
             std::vector<std::pair<uint64_t, uint64_t>> timePairs;
+            timePairs.reserve(receiver.second.size() / 2);
             for (int i = 0; i < receiver.second.size(); i += 2) {
                 uint64_t senderTime = (receiver.second[i].first + receiver.second[i + 1].first) / 2;
                 timePairs.push_back({senderTime, receiver.second[i].second});

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1117,6 +1117,11 @@ public:
                 const auto& ranges, const CoreType core_type) -> std::vector<std::pair<transfer_info_cores, uint32_t>> {
             // This API extracts all the pairs of noc multicast encodings given a set of core ranges
             std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_unicast_info;
+            size_t num_cores = 0;
+            for (const CoreRange& core_range : ranges) {
+                num_cores += core_range.size();
+            }
+            dst_noc_unicast_info.reserve(num_cores);
             for (const CoreRange& core_range : ranges) {
                 for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                     for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
@@ -1809,6 +1814,7 @@ public:
             auto& cmd_data = batched_cmd_data[i];
             size_t last_end = cmd_data.front().start;
             std::vector<ttsl::Span<const uint8_t>> batched_data;
+            batched_data.reserve(cmd_data.size() * 2);
             for (const Transfer& transfer : cmd_data) {
                 if (last_end != transfer.start) {
                     TT_ASSERT(transfer.start - last_end <= fill_data.size());
@@ -3024,6 +3030,7 @@ TraceNode create_trace_node(
     }
 
     std::vector<std::vector<uint32_t>> all_cb_configs_payloads;
+    all_cb_configs_payloads.reserve(cached_program_command_sequence.circular_buffers_on_core_ranges.size());
     const auto& hal = MetalContext::instance().hal();
     uint32_t max_cbs = hal.get_arch_num_circular_buffers();
     uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
@@ -3060,6 +3067,7 @@ TraceNode create_trace_node(
 
     std::vector<std::vector<uint8_t>> all_dfb_configs_payloads;
     if (!hal.has_tile_counter_registers()) {
+        all_dfb_configs_payloads.reserve(cached_program_command_sequence.dataflow_buffers_on_core_ranges.size());
         for (const auto& dfbs_on_core_range : cached_program_command_sequence.dataflow_buffers_on_core_ranges) {
             std::vector<uint8_t> dfb_config_payload(
                 max_cbs * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t), 0);
@@ -3351,6 +3359,13 @@ void set_core_go_message_mapping_on_device(
     uint32_t max_prefetch_command_size =
         MetalContext::instance().dispatch_mem_map(dispatch_core_type).max_prefetch_command_size();
     uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
+
+    size_t num_core_ranges = 0;
+    for (const auto& [core_range_set, go_msg_offset] : core_go_message_mapping) {
+        num_core_ranges += core_range_set.ranges().size();
+    }
+    data.reserve(num_core_ranges);
+    sub_cmds.reserve(num_core_ranges);
 
     for (const auto& [core_range_set, go_msg_offset] : core_go_message_mapping) {
         for (const auto& core_range : core_range_set.ranges()) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1315,6 +1315,7 @@ std::shared_ptr<CircularBufferImpl> detail::ProgramImpl::get_circular_buffer(CBH
 std::vector<std::shared_ptr<CircularBufferImpl>> detail::ProgramImpl::circular_buffers_on_core(
     const CoreCoord& core) const {
     std::vector<std::shared_ptr<CircularBufferImpl>> cbs_on_core;
+    cbs_on_core.reserve(circular_buffers_.size());
     for (const auto& circular_buffer : circular_buffers_) {
         if (circular_buffer->is_on_logical_core(core)) {
             cbs_on_core.push_back(circular_buffer);
@@ -1326,6 +1327,7 @@ std::vector<std::shared_ptr<CircularBufferImpl>> detail::ProgramImpl::circular_b
 std::vector<std::shared_ptr<CircularBufferImpl>> detail::ProgramImpl::circular_buffers_on_corerange(
     const CoreRange& cr) const {
     std::vector<std::shared_ptr<CircularBufferImpl>> cbs_on_core;
+    cbs_on_core.reserve(circular_buffers_.size());
     for (const auto& circular_buffer : circular_buffers_) {
         if (circular_buffer->is_on_logical_corerange(cr)) {
             cbs_on_core.push_back(circular_buffer);
@@ -1336,6 +1338,12 @@ std::vector<std::shared_ptr<CircularBufferImpl>> detail::ProgramImpl::circular_b
 
 std::vector<CoreRange> detail::ProgramImpl::circular_buffers_unique_coreranges() const {
     std::vector<CoreRange> core_ranges;
+    size_t max_core_ranges = 0;
+    for (const auto& circular_buffer : circular_buffers_) {
+        max_core_ranges += circular_buffer->core_ranges().ranges().size();
+    }
+    core_ranges.reserve(max_core_ranges);
+
     for (const auto& circular_buffer : circular_buffers_) {
         for (const CoreRange& core_range : circular_buffer->core_ranges().ranges()) {
             if (std::find(core_ranges.begin(), core_ranges.end(), core_range) == core_ranges.end()) {
@@ -1451,6 +1459,7 @@ void detail::ProgramImpl::allocate_scratchpads(const IDevice* device) {
                 // (not just exact-range matches), so the scratchpad cannot overlap a DFB on
                 // an overlapping-but-different core range. Mark each such allocator exactly once.
                 std::vector<CircularBufferAllocator*> touched;
+                touched.reserve(this->dfb_allocators_.size());
                 for (CircularBufferAllocator& a : this->dfb_allocators_) {
                     for (const CoreRange& core_range : kernel_cores.ranges()) {
                         if (a.core_range.intersects(core_range)) {
@@ -1507,7 +1516,9 @@ void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
         dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device);
     if (mesh_device != nullptr) {
         // Mesh device: track all sub-devices
-        for (IDevice* sub_device : mesh_device->get_devices()) {
+        const auto sub_devices = mesh_device->get_devices();
+        devices_to_track.reserve(sub_devices.size());
+        for (IDevice* sub_device : sub_devices) {
             devices_to_track.push_back(sub_device);
         }
     } else {
@@ -1517,6 +1528,7 @@ void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
 
     // Track which devices are NEW (not already tracked)
     std::vector<const IDevice*> new_devices;
+    new_devices.reserve(devices_to_track.size());
     for (const IDevice* dev : devices_to_track) {
         auto [iter, inserted] = this->cb_devices_.insert(dev);
         if (inserted) {
@@ -1681,7 +1693,9 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
     std::vector<AllocatorImpl*> physical_allocators;
     if (hybrid_mode) {
         if (const auto* mesh = dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device)) {
-            for (IDevice* dev : mesh->get_devices()) {
+            const auto mesh_devices = mesh->get_devices();
+            physical_allocators.reserve(mesh_devices.size());
+            for (IDevice* dev : mesh_devices) {
                 physical_allocators.push_back(dev->allocator_impl().get());
             }
         } else {
@@ -1695,7 +1709,9 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
     std::vector<const IDevice*> devices_for_svc_check;
     if (svc.has_any_claims()) {
         if (const auto* mesh = dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device)) {
-            for (IDevice* dev : mesh->get_devices()) {
+            const auto mesh_devices = mesh->get_devices();
+            devices_for_svc_check.reserve(mesh_devices.size());
+            for (IDevice* dev : mesh_devices) {
                 devices_for_svc_check.push_back(dev);
             }
         } else {
@@ -1997,6 +2013,11 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
             const auto& ranges, const CoreType core_type) -> std::vector<std::pair<transfer_info_cores, uint32_t>> {
         // This API extracts all the pairs of noc multicast encodings given a set of core ranges
         std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_unicast_info;
+        size_t num_cores = 0;
+        for (const CoreRange& core_range : ranges) {
+            num_cores += core_range.size();
+        }
+        dst_noc_unicast_info.reserve(num_cores);
         for (const CoreRange& core_range : ranges) {
             for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                 for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
@@ -2085,6 +2106,7 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
                 std::vector<multicast_transfer_info> dst_noc_multicast_info =
                     extract_dst_noc_multicast_info(device, kernel_group->core_ranges.ranges(), core_type);
                 std::vector<KernelHandle> kernel_ids;
+                kernel_ids.reserve(kernel_group->kernel_ids.size());
                 for (auto kernel_id : kernel_group->kernel_ids) {
                     KernelHandle device_local_kernel_id = program_dispatch::get_device_local_kernel_handle(kernel_id);
                     kernel_ids.push_back(device_local_kernel_id);
@@ -2117,6 +2139,7 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
                 // No checks for max dispatch class
                 // Validated during CreateKernel if the requested processor is supported
                 std::vector<KernelHandle> kernel_ids;
+                kernel_ids.reserve(kernel_group->kernel_ids.size());
                 for (auto kernel_id : kernel_group->kernel_ids) {
                     KernelHandle device_local_kernel_id = program_dispatch::get_device_local_kernel_handle(kernel_id);
                     auto kernel = this->get_kernel(device_local_kernel_id);
@@ -2423,6 +2446,13 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
         // succeeds (from the .d files left by the -E step).
         std::vector<std::shared_ptr<Kernel>> preprocessed_kernels;
 
+        size_t total_kernels = 0;
+        for (const auto& kernels : kernels_) {
+            total_kernels += kernels.size();
+        }
+        submitted_kernels.reserve(total_kernels);
+        preprocessed_kernels.reserve(total_kernels);
+
         for (auto& kernels : kernels_) {
             for (auto& [id, kernel] : kernels) {
                 validate_kernel_placement(force_slow_dispatch, kernel, device->build_id());
@@ -2604,6 +2634,7 @@ void detail::ProgramImpl::release_buffers() { owned_buffer_pool = {}; }
 std::vector<std::reference_wrapper<const Semaphore>> detail::ProgramImpl::semaphores_on_core(
     const CoreCoord& core, CoreType core_type) const {
     std::vector<std::reference_wrapper<const Semaphore>> semaphores;
+    semaphores.reserve(this->semaphores_.size());
     for (const Semaphore& s : this->semaphores_) {
         if (s.initialized_on_logical_core(core) && s.core_type() == core_type) {
             semaphores.emplace_back(std::cref(s));
@@ -2708,6 +2739,12 @@ uint32_t detail::ProgramImpl::finalize_program_offsets(
 
     // Collect dataflow buffers from all programs
     std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dataflow_buffers;
+    size_t total_dataflow_buffers = 0;
+    for (ProgramImpl* program : programs) {
+        total_dataflow_buffers += program->dataflow_buffers().size();
+    }
+    dataflow_buffers.reserve(total_dataflow_buffers);
+
     for (ProgramImpl* program : programs) {
         for (const auto& dfb : program->dataflow_buffers()) {
             dataflow_buffers.push_back(dfb);

--- a/tt_metal/impl/program/program_descriptors.cpp
+++ b/tt_metal/impl/program/program_descriptors.cpp
@@ -47,6 +47,12 @@ namespace {
 // (different kernels like reader/writer/compute can legitimately run on the same cores)
 std::vector<CoreRange> collect_all_kernel_core_ranges(const ProgramDescriptor& desc) {
     std::vector<CoreRange> all_ranges;
+    size_t total_ranges = 0;
+    for (const auto& kernel : desc.kernels) {
+        total_ranges += kernel.core_ranges.ranges().size();
+    }
+    all_ranges.reserve(total_ranges);
+
     for (const auto& kernel : desc.kernels) {
         for (const auto& range : kernel.core_ranges.ranges()) {
             all_ranges.push_back(range);

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -394,6 +394,7 @@ void h2d_as_replicate_tensor_on_1x1_mesh(
         // remote coordinates are a complete no-op here.
         const auto& view = mesh_device->get_view();
         std::vector<distributed::MeshCoordinate> local_coords;
+        local_coords.reserve(mesh_device->shape().mesh_size());
         distributed::MeshCoordinateRangeSet local_range;
         for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
             if (view.impl().is_local(coord)) {

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -124,6 +124,7 @@ ExpPrecision get_data_exp_precision(std::span<const DataFormat> data_formats) {
 
 std::vector<DataFormat> get_unpack_src_formats(std::span<const DataFormat> data_formats) {
     std::vector<DataFormat> unpack_src_format;
+    unpack_src_format.reserve(data_formats.size());
     for (auto src_format : data_formats) {
         if (src_format == DataFormat::RawUInt32 || src_format == DataFormat::RawUInt16 ||
             src_format == DataFormat::RawUInt8) {
@@ -196,6 +197,7 @@ std::vector<DataFormat> get_unpack_dst_formats(
     }
 
     std::vector<DataFormat> unpack_dst_format;
+    unpack_dst_format.reserve(buf_formats.size());
 
     for (size_t i = 0; i < buf_formats.size(); i++) {
         DataFormat src_format = buf_formats[i];
@@ -367,6 +369,7 @@ std::vector<DataFormat> get_pack_src_formats(
     bool int_fpu_en,
     tt::ARCH arch) {
     std::vector<DataFormat> pack_src_formats;
+    pack_src_formats.reserve(data_formats.size());
     DataFormat pack_src_format;
     for (auto src_format : data_formats) {
         pack_src_format = get_single_pack_src_format(
@@ -379,6 +382,7 @@ std::vector<DataFormat> get_pack_src_formats(
 
 std::vector<DataFormat> get_pack_dst_formats(std::span<const DataFormat> buf_formats) {
     std::vector<DataFormat> pack_dst_format;
+    pack_dst_format.reserve(buf_formats.size());
     for (auto dst_format : buf_formats) {
         if (dst_format == DataFormat::RawUInt32 || dst_format == DataFormat::RawUInt16 ||
             dst_format == DataFormat::RawUInt8) {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -362,6 +362,7 @@ std::string generate_tt_kernel_shim_if_present(
     // a silently-unused arg (registered name the kernel never takes).
     std::vector<std::string> cta_names;
     settings.process_named_compile_time_args([&cta_names](const std::unordered_map<std::string, uint32_t>& named) {
+        cta_names.reserve(cta_names.size() + named.size());
         for (const auto& entry : named) {
             cta_names.push_back(entry.first);
         }

--- a/tt_metal/jit_build/kernel_signature_parser.cpp
+++ b/tt_metal/jit_build/kernel_signature_parser.cpp
@@ -230,7 +230,9 @@ std::vector<std::string> extract_param_names(const std::string& list_body, const
     if (trim(list_body) == "void") {
         return names;
     }
-    for (const std::string& piece : split_top_level_commas(list_body)) {
+    const std::vector<std::string> pieces = split_top_level_commas(list_body);
+    names.reserve(pieces.size());
+    for (const std::string& piece : pieces) {
         if (trim(piece).empty()) {
             continue;  // empty list, or a trailing comma
         }

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -251,6 +251,7 @@ const tt::core_descriptor_t& MetalEnvImpl::get_core_descriptor_config(
     }
 
     std::vector<RelativeCoreCoord> compute_cores;
+    compute_cores.reserve(compute_grid_size.x * compute_grid_size.y);
     for (auto x = 0; x < compute_grid_size.x; x++) {
         for (auto y = 0; y < compute_grid_size.y; y++) {
             const RelativeCoreCoord relative_coord{.x = x, .y = y};
@@ -271,6 +272,7 @@ const tt::core_descriptor_t& MetalEnvImpl::get_core_descriptor_config(
         logical_active_eth_cores = get_control_plane().get_active_ethernet_cores(device_id);
     }
 
+    dispatch_cores.reserve(desc_yaml[dispatch_cores_string].size());
     for (const auto& core_node : desc_yaml[dispatch_cores_string]) {
         RelativeCoreCoord coord = {};
         if (core_node.IsSequence()) {
@@ -294,6 +296,7 @@ const tt::core_descriptor_t& MetalEnvImpl::get_core_descriptor_config(
     // Parse fabric_mux_cores
     std::vector<RelativeCoreCoord> fabric_mux_cores;
     if (desc_yaml["fabric_mux_cores"]) {
+        fabric_mux_cores.reserve(desc_yaml["fabric_mux_cores"].size());
         for (const auto& core_node : desc_yaml["fabric_mux_cores"]) {
             RelativeCoreCoord coord = {};
             if (core_node.IsSequence()) {
@@ -416,6 +419,7 @@ std::vector<tt::tt_metal::CoreCoord> get_logical_fabric_mux_cores_wh_b0_worker_f
 
     tt::tt_metal::CoreCoord grid_size = env.get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     std::vector<tt::tt_metal::CoreCoord> logical_fabric_mux_cores;
+    logical_fabric_mux_cores.reserve(desc_yaml["fabric_mux_cores"].size());
     for (const auto& core_node : desc_yaml["fabric_mux_cores"]) {
         if (!core_node.IsSequence()) {
             continue;

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -107,6 +107,8 @@ public:
 
     std::vector<std::string> link_objs(const Params& params) const override {
         std::vector<std::string> objs;
+        // Upper bound: tmu-crt0.o, noc.o and substitutes.o.
+        objs.reserve(3);
         if (params.is_fw) {
             // Needed to setup gp, sp, etc. for all processors which are launched with assert/deassert PC method
             // For 2 erisc, erisc0 is launched from base firmware so it's not needed
@@ -130,6 +132,8 @@ public:
 
     std::vector<std::string> includes(const Params& params) const override {
         std::vector<std::string> includes;
+        // Upper bound: 8 common includes, at most 2 from the core type switch, plus the firmware dir.
+        includes.reserve(11);
 
         // Common includes for all core types
         includes.push_back("tt_metal/hw/ckernels/blackhole/metal/common");

--- a/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.cpp
@@ -11,6 +11,9 @@ namespace tt::tt_metal::hal_1xx {
 
 std::vector<std::string> HalJitBuildQueryBase::defines(const HalJitBuildQueryInterface::Params& params) const {
     std::vector<std::string> defines;
+    // Upper bound: PROCESSOR_INDEX, ENABLE_L1_DATA_CACHE, at most 4 from the core type switch
+    // (ACTIVE_ETH), and PROGRAMMABLE_CORE_TYPE.
+    defines.reserve(7);
     const auto& l1_cache_enable_processors =
         params.rtoptions.get_feature_processors(tt::llrt::RunTimeDebugFeatureEnableL1DataCache);
     auto processor_index = hal_.get_processor_index(params.core_type, params.processor_class, params.processor_id);

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -91,6 +91,9 @@ public:
 
     std::vector<std::string> link_objs(const Params& params) const override {
         std::vector<std::string> objs;
+        // Upper bound: tmu-crt0.o, the 2 ncrisc entry objs and substitutes.o. noc.o only applies to
+        // processor_id 0, so it can never coexist with the ncrisc ones.
+        objs.reserve(4);
         if (params.is_fw and params.core_type != HalProgrammableCoreType::ACTIVE_ETH) {
             objs.push_back("runtime/hw/lib/wormhole/tmu-crt0.o");
         }
@@ -117,6 +120,8 @@ public:
 
     std::vector<std::string> includes(const Params& params) const override {
         std::vector<std::string> includes;
+        // Upper bound: 8 common includes plus at most 3 from the core type switch.
+        includes.reserve(11);
 
         // Common includes for all core types
         includes.push_back("tt_metal/hw/ckernels/wormhole_b0/metal/common");

--- a/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
@@ -11,6 +11,9 @@ namespace tt::tt_metal::hal_2xx {
 
 std::vector<std::string> HalJitBuildQueryBase::defines(const HalJitBuildQueryInterface::Params& params) const {
     std::vector<std::string> defines;
+    // Upper bound: ENABLE_L1_DATA_CACHE, at most 4 from the core type switch (ACTIVE_ETH / IDLE_ETH),
+    // and PROGRAMMABLE_CORE_TYPE.
+    defines.reserve(6);
     const auto& l1_cache_enable_processors =
         params.rtoptions.get_feature_processors(tt::llrt::RunTimeDebugFeatureEnableL1DataCache);
     auto processor_index = hal_.get_processor_index(params.core_type, params.processor_class, params.processor_id);

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -259,6 +259,8 @@ public:
 
     std::vector<std::string> link_objs(const Params& params) const override {
         std::vector<std::string> objs;
+        // Upper bound: crt0-tls.o, crt0.o, noc.o and substitutes.o.
+        objs.reserve(4);
         std::string_view cpu = params.processor_class == HalProcessorClassType::DM ? "tt-qsr64" : "tt-qsr32";
         std::string_view dir = "runtime/hw/lib/quasar";
         objs.push_back(fmt::format("{}/{}-crt0-tls.o", dir, cpu));
@@ -278,6 +280,8 @@ public:
 
     std::vector<std::string> includes(const Params& params) const override {
         std::vector<std::string> includes;
+        // Upper bound: 10 common includes, at most 2 from the core type switch, plus the firmware dir.
+        includes.reserve(13);
 
         // Common includes for all core types
         includes.push_back("tt_metal/hw/ckernels/quasar/metal/common");

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -57,7 +57,9 @@ std::vector<tt::tt_metal::CoreCoord> metal_SocDescriptor::get_metal_dram_cores(t
     // one spot rather than every DRAM loop in Metal.
     const bool exclude_noc0_endpoints = (this->arch == tt::ARCH::BLACKHOLE);
     std::vector<tt::tt_metal::CoreCoord> dram_cores;
-    for (const tt::umd::CoreCoord& core : get_cores(tt::CoreType::DRAM, coord_system)) {
+    const auto& umd_dram_cores = get_cores(tt::CoreType::DRAM, coord_system);
+    dram_cores.reserve(umd_dram_cores.size());
+    for (const tt::umd::CoreCoord& core : umd_dram_cores) {
         if (exclude_noc0_endpoints) {
             const tt::umd::CoreCoord translated = translate_coord_to(core, tt::CoordSystem::TRANSLATED);
             if (is_noc0_dram_endpoint({translated.x, translated.y})) {
@@ -223,12 +225,18 @@ tt::tt_metal::CoreCoord metal_SocDescriptor::get_dram_compute_grid_size() const 
 void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
     YAML::Node device_descriptor_yaml = YAML::LoadFile(this->device_descriptor_file_path);
     this->dram_view_size = device_descriptor_yaml["dram_view_size"].as<uint64_t>();
-    this->dram_core_size = device_descriptor_yaml["dram_views"].size() * this->dram_view_size;
+    const size_t num_dram_views_in_descriptor = device_descriptor_yaml["dram_views"].size();
+    this->dram_core_size = num_dram_views_in_descriptor * this->dram_view_size;
     this->dram_view_channels.clear();
     this->dram_view_eth_cores.clear();
     this->dram_view_worker_cores.clear();
     this->dram_view_address_offsets.clear();
     this->dram_bank_endpoint_coords.clear();
+    this->dram_view_channels.reserve(num_dram_views_in_descriptor);
+    this->dram_view_eth_cores.reserve(num_dram_views_in_descriptor);
+    this->dram_view_worker_cores.reserve(num_dram_views_in_descriptor);
+    this->dram_view_address_offsets.reserve(num_dram_views_in_descriptor);
+    this->dram_bank_endpoint_coords.reserve(num_dram_views_in_descriptor);
 
     const uint32_t dram_harvesting_mask = this->harvesting_masks.dram_harvesting_mask;
 
@@ -243,9 +251,12 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
         }
         size_t address_offset = dram_view["address_offset"].as<size_t>();
 
+        const auto eth_endpoint_ids = dram_view["eth_endpoint"].as<std::vector<int>>();
         std::vector<tt::tt_metal::CoreCoord> eth_dram_cores;
         std::vector<size_t> eth_endpoints;
-        for (int eth_endpoint : dram_view["eth_endpoint"].as<std::vector<int>>()) {
+        eth_dram_cores.reserve(eth_endpoint_ids.size());
+        eth_endpoints.reserve(eth_endpoint_ids.size());
+        for (int eth_endpoint : eth_endpoint_ids) {
             if (eth_endpoint >= get_grid_size(tt::CoreType::DRAM).y) {
                 TT_THROW(
                     "DRAM subchannel {} does not exist in the device descriptor, but is specified in "
@@ -258,9 +269,12 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
             eth_endpoints.push_back(eth_endpoint);
         }
 
+        const auto worker_endpoint_ids = dram_view["worker_endpoint"].as<std::vector<int>>();
         std::vector<tt::tt_metal::CoreCoord> worker_dram_cores;
         std::vector<size_t> worker_endpoints;
-        for (int worker_endpoint : dram_view["worker_endpoint"].as<std::vector<int>>()) {
+        worker_dram_cores.reserve(worker_endpoint_ids.size());
+        worker_endpoints.reserve(worker_endpoint_ids.size());
+        for (int worker_endpoint : worker_endpoint_ids) {
             if (worker_endpoint >= get_grid_size(tt::CoreType::DRAM).y) {
                 TT_THROW(
                     "DRAM subchannel {} does not exist in the device descriptor, but is specified in "
@@ -276,8 +290,8 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
 
         this->dram_view_channels.push_back(channel);
         this->dram_view_address_offsets.push_back(address_offset);
-        this->dram_view_eth_cores.push_back(eth_dram_cores);
-        this->dram_view_worker_cores.push_back(worker_dram_cores);
+        this->dram_view_eth_cores.push_back(std::move(eth_dram_cores));
+        this->dram_view_worker_cores.push_back(std::move(worker_dram_cores));
 
         size_t num_subchannels = get_grid_size(tt::CoreType::DRAM).y;
         size_t preferred_subchannel = worker_endpoints[0];

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -1979,7 +1979,7 @@ void RunTimeOptions::ParseFeatureCoreRange(
     }
 
     // Set the core range
-    feature_targets[feature].cores[core_type] = cores;
+    feature_targets[feature].cores[core_type] = std::move(cores);
 }
 
 bool RunTimeOptions::ParseFeatureChipIds(RunTimeDebugFeatures feature, const std::string& env_var) {
@@ -2005,7 +2005,7 @@ bool RunTimeOptions::ParseFeatureChipIds(RunTimeDebugFeatures feature, const std
         }
     }
 
-    feature_targets[feature].chip_ids = chips;
+    feature_targets[feature].chip_ids = std::move(chips);
 
     return specified;
 }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1391,6 +1391,7 @@ std::vector<tt::tt_metal::CoreCoord> Cluster::get_fabric_ethernet_routers_betwee
     std::vector<tt::tt_metal::CoreCoord> fabric_ethernet_channels;
     const auto& connected_chips = this->get_ethernet_cores_grouped_by_connected_chips(src_id);
     TT_FATAL(connected_chips.contains(dst_id), "Dst Chip {} is not connected to Src Chip {}", dst_id, src_id);
+    fabric_ethernet_channels.reserve(connected_chips.at(dst_id).size());
     for (const auto& eth_core : connected_chips.at(dst_id)) {
         if (this->device_eth_routing_info_.at(src_id).at(eth_core) == EthRouterMode::FABRIC_ROUTER) {
             fabric_ethernet_channels.push_back(eth_core);
@@ -1492,7 +1493,9 @@ void Cluster::set_internal_routing_info_for_ethernet_cores(
             mmio_devices.emplace_back(chip_id);
         }
     }
-    for (auto chip_id : this->driver_->get_target_remote_device_ids()) {
+    const auto& remote_device_ids = this->driver_->get_target_remote_device_ids();
+    non_mmio_devices.reserve(remote_device_ids.size());
+    for (auto chip_id : remote_device_ids) {
         non_mmio_devices.emplace_back(chip_id);
     }
 

--- a/tt_metal/llrt/tunnels_from_mmio_device.cpp
+++ b/tt_metal/llrt/tunnels_from_mmio_device.cpp
@@ -46,6 +46,7 @@ std::map<ChipId, std::vector<std::vector<ChipId>>> discover_tunnels_from_mmio_de
               continue;
           }
 
+          tunnels_from_mmio.reserve(all_eth_connections.at(mmio_chip_id).size());
           for (const auto& [eth_chan, connected_chip_chan] : all_eth_connections.at(mmio_chip_id)) {
               const auto& other_chip_id = std::get<0>(connected_chip_chan);
               if (device_ids.contains(other_chip_id)) {
@@ -53,7 +54,7 @@ std::map<ChipId, std::vector<std::vector<ChipId>>> discover_tunnels_from_mmio_de
                   std::vector<ChipId> first_stop = {other_chip_id};
                   auto it = std::find(tunnels_from_mmio.begin(), tunnels_from_mmio.end(), first_stop);
                   TT_FATAL(it == tunnels_from_mmio.end(), "Duplicate first tunnel stop found.");
-                  tunnels_from_mmio.push_back(first_stop);
+                  tunnels_from_mmio.push_back(std::move(first_stop));
               }
           }
 
@@ -91,7 +92,7 @@ std::map<ChipId, std::vector<std::vector<ChipId>>> discover_tunnels_from_mmio_de
               }
               dev_vec.insert(dev_vec.begin(), mmio_chip_id);
           }
-          tunnels_from_mmio_device.insert({mmio_chip_id, tunnels_from_mmio});
+          tunnels_from_mmio_device.insert({mmio_chip_id, std::move(tunnels_from_mmio)});
       }
 
       return tunnels_from_mmio_device;

--- a/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
@@ -99,6 +99,8 @@ int main() {
 
     // specify compile time args for TTNN reader/writer
     std::vector<uint32_t> reader_compile_time_args;
+    // 20 explicit args below + 2 appended by TensorAccessorArgs for an interleaved buffer
+    reader_compile_time_args.reserve(22);
     // N, H, C (treat rows as N, single H=1, columns (packed) as C)
     reader_compile_time_args.push_back(src_M);                // N
     reader_compile_time_args.push_back(1);                    // H
@@ -135,7 +137,7 @@ int main() {
         tt_metal::DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_0,
             .noc = NOC::RISCV_0_default,
-            .compile_args = reader_compile_time_args});
+            .compile_args = std::move(reader_compile_time_args)});
     KernelHandle writer_id = CreateKernel(
         program,
         "tt_metal/programming_examples/pad_multi_core/kernels/pad_writer_dims_rm_interleaved.cpp",
@@ -143,32 +145,26 @@ int main() {
         tt_metal::DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_1,
             .noc = NOC::RISCV_1_default,
-            .compile_args = writer_compile_time_args});
+            .compile_args = std::move(writer_compile_time_args)});
 
     // set kernel runtime arguments
     uint32_t start_src_idx = 0;
     uint32_t start_dst_idx = 0;
     uint32_t num_rows_per_core = src_M / num_cores;
     uint32_t num_src_sticks_per_core = num_packed_row_src * num_rows_per_core;
+    std::vector<uint32_t> reader_rt;
+    reader_rt.reserve(11);
+    std::vector<uint32_t> writer_rt;
+    writer_rt.reserve(4);
     for (uint32_t core_idx = 0; core_idx < num_cores; core_idx++) {
         CoreCoord core = {0, core_idx};
         uint32_t num_sticks_per_core = num_rows_per_core * num_packed_row_dst;
         uint32_t num_sticks_per_barrier_rt = num_packed_row_dst;  // one row per barrier
         // Reader runtime: src_addr, num_sticks_per_core, num_sticks_per_barrier, start_id, front_pad_n,c,h, start_dim_offset[0..3]
-        std::vector<uint32_t> reader_rt = {src_addr,
-                                           num_sticks_per_core,
-                                           num_sticks_per_barrier_rt,
-                                           start_src_idx,
-                                           0,
-                                           0,
-                                           0,
-                                           0,
-                                           0,
-                                           0,
-                                           0};
+        reader_rt = {src_addr, num_sticks_per_core, num_sticks_per_barrier_rt, start_src_idx, 0, 0, 0, 0, 0, 0, 0};
         tt_metal::SetRuntimeArgs(program, reader_id, core, reader_rt);
         // Writer runtime: dst_addr, num_sticks_per_core, num_sticks_per_barrier, start_id
-        std::vector<uint32_t> writer_rt = {dst_addr, num_sticks_per_core, num_sticks_per_barrier_rt, start_dst_idx};
+        writer_rt = {dst_addr, num_sticks_per_core, num_sticks_per_barrier_rt, start_dst_idx};
         tt_metal::SetRuntimeArgs(program, writer_id, core, writer_rt);
         start_src_idx += num_src_sticks_per_core;
         start_dst_idx += num_packed_row_dst * num_rows_per_core;

--- a/tt_metal/tools/mem_bench/device_utils.cpp
+++ b/tt_metal/tools/mem_bench/device_utils.cpp
@@ -23,6 +23,7 @@ namespace tt::tt_metal::tools::mem_bench {
 
 std::vector<uint32_t> read_cores(tt::tt_metal::IDevice* device, const CoreRange& cores, uint32_t addr) {
     std::vector<uint32_t> data;
+    data.reserve(cores.size());
     for (size_t xi = cores.start_coord.x; xi <= cores.end_coord.x; ++xi) {
         for (size_t yi = cores.start_coord.y; yi <= cores.end_coord.y; ++yi) {
             std::vector<uint32_t> single_data;

--- a/tt_metal/tools/mem_bench/host_utils.cpp
+++ b/tt_metal/tools/mem_bench/host_utils.cpp
@@ -48,6 +48,7 @@ std::vector<int> get_mmio_device_ids(int number_of_devices, int numa_node) {
     auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto pcie_devices = cluster.number_of_pci_devices();
     std::vector<int> device_ids;
+    device_ids.reserve(std::min<size_t>(pcie_devices, number_of_devices));
 
     // Assumes PCIe device IDs are iterated first
     for (int device_id = 0; device_id < pcie_devices && device_ids.size() < number_of_devices; ++device_id) {
@@ -70,6 +71,7 @@ std::vector<int> get_mmio_device_ids_unique_nodes(int number_of_devices) {
     auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto pcie_devices = cluster.number_of_pci_devices();
     std::vector<int> device_ids;
+    device_ids.reserve(std::min<size_t>(pcie_devices, number_of_devices));
     std::unordered_set<uint32_t> numa_nodes;
 
     for (int device_id = 0; device_id < pcie_devices && device_ids.size() < number_of_devices; ++device_id) {

--- a/tt_stl/tests/test_cleanup.cpp
+++ b/tt_stl/tests/test_cleanup.cpp
@@ -25,6 +25,7 @@ TEST(CleanupTest, Basic) {
 
 TEST(CleanupTest, MultipleCleanupsInOrder) {
     std::vector<int> log;
+    log.reserve(3);
     {
         auto cleanup1 = make_cleanup([&log]() { log.push_back(1); });
         auto cleanup2 = make_cleanup([&log]() { log.push_back(2); });

--- a/tt_stl/tests/test_hash.cpp
+++ b/tt_stl/tests/test_hash.cpp
@@ -230,7 +230,9 @@ TEST(CanonicalKeyTest, DistinguishesVectorBool) {
     // For each length 1..10, an all-true vector and an all-false vector (opposite at every index)
     // must encode differently.
     std::vector<bool> mixed_left;
+    mixed_left.reserve(10);
     std::vector<bool> mixed_right;
+    mixed_right.reserve(10);
     for (std::size_t len = 1; len <= 10; ++len) {
         const std::vector<bool> all_true(len, true);
         const std::vector<bool> all_false(len, false);

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -1772,6 +1772,7 @@ template <typename T>
 struct from_json_t<std::vector<T>> {
     std::vector<T> operator()(const nlohmann::json& json_object) noexcept {
         std::vector<T> vector;
+        vector.reserve(json_object.size());
         for (const auto& element : json_object) {
             vector.push_back(from_json<T>(element));
         }

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -78,6 +78,7 @@ static inline std::vector<json> get_tensors_json(const std::vector<ttnn::Tensor>
 static inline std::vector<json> get_tensors_json(const std::vector<std::optional<const ttnn::Tensor>>& tensors) {
     ZoneScoped;
     std::vector<json> ret;
+    ret.reserve(tensors.size());
     for (const auto& tensor : tensors) {
         if (tensor.has_value()) {
             ret.push_back(get_tensor_json(tensor.value()));
@@ -89,6 +90,7 @@ static inline std::vector<json> get_tensors_json(const std::vector<std::optional
 static inline std::vector<json> get_tensors_json(const std::vector<std::optional<ttnn::Tensor>>& tensors) {
     ZoneScoped;
     std::vector<json> ret;
+    ret.reserve(tensors.size());
     for (const auto& tensor : tensors) {
         if (tensor.has_value()) {
             ret.push_back(get_tensor_json(tensor.value()));

--- a/ttnn/core/config.cpp
+++ b/ttnn/core/config.cpp
@@ -36,8 +36,10 @@ std::vector<std::pair<std::string, std::string>> Config::get_config_entries() co
 // The callback is invoked lazily when getConfiguration RPC is queried.
 static const int register_inspector_config = [] {
     tt::tt_metal::inspector::add_config_callback([]() {
+        const auto config_entries = CONFIG.get_config_entries();
         std::vector<tt::tt_metal::inspector::ConfigurationEntry> entries;
-        for (const auto& [name, value] : CONFIG.get_config_entries()) {
+        entries.reserve(config_entries.size());
+        for (const auto& [name, value] : config_entries) {
             entries.push_back(
                 {name, value == "nullopt" ? "(unset)" : value, tt::tt_metal::inspector::ConfigScope::TtnnConfig});
         }

--- a/ttnn/core/device_operation_detail.cpp
+++ b/ttnn/core/device_operation_detail.cpp
@@ -55,6 +55,7 @@ compute_output_placements_and_shape(const std::vector<std::reference_wrapper<con
     TT_FATAL(!tensors.empty(), "Cannot compute output placements and shape with no tensors");
 
     std::vector<std::reference_wrapper<const Tensor>> sharded_tensors;
+    sharded_tensors.reserve(tensors.size());
     for (const auto& tensor_ref : tensors) {
         if (!is_fully_replicated(tensor_ref.get())) {
             sharded_tensors.push_back(tensor_ref);
@@ -141,7 +142,7 @@ compute_output_placements_and_shape(const std::vector<std::reference_wrapper<con
             "Input tensors have different distribution ranks, only imputing output tensor topology with tensors that "
             "have the max distribution rank");
     }
-    return {result_placements, tt::tt_metal::distributed::MeshShape(result_strides)};
+    return {std::move(result_placements), tt::tt_metal::distributed::MeshShape(std::move(result_strides))};
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -191,6 +192,7 @@ std::vector<MeshCoordinate> extract_tensor_coordinates_impl(
 
     const Tensor& first_tensor = tensors.front().get();
     std::vector<ttnn::MeshCoordinate> tensor_coordinates;
+    tensor_coordinates.reserve(first_tensor.device_storage().get_coords().size());
     std::transform(
         first_tensor.device_storage().get_coords().begin(),
         first_tensor.device_storage().get_coords().end(),
@@ -203,6 +205,7 @@ std::vector<MeshCoordinate> extract_tensor_coordinates_impl(
         const Tensor& tensor = tensor_ref.get();
         if (tensor.device_storage().get_coords().size() != tensor_coordinates.size()) {
             std::vector<ttnn::MeshCoordinate> tensor_mesh_coords;
+            tensor_mesh_coords.reserve(tensor.device_storage().get_coords().size());
             std::transform(
                 tensor.device_storage().get_coords().begin(),
                 tensor.device_storage().get_coords().end(),

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -96,11 +96,9 @@ Tensor from_host_shards(const std::vector<Tensor>& tensor_shards, const MeshShap
 
     auto distributed_host_buffer = DistributedHostBuffer::create(mesh_shape);
     auto shard_it = tensor_shards.begin();
-    std::vector<distributed::MeshCoordinate> coords;
     for (const auto& coord : distributed::MeshCoordinateRange(mesh_shape)) {
         HostBuffer buffer = host_buffer::get_host_buffer(*(shard_it++));
         distributed_host_buffer.emplace_shard(coord, [&]() { return std::move(buffer); });
-        coords.push_back(coord);
     }
 
     tt::tt_metal::TensorTopology topology =

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -217,17 +217,18 @@ public:
             auto distributed_buffer = make_distributed_host_buffer();
             auto remap_fn = get_remap_fn(distribution_mode_, &global_range_);
             std::vector<MeshCoordinate> buffer_coords;
+            buffer_coords.reserve(distribution_shape_.mesh_size());
             for (const auto& coord : MeshCoordinateRange(distribution_shape_)) {
                 const auto mapped_coord = remap_fn(coord);
                 buffer_coords.push_back(mapped_coord);
                 distributed_buffer.emplace_shard(mapped_coord, [&b = replicated_buffer]() { return b; });
             }
 
-            const auto tensor_topology =
-                tt::tt_metal::TensorTopology(distribution_shape_, config_.placements, buffer_coords);
+            auto tensor_topology =
+                tt::tt_metal::TensorTopology(distribution_shape_, config_.placements, std::move(buffer_coords));
 
-            return Tensor(
-                tt::tt_metal::HostTensor::from_buffer(std::move(distributed_buffer), tensor_spec, tensor_topology));
+            return Tensor(tt::tt_metal::HostTensor::from_buffer(
+                std::move(distributed_buffer), tensor_spec, std::move(tensor_topology)));
         }
 
         // Otherwise, use xtensor to chunk the data into shards.
@@ -348,6 +349,7 @@ private:
         std::unordered_map<XTensorViewKey, tt::tt_metal::HostBuffer> converted_buffers;
 
         std::vector<MeshCoordinate> buffer_coords;
+        buffer_coords.reserve(sharded_xtensor_views.size());
         size_t num_views_with_value = 0;
         for (const auto& [coord, xtensor_view] : sharded_xtensor_views) {
             if (!xtensor_view.has_value()) {
@@ -396,11 +398,11 @@ private:
         const auto actual_distribution_shape =
             (distribution_shape_.dims() == 1) ? MeshShape(num_views_with_value) : distribution_shape_;
 
-        const auto tensor_topology =
-            tt::tt_metal::TensorTopology(actual_distribution_shape, config_.placements, buffer_coords);
+        auto tensor_topology =
+            tt::tt_metal::TensorTopology(actual_distribution_shape, config_.placements, std::move(buffer_coords));
 
-        return Tensor(
-            tt::tt_metal::HostTensor::from_buffer(std::move(distributed_buffer), shard_spec, tensor_topology));
+        return Tensor(tt::tt_metal::HostTensor::from_buffer(
+            std::move(distributed_buffer), shard_spec, std::move(tensor_topology)));
     }
 
     // Mesh parameters. `mesh_device_view_` is empty when constructed from a `MeshShape` only.

--- a/ttnn/core/distributed/distribution_mode.cpp
+++ b/ttnn/core/distributed/distribution_mode.cpp
@@ -4,6 +4,8 @@
 
 #include "distribution_mode.hpp"
 
+#include <algorithm>
+
 namespace ttnn::distributed {
 
 DistributionMode compute_distribution_mode(
@@ -31,6 +33,8 @@ std::vector<tt::tt_metal::distributed::MeshCoordinate> compute_distribution_to_m
     const tt::tt_metal::distributed::MeshShape& mesh_shape) {
     DistributionMode mode = compute_distribution_mode(std::make_optional(distribution_shape), mesh_shape);
     std::vector<tt::tt_metal::distributed::MeshCoordinate> mesh_coords;
+    // In ROW_MAJOR mode the mapping stops once the mesh range is exhausted, so the mesh shape bounds the result.
+    mesh_coords.reserve(std::min(distribution_shape.mesh_size(), mesh_shape.mesh_size()));
 
     if (mode == DistributionMode::SUBMESH) {
         // For SUBMESH mode, coordinates map directly (distribution coords match mesh coords)

--- a/ttnn/core/global_semaphore.cpp
+++ b/ttnn/core/global_semaphore.cpp
@@ -64,6 +64,7 @@ MultiDeviceGlobalSemaphore create_global_semaphore_with_same_address(
             auto& global_semaphore = multi_device_global_semaphore.global_semaphores[i];
             size_t attempt = 0;
             std::vector<GlobalSemaphore> garbage;
+            garbage.reserve(attempts + 1);
             log_debug(tt::LogTTNN, "global_semaphore->address(): {}", get_global_semaphore_address(global_semaphore));
             while (get_global_semaphore_address(global_semaphore) != target_addr) {
                 auto sem = create_global_semaphore(device, cores, initial_value, buffer_type);

--- a/ttnn/core/graph/graph_trace_utils.cpp
+++ b/ttnn/core/graph/graph_trace_utils.cpp
@@ -161,6 +161,7 @@ std::pair<uint32_t, uint32_t> count_intermediate_and_output_tensors(const nlohma
 
 std::vector<std::string> extract_calltrace(const nlohmann::json& trace) {
     std::vector<std::string> op_calls;
+    op_calls.reserve(trace.size());
     size_t i = 0;
 
     while (i < trace.size()) {
@@ -182,6 +183,7 @@ nlohmann::json extract_levelized_graph(const nlohmann::json& trace, size_t max_l
 
 std::vector<OperationInfo> extract_arguments(const nlohmann::json& trace) {
     std::vector<OperationInfo> operations;
+    operations.reserve(trace.size());
     size_t i = 0;
     while (i < trace.size()) {
         const auto& v = trace[i];
@@ -190,7 +192,7 @@ std::vector<OperationInfo> extract_arguments(const nlohmann::json& trace) {
         if (!v[kArguments].empty()) {
             info.operation_name = v[kParams][kName];
             info.arguments = v[kArguments];
-            operations.push_back(info);
+            operations.push_back(std::move(info));
         }
     }
 
@@ -238,6 +240,7 @@ std::unordered_set<uint32_t> extract_output_tensors(const nlohmann::json& trace)
 std::vector<TensorInfo> extract_output_info(const nlohmann::json& trace) {
     std::vector<TensorInfo> output;
     auto output_tensors = extract_output_tensors(trace);
+    output.reserve(output_tensors.size());
 
     for (const auto& node : trace) {
         if (node[kNodeType] != kNodeBuffer) {

--- a/ttnn/core/reports.cpp
+++ b/ttnn/core/reports.cpp
@@ -44,6 +44,11 @@ std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed:
     std::vector<BufferInfo> buffer_infos;
     for (auto* device : devices) {
         const auto allocated_buffers = device->allocator()->get_allocated_buffers();
+        // Keep the geometric growth of the vector while making sure the buffers of this device fit.
+        const size_t required_size = buffer_infos.size() + allocated_buffers.size();
+        if (required_size > buffer_infos.capacity()) {
+            buffer_infos.reserve(std::max(required_size, buffer_infos.capacity() * 2));
+        }
         // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
         for (const auto& buffer : allocated_buffers) {
             auto device_id = device->id();
@@ -113,6 +118,12 @@ std::vector<BufferPageInfo> get_buffer_pages(const std::vector<tt::tt_metal::dis
             auto num_pages = buffer->num_pages();
             auto num_banks = device->allocator()->get_num_banks(buffer->buffer_type());
             auto buffer_type = buffer->buffer_type();
+
+            // Keep the geometric growth of the vector while making sure the pages of this buffer fit.
+            const size_t required_size = buffer_page_infos.size() + num_pages;
+            if (required_size > buffer_page_infos.capacity()) {
+                buffer_page_infos.reserve(std::max(required_size, buffer_page_infos.capacity() * 2));
+            }
 
             if (is_sharded(buffer->buffer_layout())) {
                 const auto& buffer_page_mapping = *buffer->get_buffer_page_mapping();

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -183,6 +183,7 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
     std::vector<uint64_t> dedup_key_to_offset(unique_keys, std::numeric_limits<uint64_t>::max());
 
     std::vector<flatbuffers::Offset<ttnn::flatbuffer::TensorShard>> shards_vector;
+    shards_vector.reserve(mesh_shape.mesh_size());
     // Used to deduplicate buffer addresses for replicated tensor data.
     std::unordered_map<const std::byte*, uint64_t> buffer_to_offset;
 

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -10,16 +10,18 @@ namespace ttnn {
 
 CoreRangeSet from_flatbuffer(const flatbuffer::CoreRangeSet* core_range_set) {
     std::vector<CoreRange> ranges;
+    ranges.reserve(core_range_set->ranges()->size());
     for (const auto* range : *core_range_set->ranges()) {
         ranges.emplace_back(
             tt::tt_metal::CoreCoord{range->start()->x(), range->start()->y()}, tt::tt_metal::CoreCoord{range->end()->x(), range->end()->y()});
     }
-    return CoreRangeSet{ranges};
+    return CoreRangeSet{std::move(ranges)};
 }
 
 flatbuffers::Offset<flatbuffer::CoreRangeSet> to_flatbuffer(
     flatbuffers::FlatBufferBuilder& builder, const CoreRangeSet& core_range_set) {
     std::vector<flatbuffers::Offset<flatbuffer::CoreRange>> range_offsets;
+    range_offsets.reserve(core_range_set.ranges().size());
     for (const auto& range : core_range_set.ranges()) {
         auto start = flatbuffer::CreateCoreCoord(builder, range.start_coord.x, range.start_coord.y);
         auto end = flatbuffer::CreateCoreCoord(builder, range.end_coord.x, range.end_coord.y);

--- a/ttnn/cpp/tools/profiler/op_profiler_json.cpp
+++ b/ttnn/cpp/tools/profiler/op_profiler_json.cpp
@@ -72,7 +72,10 @@ static json get_kernels_json(ChipId device_id, const Program& program) {
     // profiler JSON well within Tracy's 64 KiB message limit.
     std::set<std::pair<std::string_view, std::string>> seenCompute;
     std::set<std::string_view> seenDatamovement;
-    for (const auto& kernel : detail::collect_kernel_meta(program, device)) {
+    const auto kernelMeta = detail::collect_kernel_meta(program, device);
+    computeKernels.reserve(kernelMeta.size());
+    datamovementKernels.reserve(kernelMeta.size());
+    for (const auto& kernel : kernelMeta) {
         auto processor_class = kernel.processor_class;
         if (processor_class == HalProcessorClassType::COMPUTE) {
             auto fidelityStr = enchantum::to_string(kernel.math_fidelity.value());

--- a/ttnn/cpp/ttnn-nanobind/bfp_utils.cpp
+++ b/ttnn/cpp/ttnn-nanobind/bfp_utils.cpp
@@ -150,6 +150,7 @@ void py_module(nb::module_& mod) {
             result.reserve(mapping.all_cores.size());
             for (size_t i = 0; i < mapping.all_cores.size(); i++) {
                 std::vector<uint32_t> pages;
+                pages.reserve(mapping.core_host_page_indices[i].size());
                 for (auto p : mapping.core_host_page_indices[i]) {
                     if (p != tt::tt_metal::UncompressedBufferPageMapping::PADDING) {
                         pages.push_back(p);

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -871,11 +871,13 @@ void py_module_types(nb::module_& mod) {
             },
             [](tt::tt_metal::KernelDescriptor& self, const nb::list& args) {
                 self.blaze_named_args.named_per_core_runtime_args.clear();
+                self.blaze_named_args.named_per_core_runtime_args.reserve(args.size());
                 for (auto item : args) {
                     auto tup = nb::cast<nb::tuple>(item);
                     auto name = nb::cast<std::string>(tup[0]);
                     auto dict = nb::cast<nb::dict>(tup[1]);
                     std::vector<std::pair<CoreCoord, uint32_t>> core_values;
+                    core_values.reserve(dict.size());
                     for (const auto& [k, v] : dict) {
                         core_values.emplace_back(nb::cast<CoreCoord>(k), nb::cast<uint32_t>(v));
                     }
@@ -900,11 +902,13 @@ void py_module_types(nb::module_& mod) {
             },
             [](tt::tt_metal::KernelDescriptor& self, const nb::list& args) {
                 self.blaze_named_args.named_common_runtime_arg_arrays.clear();
+                self.blaze_named_args.named_common_runtime_arg_arrays.reserve(args.size());
                 for (auto item : args) {
                     auto tup = nb::cast<nb::tuple>(item);
                     auto name = nb::cast<std::string>(tup[0]);
                     auto values_list = nb::cast<nb::list>(tup[1]);
                     std::vector<uint32_t> values;
+                    values.reserve(values_list.size());
                     for (auto v : values_list) {
                         values.push_back(nb::cast<uint32_t>(v));
                     }
@@ -933,14 +937,17 @@ void py_module_types(nb::module_& mod) {
             },
             [](tt::tt_metal::KernelDescriptor& self, const nb::list& args) {
                 self.blaze_named_args.named_per_core_runtime_arg_arrays.clear();
+                self.blaze_named_args.named_per_core_runtime_arg_arrays.reserve(args.size());
                 for (auto item : args) {
                     auto tup = nb::cast<nb::tuple>(item);
                     auto name = nb::cast<std::string>(tup[0]);
                     auto dict = nb::cast<nb::dict>(tup[1]);
                     std::vector<std::pair<CoreCoord, std::vector<uint32_t>>> core_values;
+                    core_values.reserve(dict.size());
                     for (const auto& [k, v] : dict) {
                         auto values_list = nb::cast<nb::list>(v);
                         std::vector<uint32_t> values;
+                        values.reserve(values_list.size());
                         for (auto val : values_list) {
                             values.push_back(nb::cast<uint32_t>(val));
                         }

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation_types.hpp
@@ -40,6 +40,7 @@ struct BroadcastParams {
     auto attributes() const {
         using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
+        attrs.reserve(6);
         attrs.emplace_back("sender_coord", sender_coord);
         attrs.emplace_back("num_links", num_links);
         attrs.emplace_back("ring_size", ring_size);

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -477,6 +477,7 @@ std::vector<ttnn::Tensor> unpad_output_tensor(
     const ttsl::SmallVector<uint32_t>& unpad_elements,
     const int dim) {
     std::vector<ttnn::Tensor> combined_tensors;
+    combined_tensors.reserve(num_devices);
 
     ttsl::SmallVector<uint32_t> begins = {0, 0, 0, 0};
     ttsl::SmallVector<uint32_t> ends = {1, 1, 1, 1};
@@ -489,7 +490,7 @@ std::vector<ttnn::Tensor> unpad_output_tensor(
 
         ttnn::Tensor sliced_tensor = ttnn::slice(output_tensor.at(0), begins, ends, step);
 
-        combined_tensors.push_back(sliced_tensor);
+        combined_tensors.push_back(std::move(sliced_tensor));
     }
     ttnn::Tensor concat_tensor = ttnn::concat(combined_tensors, dim);
     return {concat_tensor};

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
@@ -138,7 +138,9 @@ static std::pair<std::vector<uint32_t>, std::vector<uint32_t>> shard_noc_cores_f
     TT_ASSERT(d != nullptr);
     auto const& core_range = shard_spec.grid.bounding_box();
     std::vector<uint32_t> logical_to_noc_row_map;
+    logical_to_noc_row_map.reserve(core_range.end_coord.y - core_range.start_coord.y + 1);
     std::vector<uint32_t> logical_to_noc_col_map;
+    logical_to_noc_col_map.reserve(core_range.end_coord.x - core_range.start_coord.x + 1);
     for (uint32_t y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
         CoreCoord noc_core = d->virtual_core_from_logical_core(CoreCoord(0, y), tt::CoreType::WORKER);
         logical_to_noc_row_map.push_back(noc_core.y);
@@ -148,12 +150,13 @@ static std::pair<std::vector<uint32_t>, std::vector<uint32_t>> shard_noc_cores_f
         logical_to_noc_col_map.push_back(noc_core.x);
     }
 
-    return {logical_to_noc_row_map, logical_to_noc_col_map};
+    return {std::move(logical_to_noc_row_map), std::move(logical_to_noc_col_map)};
 }
 
 std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_rt_args(IDevice const* d, Tensor const& t) {
     std::vector<uint32_t> args;
     auto const& [row_map, col_map] = shard_noc_cores_from_shard_spec(d, t.shard_spec().value());
+    args.reserve(row_map.size() + col_map.size() + 2);
     args.push_back(row_map.size());
     for (unsigned int row : row_map) {
         args.push_back(row);
@@ -168,6 +171,7 @@ std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_rt_args(IDevice const* d, T
 
 std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_ct_args(Tensor const& t) {
     std::vector<uint32_t> args;
+    args.reserve(7);
     TT_ASSERT(t.is_sharded());
     auto const& [pages_per_shard_y, pages_per_shard_x] = t.buffer()->shard_spec().shape_in_pages();
     auto const& [shard_grid_start, shard_grid_end] = shard_grid_from_shard_spec(t.shard_spec().value());

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/command_lowering.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/command_lowering.cpp
@@ -213,6 +213,7 @@ std::vector<ttnn::ccl::cmd::CclHostLowLevelWorkerCommand> tensor_slice_commands_
     const ttnn::Tensor& tensor,
     size_t packet_size_bytes) {
     std::vector<ttnn::ccl::cmd::CclHostLowLevelWorkerCommand> lowered_command_stream;
+    lowered_command_stream.reserve(command_stream.size());
     for (const auto& command : command_stream) {
         switch (command.command_code) {
             case ttnn::ccl::cmd::CclCommandCode::STREAM_CB_TO_TENSOR: [[fallthrough]];

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_program.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_program.cpp
@@ -184,6 +184,7 @@ ttnn::device_operation::CachedProgram<ReduceToRootOp::ReduceToRoot::shared_varia
 
     // Get all cores from the shard grid
     std::vector<CoreCoord> all_coord_cores;
+    all_coord_cores.reserve(shard_grid.num_cores());
     for (const auto& core_range : shard_grid.ranges()) {
         auto cores = corerange_to_cores(core_range, std::nullopt);
         all_coord_cores.insert(all_coord_cores.end(), cores.begin(), cores.end());
@@ -645,6 +646,7 @@ ttnn::device_operation::CachedProgram<ReduceToRootOp::ReduceToRoot::shared_varia
     // Split cores into links - divide all cores evenly between links
     constexpr auto num_links = 2;
     std::vector<CoreCoord> cores;
+    cores.reserve(num_shard_cores);
     std::vector<CoreRangeSet> cores_per_link;
 
     // Split cores evenly: first half to link 1, second half to link 2
@@ -830,7 +832,7 @@ ttnn::device_operation::CachedProgram<ReduceToRootOp::ReduceToRoot::shared_varia
         ReduceToRootOp::ReduceToRoot::shared_variables_t{
             .send_unary_reader_kernel_id = is_sender_device ? reader_kernel : 0,
             .send_unary_writer_kernel_id = is_sender_device ? writer_kernel : 0,
-            .cores = cores,
+            .cores = std::move(cores),
             .root1_reader_kernel_id = is_root_device ? reader_kernel : 0,
             .root1_writer_kernel_id = is_root_device ? writer_kernel : 0,
             .root2_reader_kernel_id = is_root2_device ? reader_kernel : 0,

--- a/ttnn/cpp/ttnn/operations/ccl/sharding_addrgen_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/sharding_addrgen_helper.cpp
@@ -25,6 +25,7 @@ uint32_t get_sharding_core_count(const ttnn::Tensor& t) {
 
 std::vector<CoreCoord> get_shard_cores(const ttnn::Tensor& t) {
     std::vector<CoreCoord> coordinates;
+    coordinates.reserve(get_sharding_core_count(t));
     const tt::tt_metal::IDevice* device = t.device();
     struct ShardSpec shard_spec = t.shard_spec().value();
     const auto core_ranges = t.buffer()->shard_spec().grid().ranges();
@@ -65,6 +66,7 @@ std::vector<CoreCoord> get_shard_cores(const ttnn::Tensor& t) {
 
 std::vector<uint32_t> generate_run_time_args(const ttnn::Tensor& t) {
     std::vector<uint32_t> args;
+    args.reserve((get_sharding_core_count(t) + 1) / 2);
     const tt::tt_metal::IDevice* device = t.device();
     struct ShardSpec shard_spec = t.shard_spec().value();
     const auto core_ranges = t.buffer()->shard_spec().grid().ranges();
@@ -128,6 +130,7 @@ void extend_sharding_run_time_args(const ttnn::Tensor& t, std::vector<uint32_t>&
 
 std::vector<uint32_t> generate_compile_time_args(const ttnn::Tensor& t) {
     std::vector<uint32_t> args;
+    args.reserve(7);
     TT_ASSERT(t.is_sharded());
     TT_FATAL(
         t.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -126,6 +126,7 @@ ActivationReuseConfig calculate_activation_reuse_params(
     config.num_cores_with_non_meaningful_work = tt::div_up(total_remaining_tiles_to_push, single_core_height_ntiles);
 
     std::vector<CoreCoord> all_input_cores;
+    all_input_cores.reserve(input_cores.num_cores());
     for (const CoreRange& range : input_cores.ranges()) {
         for (const CoreCoord& core : range) {
             all_input_cores.push_back(core);
@@ -870,7 +871,8 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
         writer_defines["CONFIG_TENSOR_IN_DRAM"] = "1";               // Needed for split reader
         writer_mcast_sender_defines["CONFIG_TENSOR_IN_DRAM"] = "1";  // Needed for split reader
-        reader_compile_time_args.push_back(conv_reader_indices_buffer->address());
+        reader_compile_time_args.push_back(
+            conv_reader_indices_buffer->address());  // smuggled-rta-ok: compile-time args, not runtime args
         reader_compile_time_args.push_back(conv_reader_indices_buffer->page_size());
         tt::tt_metal::TensorAccessorArgs(conv_reader_indices_buffer).append_to(reader_compile_time_args);
     } else {

--- a/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
@@ -451,6 +451,8 @@ struct BlockRep {
 
         std::vector<BlockRep> first;
         std::vector<BlockRep> second;
+        first.reserve(2);
+        second.reserve(2);
 
         int rep_idx = idx / single_rep();
         if (rep_idx > 0) {
@@ -478,7 +480,7 @@ struct BlockRep {
             second.emplace_back(n_data, n_mixed, n_pads, remaining_times);
         }
 
-        return {first, second};
+        return {std::move(first), std::move(second)};
     }
 };
 
@@ -584,7 +586,7 @@ inline std::vector<std::vector<BlockRep>> distribute_work(
             }
         }
 
-        core_assignments.push_back(core_blocks);
+        core_assignments.push_back(std::move(core_blocks));
     }
 
     return core_assignments;

--- a/ttnn/cpp/ttnn/operations/data_movement/chunk/chunk.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/chunk/chunk.cpp
@@ -24,6 +24,8 @@ std::vector<ttnn::Tensor> chunk(const ttnn::Tensor& input_tensor, const uint32_t
     int chunk_size = tt::div_up(size_along_dim, num_chunks);
 
     std::vector<ttnn::Tensor> chunks;
+    // A chunk holds at least one element, so fewer than num_chunks are produced for a small dim.
+    chunks.reserve(std::min(num_chunks, static_cast<uint32_t>(size_along_dim)));
     int start = 0;
 
     while (start < size_along_dim) {
@@ -40,7 +42,7 @@ std::vector<ttnn::Tensor> chunk(const ttnn::Tensor& input_tensor, const uint32_t
 
         ttnn::Tensor chunk_tensor = ttnn::slice(input_tensor, slice_start, slice_end, slice_step);
 
-        chunks.push_back(chunk_tensor);
+        chunks.push_back(std::move(chunk_tensor));
 
         start = end;
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
@@ -123,6 +123,8 @@ tt::tt_metal::ProgramDescriptor ConcatS2SMultiProgramFactory::create_descriptor(
 
     std::vector<uint32_t> runtime_args_0;
     std::vector<uint32_t> runtime_args_1;
+    runtime_args_0.reserve(num_input_tensors * 4);
+    runtime_args_1.reserve(num_input_tensors * 4);
     for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
         const auto input_num_sticks_per_risc = tt::div_up(input_num_sticks[input_id], 2);
         runtime_args_0.push_back(input_num_pages_per_stick[input_id]);

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -376,6 +376,7 @@ tt::tt_metal::ProgramDescriptor FillPadL1ShardedProgramFactory::create_descripto
     };
 
     std::vector<ShardCoreInfo> active;
+    active.reserve(all_shard_cores.size());
 
     for (uint32_t i = 0; i < static_cast<uint32_t>(all_shard_cores.size()); ++i) {
         uint32_t row, col;

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.cpp
@@ -27,6 +27,7 @@ std::vector<CoreRange> get_multicast_regions(const CoreRangeSet& all_cores, cons
     TT_ASSERT(logical_controller == logical_zero);
 
     std::vector<CoreRange> logical_core_ranges;
+    logical_core_ranges.reserve(3);
     auto split_core_range_containing_controller = [&](const CoreRange& controller_core_range) {
         TT_ASSERT(controller_core_range.start_coord == logical_controller);
         CoreRange right_block(

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
@@ -180,6 +180,7 @@ ProgramDescriptor NonZeroIndicesProgramFactory::create_descriptor(
     // Buffer* slots are auto-patched by the framework on program cache hits.
     // Geometry uint32_t args are fixed by the tensor spec (part of the program cache key).
     std::vector<std::variant<uint32_t, Buffer*>> runtime_args_list;
+    runtime_args_list.reserve(3 + geom_args.size());
     runtime_args_list.push_back(input.buffer());
     runtime_args_list.push_back(out_num_indices.buffer());
     runtime_args_list.push_back(out_indices.buffer());

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -21,9 +21,11 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_and_repeated_values(s
     if (values.empty()) {
         return chunks;
     }
+    chunks.reserve(values.size());
 
     // Initialize the first chunk
     std::vector<uint32_t> current_chunk;
+    current_chunk.reserve(values.size());
     current_chunk.push_back(values[0]);
 
     for (size_t i = 1; i < values.size(); ++i) {
@@ -36,7 +38,7 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_and_repeated_values(s
         }
     }
     // Add the last chunk
-    chunks.push_back(current_chunk);
+    chunks.push_back(std::move(current_chunk));
     return chunks;
 }
 
@@ -83,6 +85,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // figure out the start read stick id for each core, and the start id for each dim
         std::vector<int> stick_ids_per_core;
+        stick_ids_per_core.reserve(num_sticks_per_core_padded);
         int front_pad_stick_id = -2;
         int pad_stick_id = -1;
         for (uint32_t j = 0; j < num_sticks_per_core_padded; ++j) {
@@ -153,6 +156,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // reader rt args
         std::vector<uint32_t> reader_kernel_args;
+        reader_kernel_args.reserve(1 + 3 * core_stick_map.size() + 2 * num_sticks_per_core_padded);
         reader_kernel_args.push_back(core_stick_map.size());  // num_cores
 
         for (const auto& core_stick_pair : core_stick_map) {
@@ -168,10 +172,11 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // coalesce the sticks into chunks
         std::vector<std::vector<std::vector<uint32_t>>> stick_chunks_per_core;
+        stick_chunks_per_core.reserve(core_stick_map.size());
         for (auto core_stick_pair : core_stick_map) {
             auto stick_chunks = group_contiguous_and_repeated_values(core_stick_pair.second);
-            stick_chunks_per_core.push_back(stick_chunks);
             reader_kernel_args.push_back(stick_chunks.size());  // num_chunks for current core
+            stick_chunks_per_core.push_back(std::move(stick_chunks));
         }
         for (const auto& stick_chunks : stick_chunks_per_core) {
             for (auto chunk : stick_chunks) {
@@ -180,7 +185,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             }
         }
 
-        ret_val[i] = {reader_kernel_args, writer_kernel_args};
+        ret_val[i] = {std::move(reader_kernel_args), std::move(writer_kernel_args)};
     }
 
     return ret_val;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -209,6 +209,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileInvariant::
     // Constant reader tail shared by every core: output shape, inverse permutation, input strides.
     // The src buffer binding and per-core scalar slots are prepended per core in the loop below.
     std::vector<uint32_t> reader_common_args;
+    reader_common_args.reserve(output_shape_view.size() + inv_perm.size() + input_tile_strides.size());
     reader_common_args.insert(reader_common_args.end(), output_shape_view.begin(), output_shape_view.end());
     reader_common_args.insert(reader_common_args.end(), inv_perm.begin(), inv_perm.end());
     reader_common_args.insert(reader_common_args.end(), input_tile_strides.begin(), input_tile_strides.end());

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
@@ -438,6 +438,7 @@ ProgramDescriptor RollShardedProgramFactory::create_descriptor(
     auto build_runtime_args_dram_rm = [&](uint32_t dst_core_idx, const std::vector<RollTransferDesc>& descs) {
         // Collect unique source shards (at most 2) and assign them to staging slots 0/1.
         std::vector<uint32_t> src_shards;
+        src_shards.reserve(2);
         std::unordered_map<uint32_t, uint32_t> src_to_slot;
         for (const auto& td : descs) {
             if (!src_to_slot.contains(td.src_dram_shard_idx)) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
@@ -270,6 +270,7 @@ std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> create
             continue;
         }
         std::vector<detail::CompressedStrideBlock> compressed_blocks;
+        compressed_blocks.reserve(page_strides.size());
         auto it = page_strides.cbegin();
         while (it != page_strides.cend()) {
             size_t best_pattern_len = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
@@ -62,6 +62,7 @@ compute_width_sharding_reshard_segments(
     const uint32_t remote_stride_bytes = tt::align(element_size * remote_shard_width, remote_alignment);
 
     std::vector<WidthShardingReshardSegmentForSingleCore> runtime_args_for_each_core;
+    runtime_args_for_each_core.reserve(num_local_shards);
 
     bool is_final_transfer = false;
     uint32_t local_shard_offset = 0;
@@ -100,7 +101,7 @@ compute_width_sharding_reshard_segments(
             }
         }
         local_shard_offset = 0;
-        runtime_args_for_each_core.push_back(core_args);
+        runtime_args_for_each_core.push_back(std::move(core_args));
     }
 
     TT_FATAL(
@@ -109,7 +110,7 @@ compute_width_sharding_reshard_segments(
         num_local_shards,
         runtime_args_for_each_core.size());  // sanity check
 
-    return {runtime_args_for_each_core, total_num_sticks, local_stride_bytes, remote_stride_bytes};
+    return {std::move(runtime_args_for_each_core), total_num_sticks, local_stride_bytes, remote_stride_bytes};
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -25,8 +25,19 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<ui
         return chunks;
     }
 
+    // Contiguous values coalesce into far fewer chunks than there are values, so count the
+    // runs up front instead of reserving the worst case
+    size_t num_chunks = 1;
+    for (size_t i = 1; i < values.size(); ++i) {
+        if (values[i] != values[i - 1] + 1) {
+            ++num_chunks;
+        }
+    }
+    chunks.reserve(num_chunks);
+
     // Initialize the first chunk
     std::vector<uint32_t> current_chunk;
+    current_chunk.reserve(values.size());
     current_chunk.push_back(values[0]);
 
     for (size_t i = 1; i < values.size(); ++i) {
@@ -39,7 +50,7 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<ui
         }
     }
     // Add the last chunk
-    chunks.push_back(current_chunk);
+    chunks.push_back(std::move(current_chunk));
     return chunks;
 }
 
@@ -110,6 +121,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // stores all sticks id for a core
         std::vector<uint32_t> stick_ids_per_core;
+        stick_ids_per_core.reserve(num_sticks_per_core_unpadded);
         uint32_t src_stick_id = start_id;
         for (uint32_t i = 0; i < num_sticks_per_core_unpadded; ++i) {
             stick_ids_per_core.push_back(src_stick_id);
@@ -151,6 +163,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // reader rt args
         std::vector<uint32_t> reader_kernel_args;
+        reader_kernel_args.reserve(1 + 3 * core_stick_map.size() + 2 * num_sticks_per_core_unpadded);
         reader_kernel_args.push_back(core_stick_map.size());  // num_cores
 
         for (const auto& core_stick_pair : core_stick_map) {
@@ -166,11 +179,12 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // coalesce the sticks into chunks
         std::vector<std::vector<std::vector<uint32_t>>> stick_chunks_per_core;
+        stick_chunks_per_core.reserve(core_stick_map.size());
         for (auto core_stick_pair : core_stick_map) {
             auto stick_chunks = group_contiguous_values(core_stick_pair.second);
-            stick_chunks_per_core.push_back(stick_chunks);
-
             reader_kernel_args.push_back(stick_chunks.size());  // num_chunks for current core
+
+            stick_chunks_per_core.push_back(std::move(stick_chunks));
         }
         for (const auto& stick_chunks : stick_chunks_per_core) {
             for (auto chunk : stick_chunks) {
@@ -180,7 +194,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         }
 
         std::vector<uint32_t> writer_kernel_args;
-        ret_val[i] = {reader_kernel_args, writer_kernel_args};
+        ret_val[i] = {std::move(reader_kernel_args), std::move(writer_kernel_args)};
     }
 
     return ret_val;

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -481,6 +481,7 @@ Tensor build_physical_core_lookup_table_tensor(const SortInputs& tensor_args, st
     // cache miss; the framework keeps the tensor (and its buffer) alive for cache hits
     // and patches its base address into the reader runtime args via BufferBinding.
     std::vector<uint32_t> physical_core_lookup_table_data;
+    physical_core_lookup_table_data.reserve(layout.core_range.num_cores() * 2);
     for (const auto& core_range : layout.core_range.ranges()) {
         for (const auto& core_coord : core_range) {
             const auto physical_core = device->worker_core_from_logical_core(core_coord);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -274,6 +274,7 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
     };
 
     std::vector<KernelDescriptor> compute_kernels;
+    compute_kernels.reserve(4);
     if (!core_range.empty()) {
         compute_kernels.push_back(
             make_compute_kernel(core_range, {single_sub_block_wh, single_sub_block_size, third_dim}));

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
@@ -262,6 +262,7 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
     };
 
     std::vector<KernelDescriptor> compute_kernels;
+    compute_kernels.reserve(4);
     if (!core_range.empty()) {
         compute_kernels.push_back(
             make_compute_kernel(core_range, {single_sub_block_wh, single_sub_block_size, third_dim}));

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -143,6 +143,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
 
     std::vector<uint32_t> reader_compile_time_args;
     std::vector<uint32_t> reader_common_runtime_args;
+    reader_compile_time_args.reserve(5);
     reader_compile_time_args.push_back(N);
     reader_compile_time_args.push_back(H);
     reader_compile_time_args.push_back(C);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -35,11 +35,13 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores);
 
     std::vector<uint32_t> shard_grid_x_map;
+    shard_grid_x_map.reserve(num_cores_x);
     for (uint32_t i = 0; i < num_cores_x; ++i) {
         auto physical_core = device->worker_core_from_logical_core(CoreCoord(i, 0));
         shard_grid_x_map.push_back(physical_core.x);
     }
     std::vector<uint32_t> shard_grid_y_map;
+    shard_grid_y_map.reserve(num_cores_y);
     for (uint32_t i = 0; i < num_cores_y; ++i) {
         auto physical_core = device->worker_core_from_logical_core(CoreCoord(0, i));
         shard_grid_y_map.push_back(physical_core.y);
@@ -61,7 +63,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 
         std::vector<uint32_t> writer_runtime_args;
 
-        ret_val[i] = {reader_runtime_args, writer_runtime_args};
+        ret_val[i] = {std::move(reader_runtime_args), std::move(writer_runtime_args)};
 
         for (uint32_t j = 0; j < num_sticks_per_core; ++j) {
             curr_c++;
@@ -102,6 +104,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 
     uint32_t height = 0;
     std::vector<CoreCoord> cores;
+    cores.reserve(num_cores);
     for (uint32_t i = 0; i < num_cores; i++) {
         CoreCoord core;
         if (row_major) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -157,6 +157,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
 
     Buffer* src0_buffer = input_tensor.buffer();
     std::vector<uint32_t> reader_compile_time_args;
+    reader_compile_time_args.reserve(3);
     reader_compile_time_args.push_back(sub_tile_line_bytes);
     reader_compile_time_args.push_back(cb_data_format == tt::DataFormat::Float32 ? 1 : 0);
     reader_compile_time_args.push_back(alignment);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -214,6 +214,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     std::vector<uint32_t> reader_compile_time_args;
     std::vector<uint32_t> reader_common_runtime_args;
     if (row_major) {
+        reader_compile_time_args.reserve(9);
         reader_compile_time_args.push_back(ht);
         reader_compile_time_args.push_back(H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT);
         reader_compile_time_args.push_back(H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT);
@@ -268,6 +269,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
 
     std::vector<uint32_t> compute_kernel_args = {};
     if (row_major) {
+        compute_kernel_args.reserve(3);
         compute_kernel_args.push_back(ht);
         compute_kernel_args.push_back(wt);
         compute_kernel_args.push_back(ht * wt);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
@@ -232,6 +232,7 @@ ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
     };
 
     std::vector<KernelDescriptor> compute_kernels;
+    compute_kernels.reserve(4);
     if (!core_range.empty()) {
         compute_kernels.push_back(
             make_compute_kernel(core_range, {single_sub_block_size_wh, single_sub_block_size, third_dim}));

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -52,6 +52,7 @@ std::vector<Tensor> _min_or_max_bw(
     const Tensor& other,
     const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    grad_tensor.reserve(2);
     Tensor t_scale_grad = ttnn::multiply(grad, 0.5f, std::nullopt, output_mem_config);
     Tensor t_sub = ttnn::subtract(other, input, std::nullopt, output_mem_config);
     Tensor t_sub_gtz = ttnn::gtz(t_sub, output_mem_config);
@@ -70,12 +71,12 @@ std::vector<Tensor> _min_or_max_bw(
 
     if (min_or_max) {
         // MAX
-        grad_tensor.emplace_back(grad_other);
-        grad_tensor.emplace_back(grad_input);
+        grad_tensor.emplace_back(std::move(grad_other));
+        grad_tensor.emplace_back(std::move(grad_input));
     } else {
         // MIN
-        grad_tensor.emplace_back(grad_input);
-        grad_tensor.emplace_back(grad_other);
+        grad_tensor.emplace_back(std::move(grad_input));
+        grad_tensor.emplace_back(std::move(grad_other));
     }
     return grad_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
@@ -22,13 +22,14 @@ std::vector<Tensor> addcmul_bw(
     const std::optional<MemoryConfig>& memory_config) {
     auto output_mem_config = memory_config.value_or(input_a.memory_config());
     std::vector<Tensor> grad_tensor;
+    grad_tensor.reserve(3);
     grad_tensor.emplace_back(grad);
     Tensor grad_a = ttnn::multiply(
         ttnn::multiply(grad, tensor2, std::nullopt, output_mem_config), value, std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_a);
+    grad_tensor.emplace_back(std::move(grad_a));
     Tensor grad_b = ttnn::multiply(
         ttnn::multiply(grad, tensor1, std::nullopt, output_mem_config), value, std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_b);
+    grad_tensor.emplace_back(std::move(grad_b));
     return grad_tensor;
 }
 
@@ -41,6 +42,7 @@ std::vector<Tensor> addcdiv_bw(
     const std::optional<MemoryConfig>& memory_config) {
     auto output_mem_config = memory_config.value_or(input_a.memory_config());
     std::vector<Tensor> grad_tensor;
+    grad_tensor.reserve(3);
     grad_tensor.emplace_back(grad);
     float t_inf = std::numeric_limits<float>::infinity();
     float t_nan = std::nanf("");
@@ -79,13 +81,14 @@ std::vector<std::optional<Tensor>> where_bw(
     std::optional<Tensor> input_grad,
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<Tensor>> result;
+    result.reserve(2);
     if (are_required_outputs.at(0)) {
         if (input_grad.has_value()) {
             ttnn::where(condition, grad, 0.0f, output_mem_config, input_grad);
         } else {
             input_grad = ttnn::where(condition, grad, 0.0f, output_mem_config);
         }
-        result.emplace_back(input_grad);
+        result.emplace_back(std::move(input_grad));
     } else {
         result.emplace_back(std::nullopt);
     }
@@ -95,7 +98,7 @@ std::vector<std::optional<Tensor>> where_bw(
         } else {
             other_grad = ttnn::where(condition, 0.0f, grad, output_mem_config);
         }
-        result.emplace_back(other_grad);
+        result.emplace_back(std::move(other_grad));
     } else {
         result.emplace_back(std::nullopt);
     }
@@ -110,14 +113,15 @@ std::vector<Tensor> lerp_bw(
     const Tensor& weight,
     const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    grad_tensor.reserve(3);
     Tensor result_1 = ttnn::multiply(
         grad, ttnn::rsub(weight, 1.0f, std::nullopt, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(result_1);
+    grad_tensor.emplace_back(std::move(result_1));
     Tensor result_2 = ttnn::multiply(grad, weight, std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(result_2);
+    grad_tensor.emplace_back(std::move(result_2));
     Tensor zero = ttnn::multiply(
         grad, ttnn::subtract(end, input, std::nullopt, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(zero);
+    grad_tensor.emplace_back(std::move(zero));
     return grad_tensor;
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/adaptive_pool/adaptive_pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/adaptive_pool/adaptive_pool_utils.cpp
@@ -60,6 +60,7 @@ std::vector<uint32_t> calculate_actual_stride_patterns(
     uint32_t /*pad_before*/,
     uint32_t /*pad_after*/) {
     std::vector<uint32_t> actual_strides;
+    actual_strides.reserve(output_size);
 
     // Calculate the actual start positions in the padded input for each output
     for (uint32_t out_idx = 1; out_idx < output_size; out_idx++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
@@ -320,8 +320,11 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
         num_links, num_cores_per_link, mesh_device, sub_device_id, core_grid_offset, sub_core_grid);
 
     std::vector<CoreRange> sender_worker_core_ranges;
+    sender_worker_core_ranges.reserve(num_links * num_directions_per_link * num_workers_per_direction);
     std::vector<CoreRange> mux_core_ranges;
+    mux_core_ranges.reserve(num_links * num_directions_per_link);
     std::vector<CoreRange> termination_master_core_ranges;
+    termination_master_core_ranges.reserve(num_links * num_directions_per_link);
 
     std::set<CoreRange> sender_forward_core_ranges;
     std::set<CoreRange> sender_backward_core_ranges;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation_types.hpp
@@ -8,6 +8,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/global_semaphore.hpp"
+#include <cstddef>
 #include <optional>
 #include <vector>
 
@@ -49,7 +50,9 @@ struct AllGatherConcatParams {
     // Add attributes method for reflection
     auto attributes() const {
         using ttsl::reflection::Attribute;
+        constexpr std::size_t kNumAttributes = 9;
         std::vector<std::tuple<std::string, Attribute>> attrs;
+        attrs.reserve(kNumAttributes);
 
         attrs.emplace_back("dim", dim);
         attrs.emplace_back("num_links", num_links);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program_factory.cpp
@@ -234,6 +234,7 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
 
     llama_config llama_configuration;
     std::vector<CoreRange> q_cores_vector;
+    q_cores_vector.reserve(ring_core_ranges.size());
     uint32_t range_count = 0;
     for (auto cr : ring_core_ranges) {
         q_cores_vector.push_back(cr);
@@ -398,7 +399,9 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
     log_trace(tt::LogOp, "output_cores_this_device: {}", output_cores_this_device);
 
     std::vector<uint32_t> nlp_local_core_x;
+    nlp_local_core_x.reserve(llama_configuration.num_cores_input_tensor);
     std::vector<uint32_t> nlp_local_core_y;
+    nlp_local_core_y.reserve(llama_configuration.num_cores_input_tensor);
     for (uint32_t k = 0; k < llama_configuration.num_cores_input_tensor; k++) {
         auto this_core = mesh_device->worker_core_from_logical_core(input_cores_vec[k]);
         nlp_local_core_x.push_back(this_core.x);
@@ -492,9 +495,13 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
 
         auto sem_mcast_ranges = CoreRangeSet(llama_configuration.semaphore_mcast_ranges);
         std::vector<uint32_t> mcast_start_x;
+        mcast_start_x.reserve(sem_mcast_ranges.ranges().size());
         std::vector<uint32_t> mcast_start_y;
+        mcast_start_y.reserve(sem_mcast_ranges.ranges().size());
         std::vector<uint32_t> mcast_end_x;
+        mcast_end_x.reserve(sem_mcast_ranges.ranges().size());
         std::vector<uint32_t> mcast_end_y;
+        mcast_end_y.reserve(sem_mcast_ranges.ranges().size());
 
         for (const auto& range : sem_mcast_ranges.ranges()) {
             auto start_core = mesh_device->worker_core_from_logical_core(range.start_coord);
@@ -547,7 +554,9 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
         // the upper half of the tile and rest are in the lower half of tile.
         const auto& core = cores[i];
         std::vector<uint32_t> input_cores_x;
+        input_cores_x.reserve(llama_configuration.num_cores_input_tensor);
         std::vector<uint32_t> input_cores_y;
+        input_cores_y.reserve(llama_configuration.num_cores_input_tensor);
         std::array<uint32_t, 8> kernel_core_noc_x = {19, 20, 21, 19, 20, 21, 19, 20};
         std::array<uint32_t, 8> kernel_core_noc_y = {18, 18, 18, 19, 19, 19, 20, 20};
         for (uint32_t k = 0; k < llama_configuration.num_cores_input_tensor; k++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
@@ -575,6 +575,7 @@ all_gather_minimal_matmul_async_factory_helper(
     };
 
     std::vector<CoreRange> mux_core_ranges;
+    mux_core_ranges.reserve(num_mux_cores);
     for (uint32_t mux_id = 0; mux_id < num_mux_cores; ++mux_id) {
         uint32_t dir = mux_id % 2;  // 2 being the number of directions
         if (mux_connection_valid(dir)) {
@@ -723,6 +724,7 @@ all_gather_minimal_matmul_async_factory_helper(
         }
 
         std::vector<CoreRange> fsdp_mux_core_ranges;
+        fsdp_mux_core_ranges.reserve(num_mux_cores);
         for (uint32_t mux_id = 0; mux_id < num_mux_cores; ++mux_id) {
             uint32_t dir = mux_id % 2;
             if (fsdp_mux_connection_valid(dir)) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 #include <tt_stl/reflection.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <tuple>
@@ -58,7 +59,9 @@ struct AllReduceAsyncParams {
     // Add attributes method for reflection
     auto attributes() const {
         using ttsl::reflection::Attribute;
+        constexpr std::size_t kNumAttributes = 9;
         std::vector<std::tuple<std::string, Attribute>> attrs;
+        attrs.reserve(kNumAttributes);
 
         attrs.emplace_back("num_links", num_links);
         attrs.emplace_back("ring_size", ring_size);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_factory.cpp
@@ -203,6 +203,7 @@ AllReduceAsyncMeshWorkloadFactory::cached_program_t AllReduceAsyncMeshWorkloadFa
         tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0)));
 
     std::vector<CoreRange> output_cores;
+    output_cores.reserve(sub_device_cores.ranges().size());
     for (const auto& cr : sub_device_cores.ranges()) {
         const auto intersection = output_tensor_cores.intersection(cr);
         if (!intersection.empty()) {
@@ -267,6 +268,7 @@ AllReduceAsyncMeshWorkloadFactory::cached_program_t AllReduceAsyncMeshWorkloadFa
     // Create output tensor splits
     // TODO: Currently does not support output shards being split across multiple links
     std::vector<CoreRangeSet> output_corerangeset_per_link;
+    output_corerangeset_per_link.reserve(num_links);
     std::vector<uint32_t> num_output_cores_in_link(num_links, 0);
     uint32_t output_cores_per_link = tt::div_up(output_tensor_cores.num_cores(), num_links);
     uint32_t num_assigned_cores = 0;
@@ -469,10 +471,16 @@ AllReduceAsyncMeshWorkloadFactory::cached_program_t AllReduceAsyncMeshWorkloadFa
         uint32_t input_first_core_tile_start_offset = input_tensor_tile_offset_per_link[link];
         uint32_t output_first_core_tile_start_offset = 0;
 
+        const uint32_t num_input_cores_in_link =
+            input_cores_idx_per_link[link].second - input_cores_idx_per_link[link].first;
         std::vector<uint32_t> input_tensor_cores_x;
+        input_tensor_cores_x.reserve(num_input_cores_in_link);
         std::vector<uint32_t> input_tensor_cores_y;
+        input_tensor_cores_y.reserve(num_input_cores_in_link);
         std::vector<uint32_t> output_tensor_cores_x;
+        output_tensor_cores_x.reserve(num_output_cores_in_link[link]);
         std::vector<uint32_t> output_tensor_cores_y;
+        output_tensor_cores_y.reserve(num_output_cores_in_link[link]);
         for (uint32_t i = input_cores_idx_per_link[link].first; i < input_cores_idx_per_link[link].second; i++) {
             auto this_core = mesh_device->worker_core_from_logical_core(input_cores_vec[i]);
             input_tensor_cores_x.push_back(this_core.x);
@@ -503,10 +511,15 @@ AllReduceAsyncMeshWorkloadFactory::cached_program_t AllReduceAsyncMeshWorkloadFa
         tt::tt_metal::SetRuntimeArgs(program, worker_sender_reader_kernel_id, {core}, reader_rt_args);
 
         // Set writer runtime args
+        const size_t num_mcast_ranges = output_corerangeset_per_link[link].ranges().size();
         std::vector<uint32_t> mcast_start_x;
+        mcast_start_x.reserve(num_mcast_ranges);
         std::vector<uint32_t> mcast_start_y;
+        mcast_start_y.reserve(num_mcast_ranges);
         std::vector<uint32_t> mcast_end_x;
+        mcast_end_x.reserve(num_mcast_ranges);
         std::vector<uint32_t> mcast_end_y;
+        mcast_end_y.reserve(num_mcast_ranges);
 
         uint32_t num_mcast_cores = 0;
         for (const auto& range : output_corerangeset_per_link[link].ranges()) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation_types.hpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/global_semaphore.hpp"
 #include <tt-metalium/sub_device.hpp>
+#include <cstddef>
 #include <optional>
 
 namespace ttnn::experimental::prim {
@@ -43,7 +44,10 @@ struct AllToAllAsyncParams {
 
     auto attributes() const {
         using ttsl::reflection::Attribute;
+        // Seven unconditional attributes plus the optional sub_device_id.
+        constexpr std::size_t kMaxNumAttributes = 8;
         std::vector<std::tuple<std::string, Attribute>> attrs;
+        attrs.reserve(kMaxNumAttributes);
         attrs.emplace_back("in_dim", in_dim);
         attrs.emplace_back("out_dim", out_dim);
         attrs.emplace_back("num_links", num_links);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_program_factory.cpp
@@ -712,6 +712,9 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
     std::vector<CoreCoord> termination_master_virtual_cores;
     std::vector<uint32_t> termination_master_semaphore_ids;
     if (use_mux) {
+        termination_master_cores.reserve(num_links);
+        termination_master_virtual_cores.reserve(num_links);
+        termination_master_semaphore_ids.reserve(num_links);
         for (uint32_t link = 0; link < num_links; link++) {
             uint32_t master_worker_idx = link * workers_per_link;  // First worker on this link
             const auto& master_core = sender_cores[master_worker_idx];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation_types.hpp
@@ -34,6 +34,7 @@ struct DeepseekMoEReduceScatterParams {
     auto attributes() const {
         using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
+        attrs.reserve(4);
         attrs.emplace_back("output_memory_config", output_memory_config);
         attrs.emplace_back("dim", dim);
         attrs.emplace_back("num_links", num_links);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_device_operation_types.hpp
@@ -82,6 +82,7 @@ struct DitFusedDistributedRmsnormParams {
     auto attributes() const {
         using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
+        attrs.reserve(11);
         attrs.emplace_back("epsilon", epsilon);
         attrs.emplace_back("num_heads_per_device", num_heads_per_device);
         attrs.emplace_back("per_head_norm", per_head_norm);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
@@ -89,6 +89,7 @@ process_agmm_fusion_program_and_create_override_variables(
     if (restricted_cores.has_value()) {
         subdevice_cores = subdevice_cores.subtract(restricted_cores.value());
     }
+    non_idle_cores_vec.reserve(subdevice_cores.ranges().size());
     for (const auto& cr : subdevice_cores.ranges()) {
         auto intersection = non_idle_cores.intersection(cr);
         if (!intersection.empty()) {
@@ -253,8 +254,11 @@ process_agmm_fusion_program_and_create_override_variables(
     tt_metal::CircularBufferConfig output_cb_config =
         tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
     std::vector<tt::tt_metal::CBHandle> cb_outputs;
+    cb_outputs.reserve(out_buffers.size());
     std::vector<tt::tt_metal::CBHandle> output_cb_indices;
+    output_cb_indices.reserve(out_buffers.size());
     std::vector<tt::tt_metal::CBHandle> interm_cb_indices;
+    interm_cb_indices.reserve(out_buffers.size());
 
     if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
         // interm0
@@ -547,6 +551,7 @@ process_agmm_fusion_program_and_create_override_variables(
 
     uint32_t bank_id = 0;
     std::vector<uint32_t> bank_ids;
+    bank_ids.reserve(num_cores);
     for (uint32_t i = 0; i < num_cores; ++i) {  // runtime args for mm cores
         const auto& core = worker_cores_vec[i];
         /* in0 - multicast receiver setup (no ring topology needed) */

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation_types.hpp
@@ -58,6 +58,7 @@ struct LlamaAllGatherMatmulAsyncParams {
     auto attributes() const {
         using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
+        attrs.reserve(9);
         attrs.emplace_back("devices", devices);
         attrs.emplace_back("dim", dim);
         attrs.emplace_back("num_links", num_links);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -185,6 +185,11 @@ std::vector<std::vector<ReadRequest>> distribute_work_evenly(
 std::vector<ReadRequest> flatten_schedule(const std::vector<std::vector<ReadRequest>>& schedule) {
     // create a flattened schedule
     std::vector<ReadRequest> schedule_flattened;
+    size_t total_num_requests = 0;
+    for (const auto& chunk : schedule) {
+        total_num_requests += chunk.size();
+    }
+    schedule_flattened.reserve(total_num_requests);
     for (const auto& chunk : schedule) {
         schedule_flattened.insert(schedule_flattened.end(), chunk.begin(), chunk.end());
     }
@@ -623,6 +628,7 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_proc
                                std::optional<uint32_t> num_max_cores = std::nullopt) -> std::vector<CoreCoord> {
         std::vector<CoreCoord> worker_cores;
         auto num_cores = num_max_cores.has_value() ? num_max_cores.value() : cores.size();
+        worker_cores.reserve(num_cores);
         for (uint32_t i = 0; i < num_cores; ++i) {
             const auto& core = cores[i];
             worker_cores.push_back(mesh_device->worker_core_from_logical_core(core));

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_device_op.cpp
@@ -115,9 +115,10 @@ LlamaReduceScatterCreateHeadsDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto output_specs = compute_output_specs(operation_attributes, tensor_args);
     std::vector<ttnn::Tensor> tensors{};
+    tensors.reserve(output_specs.size());
     for (auto& output_spec : output_specs) {
         auto tensor = create_device_tensor(output_spec, tensor_args.input_tensor.device());
-        tensors.push_back(tensor);
+        tensors.push_back(std::move(tensor));
     }
     return tensors;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
@@ -196,6 +196,11 @@ uint32_t find_atomic_inc_core(std::vector<std::vector<ReadRequest>> schedule) {
 std::vector<ReadRequest> flatten_schedule(const std::vector<std::vector<ReadRequest>>& schedule) {
     // create a flattened schedule
     std::vector<ReadRequest> schedule_flattened;
+    size_t total_num_requests = 0;
+    for (const auto& chunk : schedule) {
+        total_num_requests += chunk.size();
+    }
+    schedule_flattened.reserve(total_num_requests);
     for (const auto& chunk : schedule) {
         schedule_flattened.insert(schedule_flattened.end(), chunk.begin(), chunk.end());
     }
@@ -596,6 +601,7 @@ LlamaReduceScatterCreateHeadsDeviceOperation::LlamaReduceScatterCreateHeads::cre
                                std::optional<uint32_t> num_max_cores = std::nullopt) -> std::vector<CoreCoord> {
         std::vector<CoreCoord> worker_cores;
         auto num_cores = num_max_cores.has_value() ? num_max_cores.value() : cores.size();
+        worker_cores.reserve(num_cores);
         for (uint32_t i = 0; i < num_cores; ++i) {
             const auto& core = cores[i];
             worker_cores.push_back(mesh_device->worker_core_from_logical_core(core));

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation_types.hpp
@@ -40,6 +40,7 @@ struct SelectiveReduceCombineParams {
     auto attributes() const {
         using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
+        attrs.reserve(13);
         attrs.emplace_back("hidden_size", hidden_size);
         attrs.emplace_back("batch_size", batch_size);
         attrs.emplace_back("seq_size", seq_size);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
@@ -65,6 +65,7 @@ struct MoEComputeParams {
     auto attributes() const {
         using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
+        attrs.reserve(11);
         attrs.emplace_back("layer_id", layer_id);
         attrs.emplace_back("output_height_shard_dim", output_height_shard_dim);
         attrs.emplace_back("intermediate_size", intermediate_size);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -1311,6 +1311,7 @@ MoEComputeMeshWorkloadFactory::create_at(
 
     // Set the runtime arguments for the kernels
     std::vector<uint32_t> matmul_runtime_args;
+    matmul_runtime_args.reserve(6 + matmul_tensors.size() + num_dram_banks);
     matmul_runtime_args.push_back(0);  // DRAM Bank ID placeholder
     matmul_runtime_args.push_back(0);  // VChannel placeholder
     for (const auto& tensor : matmul_tensors) {
@@ -1393,6 +1394,7 @@ MoEComputeMeshWorkloadFactory::create_at(
     // matmul cores ordered by core ID, this will be used by selective combine to direct semaphore signaling
     std::vector<CoreCoord> ring_pos2core(matmul_num_cores);
     std::vector<uint32_t> vchannels;
+    vchannels.reserve(matmul_cores.size());
     uint32_t dram_bank = 0;
     for (auto core : matmul_cores) {
         uint32_t vchannel = dram_bank & 0x3;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
@@ -98,6 +98,7 @@ ttnn::Tensor front_pack_per_core(
     ttsl::SmallVector<uint32_t> zshape(rank, 0);
 
     std::vector<ttnn::Tensor> pieces;
+    pieces.reserve(2 * num_cores);
     uint32_t cursor = 0;  // real tiles consumed so far (along `ax`)
     for (uint32_t c = 0; c < num_cores; ++c) {
         const uint32_t r = tp_map[c];
@@ -152,6 +153,7 @@ ttnn::Tensor prepare_w2_no_n_pad(
     const uint32_t w2_groups_per_core = ceil_div(Kt, num_cores * first_pair_sum);
 
     std::vector<ttnn::Tensor> each_shard;
+    each_shard.reserve(3 * num_cores);
     uint32_t start_col = 0;
     const uint32_t full_block_width = (w2_groups_per_core - 1) * 4 * TILE_SIZE;
     for (const auto& [last_group_tiles, last_group_pad_tiles] : w2_shard_map) {
@@ -542,6 +544,7 @@ ttnn::Tensor prepare_w0_w1_tensor_for_moe_compute(
     }
 
     std::vector<ttnn::Tensor> each_shard;
+    each_shard.reserve(2 * shard_map.size());
     uint32_t start_tile = 0;
     for (uint32_t num_tiles : shard_map) {
         each_shard.push_back(slice_basic(
@@ -701,6 +704,7 @@ ttnn::Tensor prepare_w2_tensor_with_bias(
     pad_rows.deallocate(/*force=*/true);
 
     std::vector<ttnn::Tensor> b2_each_shard;
+    b2_each_shard.reserve(3 * num_cores);
     uint32_t start_col = 0;
     const uint32_t full_block_width = (w2_groups_per_core - 1) * 4 * TILE_SIZE;
     for (const auto& [last_group_tiles, last_group_pad_tiles] : w2_shard_map) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_core_placement.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_core_placement.cpp
@@ -117,6 +117,7 @@ std::optional<CoreRange> find_dense_combine_rectangle_avoiding(
     const uint32_t y_limit = std::min(max_y_inclusive + 1, static_cast<uint32_t>(worker_grid.y));
 
     std::vector<std::pair<uint32_t, uint32_t>> factorizations;
+    factorizations.reserve(num_cores);
     for (uint32_t width = 1; width <= num_cores; ++width) {
         if (num_cores % width != 0) {
             continue;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
@@ -368,6 +368,7 @@ MoEGPTMeshWorkloadFactory::create_at(
     }
 
     std::vector<uint32_t> runtime_args;
+    runtime_args.reserve(13);
     runtime_args.push_back(0);
     runtime_args.push_back(0);
     for (uint32_t i = 0; i < 4; ++i) {
@@ -384,6 +385,7 @@ MoEGPTMeshWorkloadFactory::create_at(
     runtime_args.push_back(output_base_l1_addr);   // [12] output_base_l1_addr
 
     std::vector<uint32_t> vchannels;
+    vchannels.reserve(dram_bank2core_coords.size());
     uint32_t dram_bank = 0;
     for (auto core : dram_bank2core_coords) {
         uint32_t vchannel = dram_bank & 0x3;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
@@ -378,6 +378,8 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
             is_last_w_device);
 
         // W fabric core coordinates (placed after H fabric cores in first row)
+        w_fabric_logical_cores.reserve(num_w_fabric_cores);
+        w_fabric_virtual_cores.reserve(num_w_fabric_cores);
         for (uint32_t i = 0; i < num_w_fabric_cores; i++) {
             CoreCoord wc = {num_h_fabric_cores + i, 0};
             w_fabric_logical_cores.push_back(wc);
@@ -660,6 +662,7 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
             uint32_t a_offset = 0;
 
             uint32_t unit_offset = 0;
+            local_copy_core_coords.reserve(num_local_cores);
             for (uint32_t i = 0; i < num_local_cores; ++i) {
                 const uint32_t units_for_core = base + (i < rem ? 1u : 0u);
                 const uint32_t a_count = a_base + (i < a_rem ? 1u : 0u);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -414,7 +414,9 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     };
 
     std::vector<CoreRange> sender_worker_core_ranges;
+    sender_worker_core_ranges.reserve(num_links * num_directions_per_link * num_workers_per_direction);
     std::vector<CoreRange> mux_core_ranges;
+    mux_core_ranges.reserve(num_links * num_directions_per_link);
     if (num_mux_cores_per_direction_per_link) {
         uint32_t core_id = 0;
         for (uint32_t link = 0; link < num_links; link++) {
@@ -642,6 +644,12 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     // Positional args: routing info, TensorAccessorArgs. The V2 fabric mux client needs no worker-side
     // compile-time args (the device-side FabricMuxV2Sender is built entirely from runtime args).
     std::vector<uint32_t> writer_compile_args;
+    // Each TensorAccessorArgs always emits args_config and aligned_page_size; a sharded accessor reserves the
+    // extra space for its own shape/bank words when appending.
+    constexpr uint32_t min_args_per_tensor_accessor = 2;
+    writer_compile_args.reserve(
+        unicast_forward_args.size() + mcast_forward_args.size() + unicast_backward_args.size() +
+        mcast_backward_args.size() + 2 * min_args_per_tensor_accessor);
 
     writer_compile_args.insert(writer_compile_args.end(), unicast_forward_args.begin(), unicast_forward_args.end());
     writer_compile_args.insert(writer_compile_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
@@ -1044,8 +1052,11 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     };
 
     std::vector<CoreRange> sender_worker_core_ranges;
+    sender_worker_core_ranges.reserve(num_links * num_directions_per_link * num_workers_per_direction);
     std::vector<CoreRange> mux_core_ranges;
+    mux_core_ranges.reserve(num_links * num_directions_per_link);
     std::vector<CoreRange> termination_master_core_ranges;
+    termination_master_core_ranges.reserve(num_links * num_directions_per_link);
     uint32_t core_id = 0;
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation_types.hpp
@@ -69,6 +69,7 @@ struct RMSAllGatherParams {
     auto attributes() const {
         using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
+        attrs.reserve(10);
         attrs.emplace_back("eps", eps);
         attrs.emplace_back("subblock_wt", subblock_wt);
         attrs.emplace_back("block_wt", block_wt);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
@@ -227,6 +227,8 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
     std::vector<uint32_t> storage_core_noc_y;
     std::vector<CoreCoord> storage_core_coords =
         corerange_to_cores(all_storage_cores, all_storage_cores.num_cores(), true);
+    storage_core_noc_x.reserve(storage_core_coords.size());
+    storage_core_noc_y.reserve(storage_core_coords.size());
     for (auto core : storage_core_coords) {
         storage_core_noc_x.push_back((std::uint32_t)mesh_device->worker_core_from_logical_core(core).x);
         storage_core_noc_y.push_back((std::uint32_t)mesh_device->worker_core_from_logical_core(core).y);
@@ -950,6 +952,7 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
                 std::swap(mcast_start, mcast_end);
             }
             std::vector<uint32_t> mcast_sender_args;
+            mcast_sender_args.reserve(6 + in0_mcast_noc_x.size() + in0_mcast_noc_y.size());
             mcast_sender_args.push_back(mcast_start.x);
             mcast_sender_args.push_back(mcast_start.y);
             mcast_sender_args.push_back(mcast_end.x);
@@ -963,6 +966,7 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
             (not use_two_stage_reduce and width_index < num_cores_all_to_all) or
             (use_two_stage_reduce and width_index_two_stage < 1)) {
             std::vector<uint32_t> mcast_receiver_args;
+            mcast_receiver_args.reserve(4 + in0_mcast_noc_x.size() + in0_mcast_noc_y.size());
             mcast_receiver_args.push_back(all_to_all_worker_tile_offset_size_bytes);
             bool is_second_stage_reader;
             if (use_two_stage_reduce and width_index < 1) {
@@ -980,6 +984,7 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
                 program, reader_mcast_receiver_kernels_id_all_to_all, core, mcast_receiver_args);
         } else {
             std::vector<uint32_t> mcast_receiver_args;
+            mcast_receiver_args.reserve(6);
             mcast_receiver_args.push_back(all_to_all_worker_tile_offset_size_bytes);
             mcast_receiver_args.push_back(0);
             mcast_receiver_args.push_back(0);
@@ -1127,6 +1132,7 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
                 writer_mcast_sender_args.end(), all_gather_rts.begin(), all_gather_rts.end());
             writer_mcast_sender_args.at(0) = writer_mcast_sender_args.size();
             std::vector<uint32_t> writer_mcast_post_sender_args;
+            writer_mcast_post_sender_args.reserve(4 + write_back_writer_args.size());
             if (use_two_stage_reduce) {
                 if (width_index < 1) {
                     writer_mcast_post_sender_args.push_back(cinv_bits);
@@ -1172,6 +1178,7 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
                 writer_mcast_receiver_args.end(), all_gather_rts.begin(), all_gather_rts.end());
             writer_mcast_receiver_args.at(0) = writer_mcast_receiver_args.size();
             std::vector<uint32_t> writer_mcast_post_receiver_args;
+            writer_mcast_post_receiver_args.reserve(4 + write_back_writer_args.size());
             writer_mcast_post_receiver_args.push_back(cinv_bits);
             writer_mcast_post_receiver_args.push_back(e.u);
             writer_mcast_post_receiver_args.push_back(gamma_dram_addr);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_program_factory.cpp
@@ -57,9 +57,13 @@ RecvAsyncMeshWorkloadFactory::create_at(
     const auto& socket_connection_config = mesh_socket.get_config().socket_connection_config;
 
     std::vector<CoreCoord> receiver_core_coords;
+    receiver_core_coords.reserve(socket_connection_config.size());
     std::vector<tt::tt_fabric::FabricNodeId> sender_fabric_node_ids;
+    sender_fabric_node_ids.reserve(socket_connection_config.size());
     std::vector<tt::tt_fabric::FabricNodeId> receiver_fabric_node_ids;
+    receiver_fabric_node_ids.reserve(socket_connection_config.size());
     std::vector<uint32_t> connection_indices;
+    connection_indices.reserve(socket_connection_config.size());
 
     // TODO #24995: Find appropriate receiver cores and fabric node IDs based on mesh socket configuration
     for (uint32_t i = 0; i < socket_connection_config.size(); ++i) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_program_factory.cpp
@@ -55,10 +55,15 @@ SendAsyncMeshWorkloadFactory::create_at(
     const auto& socket_connection_config = mesh_socket.get_config().socket_connection_config;
 
     std::vector<CoreCoord> sender_core_coords;
+    sender_core_coords.reserve(socket_connection_config.size());
     std::vector<CoreCoord> receiver_core_coords;
+    receiver_core_coords.reserve(socket_connection_config.size());
     std::vector<tt::tt_fabric::FabricNodeId> sender_fabric_node_ids;
+    sender_fabric_node_ids.reserve(socket_connection_config.size());
     std::vector<tt::tt_fabric::FabricNodeId> receiver_fabric_node_ids;
+    receiver_fabric_node_ids.reserve(socket_connection_config.size());
     std::vector<size_t> connection_indices;
+    connection_indices.reserve(socket_connection_config.size());
 
     for (size_t conn_idx = 0; conn_idx < socket_connection_config.size(); ++conn_idx) {
         const auto& connection = socket_connection_config[conn_idx];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_program_factory.cpp
@@ -150,9 +150,11 @@ SliceReshardAsyncProgramFactory::cached_program_t SliceReshardAsyncProgramFactor
     CreateCircularBuffer(program, worker_core_ranges, cb_sender_config);
 
     // KERNEL CREATION
-    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
-    std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
     uint32_t num_directions = 2;
+    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
+    reader_kernel_ids.reserve(args.num_links * num_directions);
+    std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
+    writer_kernel_ids.reserve(args.num_links * num_directions);
     uint32_t stick_start_id = 0;
     for (uint32_t link = 0; link < args.num_links; link++) {
         uint32_t num_sticks_to_read = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
@@ -320,7 +320,9 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     std::set<CoreRange> mux_forward_core_ranges;
     std::set<CoreRange> mux_backward_core_ranges;
     std::vector<CoreCoord> sender_forward_cores;
+    sender_forward_cores.reserve(num_links * num_workers_per_direction);
     std::vector<CoreCoord> sender_backward_cores;
+    sender_backward_cores.reserve(num_links * num_workers_per_direction);
     uint32_t core_id = 0;
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
@@ -435,7 +437,9 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     }
 
     std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
+    reader_kernel_ids.reserve(num_links * num_directions_per_link * num_workers_per_direction);
     std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
+    writer_kernel_ids.reserve(num_links * num_directions_per_link * num_workers_per_direction);
     const uint32_t l1_unreserved_base_address =
         mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     const size_t mux_base_l1_address = l1_unreserved_base_address;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_op_device_operation_types.hpp
@@ -55,6 +55,7 @@ struct operation_attributes_t {
     auto attributes() const {
         using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
+        attrs.reserve(17);
         attrs.emplace_back("dim", dim);
         attrs.emplace_back("num_links", num_links);
         attrs.emplace_back("ring_size", ring_size);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
@@ -257,8 +257,11 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
     };
 
     std::vector<CoreRange> sender_worker_core_ranges;
+    sender_worker_core_ranges.reserve(num_links * num_directions_per_link * num_workers_per_direction);
     std::vector<CoreRange> mux_core_ranges;
+    mux_core_ranges.reserve(num_links * num_directions_per_link);
     std::vector<CoreRange> termination_master_core_ranges;
+    termination_master_core_ranges.reserve(num_links * num_directions_per_link);
     uint32_t core_id = 0;
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
@@ -159,6 +159,7 @@ std::vector<LowLevelGatherTransfer> lower_gather_transfers(
     uint32_t element_size_bytes,
     uint32_t output_shard_width) {
     std::vector<LowLevelGatherTransfer> low_level_transfers;
+    low_level_transfers.reserve(transfers.size());
 
     const uint32_t num_input_cores = input_cores.size();
 
@@ -286,6 +287,7 @@ BlockedTransfersWithCount group_transfers_by_output_column_blocks(
 
     // Convert to vector of BlockedTransferGroup
     std::vector<BlockedTransferGroup> blocked_groups;
+    blocked_groups.reserve(groups.size());
     for (const auto& [key, transfers_list] : groups) {
         BlockedTransferGroup group(key.first, key.second, block_size);
         group.transfers = transfers_list;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/mla/matmul_wo/device/matmul_wo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/mla/matmul_wo/device/matmul_wo_program_factory.cpp
@@ -22,6 +22,7 @@ namespace ttnn::operations::experimental::deepseek::mla::program {
 static std::vector<CoreCoord> find_collector_core_coords(
     const CoreCoord& full_grid_size, const std::set<CoreCoord>& dram_cores_set, size_t num_collectors) {
     std::vector<CoreCoord> collector_core_coords;
+    collector_core_coords.reserve(num_collectors);
     for (int32_t y = full_grid_size.y - 1; y >= 0; --y) {
         for (int32_t x = full_grid_size.x - 1; x >= 0; --x) {
             const auto core_coord = CoreCoord(x, y);
@@ -64,6 +65,7 @@ MatmulWOProgramFactory::cached_program_t MatmulWOProgramFactory::create(
 
     // Convert the collector core coordinates to physical coordinates
     std::vector<uint32_t> collector_core_physical_coords;
+    collector_core_physical_coords.reserve(2 * collector_core_coords.size());
     for (const auto& core_coord : collector_core_coords) {
         const auto physical_core_coord = tensor_args.input_tensor.device()->worker_core_from_logical_core(core_coord);
         collector_core_physical_coords.push_back(physical_core_coord.x);
@@ -220,6 +222,7 @@ MatmulWOProgramFactory::cached_program_t MatmulWOProgramFactory::create(
 
     // Set the runtime arguments for the kernels
     std::vector<uint32_t> runtime_args;
+    runtime_args.reserve(2 + tensors.size());
     runtime_args.push_back(0);  // DRAM Bank ID placeholder
     runtime_args.push_back(0);  // VChannel placeholder
     for (const auto& tensor : tensors) {
@@ -227,6 +230,7 @@ MatmulWOProgramFactory::cached_program_t MatmulWOProgramFactory::create(
     }
 
     std::vector<uint32_t> vchannels;
+    vchannels.reserve(dram_bank2core_coords.size());
     uint32_t dram_bank = 0;
     for (auto core : dram_bank2core_coords) {
         uint32_t vchannel = dram_bank & 0x3;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_program_factory.cpp
@@ -199,6 +199,7 @@ MoEGateMMProgramFactory::cached_program_t MoEGateMMProgramFactory::create(
 
     // Set the runtime arguments for the kernels
     std::vector<uint32_t> runtime_args;
+    runtime_args.reserve(10 + tensors.size());
     runtime_args.push_back(0);  // DRAM Bank ID placeholder
     runtime_args.push_back(0);  // VChannel placeholder
 
@@ -217,6 +218,7 @@ MoEGateMMProgramFactory::cached_program_t MoEGateMMProgramFactory::create(
     runtime_args.push_back(raw_scores_semaphore_id);
 
     std::vector<uint32_t> vchannels;
+    vchannels.reserve(dram_bank2core_coords.size());
     uint32_t dram_bank = 0;
     for (auto core : dram_bank2core_coords) {
         uint32_t vchannel = dram_bank & 0x3;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -310,7 +310,9 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     constexpr uint32_t MAX_UNTILIZERS_PER_SENDER = 4;
     {
         std::vector<CoreCoord> trimmed_all_untilizer_cores;
+        trimmed_all_untilizer_cores.reserve(num_cores * MAX_UNTILIZERS_PER_SENDER);
         std::vector<uint32_t> trimmed_untilizer_sender_map;
+        trimmed_untilizer_sender_map.reserve(num_cores * MAX_UNTILIZERS_PER_SENDER);
         for (uint32_t s = 0; s < num_cores; s++) {
             if (sender_untilizer_groups[s].size() > MAX_UNTILIZERS_PER_SENDER) {
                 sender_untilizer_groups[s].resize(MAX_UNTILIZERS_PER_SENDER);
@@ -1090,6 +1092,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
 
     // Pre-compute NOC coordinates for all sender cores (for inter-core barrier signaling)
     std::vector<std::pair<uint32_t, uint32_t>> sender_noc_coords;
+    sender_noc_coords.reserve(sender_cores.size());
     for (const auto& sc : sender_cores) {
         auto noc_coord = mesh_device->virtual_core_from_logical_core(sc, tt::CoreType::WORKER);
         sender_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
@@ -1268,6 +1271,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         if (num_links > 0) {
             // Combine-axis neighbors (each a distinct fabric direction) as fabric nodes.
             std::vector<tt::tt_fabric::FabricNodeId> dst_nodes;
+            dst_nodes.reserve(neighbors.size());
             for (const auto& neighbor_coordinate : neighbors) {
                 if (neighbor_coordinate[0] == mesh_coordinate[0] && neighbor_coordinate[1] == mesh_coordinate[1]) {
                     continue;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -199,6 +199,7 @@ tt::tt_metal::ProgramDescriptor create_dispatch_program(
     // laid out [sender, u1, ..., uN] consecutively along x per sender group.
     uint32_t sender_row_y = subdevice_cores.at(0).y;
     std::vector<CoreCoord> all_row_cores;
+    all_row_cores.reserve(subdevice_cores.size());
     for (const auto& core : subdevice_cores) {
         if (core.y == sender_row_y) {
             all_row_cores.push_back(core);
@@ -881,6 +882,7 @@ tt::tt_metal::ProgramDescriptor create_dispatch_program(
 
     // ==================== Pre-compute NOC coordinates ====================
     std::vector<std::pair<uint32_t, uint32_t>> sender_noc_coords;
+    sender_noc_coords.reserve(sender_cores.size());
     for (const auto& sc : sender_cores) {
         auto noc_coord = mesh_device->virtual_core_from_logical_core(sc, tt::CoreType::WORKER);
         sender_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
@@ -961,6 +963,7 @@ tt::tt_metal::ProgramDescriptor create_dispatch_program(
         if (operation_attributes.num_links > 0) {
             // Dispatch-axis neighbors (each a distinct fabric direction) as fabric nodes.
             std::vector<tt::tt_fabric::FabricNodeId> dst_nodes;
+            dst_nodes.reserve(neighbors.size());
             for (const auto& neighbor_coordinate : neighbors) {
                 if (neighbor_coordinate[0] == mesh_coordinate[0] && neighbor_coordinate[1] == mesh_coordinate[1]) {
                     continue;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/inbound_socket_service_sync/device/inbound_socket_service_sync_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/inbound_socket_service_sync/device/inbound_socket_service_sync_program_factory.cpp
@@ -41,6 +41,7 @@ ProgramDescriptor InboundSocketServiceSyncProgramFactory::create_descriptor(
     // Enumerate worker cores row-major (y outer, x inner) — must match the
     // service's worker enumeration so per-worker page slices stay stable.
     std::vector<CoreCoord> workers;
+    workers.reserve(args.worker_cores.size());
     for (uint32_t y = args.worker_cores.start_coord.y; y <= args.worker_cores.end_coord.y; ++y) {
         for (uint32_t x = args.worker_cores.start_coord.x; x <= args.worker_cores.end_coord.x; ++x) {
             workers.emplace_back(x, y);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/device/outbound_socket_service_sync_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/device/outbound_socket_service_sync_program_factory.cpp
@@ -42,6 +42,7 @@ ProgramDescriptor OutboundSocketServiceSyncProgramFactory::create_descriptor(
     // Enumerate worker cores row-major (y outer, x inner) -- must match the service's
     // worker enumeration so per-worker page slices stay stable.
     std::vector<CoreCoord> workers;
+    workers.reserve(args.worker_cores.size());
     for (uint32_t y = args.worker_cores.start_coord.y; y <= args.worker_cores.end_coord.y; ++y) {
         for (uint32_t x = args.worker_cores.start_coord.x; x <= args.worker_cores.end_coord.x; ++x) {
             workers.emplace_back(x, y);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_device_operation.cpp
@@ -109,6 +109,7 @@ tt::tt_metal::TensorSpec PostCombineReduceDeviceOperation::compute_output_specs(
     // Input: [B, C, seq_len, num_experts, emb_dim]
     // Output: [B, C, seq_len, emb_dim]
     std::vector<uint32_t> output_shape_vec;
+    output_shape_vec.reserve(input_shape.rank());
     for (uint32_t i = 0; i < input_shape.rank(); ++i) {
         if (i != operation_attributes.expert_dim) {
             output_shape_vec.push_back(input_shape[i]);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -301,6 +301,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // Candidate gate/up K-block widths: divisors of K_gate_tiles no wider
         // than the requested in0_block_w_gu, largest first.
         std::vector<uint32_t> w_gu_candidates;
+        w_gu_candidates.reserve(std::min<uint32_t>(in0_block_w_gu, K_gate_tiles));
         for (uint32_t w = std::min<uint32_t>(in0_block_w_gu, K_gate_tiles); w >= 1; --w) {
             if (K_gate_tiles % w == 0) {
                 w_gu_candidates.push_back(w);

--- a/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_helpers.hpp
@@ -44,6 +44,7 @@ inline std::optional<std::uint32_t> find_io_tensor_index(std::uint32_t value, co
 inline std::vector<std::pair<uint32_t, uint32_t>> compute_cb_io_tensor_map(
     const tt::tt_metal::ProgramDescriptor& desc, const std::vector<OptionalAddr>& tensor_addrs) {
     std::vector<std::pair<uint32_t, uint32_t>> result;
+    result.reserve(desc.cbs.size());
     for (size_t ci = 0; ci < desc.cbs.size(); ++ci) {
         const auto* buf = desc.cbs[ci].buffer;
         if (buf != nullptr) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_metal_v2_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_metal_v2_factory.cpp
@@ -389,6 +389,8 @@ ProgramArtifacts create_no_bcast_artifacts(
     const uint32_t c_entries = c_borrowed ? full_shard_tiles(c, *c.shard_spec()) : 2u;
 
     std::vector<m2::DataflowBufferSpec> dfbs;
+    constexpr uint32_t num_mandatory_dfbs = 3;  // in0, in1, out
+    dfbs.reserve(num_mandatory_dfbs + (has_lhs_act ? 1 : 0) + (has_rhs_act ? 1 : 0));
     dfbs.push_back(
         make_dfb(IN0, a_tile_bytes, a_entries, a_df, a_tile, a_borrowed ? std::optional{T_A} : std::nullopt));
     dfbs.push_back(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -154,6 +154,7 @@ ActivationReuseConfig calculate_activation_reuse_params(
     config.num_cores_with_non_meaningful_work = tt::div_up(total_remaining_tiles_to_push, single_core_height_ntiles);
 
     std::vector<CoreCoord> all_input_cores;
+    all_input_cores.reserve(input_cores.num_cores());
     for (const CoreRange& range : input_cores.ranges()) {
         for (const CoreCoord& core : range) {
             all_input_cores.push_back(core);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -523,6 +523,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     std::set<CoreCoord> worker_cores_set(all_worker_cores_ordered.begin(), all_worker_cores_ordered.end());
 
     std::vector<uint32_t> bank_ids;
+    bank_ids.reserve(all_worker_cores_ordered.size());
 
     // Idle cores in the bounding box
     for (const auto& core : all_cores_in_rect_grid_vec) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -2012,6 +2012,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     if (restricted_cores.has_value()) {
         subdevice_cores = subdevice_cores.subtract(restricted_cores.value());
     }
+    non_idle_cores_vec.reserve(subdevice_cores.ranges().size() * non_idle_cores.ranges().size());
     for (const auto& cr : subdevice_cores.ranges()) {
         auto intersection = non_idle_cores.intersection(cr);
         if (intersection.empty()) {
@@ -2194,8 +2195,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     tt_metal::CircularBufferConfig output_cb_config =
         tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
     std::vector<tt::tt_metal::CBHandle> cb_outputs;
+    cb_outputs.reserve(out_buffers.size());
     std::vector<tt::tt_metal::CBHandle> output_cb_indices;
+    output_cb_indices.reserve(out_buffers.size());
     std::vector<tt::tt_metal::CBHandle> interm_cb_indices;
+    interm_cb_indices.reserve(out_buffers.size());
 
     if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
         // interm0
@@ -2489,7 +2493,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
             uint32_t banks_in_first_col = num_banks / 2;
 
             std::vector<std::pair<uint32_t, uint32_t>> first_col_anchors;   // (y, bank_id)
+            first_col_anchors.reserve(banks_in_first_col);
             std::vector<std::pair<uint32_t, uint32_t>> second_col_anchors;  // (y, bank_id)
+            second_col_anchors.reserve(num_banks - banks_in_first_col);
 
             for (uint32_t bank = 0; bank < num_banks; ++bank) {
                 const auto& core = optimal_dram_workers[bank];
@@ -2538,6 +2544,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
 
     uint32_t bank_id = 0;
     std::vector<uint32_t> bank_ids;
+    bank_ids.reserve(num_cores);
     for (uint32_t i = 0; i < num_cores; ++i) {
         bool send_to_hop_core = i == 0 && use_hop_cores;
         const auto& core = worker_cores_vec[i];

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -658,6 +658,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     uint32_t sender_id = 0;
     for (auto core : mcast_senders_coords) {
         std::vector<uint32_t> mm_in0_sender_args;
+        mm_in0_sender_args.reserve(3 + in0_mcast_sender_noc_x.size() + in0_mcast_sender_noc_y.size());
 
         uint32_t worker_core_type;
         if (find(storage_worker_common.begin(), storage_worker_common.end(), core) != storage_worker_common.end()) {
@@ -683,6 +684,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     std::vector<CoreCoord> mcast_receiver_coords = corerange_to_cores(mcast_receivers);
     for (auto core : mcast_receiver_coords) {
         std::vector<uint32_t> mm_in0_receiver_args;
+        mm_in0_receiver_args.reserve(3 + in0_mcast_sender_noc_x.size() + in0_mcast_sender_noc_y.size());
         uint32_t worker_core_type = 3;
         mm_in0_receiver_args.push_back((std::uint32_t)worker_core_type);
         mm_in0_receiver_args.push_back((std::uint32_t)0);
@@ -711,6 +713,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     // Compute and in1 sender/writer runtime args
     uint32_t bank_id = 0;
     std::vector<uint32_t> bank_ids;
+    bank_ids.reserve(all_worker_cores_ordered.size());
     uint32_t curr_storage_core_idx = 0;
     uint32_t per_core_N_storage_curr_stride = 0;
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
@@ -35,6 +35,8 @@ std::vector<CoreRange> get_multicast_regions(const CoreRangeSet& all_cores, cons
     TT_ASSERT(logical_controller == logical_zero);
 
     std::vector<CoreRange> logical_core_ranges;
+    // splitting the controller-containing range adds one range to the input set
+    logical_core_ranges.reserve(all_cores.ranges().size() + 1);
     auto split_core_range_containing_controller = [&](const CoreRange& controller_core_range) {
         TT_ASSERT(controller_core_range.start_coord == logical_controller);
         CoreRange right_block(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -30,9 +30,11 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_and_repeated_values(s
     if (values.empty()) {
         return chunks;
     }
+    chunks.reserve(values.size());
 
     // Initialize the first chunk
     std::vector<uint32_t> current_chunk;
+    current_chunk.reserve(values.size());
     current_chunk.push_back(values[0]);
 
     for (size_t i = 1; i < values.size(); ++i) {
@@ -92,6 +94,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // figure out the start read stick id for each core, and the start id for each dim
         std::vector<int> stick_ids_per_core;
+        stick_ids_per_core.reserve(num_sticks_per_core_padded);
         int front_pad_stick_id = -2;
         int pad_stick_id = -1;
         for (uint32_t j = 0; j < num_sticks_per_core_padded; ++j) {
@@ -162,6 +165,9 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // reader rt args
         std::vector<uint32_t> reader_kernel_args;
+        // num_cores + (noc x, noc y, num_chunks) per core + (start id, length) per chunk, where a chunk
+        // holds at least one stick
+        reader_kernel_args.reserve(1 + (3 * core_stick_map.size()) + (2 * num_sticks_per_core_padded));
         reader_kernel_args.push_back(core_stick_map.size());  // num_cores
 
         for (const auto& core_stick_pair : core_stick_map) {
@@ -177,6 +183,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // coalesce the sticks into chunks
         std::vector<std::vector<std::vector<uint32_t>>> stick_chunks_per_core;
+        stick_chunks_per_core.reserve(core_stick_map.size());
         for (auto core_stick_pair : core_stick_map) {
             auto stick_chunks = group_contiguous_and_repeated_values(core_stick_pair.second);
             stick_chunks_per_core.push_back(stick_chunks);
@@ -189,7 +196,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             }
         }
 
-        ret_val[i] = {reader_kernel_args, writer_kernel_args};
+        ret_val[i] = {std::move(reader_kernel_args), std::move(writer_kernel_args)};
     }
 
     return ret_val;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
@@ -69,6 +69,7 @@ std::vector<ScalarInfo> get_bf16_avg_pool_config_scalars(
         "(ceil_pad_h > 0 || ceil_pad_w > 0) or count_include_pad == false and (pad_h > 0 || pad_w > 0)");
 
     std::vector<ScalarInfo> scalars;
+    scalars.reserve(config.max_out_nhw_per_core);
     bool first_scalar = true;
     uint32_t last_pool_area = 0;
 
@@ -151,6 +152,8 @@ Tensor create_scalar_config_tensor(
         default: break;
     }
 
+    scalars_per_core.reserve(num_iterations);
+
     {
         uint32_t nhw_linear = 0;
         uint32_t output_stick_n = 0;
@@ -228,6 +231,7 @@ std::vector<uint32_t> generate_core_starting_indices(
         case tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED: repeat_factor = num_cores_x; break;
         default: TT_FATAL(false, "Unsupported shard scheme");
     };
+    starting_indices.reserve(shard_boundaries.size() * repeat_factor);
     for (const auto& item : shard_boundaries) {
         const auto& [output_shard_start, _] = item.output_range;
         if (output_shard_start >= op_trace_metadata.size()) {
@@ -691,6 +695,12 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
     // whenever pool2d uses a split reader. (mpwi has a single input/scalar stream — reader1 is
     // the writer face.)
     const bool has_second_input_cb = cb_sizes.has_split_reader && !return_indices;
+
+    // mandatory: in_scalar_0, clear_value, in_shard, reader_indices, in_0, out
+    constexpr uint32_t num_mandatory_dfbs = 6;
+    dfbs.reserve(
+        num_mandatory_dfbs + (has_second_input_cb ? 2 : 0) + (return_indices ? 9 : 0) +
+        (cb_sizes.has_pre_tilize ? 2 : 0) + (cb_sizes.has_out_idx ? 1 : 0) + (one_scalar_per_core ? 0 : 1));
 
     dfbs.push_back(local_dfb(
         DFB_IN_SCALAR_0, cb_sizes.scalar_cb_pagesize, cb_sizes.scalar_cb_npages, params.data_format, scalar_face));

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
@@ -27,9 +27,11 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_values_sharded(std::v
     if (values.empty()) {
         return chunks;
     }
+    chunks.reserve(values.size());
 
     // Initialize the first chunk
     std::vector<uint32_t> current_chunk;
+    current_chunk.reserve(values.size());
     current_chunk.push_back(values[0]);
 
     for (size_t i = 1; i < values.size(); ++i) {
@@ -111,6 +113,7 @@ inline std::vector<std::vector<uint32_t>> get_slice_runtime_varargs_rm_sharded(
 
         // stores all sticks id for a core
         std::vector<uint32_t> stick_ids_per_core;
+        stick_ids_per_core.reserve(num_sticks_per_core_unpadded);
         uint32_t src_stick_id = start_id;
         for (uint32_t s = 0; s < num_sticks_per_core_unpadded; ++s) {
             stick_ids_per_core.push_back(src_stick_id);
@@ -152,6 +155,7 @@ inline std::vector<std::vector<uint32_t>> get_slice_runtime_varargs_rm_sharded(
 
         // reader varargs
         std::vector<uint32_t> reader_varargs;
+        reader_varargs.reserve(1 + (3 * core_stick_map.size()));
         reader_varargs.push_back(core_stick_map.size());  // num_cores
 
         for (const auto& core_stick_pair : core_stick_map) {
@@ -167,12 +171,16 @@ inline std::vector<std::vector<uint32_t>> get_slice_runtime_varargs_rm_sharded(
 
         // coalesce the sticks into chunks
         std::vector<std::vector<std::vector<uint32_t>>> stick_chunks_per_core;
+        stick_chunks_per_core.reserve(core_stick_map.size());
+        size_t num_chunks_total = 0;
         for (auto core_stick_pair : core_stick_map) {
             auto stick_chunks = group_contiguous_values_sharded(core_stick_pair.second);
+            num_chunks_total += stick_chunks.size();
             stick_chunks_per_core.push_back(stick_chunks);
 
             reader_varargs.push_back(stick_chunks.size());  // num_chunks for current core
         }
+        reader_varargs.reserve(reader_varargs.size() + (2 * num_chunks_total));
         for (const auto& stick_chunks : stick_chunks_per_core) {
             for (auto chunk : stick_chunks) {
                 reader_varargs.push_back(chunk[0]);      // start id of a chunk

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
@@ -259,6 +259,7 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
     };
 
     std::vector<KernelDescriptor> compute_kernels;
+    compute_kernels.reserve(4);
     if (!core_range.empty()) {
         compute_kernels.push_back(
             make_compute_kernel(core_range, {single_sub_block_wh, single_sub_block_size, third_dim}));

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -41,11 +41,13 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores);
 
     std::vector<uint32_t> shard_grid_x_map;
+    shard_grid_x_map.reserve(num_cores_x);
     for (uint32_t i = 0; i < num_cores_x; ++i) {
         auto physical_core = device->worker_core_from_logical_core(CoreCoord(i, 0));
         shard_grid_x_map.push_back(physical_core.x);
     }
     std::vector<uint32_t> shard_grid_y_map;
+    shard_grid_y_map.reserve(num_cores_y);
     for (uint32_t i = 0; i < num_cores_y; ++i) {
         auto physical_core = device->worker_core_from_logical_core(CoreCoord(0, i));
         shard_grid_y_map.push_back(physical_core.y);
@@ -108,6 +110,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 
     uint32_t height = 0;
     std::vector<CoreCoord> cores;
+    cores.reserve(num_cores);
     for (uint32_t i = 0; i < num_cores; i++) {
         CoreCoord core;
         if (row_major) {
@@ -135,8 +138,13 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
         std::vector<uint32_t> read_stick_offset;
 
         uint32_t num_sticks_per_core = shard_height;
+        read_cores_indices.reserve(num_sticks_per_core);
+        read_cores_noc_x.reserve(num_sticks_per_core);
+        read_cores_noc_y.reserve(num_sticks_per_core);
+        read_stick_offset.reserve(num_sticks_per_core);
 
         std::vector<uint32_t> stick_ids_per_core;
+        stick_ids_per_core.reserve(num_sticks_per_core);
         for (uint32_t j = 0; j < num_sticks_per_core; ++j) {
             stick_ids_per_core.push_back(curr_sticks_read);
             curr_c++;
@@ -188,6 +196,9 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
         uint32_t num_C_blocks_per_core_reader = num_C_blocks_per_core, num_C_blocks_per_core_writer = 0;
 
         uint32_t num_non_repeat_cores = read_cores_indices.size();
+        non_repeat_stick_offset_values.reserve(num_non_repeat_cores);
+        non_repeat_noc_x_values.reserve(num_non_repeat_cores);
+        non_repeat_noc_y_values.reserve(num_non_repeat_cores);
         uint32_t read_stick_stride = read_stick_offset.size() > 1 ? read_stick_offset[1] - read_stick_offset[0] : 0;
 
         if (num_H_per_core == 1) {  // each core only has one H block or part of H block

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
@@ -83,6 +83,7 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
     const uint32_t num_output_tiles = row_major ? ht * 2 : 2;
 
     std::vector<DataflowBufferSpec> dfbs;
+    dfbs.reserve(3);
     dfbs.push_back(DataflowBufferSpec{
         .unique_id = CB_IN0,
         .entry_size = src0_single_tile_size,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -99,6 +99,7 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedRMProgramFactory::cre
     // cb_out_stage exists only on the ht>8 path (compute -> writer staging).
     // ------------------------------------------------------------------------
     std::vector<DataflowBufferSpec> dfbs;
+    dfbs.reserve(3);
     // cb_in0 is gone: the reader reads the resident input shard via tensor::input (local TensorAccessor),
     // not a borrowed self-loop fake-CB.
     dfbs.push_back(DataflowBufferSpec{
@@ -216,7 +217,9 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedRMProgramFactory::cre
     };
 
     std::vector<KernelSpec> kernels;
+    kernels.reserve(3);
     std::vector<KernelSpecName> wu_kernels;
+    wu_kernels.reserve(3);
     kernels.push_back(std::move(reader_spec));
     kernels.push_back(std::move(compute_spec));
     wu_kernels.push_back(READER_KERNEL);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_program_factory.cpp
@@ -402,6 +402,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreProgramFactory::create
 
     ProgramRunArgs run_args;
     std::vector<KernelRunArgs> kra;
+    kra.reserve(4);
     kra.push_back(KernelRunArgs{.kernel = READER, .runtime_arg_values = std::move(reader_node_args)});
     kra.push_back(KernelRunArgs{.kernel = WRITER, .runtime_arg_values = std::move(writer_node_args)});
     if (has_full) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
@@ -155,6 +155,7 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create_program_artifacts(
     uint32_t num_cols_per_output_block = output_page_width;
 
     std::vector<uint32_t> writer_common_runtime_args;
+    writer_common_runtime_args.reserve(output.padded_shape().size() + input.padded_shape().size());
     for (const auto dim : output.padded_shape()) {
         writer_common_runtime_args.push_back(dim);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
@@ -293,6 +293,7 @@ tt::tt_metal::ProgramDescriptor FastReduceNCProgramFactory::create_descriptor(
     // the tile_offset is incremented by it for the reader to adjust it's
     // reading pattern.
     std::vector<CoreCoord> ordered_cores;
+    ordered_cores.reserve(use_sub_core_grids ? all_cores.num_cores() : num_cores_to_be_used);
     if (use_sub_core_grids) {
         for (const auto& range : all_cores.ranges()) {
             for (auto y = range.start_coord.y; y <= range.end_coord.y; ++y) {

--- a/ttnn/cpp/ttnn/operations/experimental/topk_router_gpt/device/topk_router_gpt_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_router_gpt/device/topk_router_gpt_program_factory.cpp
@@ -247,6 +247,7 @@ TopkRouterGptProgramFactory::cached_program_t TopkRouterGptProgramFactory::creat
 
     // VChannel computation with conflict avoidance
     std::vector<uint32_t> vchannels;
+    vchannels.reserve(num_cores);
     for (uint32_t bank_id = 0; bank_id < num_cores; bank_id++) {
         uint32_t vchannel = bank_id & 0x3;
         auto it = std::find_if(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
@@ -381,6 +381,7 @@ ProgramDescriptor AllReduceCreateQkvHeadsMeshWorkloadFactory::create_descriptor(
     // Create output tensor splits
     // TODO: Currently does not support output shards being split across multiple links
     std::vector<CoreRangeSet> output_corerangeset_per_link;
+    output_corerangeset_per_link.reserve(operation_attributes.num_links);
     std::vector<uint32_t> num_output_cores_in_link(operation_attributes.num_links, 0);
     uint32_t output_cores_per_link = tt::div_up(output_tensor_cores.num_cores(), operation_attributes.num_links);
     uint32_t num_assigned_cores = 0;
@@ -692,10 +693,16 @@ ProgramDescriptor AllReduceCreateQkvHeadsMeshWorkloadFactory::create_descriptor(
         uint32_t input_first_core_tile_start_offset = input_tensor_tile_offset_per_link[link];
         uint32_t output_first_core_tile_start_offset = 0;
 
+        const uint32_t num_input_cores_in_link =
+            input_cores_idx_per_link[link].second - input_cores_idx_per_link[link].first;
         std::vector<uint32_t> input_tensor_cores_x;
+        input_tensor_cores_x.reserve(num_input_cores_in_link);
         std::vector<uint32_t> input_tensor_cores_y;
+        input_tensor_cores_y.reserve(num_input_cores_in_link);
         std::vector<uint32_t> output_tensor_cores_x;
+        output_tensor_cores_x.reserve(num_output_cores_in_link[link]);
         std::vector<uint32_t> output_tensor_cores_y;
+        output_tensor_cores_y.reserve(num_output_cores_in_link[link]);
         for (uint32_t i = input_cores_idx_per_link[link].first; i < input_cores_idx_per_link[link].second; i++) {
             auto this_core = mesh_device->worker_core_from_logical_core(input_cores_vec[i]);
             input_tensor_cores_x.push_back(this_core.x);
@@ -728,10 +735,15 @@ ProgramDescriptor AllReduceCreateQkvHeadsMeshWorkloadFactory::create_descriptor(
         desc.kernels[worker_sender_reader_kernel_id].emplace_runtime_args(core, reader_rt_args);
 
         // Set writer runtime args
+        const size_t num_mcast_ranges = output_corerangeset_per_link[link].ranges().size();
         std::vector<uint32_t> mcast_start_x;
+        mcast_start_x.reserve(num_mcast_ranges);
         std::vector<uint32_t> mcast_start_y;
+        mcast_start_y.reserve(num_mcast_ranges);
         std::vector<uint32_t> mcast_end_x;
+        mcast_end_x.reserve(num_mcast_ranges);
         std::vector<uint32_t> mcast_end_y;
+        mcast_end_y.reserve(num_mcast_ranges);
 
         uint32_t num_mcast_cores = 0;
         for (const auto& range : output_corerangeset_per_link[link].ranges()) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -522,6 +522,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     std::set<CoreCoord> worker_cores_set(all_worker_cores_ordered.begin(), all_worker_cores_ordered.end());
 
     std::vector<uint32_t> bank_ids;
+    bank_ids.reserve(all_worker_cores_ordered.size());
 
     // Idle cores in the bounding box
     for (const auto& core : all_cores_in_rect_grid_vec) {
@@ -529,13 +530,13 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
 
         if (!is_worker) {
             std::vector<uint32_t> in0_idle_args = {0u};
-            in0_reader_kernel_desc.runtime_args.emplace_back(core, in0_idle_args);
+            in0_reader_kernel_desc.runtime_args.emplace_back(core, std::move(in0_idle_args));
 
             std::vector<uint32_t> in1_idle_args = {0u};
-            in1_writer_kernel_desc.runtime_args.emplace_back(core, in1_idle_args);
+            in1_writer_kernel_desc.runtime_args.emplace_back(core, std::move(in1_idle_args));
 
             std::vector<uint32_t> compute_idle_args = {0u};
-            compute_kernel_desc.runtime_args.emplace_back(core, compute_idle_args);
+            compute_kernel_desc.runtime_args.emplace_back(core, std::move(compute_idle_args));
         }
     }
 
@@ -582,7 +583,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
         std::vector<uint32_t> compute_runtime_args = {
             1u,
         };
-        compute_kernel_desc.runtime_args.emplace_back(core, compute_runtime_args);
+        compute_kernel_desc.runtime_args.emplace_back(core, std::move(compute_runtime_args));
     }
 
     // Push all kernel descriptors

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -2084,6 +2084,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     CoreRangeSet non_idle_cores = all_worker_cores.merge(hop_cores);
     CoreRangeSet all_cores = non_idle_cores;
     std::vector<CoreRange> non_idle_cores_vec;
+    non_idle_cores_vec.reserve(non_idle_cores.ranges().size());
     auto subdevice_cores = device->worker_cores(
         tt::tt_metal::HalProgrammableCoreType::TENSIX,
         sub_device_id.has_value() ? *sub_device_id : device->get_sub_device_ids().at(0));
@@ -2282,8 +2283,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     tt_metal::CircularBufferConfig output_cb_config =
         tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
     std::vector<tt::tt_metal::CBHandle> cb_outputs;
+    cb_outputs.reserve(out_buffers.size());
     std::vector<tt::tt_metal::CBHandle> output_cb_indices;
+    output_cb_indices.reserve(out_buffers.size());
     std::vector<tt::tt_metal::CBHandle> interm_cb_indices;
+    interm_cb_indices.reserve(out_buffers.size());
 
     if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
         // interm0
@@ -2603,6 +2607,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
 
             std::vector<std::pair<uint32_t, uint32_t>> first_col_anchors;   // (y, bank_id)
             std::vector<std::pair<uint32_t, uint32_t>> second_col_anchors;  // (y, bank_id)
+            first_col_anchors.reserve(banks_in_first_col);
+            second_col_anchors.reserve(num_banks - banks_in_first_col);
 
             for (uint32_t bank = 0; bank < num_banks; ++bank) {
                 const auto& core = optimal_dram_workers[bank];
@@ -2651,6 +2657,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
 
     uint32_t bank_id = 0;
     std::vector<uint32_t> bank_ids;
+    bank_ids.reserve(num_cores);
     for (uint32_t i = 0; i < num_cores; ++i) {
         bool send_to_hop_core = i == 0 && use_hop_cores;
         const auto& core = worker_cores_vec[i];
@@ -2809,10 +2816,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
 
     return MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t{
         {mm_kernel_in1_sender_writer_id},
-        shared_cbs,
+        std::move(shared_cbs),
         false,
         CoreCoord{0, 0},
-        worker_cores_vec,
+        std::move(worker_cores_vec),
         0,
         ttnn::prim::Matmul1DType::GATHER_IN0};
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -656,6 +656,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     uint32_t sender_id = 0;
     for (auto core : mcast_senders_coords) {
         std::vector<uint32_t> mm_in0_sender_args;
+        mm_in0_sender_args.reserve(3 + in0_mcast_sender_noc_x.size() + in0_mcast_sender_noc_y.size());
 
         uint32_t worker_core_type;
         if (find(storage_worker_common.begin(), storage_worker_common.end(), core) != storage_worker_common.end()) {
@@ -673,7 +674,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         mm_in0_sender_args.insert(
             mm_in0_sender_args.end(), in0_mcast_sender_noc_y.begin(), in0_mcast_sender_noc_y.end());
 
-        in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+        in0_sender_kernel_desc.runtime_args.emplace_back(core, std::move(mm_in0_sender_args));
         sender_id++;
     }
 
@@ -681,6 +682,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     std::vector<CoreCoord> mcast_receiver_coords = corerange_to_cores(mcast_receivers);
     for (auto core : mcast_receiver_coords) {
         std::vector<uint32_t> mm_in0_receiver_args;
+        mm_in0_receiver_args.reserve(3 + in0_mcast_sender_noc_x.size() + in0_mcast_sender_noc_y.size());
         uint32_t worker_core_type = 3;
         mm_in0_receiver_args.push_back((std::uint32_t)worker_core_type);
         mm_in0_receiver_args.push_back((std::uint32_t)0);
@@ -690,7 +692,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         mm_in0_receiver_args.insert(
             mm_in0_receiver_args.end(), in0_mcast_sender_noc_y.begin(), in0_mcast_sender_noc_y.end());
 
-        in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_receiver_args);
+        in0_sender_kernel_desc.runtime_args.emplace_back(core, std::move(mm_in0_receiver_args));
     }
 
     // in0 sender runtime args (idle cores in rect grid)
@@ -702,13 +704,14 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
             uint32_t worker_core_type = 0;
             mm_in0_idle_args.push_back((std::uint32_t)worker_core_type);
 
-            in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_idle_args);
+            in0_sender_kernel_desc.runtime_args.emplace_back(core, std::move(mm_in0_idle_args));
         }
     }
 
     // Compute and in1 sender/writer runtime args
     uint32_t bank_id = 0;
     std::vector<uint32_t> bank_ids;
+    bank_ids.reserve(all_worker_cores_ordered.size());
     uint32_t curr_storage_core_idx = 0;
     uint32_t per_core_N_storage_curr_stride = 0;
 
@@ -740,16 +743,16 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
             bool is_worker_core = false;
             std::vector<uint32_t> mm_in1_sender_writer_args;
             mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);
-            in1_sender_writer_kernel_desc.runtime_args.emplace_back(core, mm_in1_sender_writer_args);
+            in1_sender_writer_kernel_desc.runtime_args.emplace_back(core, std::move(mm_in1_sender_writer_args));
 
             std::vector<uint32_t> mm_compute_args;
             mm_compute_args.push_back((std::uint32_t)is_worker_core);
-            compute_kernel_desc.runtime_args.emplace_back(core, mm_compute_args);
+            compute_kernel_desc.runtime_args.emplace_back(core, std::move(mm_compute_args));
         } else {
             bool is_worker_core = true;
             std::vector<uint32_t> mm_compute_args;
             mm_compute_args.push_back((std::uint32_t)is_worker_core);
-            compute_kernel_desc.runtime_args.emplace_back(core, mm_compute_args);
+            compute_kernel_desc.runtime_args.emplace_back(core, std::move(mm_compute_args));
         }
     }
 
@@ -760,8 +763,8 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         bool is_worker_core = true;
         std::vector<uint32_t> mm_in1_sender_writer_args;
         mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);
-        mm_in1_sender_writer_args.push_back(in1_tensor.address());  // [1]: will be replaced by Buffer*
-        mm_in1_sender_writer_args.push_back(bias.has_value() ? bias->address() : 0u);  // [2]: may be replaced
+        mm_in1_sender_writer_args.push_back(in1_tensor.address());                     // [1] smuggled-rta-ok: rebound
+        mm_in1_sender_writer_args.push_back(bias.has_value() ? bias->address() : 0u);  // [2] smuggled-rta-ok
 
         uint32_t vc = bank_id & 0x3;
         bank_ids.push_back(bank_id);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
@@ -59,6 +59,7 @@ MorehAdamOperation::spec_return_value_t MorehAdamOperation::compute_output_specs
     auto dtype = tensor_args.param_in.dtype();
 
     std::vector<std::optional<tt::tt_metal::TensorSpec>> ret;
+    ret.reserve(4);
     tt::tt_metal::TensorSpec out_spec(
         output_shape, TensorLayout(dtype, PageConfig(Layout::TILE), operation_attributes.memory_config));
     for (int idx = 0; idx < 3; idx++) {
@@ -85,6 +86,7 @@ MorehAdamOperation::tensor_return_value_t MorehAdamOperation::create_output_tens
     auto* device = tensor_args.param_in.device();
 
     std::vector<std::optional<Tensor>> ret;
+    ret.reserve(output_specs.size());
     auto memory_config = operation_attributes.memory_config;
 
     for (size_t idx = 0; idx < output_specs.size(); idx++) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
@@ -64,6 +64,7 @@ MorehAdamWDeviceOperation::spec_return_value_t MorehAdamWDeviceOperation::comput
     auto memory_config = operation_attributes.memory_config;
 
     std::vector<std::optional<tt::tt_metal::TensorSpec>> result;
+    result.reserve(4);
     tt::tt_metal::TensorSpec outSpec(output_shape, TensorLayout(dtype, PageConfig(Layout::TILE), memory_config));
 
     if (tensor_args.param_out.has_value()) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
@@ -21,6 +21,7 @@ namespace {
 template <typename OutputDataType, typename InputDataType>
 std::vector<OutputDataType> cast_vec(ttsl::Span<const InputDataType> data_to_convert) {
     std::vector<OutputDataType> converted_data;
+    converted_data.reserve(data_to_convert.size());
     for (auto datum : data_to_convert) {
         if constexpr (std::is_same_v<OutputDataType, float> and std::is_same_v<InputDataType, bfloat16>) {
             converted_data.push_back(static_cast<float>(datum));

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
@@ -39,6 +39,7 @@ ttnn::device_operation::ProgramArtifacts MorehFoldOperation::MultiCore::create_p
     auto output_shape_rank = output.logical_shape().rank();
 
     std::vector<uint32_t> ls;
+    ls.reserve(2);
     for (uint32_t i = 0; i < 2; ++i) {
         uint32_t l = (((output_size[i] + 2 * padding[i] - dilation[i] * (kernel_size[i] - 1) - 1) / stride[i]) + 1);
         ls.push_back(l);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/moreh_group_norm_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/moreh_group_norm_backward.cpp
@@ -27,6 +27,7 @@ std::vector<std::optional<Tensor>> moreh_group_norm_backward(
     const std::optional<MemoryConfig>& beta_grad_memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     std::vector<std::optional<Tensor>> outputs;
+    outputs.reserve(3);
 
     if (are_required_outputs[0]) {
         outputs.push_back(ttnn::prim::moreh_group_norm_backward_input_grad(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
@@ -136,6 +136,7 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
     bool math_approx_mode,
     const std::vector<tt::tt_metal::UnpackToDestMode>& unpack_to_dest_mode) {
     std::vector<KernelHandle> compute_kernel_ids{};
+    compute_kernel_ids.reserve(args.size());
     KernelHandle compute_kernel_id{};
     for (auto arg : args) {
         compute_kernel_id = CreateComputeKernel(
@@ -177,6 +178,7 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
     const std::vector<ComputeKernelArg>& args,
     const ComputeKernelConfig& config) {
     std::vector<KernelHandle> compute_kernel_ids{};
+    compute_kernel_ids.reserve(args.size());
     KernelHandle compute_kernel_id{};
     for (auto arg : args) {
         compute_kernel_id = CreateComputeKernel(program, file_name, arg, config);
@@ -210,6 +212,7 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
     tt::DataFormat data_format,
     const std::vector<CircularBufferArg>& args) {
     std::vector<CBHandle> cb_ids{};
+    cb_ids.reserve(args.size());
     CBHandle cb_id{};
     for (const auto& arg : args) {
         cb_id = CreateCircularBuffer(program, core_range, data_format, arg);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_device_operation.cpp
@@ -44,6 +44,7 @@ MorehSgdOperation::spec_return_value_t MorehSgdOperation::compute_output_specs(
     Layout layout{Layout::TILE};
 
     std::vector<std::optional<tt::tt_metal::TensorSpec>> ret;
+    ret.reserve(2);
 
     if (tensor_args.param_out.has_value()) {
         ret.push_back(tensor_args.param_out->tensor_spec());
@@ -71,6 +72,7 @@ MorehSgdOperation::tensor_return_value_t MorehSgdOperation::create_output_tensor
     auto* device = tensor_args.param_in.device();
 
     std::vector<std::optional<Tensor>> ret;
+    ret.reserve(2);
 
     if (tensor_args.param_out.has_value()) {
         ret.push_back(tensor_args.param_out);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
@@ -46,6 +46,7 @@ void MorehSumBackwardOperation::validate_inputs(
         }
     } else {
         std::vector<uint32_t> expected_output_grad_shape;
+        expected_output_grad_shape.reserve(input_rank);
         std::vector<uint32_t> reduced_dims(input_rank, 0);
         for (auto dim : dims) {
             TT_FATAL(dim < input_rank, "dim {} < input_rank {}", dim, input_rank);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -348,6 +348,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
 
     std::vector<std::vector<CoreCoord>> mcast_groups;
     std::vector<std::vector<CoreCoord>> mcast_virtual_groups;
+    mcast_groups.reserve(core_coords.size());
+    mcast_virtual_groups.reserve(core_coords.size());
     int group_index = -1;
     for (size_t i = 0; i < core_coords.size(); ++i) {
         if (mcast_sender_core_ranges_all.contains(CoreRange(core_coords[i]))) {
@@ -1080,6 +1082,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
                     std::swap(mcast_start, mcast_end);
                 }
                 tt::tt_metal::KernelDescriptor::RTArgList mcast_sender_args;
+                mcast_sender_args.reserve(22 + group.size() * 2);
                 mcast_sender_args.push_back(a.buffer());
                 mcast_sender_args.push_back(output.buffer());
                 mcast_sender_args.push_back(in0_start_id);
@@ -1125,6 +1128,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
                 }
 
                 std::vector<uint32_t> mcast_noc_xy;
+                mcast_noc_xy.reserve(group.size() * 2);
                 for (const auto& gcore : group) {
                     CoreCoord coord = device->worker_core_from_logical_core(gcore);
                     mcast_noc_xy.push_back(coord.x);
@@ -1177,6 +1181,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         }
 
         tt::tt_metal::KernelDescriptor::RTArgList writer_mcast_sender_args;
+        writer_mcast_sender_args.reserve(10);
         writer_mcast_sender_args.push_back(eps_u);
         writer_mcast_sender_args.push_back(output.buffer());
         if (gamma.has_value()) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -482,6 +482,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
 
     std::vector<std::vector<CoreCoord>> mcast_groups;
     std::vector<std::vector<CoreCoord>> mcast_virtual_groups;
+    mcast_groups.reserve(core_coords.size());
+    mcast_virtual_groups.reserve(core_coords.size());
     int group_index = -1;
     for (size_t i = 0; i < core_coords.size(); ++i) {
         if (mcast_sender_core_ranges_all.contains(CoreRange(core_coords[i]))) {
@@ -1337,6 +1339,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
                 std::swap(mcast_start, mcast_end);
             }
             tt::tt_metal::KernelDescriptor::RTArgList mcast_sender_args;
+            mcast_sender_args.reserve(22 + group.size() * 2);
             mcast_sender_args.push_back(a.buffer());
             mcast_sender_args.push_back(output.buffer());
             mcast_sender_args.push_back(in0_start_id);
@@ -1382,6 +1385,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
             }
 
             std::vector<uint32_t> mcast_noc_xy;
+            mcast_noc_xy.reserve(group.size() * 2);
             for (const auto& gcore : group) {
                 CoreCoord coord = device->worker_core_from_logical_core(gcore);
                 mcast_noc_xy.push_back(coord.x);
@@ -1432,6 +1436,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         }
 
         tt::tt_metal::KernelDescriptor::RTArgList writer_mcast_sender_args;
+        writer_mcast_sender_args.reserve(10);
         writer_mcast_sender_args.push_back(eps_u);
         writer_mcast_sender_args.push_back(output.buffer());
         if (gamma.has_value()) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -366,6 +366,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     }
     std::vector<std::vector<CoreCoord>> core_coords2D;
     if (shard_orientation == ShardOrientation::ROW_MAJOR) {
+        core_coords2D.reserve((num_cores_c / num_cores_per_group) * num_cores_r);
         for (uint32_t i = 0; i < num_cores_c / num_cores_per_group; ++i) {
             for (uint32_t j = 0; j < num_cores_r; ++j) {
                 std::vector<CoreCoord> temp;
@@ -374,10 +375,11 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
                     const uint32_t idx = j * num_cores_c + i * num_cores_per_group + k;
                     temp.push_back(core_coords[idx]);
                 }
-                core_coords2D.push_back(temp);
+                core_coords2D.push_back(std::move(temp));
             }
         }
     } else {
+        core_coords2D.reserve((num_cores_r / num_cores_per_group) * num_cores_c);
         for (uint32_t i = 0; i < num_cores_r / num_cores_per_group; ++i) {
             for (uint32_t j = 0; j < num_cores_c; ++j) {
                 std::vector<CoreCoord> temp;
@@ -386,7 +388,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
                     const uint32_t idx = j * num_cores_r + k + i * num_cores_per_group;
                     temp.push_back(core_coords[idx]);
                 }
-                core_coords2D.push_back(temp);
+                core_coords2D.push_back(std::move(temp));
             }
         }
     }
@@ -419,6 +421,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     CoreRangeSet mcast_receiver_cores = CoreRangeSet(mcast_receiver_core_ranges);
     // mcast groups
     std::vector<std::vector<CoreCoord>> mcast_groups;
+    mcast_groups.reserve(num_cores);
     int group_index = -1;
     if (is_height_sharding) {
         for (uint32_t i = 0; i < num_cores; ++i) {
@@ -1134,6 +1137,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
                     std::swap(mcast_start, mcast_end);
                 }
                 std::vector<uint32_t> mcast_sender_args;
+                mcast_sender_args.reserve(17 + group.size() * 2);
                 mcast_sender_args.push_back(static_cast<uint32_t>(!mcast_group_first.empty()));
                 mcast_sender_args.push_back(static_cast<uint32_t>(!mcast_group_last.empty()));
                 mcast_sender_args.push_back(mcast_start.x);
@@ -1203,6 +1207,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
 
                 // add all coords within a group
                 std::vector<uint32_t> mcast_noc_xy;
+                mcast_noc_xy.reserve(group.size() * 2);
                 for (const auto& gcore : group) {
                     CoreCoord coord = device->worker_core_from_logical_core(gcore);
                     mcast_noc_xy.push_back(coord.x);
@@ -1230,6 +1235,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     uint32_t input_mask_tile_start_id = 0;
     for (const auto& core : core_coords) {
         tt::tt_metal::KernelDescriptor::RTArgList writer_mcast_sender_args;
+        writer_mcast_sender_args.reserve(8);
         writer_mcast_sender_args.push_back(eps_u);
         if (gamma.has_value()) {
             writer_mcast_sender_args.push_back(gamma.value().buffer());

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -1464,6 +1464,7 @@ std::vector<uint32_t> build_reader_sender_args(
     }
 
     std::vector<uint32_t> args;
+    args.reserve(7 + ctx.mcast_noc_x.size() + ctx.mcast_noc_y.size());
     args.push_back(mcast_start.x);
     args.push_back(mcast_start.y);
     args.push_back(mcast_end.x);
@@ -1493,6 +1494,7 @@ std::vector<uint32_t> build_reader_sender_args(
 std::vector<uint32_t> build_reader_receiver_all_to_all_args(
     const CoreCoord& core, const CoreIndices& idx, const RuntimeArgsContext& ctx) {
     std::vector<uint32_t> args;
+    args.reserve(6 + ctx.mcast_noc_x.size() + ctx.mcast_noc_y.size());
 
     bool is_last_all_to_all_worker;
     if (ctx.grid.use_two_stage_reduce) {
@@ -1530,6 +1532,7 @@ std::vector<uint32_t> build_reader_receiver_all_to_all_args(
 
 std::vector<uint32_t> build_reader_receiver_not_all_to_all_args(const CoreIndices& idx, const RuntimeArgsContext& ctx) {
     std::vector<uint32_t> args;
+    args.reserve(7);
     args.push_back(false);  // is_last_all_to_all_worker
     args.push_back(idx.all_to_all_worker_tile_offset_bytes);
     args.push_back(0);  // is_second_stage_reader
@@ -1594,6 +1597,7 @@ std::vector<uint32_t> build_writer_args(
     const std::vector<uint32_t>& write_back_args,
     bool is_all_to_all) {
     std::vector<uint32_t> args;
+    args.reserve(6 + write_back_args.size());
 
     if (is_all_to_all) {
         if (ctx.grid.use_two_stage_reduce && idx.width_index >= ctx.workers.num_cores_all_to_all_first_stage) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -379,11 +379,12 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
     CoreRangeSet all_cores = CoreRangeSet(std::vector{all_cores_range});
 
     std::vector<CoreRange> merge_core_ranges_vec;
+    merge_core_ranges_vec.reserve(cores_x);
     for (uint32_t x = 0; x < cores_x; ++x) {
         CoreCoord merge_core = {x, 0};
         merge_core_ranges_vec.emplace_back(CoreRange(merge_core, merge_core));
     }
-    CoreRangeSet merge_cores(merge_core_ranges_vec);
+    CoreRangeSet merge_cores(std::move(merge_core_ranges_vec));
 
     // Translate CreateSemaphore(...) to SemaphoreDescriptor with id 0.
     constexpr uint32_t reducer_semaphore_id = 0;
@@ -426,6 +427,7 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
             uint32_t out_tile_offset = x * out0_tiles;
 
             KernelDescriptor::RTArgList reader_args;
+            reader_args.reserve(9);
             reader_args.push_back(a.buffer());
             reader_args.push_back(tiles_per_core_x);
             reader_args.push_back(tiles_per_core_y);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized_sharded.cpp
@@ -365,6 +365,8 @@ SoftmaxDeviceOperation::SoftmaxShardedProgramFactoryAttentionOptimized::create_d
     uint32_t num_cores_per_batch_index = 0;
 
     if (shard_orient == tt::tt_metal::ShardOrientation::COL_MAJOR) {
+        std::vector<std::variant<uint32_t, Buffer*>> reader_args;
+        reader_args.reserve(4);
         for (uint32_t core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
             for (uint32_t core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
                 CoreCoord core = {
@@ -372,7 +374,7 @@ SoftmaxDeviceOperation::SoftmaxShardedProgramFactoryAttentionOptimized::create_d
                     static_cast<std::size_t>(start_core_y) + core_idx_y};
 
                 // reader args
-                std::vector<std::variant<uint32_t, Buffer*>> reader_args;
+                reader_args.clear();
                 reader_args.push_back(scale_u);
                 reader_args.push_back(mask_buffer);
                 reader_args.push_back(mask_start_tile_id);
@@ -406,6 +408,8 @@ SoftmaxDeviceOperation::SoftmaxShardedProgramFactoryAttentionOptimized::create_d
             }
         }
     } else {
+        std::vector<std::variant<uint32_t, Buffer*>> reader_args;
+        reader_args.reserve(4);
         for (uint32_t core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
             for (uint32_t core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
                 CoreCoord core = {
@@ -413,7 +417,7 @@ SoftmaxDeviceOperation::SoftmaxShardedProgramFactoryAttentionOptimized::create_d
                     static_cast<std::size_t>(start_core_y) + core_idx_y};
 
                 // reader args
-                std::vector<std::variant<uint32_t, Buffer*>> reader_args;
+                reader_args.clear();
                 reader_args.push_back(scale_u);
                 reader_args.push_back(mask_buffer);
                 reader_args.push_back(mask_start_tile_id);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -157,6 +157,8 @@ static Tensor create_scalar_config_tensor(
         default: break;
     }
 
+    scalars_per_core.reserve(num_iterations);
+
     {
         uint32_t nhw_linear = 0;
         uint32_t output_stick_n = 0;
@@ -192,6 +194,8 @@ static Tensor create_scalar_config_tensor(
         max_scalars_cnt,
         num_iterations,
         in_memory_layout);
+
+    config_vector.reserve(scalars_per_core.size() * (config_tensor_in_dram ? 1 : num_shards_c) * entries_per_core);
 
     switch (in_memory_layout) {
         case TensorMemoryLayout::HEIGHT_SHARDED:
@@ -241,6 +245,7 @@ std::vector<uint32_t> generate_core_starting_indices(
         case tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED: repeat_factor = num_cores_x; break;
         default: TT_FATAL(false, "Unsupported shard scheme");
     };
+    starting_indices.reserve(shard_boundaries.size() * repeat_factor);
     for (const auto& item : shard_boundaries) {
         const auto& [output_shard_start, _] = item.output_range;
         if (output_shard_start >= op_trace_metadata.size()) {

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.cpp
@@ -162,6 +162,12 @@ Tensor create_config_tensor(
         }
     };
 
+    // Each entry of dst_core_end_idx_map is padded up to a whole reader block, or to a whole core block when there is a
+    // single output stick per core; the extra entry accounts for the trailing per-core padding.
+    const uint32_t elems_per_idx_map_entry = output_nsticks_per_core > 1 ? elems_per_core_reader : elems_per_core;
+    config_vector.reserve(
+        (ch_end_core - ch_start_core + 1) * (dst_core_end_idx_map.size() + 1) * elems_per_idx_map_entry);
+
     uint32_t per_core_start_idx = 0;
     for (size_t i = ch_start_core; i <= ch_end_core; i++) {
         for (size_t ind = 0, j = 0; ind < dst_core_end_idx_map.size(); ind++) {

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp
@@ -114,11 +114,12 @@ ProgramDescriptor DramPrefetcherOperation::create_descriptor(
     const auto& all_reader_core_range = global_cb.sender_cores();
     auto reader_core_range_vec = corerange_to_cores(all_reader_core_range, std::nullopt, true);
     std::vector<CoreRange> active_reader_core_range_vec;
+    active_reader_core_range_vec.reserve(num_readers);
     for (uint32_t i = 0; i < num_readers; ++i) {
         auto core = reader_core_range_vec[i];
         active_reader_core_range_vec.push_back(CoreRange{core, core});
     }
-    auto reader_core_range = CoreRangeSet{active_reader_core_range_vec};
+    auto reader_core_range = CoreRangeSet{std::move(active_reader_core_range_vec)};
 
     /* read cb setup */
     uint32_t reader_cb_single_tile_size = max_tile_size;
@@ -218,9 +219,13 @@ ProgramDescriptor DramPrefetcherOperation::create_descriptor(
     /* Runtime args */
     std::vector<uint32_t> page_sizes;
     std::vector<uint32_t> block_num_pages;
+    page_sizes.reserve(num_tensors);
+    block_num_pages.reserve(num_tensors);
 
     std::vector<uint32_t> coalesced_page_sizes;
     std::vector<uint32_t> coalesced_num_pages;
+    coalesced_page_sizes.reserve(num_tensors);
+    coalesced_num_pages.reserve(num_tensors);
 
     uint32_t max_page_size = 8192;
 
@@ -238,6 +243,7 @@ ProgramDescriptor DramPrefetcherOperation::create_descriptor(
     }
 
     std::vector<uint32_t> bank_ids;
+    bank_ids.reserve(reader_core_range.num_cores());
     const auto& reader_cores = corerange_to_cores(reader_core_range, std::nullopt, true);
 
     KernelDescriptor reader_desc;
@@ -281,7 +287,9 @@ ProgramDescriptor DramPrefetcherOperation::create_descriptor(
             }
         }
 
-        std::vector<uint32_t> reader_rt_args = {bank_id, vc, total_num_blocks_in_buffer};
+        std::vector<uint32_t> reader_rt_args;
+        reader_rt_args.reserve(3 + 3 * num_tensors);
+        reader_rt_args.insert(reader_rt_args.end(), {bank_id, vc, total_num_blocks_in_buffer});
         reader_rt_args.insert(reader_rt_args.end(), page_sizes.begin(), page_sizes.end());
         reader_rt_args.insert(reader_rt_args.end(), block_num_pages.begin(), block_num_pages.end());
         reader_rt_args.insert(reader_rt_args.end(), tensor_block_num_tiles.begin(), tensor_block_num_tiles.end());
@@ -290,6 +298,7 @@ ProgramDescriptor DramPrefetcherOperation::create_descriptor(
 
         /* writer kernel */
         std::vector<uint32_t> writer_rt_args;
+        writer_rt_args.reserve(5 * num_tensors);
         writer_rt_args.insert(writer_rt_args.end(), coalesced_page_sizes.begin(), coalesced_page_sizes.end());
         writer_rt_args.insert(writer_rt_args.end(), coalesced_num_pages.begin(), coalesced_num_pages.end());
         writer_rt_args.insert(writer_rt_args.end(), tensor_block_num_tiles.begin(), tensor_block_num_tiles.end());

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -456,6 +456,7 @@ std::vector<ShardBoundary> generate_shard_boundaries(const SlidingWindowConfig& 
     std::vector<ShardBoundary> shard_boundaries;
 
     const uint32_t num_cores = config.num_cores_nhw;
+    shard_boundaries.reserve(num_cores);
     const uint32_t output_shard_h = config.get_output_shard_y(config.snap_to_tile);
 
     const uint32_t ceil_padding_w = config.get_ceil_pad_w();
@@ -652,6 +653,11 @@ struct DestinationTransferPair {
 
 static std::vector<DestinationTransferPair> flatten_gather_config(const GatherConfig& input) {
     std::vector<DestinationTransferPair> all;
+    size_t total_transfers = 0;
+    for (const auto& route : input.routes) {
+        total_transfers += route.transfers.size();
+    }
+    all.reserve(total_transfers);
     for (const auto& route : input.routes) {
         for (const auto& t : route.transfers) {
             all.push_back({route.header.noc_x, route.header.noc_y, t.src_id, t.dst_id, t.size});
@@ -858,6 +864,7 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
         const auto& config = local_config[core_id];
         const auto& [src_core_id, dst_core_id, num_copies] = config.first;
         std::vector<GatherTransfer> transfers;
+        transfers.reserve(config.second.size());
         for (const auto& transfer : config.second) {
             const uint16_t src_offset_id = std::get<0>(transfer);
             const uint16_t dst_offset_id = std::get<1>(transfer);
@@ -865,13 +872,14 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
             transfers.emplace_back(src_offset_id, dst_offset_id, size);
         }
         GatherHeader header{src_core_id, dst_core_id, transfers.size()};
-        gather_configs[core_id].routes.push_back(GatherRoute{header, transfers});
+        gather_configs[core_id].routes.push_back(GatherRoute{header, std::move(transfers)});
     }
 
     for (int core_id = 0; core_id < remote_config.size(); core_id++) {
         for (const auto& destination : remote_config[core_id]) {
             const auto& [src_core_id, dst_core_id, num_copies] = destination.first;
             std::vector<GatherTransfer> transfers;
+            transfers.reserve(destination.second.size());
             for (const auto& transfer : destination.second) {
                 const uint16_t src_offset_id = std::get<0>(transfer);
                 const uint16_t dst_offset_id = std::get<1>(transfer);
@@ -879,31 +887,36 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
                 transfers.emplace_back(src_offset_id, dst_offset_id, size);
             }
             GatherHeader header{src_core_id, dst_core_id, transfers.size()};
-            gather_configs[core_id].routes.push_back(GatherRoute{header, transfers});
+            gather_configs[core_id].routes.push_back(GatherRoute{header, std::move(transfers)});
         }
     }
 
     const bool use_blocking = is_in_tiled;
     std::vector<GatherConfig> ordered_gather_configs0;
+    ordered_gather_configs0.reserve(gather_configs.size());
     std::vector<GatherConfig> ordered_gather_configs1;
+    ordered_gather_configs1.reserve(gather_configs.size());
     std::vector<uint16_t> number_of_blocks_per_core;
+    if (use_blocking) {
+        number_of_blocks_per_core.reserve(gather_configs.size());
+    }
     for (const auto& config : gather_configs) {
         if (use_blocking) {
             const auto quantized = quantize_transfers_along_block_boundaries(config, block_size);
             const auto ordered = reorder_transfers_globally(quantized);
-            const auto [first, second, number_of_blocks] = divide_blocks_between_cores(ordered, block_size);
-            ordered_gather_configs0.push_back(first);
-            ordered_gather_configs1.push_back(second);
+            auto [first, second, number_of_blocks] = divide_blocks_between_cores(ordered, block_size);
+            ordered_gather_configs0.push_back(std::move(first));
+            ordered_gather_configs1.push_back(std::move(second));
             number_of_blocks_per_core.push_back(number_of_blocks);
         } else {
-            const auto [first, second] = divide_transfers_between_cores(config);
-            ordered_gather_configs0.push_back(first);
-            ordered_gather_configs1.push_back(second);
+            auto [first, second] = divide_transfers_between_cores(config);
+            ordered_gather_configs0.push_back(std::move(first));
+            ordered_gather_configs1.push_back(std::move(second));
         }
     }
 
-    const auto serialized_gather_configs0 = serialize_gather_configs(ordered_gather_configs0);
-    const auto serialized_gather_configs1 = serialize_gather_configs(ordered_gather_configs1);
+    auto serialized_gather_configs0 = serialize_gather_configs(ordered_gather_configs0);
+    auto serialized_gather_configs1 = serialize_gather_configs(ordered_gather_configs1);
 
     // Flatten and uniformize the lengths of each config list
     auto flatten_pad_config = [](auto& config) -> std::vector<std::vector<uint16_t>> {
@@ -913,6 +926,7 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
             max_len = std::max(max_len, 2 * data.size());  // each data is 2 * data.size()
         }
         std::vector<std::vector<uint16_t>> flattened_config;
+        flattened_config.reserve(config.size());
         for (auto& data : config) {
             std::vector<uint16_t> flat_data(max_len, 0);
             uint32_t idx = 0;
@@ -924,7 +938,7 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
             // null plug
             flat_data.emplace_back(0);
             flat_data.emplace_back(0);
-            flattened_config.emplace_back(flat_data);
+            flattened_config.emplace_back(std::move(flat_data));
         }
         return flattened_config;
     };
@@ -963,11 +977,11 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
     align_config(flattened_pad_config1, 2);
 
     return HaloGatherKernelConfig{
-        flattened_pad_config0,
-        flattened_pad_config1,
-        serialized_gather_configs0,
-        serialized_gather_configs1,
-        number_of_blocks_per_core};
+        std::move(flattened_pad_config0),
+        std::move(flattened_pad_config1),
+        std::move(serialized_gather_configs0),
+        std::move(serialized_gather_configs1),
+        std::move(number_of_blocks_per_core)};
 }
 
 void visualize_sliding_window_op_config(const std::vector<std::vector<uint16_t>>& config) {
@@ -1072,6 +1086,7 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     uint32_t reader1_datums,
     bool pad_cores) {
     std::vector<std::vector<uint16_t>> sharded_input_top_left_indices;
+    sharded_input_top_left_indices.reserve(shard_boundaries.size());
     for (const auto& item : shard_boundaries) {
         const auto& [output_shard_start, output_shard_end] = item.output_range;
         const auto& [input_shard_start, input_shard_end] = item.input_range;
@@ -1079,7 +1094,7 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
         // sanity check
         if (output_shard_start >= op_trace_metadata.size()) {
             // this core has no output
-            sharded_input_top_left_indices.push_back(local_top_left_indices);
+            sharded_input_top_left_indices.push_back(std::move(local_top_left_indices));
             continue;
         }
         TT_ASSERT(input_shard_start == op_trace_metadata[output_shard_start]);
@@ -1125,7 +1140,7 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
                 use_reader0 = !use_reader0;
             }
         }
-        sharded_input_top_left_indices.push_back(local_top_left_indices);
+        sharded_input_top_left_indices.push_back(std::move(local_top_left_indices));
     }
 
     uint32_t indices_length_per_core = sharded_input_top_left_indices[0].size();
@@ -1156,10 +1171,15 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
 
 std::vector<uint16_t> flatten(const std::vector<std::vector<uint16_t>>& input, uint32_t extend_with_zeroes) {
     std::vector<uint16_t> flattened_vector;
-    for (auto sub_vec : input) {
+    size_t total_size = 0;
+    for (const auto& sub_vec : input) {
+        total_size += sub_vec.size() + extend_with_zeroes;
+    }
+    flattened_vector.reserve(total_size);
+    const std::vector<uint16_t> extend_v(extend_with_zeroes, 0);
+    for (const auto& sub_vec : input) {
         flattened_vector.insert(flattened_vector.end(), sub_vec.begin(), sub_vec.end());
         if (extend_with_zeroes > 0) {
-            std::vector<uint16_t> extend_v(extend_with_zeroes, 0);
             flattened_vector.insert(flattened_vector.end(), extend_v.begin(), extend_v.end());
         }
     }
@@ -1189,6 +1209,7 @@ uint32_t get_repeat_factor_for_replicating_nhw_config_across_grid(const Parallel
 
 std::vector<uint16_t> replicate_config(const std::vector<uint16_t>& config_vector, int factor) {
     std::vector<uint16_t> repeat_config;
+    repeat_config.reserve(config_vector.size() * static_cast<size_t>(factor));
     for (uint32_t i = 0; i < factor; ++i) {
         repeat_config.insert(repeat_config.end(), config_vector.begin(), config_vector.end());
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
@@ -63,7 +63,11 @@ uint32_t allocate_per_core_semaphore(
     return sem_id_opt.value();
 }
 
-// Appends 17 runtime args for a fabric MUX client worker.
+// Number of runtime args appended per fabric MUX client worker. Kept in sync with the
+// pushes in fabric_mux_connection_rt_args() and its disconnected-connection counterpart.
+constexpr uint32_t kFabricMuxConnectionRtArgCount = 17;
+
+// Appends kFabricMuxConnectionRtArgCount runtime args for a fabric MUX client worker.
 // Allocates 5 per-core semaphores on worker_logical_core for the connection state.
 void fabric_mux_connection_rt_args(
     const bool mux_connection_valid,
@@ -1114,6 +1118,7 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
             uint32_t ref_q_chunks;
         };
         std::vector<McastCandidate> candidates;
+        candidates.reserve(head_segments.size());
         bool all_eligible = true;
 
         for (uint32_t head_id = 0; head_id < head_segments.size(); ++head_id) {
@@ -1123,6 +1128,7 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
             }
 
             std::vector<uint32_t> chain_core_indices;
+            chain_core_indices.reserve(segments.size());
             for (const auto& seg : segments) {
                 if (seg.core_idx < core_chain_info.size() && core_chain_info[seg.core_idx].participates &&
                     core_chain_info[seg.core_idx].batch == (head_id / NH) &&
@@ -1208,6 +1214,7 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
             mcast_chains = candidates.size();
             // Track injector physical X columns for DRAM channel spreading
             std::vector<uint32_t> injector_phys_x;
+            injector_phys_x.reserve(candidates.size());
             for (const auto& cand : candidates) {
                 const uint32_t chain_size = cand.core_indices.size();
                 const uint32_t num_receivers = chain_size - 1;
@@ -1590,6 +1597,7 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
             // fabric_mux_connection_rt_args appends to a std::vector<uint32_t>; collect mux args
             // separately and then merge into the RTArgList so BufferBinding entries above are preserved.
             std::vector<uint32_t> mux_writer_args;
+            mux_writer_args.reserve(kFabricMuxConnectionRtArgCount);
             if (link_in_range) {
                 const CoreCoord& mux_core =
                     is_backward ? mux_backward_logical_cores[link] : mux_forward_logical_cores[link];
@@ -1697,6 +1705,7 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
 
     // ---- Fabric MUX cores ----
     std::vector<CoreRange> mux_core_ranges;
+    mux_core_ranges.reserve(2 * args.num_links);
     for (uint32_t link = 0; link < args.num_links; ++link) {
         if (backward_coord.has_value()) {
             mux_core_ranges.emplace_back(mux_backward_logical_cores[link]);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -1817,6 +1817,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             uint32_t ref_q_chunks;
         };
         std::vector<McastCandidate> candidates;
+        candidates.reserve(head_segments.size());
         bool all_eligible = true;
 
         for (uint32_t head_id = 0; head_id < head_segments.size(); ++head_id) {
@@ -1827,7 +1828,9 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
 
             // Gather chain participants with their per-head q_chunk_count
             std::vector<uint32_t> chain_core_indices;
+            chain_core_indices.reserve(segments.size());
             std::vector<uint32_t> chain_q_counts;
+            chain_q_counts.reserve(segments.size());
             for (const auto& seg : segments) {
                 if (seg.core_idx < head_chain_configs.size() && head_chain_configs[seg.core_idx].participates &&
                     head_chain_configs[seg.core_idx].batch == (head_id / NH) &&

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -936,6 +936,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
         uint32_t chains_skipped = 0;
         // Track injector physical X columns for DRAM channel spreading
         std::vector<uint32_t> injector_phys_x;
+        injector_phys_x.reserve(head_segments.size());
 
         for (uint32_t head_id = 0; head_id < head_segments.size(); ++head_id) {
             auto& segments = head_segments[head_id];
@@ -981,6 +982,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
             // Build chain in wrap order: start, start+1, ..., N-1, 0, 1, ..., start-1.
             // Break on conflict (core already in a different chain).
             std::vector<std::size_t> chain_order;
+            chain_order.reserve(segments.size());
             for (std::size_t step = 0; step < segments.size(); ++step) {
                 std::size_t idx = (start + step) % segments.size();
                 const auto& seg = segments[idx];
@@ -1135,6 +1137,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
             uint32_t ref_q_chunks;
         };
         std::vector<McastCandidate> candidates;
+        candidates.reserve(head_segments.size());
         bool all_eligible = true;
         uint32_t total_multi_core_chains = 0;
 
@@ -1146,6 +1149,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
 
             // Collect chain core indices that actually participate in this head's chain
             std::vector<uint32_t> chain_core_indices;
+            chain_core_indices.reserve(segments.size());
             for (const auto& seg : segments) {
                 if (seg.core_idx < core_chain_info.size() && core_chain_info[seg.core_idx].participates &&
                     core_chain_info[seg.core_idx].batch == (head_id / NQH) &&


### PR DESCRIPTION
PR Cathegory:
  memory work optimization
Summary:
  Preallocate memory for further usage to avoid possible sequential reallocation. Move vectors into structured return values instead of copying them out.
  This PR unites the code changes from the 56 per-module pull requests of the `AlexeyZaytsev-epam/memory_work_optimization_*` series (#51698 - #51962) into a single change set: 235 files, +953 / -139.
Notes for reviewers:
NA
