### PR TITLE
[Bug Fix] `reduce_scatter_minimal_async` cap num workers so none have zero work, fixes T3K test hang.

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -14,6 +14,9 @@
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 #include "ttnn/operations/experimental/ccl/composite_common.hpp"
+#include "ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp"
+
+#include <algorithm>
 
 namespace ttnn {
 using namespace ttnn::operations::ccl;
@@ -88,6 +91,16 @@ ttnn::Tensor reduce_scatter(
             resolved_compute_kernel_config,
             use_l1_small_for_semaphores);
     }
+    // The program factory splits the pages of one output channel (one batch for dim 0 scatters) across
+    // all num_links * num_workers_per_direction workers. Small tensors can have fewer pages than links,
+    // and a link whose workers get an empty page range hangs waiting on a barrier the others already
+    // passed, so cap the link count to the pages actually available. Resolved here rather than in the
+    // program factory so that the num_links op attribute and the program agree -- the cache-hit
+    // override_runtime_arguments path iterates over the attribute.
+    const uint32_t pages_to_distribute = ttnn::experimental::ccl::reduce_scatter_pages_to_distribute(
+        input_tensor, normalized_dim, ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis));
+    num_links_ = std::max(1u, std::min(num_links_, pages_to_distribute));
+
     return ttnn::prim::reduce_scatter(
                input_tensor,
                normalized_dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.cpp
@@ -263,6 +263,15 @@ std::tuple<uint32_t, uint32_t, uint32_t> reduce_scatter_map_2d_to_4d(uint32_t di
     return {normalized_dim, /*input_tensor_C=*/1, /*input_tensor_B=*/1};
 }
 
+uint32_t reduce_scatter_clamp_workers_to_available_pages(
+    uint32_t num_workers_per_direction, uint32_t num_links, uint32_t pages_to_distribute) {
+    TT_FATAL(num_links > 0, "num_links must be non-zero");
+    // reduce_scatter_get_tile_offsets splits pages across all links' workers, so the per-direction
+    // budget is the page count divided by num_links.
+    const uint32_t max_useful_workers_per_direction = pages_to_distribute / num_links;
+    return std::max(1u, std::min(num_workers_per_direction, max_useful_workers_per_direction));
+}
+
 std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> reduce_scatter_get_tile_offsets(
     uint32_t worker_id,
     uint32_t num_workers,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.cpp
@@ -265,7 +265,10 @@ std::tuple<uint32_t, uint32_t, uint32_t> reduce_scatter_map_2d_to_4d(uint32_t di
 
 uint32_t reduce_scatter_clamp_workers_to_available_pages(
     uint32_t num_workers_per_direction, uint32_t num_links, uint32_t pages_to_distribute) {
-    TT_FATAL(num_links > 0, "num_links must be non-zero");
+    TT_FATAL(
+        num_links > 0 && num_links >= pages_to_distribute,
+        "num_links must be between zero and the number of input pages got: {}",
+        num_links);
     // reduce_scatter_get_tile_offsets splits pages across all links' workers, so the per-direction
     // budget is the page count divided by num_links.
     const uint32_t max_useful_workers_per_direction = pages_to_distribute / num_links;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.cpp
@@ -263,11 +263,37 @@ std::tuple<uint32_t, uint32_t, uint32_t> reduce_scatter_map_2d_to_4d(uint32_t di
     return {normalized_dim, /*input_tensor_C=*/1, /*input_tensor_B=*/1};
 }
 
+uint32_t reduce_scatter_pages_to_distribute(const ttnn::Tensor& input_tensor, uint32_t dim, uint32_t ring_size) {
+    const auto& input_tensor_shape = input_tensor.padded_shape();
+    const auto [normalized_dim, input_tensor_C, input_tensor_B] =
+        (input_tensor_shape.rank() == 2) ? reduce_scatter_map_2d_to_4d(dim)
+                                         : reduce_scatter_map_nd_to_4d(input_tensor_shape, dim);
+
+    // Only the batch/channel divisions matter here; the Ht/Wt scatter splits are absorbed into the
+    // per-channel page count.
+    const uint32_t slice_B = (normalized_dim == 0) ? input_tensor_B / ring_size : input_tensor_B;
+    const uint32_t slice_C = (normalized_dim == 1) ? input_tensor_C / ring_size : input_tensor_C;
+    if (ring_size == 0 || slice_B == 0 || slice_C == 0) {
+        // Shape isn't cleanly scatterable over this ring; validation reports that properly later, so
+        // don't divide by zero on the way there.
+        return 0;
+    }
+
+    const uint32_t output_tensor_num_pages = input_tensor.buffer()->num_pages() / ring_size;
+    const uint32_t output_batch_num_pages = output_tensor_num_pages / slice_B;
+    // dim 0 scatters hand out a batch of pages at a time, every other dim a channel.
+    return (normalized_dim == 0) ? output_batch_num_pages : output_batch_num_pages / slice_C;
+}
+
 uint32_t reduce_scatter_clamp_workers_to_available_pages(
     uint32_t num_workers_per_direction, uint32_t num_links, uint32_t pages_to_distribute) {
+    TT_FATAL(num_links > 0, "num_links must be non-zero");
     TT_FATAL(
-        num_links > 0 && num_links >= pages_to_distribute,
-        "num_links must be between zero and the number of input pages got: {}",
+        pages_to_distribute >= num_links,
+        "reduce_scatter has {} page(s) to distribute across {} link(s). num_links must be capped to the page count "
+        "before the program is built (see reduce_scatter_pages_to_distribute), otherwise a link is left with no "
+        "pages and its workers hang.",
+        pages_to_distribute,
         num_links);
     // reduce_scatter_get_tile_offsets splits pages across all links' workers, so the per-direction
     // budget is the page count divided by num_links.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp
@@ -128,8 +128,14 @@ std::tuple<uint32_t, uint32_t, uint32_t> reduce_scatter_map_nd_to_4d(const ttnn:
 // Maps a 2D tensor dim to the canonical 4D representation (normalized_dim=2 or 3, C=1, B=1).
 std::tuple<uint32_t, uint32_t, uint32_t> reduce_scatter_map_2d_to_4d(uint32_t dim);
 
+// Number of pages that reduce_scatter_get_tile_offsets splits across all of the links' workers:
+// the per-channel output page count, or the per-batch count for dim 0 scatters. Returns 0 if the
+// shape doesn't divide cleanly over the ring (validation reports that case with a real message).
+uint32_t reduce_scatter_pages_to_distribute(const ttnn::Tensor& input_tensor, uint32_t dim, uint32_t ring_size);
+
 // Caps the per-direction worker count so that every worker is assigned at least one page.
-// Workers assigned no pages result in a hang.
+// Workers assigned no pages result in a hang. Requires num_links to already be capped to
+// reduce_scatter_pages_to_distribute.
 uint32_t reduce_scatter_clamp_workers_to_available_pages(
     uint32_t num_workers_per_direction, uint32_t num_links, uint32_t pages_to_distribute);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp
@@ -128,6 +128,11 @@ std::tuple<uint32_t, uint32_t, uint32_t> reduce_scatter_map_nd_to_4d(const ttnn:
 // Maps a 2D tensor dim to the canonical 4D representation (normalized_dim=2 or 3, C=1, B=1).
 std::tuple<uint32_t, uint32_t, uint32_t> reduce_scatter_map_2d_to_4d(uint32_t dim);
 
+// Caps the per-direction worker count so that every worker is assigned at least one page.
+// Workers assigned no pages result in a hang.
+uint32_t reduce_scatter_clamp_workers_to_available_pages(
+    uint32_t num_workers_per_direction, uint32_t num_links, uint32_t pages_to_distribute);
+
 // Computes per-worker tile read start/end offsets for the scatter dimension.
 std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> reduce_scatter_get_tile_offsets(
     uint32_t worker_id,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -375,6 +375,54 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 
     bool fuse_op = fused_op_signaler.has_value();
 
+    // Tensor Info
+    const auto& input_tensor_shape = input_tensor.padded_shape();
+    TT_FATAL(
+        !(input_tensor_shape[-2] % tt::constants::TILE_HEIGHT),
+        "Input tensor height ({}) must be divisible by tile height ({}).",
+        input_tensor_shape[-2],
+        tt::constants::TILE_HEIGHT);
+    TT_FATAL(
+        !(input_tensor_shape[-1] % tt::constants::TILE_WIDTH),
+        "Input tensor width ({}) must be divisible by tile width ({}).",
+        input_tensor_shape[-1],
+        tt::constants::TILE_WIDTH);
+
+    const auto [normalized_dim, input_tensor_C, input_tensor_B] =
+        (input_tensor_shape.rank() == 2)
+            ? ttnn::experimental::ccl::reduce_scatter_map_2d_to_4d(dim)
+            : ttnn::experimental::ccl::reduce_scatter_map_nd_to_4d(input_tensor_shape, dim);
+    const uint32_t input_tensor_Ht = input_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
+    const uint32_t input_tensor_Wt = input_tensor_shape[-1] / tt::constants::TILE_WIDTH;
+
+    uint32_t slice_B = input_tensor_B;
+    uint32_t slice_C = input_tensor_C;
+    uint32_t slice_Ht = input_tensor_Ht;
+    uint32_t slice_Wt = input_tensor_Wt;
+    if (normalized_dim == 0) {
+        slice_B /= ring_size;
+    } else if (normalized_dim == 1) {
+        slice_C /= ring_size;
+    } else if (normalized_dim == 2) {
+        slice_Ht /= ring_size;
+    } else if (normalized_dim == 3) {
+        slice_Wt /= ring_size;
+    } else {
+        TT_FATAL(
+            false, "reduce_scatter_minimal_async ring implementation only supports scattering on dim 0, 1, 2, or 3");
+    }
+
+    TT_FATAL(
+        !(fuse_op && normalized_dim == 0),
+        "reduce_scatter_minimal_async ring implementation can't be fused with matmul when scattering on dim 0");
+
+    const uint32_t input_tensor_num_pages = input_tensor.buffer()->num_pages();
+    const uint32_t output_tensor_num_pages = input_tensor_num_pages / ring_size;
+    const uint32_t input_batch_num_pages = input_tensor_num_pages / input_tensor_B;
+    const uint32_t output_batch_num_pages = output_tensor_num_pages / slice_B;
+    const uint32_t input_channel_num_pages = input_batch_num_pages / input_tensor_C;
+    const uint32_t output_channel_num_pages = output_batch_num_pages / slice_C;
+
     // op hyperparams
     // Get worker cores
     // 2 senders per direction (2: forward, backward) per link (num_links)
@@ -392,6 +440,10 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
             ring_size,
             num_directions_per_link,
             num_mux_cores_per_direction_per_link));
+    // Never allocate more workers than there are pages to hand out; an empty-range worker deadlocks
+    // the per-batch barrier below.
+    num_workers_per_direction = ttnn::experimental::ccl::reduce_scatter_clamp_workers_to_available_pages(
+        num_workers_per_direction, num_links, normalized_dim == 0 ? output_batch_num_pages : output_channel_num_pages);
     if (num_workers_per_direction == 1) {
         num_mux_cores_per_direction_per_link = 0;
     }
@@ -445,54 +497,6 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 
     CoreRangeSet sender_worker_core_range_set = CoreRangeSet(sender_worker_core_ranges);
     CoreRangeSet mux_core_range_set = CoreRangeSet(mux_core_ranges);
-
-    // Tensor Info
-    const auto& input_tensor_shape = input_tensor.padded_shape();
-    TT_FATAL(
-        !(input_tensor_shape[-2] % tt::constants::TILE_HEIGHT),
-        "Input tensor height ({}) must be divisible by tile height ({}).",
-        input_tensor_shape[-2],
-        tt::constants::TILE_HEIGHT);
-    TT_FATAL(
-        !(input_tensor_shape[-1] % tt::constants::TILE_WIDTH),
-        "Input tensor width ({}) must be divisible by tile width ({}).",
-        input_tensor_shape[-1],
-        tt::constants::TILE_WIDTH);
-
-    const auto [normalized_dim, input_tensor_C, input_tensor_B] =
-        (input_tensor_shape.rank() == 2)
-            ? ttnn::experimental::ccl::reduce_scatter_map_2d_to_4d(dim)
-            : ttnn::experimental::ccl::reduce_scatter_map_nd_to_4d(input_tensor_shape, dim);
-    const uint32_t input_tensor_Ht = input_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
-    const uint32_t input_tensor_Wt = input_tensor_shape[-1] / tt::constants::TILE_WIDTH;
-
-    uint32_t slice_B = input_tensor_B;
-    uint32_t slice_C = input_tensor_C;
-    uint32_t slice_Ht = input_tensor_Ht;
-    uint32_t slice_Wt = input_tensor_Wt;
-    if (normalized_dim == 0) {
-        slice_B /= ring_size;
-    } else if (normalized_dim == 1) {
-        slice_C /= ring_size;
-    } else if (normalized_dim == 2) {
-        slice_Ht /= ring_size;
-    } else if (normalized_dim == 3) {
-        slice_Wt /= ring_size;
-    } else {
-        TT_FATAL(
-            false, "reduce_scatter_minimal_async ring implementation only supports scattering on dim 0, 1, 2, or 3");
-    }
-
-    TT_FATAL(
-        !(fuse_op && normalized_dim == 0),
-        "reduce_scatter_minimal_async ring implementation can't be fused with matmul when scattering on dim 0");
-
-    const uint32_t input_tensor_num_pages = input_tensor.buffer()->num_pages();
-    const uint32_t output_tensor_num_pages = input_tensor_num_pages / ring_size;
-    const uint32_t input_batch_num_pages = input_tensor_num_pages / input_tensor_B;
-    const uint32_t output_batch_num_pages = output_tensor_num_pages / slice_B;
-    const uint32_t input_channel_num_pages = input_batch_num_pages / input_tensor_C;
-    const uint32_t output_channel_num_pages = output_batch_num_pages / slice_C;
 
     // Extract compute kernel config parameters
     const bool fp32_dest_acc_en = ttnn::get_fp32_dest_acc_en(compute_kernel_config);
@@ -1077,6 +1081,56 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     bool is_first_chip = ring_index == 0;
     bool is_last_chip = ring_index == ring_size - 1;
 
+    bool fuse_op = fused_op_signaler.has_value();
+
+    // Tensor Info
+    const auto& input_tensor_shape = input_tensor.padded_shape();
+    TT_FATAL(
+        !(input_tensor_shape[-2] % tt::constants::TILE_HEIGHT),
+        "Input tensor height ({}) must be divisible by tile height ({}).",
+        input_tensor_shape[-2],
+        tt::constants::TILE_HEIGHT);
+    TT_FATAL(
+        !(input_tensor_shape[-1] % tt::constants::TILE_WIDTH),
+        "Input tensor width ({}) must be divisible by tile width ({}).",
+        input_tensor_shape[-1],
+        tt::constants::TILE_WIDTH);
+
+    const auto [normalized_dim, input_tensor_C, input_tensor_B] =
+        (input_tensor_shape.rank() == 2)
+            ? ttnn::experimental::ccl::reduce_scatter_map_2d_to_4d(dim)
+            : ttnn::experimental::ccl::reduce_scatter_map_nd_to_4d(input_tensor_shape, dim);
+    const uint32_t input_tensor_Ht = input_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
+    const uint32_t input_tensor_Wt = input_tensor_shape[-1] / tt::constants::TILE_WIDTH;
+
+    uint32_t slice_B = input_tensor_B;
+    uint32_t slice_C = input_tensor_C;
+    uint32_t slice_Ht = input_tensor_Ht;
+    uint32_t slice_Wt = input_tensor_Wt;
+    if (normalized_dim == 0) {
+        slice_B /= ring_size;
+    } else if (normalized_dim == 1) {
+        slice_C /= ring_size;
+    } else if (normalized_dim == 2) {
+        slice_Ht /= ring_size;
+    } else if (normalized_dim == 3) {
+        slice_Wt /= ring_size;
+    } else {
+        TT_FATAL(
+            false, "reduce_scatter_minimal_async line implementation only supports scattering on dim 0, 1, 2, or 3");
+    }
+
+    TT_FATAL(
+        !(fuse_op && normalized_dim == 0),
+        "reduce_scatter_minimal_async line implementation can't be fused with matmul when scattering on dim 0");
+
+    const uint32_t input_tensor_num_pages = input_tensor.buffer()->num_pages();
+    const uint32_t output_tensor_num_pages = input_tensor_num_pages / ring_size;
+    const uint32_t input_batch_num_pages = input_tensor_num_pages / input_tensor_B;
+    const uint32_t output_batch_num_pages = output_tensor_num_pages / slice_B;
+    const uint32_t input_channel_num_pages = input_batch_num_pages / input_tensor_C;
+    const uint32_t output_channel_num_pages = output_batch_num_pages / slice_C;
+
     // op hyperparams
     // Get worker cores
     // 2 senders (reader + core + writer) per direction (forward, backward) per link
@@ -1093,6 +1147,10 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
             ring_size,
             num_directions_per_link,
             num_mux_cores_per_direction_per_link));
+    // Never allocate more workers than there are pages to hand out; an empty-range worker moves no
+    // data and only adds synchronization overhead.
+    num_workers_per_direction = ttnn::experimental::ccl::reduce_scatter_clamp_workers_to_available_pages(
+        num_workers_per_direction, num_links, normalized_dim == 0 ? output_batch_num_pages : output_channel_num_pages);
     log_trace(tt::LogOp, "DEBUG: num_workers_per_direction: {}", num_workers_per_direction);
     uint32_t num_buffers_full_size_channels = num_buffers_per_channel.value_or(1);
 
@@ -1102,8 +1160,6 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
         sender_device_coord,
         is_first_chip,
         is_last_chip);
-
-    bool fuse_op = fused_op_signaler.has_value();
 
     // Get OP Config, topology config
     uint32_t page_size = input_tensor.buffer()->page_size();
@@ -1200,54 +1256,6 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
             cb_num_pages * l1_scratch_cb_page_size_bytes, {{compute_output_cb_index, df}})
             .set_page_size(compute_output_cb_index, l1_scratch_cb_page_size_bytes);
     CreateCircularBuffer(program, sender_worker_core_range_set, cb_compute_output_config);
-
-    // Tensor Info
-    const auto& input_tensor_shape = input_tensor.padded_shape();
-    TT_FATAL(
-        !(input_tensor_shape[-2] % tt::constants::TILE_HEIGHT),
-        "Input tensor height ({}) must be divisible by tile height ({}).",
-        input_tensor_shape[-2],
-        tt::constants::TILE_HEIGHT);
-    TT_FATAL(
-        !(input_tensor_shape[-1] % tt::constants::TILE_WIDTH),
-        "Input tensor width ({}) must be divisible by tile width ({}).",
-        input_tensor_shape[-1],
-        tt::constants::TILE_WIDTH);
-
-    const auto [normalized_dim, input_tensor_C, input_tensor_B] =
-        (input_tensor_shape.rank() == 2)
-            ? ttnn::experimental::ccl::reduce_scatter_map_2d_to_4d(dim)
-            : ttnn::experimental::ccl::reduce_scatter_map_nd_to_4d(input_tensor_shape, dim);
-    const uint32_t input_tensor_Ht = input_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
-    const uint32_t input_tensor_Wt = input_tensor_shape[-1] / tt::constants::TILE_WIDTH;
-
-    uint32_t slice_B = input_tensor_B;
-    uint32_t slice_C = input_tensor_C;
-    uint32_t slice_Ht = input_tensor_Ht;
-    uint32_t slice_Wt = input_tensor_Wt;
-    if (normalized_dim == 0) {
-        slice_B /= ring_size;
-    } else if (normalized_dim == 1) {
-        slice_C /= ring_size;
-    } else if (normalized_dim == 2) {
-        slice_Ht /= ring_size;
-    } else if (normalized_dim == 3) {
-        slice_Wt /= ring_size;
-    } else {
-        TT_FATAL(
-            false, "reduce_scatter_minimal_async line implementation only supports scattering on dim 0, 1, 2, or 3");
-    }
-
-    TT_FATAL(
-        !(fuse_op && normalized_dim == 0),
-        "reduce_scatter_minimal_async line implementation can't be fused with matmul when scattering on dim 0");
-
-    const uint32_t input_tensor_num_pages = input_tensor.buffer()->num_pages();
-    const uint32_t output_tensor_num_pages = input_tensor_num_pages / ring_size;
-    const uint32_t input_batch_num_pages = input_tensor_num_pages / input_tensor_B;
-    const uint32_t output_batch_num_pages = output_tensor_num_pages / slice_B;
-    const uint32_t input_channel_num_pages = input_batch_num_pages / input_tensor_C;
-    const uint32_t output_channel_num_pages = output_batch_num_pages / slice_C;
 
     bool input_is_sharded = input_tensor.is_sharded();
     bool intermediate_is_sharded = intermediate_tensor.is_sharded();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -375,54 +375,6 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 
     bool fuse_op = fused_op_signaler.has_value();
 
-    // Tensor Info
-    const auto& input_tensor_shape = input_tensor.padded_shape();
-    TT_FATAL(
-        !(input_tensor_shape[-2] % tt::constants::TILE_HEIGHT),
-        "Input tensor height ({}) must be divisible by tile height ({}).",
-        input_tensor_shape[-2],
-        tt::constants::TILE_HEIGHT);
-    TT_FATAL(
-        !(input_tensor_shape[-1] % tt::constants::TILE_WIDTH),
-        "Input tensor width ({}) must be divisible by tile width ({}).",
-        input_tensor_shape[-1],
-        tt::constants::TILE_WIDTH);
-
-    const auto [normalized_dim, input_tensor_C, input_tensor_B] =
-        (input_tensor_shape.rank() == 2)
-            ? ttnn::experimental::ccl::reduce_scatter_map_2d_to_4d(dim)
-            : ttnn::experimental::ccl::reduce_scatter_map_nd_to_4d(input_tensor_shape, dim);
-    const uint32_t input_tensor_Ht = input_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
-    const uint32_t input_tensor_Wt = input_tensor_shape[-1] / tt::constants::TILE_WIDTH;
-
-    uint32_t slice_B = input_tensor_B;
-    uint32_t slice_C = input_tensor_C;
-    uint32_t slice_Ht = input_tensor_Ht;
-    uint32_t slice_Wt = input_tensor_Wt;
-    if (normalized_dim == 0) {
-        slice_B /= ring_size;
-    } else if (normalized_dim == 1) {
-        slice_C /= ring_size;
-    } else if (normalized_dim == 2) {
-        slice_Ht /= ring_size;
-    } else if (normalized_dim == 3) {
-        slice_Wt /= ring_size;
-    } else {
-        TT_FATAL(
-            false, "reduce_scatter_minimal_async ring implementation only supports scattering on dim 0, 1, 2, or 3");
-    }
-
-    TT_FATAL(
-        !(fuse_op && normalized_dim == 0),
-        "reduce_scatter_minimal_async ring implementation can't be fused with matmul when scattering on dim 0");
-
-    const uint32_t input_tensor_num_pages = input_tensor.buffer()->num_pages();
-    const uint32_t output_tensor_num_pages = input_tensor_num_pages / ring_size;
-    const uint32_t input_batch_num_pages = input_tensor_num_pages / input_tensor_B;
-    const uint32_t output_batch_num_pages = output_tensor_num_pages / slice_B;
-    const uint32_t input_channel_num_pages = input_batch_num_pages / input_tensor_C;
-    const uint32_t output_channel_num_pages = output_batch_num_pages / slice_C;
-
     // op hyperparams
     // Get worker cores
     // 2 senders per direction (2: forward, backward) per link (num_links)
@@ -440,10 +392,12 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
             ring_size,
             num_directions_per_link,
             num_mux_cores_per_direction_per_link));
-    // Never allocate more workers than there are pages to hand out; an empty-range worker deadlocks
-    // the per-batch barrier below.
+    // Never allocate more workers than there are pages to hand out; a worker with an empty page range
+    // never reaches the per-batch barrier the others wait on, so the op hangs.
     num_workers_per_direction = ttnn::experimental::ccl::reduce_scatter_clamp_workers_to_available_pages(
-        num_workers_per_direction, num_links, normalized_dim == 0 ? output_batch_num_pages : output_channel_num_pages);
+        num_workers_per_direction,
+        num_links,
+        ttnn::experimental::ccl::reduce_scatter_pages_to_distribute(input_tensor, dim, ring_size));
     if (num_workers_per_direction == 1) {
         num_mux_cores_per_direction_per_link = 0;
     }
@@ -497,6 +451,54 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 
     CoreRangeSet sender_worker_core_range_set = CoreRangeSet(sender_worker_core_ranges);
     CoreRangeSet mux_core_range_set = CoreRangeSet(mux_core_ranges);
+
+    // Tensor Info
+    const auto& input_tensor_shape = input_tensor.padded_shape();
+    TT_FATAL(
+        !(input_tensor_shape[-2] % tt::constants::TILE_HEIGHT),
+        "Input tensor height ({}) must be divisible by tile height ({}).",
+        input_tensor_shape[-2],
+        tt::constants::TILE_HEIGHT);
+    TT_FATAL(
+        !(input_tensor_shape[-1] % tt::constants::TILE_WIDTH),
+        "Input tensor width ({}) must be divisible by tile width ({}).",
+        input_tensor_shape[-1],
+        tt::constants::TILE_WIDTH);
+
+    const auto [normalized_dim, input_tensor_C, input_tensor_B] =
+        (input_tensor_shape.rank() == 2)
+            ? ttnn::experimental::ccl::reduce_scatter_map_2d_to_4d(dim)
+            : ttnn::experimental::ccl::reduce_scatter_map_nd_to_4d(input_tensor_shape, dim);
+    const uint32_t input_tensor_Ht = input_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
+    const uint32_t input_tensor_Wt = input_tensor_shape[-1] / tt::constants::TILE_WIDTH;
+
+    uint32_t slice_B = input_tensor_B;
+    uint32_t slice_C = input_tensor_C;
+    uint32_t slice_Ht = input_tensor_Ht;
+    uint32_t slice_Wt = input_tensor_Wt;
+    if (normalized_dim == 0) {
+        slice_B /= ring_size;
+    } else if (normalized_dim == 1) {
+        slice_C /= ring_size;
+    } else if (normalized_dim == 2) {
+        slice_Ht /= ring_size;
+    } else if (normalized_dim == 3) {
+        slice_Wt /= ring_size;
+    } else {
+        TT_FATAL(
+            false, "reduce_scatter_minimal_async ring implementation only supports scattering on dim 0, 1, 2, or 3");
+    }
+
+    TT_FATAL(
+        !(fuse_op && normalized_dim == 0),
+        "reduce_scatter_minimal_async ring implementation can't be fused with matmul when scattering on dim 0");
+
+    const uint32_t input_tensor_num_pages = input_tensor.buffer()->num_pages();
+    const uint32_t output_tensor_num_pages = input_tensor_num_pages / ring_size;
+    const uint32_t input_batch_num_pages = input_tensor_num_pages / input_tensor_B;
+    const uint32_t output_batch_num_pages = output_tensor_num_pages / slice_B;
+    const uint32_t input_channel_num_pages = input_batch_num_pages / input_tensor_C;
+    const uint32_t output_channel_num_pages = output_batch_num_pages / slice_C;
 
     // Extract compute kernel config parameters
     const bool fp32_dest_acc_en = ttnn::get_fp32_dest_acc_en(compute_kernel_config);
@@ -1081,56 +1083,6 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     bool is_first_chip = ring_index == 0;
     bool is_last_chip = ring_index == ring_size - 1;
 
-    bool fuse_op = fused_op_signaler.has_value();
-
-    // Tensor Info
-    const auto& input_tensor_shape = input_tensor.padded_shape();
-    TT_FATAL(
-        !(input_tensor_shape[-2] % tt::constants::TILE_HEIGHT),
-        "Input tensor height ({}) must be divisible by tile height ({}).",
-        input_tensor_shape[-2],
-        tt::constants::TILE_HEIGHT);
-    TT_FATAL(
-        !(input_tensor_shape[-1] % tt::constants::TILE_WIDTH),
-        "Input tensor width ({}) must be divisible by tile width ({}).",
-        input_tensor_shape[-1],
-        tt::constants::TILE_WIDTH);
-
-    const auto [normalized_dim, input_tensor_C, input_tensor_B] =
-        (input_tensor_shape.rank() == 2)
-            ? ttnn::experimental::ccl::reduce_scatter_map_2d_to_4d(dim)
-            : ttnn::experimental::ccl::reduce_scatter_map_nd_to_4d(input_tensor_shape, dim);
-    const uint32_t input_tensor_Ht = input_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
-    const uint32_t input_tensor_Wt = input_tensor_shape[-1] / tt::constants::TILE_WIDTH;
-
-    uint32_t slice_B = input_tensor_B;
-    uint32_t slice_C = input_tensor_C;
-    uint32_t slice_Ht = input_tensor_Ht;
-    uint32_t slice_Wt = input_tensor_Wt;
-    if (normalized_dim == 0) {
-        slice_B /= ring_size;
-    } else if (normalized_dim == 1) {
-        slice_C /= ring_size;
-    } else if (normalized_dim == 2) {
-        slice_Ht /= ring_size;
-    } else if (normalized_dim == 3) {
-        slice_Wt /= ring_size;
-    } else {
-        TT_FATAL(
-            false, "reduce_scatter_minimal_async line implementation only supports scattering on dim 0, 1, 2, or 3");
-    }
-
-    TT_FATAL(
-        !(fuse_op && normalized_dim == 0),
-        "reduce_scatter_minimal_async line implementation can't be fused with matmul when scattering on dim 0");
-
-    const uint32_t input_tensor_num_pages = input_tensor.buffer()->num_pages();
-    const uint32_t output_tensor_num_pages = input_tensor_num_pages / ring_size;
-    const uint32_t input_batch_num_pages = input_tensor_num_pages / input_tensor_B;
-    const uint32_t output_batch_num_pages = output_tensor_num_pages / slice_B;
-    const uint32_t input_channel_num_pages = input_batch_num_pages / input_tensor_C;
-    const uint32_t output_channel_num_pages = output_batch_num_pages / slice_C;
-
     // op hyperparams
     // Get worker cores
     // 2 senders (reader + core + writer) per direction (forward, backward) per link
@@ -1147,10 +1099,12 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
             ring_size,
             num_directions_per_link,
             num_mux_cores_per_direction_per_link));
-    // Never allocate more workers than there are pages to hand out; an empty-range worker moves no
-    // data and only adds synchronization overhead.
+    // Never allocate more workers than there are pages to hand out; a worker with an empty page range
+    // moves no data and only adds synchronization overhead.
     num_workers_per_direction = ttnn::experimental::ccl::reduce_scatter_clamp_workers_to_available_pages(
-        num_workers_per_direction, num_links, normalized_dim == 0 ? output_batch_num_pages : output_channel_num_pages);
+        num_workers_per_direction,
+        num_links,
+        ttnn::experimental::ccl::reduce_scatter_pages_to_distribute(input_tensor, dim, ring_size));
     log_trace(tt::LogOp, "DEBUG: num_workers_per_direction: {}", num_workers_per_direction);
     uint32_t num_buffers_full_size_channels = num_buffers_per_channel.value_or(1);
 
@@ -1160,6 +1114,8 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
         sender_device_coord,
         is_first_chip,
         is_last_chip);
+
+    bool fuse_op = fused_op_signaler.has_value();
 
     // Get OP Config, topology config
     uint32_t page_size = input_tensor.buffer()->page_size();
@@ -1256,6 +1212,54 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
             cb_num_pages * l1_scratch_cb_page_size_bytes, {{compute_output_cb_index, df}})
             .set_page_size(compute_output_cb_index, l1_scratch_cb_page_size_bytes);
     CreateCircularBuffer(program, sender_worker_core_range_set, cb_compute_output_config);
+
+    // Tensor Info
+    const auto& input_tensor_shape = input_tensor.padded_shape();
+    TT_FATAL(
+        !(input_tensor_shape[-2] % tt::constants::TILE_HEIGHT),
+        "Input tensor height ({}) must be divisible by tile height ({}).",
+        input_tensor_shape[-2],
+        tt::constants::TILE_HEIGHT);
+    TT_FATAL(
+        !(input_tensor_shape[-1] % tt::constants::TILE_WIDTH),
+        "Input tensor width ({}) must be divisible by tile width ({}).",
+        input_tensor_shape[-1],
+        tt::constants::TILE_WIDTH);
+
+    const auto [normalized_dim, input_tensor_C, input_tensor_B] =
+        (input_tensor_shape.rank() == 2)
+            ? ttnn::experimental::ccl::reduce_scatter_map_2d_to_4d(dim)
+            : ttnn::experimental::ccl::reduce_scatter_map_nd_to_4d(input_tensor_shape, dim);
+    const uint32_t input_tensor_Ht = input_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
+    const uint32_t input_tensor_Wt = input_tensor_shape[-1] / tt::constants::TILE_WIDTH;
+
+    uint32_t slice_B = input_tensor_B;
+    uint32_t slice_C = input_tensor_C;
+    uint32_t slice_Ht = input_tensor_Ht;
+    uint32_t slice_Wt = input_tensor_Wt;
+    if (normalized_dim == 0) {
+        slice_B /= ring_size;
+    } else if (normalized_dim == 1) {
+        slice_C /= ring_size;
+    } else if (normalized_dim == 2) {
+        slice_Ht /= ring_size;
+    } else if (normalized_dim == 3) {
+        slice_Wt /= ring_size;
+    } else {
+        TT_FATAL(
+            false, "reduce_scatter_minimal_async line implementation only supports scattering on dim 0, 1, 2, or 3");
+    }
+
+    TT_FATAL(
+        !(fuse_op && normalized_dim == 0),
+        "reduce_scatter_minimal_async line implementation can't be fused with matmul when scattering on dim 0");
+
+    const uint32_t input_tensor_num_pages = input_tensor.buffer()->num_pages();
+    const uint32_t output_tensor_num_pages = input_tensor_num_pages / ring_size;
+    const uint32_t input_batch_num_pages = input_tensor_num_pages / input_tensor_B;
+    const uint32_t output_batch_num_pages = output_tensor_num_pages / slice_B;
+    const uint32_t input_channel_num_pages = input_batch_num_pages / input_tensor_C;
+    const uint32_t output_channel_num_pages = output_batch_num_pages / slice_C;
 
     bool input_is_sharded = input_tensor.is_sharded();
     bool intermediate_is_sharded = intermediate_tensor.is_sharded();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reduce_scatter_minimal_async.hpp"
+
+#include <algorithm>
+
 #include "device/reduce_scatter_minimal_async_op_device_operation.hpp"
 #include "ttnn/operations/experimental/ccl/composite_common.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_common/reduce_scatter_program_utils.hpp"
@@ -30,9 +33,8 @@ ttnn::Tensor reduce_scatter_minimal_async(
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto* mesh_device = input_tensor.device();
     TT_FATAL(mesh_device != nullptr, "Mesh device is required for reduce_scatter_minimal_async operation");
-    uint32_t resolved_num_links = std::min(
-        num_links.value_or(ttnn::operations::ccl::common::get_num_links(*mesh_device, cluster_axis)),
-        input_tensor.buffer()->num_pages());
+    uint32_t resolved_num_links =
+        num_links.value_or(ttnn::operations::ccl::common::get_num_links(*mesh_device, cluster_axis));
 
     int32_t rank = input_tensor.logical_shape().rank();
     int32_t scatter_dim = (dim < 0) ? rank + dim : dim;
@@ -70,6 +72,16 @@ ttnn::Tensor reduce_scatter_minimal_async(
             num_buffers_per_channel,
             resolved_compute_kernel_config);
     }
+
+    // The program factory splits the pages of one output channel (one batch for dim 0 scatters) across
+    // all num_links * num_workers_per_direction workers. Small tensors can have fewer pages than links,
+    // and a link whose workers get an empty page range hangs waiting on a barrier the others already
+    // passed, so cap the link count to the pages actually available. Resolved here rather than in the
+    // program factory so that the num_links op attribute and the program agree -- the cache-hit
+    // override_runtime_arguments path iterates over the attribute.
+    const uint32_t pages_to_distribute =
+        ttnn::experimental::ccl::reduce_scatter_pages_to_distribute(input_tensor, scatter_dim, num_devices);
+    resolved_num_links = std::max(1u, std::min(resolved_num_links, pages_to_distribute));
 
     bool using_persistent_buffers = persistent_output_buffers.has_value();
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -30,8 +30,9 @@ ttnn::Tensor reduce_scatter_minimal_async(
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto* mesh_device = input_tensor.device();
     TT_FATAL(mesh_device != nullptr, "Mesh device is required for reduce_scatter_minimal_async operation");
-    uint32_t resolved_num_links =
-        num_links.value_or(ttnn::operations::ccl::common::get_num_links(*mesh_device, cluster_axis));
+    uint32_t resolved_num_links = std::min(
+        num_links.value_or(ttnn::operations::ccl::common::get_num_links(*mesh_device, cluster_axis)),
+        input_tensor.buffer()->num_pages());
 
     int32_t rank = input_tensor.logical_shape().rank();
     int32_t scatter_dim = (dim < 0) ? rank + dim : dim;


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/51808

### Summary
T3K test [pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/30336877623/job/90207419968) was hanging. Worker cores were spun up based on a heuristic that didn't directly account for workers getting assigned zero pages, leading to a hang. Tweaked the logic for assigned workers and picking pages so everyone has something to do.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/reduce-scatter-t3k-test-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/reduce-scatter-t3k-test-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/reduce-scatter-t3k-test-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/reduce-scatter-t3k-test-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amorrison/reduce-scatter-t3k-test-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amorrison/reduce-scatter-t3k-test-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/reduce-scatter-t3k-test-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/reduce-scatter-t3k-test-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/reduce-scatter-t3k-test-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/reduce-scatter-t3k-test-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/reduce-scatter-t3k-test-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/reduce-scatter-t3k-test-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/reduce-scatter-t3k-test-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/reduce-scatter-t3k-test-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/reduce-scatter-t3k-test-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/reduce-scatter-t3k-test-hang)