### PR TITLE
[Bug] eth fw: yield to base fw if txq is never busy

### DIFF
--- a/tt_metal/hw/inc/internal/ethernet/dataflow_api.h
+++ b/tt_metal/hw/inc/internal/ethernet/dataflow_api.h
@@ -149,8 +149,6 @@ void eth_noc_async_write_barrier() {
  * | src_addr          | Source address in local eth core L1 memory              | uint32_t | 0..256kB | True     |
  * | dst_addr          | Destination address in remote eth core L1 memory        | uint32_t | 0..256kB | True     |
  * | num_bytes         | Size of data transfer in bytes, must be multiple of 16  | uint32_t | 0..256kB | True     |
- * | wait_min          | Packets without a context switch before run_routing()   | uint32_t | Any uint32_t value | False
- * |
  */
 FORCE_INLINE
 void eth_send_bytes(
@@ -158,21 +156,11 @@ void eth_send_bytes(
     uint32_t dst_addr,
     uint32_t num_bytes,
     uint32_t num_bytes_per_send = 16,
-    uint32_t num_bytes_per_send_word_size = 1,
-    uint32_t wait_min = 100) {
+    uint32_t num_bytes_per_send_word_size = 1) {
     uint32_t num_bytes_sent = 0;
-    uint32_t count = 0;
     while (num_bytes_sent < num_bytes) {
-        bool context_switched = internal_::eth_send_packet(
+        internal_::eth_send_packet(
             0, ((num_bytes_sent + src_addr) >> 4), ((num_bytes_sent + dst_addr) >> 4), num_bytes_per_send_word_size);
-        if (context_switched) {
-            count = 0;
-        } else if (count == wait_min) {
-            run_routing();
-            count = 0;
-        } else {
-            count++;
-        }
         num_bytes_sent += num_bytes_per_send;
     }
     erisc_info->channels[0].bytes_sent += num_bytes;

--- a/tt_metal/hw/inc/internal/ethernet/dataflow_api.h
+++ b/tt_metal/hw/inc/internal/ethernet/dataflow_api.h
@@ -149,6 +149,8 @@ void eth_noc_async_write_barrier() {
  * | src_addr          | Source address in local eth core L1 memory              | uint32_t | 0..256kB | True     |
  * | dst_addr          | Destination address in remote eth core L1 memory        | uint32_t | 0..256kB | True     |
  * | num_bytes         | Size of data transfer in bytes, must be multiple of 16  | uint32_t | 0..256kB | True     |
+ * | wait_min          | Packets without a context switch before run_routing()   | uint32_t | Any uint32_t value | False
+ * |
  */
 FORCE_INLINE
 void eth_send_bytes(
@@ -156,11 +158,21 @@ void eth_send_bytes(
     uint32_t dst_addr,
     uint32_t num_bytes,
     uint32_t num_bytes_per_send = 16,
-    uint32_t num_bytes_per_send_word_size = 1) {
+    uint32_t num_bytes_per_send_word_size = 1,
+    uint32_t wait_min = 100) {
     uint32_t num_bytes_sent = 0;
+    uint32_t count = 0;
     while (num_bytes_sent < num_bytes) {
-        internal_::eth_send_packet(
+        bool context_switched = internal_::eth_send_packet(
             0, ((num_bytes_sent + src_addr) >> 4), ((num_bytes_sent + dst_addr) >> 4), num_bytes_per_send_word_size);
+        if (context_switched) {
+            count = 0;
+        } else if (count == wait_min) {
+            run_routing();
+            count = 0;
+        } else {
+            count++;
+        }
         num_bytes_sent += num_bytes_per_send;
     }
     erisc_info->channels[0].bytes_sent += num_bytes;

--- a/tt_metal/hw/inc/internal/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/internal/ethernet/tunneling.h
@@ -82,7 +82,7 @@ FORCE_INLINE bool eth_txq_is_busy(uint32_t q_num) {
 }
 
 template <bool ctx_switch = true>
-FORCE_INLINE bool eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_addr, uint32_t num_words) {
+FORCE_INLINE void eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_addr, uint32_t num_words) {
     DEBUG_SANITIZE_ETH(src_word_addr << 4, dest_word_addr << 4, num_words << 4);
     WATCHER_CHECK_ETH_LINK_STATUS();
     bool context_switched = false;
@@ -97,7 +97,18 @@ FORCE_INLINE bool eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32
     eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, dest_word_addr << 4);
     eth_txq_reg_write(q_num, ETH_TXQ_TRANSFER_SIZE_BYTES, num_words << 4);
     eth_txq_reg_write(q_num, ETH_TXQ_CMD, ETH_TXQ_CMD_START_DATA);
-    return context_switched;
+    if constexpr (ctx_switch) {
+        static uint32_t count = 0;
+        constexpr uint32_t wait_min = 100;
+        if (context_switched) {
+            count = 0;
+        } else if (count == wait_min) {
+            count = 0;
+            risc_context_switch();
+        } else {
+            count++;
+        }
+    }
 }
 
 FORCE_INLINE

--- a/tt_metal/hw/inc/internal/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/internal/ethernet/tunneling.h
@@ -82,12 +82,14 @@ FORCE_INLINE bool eth_txq_is_busy(uint32_t q_num) {
 }
 
 template <bool ctx_switch = true>
-FORCE_INLINE void eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_addr, uint32_t num_words) {
+FORCE_INLINE bool eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_addr, uint32_t num_words) {
     DEBUG_SANITIZE_ETH(src_word_addr << 4, dest_word_addr << 4, num_words << 4);
     WATCHER_CHECK_ETH_LINK_STATUS();
+    bool context_switched = false;
     while (eth_txq_is_busy(q_num)) {
         // Note, this is overly eager... Kills perf on allgather
         if constexpr (ctx_switch) {
+            context_switched = true;
             risc_context_switch();
         }
     }
@@ -95,6 +97,7 @@ FORCE_INLINE void eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32
     eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, dest_word_addr << 4);
     eth_txq_reg_write(q_num, ETH_TXQ_TRANSFER_SIZE_BYTES, num_words << 4);
     eth_txq_reg_write(q_num, ETH_TXQ_CMD, ETH_TXQ_CMD_START_DATA);
+    return context_switched;
 }
 
 FORCE_INLINE


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The ethernet send kernel assumes that every packet sent will trigger the eth txq as busy, but on simulated devices the queue may never register as busy. This starves the base fw and results in a heartbeat timeout.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=micah/eth-send-yield)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:micah/eth-send-yield)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=micah/eth-send-yield)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:micah/eth-send-yield)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=micah/eth-send-yield)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:micah/eth-send-yield)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=micah/eth-send-yield)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:micah/eth-send-yield)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=micah/eth-send-yield)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:micah/eth-send-yield)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=micah/eth-send-yield)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:micah/eth-send-yield)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=micah/eth-send-yield)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:micah/eth-send-yield)