### PR TITLE
[Feature] Change CBReaderWithManualRelease to use page based reading

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -958,7 +958,6 @@ static_assert(SD_PREFETCHER_PAGE_BATCH_SIZE == 1);
 
 static constexpr uint32_t SD_PREFETCH_CMDDAT_LOG_PAGE_SIZE = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
 static constexpr uint32_t SD_PREFETCH_CMDDAT_PAGE_SIZE = 1u << SD_PREFETCH_CMDDAT_LOG_PAGE_SIZE;
-static constexpr uint32_t SD_PREFETCH_CMDDAT_BLOCKS = DispatchSettings::PREFETCH_D_BUFFER_BLOCKS;
 inline CoreCoord sd_prefetch_core(const tt_metal::IDevice* device) {
     return tt::tt_metal::detail::sd_cq_prefetch_core(device);
 }
@@ -1583,7 +1582,6 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
         {"MY_UPSTREAM_CB_SEM_ID", "0"},  // not used when IS_H_VARIANT=1
         {"UPSTREAM_CB_SEM_ID", "0"},
         {"CMDDAT_Q_LOG_PAGE_SIZE", std::to_string(SD_PREFETCH_CMDDAT_LOG_PAGE_SIZE)},
-        {"CMDDAT_Q_BLOCKS", std::to_string(SD_PREFETCH_CMDDAT_BLOCKS)},
         {"DISPATCH_S_BUFFER_BASE", "0"},
         {"MY_DISPATCH_S_CB_SEM_ID", "0"},
         {"DOWNSTREAM_DISPATCH_S_CB_SEM_ID", "0"},

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -110,8 +110,6 @@ public:
 
     static constexpr uint32_t PREFETCH_D_BUFFER_LOG_PAGE_SIZE = 12;
 
-    static constexpr uint32_t PREFETCH_D_BUFFER_BLOCKS = 4;
-
     static constexpr uint32_t EVENT_PADDED_SIZE = 16;
 
     // When page size of buffer to write/read exceeds the max prefetch command size, the PCIe-aligned page size is

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -144,7 +144,6 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.my_upstream_cb_sem_id = 0;
         dependent_config_.upstream_cb_sem_id = 0;
         static_config_.cmddat_q_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-        static_config_.cmddat_q_blocks = DispatchSettings::PREFETCH_D_BUFFER_BLOCKS;
 
         uint32_t dispatch_s_buffer_base = 0xff;
         if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
@@ -204,7 +203,6 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.my_downstream_cb_sem_id = tt::tt_metal::CreateSemaphore(
             *program_, logical_core_, my_dispatch_constants.prefetch_d_buffer_pages(), GetCoreType());
         static_config_.cmddat_q_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-        static_config_.cmddat_q_blocks = DispatchSettings::PREFETCH_D_BUFFER_BLOCKS;
 
         // PREFETCH_H has no DISPATCH_S
         static_config_.dispatch_s_buffer_base = 0;
@@ -240,7 +238,6 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.my_upstream_cb_sem_id =
             tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
         static_config_.cmddat_q_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-        static_config_.cmddat_q_blocks = DispatchSettings::PREFETCH_D_BUFFER_BLOCKS;
 
         uint32_t dispatch_s_buffer_base = 0xff;
         {  // Just to make it match previous implementation
@@ -495,7 +492,6 @@ void PrefetchKernel::CreateKernel() {
         {"MY_UPSTREAM_CB_SEM_ID", std::to_string(static_config_.my_upstream_cb_sem_id.value())},
         {"UPSTREAM_CB_SEM_ID", std::to_string(dependent_config_.upstream_cb_sem_id.value())},
         {"CMDDAT_Q_LOG_PAGE_SIZE", std::to_string(static_config_.cmddat_q_log_page_size.value())},
-        {"CMDDAT_Q_BLOCKS", std::to_string(static_config_.cmddat_q_blocks.value())},
         {"DISPATCH_S_BUFFER_BASE", std::to_string(static_config_.dispatch_s_buffer_base.value())},
         {"MY_DISPATCH_S_CB_SEM_ID", std::to_string(static_config_.my_dispatch_s_cb_sem_id.value())},
         {"DOWNSTREAM_DISPATCH_S_CB_SEM_ID", std::to_string(dependent_config_.downstream_dispatch_s_cb_sem_id.value())},

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -40,7 +40,6 @@ struct prefetch_static_config_t {
     std::optional<uint32_t> cmddat_q_pages;
     std::optional<uint32_t> my_upstream_cb_sem_id;
     std::optional<uint32_t> cmddat_q_log_page_size;
-    std::optional<uint32_t> cmddat_q_blocks;
 
     // Used for prefetch_d <--> dispatch_s data path
     std::optional<uint32_t> dispatch_s_buffer_base;

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -423,8 +423,8 @@ private:
 //  - Provides non-blocking availability via acquire_pages() and a blocking drain via wait_all_pages().
 // Notes:
 //  - This class only accounts for pages locally; it does NOT release credits back to the producer.
-//    Use CBReaderWithReleasePolicy or CBReaderWithManualRelease when credits must be returned.
-//  - Credits are returned per-block, not per-page.
+//    Use CBReaderWithReleasePolicy for block-based credit release, or CBReaderWithManualRelease when the caller
+//    returns credits explicitly.
 template <
     uint32_t my_sem_id,
     uint32_t cb_log_page_size,
@@ -614,40 +614,38 @@ private:
     uint32_t block_noc_writes_to_clear_{0};
 };
 
-template <
-    uint32_t my_sem_id,
-    uint32_t cb_log_page_size,
-    uint32_t cb_blocks,
-    uint32_t cb_pages_per_block,
-    uint32_t cb_base,
-    uint32_t cb_end>
-class CBReaderWithManualRelease : public CBReader<my_sem_id, cb_log_page_size, cb_blocks, cb_pages_per_block, cb_base> {
+template <uint32_t my_sem_id, uint32_t cb_log_page_size, uint32_t cb_base, uint32_t cb_end>
+class CBReaderWithManualRelease {
+    static_assert((cb_end - cb_base) % (1 << cb_log_page_size) == 0, "CB size must be a whole number of pages");
+
 public:
     FORCE_INLINE void init() {
-        this->CBReader<my_sem_id, cb_log_page_size, cb_blocks, cb_pages_per_block, cb_base>::init();
+        cb_fence_ = cb_base;
+        upstream_count_ = 0;
+        local_count_ = 0;
     }
+
+    // Return available space (in bytes) after data_ptr. This data will always be contiguous in memory and will never
+    // wrap around.
+    uint32_t available_bytes(uintptr_t data_ptr) const { return static_cast<uint32_t>(cb_fence_ - data_ptr); }
 
     // Get a new CB page. Will update cmd_ptr on wrap-around. Returns the number of pages acquired. Will not release
     // pages to writer.
     FORCE_INLINE uint32_t get_cb_page(uintptr_t& cmd_ptr) {
-        // Strided past the data that has arrived, get the next page
-        if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {
-            if (this->rd_block_idx_ == cb_blocks - 1) {
-                cmd_ptr = cb_base;
-                this->cb_fence_ = cb_base;
-            }
-            this->move_rd_to_next_block();
+        if (cb_fence_ == cb_end) {
+            cmd_ptr = cb_base;
+            cb_fence_ = cb_base;
         }
 
-        return this->acquire_pages();
+        return acquire_pages();
     }
 
     // Returns how much data is available. Will block until data is available.
     FORCE_INLINE uint32_t wait_for_available_data(uintptr_t& cmd_ptr) {
-        if (this->available_bytes(cmd_ptr) == 0) {
+        if (available_bytes(cmd_ptr) == 0) {
             get_cb_page(cmd_ptr);
         }
-        return this->available_bytes(cmd_ptr);
+        return available_bytes(cmd_ptr);
     }
 
     // Advance cmd_ptr by length. If we wrap around, wrap the fence (should only happen if we hit the end exactly).
@@ -657,17 +655,47 @@ public:
         if (cmd_ptr + length >= cb_end) {
             length -= static_cast<uint32_t>(cb_end - cmd_ptr);
             cmd_ptr = cb_base;
-            if (this->cb_fence_ == cb_end) {
+            if (cb_fence_ == cb_end) {
                 // We hit the nail on the head, wrap the fence
                 ASSERT(length == 0);
-                this->cb_fence_ = cb_base;
-                // TODO eliminate usage of block_next_start_addr_ in this CB reader. rd_block_idx_ will point to the
-                // last block, not the first block, so the limit calculation in acquire_pages will be incorrect. We
-                // don't really use blocks for anything, here, so we should get rid of them and simplify the code.
+                cb_fence_ = cb_base;
             }
         }
         cmd_ptr += length;
     }
+
+private:
+    // Acquire pages from upstream up to the end of the ring. Pages are released manually by the caller.
+    FORCE_INLINE uint32_t acquire_pages() {
+        volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+            l1_uncached_addr(get_semaphore<programmable_core_type>(my_sem_id)));
+
+        if (local_count_ == upstream_count_) {
+            WAYPOINT("UAPW");
+            uint32_t heartbeat = 0;
+            do {
+                invalidate_l1_cache();
+                IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat, 0);
+            } while ((upstream_count_ = *sem_addr) == local_count_);
+            WAYPOINT("UAPD");
+        }
+
+        uint32_t limit = static_cast<uint32_t>((cb_end - cb_fence_) >> cb_log_page_size);
+        uint32_t available = upstream_count_ - local_count_;
+        uint32_t usable = (available > limit) ? limit : available;
+
+        local_count_ += usable;
+        cb_fence_ += usable << cb_log_page_size;
+
+        return usable;
+    }
+
+    // Byte address fence delimiting the end of currently usable data (do not process beyond this address).
+    uintptr_t cb_fence_{0};
+    // Last value read from the upstream semaphore (producer credits). Cached snapshot for availability checks.
+    uint32_t upstream_count_{0};
+    // Number of pages this reader has already accounted for (consumed) into the cb_fence_ region.
+    uint32_t local_count_{0};
 };
 
 constexpr uint32_t l1_to_local_cache_copy_chunk = 6;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -78,7 +78,6 @@ constexpr uint32_t cmddat_q_pages = CMDDAT_Q_PAGES;
 constexpr uint32_t my_upstream_cb_sem_id = MY_UPSTREAM_CB_SEM_ID;
 constexpr uint32_t upstream_cb_sem_id = UPSTREAM_CB_SEM_ID;
 constexpr uint32_t cmddat_q_log_page_size = CMDDAT_Q_LOG_PAGE_SIZE;
-constexpr uint32_t cmddat_q_blocks = CMDDAT_Q_BLOCKS;
 
 // used for prefetch_d <--> dispatch_s data path
 constexpr uint32_t dispatch_s_buffer_base = DISPATCH_S_BUFFER_BASE;
@@ -186,8 +185,6 @@ constexpr uint32_t scratch_db_base1 = scratch_db_base + scratch_db_half_size;
 constexpr uint32_t prefetch_q_log_minsize = 4;
 
 const uint32_t scratch_db_top[2] = {scratch_db_base0, scratch_db_base1};
-
-constexpr uint32_t cmddat_q_pages_per_block = cmddat_q_pages / cmddat_q_blocks;
 
 // Currently capping the same as dispatch
 constexpr uint32_t max_read_packed_cmd =
@@ -2478,14 +2475,7 @@ static uintptr_t process_relay_inline_all(uintptr_t data_ptr, uintptr_t fence, b
 // We require that all data for a single fetch is available before processing commands. We can't use a normal
 // CBReaderWithReleasePolicy because that always releases pages when advancing between blocks,
 // which would cause problems if the data spans multiple blocks.
-CBReaderWithManualRelease<
-    my_upstream_cb_sem_id,
-    cmddat_q_log_page_size,
-    cmddat_q_blocks,
-    cmddat_q_pages_per_block,
-    cmddat_q_base,
-    cmddat_q_end>
-    h_cmddat_q_reader;
+CBReaderWithManualRelease<my_upstream_cb_sem_id, cmddat_q_log_page_size, cmddat_q_base, cmddat_q_end> h_cmddat_q_reader;
 
 // Used in prefetch_d downstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
 inline void relay_raw_data_to_downstream(uintptr_t& data_ptr, uint64_t wlength, uint32_t& local_downstream_data_ptr) {


### PR DESCRIPTION
### PR Category
Feature

### Summary

Closes #31835

* Refactored CBReaderWithManualRelease to use page reading only without blocks
* Removed unused config params

### Notes for reviewers

CBReaderWithManualRelease is only used within cq_prefetch.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/remove-blocks-prefetch-cb-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/remove-blocks-prefetch-cb-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/remove-blocks-prefetch-cb-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/remove-blocks-prefetch-cb-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=anashTT/remove-blocks-prefetch-cb-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:anashTT/remove-blocks-prefetch-cb-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/remove-blocks-prefetch-cb-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/remove-blocks-prefetch-cb-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/remove-blocks-prefetch-cb-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/remove-blocks-prefetch-cb-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/remove-blocks-prefetch-cb-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/remove-blocks-prefetch-cb-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/remove-blocks-prefetch-cb-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/remove-blocks-prefetch-cb-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/remove-blocks-prefetch-cb-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/remove-blocks-prefetch-cb-reader)