### PR TITLE
Fix merged KV chunk table stage layout

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
@@ -18,7 +18,11 @@ NOTE: per-layer LayerAck channel + scheduler-driven migration are NOT here
 """
 
 import ttnn
-from models.demos.common.prefill.runners.migration import serialize_kv_chunk_table, serialize_prebuilt_kv_chunk_table
+from models.demos.common.prefill.runners.migration import (
+    allgather_kv_stage_layout,
+    serialize_kv_chunk_table,
+    serialize_prebuilt_kv_chunk_table,
+)
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
     PREFILL_CHUNK_OUTPUT_TOKENS,
@@ -178,6 +182,16 @@ def _build_and_serialize_merged_kv_chunk_table(
     table = disagg.KvChunkAddressTable(configs)
 
     for config_id, (cache, cfg) in enumerate(zip(caches, configs)):
+        # The merged table has one config per physical cache, so each config needs a layout with that
+        # cache's DRAM base address. The dual-cache path is single-stage today, but this remains a
+        # collective to match the single-config builder and to produce the mesh/fabric-node metadata.
+        stage_layout = allgather_kv_stage_layout(
+            mesh_device,
+            int(cache.buffer_address()),
+            mesh_shape,
+            first_layer_idx=0,
+            num_my_layers=cfg.num_layers,
+        )
         populate_kv_chunk_address_table_kimi(
             lookup_table=table,
             config=cfg,
@@ -189,6 +203,7 @@ def _build_and_serialize_merged_kv_chunk_table(
             chunk_size_bytes=cfg.chunk_size_bytes,
             num_users=num_users,
             config_id=config_id,
+            stage_layout=stage_layout,
         )
 
     return serialize_prebuilt_kv_chunk_table(table=table, path=path)


### PR DESCRIPTION
## Summary
- build a stage layout for each cache configuration in the merged KV chunk table path
- pass the per-cache layout to `populate_kv_chunk_address_table_kimi`
- preserve each cache configuration’s DRAM base address

## Root cause
This fixes a regression introduced by [f1941c28053](https://github.com/tenstorrent/tt-metal/commit/f1941c28053005a6e37eceecc1076a93305c4deb), [#48826](https://github.com/tenstorrent/tt-metal/pull/48826). That change made `populate_kv_chunk_address_table_kimi` iterate `stage_layout`, but the merged KVPE/index-cache builder still called it with `None`. [#51684](https://github.com/tenstorrent/tt-metal/pull/51684) fixed the stale keyword argument and exposed this missing-layout failure.

## Targeted CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/fix-kv-chunk-table-stage-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/fix-kv-chunk-table-stage-layout)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-kv-chunk-table-stage-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-kv-chunk-table-stage-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-kv-chunk-table-stage-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-kv-chunk-table-stage-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-kv-chunk-table-stage-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/fix-kv-chunk-table-stage-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-kv-chunk-table-stage-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-kv-chunk-table-stage-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-kv-chunk-table-stage-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-kv-chunk-table-stage-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-kv-chunk-table-stage-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-kv-chunk-table-stage-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-kv-chunk-table-stage-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-kv-chunk-table-stage-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-kv-chunk-table-stage-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-kv-chunk-table-stage-layout)