### PR TITLE
Add Cursor Cloud dev-environment instructions (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is **tenstorrent/tt-metal**, a C++/Python SDK + model zoo for Tenstorrent AI
+accelerators (Wormhole / Blackhole / Quasar). See `README.md`, `INSTALLING.md`,
+`CONTRIBUTING.md`, and `tt_metal/tt-llk/tests/README.md` for the full docs.
+
+### Hardware reality in the cloud VM
+
+There is **no Tenstorrent device** in the Cursor Cloud VM (`/dev/tenstorrent`
+does not exist). Anything that opens a real device cannot run end to end here:
+the full `./build_metal.sh` C++ build + `ttnn` Python API + `models/` demos +
+`tt-train` all require silicon (or a much heavier RTL/emulation setup) to
+actually execute. Do not expect `python3 -m ttnn.examples.usage.run_op_on_device`
+or device pytest suites to pass without hardware.
+
+### What DOES run without hardware: LLK tests on the ttsim functional simulator
+
+The supported silicon-free path is the low-level-kernel (LLK) test suite running
+on [ttsim](https://github.com/tenstorrent/ttsim), Tenstorrent's functional
+simulator. It compiles real kernels with the SFPI compiler and runs
+unpack → math → pack on a modeled Blackhole/Wormhole chip. Full docs:
+`tt_metal/tt-llk/tests/TTSIM.md`.
+
+The environment set up by the update script / snapshot already provides:
+- Python 3.10 venv at `tt_metal/tt-llk/tests/.venv` (deps from
+  `tt_metal/tt-llk/tests/requirements.txt`, includes `tt-exalens`, `tt-umd`,
+  CPU `torch`).
+- SFPI toolchain at `tt_metal/tt-llk/tests/sfpi` (via `setup_testing_env.sh`).
+- ttsim Blackhole library + SoC descriptor at `~/sim/` (`libttsim_bh.so`,
+  `soc_descriptor.yaml`). This lives in `$HOME`, not the repo — if the snapshot
+  is ever reset, re-download it per `TTSIM.md` (Blackhole/Wormhole libs from
+  the ttsim GitHub releases; copy `tt_metal/soc_descriptors/blackhole_140_arch.yaml`
+  to `~/sim/soc_descriptor.yaml`).
+
+Run a test on the simulator:
+
+```bash
+source tt_metal/tt-llk/tests/.venv/bin/activate
+export TT_METAL_SIMULATOR=~/sim/libttsim_bh.so
+export TT_METAL_DISABLE_SFPLOADMACRO=1   # ttsim does not implement SFPLOADMACRO
+cd tt_metal/tt-llk/tests/python_tests
+pytest -v --run-simulator --timeout=300 \
+  "test_eltwise_unary_datacopy.py::test_unary_datacopy[formats:Float16_b->Float16_b-dest_acc:No-num_faces:4-tilize:No-input_dimensions:[64, 64]]"
+```
+
+Non-obvious gotchas:
+- `--run-simulator` is required; without `TT_METAL_SIMULATOR` set the suite
+  exits with an error.
+- **`-k` filtering is a trap here.** Every parametrized test id contains the
+  substring `tilize` (as `tilize:No`/`tilize:Yes`), so the smoke-test example in
+  `TTSIM.md` (`-k "Float16_b and not tilize"`) deselects *all* tests. Prefer
+  running explicit node ids (as above). Also note `-k` rejects the `>`, `:`,
+  and `,` characters that appear in ids, so you cannot paste a full id into `-k`.
+- ttsim is slow-dispatch only and substantially slower than silicon; use it for
+  correctness, not performance numbers. Unmodeled opcodes surface as
+  `UnimplementedFunctionality` from the simulator (a ttsim ISA gap, not a test
+  bug).
+
+### Linting
+
+Canonical lint is pre-commit (`.pre-commit-config.yaml` at the repo root, plus
+LLK-specific hooks in the same file; `tt_metal/tt-llk/` has its own config too).
+`pre-commit` is installed in the tt-llk venv.
+
+Gotcha: `pre-commit install` fails in the cloud VM with *"Cowardly refusing to
+install hooks with `core.hooksPath` set"* (the agent sets `core.hooksPath`).
+This is harmless — do **not** unset `core.hooksPath`. Just run hooks directly
+without installing the git hook:
+
+```bash
+source tt_metal/tt-llk/tests/.venv/bin/activate
+pre-commit run --files <paths...>   # or: pre-commit run --all-files (slow on this monorepo)
+```
+
+The first `pre-commit run` downloads hook environments (clang-format, black,
+isort, autoflake, pylint, yamllint, codespell, gersemi); these are cached in the
+snapshot afterward.
+
+### Building full tt-metal (optional, hardware-bound)
+
+`./install_dependencies.sh` + `./build_metal.sh` + `./create_venv.sh` build the
+full C++/Python stack (needs Clang, Ninja, submodules, SFPI). This is a large
+build and, without a device, the resulting `ttnn`/models still cannot execute
+kernels. Only pursue it if the task specifically needs the C++ build to compile.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and documents a working development environment for this repository in the Cursor Cloud VM, and captures durable, non-obvious guidance for future agents in a new `AGENTS.md`.

## Context

`tt-metal` is a C++/Python SDK for Tenstorrent AI accelerators. The cloud VM has **no Tenstorrent device** (`/dev/tenstorrent` is absent), so the full `build_metal.sh` C++ build + `ttnn`/`models`/`tt-train` cannot execute kernels end to end here. The supported **silicon-free** path is the LLK test suite running on the [`ttsim`](https://github.com/tenstorrent/ttsim) functional simulator, which compiles real kernels with SFPI and runs unpack → math → pack on a modeled Blackhole chip.

## What was set up (in the VM snapshot)

- System build deps (`libyaml-cpp-dev`, `libhwloc-dev`, `libzmq3-dev`, `git-lfs`, `xxd`, etc.), `uv`, and Python 3.10.
- Python 3.10 venv at `tt_metal/tt-llk/tests/.venv` from `tt_metal/tt-llk/tests/requirements.txt` (includes `tt-exalens`, `tt-umd`, CPU `torch`).
- SFPI toolchain via `tt_metal/tt-llk/tests/setup_testing_env.sh`.
- `ttsim` Blackhole library + SoC descriptor at `~/sim/`.

## Verified end to end

- **Run (hello world compute):** LLK datacopy tests pass on the ttsim simulator (real kernels, unpack→math→pack) across multiple formats, tile shapes, and dest-accumulation modes — `pytest --run-simulator` from `tt_metal/tt-llk/tests/python_tests`.
- **Lint:** `pre-commit run` passes (black/isort/autoflake/pylint/codespell + repo-wide checks).

## Update script (registered separately)

Minimal + idempotent: ensures `uv`, refreshes the tt-llk test venv from `requirements.txt`, and refreshes SFPI (a no-op when already current). It only references files already in the repo, so it is safe even if this PR is not merged.

## Notes captured in AGENTS.md

- No hardware ⇒ device suites / `ttnn` / models can't run E2E; use the ttsim LLK path.
- `pre-commit install` fails with `core.hooksPath set` in the cloud VM — harmless; run `pre-commit run --files ...` directly (do not unset `core.hooksPath`).
- `-k` gotcha: every test id contains `tilize`, so `-k "... and not tilize"` deselects everything; use explicit node ids.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08d03e23-ca38-4699-9384-17547cda286f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08d03e23-ca38-4699-9384-17547cda286f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kzhao/cloud-dev-env-setup-286f)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kzhao/cloud-dev-env-setup-286f)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kzhao/cloud-dev-env-setup-286f)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kzhao/cloud-dev-env-setup-286f)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kzhao/cloud-dev-env-setup-286f)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kzhao/cloud-dev-env-setup-286f)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kzhao/cloud-dev-env-setup-286f)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kzhao/cloud-dev-env-setup-286f)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kzhao/cloud-dev-env-setup-286f)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kzhao/cloud-dev-env-setup-286f)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kzhao/cloud-dev-env-setup-286f)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kzhao/cloud-dev-env-setup-286f)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kzhao/cloud-dev-env-setup-286f)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kzhao/cloud-dev-env-setup-286f)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kzhao/cloud-dev-env-setup-286f)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kzhao/cloud-dev-env-setup-286f)