### PR TITLE
[Cleanup] Rename allow_force_argmax to allow_greedy_fastpath

### DIFF
--- a/models/common/models/deepseek_r1_distill_qwen_14b/model.py
+++ b/models/common/models/deepseek_r1_distill_qwen_14b/model.py
@@ -592,10 +592,10 @@ class DeepSeekR1Qwen14B(LightweightModule):
         # Buffers are lazy (nothing materializes until the first on-device sampled decode), so
         # this is harmless when sampling_params is None (host-argmax path, the demo default).
         # On-device argmax + top-k both capture/replay on 1x1/1x2/1x8 meshes (test_sampling1d_trace
-        # _capture), so the gate is all 1D meshes. allow_force_argmax=False clones TTTv1's
-        # default_sampling_force_argmax decision for all non-Galaxy meshes (Qwen2 generic path,
+        # _capture), so the gate is all 1D meshes. allow_greedy_fastpath=False clones TTTv1's
+        # default_sampling_greedy_fastpath decision for all non-Galaxy meshes (Qwen2 generic path,
         # model_config.py): the perf recipe (temp=0, top_k=32, top_p=0.08) routes through the cheap
-        # top-k op path, never the full-vocab force-argmax all-gather.
+        # top-k op path, never the full-vocab greedy fast-path all-gather.
         self.supports_on_device_sampling = self.num_devices >= 1
         self.sampling = (
             Sampling1D(
@@ -603,7 +603,7 @@ class DeepSeekR1Qwen14B(LightweightModule):
                 mesh_device=mesh_device,
                 tt_ccl=self.tt_ccl,
                 max_batch_size=_nearest_32(cfg.max_batch_size),
-                allow_force_argmax=False,
+                allow_greedy_fastpath=False,
                 pad_to_power_of_2=True,
             )
             if self.supports_on_device_sampling

--- a/models/common/models/executor.py
+++ b/models/common/models/executor.py
@@ -243,16 +243,16 @@ def _build_batched_prefill_group(tokens, prompt_lens, page_table, positions, pad
     return folded, group_pt, group_idxs, last_token_idxs
 
 
-def _build_decode_topk_param_tensors(mesh_device, sampling_params, batch_size, allow_force_argmax=True):
+def _build_decode_topk_param_tensors(mesh_device, sampling_params, batch_size, allow_greedy_fastpath=True):
     """Build replicated (k, p, temp) device tensors for ``Sampling1D``'s top-k path.
 
     Reuses ``format_sampling_params`` (so temperature inversion, top-p clamping and the
     ``temp==0 -> k=1`` rewrite match TTTv1 / PERF.md exactly), then mirrors TTSampling's
     1D layout: ROW_MAJOR, uint32 k / bfloat16 p / bfloat16 temp, replicated across the mesh.
 
-    Returns ``None`` **only when force-argmax is allowed** and the formatted params reduce to
+    Returns ``None`` **only when greedy fast-path is allowed** and the formatted params reduce to
     greedy (all k==1, p==0, temp==1) — the caller then uses the cheaper full-vocab argmax path.
-    When ``allow_force_argmax`` is False the model has no argmax path, so greedy params must
+    When ``allow_greedy_fastpath`` is False the model has no argmax path, so greedy params must
     still build real tensors and route through the top-k op (k=1 top-k == argmax-via-topk),
     exactly as TTTv1 does for the ``temp=0`` PERF.md recipe — never returning ``None``.
 
@@ -272,7 +272,7 @@ def _build_decode_topk_param_tensors(mesh_device, sampling_params, batch_size, a
     p = list(fmt.top_p)[:batch_size]
     temp = list(fmt.temperature)[:batch_size]
 
-    if allow_force_argmax and all(kk == 1 for kk in k) and all(pp == 0 for pp in p) and all(tt == 1 for tt in temp):
+    if allow_greedy_fastpath and all(kk == 1 for kk in k) and all(pp == 0 for pp in p) and all(tt == 1 for tt in temp):
         return None
 
     mapper = ttnn.ReplicateTensorToMesh(mesh_device)
@@ -460,10 +460,10 @@ class EagerLLMExecutor:
     def _sampling_decode_forward(self, logits, sampling_params, tt_out_tok=None):
         """Run ``model.sampling`` on device, choosing the path that matches PERF.md.
 
-        Routing depends on the model's ``allow_force_argmax``:
-          * ``allow_force_argmax=True``  — greedy params reducing to (k==1, p==0, temp==1) take
-            the force-argmax full-vocab all-gather path (``decode_forward`` with no k/p/temp).
-          * ``allow_force_argmax=False`` (the 1B/7B recipe) — there is no argmax path, so *every*
+        Routing depends on the model's ``allow_greedy_fastpath``:
+          * ``allow_greedy_fastpath=True``  — greedy params reducing to (k==1, p==0, temp==1) take
+            the full-vocab greedy fast-path all-gather path (``decode_forward`` with no k/p/temp).
+          * ``allow_greedy_fastpath=False`` (the 1B/7B recipe) — there is no argmax path, so *every*
             recipe, greedy included, builds k/p/temp tensors and takes the **top-k op path**:
             per-device ``ttnn.topk`` → barrier-free all-gather of the ``[*,32]`` tuples →
             ``ttnn.sampling``. This mirrors TTTv1, whose ``temp=0`` PERF.md recipe always runs
@@ -481,14 +481,14 @@ class EagerLLMExecutor:
         return self.model.sampling.decode_forward(logits, k=k_tt, p=p_tt, temp=temp_tt, tt_out_tok=tt_out_tok)
 
     def _get_decode_sampling_kpt(self, sampling_params):
-        """Lazily build + cache (k, p, temp) device tensors, or None for force-argmax."""
+        """Lazily build + cache (k, p, temp) device tensors, or None for the greedy fast-path."""
         if getattr(self, "_decode_sampling_kpt_built", False):
             return self._decode_sampling_kpt
         self._decode_sampling_kpt = _build_decode_topk_param_tensors(
             self.mesh_device,
             sampling_params,
             self.model.sampling.config.max_batch_size,
-            allow_force_argmax=self.model.sampling.config.allow_force_argmax,
+            allow_greedy_fastpath=self.model.sampling.config.allow_greedy_fastpath,
         )
         self._decode_sampling_kpt_built = True
         return self._decode_sampling_kpt
@@ -1367,7 +1367,7 @@ class TracedLLMExecutor:
                 trace (generator ``refresh_trace_inputs=False`` + ``_increment_decode_positions_device``).
                 Valid ONLY for free-running greedy/top-k generation, NOT teacher forcing (which injects
                 host tokens every step), so accuracy/teacher-forcing runs must leave this OFF. Also inert
-                on the force-argmax path (``_decode_loop_active`` gates it to the top-k op path).
+                on the greedy fast-path (``_decode_loop_active`` gates it to the top-k op path).
         """
         self.model = model
         self.mesh_device = mesh_device
@@ -1478,12 +1478,12 @@ class TracedLLMExecutor:
         Requires: the opt-in flag, on-device sampling, AND the top-k op path (``ttnn.sampling``),
         whose output is uint32 ``[1,1,1,32]`` on Wormhole/Blackhole — an exact match for the
         persistent token buffer, so it can be fed back in place via ``output_tensor=`` with no
-        realloc. The force-argmax path (``ttnn.argmax`` → uint32 ``[1,1,32]``, rank-3) does NOT
+        realloc. The greedy fast-path (``ttnn.argmax`` → uint32 ``[1,1,32]``, rank-3) does NOT
         match the rank-4 token buffer, so the loop stays off there and falls back to host resupply.
         """
         if not self.ondevice_decode_loop or sampling_params is None or self.model.sampling is None:
             return False
-        # kpt is None only for the force-argmax path; non-None => top-k op path.
+        # kpt is None only for the greedy fast-path; non-None => top-k op path.
         return self._eager._get_decode_sampling_kpt(sampling_params) is not None
 
     def _prepare_prefill_trace_inputs_host(
@@ -2239,7 +2239,7 @@ class TracedLLMExecutor:
         """
         if sampling_params is None or self.model.sampling is None:
             return
-        # k/p/temp param tensors (cached on the eager engine; returns None for force-argmax models).
+        # k/p/temp param tensors (cached on the eager engine; returns None for the greedy fast-path models).
         self._eager._get_decode_sampling_kpt(sampling_params)
         # Sampling1D persistent device buffers (local indices / offsets / seeds / user ids).
         if hasattr(self.model.sampling, "load_device_buffers"):
@@ -2839,7 +2839,7 @@ def run_perf_benchmark(
     # unchanged: the device produces the same tokens; we only read them back deferred,
     # then drain the last one so generated_token_ids is byte-identical to the blocking
     # loop. Pass pipeline_readback=False to A/B back to the blocking readback.
-    # Every other path (host resupply, force-argmax, host sampling) is unaffected —
+    # Every other path (host resupply, greedy fast-path, host sampling) is unaffected —
     # only _decode_loop_active (executor.ondevice_decode_loop + top-k) qualifies.
     _engine = getattr(executor, "_engine", executor)
     _pipeline_readback = (

--- a/models/common/models/llama32_1b/model.py
+++ b/models/common/models/llama32_1b/model.py
@@ -661,12 +661,12 @@ class Llama32_1BTransformer1D(LightweightModule):
                 mesh_device=mesh_device,
                 tt_ccl=self.tt_ccl,
                 max_batch_size=_nearest_32(cfg.max_batch_size),
-                # Clone TTTv1's decision: default_sampling_force_argmax.allow_force_argmax=False for
+                # Clone TTTv1's decision: default_sampling_greedy_fastpath.allow_greedy_fastpath=False for
                 # all non-Galaxy meshes (only Llama-3.1-8B on TG flips it True). The 1B perf recipe
                 # (temp=0, top_p=0.08, top_k=32) routes through the cheap top-k op path — per-device
                 # ttnn.topk -> all-gather of the [*,32] tuples -> ttnn.sampling — never the full-vocab
                 # argmax all-gather. See models/tt_transformers/tt/model_config.py:1007.
-                allow_force_argmax=False,
+                allow_greedy_fastpath=False,
                 pad_to_power_of_2=True,
             )
             if self.supports_on_device_sampling

--- a/models/common/models/llama32_3b/model.py
+++ b/models/common/models/llama32_3b/model.py
@@ -656,12 +656,12 @@ class Llama32_3BTransformer1D(LightweightModule):
                 mesh_device=mesh_device,
                 tt_ccl=self.tt_ccl,
                 max_batch_size=_nearest_32(cfg.max_batch_size),
-                # Clone TTTv1's decision: default_sampling_force_argmax.allow_force_argmax=False for
+                # Clone TTTv1's decision: default_sampling_greedy_fastpath.allow_greedy_fastpath=False for
                 # all non-Galaxy meshes (only Llama-3.1-8B on TG flips it True). The perf recipe
                 # (temp=0, top_p=0.08, top_k=32) routes through the cheap top-k op path — per-device
                 # ttnn.topk -> all-gather of the [*,32] tuples -> ttnn.sampling — never the full-vocab
                 # argmax all-gather. See models/tt_transformers/tt/model_config.py:1007.
-                allow_force_argmax=False,
+                allow_greedy_fastpath=False,
                 pad_to_power_of_2=True,
             )
             if self.supports_on_device_sampling

--- a/models/common/models/llama33_70b/model.py
+++ b/models/common/models/llama33_70b/model.py
@@ -632,12 +632,12 @@ class Llama33_70BTransformer1D(LightweightModule):
                 mesh_device=mesh_device,
                 tt_ccl=self.tt_ccl,
                 max_batch_size=_nearest_32(cfg.max_batch_size),
-                # Clone TTTv1's decision: default_sampling_force_argmax.allow_force_argmax=False for
+                # Clone TTTv1's decision: default_sampling_greedy_fastpath.allow_greedy_fastpath=False for
                 # all non-Galaxy meshes (only Llama-3.1-8B on TG flips it True). The perf recipe
                 # (temp=0, top_p=0.08, top_k=32) routes through the cheap top-k op path — per-device
                 # ttnn.topk -> all-gather of the [*,32] tuples -> ttnn.sampling — never the full-vocab
                 # argmax all-gather.
-                allow_force_argmax=False,
+                allow_greedy_fastpath=False,
                 pad_to_power_of_2=True,
             )
             if self.supports_on_device_sampling

--- a/models/common/models/mistral_7b/model.py
+++ b/models/common/models/mistral_7b/model.py
@@ -533,11 +533,11 @@ class Mistral7B(LightweightModule):
                 mesh_device=mesh_device,
                 tt_ccl=self.tt_ccl,
                 max_batch_size=_nearest_32(cfg.max_batch_size),
-                # Clone TTTv1: allow_force_argmax=False for all non-Galaxy meshes (only
+                # Clone TTTv1: allow_greedy_fastpath=False for all non-Galaxy meshes (only
                 # Llama-3.1-8B on TG flips it True; Mistral-7B never does). The greedy recipe
                 # (temp=0, top_k=32, top_p=0.08) routes through the cheap top-k op path, not the
-                # full-vocab force-argmax all-gather. See model_config.py default_sampling_params.
-                allow_force_argmax=False,
+                # full-vocab greedy fast-path all-gather. See model_config.py default_sampling_params.
+                allow_greedy_fastpath=False,
                 pad_to_power_of_2=True,
             )
             if self.supports_on_device_sampling

--- a/models/common/models/phi4/model.py
+++ b/models/common/models/phi4/model.py
@@ -543,11 +543,11 @@ class Phi4Transformer(LightweightModule):
                 mesh_device=mesh_device,
                 tt_ccl=self.tt_ccl,
                 max_batch_size=_nearest_32(cfg.max_batch_size),
-                # Clone TTTv1's decision: allow_force_argmax=False for all non-Galaxy meshes
+                # Clone TTTv1's decision: allow_greedy_fastpath=False for all non-Galaxy meshes
                 # (only Llama-3.1-8B on TG flips it True). Phi-4's top-k recipe routes through the
                 # cheap per-device ttnn.topk -> all-gather of [*,32] tuples -> ttnn.sampling path,
                 # never the full-vocab argmax all-gather.
-                allow_force_argmax=False,
+                allow_greedy_fastpath=False,
                 pad_to_power_of_2=True,
             )
             if self.supports_on_device_sampling

--- a/models/common/models/qwen25_72b/model.py
+++ b/models/common/models/qwen25_72b/model.py
@@ -610,11 +610,11 @@ class Qwen25_72B(LightweightModule):
                 mesh_device=mesh_device,
                 tt_ccl=self.tt_ccl,
                 max_batch_size=_nearest_32(cfg.max_batch_size),
-                # Clone TTTv1's decision: default_sampling_force_argmax.allow_force_argmax=False
+                # Clone TTTv1's decision: default_sampling_greedy_fastpath.allow_greedy_fastpath=False
                 # for all non-Galaxy meshes (only Llama-3.1-8B on TG flips it True). The greedy
                 # recipe (temp=0, top_k=32, top_p=0.08) routes through the cheap top-k op path,
-                # never the full-vocab force-argmax all-gather. See model_config.py:1007.
-                allow_force_argmax=False,
+                # never the full-vocab greedy fast-path all-gather. See model_config.py:1007.
+                allow_greedy_fastpath=False,
                 pad_to_power_of_2=True,
             )
             if self.supports_on_device_sampling

--- a/models/common/models/qwen25_7b/model.py
+++ b/models/common/models/qwen25_7b/model.py
@@ -675,12 +675,12 @@ class Qwen25_7B(LightweightModule):
                 mesh_device=mesh_device,
                 tt_ccl=self.tt_ccl,
                 max_batch_size=_nearest_32(cfg.max_batch_size),
-                # Clone TTTv1's decision: default_sampling_force_argmax.allow_force_argmax=False for
+                # Clone TTTv1's decision: default_sampling_greedy_fastpath.allow_greedy_fastpath=False for
                 # all non-Galaxy meshes (only Llama-3.1-8B on TG flips it True). The perf recipe
                 # (temp=0, top_p=0.08, top_k=32) routes through the cheap top-k op path — per-device
                 # ttnn.topk -> all-gather of the [*,32] tuples -> ttnn.sampling — never the full-vocab
                 # argmax all-gather. See models/tt_transformers/tt/model_config.py:1007.
-                allow_force_argmax=False,
+                allow_greedy_fastpath=False,
                 pad_to_power_of_2=True,
             )
             if self.supports_on_device_sampling

--- a/models/common/models/qwen25_coder_32b/model.py
+++ b/models/common/models/qwen25_coder_32b/model.py
@@ -644,7 +644,7 @@ class Qwen25Coder32B(LightweightModule):
         # default). Qwen2.5-Coder-32B is a T3K-only port (8 devices), where Sampling1D's all-gather
         # uses a barrier-free Ring and is trace-capture-safe.
         #
-        # Clone TTTv1's decision: ``default_sampling_force_argmax.allow_force_argmax=False`` for all
+        # Clone TTTv1's decision: ``default_sampling_greedy_fastpath.allow_greedy_fastpath=False`` for all
         # non-Galaxy meshes (only Llama-3.1-8B on TG flips it True). The PERF.md recipe
         # (temp=0, top_k=32, top_p=0.08) routes through the cheap top-k op path -- per-device
         # ttnn.topk -> all-gather of the [*,32] tuples -> ttnn.sampling -- never the full-vocab
@@ -656,7 +656,7 @@ class Qwen25Coder32B(LightweightModule):
                 mesh_device=mesh_device,
                 tt_ccl=self.tt_ccl,
                 max_batch_size=_nearest_32(cfg.max_batch_size),
-                allow_force_argmax=False,
+                allow_greedy_fastpath=False,
                 pad_to_power_of_2=True,
             )
             if self.supports_on_device_sampling

--- a/models/common/models/qwen2_7b/model.py
+++ b/models/common/models/qwen2_7b/model.py
@@ -669,10 +669,10 @@ class Qwen2_7B(LightweightModule):
                 mesh_device=mesh_device,
                 tt_ccl=self.tt_ccl,
                 max_batch_size=_nearest_32(cfg.max_batch_size),
-                # Clone TTTv1's decision: default_sampling_force_argmax.allow_force_argmax=False for
+                # Clone TTTv1's decision: default_sampling_greedy_fastpath.allow_greedy_fastpath=False for
                 # all non-Galaxy meshes. The top-k perf recipe (temp=0, top_p=0.08, top_k=32) routes
                 # through the cheap top-k op path, never the full-vocab argmax all-gather.
-                allow_force_argmax=False,
+                allow_greedy_fastpath=False,
                 pad_to_power_of_2=True,
             )
             if self.supports_on_device_sampling

--- a/models/common/models/qwen3_32b/model.py
+++ b/models/common/models/qwen3_32b/model.py
@@ -624,11 +624,11 @@ class Qwen3_32B(LightweightModule):
             mesh_device=mesh_device,
             tt_ccl=self.tt_ccl,
             max_batch_size=_nearest_32(cfg.max_batch_size),
-            # Clone TTTv1's decision: allow_force_argmax=False for all non-Galaxy meshes (only
+            # Clone TTTv1's decision: allow_greedy_fastpath=False for all non-Galaxy meshes (only
             # Llama-3.1-8B on TG flips it True). The perf recipe (temp=0, top_k=32, top_p=0.08)
             # routes through the cheap top-k op path — per-device ttnn.topk -> all-gather of the
             # [*,32] tuples -> ttnn.sampling — never the full-vocab argmax all-gather.
-            allow_force_argmax=False,
+            allow_greedy_fastpath=False,
             pad_to_power_of_2=True,
         )
 

--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -29,6 +29,20 @@ from models.common.sampling.vocab_padding import (
     get_vocab_shard_dims,
 )
 
+# Renamed from "allow_force_argmax" (#51987). from_model_args reads the key with a .get()
+# default, so a SAMPLING_AG_CONFIG still carrying the old key would silently disable the
+# fast-path and surface only as a decode perf regression. Reject it instead.
+_LEGACY_GREEDY_FASTPATH_KEY = "allow_force_argmax"
+
+
+def _reject_legacy_greedy_fastpath_key(ag_cfg) -> None:
+    if _LEGACY_GREEDY_FASTPATH_KEY in ag_cfg:
+        raise ValueError(
+            f"SAMPLING_AG_CONFIG uses the removed key '{_LEGACY_GREEDY_FASTPATH_KEY}'; "
+            "rename it to 'allow_greedy_fastpath'."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Power-of-2 helpers (local copies; keep this TTTv2 module self-contained)
 # ---------------------------------------------------------------------------
@@ -68,7 +82,7 @@ class Sampling1DConfig:
     start_core: Optional[ttnn.CoreCoord] = None  # None → CoreCoord(0,0)
     num_gather_links: int = 1
     sampling_memory_config: Optional[ttnn.MemoryConfig] = None  # None → DRAM_MEMORY_CONFIG
-    allow_force_argmax: bool = False
+    allow_greedy_fastpath: bool = False
     num_argmax_gather_links: Optional[int] = None  # None → same as num_gather_links
     ag_topology: Optional[ttnn.Topology] = None  # None → Topology.Linear
     # Pad each per-device logit shard up to the next power of 2 before ttnn.topk. Big device-perf
@@ -235,7 +249,7 @@ class Sampling1D(LightweightModule):
 
         Args:
             logits: Input logits tensor (sharded across devices)
-            k, p, temp: Per-call sampling parameters. All None + allow_force_argmax → argmax path.
+            k, p, temp: Per-call sampling parameters. All None + allow_greedy_fastpath → argmax path.
                 All provided → top-k sampling path.
             seeds: Optional per-call seed override. If None, uses config seeds buffer.
             tt_out_tok: Optional output tensor to write results to.
@@ -258,10 +272,10 @@ class Sampling1D(LightweightModule):
 
         # Route: argmax or top-k
         if k is None and p is None and temp is None:
-            if cfg.allow_force_argmax:
+            if cfg.allow_greedy_fastpath:
                 return self._sample_argmax(logits, tt_out_tok)
             else:
-                raise ValueError("k/p/temp are all None but allow_force_argmax is False")
+                raise ValueError("k/p/temp are all None but allow_greedy_fastpath is False")
         if k is None or p is None or temp is None:
             raise ValueError("k, p, temp must all be provided, or all be None (for argmax)")
 
@@ -287,14 +301,14 @@ class Sampling1D(LightweightModule):
             output_tensor=tt_out_tok,
             keepdim=False,
         )
-        # Argmax path never emits logprobs (main's contract: force-argmax is disabled whenever
+        # Argmax path never emits logprobs (main's contract: the greedy fast-path is disabled whenever
         # logprobs are requested). Return None unconditionally — do not call the calculator.
         return tt_out_tok, None
 
     def _get_argmax_all_gather_config(self, cluster_axis):
         """Clamp the tuned all-gather config to what the actual submesh supports.
 
-        Port of main's ``_get_force_argmax_all_gather_config`` (#44246): bound num_links to the
+        Port of main's ``_get_greedy_fastpath_all_gather_config`` (#44246): bound num_links to the
         links available on the submesh, and force Linear topology below 8 devices (Ring routing
         like D0→D12 only wraps cleanly on T3K-class 8-device groups).
         """
@@ -655,12 +669,13 @@ class Sampling1D(LightweightModule):
 
         sampling_memory_config = mc.get("DECODE_SAMPLING_INPUT_MEMCFG", ttnn.DRAM_MEMORY_CONFIG)
 
-        allow_force_argmax = False
+        allow_greedy_fastpath = False
         num_argmax_gather_links = num_gather_links
         ag_topology = ttnn.Topology.Linear
         if "SAMPLING_AG_CONFIG" in mc:
             ag_cfg = mc["SAMPLING_AG_CONFIG"]
-            allow_force_argmax = ag_cfg.get("allow_force_argmax", False)
+            _reject_legacy_greedy_fastpath_key(ag_cfg)
+            allow_greedy_fastpath = ag_cfg.get("allow_greedy_fastpath", False)
             num_argmax_gather_links = ag_cfg.get("num_links", num_gather_links)
             ag_topology = ag_cfg.get("topology", ttnn.Topology.Linear)
 
@@ -676,7 +691,7 @@ class Sampling1D(LightweightModule):
             start_core=getattr(args, "start_core", ttnn.CoreCoord(0, 0)),
             num_gather_links=num_gather_links,
             sampling_memory_config=sampling_memory_config,
-            allow_force_argmax=allow_force_argmax,
+            allow_greedy_fastpath=allow_greedy_fastpath,
             num_argmax_gather_links=num_argmax_gather_links,
             ag_topology=ag_topology,
             pad_to_power_of_2=getattr(args, "pad_logits_to_power_of_2", False),

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -99,7 +99,7 @@ plus `apply_decode_state(...)`.
 
 **`padded_vocab_size` vs `vocab_size`**: TTSampling device offsets for global token IDs must use the padded vocab size to match how the LM head shards logits across devices. Using unpadded `vocab_size` for offsets shifts token IDs from devices 1+ and produces garbled output.
 
-**Padded vocab logits**: If the LM head pads output weights beyond the real tokenizer vocabulary, the sampler must mask those padded token IDs before force-argmax or local top-k. Zero-padded LM-head weights are useful for legal sharded matmul shapes, but they are not a sampling mask.
+**Padded vocab logits**: If the LM head pads output weights beyond the real tokenizer vocabulary, the sampler must mask those padded token IDs before the greedy fast-path argmax or local top-k. Zero-padded LM-head weights are useful for legal sharded matmul shapes, but they are not a sampling mask.
 
 **`sampling_dp`**: When >1, k/p/temp tensors must have length `max_batch_size * sampling_dp` and are row-sharded via `ShardTensor2dMesh(dims=(0, None))`. Use `chunk_sampling_params` + `apply_decode_state` to distribute params across mesh rows.
 
@@ -108,7 +108,7 @@ runtime prefill compute layout matches the sampling-group layout. If a model
 uses `sampling_dp > 1` but does not expose a row-sharded batched-prefill input
 contract, batched prefill must fall back to sequential prefill for correctness.
 
-**Trace invalidation**: Changing `force_argmax_sampling` state invalidates captured traces. Force-argmax is triggered when callers pass k=1, p=1.0, temp=1.0 (note: p=1.0 means "no top-p filtering", distinct from the internal initialization default of p=0). `SamplingGenerator.reset_sampling_params` handles this.
+**Trace invalidation**: Changing `greedy_fastpath` state invalidates captured traces. The greedy fast-path is taken when callers pass k=1, p=1.0, temp=1.0 (note: p=1.0 means "no top-p filtering", distinct from the internal initialization default of p=0). `SamplingGenerator.reset_sampling_params` handles this.
 
 ## Future Work
 

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -67,7 +67,7 @@ SAMPLING_PARAM_FIELDS = tuple(f.name for f in fields(SamplingParams))
 class _TraceKey:
     penalties_on: bool
     log_probs_on: bool
-    force_argmax: bool
+    greedy_fastpath: bool
 
 
 class SamplingGenerator:
@@ -114,8 +114,8 @@ class SamplingGenerator:
     def _new_trace_state(self):
         return {"id": None, "input": None, "output": None, "kwargs": {}}
 
-    def _trace_slot(self, penalties_on: bool, log_probs_on: bool, force_argmax: bool):
-        key = _TraceKey(penalties_on=penalties_on, log_probs_on=log_probs_on, force_argmax=force_argmax)
+    def _trace_slot(self, penalties_on: bool, log_probs_on: bool, greedy_fastpath: bool):
+        key = _TraceKey(penalties_on=penalties_on, log_probs_on=log_probs_on, greedy_fastpath=greedy_fastpath)
         slot = self._trace_states.get(key)
         if slot is None:
             slot = self._new_trace_state()
@@ -130,7 +130,7 @@ class SamplingGenerator:
             if slot["id"] is None:
                 continue
             logger.debug(
-                f"Resetting sampling trace (penalties={key.penalties_on}, log_probs={key.log_probs_on}, force_argmax={key.force_argmax}, trace_id={slot['id']})"
+                f"Resetting sampling trace (penalties={key.penalties_on}, log_probs={key.log_probs_on}, greedy_fastpath={key.greedy_fastpath}, trace_id={slot['id']})"
             )
             try:
                 ttnn.release_trace(self.mesh_device, slot["id"])
@@ -224,7 +224,7 @@ class SamplingGenerator:
     # Sampling helpers
     # ---------------------------------------------------------------------
     def reset_sampling_params(self, sampling_params, empty_slots: list[int] | None = None):
-        old_force_argmax_sampling = self.tt_sampling.force_argmax_sampling
+        old_greedy_fastpath = self.tt_sampling.greedy_fastpath
         num_logprobs = getattr(sampling_params, "num_logprobs", None)
         self.tt_sampling.reset_params(
             k=sampling_params.top_k,
@@ -234,7 +234,7 @@ class SamplingGenerator:
             num_logprobs=num_logprobs,
             empty_slots=empty_slots,
         )
-        if self.tt_sampling.force_argmax_sampling != old_force_argmax_sampling:
+        if self.tt_sampling.greedy_fastpath != old_greedy_fastpath:
             self.reset_trace()
 
         old_penalties_active = self._penalties_active
@@ -244,7 +244,7 @@ class SamplingGenerator:
             and is_default_value(sampling_params.repetition_penalty, self._DEFAULT_PENALTIES["repetition"])
         )
         if (
-            not self.tt_sampling.force_argmax_sampling
+            not self.tt_sampling.greedy_fastpath
             or self._penalties_active
             or self._penalties_active != old_penalties_active
         ):
@@ -299,13 +299,13 @@ class SamplingGenerator:
         """
         penalties_on = self._penalties_active
         log_probs_on = getattr(self, "_log_probs_active", False)
-        force_argmax = self.tt_sampling.force_argmax_sampling
+        greedy_fastpath = self.tt_sampling.greedy_fastpath
 
-        key, slot = self._trace_slot(penalties_on, log_probs_on, force_argmax)
+        key, slot = self._trace_slot(penalties_on, log_probs_on, greedy_fastpath)
 
         if not skip_precompile:
             logger.debug(
-                f"Pre-compiling sampling path before trace capture (penalties={penalties_on},log_probs_on={log_probs_on},force_argmax={force_argmax})"
+                f"Pre-compiling sampling path before trace capture (penalties={penalties_on},log_probs_on={log_probs_on},greedy_fastpath={greedy_fastpath})"
             )
             self._run_sampling(
                 logits,
@@ -362,7 +362,7 @@ class SamplingGenerator:
 
         penalties_on = self._penalties_active
         log_probs_on = getattr(self, "_log_probs_active", False)
-        force_argmax = self.tt_sampling.force_argmax_sampling
+        greedy_fastpath = self.tt_sampling.greedy_fastpath
         # Explicit request seeds update a persistent seed tensor every token;
         # run them directly so trace replay cannot observe stale seed state.
         use_internal_trace = enable_trace and not self.seed_manager.has_active_request_seed()
@@ -374,7 +374,7 @@ class SamplingGenerator:
                 tt_out_tok=tt_out_tok,
             )
         else:
-            key, slot = self._trace_slot(penalties_on, log_probs_on, force_argmax)
+            key, slot = self._trace_slot(penalties_on, log_probs_on, greedy_fastpath)
             if slot["id"] is None:
                 return self.capture_trace(
                     logits,

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -30,6 +30,19 @@ TIEBREAK_DELTA_SCALE = 2**-6
 # so it never perturbs a non-zero maximum.
 TIEBREAK_DELTA_FLOOR = 1e-30
 
+# Renamed from "allow_force_argmax" (#51987). A SAMPLING_AG_CONFIG still carrying the old key
+# would otherwise fall back to a disabled fast-path, which shows up only as a silent decode
+# perf regression, so reject it explicitly instead.
+_LEGACY_GREEDY_FASTPATH_KEY = "allow_force_argmax"
+
+
+def _reject_legacy_greedy_fastpath_key(sampling_ag_config):
+    if _LEGACY_GREEDY_FASTPATH_KEY in sampling_ag_config:
+        raise ValueError(
+            f"SAMPLING_AG_CONFIG uses the removed key '{_LEGACY_GREEDY_FASTPATH_KEY}'; "
+            "rename it to 'allow_greedy_fastpath'."
+        )
+
 
 class TTSampling(LightweightModule):
     """
@@ -64,7 +77,7 @@ class TTSampling(LightweightModule):
         otherwise uses standard all_gather where the CCL API handles memory allocation (tt-transformers).
     """
 
-    def _is_force_argmax_sampling(self, k, p, temp):
+    def _is_greedy_fastpath(self, k, p, temp):
         """Detect whether all users request deterministic greedy decoding.
 
         When every user in the batch has k=1 (top-1), p=0.0 or p=1.0 (no top-p filter),
@@ -76,13 +89,16 @@ class TTSampling(LightweightModule):
 
         Note: callers may represent greedy rows with p=1.0, while the
         device argmax-style representation uses p=0.0.
-        The model config must also set allow_force_argmax=True for this to activate.
+        The model config must also set allow_greedy_fastpath=True for this to activate.
+
+        The fast path never changes which token is emitted -- greedy decoding is argmax
+        either way -- so this is purely a choice of implementation, not of semantics.
 
         Changing this state between decode steps invalidates captured traces, so
-        SamplingGenerator maintains separate trace slots keyed by force_argmax.
+        SamplingGenerator maintains separate trace slots keyed by greedy_fastpath.
         """
         return (
-            self._allow_force_argmax_sampling
+            self._allow_greedy_fastpath
             and is_default_value(k, 1)
             and (is_default_value(p, 1.0) or is_default_value(p, 0.0))
             and is_default_value(temp, 1.0)
@@ -100,8 +116,8 @@ class TTSampling(LightweightModule):
         return ttnn.uint16
 
     @property
-    def force_argmax_sampling(self) -> bool:
-        return self._force_argmax_sampling
+    def greedy_fastpath(self) -> bool:
+        return self._greedy_fastpath
 
     def __init__(
         self,
@@ -180,18 +196,20 @@ class TTSampling(LightweightModule):
         else:
             self.sampling_memory_config = ttnn.DRAM_MEMORY_CONFIG
 
-        # Force argmax sampling
+        # Greedy fast-path (see _is_greedy_fastpath: cheaper implementation of greedy
+        # decode, gated on every user in the batch already asking for greedy sampling)
         if hasattr(args, "model_config") and "SAMPLING_AG_CONFIG" in args.model_config:
             # The model config may describe the fastest full-size Galaxy path, but
             # the actual CCL shape is resolved from the runtime mesh below.
             sampling_ag_config = args.model_config["SAMPLING_AG_CONFIG"]
-            self._allow_force_argmax_sampling = sampling_ag_config["allow_force_argmax"]
+            _reject_legacy_greedy_fastpath_key(sampling_ag_config)
+            self._allow_greedy_fastpath = sampling_ag_config["allow_greedy_fastpath"]
             self.num_argmax_gather_links = sampling_ag_config["num_links"]
             self.argmax_chunks_per_sync = sampling_ag_config.get("chunks_per_sync", 10)
             self.argmax_num_workers_per_link = 1
             self.ag_topology = sampling_ag_config["topology"]
         else:
-            self._allow_force_argmax_sampling = False
+            self._allow_greedy_fastpath = False
             self.num_argmax_gather_links = self.num_gather_links
             self.argmax_chunks_per_sync = 10
             self.argmax_num_workers_per_link = 1
@@ -208,7 +226,7 @@ class TTSampling(LightweightModule):
         if temp is None:
             temp = torch.ones(total_param_size)
 
-        self._force_argmax_sampling = self._is_force_argmax_sampling(k, p, temp)
+        self._greedy_fastpath = self._is_greedy_fastpath(k, p, temp)
 
         # Create sampling parameter tensors on device
         # When _sampling_dp > 1, dims=(0, None) shards the [128] tensor across 4 rows → [32] per row
@@ -529,7 +547,7 @@ class TTSampling(LightweightModule):
             return None
         return self.sampling_all_gather_axis
 
-    def _get_force_argmax_all_gather_config(self, cluster_axis):
+    def _get_greedy_fastpath_all_gather_config(self, cluster_axis):
         num_links = self.num_argmax_gather_links
         if hasattr(self.tt_ccl, "get_num_links"):
             # Clamp the tuned config to the links available on the actual submesh.
@@ -553,8 +571,8 @@ class TTSampling(LightweightModule):
         empty_slots: list[int] | None = None,
     ):
         """Update sampling parameters (k, p, temperature, logprobs) dynamically."""
-        self._force_argmax_sampling = self._is_force_argmax_sampling(k, p, temp)
-        if not self._force_argmax_sampling:
+        self._greedy_fastpath = self._is_greedy_fastpath(k, p, temp)
+        if not self._greedy_fastpath:
             # When _sampling_dp > 1, create multi-device host tensors so
             # copy_host_to_device_tensor writes per-row shards correctly.
             if self._sampling_dp > 1:
@@ -711,8 +729,8 @@ class TTSampling(LightweightModule):
         Returns:
             Sampled token indices tensor
         """
-        if self._force_argmax_sampling:
-            logger.info("Forcing argmax sampling")
+        if self._greedy_fastpath:
+            logger.info("Using greedy fast-path (argmax) sampling")
             slice_valid_vocab = self._can_slice_valid_vocab_for_argmax()
             if not slice_valid_vocab:
                 x = self._mask_invalid_vocab_logits(x)
@@ -720,9 +738,9 @@ class TTSampling(LightweightModule):
             num_devices = self.mesh_device.get_num_devices()
             if num_devices > 1:
                 cluster_axis = self._get_sampling_cluster_axis()
-                num_links, topology = self._get_force_argmax_all_gather_config(cluster_axis)
+                num_links, topology = self._get_greedy_fastpath_all_gather_config(cluster_axis)
                 logger.debug(
-                    f"Force argmax sampling all-gather: cluster_axis={cluster_axis}, "
+                    f"Greedy fast-path all-gather: cluster_axis={cluster_axis}, "
                     f"num_links={num_links}, topology={topology}"
                 )
                 x = ttnn.experimental.all_gather_async(
@@ -748,7 +766,7 @@ class TTSampling(LightweightModule):
                 output_tensor=tt_out_tok,
                 keepdim=False,
             )
-            # Argmax path: logprobs not supported (force-argmax is disabled
+            # Argmax path: logprobs not supported (the greedy fast-path is disabled
             # when logprobs are enabled via format_sampling_params guard).
             self.tt_log_probs = None
             return tt_out_tok, self.tt_log_probs

--- a/models/common/tests/demos/deepseek_r1_distill_qwen_14b/demo.py
+++ b/models/common/tests/demos/deepseek_r1_distill_qwen_14b/demo.py
@@ -517,9 +517,9 @@ def _run_perf_benchmark(
 
         # On-device sampling toggle (SAMPLING_MODE env):
         #   host            -> sampling_params=None (host-argmax, the default shipped path)
-        #   on_device       -> greedy temp=0,k=1,p=0  => trace-captured FORCE-ARGMAX full-vocab path
+        #   on_device       -> greedy temp=0,k=1,p=0  => trace-captured GREEDY FAST-PATH full-vocab path
         #   on_device_topk  -> temp=0,k=32,p=0.08     => trace-captured TOP-K op path (gathers only
-        #                      the [*,32] tuples; faster than force-argmax on >=8-device meshes)
+        #                      the [*,32] tuples; faster than the greedy fast-path on >=8-device meshes)
         sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
         _on_device_params = {
             "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),

--- a/models/common/tests/demos/llama32_1b/demo.py
+++ b/models/common/tests/demos/llama32_1b/demo.py
@@ -223,7 +223,7 @@ PERF_TOLERANCE = 0.05
 
 
 def _sampling_bucket() -> str:
-    """Map SAMPLING_MODE to a perf-gate bucket. Non-topk on-device modes (e.g. force-argmax)
+    """Map SAMPLING_MODE to a perf-gate bucket. Non-topk on-device modes (e.g. the greedy fast-path)
     fall into ``on_device_topk`` so they stay gated, never silently un-gated."""
     return "host" if os.environ.get("SAMPLING_MODE", "host").lower() == "host" else "on_device_topk"
 
@@ -730,7 +730,7 @@ def test_llama32_1b(test_config, mesh_device, optimizations):
             # because host argmax and on-device sampling are ~1.7x apart on 1B (on-device pays the
             # slow ttnn.topk). Each per-path N300 target is freshly measured on this base and sits
             # at/above same-box TTTv1 ci-32 for the comparable path (see EXPECTED_METRICS_BATCH32_CI).
-            # Non-topk on-device modes (force-argmax) fall back to the on_device_topk bucket so they
+            # Non-topk on-device modes (greedy fast-path) fall back to the on_device_topk bucket so they
             # stay gated, never silently un-gated; N150/T3K fall back to the short-context constant.
             _bucket = _sampling_bucket()
             expected = EXPECTED_METRICS_BATCH32_CI.get(_bucket, {}).get(
@@ -926,9 +926,9 @@ def _run_perf_benchmark(
 
     # On-device sampling toggle for N150/N300 evidence-gathering (see sampling handoff docs):
     #   host            -> sampling_params=None (host-argmax, the default shipped path)
-    #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured FORCE-ARGMAX full-vocab path
+    #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured GREEDY FAST-PATH full-vocab path
     #   on_device_topk  -> temp=0,k=32,p=0.08    => trace-captured TOP-K op path (gathers only
-    #                      the [*,32] tuples; PERF.md-parity recipe, faster than force-argmax)
+    #                      the [*,32] tuples; PERF.md-parity recipe, faster than the greedy fast-path)
     sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
     _on_device_params = {
         "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),
@@ -949,7 +949,7 @@ def _run_perf_benchmark(
         model.model_args.disable_batched_prefill = True
 
     # Free-running perf run: enable the executor's on-device decode loop on the on-device sampling
-    # path (inert on host/force-argmax; gated to the top-k path by _decode_loop_active). This is the
+    # path (inert on host/greedy fast-path; gated to the top-k path by _decode_loop_active). This is the
     # #49282 T3K batch-1 decode-gap fix — it must be active on the perf path for the T3K b1 gate.
     # fast_prefill_last_token: slice the single consumed last-token row on device before readback so the
     # batch-1 host concat/readback moves one row instead of the full [1,1,32,vocab] tile — closes most of

--- a/models/common/tests/demos/llama32_3b/demo.py
+++ b/models/common/tests/demos/llama32_3b/demo.py
@@ -237,7 +237,7 @@ _BATCH32_CI_MAX_SEQ_LEN: dict[str, int] = {
 
 
 def _sampling_bucket() -> str:
-    """Map SAMPLING_MODE to a perf-gate bucket. Non-topk on-device modes (e.g. force-argmax)
+    """Map SAMPLING_MODE to a perf-gate bucket. Non-topk on-device modes (e.g. the greedy fast-path)
     fall into ``on_device_topk`` so they stay gated, never silently un-gated."""
     return "host" if os.environ.get("SAMPLING_MODE", "host").lower() == "host" else "on_device_topk"
 
@@ -743,7 +743,7 @@ def test_llama32_3b(test_config, mesh_device, optimizations):
             max_seq_len = _BATCH32_CI_MAX_SEQ_LEN.get(device_name, 2048)
             # Own perf gate measured at the seq2048/decode1024 workload (NOT the lighter batch-32
             # constant, which would be a config-artifact miss). The gate is keyed by SAMPLING_MODE
-            # (host argmax vs on-device sampling differ on 3B). Non-topk on-device modes (force-argmax)
+            # (host argmax vs on-device sampling differ on 3B). Non-topk on-device modes (greedy fast-path)
             # fall back to the on_device_topk bucket; cells not measured fall back to the short-context
             # batch-32 constant so they stay gated, never silently un-gated.
             _bucket = _sampling_bucket()
@@ -956,7 +956,7 @@ def _run_perf_benchmark(
     #   on_device_topk  -> temp=0,k=32,p=0.08      => trace-captured TOP-K op path with k=32
     #                      (PERF.md-parity recipe). Both on-device modes route through the same
     #                      per-device ttnn.topk -> all-gather of the [*,k] tuples -> ttnn.sampling
-    #                      op path (the model is built with allow_force_argmax=False, so the
+    #                      op path (the model is built with allow_greedy_fastpath=False, so the
     #                      full-vocab argmax all-gather is never taken); they differ only in k.
     sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
     _on_device_params = {
@@ -971,7 +971,7 @@ def _run_perf_benchmark(
     logger.info(f"[{case_name}] SAMPLING_MODE={sampling_mode} -> sampling_params={sampling_params}")
 
     # Free-running perf run: enable the executor's on-device decode loop on the on-device sampling
-    # path (inert on host/force-argmax; gated to the top-k path by _decode_loop_active).
+    # path (inert on host/greedy fast-path; gated to the top-k path by _decode_loop_active).
     # fast_prefill_last_token: slice the single consumed last-token row on device before readback so the
     # batch-1 host concat/readback moves one row instead of the full [1,1,32,vocab] tile — closes most of
     # the residual T3K batch-1 PREFILL TTFT gap vs TTTv1 (which reads back only tokens). Inert for batch>1.

--- a/models/common/tests/demos/llama33_70b/demo.py
+++ b/models/common/tests/demos/llama33_70b/demo.py
@@ -480,8 +480,8 @@ def _run_perf_benchmark(
         # On-device sampling toggle for SKU evidence-gathering:
         #   host            -> sampling_params=None (host-argmax, the default shipped path)
         #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured top-k op path with k=1.
-        #                      Sampling1D is built allow_force_argmax=False, so even greedy routes
-        #                      through ttnn.topk (k=1 top-k == argmax-via-topk), NOT the force-argmax
+        #                      Sampling1D is built allow_greedy_fastpath=False, so even greedy routes
+        #                      through ttnn.topk (k=1 top-k == argmax-via-topk), NOT the greedy fast-path
         #                      full-vocab all-gather.
         #   on_device_topk  -> temp=0,k=32,p=0.08    => trace-captured top-k op path with k=32
         #                      (gathers only the [*,32] tuples). On T3K (8 dev) the vocab

--- a/models/common/tests/demos/mistral_7b/demo.py
+++ b/models/common/tests/demos/mistral_7b/demo.py
@@ -562,9 +562,9 @@ def _run_perf_benchmark(model, mesh_device, expected, batch_size, case_name):
 
         # On-device sampling toggle (see the rebase/sampling handoff docs):
         #   host            -> sampling_params=None (host-argmax, the default shipped path)
-        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured FORCE-ARGMAX full-vocab path
+        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured GREEDY FAST-PATH full-vocab path
         #   on_device_topk  -> temp=0,k=32,p=0.08    => trace-captured TOP-K op path (gathers only
-        #                      the [*,32] tuples; PERF.md-parity recipe, faster than force-argmax)
+        #                      the [*,32] tuples; PERF.md-parity recipe, faster than the greedy fast-path)
         sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
         _on_device_params = {
             "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),

--- a/models/common/tests/demos/phi4/demo.py
+++ b/models/common/tests/demos/phi4/demo.py
@@ -504,9 +504,9 @@ def _run_perf_benchmark(
 
         # On-device sampling toggle for N150/N300 evidence-gathering (see sampling handoff docs):
         #   host            -> sampling_params=None (host-argmax, the default shipped path)
-        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured FORCE-ARGMAX full-vocab path
+        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured GREEDY FAST-PATH full-vocab path
         #   on_device_topk  -> temp=0,k=32,p=0.08    => trace-captured TOP-K op path (gathers only
-        #                      the [*,32] tuples; faster than force-argmax)
+        #                      the [*,32] tuples; faster than the greedy fast-path)
         sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
         _on_device_params = {
             "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),

--- a/models/common/tests/demos/qwen25_72b/demo.py
+++ b/models/common/tests/demos/qwen25_72b/demo.py
@@ -493,7 +493,7 @@ def _run_perf_benchmark(
         # On-device sampling toggle (Qwen2.5-72B runs on T3K where on-device top-k wins; see the
         # rebase handoff crossover table):
         #   host            -> sampling_params=None (host-argmax, the default shipped path)
-        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured FORCE-ARGMAX full-vocab path
+        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured GREEDY FAST-PATH full-vocab path
         #   on_device_topk  -> temp=0,k=32,p=0.08    => trace-captured TOP-K op path (PERF.md recipe)
         sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
         _on_device_params = {

--- a/models/common/tests/demos/qwen25_7b/demo.py
+++ b/models/common/tests/demos/qwen25_7b/demo.py
@@ -529,9 +529,9 @@ def _run_perf_benchmark(model, mesh_device, expected, batch_size, case_name):
 
         # On-device sampling toggle for N150/N300 evidence-gathering (see sampling handoff docs):
         #   host            -> sampling_params=None (host-argmax, the default shipped path)
-        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured FORCE-ARGMAX full-vocab path
+        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured GREEDY FAST-PATH full-vocab path
         #   on_device_topk  -> temp=0,k=32,p=0.08    => trace-captured TOP-K op path (gathers only
-        #                      the [*,32] tuples; PERF.md-parity recipe, faster than force-argmax)
+        #                      the [*,32] tuples; PERF.md-parity recipe, faster than the greedy fast-path)
         sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
         _on_device_params = {
             "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),

--- a/models/common/tests/demos/qwen25_coder_32b/demo.py
+++ b/models/common/tests/demos/qwen25_coder_32b/demo.py
@@ -528,9 +528,9 @@ def _run_perf_benchmark(model, mesh_device, expected, batch_size, case_name):
         # On-device sampling toggle (the model owns its Sampling1D, constructed in __init__; the
         # demo only picks behavior per request):
         #   host            -> sampling_params=None (host-argmax, the default shipped path)
-        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured FORCE-ARGMAX full-vocab path
+        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured GREEDY FAST-PATH full-vocab path
         #   on_device_topk  -> temp=0,k=32,p=0.08    => trace-captured TOP-K op path (PERF.md-parity
-        #                      recipe; gathers only the [*,32] tuples, faster than force-argmax)
+        #                      recipe; gathers only the [*,32] tuples, faster than the greedy fast-path)
         # Default to on-device sampling: it is the path these perf gates were measured on and the one
         # TTTv1 uses for its published numbers (host argmax stitches full-vocab logits every step and
         # is ~2x slower on T3K's 8-way 152k vocab). Override with SAMPLING_MODE=host to measure it.

--- a/models/common/tests/demos/qwen2_7b/demo.py
+++ b/models/common/tests/demos/qwen2_7b/demo.py
@@ -552,9 +552,9 @@ def _run_perf_benchmark(model, mesh_device, expected, batch_size, case_name):
 
         # On-device sampling toggle (see sampling handoff docs):
         #   host            -> sampling_params=None (host-argmax, the default shipped path)
-        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured FORCE-ARGMAX full-vocab path
+        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured GREEDY FAST-PATH full-vocab path
         #   on_device_topk  -> temp=0,k=32,p=0.08    => trace-captured TOP-K op path (gathers only
-        #                      the [*,32] tuples; faster than force-argmax on >=8-device meshes)
+        #                      the [*,32] tuples; faster than the greedy fast-path on >=8-device meshes)
         sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
         _on_device_params = {
             "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),

--- a/models/common/tests/demos/qwen3_32b/demo.py
+++ b/models/common/tests/demos/qwen3_32b/demo.py
@@ -535,7 +535,7 @@ def _run_perf_benchmark(model, mesh_device, expected, batch_size, case_name):
         # On-device sampling toggle (see the rebase / sampling handoff docs):
         #   host            -> sampling_params=None (host-argmax; slow — full-vocab all-gather + PCIe
         #                      readback every step; NOT comparable to TTTv1)
-        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured FORCE-ARGMAX full-vocab path
+        #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured GREEDY FAST-PATH full-vocab path
         #   on_device_topk  -> temp=0,k=32,p=0.08    => trace-captured TOP-K op path (gathers only
         #                      the [*,32] tuples; PERF.md-parity recipe, faster on >=8-dev meshes)
         # DEFAULT is on_device_topk: on T3K (8 devices) the vocab shards 8-ways and TTTv1 auto-uses

--- a/models/common/tests/modules/sampling/test_sampling_1d.py
+++ b/models/common/tests/modules/sampling/test_sampling_1d.py
@@ -35,11 +35,11 @@ def _list_collected_sampling_cases() -> list[pytest.param]:
     Collected from TTTv1 demo runs (Phase B of test_case_collection.md).
 
     Each entry is:
-        (mesh_shape, vocab_size, k, p, temp, force_argmax, hf_model_name)
+        (mesh_shape, vocab_size, k, p, temp, greedy_fastpath, hf_model_name)
 
     Source CSVs: sampling_generator_config_collected.csv,
                  sampling_generator_params_collected.csv
-    Deduplicated by (topology, vocab, k, p, temp, force_argmax).
+    Deduplicated by (topology, vocab, k, p, temp, greedy_fastpath).
     """
     # fmt: off
     return [
@@ -95,17 +95,17 @@ class TestConfigUnit:
         cfg = Sampling1DConfig(vocab_size=1024)
         assert cfg.max_batch_size == 32
         assert cfg.max_top_k == 32
-        assert cfg.allow_force_argmax is False
+        assert cfg.allow_greedy_fastpath is False
         assert cfg.num_gather_links == 1
         assert cfg.mesh_device is None
         assert cfg.index_offsets is None
         assert cfg.seeds is None
 
     def test_config_custom(self):
-        cfg = Sampling1DConfig(vocab_size=128256, max_top_k=64, allow_force_argmax=True)
+        cfg = Sampling1DConfig(vocab_size=128256, max_top_k=64, allow_greedy_fastpath=True)
         assert cfg.vocab_size == 128256
         assert cfg.max_top_k == 64
-        assert cfg.allow_force_argmax is True
+        assert cfg.allow_greedy_fastpath is True
 
     def test_config_not_resolved_without_device(self):
         cfg = Sampling1DConfig(vocab_size=1024)
@@ -149,9 +149,9 @@ class TestSampling1DDevice:
         assert isinstance(sampler._user_ids, ttnn.Tensor)
 
     @pytest.mark.parametrize("vocab_size", [1024])
-    def test_force_argmax(self, ttnn_mesh_device, vocab_size):
-        """allow_force_argmax=True, k/p/temp=None → matches torch.argmax."""
-        sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_force_argmax=True)
+    def test_greedy_fastpath(self, ttnn_mesh_device, vocab_size):
+        """allow_greedy_fastpath=True, k/p/temp=None → matches torch.argmax."""
+        sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_greedy_fastpath=True)
         sampler.load_device_buffers()
         B = sampler.config.max_batch_size
 
@@ -260,19 +260,19 @@ class TestSampling1DDevice:
     # ------------------------------------------------------------------
 
     @pytest.mark.parametrize("vocab_size", [1024])
-    def test_error_all_none_no_force_argmax(self, ttnn_mesh_device, vocab_size, expect_error):
-        """decode_forward with all-None k/p/temp when allow_force_argmax=False → ValueError (line 178)."""
+    def test_error_all_none_no_greedy_fastpath(self, ttnn_mesh_device, vocab_size, expect_error):
+        """decode_forward with all-None k/p/temp when allow_greedy_fastpath=False → ValueError (line 178)."""
         sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
         logits_host = torch.randn(1, 1, 32, vocab_size, dtype=torch.bfloat16)
         logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
 
-        with expect_error(ValueError, "allow_force_argmax is False"):
+        with expect_error(ValueError, "allow_greedy_fastpath is False"):
             sampler.decode_forward(logits_tt)
 
     @pytest.mark.parametrize("vocab_size", [1024])
     def test_forward_dispatches_to_decode_forward(self, ttnn_mesh_device, vocab_size):
         """forward() delegates to decode_forward() (line 186)."""
-        sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_force_argmax=True)
+        sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_greedy_fastpath=True)
         logits_host = torch.randn(1, 1, 32, vocab_size, dtype=torch.bfloat16)
         logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
 
@@ -343,7 +343,29 @@ class TestSampling1DDevice:
         assert sampler.config.num_gather_links == 1
 
     def test_from_model_args_with_sampling_ag_config(self, ttnn_mesh_device):
-        """from_model_args reads allow_force_argmax/num_links/topology from SAMPLING_AG_CONFIG (lines 416-419)."""
+        """from_model_args reads allow_greedy_fastpath/num_links/topology from SAMPLING_AG_CONFIG (lines 416-419)."""
+
+        class MockArgs:
+            padded_vocab_size = 1024
+            sub_core_grids = None
+            sub_core_grid_topk = None
+            start_core = ttnn.CoreCoord(0, 0)
+            max_top_k = 32
+
+        model_config = {
+            "SAMPLING_AG_CONFIG": {
+                "allow_greedy_fastpath": True,
+                "num_links": 3,
+                "topology": ttnn.Topology.Linear,
+            }
+        }
+        sampler = Sampling1D.from_model_args(ttnn_mesh_device, None, MockArgs(), model_config=model_config)
+        assert sampler.config.allow_greedy_fastpath is True
+        assert sampler.config.num_argmax_gather_links == 3
+        assert sampler.config.ag_topology == ttnn.Topology.Linear
+
+    def test_from_model_args_rejects_legacy_key(self, ttnn_mesh_device, expect_error):
+        """The pre-#51987 key must raise, not silently read as a disabled fast-path."""
 
         class MockArgs:
             padded_vocab_size = 1024
@@ -359,10 +381,8 @@ class TestSampling1DDevice:
                 "topology": ttnn.Topology.Linear,
             }
         }
-        sampler = Sampling1D.from_model_args(ttnn_mesh_device, None, MockArgs(), model_config=model_config)
-        assert sampler.config.allow_force_argmax is True
-        assert sampler.config.num_argmax_gather_links == 3
-        assert sampler.config.ag_topology == ttnn.Topology.Linear
+        with expect_error(ValueError, "allow_force_argmax"):
+            Sampling1D.from_model_args(ttnn_mesh_device, None, MockArgs(), model_config=model_config)
 
     # ------------------------------------------------------------------
     # Buffer passthrough: _resolve_buf ttnn.Tensor path (lines 493-494)
@@ -582,11 +602,11 @@ def _make_sampling_params(ttnn_mesh_device, B, *, k_val=1, p_val=0.0, temp_val=1
 
 @pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
 @pytest.mark.parametrize(
-    "mesh_shape,vocab_size,k_val,p_val,temp_val,force_argmax,hf_model_name",
+    "mesh_shape,vocab_size,k_val,p_val,temp_val,greedy_fastpath,hf_model_name",
     _list_collected_sampling_cases(),
 )
 def test_sampling1d_topk1_vs_argmax(
-    ttnn_mesh_device, mesh_shape, vocab_size, k_val, p_val, temp_val, force_argmax, hf_model_name
+    ttnn_mesh_device, mesh_shape, vocab_size, k_val, p_val, temp_val, greedy_fastpath, hf_model_name
 ):
     """
     Top-k=1, p=0.0, temp=1.0 should produce the same result as torch.argmax.
@@ -654,7 +674,7 @@ def test_sampling1d_topk1_vs_argmax(
 @pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
 def test_sampling1d_argmax_vs_reference(ttnn_mesh_device):
     """
-    Force-argmax path (k/p/temp=None, allow_force_argmax=True) vs torch.argmax.
+    Greedy fast-path (k/p/temp=None, allow_greedy_fastpath=True) vs torch.argmax.
 
     Tests the all-gather-free argmax path on single device.
     """
@@ -665,7 +685,7 @@ def test_sampling1d_argmax_vs_reference(ttnn_mesh_device):
     sampler = Sampling1D(
         vocab_size=vocab_size,
         mesh_device=ttnn_mesh_device,
-        allow_force_argmax=True,
+        allow_greedy_fastpath=True,
     )
 
     logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
@@ -769,7 +789,7 @@ def test_sampling1d_argmax_slices_qwen3_32b_padded_tail(ttnn_mesh_device):
         vocab_size=padded_vocab_size,
         valid_vocab_size=valid_vocab_size,
         mesh_device=ttnn_mesh_device,
-        allow_force_argmax=True,
+        allow_greedy_fastpath=True,
     )
 
     logits_host = torch.full((1, 1, B, padded_vocab_size), -1.0, dtype=torch.bfloat16)
@@ -1464,7 +1484,7 @@ def test_sampling1d_logprobs_disabled_returns_none(ttnn_mesh_device):
     B = 32
     vocab_size = 1024
 
-    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_force_argmax=True)
+    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_greedy_fastpath=True)
     logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
     cluster_shape = tuple(ttnn_mesh_device.shape)
 
@@ -1489,12 +1509,12 @@ def test_sampling1d_argmax_never_emits_logprobs(ttnn_mesh_device):
     B = 32
     vocab_size = 1024
 
-    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_force_argmax=True)
+    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_greedy_fastpath=True)
     logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
     logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
 
     _, log_probs = sampler.decode_forward(logits_tt, enable_log_probs=True)
-    assert log_probs is None, "argmax path must never compute logprobs (force-argmax ⇒ no logprobs)"
+    assert log_probs is None, "argmax path must never compute logprobs (greedy fast-path ⇒ no logprobs)"
 
 
 @pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
@@ -1597,7 +1617,7 @@ def test_sampling1d_trace_capture(ttnn_mesh_device, mode):
         vocab_size=vocab_size,
         mesh_device=mesh_device,
         max_batch_size=B,
-        allow_force_argmax=True,
+        allow_greedy_fastpath=True,
         pad_to_power_of_2=(mode == "topk" and num_devices > 1),
     )
 

--- a/models/demos/blackhole/qwen36/demo/text_demo.py
+++ b/models/demos/blackhole/qwen36/demo/text_demo.py
@@ -780,7 +780,7 @@ def _run_tp_generation_batched(model, tokenizer, token_ids, max_generated_tokens
     #            B=1 fast path to B>1): each device reduces its OWN vocab shard to (idx, max)
     #            on device, then only 2 tiny [num_devices, B] tensors are read to host — no
     #            full-vocab all-gather, no [B,1,vocab] logits transfer.
-    #   "sample" - TTSampling force-argmax path (all-gathers full logits across devices before
+    #   "sample" - TTSampling greedy fast-path (all-gathers full logits across devices before
     #            arg-maxing). Avoids the full logits HOST transfer but adds a real device-side
     #            all-gather; measured slower overall than "shard" — kept for comparison.
     #   "host"  - legacy: full [B,1,vocab] logits to host, then torch.argmax. Baseline.

--- a/models/demos/blackhole/qwen36/tt/model_config.py
+++ b/models/demos/blackhole/qwen36/tt/model_config.py
@@ -36,7 +36,7 @@ class Qwen36ModelArgs(ModelArgs):
             os.environ["HF_MODEL"] = snapshot_download(hf_model, local_files_only=offline)
         super().__init__(mesh_device, max_batch_size=max_batch_size, max_seq_len=max_seq_len, **kwargs)
         if mesh_device is not None:
-            self.model_config["SAMPLING_AG_CONFIG"]["allow_force_argmax"] = True
+            self.model_config["SAMPLING_AG_CONFIG"]["allow_greedy_fastpath"] = True
 
         # Mirror CKPT_DIR -> checkpoint_dir for weight_cache_path / load_state_dict.
         self.checkpoint_dir = self.CKPT_DIR

--- a/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
@@ -325,9 +325,9 @@ class TtQwenModelArgs(TtModelArgs):
         # scatter_add bincounts) is not supported, so route greedy sampling through the
         # simple all-gather + ttnn.argmax path. Topology follows the 2D-torus fabric (Ring).
         # On Wormhole the full ttnn.sampling pipeline is supported and greedy sampling goes
-        # through it (with correct sub_core_grids), so force-argmax must stay disabled there.
+        # through it (with correct sub_core_grids), so the greedy fast-path must stay disabled there.
         self.model_config["SAMPLING_AG_CONFIG"] = {
-            "allow_force_argmax": self.is_blackhole,
+            "allow_greedy_fastpath": self.is_blackhole,
             "num_links": self.model_config["GALAXY_NUM_LINKS"],
             "chunks_per_sync": 10,
             "topology": ttnn.Topology.Ring,

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -510,8 +510,8 @@ def test_demo(
 
         # Start decoding
         iteration = 0
-        # Diagnostic A/B toggle (#48037). The gibberish fix is enabling the on-device force-argmax
-        # sampling path for the qwen25_vl Transformer (allow_force_argmax via SAMPLING_AG_CONFIG;
+        # Diagnostic A/B toggle (#48037). The gibberish fix is enabling the on-device greedy fast-path
+        # sampling path for the qwen25_vl Transformer (allow_greedy_fastpath via SAMPLING_AG_CONFIG;
         # see tt/model.py), which keeps greedy decode on-device. Setting TT_QWEN_FORCE_HOST_SAMPLING=1
         # forces host argmax instead: a known-good reference (correct output) but slower (per-step
         # logits read-back, fails the wh_llmbox_perf decode target), useful only for local A/B.

--- a/models/demos/qwen25_vl/tt/model.py
+++ b/models/demos/qwen25_vl/tt/model.py
@@ -339,12 +339,12 @@ class Transformer(TTTransformer):
     # Symptom: on-device sampling produced gibberish at batch-32 (BERTScore F1 ~0.34)
     # but is correct at batch-1, and host argmax of the same batch-32 run is correct
     # (F1 0.791) -> the decode forward is fine; only the on-device sampling path is wrong
-    # at batch-32. Root cause: with allow_force_argmax disabled (the non-Galaxy default),
+    # at batch-32. Root cause: with allow_greedy_fastpath disabled (the non-Galaxy default),
     # greedy decode (temperature=0 -> k=1,p=0,temp=1) goes through the heavy top-k/top-p
     # multi-all-gather sampling pipeline, which is what corrupts at batch-32, rather than
     # the simple single-gather argmax path.
     #
-    # Fix: route greedy decode through the force-argmax path (enabled in __init__ below),
+    # Fix: route greedy decode through the greedy fast-path (enabled in __init__ below),
     # and re-stage the decode trace inputs from host every step + run the sampling op
     # eagerly so the all-gather re-acquires a fresh multi_device_global_semaphore each
     # step instead of reusing a stale one frozen into a captured trace.
@@ -361,12 +361,12 @@ class Transformer(TTTransformer):
         paged_attention_config=None,
         use_paged_kv_cache=False,
     ):
-        # Enable the single-gather force-argmax sampling path for greedy decode. The
-        # non-Galaxy default (default_sampling_force_argmax) sets allow_force_argmax=False,
+        # Enable the single-gather greedy fast-path sampling path for greedy decode. The
+        # non-Galaxy default (default_sampling_greedy_fastpath) sets allow_greedy_fastpath=False,
         # which forces greedy decode onto the heavy top-k/top-p pipeline that corrupts at
         # batch-32 (#48037). Must be set before super().__init__ builds the sampling module.
         ag_cfg = dict(args.model_config.get("SAMPLING_AG_CONFIG", {}) or {})
-        ag_cfg["allow_force_argmax"] = True
+        ag_cfg["allow_greedy_fastpath"] = True
         args.model_config["SAMPLING_AG_CONFIG"] = ag_cfg
 
         # Call parent constructor with vision-specific classes

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -581,7 +581,7 @@ def test_demo(
         # Start decoding
         iteration = 0
         # Diagnostic A/B toggle (#48037). The actual gibberish fix is on the model side
-        # (Transformer in tt/model.py: force-argmax sampling path + always-refresh + eager sampling),
+        # (Transformer in tt/model.py: greedy fast-path sampling path + always-refresh + eager sampling),
         # which keeps on-device sampling. Setting TT_QWEN_FORCE_HOST_SAMPLING=1 forces host argmax
         # instead: a known-good reference (correct output) but slower (per-step logits read-back),
         # useful to compare against the on-device path locally.

--- a/models/demos/qwen3_vl/tt/model.py
+++ b/models/demos/qwen3_vl/tt/model.py
@@ -460,12 +460,12 @@ class Transformer(TTTransformer):
     # Symptom: on-device sampling produced gibberish at batch-32 (BERTScore F1 ~0.34)
     # but is correct at batch-1, and host argmax of the same batch-32 run is correct
     # (F1 0.79) -> the decode forward is fine; only the on-device sampling path is wrong
-    # at batch-32. Root cause: with allow_force_argmax disabled (the non-Galaxy default),
+    # at batch-32. Root cause: with allow_greedy_fastpath disabled (the non-Galaxy default),
     # greedy decode (temperature=0 -> k=1,p=0,temp=1) goes through the heavy top-k/top-p
     # multi-all-gather sampling pipeline, which is what corrupts at batch-32, rather than
     # the simple single-gather argmax path.
     #
-    # Fix: route greedy decode through the force-argmax path (enabled in __init__ below),
+    # Fix: route greedy decode through the greedy fast-path (enabled in __init__ below),
     # and re-stage the decode trace inputs from host every step + run the sampling op
     # eagerly so the all-gather re-acquires a fresh multi_device_global_semaphore each
     # step instead of reusing a stale one frozen into a captured trace.
@@ -482,12 +482,12 @@ class Transformer(TTTransformer):
         paged_attention_config=None,
         use_paged_kv_cache=False,
     ):
-        # Enable the single-gather force-argmax sampling path for greedy decode. The
-        # non-Galaxy default (default_sampling_force_argmax) sets allow_force_argmax=False,
+        # Enable the single-gather greedy fast-path sampling path for greedy decode. The
+        # non-Galaxy default (default_sampling_greedy_fastpath) sets allow_greedy_fastpath=False,
         # which forces greedy decode onto the heavy top-k/top-p pipeline that corrupts at
         # batch-32 (#48037). Must be set before super().__init__ builds the sampling module.
         ag_cfg = dict(args.model_config.get("SAMPLING_AG_CONFIG", {}) or {})
-        ag_cfg["allow_force_argmax"] = True
+        ag_cfg["allow_greedy_fastpath"] = True
         args.model_config["SAMPLING_AG_CONFIG"] = ag_cfg
 
         # Call parent constructor with vision-specific classes

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1711,7 +1711,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             if isinstance(logits_i, tuple):
                 logits_i = logits_i[0]
             # Some models must run the on-device sampling op eagerly rather than from its
-            # own captured trace: the force-argmax path does an all_gather_async whose
+            # own captured trace: the greedy fast-path does an all_gather_async whose
             # multi_device_global_semaphore is taken from get_and_cycle_*() at capture time
             # and frozen into the trace, so replaying the sampling trace reuses a stale
             # semaphore and the gather corrupts from the 2nd decode step (#48037). Running

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1078,8 +1078,18 @@ class ModelArgs:
                 "num_workers_per_link": 2,
                 "rs_memory_config": ttnn.DRAM_MEMORY_CONFIG,
             }
-            default_sampling_force_argmax = {
-                "allow_force_argmax": False,
+            # allow_greedy_fastpath permits -- but does not itself trigger -- a cheaper
+            # implementation of greedy decode. It only takes effect when every user in the
+            # batch already asks for greedy sampling (k=1, no top-p, temp=1), so it never
+            # changes which token is emitted; greedy is argmax on either path.
+            #   fast path: one all-gather of the full logits (skipped entirely at
+            #              num_devices == 1) + on-device argmax.
+            #   normal path: local top-k per device, three all-gathers (values, indices,
+            #                sampled tokens), then top-k/top-p/temperature/RNG over the
+            #                padded vocab.
+            # The fast path also cannot produce log-probs, since it runs no softmax.
+            default_sampling_greedy_fastpath = {
+                "allow_greedy_fastpath": False,
                 "num_links": 1,
                 "chunks_per_sync": 10,
                 "num_workers_per_link": 2,
@@ -1096,8 +1106,8 @@ class ModelArgs:
                         "num_workers_per_link": 1,
                         "rs_memory_config": ttnn.L1_MEMORY_CONFIG,
                     },
-                    "sampling_force_argmax": {
-                        "allow_force_argmax": True,
+                    "sampling_greedy_fastpath": {
+                        "allow_greedy_fastpath": True,
                         "num_links": 4,
                         "chunks_per_sync": 10,
                         "num_workers_per_link": 2,
@@ -1114,14 +1124,14 @@ class ModelArgs:
                 self.model_config["ATTN_AGMM_CONFIG"] = model_specific_ccl_configs[self.base_model_name]["attn_agmm"]
                 self.model_config["MLP_RS_CONFIG"] = model_specific_ccl_configs[self.base_model_name]["mlp_rs"]
                 self.model_config["SAMPLING_AG_CONFIG"] = model_specific_ccl_configs[self.base_model_name][
-                    "sampling_force_argmax"
+                    "sampling_greedy_fastpath"
                 ]
             else:
                 self.model_config["ATTN_LN_AG_CONFIG"] = default_ln_ag
                 self.model_config["FFN_LN_AG_CONFIG"] = default_ln_ag
                 self.model_config["ATTN_AGMM_CONFIG"] = default_agmm
                 self.model_config["MLP_RS_CONFIG"] = default_mlp_rs
-                self.model_config["SAMPLING_AG_CONFIG"] = default_sampling_force_argmax
+                self.model_config["SAMPLING_AG_CONFIG"] = default_sampling_greedy_fastpath
 
             logger.info(f"Attention grid: {self.attn_input_grid}")
             logger.info(f"MLP grid: {self.mlp_core_grid}")


### PR DESCRIPTION
### Ticket
Closes #51987

### Problem
`allow_force_argmax` never forced argmax. It was a permission bit for a cheaper implementation of greedy decode: `_is_force_argmax_sampling` ANDed the flag with the actual sampling params, so the path was only taken when every user in the batch already asked for greedy sampling (k=1, no top-p, temp=1). Setting it `True` never changed which token came out — greedy decode is argmax either way.

The name read as "override sampling and always take argmax," which is not what it does, and it repeatedly derailed review of #48886. Raised there by @tchedaTT:

> "allow_force_argmax" doesn't really force the argmax, a more appropriate name would be "allow_greedy_fastpath". The envvar is an additional gate, the path is only taken when the sampling would be greedy anyway.

### Change
Pure rename, no behavior change:

| Old | New |
|---|---|
| `allow_force_argmax` (config key) | `allow_greedy_fastpath` |
| `TTSampling._allow_force_argmax_sampling` | `_allow_greedy_fastpath` |
| `TTSampling._is_force_argmax_sampling()` | `_is_greedy_fastpath()` |
| `TTSampling.force_argmax_sampling` / `_force_argmax_sampling` | `greedy_fastpath` / `_greedy_fastpath` |
| `_TraceKey.force_argmax` | `_TraceKey.greedy_fastpath` |
| `_get_force_argmax_all_gather_config()` | `_get_greedy_fastpath_all_gather_config()` |
| `default_sampling_force_argmax` / `"sampling_force_argmax"` | `default_sampling_greedy_fastpath` / `"sampling_greedy_fastpath"` |
| `Sampling1DConfig.allow_force_argmax`, `Sampling1D(allow_force_argmax=)`, `_build_decode_topk_param_tensors(allow_force_argmax=)` | `allow_greedy_fastpath` |

Prose that named the mechanism "force-argmax" moved to "greedy fast-path" too, including the log lines (`Forcing argmax sampling` → `Using greedy fast-path (argmax) sampling`). No test or script greps those strings. Identifiers that genuinely describe the argmax *operation* are untouched: `_can_slice_valid_vocab_for_argmax`, `_slice_valid_vocab_for_argmax`, `argmax_chunks_per_sync`, `num_argmax_gather_links`.

Two additions beyond the mechanical rename:

**1. Explanatory comment where the flag is created** (`model_config.py`), spelling out fast path vs normal path, that the flag permits rather than triggers, and that the fast path cannot produce log-probs.

**2. The old key is now rejected, not ignored.** `from_model_args` read it as `ag_cfg.get("allow_force_argmax", False)`, so a `SAMPLING_AG_CONFIG` still carrying the old key would have silently fallen back to a disabled fast-path — visible only as a decode perf regression, with no error. Both read sites (`tt_sampling.py`, `sampling_1d.py`) now raise `ValueError` naming the replacement. Covered by a new test, `test_from_model_args_rejects_legacy_key`.

### Scope
37 files, 105 identifier occurrences plus the prose pass. Verified zero residual `force_argmax` / `force-argmax` repo-wide outside `models/experimental/`, and every touched Python file byte-compiles.

**`models/experimental/` is deliberately excluded** (per the issue). I checked this is safe rather than assuming it: that tree carries its own copies of `tt_sampling.py`, `sampling/generator.py`, and `modules/sampling/sampling_1d.py`, and only ever reads its own literals. Its live model passes `allow_force_argmax=False` directly to its own `Sampling1DConfig`; its `from_model_args` is called only from its own tests with hand-built mock configs. Nothing there consumes `SAMPLING_AG_CONFIG` from `tt_transformers`' `ModelArgs`, so the renamed key cannot reach it. It should be renamed for consistency in a follow-up, but it is not a break today.

### Test plan
Draft while CI runs. This is a rename, so the bar is "nothing moved" — broad green across the model fleet rather than a targeted new signal.

- **All Model Tests**, tiers 1+2+3, unit + e2e, all SKUs: [30830578466](https://github.com/tenstorrent/tt-metal/actions/runs/30830578466)
- **vLLM nightly**, all models: [30830582534](https://github.com/tenstorrent/tt-metal/actions/runs/30830582534)

vLLM is included because `SamplingGenerator` is what the vLLM path drives, and the renamed property is read on every `reset_sampling_params`.

### Note for reviewers
Two open PRs touch renamed lines and will need a trivial rebase whichever lands second:
- **#51665** rewrites the `README.md` "Trace invalidation" paragraph that this PR renames a symbol inside, and edits the same `reset_sampling_params` block.
- **#48886** changes `default_sampling_force_argmax` → the dict this PR renames to `default_sampling_greedy_fastpath`.

Neither conflicts semantically; both are one-line textual conflicts. Happy to sequence behind them if that's easier — this PR has no urgency and pure renames are cheap to redo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
