### PR TITLE
Preallocate vector capacity and move vectors into structured return values

### DIFF
--- a/tt_metal/fabric/topology_solver.cpp
+++ b/tt_metal/fabric/topology_solver.cpp
@@ -20,6 +20,7 @@ std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_graph_logical(con
 
     // Collect all mesh and switch instances (same order as MeshGraph: meshes then switches)
     std::vector<GlobalNodeId> mesh_and_switch_instances;
+    mesh_and_switch_instances.reserve(mgd.all_meshes().size() + mgd.all_switches().size());
     for (GlobalNodeId id : mgd.all_meshes()) {
         mesh_and_switch_instances.push_back(id);
     }
@@ -136,9 +137,11 @@ std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> build_adjacency_graph_phy
     for (const auto& [mesh_id, mesh_asics] : mesh_asic_ids) {
         auto get_local_adjacents = [&](tt::tt_metal::AsicID asic_id,
                                        const std::unordered_set<tt::tt_metal::AsicID>& mesh_asics) {
+            const auto neighbors = physical_system_descriptor.get_asic_neighbors(asic_id);
             std::vector<tt::tt_metal::AsicID> adjacents;
+            adjacents.reserve(neighbors.size());
 
-            for (const auto& neighbor : physical_system_descriptor.get_asic_neighbors(asic_id)) {
+            for (const auto& neighbor : neighbors) {
                 // Skip self-connections
                 if (neighbor == asic_id) {
                     continue;

--- a/tt_metal/fabric/topology_solver.cpp
+++ b/tt_metal/fabric/topology_solver.cpp
@@ -137,11 +137,9 @@ std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> build_adjacency_graph_phy
     for (const auto& [mesh_id, mesh_asics] : mesh_asic_ids) {
         auto get_local_adjacents = [&](tt::tt_metal::AsicID asic_id,
                                        const std::unordered_set<tt::tt_metal::AsicID>& mesh_asics) {
-            const auto neighbors = physical_system_descriptor.get_asic_neighbors(asic_id);
             std::vector<tt::tt_metal::AsicID> adjacents;
-            adjacents.reserve(neighbors.size());
 
-            for (const auto& neighbor : neighbors) {
+            for (const auto& neighbor : physical_system_descriptor.get_asic_neighbors(asic_id)) {
                 // Skip self-connections
                 if (neighbor == asic_id) {
                     continue;

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -2128,9 +2128,7 @@ void ProgramImpl::finalize_single_dfb_config(
     // For remapper mode, pre-allocate clientTypes for each consumer
     // Also allocate producer clientTypes (clientL)
     std::vector<uint8_t> consumer_client_types;
-    consumer_client_types.reserve(consumer_risc_ids.size());
     std::vector<uint8_t> producer_client_types;
-    producer_client_types.reserve(producer_risc_ids.size());
     ClientTypeAllocator client_type_allocator;
 
     if (use_remapper) {

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -2089,9 +2089,13 @@ void ProgramImpl::finalize_single_dfb_config(
     uint8_t num_producer_tcs = calculate_num_tile_counters(config, true);
     uint8_t num_consumer_tcs = calculate_num_tile_counters(config, false);
 
+    // One risc id per bit of the risc masks: bits 0-7 are DM riscs, bits 8-15 are Tensix riscs.
+    constexpr uint8_t num_risc_ids = std::numeric_limits<decltype(config.producer_risc_mask)>::digits;
     std::vector<uint8_t> producer_risc_ids;
+    producer_risc_ids.reserve(num_risc_ids);
     std::vector<uint8_t> consumer_risc_ids;
-    for (uint8_t risc_id = 0; risc_id < 16; risc_id++) {
+    consumer_risc_ids.reserve(num_risc_ids);
+    for (uint8_t risc_id = 0; risc_id < num_risc_ids; risc_id++) {
         if (config.producer_risc_mask & (1 << risc_id)) {
             producer_risc_ids.push_back(risc_id);
         }
@@ -2099,6 +2103,7 @@ void ProgramImpl::finalize_single_dfb_config(
             consumer_risc_ids.push_back(risc_id);
         }
     }
+    new_hw_risc_configs.reserve(producer_risc_ids.size() + consumer_risc_ids.size());
 
     // Determine tensix_id based on which RISC in the pair is Tensix
     // Without remapper,Tensix RISCs can only access TCs from their own tensix_id
@@ -2123,7 +2128,9 @@ void ProgramImpl::finalize_single_dfb_config(
     // For remapper mode, pre-allocate clientTypes for each consumer
     // Also allocate producer clientTypes (clientL)
     std::vector<uint8_t> consumer_client_types;
+    consumer_client_types.reserve(consumer_risc_ids.size());
     std::vector<uint8_t> producer_client_types;
+    producer_client_types.reserve(producer_risc_ids.size());
     ClientTypeAllocator client_type_allocator;
 
     if (use_remapper) {
@@ -2638,6 +2645,7 @@ void ProgramImpl::apply_dfb_size_overrides(const std::vector<DfbSizeOverride>& o
 std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>
 ProgramImpl::dataflow_buffers_on_core(const CoreCoord& core) const {
     std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dfbs_on_core;
+    dfbs_on_core.reserve(dataflow_buffers_.size());
     for (const auto& dfb : dataflow_buffers_) {
         if (dfb->core_ranges.intersects(core)) {
             dfbs_on_core.push_back(dfb);
@@ -2648,6 +2656,7 @@ ProgramImpl::dataflow_buffers_on_core(const CoreCoord& core) const {
 
 std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> ProgramImpl::dataflow_buffers_on_corerange(const CoreRange& cr) const {
     std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dfbs_on_core;
+    dfbs_on_core.reserve(dataflow_buffers_.size());
     for (const auto& dfb : dataflow_buffers_) {
         if (dfb->core_ranges.intersects(cr)) {
             dfbs_on_core.push_back(dfb);
@@ -2658,6 +2667,12 @@ std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBuf
 
 std::vector<CoreRange> ProgramImpl::dataflow_buffers_unique_coreranges() const {
     std::vector<CoreRange> core_ranges;
+    size_t max_core_ranges = 0;
+    for (const auto& dfb : dataflow_buffers_) {
+        max_core_ranges += dfb->core_ranges.ranges().size();
+    }
+    core_ranges.reserve(max_core_ranges);
+
     for (const auto& dfb : dataflow_buffers_) {
         for (const CoreRange& core_range : dfb->core_ranges.ranges()) {
             if (std::find(core_ranges.begin(), core_ranges.end(), core_range) == core_ranges.end()) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1304,6 +1304,7 @@ std::shared_ptr<CircularBufferImpl> detail::ProgramImpl::get_circular_buffer(CBH
 std::vector<std::shared_ptr<CircularBufferImpl>> detail::ProgramImpl::circular_buffers_on_core(
     const CoreCoord& core) const {
     std::vector<std::shared_ptr<CircularBufferImpl>> cbs_on_core;
+    cbs_on_core.reserve(circular_buffers_.size());
     for (const auto& circular_buffer : circular_buffers_) {
         if (circular_buffer->is_on_logical_core(core)) {
             cbs_on_core.push_back(circular_buffer);
@@ -1315,6 +1316,7 @@ std::vector<std::shared_ptr<CircularBufferImpl>> detail::ProgramImpl::circular_b
 std::vector<std::shared_ptr<CircularBufferImpl>> detail::ProgramImpl::circular_buffers_on_corerange(
     const CoreRange& cr) const {
     std::vector<std::shared_ptr<CircularBufferImpl>> cbs_on_core;
+    cbs_on_core.reserve(circular_buffers_.size());
     for (const auto& circular_buffer : circular_buffers_) {
         if (circular_buffer->is_on_logical_corerange(cr)) {
             cbs_on_core.push_back(circular_buffer);
@@ -1325,6 +1327,12 @@ std::vector<std::shared_ptr<CircularBufferImpl>> detail::ProgramImpl::circular_b
 
 std::vector<CoreRange> detail::ProgramImpl::circular_buffers_unique_coreranges() const {
     std::vector<CoreRange> core_ranges;
+    size_t max_core_ranges = 0;
+    for (const auto& circular_buffer : circular_buffers_) {
+        max_core_ranges += circular_buffer->core_ranges().ranges().size();
+    }
+    core_ranges.reserve(max_core_ranges);
+
     for (const auto& circular_buffer : circular_buffers_) {
         for (const CoreRange& core_range : circular_buffer->core_ranges().ranges()) {
             if (std::find(core_ranges.begin(), core_ranges.end(), core_range) == core_ranges.end()) {
@@ -1440,6 +1448,7 @@ void detail::ProgramImpl::allocate_scratchpads(const IDevice* device) {
                 // (not just exact-range matches), so the scratchpad cannot overlap a DFB on
                 // an overlapping-but-different core range. Mark each such allocator exactly once.
                 std::vector<CircularBufferAllocator*> touched;
+                touched.reserve(this->dfb_allocators_.size());
                 for (CircularBufferAllocator& a : this->dfb_allocators_) {
                     for (const CoreRange& core_range : kernel_cores.ranges()) {
                         if (a.core_range.intersects(core_range)) {
@@ -1496,7 +1505,9 @@ void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
         dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device);
     if (mesh_device != nullptr) {
         // Mesh device: track all sub-devices
-        for (IDevice* sub_device : mesh_device->get_devices()) {
+        const auto sub_devices = mesh_device->get_devices();
+        devices_to_track.reserve(sub_devices.size());
+        for (IDevice* sub_device : sub_devices) {
             devices_to_track.push_back(sub_device);
         }
     } else {
@@ -1506,6 +1517,7 @@ void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
 
     // Track which devices are NEW (not already tracked)
     std::vector<const IDevice*> new_devices;
+    new_devices.reserve(devices_to_track.size());
     for (const IDevice* dev : devices_to_track) {
         auto [iter, inserted] = this->cb_devices_.insert(dev);
         if (inserted) {
@@ -1670,7 +1682,9 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
     std::vector<AllocatorImpl*> physical_allocators;
     if (hybrid_mode) {
         if (const auto* mesh = dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device)) {
-            for (IDevice* dev : mesh->get_devices()) {
+            const auto mesh_devices = mesh->get_devices();
+            physical_allocators.reserve(mesh_devices.size());
+            for (IDevice* dev : mesh_devices) {
                 physical_allocators.push_back(dev->allocator_impl().get());
             }
         } else {
@@ -1684,7 +1698,9 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
     std::vector<const IDevice*> devices_for_svc_check;
     if (svc.has_any_claims()) {
         if (const auto* mesh = dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device)) {
-            for (IDevice* dev : mesh->get_devices()) {
+            const auto mesh_devices = mesh->get_devices();
+            devices_for_svc_check.reserve(mesh_devices.size());
+            for (IDevice* dev : mesh_devices) {
                 devices_for_svc_check.push_back(dev);
             }
         } else {
@@ -1986,6 +2002,11 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
             const auto& ranges, const CoreType core_type) -> std::vector<std::pair<transfer_info_cores, uint32_t>> {
         // This API extracts all the pairs of noc multicast encodings given a set of core ranges
         std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_unicast_info;
+        size_t num_cores = 0;
+        for (const CoreRange& core_range : ranges) {
+            num_cores += core_range.size();
+        }
+        dst_noc_unicast_info.reserve(num_cores);
         for (const CoreRange& core_range : ranges) {
             for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                 for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
@@ -2074,6 +2095,7 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
                 std::vector<multicast_transfer_info> dst_noc_multicast_info =
                     extract_dst_noc_multicast_info(device, kernel_group->core_ranges.ranges(), core_type);
                 std::vector<KernelHandle> kernel_ids;
+                kernel_ids.reserve(kernel_group->kernel_ids.size());
                 for (auto kernel_id : kernel_group->kernel_ids) {
                     KernelHandle device_local_kernel_id = program_dispatch::get_device_local_kernel_handle(kernel_id);
                     kernel_ids.push_back(device_local_kernel_id);
@@ -2106,6 +2128,7 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
                 // No checks for max dispatch class
                 // Validated during CreateKernel if the requested processor is supported
                 std::vector<KernelHandle> kernel_ids;
+                kernel_ids.reserve(kernel_group->kernel_ids.size());
                 for (auto kernel_id : kernel_group->kernel_ids) {
                     KernelHandle device_local_kernel_id = program_dispatch::get_device_local_kernel_handle(kernel_id);
                     auto kernel = this->get_kernel(device_local_kernel_id);
@@ -2412,6 +2435,13 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
         // succeeds (from the .d files left by the -E step).
         std::vector<std::shared_ptr<Kernel>> preprocessed_kernels;
 
+        size_t total_kernels = 0;
+        for (const auto& kernels : kernels_) {
+            total_kernels += kernels.size();
+        }
+        submitted_kernels.reserve(total_kernels);
+        preprocessed_kernels.reserve(total_kernels);
+
         for (auto& kernels : kernels_) {
             for (auto& [id, kernel] : kernels) {
                 validate_kernel_placement(force_slow_dispatch, kernel, device->build_id());
@@ -2593,6 +2623,7 @@ void detail::ProgramImpl::release_buffers() { owned_buffer_pool = {}; }
 std::vector<std::reference_wrapper<const Semaphore>> detail::ProgramImpl::semaphores_on_core(
     const CoreCoord& core, CoreType core_type) const {
     std::vector<std::reference_wrapper<const Semaphore>> semaphores;
+    semaphores.reserve(this->semaphores_.size());
     for (const Semaphore& s : this->semaphores_) {
         if (s.initialized_on_logical_core(core) && s.core_type() == core_type) {
             semaphores.emplace_back(std::cref(s));
@@ -2697,6 +2728,12 @@ uint32_t detail::ProgramImpl::finalize_program_offsets(
 
     // Collect dataflow buffers from all programs
     std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dataflow_buffers;
+    size_t total_dataflow_buffers = 0;
+    for (ProgramImpl* program : programs) {
+        total_dataflow_buffers += program->dataflow_buffers().size();
+    }
+    dataflow_buffers.reserve(total_dataflow_buffers);
+
     for (ProgramImpl* program : programs) {
         for (const auto& dfb : program->dataflow_buffers()) {
             dataflow_buffers.push_back(dfb);

--- a/tt_metal/impl/tensor/distributed_tensor_apis.cpp
+++ b/tt_metal/impl/tensor/distributed_tensor_apis.cpp
@@ -222,6 +222,7 @@ void h2d_as_replicate_tensor_on_1x1_mesh(
         // remote coordinates are a complete no-op here.
         const auto& view = mesh_device->get_view();
         std::vector<distributed::MeshCoordinate> local_coords;
+        local_coords.reserve(mesh_device->shape().mesh_size());
         distributed::MeshCoordinateRangeSet local_range;
         for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
             if (view.impl().is_local(coord)) {

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -219,17 +219,18 @@ public:
             auto distributed_buffer = make_distributed_host_buffer();
             auto remap_fn = get_remap_fn(distribution_mode_, &global_range_);
             std::vector<MeshCoordinate> buffer_coords;
+            buffer_coords.reserve(distribution_shape_.mesh_size());
             for (const auto& coord : MeshCoordinateRange(distribution_shape_)) {
                 const auto mapped_coord = remap_fn(coord);
                 buffer_coords.push_back(mapped_coord);
                 distributed_buffer.emplace_shard(mapped_coord, [&b = replicated_buffer]() { return b; });
             }
 
-            const auto tensor_topology =
-                tt::tt_metal::TensorTopology(distribution_shape_, config_.placements, buffer_coords);
+            auto tensor_topology =
+                tt::tt_metal::TensorTopology(distribution_shape_, config_.placements, std::move(buffer_coords));
 
             return Tensor(tt::tt_metal::host_tensor_from_buffer_with_topology(
-                std::move(distributed_buffer), tensor_spec, tensor_topology));
+                std::move(distributed_buffer), tensor_spec, std::move(tensor_topology)));
         }
 
         // Otherwise, use xtensor to chunk the data into shards.
@@ -351,6 +352,7 @@ private:
         std::unordered_map<XTensorViewKey, tt::tt_metal::HostBuffer> converted_buffers;
 
         std::vector<MeshCoordinate> buffer_coords;
+        buffer_coords.reserve(sharded_xtensor_views.size());
         size_t num_views_with_value = 0;
         for (const auto& [coord, xtensor_view] : sharded_xtensor_views) {
             if (!xtensor_view.has_value()) {
@@ -399,11 +401,11 @@ private:
         const auto actual_distribution_shape =
             (distribution_shape_.dims() == 1) ? MeshShape(num_views_with_value) : distribution_shape_;
 
-        const auto tensor_topology =
-            tt::tt_metal::TensorTopology(actual_distribution_shape, config_.placements, buffer_coords);
+        auto tensor_topology =
+            tt::tt_metal::TensorTopology(actual_distribution_shape, config_.placements, std::move(buffer_coords));
 
         return Tensor(tt::tt_metal::host_tensor_from_buffer_with_topology(
-            std::move(distributed_buffer), shard_spec, tensor_topology));
+            std::move(distributed_buffer), shard_spec, std::move(tensor_topology)));
     }
 
     // Mesh parameters. `mesh_device_view_` is empty when constructed from a `MeshShape` only.

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -126,6 +126,7 @@ ActivationReuseConfig calculate_activation_reuse_params(
     config.num_cores_with_non_meaningful_work = tt::div_up(total_remaining_tiles_to_push, single_core_height_ntiles);
 
     std::vector<CoreCoord> all_input_cores;
+    all_input_cores.reserve(input_cores.num_cores());
     for (const CoreRange& range : input_cores.ranges()) {
         for (const CoreCoord& core : range) {
             all_input_cores.push_back(core);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -53,11 +53,13 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores);
 
     std::vector<uint32_t> shard_grid_x_map;
+    shard_grid_x_map.reserve(num_cores_x);
     for (uint32_t i = 0; i < num_cores_x; ++i) {
         auto physical_core = device->worker_core_from_logical_core(CoreCoord(i, 0));
         shard_grid_x_map.push_back(physical_core.x);
     }
     std::vector<uint32_t> shard_grid_y_map;
+    shard_grid_y_map.reserve(num_cores_y);
     for (uint32_t i = 0; i < num_cores_y; ++i) {
         auto physical_core = device->worker_core_from_logical_core(CoreCoord(0, i));
         shard_grid_y_map.push_back(physical_core.y);
@@ -80,7 +82,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 
         std::vector<uint32_t> writer_runtime_args;
 
-        ret_val[i] = {reader_runtime_args, writer_runtime_args};
+        ret_val[i] = {std::move(reader_runtime_args), std::move(writer_runtime_args)};
 
         for (uint32_t j = 0; j < num_sticks_per_core; ++j) {
             curr_c++;
@@ -121,6 +123,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 
     uint32_t height = 0;
     std::vector<CoreCoord> cores;
+    cores.reserve(num_cores);
     for (uint32_t i = 0; i < num_cores; ++i) {
         CoreCoord core;
         if (row_major) {

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -456,6 +456,7 @@ std::vector<ShardBoundary> generate_shard_boundaries(const SlidingWindowConfig& 
     std::vector<ShardBoundary> shard_boundaries;
 
     const uint32_t num_cores = config.num_cores_nhw;
+    shard_boundaries.reserve(num_cores);
     const uint32_t output_shard_h = config.get_output_shard_y(config.snap_to_tile);
 
     const uint32_t ceil_padding_w = config.get_ceil_pad_w();
@@ -652,6 +653,11 @@ struct DestinationTransferPair {
 
 static std::vector<DestinationTransferPair> flatten_gather_config(const GatherConfig& input) {
     std::vector<DestinationTransferPair> all;
+    size_t total_transfers = 0;
+    for (const auto& route : input.routes) {
+        total_transfers += route.transfers.size();
+    }
+    all.reserve(total_transfers);
     for (const auto& route : input.routes) {
         for (const auto& t : route.transfers) {
             all.push_back({route.header.noc_x, route.header.noc_y, t.src_id, t.dst_id, t.size});
@@ -858,6 +864,7 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
         const auto& config = local_config[core_id];
         const auto& [src_core_id, dst_core_id, num_copies] = config.first;
         std::vector<GatherTransfer> transfers;
+        transfers.reserve(config.second.size());
         for (const auto& transfer : config.second) {
             const uint16_t src_offset_id = std::get<0>(transfer);
             const uint16_t dst_offset_id = std::get<1>(transfer);
@@ -865,13 +872,14 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
             transfers.emplace_back(src_offset_id, dst_offset_id, size);
         }
         GatherHeader header{src_core_id, dst_core_id, transfers.size()};
-        gather_configs[core_id].routes.push_back(GatherRoute{header, transfers});
+        gather_configs[core_id].routes.push_back(GatherRoute{header, std::move(transfers)});
     }
 
     for (int core_id = 0; core_id < remote_config.size(); core_id++) {
         for (const auto& destination : remote_config[core_id]) {
             const auto& [src_core_id, dst_core_id, num_copies] = destination.first;
             std::vector<GatherTransfer> transfers;
+            transfers.reserve(destination.second.size());
             for (const auto& transfer : destination.second) {
                 const uint16_t src_offset_id = std::get<0>(transfer);
                 const uint16_t dst_offset_id = std::get<1>(transfer);
@@ -879,31 +887,36 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
                 transfers.emplace_back(src_offset_id, dst_offset_id, size);
             }
             GatherHeader header{src_core_id, dst_core_id, transfers.size()};
-            gather_configs[core_id].routes.push_back(GatherRoute{header, transfers});
+            gather_configs[core_id].routes.push_back(GatherRoute{header, std::move(transfers)});
         }
     }
 
     const bool use_blocking = is_in_tiled;
     std::vector<GatherConfig> ordered_gather_configs0;
+    ordered_gather_configs0.reserve(gather_configs.size());
     std::vector<GatherConfig> ordered_gather_configs1;
+    ordered_gather_configs1.reserve(gather_configs.size());
     std::vector<uint16_t> number_of_blocks_per_core;
+    if (use_blocking) {
+        number_of_blocks_per_core.reserve(gather_configs.size());
+    }
     for (const auto& config : gather_configs) {
         if (use_blocking) {
             const auto quantized = quantize_transfers_along_block_boundaries(config, block_size);
             const auto ordered = reorder_transfers_globally(quantized);
-            const auto [first, second, number_of_blocks] = divide_blocks_between_cores(ordered, block_size);
-            ordered_gather_configs0.push_back(first);
-            ordered_gather_configs1.push_back(second);
+            auto [first, second, number_of_blocks] = divide_blocks_between_cores(ordered, block_size);
+            ordered_gather_configs0.push_back(std::move(first));
+            ordered_gather_configs1.push_back(std::move(second));
             number_of_blocks_per_core.push_back(number_of_blocks);
         } else {
-            const auto [first, second] = divide_transfers_between_cores(config);
-            ordered_gather_configs0.push_back(first);
-            ordered_gather_configs1.push_back(second);
+            auto [first, second] = divide_transfers_between_cores(config);
+            ordered_gather_configs0.push_back(std::move(first));
+            ordered_gather_configs1.push_back(std::move(second));
         }
     }
 
-    const auto serialized_gather_configs0 = serialize_gather_configs(ordered_gather_configs0);
-    const auto serialized_gather_configs1 = serialize_gather_configs(ordered_gather_configs1);
+    auto serialized_gather_configs0 = serialize_gather_configs(ordered_gather_configs0);
+    auto serialized_gather_configs1 = serialize_gather_configs(ordered_gather_configs1);
 
     // Flatten and uniformize the lengths of each config list
     auto flatten_pad_config = [](auto& config) -> std::vector<std::vector<uint16_t>> {
@@ -913,6 +926,7 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
             max_len = std::max(max_len, 2 * data.size());  // each data is 2 * data.size()
         }
         std::vector<std::vector<uint16_t>> flattened_config;
+        flattened_config.reserve(config.size());
         for (auto& data : config) {
             std::vector<uint16_t> flat_data(max_len, 0);
             uint32_t idx = 0;
@@ -924,7 +938,7 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
             // null plug
             flat_data.emplace_back(0);
             flat_data.emplace_back(0);
-            flattened_config.emplace_back(flat_data);
+            flattened_config.emplace_back(std::move(flat_data));
         }
         return flattened_config;
     };
@@ -963,11 +977,11 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
     align_config(flattened_pad_config1, 2);
 
     return HaloGatherKernelConfig{
-        flattened_pad_config0,
-        flattened_pad_config1,
-        serialized_gather_configs0,
-        serialized_gather_configs1,
-        number_of_blocks_per_core};
+        std::move(flattened_pad_config0),
+        std::move(flattened_pad_config1),
+        std::move(serialized_gather_configs0),
+        std::move(serialized_gather_configs1),
+        std::move(number_of_blocks_per_core)};
 }
 
 void visualize_sliding_window_op_config(const std::vector<std::vector<uint16_t>>& config) {
@@ -1072,6 +1086,7 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     uint32_t reader1_datums,
     bool pad_cores) {
     std::vector<std::vector<uint16_t>> sharded_input_top_left_indices;
+    sharded_input_top_left_indices.reserve(shard_boundaries.size());
     for (const auto& item : shard_boundaries) {
         const auto& [output_shard_start, output_shard_end] = item.output_range;
         const auto& [input_shard_start, input_shard_end] = item.input_range;
@@ -1079,7 +1094,7 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
         // sanity check
         if (output_shard_start >= op_trace_metadata.size()) {
             // this core has no output
-            sharded_input_top_left_indices.push_back(local_top_left_indices);
+            sharded_input_top_left_indices.push_back(std::move(local_top_left_indices));
             continue;
         }
         TT_ASSERT(input_shard_start == op_trace_metadata[output_shard_start]);
@@ -1125,7 +1140,7 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
                 use_reader0 = !use_reader0;
             }
         }
-        sharded_input_top_left_indices.push_back(local_top_left_indices);
+        sharded_input_top_left_indices.push_back(std::move(local_top_left_indices));
     }
 
     uint32_t indices_length_per_core = sharded_input_top_left_indices[0].size();
@@ -1156,10 +1171,15 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
 
 std::vector<uint16_t> flatten(const std::vector<std::vector<uint16_t>>& input, uint32_t extend_with_zeroes) {
     std::vector<uint16_t> flattened_vector;
-    for (auto sub_vec : input) {
+    size_t total_size = 0;
+    for (const auto& sub_vec : input) {
+        total_size += sub_vec.size() + extend_with_zeroes;
+    }
+    flattened_vector.reserve(total_size);
+    const std::vector<uint16_t> extend_v(extend_with_zeroes, 0);
+    for (const auto& sub_vec : input) {
         flattened_vector.insert(flattened_vector.end(), sub_vec.begin(), sub_vec.end());
         if (extend_with_zeroes > 0) {
-            std::vector<uint16_t> extend_v(extend_with_zeroes, 0);
             flattened_vector.insert(flattened_vector.end(), extend_v.begin(), extend_v.end());
         }
     }
@@ -1189,6 +1209,7 @@ uint32_t get_repeat_factor_for_replicating_nhw_config_across_grid(const Parallel
 
 std::vector<uint16_t> replicate_config(const std::vector<uint16_t>& config_vector, int factor) {
     std::vector<uint16_t> repeat_config;
+    repeat_config.reserve(config_vector.size() * static_cast<size_t>(factor));
     for (uint32_t i = 0; i < factor; ++i) {
         repeat_config.insert(repeat_config.end(), config_vector.begin(), config_vector.end());
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -945,6 +945,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
         uint32_t chains_skipped = 0;
         // Track injector physical X columns for DRAM channel spreading
         std::vector<uint32_t> injector_phys_x;
+        injector_phys_x.reserve(head_segments.size());
 
         for (uint32_t head_id = 0; head_id < head_segments.size(); ++head_id) {
             auto& segments = head_segments[head_id];
@@ -990,6 +991,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
             // Build chain in wrap order: start, start+1, ..., N-1, 0, 1, ..., start-1.
             // Break on conflict (core already in a different chain).
             std::vector<std::size_t> chain_order;
+            chain_order.reserve(segments.size());
             for (std::size_t step = 0; step < segments.size(); ++step) {
                 std::size_t idx = (start + step) % segments.size();
                 const auto& seg = segments[idx];
@@ -1144,6 +1146,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
             uint32_t ref_q_chunks;
         };
         std::vector<McastCandidate> candidates;
+        candidates.reserve(head_segments.size());
         bool all_eligible = true;
         uint32_t total_multi_core_chains = 0;
 
@@ -1155,6 +1158,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
 
             // Collect chain core indices that actually participate in this head's chain
             std::vector<uint32_t> chain_core_indices;
+            chain_core_indices.reserve(segments.size());
             for (const auto& seg : segments) {
                 if (seg.core_idx < core_chain_info.size() && core_chain_info[seg.core_idx].participates &&
                     core_chain_info[seg.core_idx].batch == (head_id / NQH) &&


### PR DESCRIPTION
PR Cathegory:
  memory work optimization
Summary:
  Preallocate memory for further usage to avoid possible sequential reallocation. Move vectors into structured return values instead of copying them out.
could give up to 4% performance improvement.
see [https://github.com/tenstorrent/tt-metal/pull/51685](https://github.com/tenstorrent/tt-metal/pull/51685) for details
Notes for reviewers:
  NA
[![(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_united_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_united_2)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_united_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_united_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_united_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_united_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_united_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_united_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_united_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_united_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_united_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_united_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_united_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_united_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_united_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_united_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_united_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_united_2)