### PR TITLE
[Cleanup] Deprecating `MeshDevice::get_devices`

### DIFF
--- a/tests/tt_metal/distributed/hd_socket_test_utils.cpp
+++ b/tests/tt_metal/distributed/hd_socket_test_utils.cpp
@@ -4,12 +4,13 @@
 
 #include "hd_socket_test_utils.hpp"
 #include "tt_metal/fabric/physical_system_discovery.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::distributed {
 
 bool is_device_coord_mmio_mapped(const std::shared_ptr<MeshDevice>& mesh_device, const MeshCoordinate& device_coord) {
     const auto& cluster = MetalContext::instance().get_cluster();
-    auto device_id = mesh_device->get_device(device_coord)->id();
+    auto device_id = mesh_device->impl().get_device(device_coord)->id();
     return cluster.get_associated_mmio_device(device_id) == device_id;
 }
 

--- a/tests/tt_metal/distributed/test_hd_sockets.cpp
+++ b/tests/tt_metal/distributed/test_hd_sockets.cpp
@@ -26,6 +26,7 @@
 #include <tt-metalium/tt_align.hpp>
 #include "tt_metal/llrt/tt_cluster.hpp"
 #include "tt_metal/distributed/fd_mesh_command_queue.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::distributed {
 
@@ -95,7 +96,7 @@ void test_h2d_socket(
         cluster.read_core(
             recv_data_readback.data(),
             data_size,
-            tt_cxy_pair(mesh_device->get_device(recv_core.device_coord)->id(), recv_core_virtual),
+            tt_cxy_pair(mesh_device->impl().get_device(recv_core.device_coord)->id(), recv_core_virtual),
             recv_data_buffer->address());
         EXPECT_EQ(src_vec, recv_data_readback);
     }
@@ -341,7 +342,7 @@ void test_hd_socket_multithreaded_loopback(
 bool is_device_coord_mmio_mapped(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device, const MeshCoordinate& device_coord) {
     const auto& cluster = MetalContext::instance().get_cluster();
-    auto device_id = mesh_device->get_device(device_coord)->id();
+    auto device_id = mesh_device->impl().get_device(device_coord)->id();
     return cluster.get_associated_mmio_device(device_id) == device_id;
 }
 

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -68,7 +68,7 @@ TEST_F(MeshDevice2x4Test, SystemMeshTearDownWithoutClose) {
 
 TEST_F(MeshDevice2x4Test, MemoryAllocationStatistics) {
     auto stats = mesh_device_->allocator()->get_statistics(tt::tt_metal::BufferType::DRAM);
-    for (auto* device : mesh_device_->get_devices()) {
+    for (auto* device : mesh_device_->impl().get_devices()) {
         auto device_stats = device->allocator()->get_statistics(tt::tt_metal::BufferType::DRAM);
         EXPECT_EQ(stats.total_allocatable_size_bytes, device_stats.total_allocatable_size_bytes);
     }
@@ -103,14 +103,14 @@ TEST_F(MeshDevice2x4Test, CreateSubmeshInvalidConfig) {
 
 TEST_F(MeshDevice2x4Test, CreateSubmesh) {
     EXPECT_EQ(mesh_device_->shape(), MeshShape(2, 4));
-    EXPECT_THAT(mesh_device_->get_devices(), SizeIs(8));
+    EXPECT_THAT(mesh_device_->impl().get_devices(), SizeIs(8));
     EXPECT_TRUE(mesh_device_->is_parent_mesh());
     EXPECT_THAT(mesh_device_->get_submeshes(), IsEmpty());
 
     auto submesh = mesh_device_->create_submesh(MeshShape{1, 2}, MeshCoordinate{1, 1});
     EXPECT_THAT(mesh_device_->get_submeshes(), SizeIs(1));
     EXPECT_EQ(submesh->shape(), MeshShape(1, 2));
-    EXPECT_THAT(submesh->get_devices(), SizeIs(2));
+    EXPECT_THAT(submesh->impl().get_devices(), SizeIs(2));
     EXPECT_FALSE(submesh->is_parent_mesh());
     EXPECT_THAT(submesh->get_submeshes(), IsEmpty());
 
@@ -136,7 +136,7 @@ TEST_F(MeshDevice2x4Test, CreateSubmeshes) {
     EXPECT_THAT(submeshes, SizeIs(4));
     for (const auto& submesh : submeshes) {
         EXPECT_EQ(submesh->shape(), MeshShape(1, 2));
-        EXPECT_THAT(submesh->get_devices(), SizeIs(2));
+        EXPECT_THAT(submesh->impl().get_devices(), SizeIs(2));
     }
 
     EXPECT_EQ(mesh_device_->get_submeshes(), submeshes);

--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -36,6 +36,7 @@
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::distributed::test {
 namespace {
@@ -145,7 +146,7 @@ TEST_F(MeshSubDeviceTestSuite, DataCopyOnSubDevices) {
         // buffer data
         EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), input_buf, src_vec, true);
 
-        for (auto* device : mesh_device_->get_devices()) {
+        for (auto* device : mesh_device_->impl().get_devices()) {
             MetalContext::instance().get_cluster().write_core(
                 device->id(), syncer_core_phys, std::vector<uint32_t>{1}, global_sem.address());
         }

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -49,6 +49,7 @@
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::distributed::test {
 namespace {
@@ -460,7 +461,7 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), datacopy_mesh_workload, false);
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), add_mesh_workload, false);
 
-    for (auto* device : mesh_device_->get_devices()) {
+    for (auto* device : mesh_device_->impl().get_devices()) {
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             device->id(), syncer_core_phys, std::vector<uint32_t>{1}, global_sem.address());
     }
@@ -483,7 +484,7 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
         mesh_device_->set_sub_device_stall_group({{SubDeviceId{2}}});
         EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), input_buf, src_vec, true);
 
-        for (auto* device : mesh_device_->get_devices()) {
+        for (auto* device : mesh_device_->impl().get_devices()) {
             tt::tt_metal::MetalContext::instance().get_cluster().write_core(
                 device->id(), syncer_core_phys, std::vector<uint32_t>{1}, global_sem.address());
         }

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -771,7 +771,7 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSemaphoreSanity) {
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_workload, false);
     Finish(mesh_device_->mesh_command_queue());
 
-    for (auto* const device : mesh_device_->get_devices()) {
+    for (auto* const device : mesh_device_->impl().get_devices()) {
         validate_sems(mesh_device_, device, full_grid, mesh_workload, expected_semaphore_values);
     }
 }

--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
@@ -18,6 +18,7 @@
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "intermesh_routing_test_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_fabric::fabric_router_tests::multihost_utils {
 std::random_device rd;  // Non-deterministic seed source
@@ -90,7 +91,7 @@ void run_unicast_sender_step(BaseFabricFixture* fixture, tt::tt_metal::distribut
     );
     // Randomly select a tx device
     auto random_dev = std::uniform_int_distribution<uint32_t>(0, devices.size() - 1)(global_rng);
-    auto src_physical_device_id = devices[random_dev]->get_devices()[0]->id();
+    auto src_physical_device_id = devices[random_dev]->impl().get_devices()[0]->id();
     auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
     auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
     const auto& sender_device = devices[random_dev];
@@ -165,7 +166,7 @@ void run_unicast_sender_step(BaseFabricFixture* fixture, tt::tt_metal::distribut
     std::vector<uint32_t> sender_status;
 
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -212,7 +213,7 @@ void run_unicast_recv_step(BaseFabricFixture* fixture, tt::tt_metal::distributed
 
     // Randomly select an rx device
     auto random_dev = std::uniform_int_distribution<uint32_t>(0, devices.size() - 1)(global_rng);
-    auto dst_physical_device_id = devices[random_dev]->get_devices()[0]->id();
+    auto dst_physical_device_id = devices[random_dev]->impl().get_devices()[0]->id();
     auto dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_physical_device_id);
     const auto& receiver_device = devices[random_dev];
 
@@ -255,7 +256,7 @@ void run_unicast_recv_step(BaseFabricFixture* fixture, tt::tt_metal::distributed
     std::vector<uint32_t> receiver_status;
 
     tt_metal::detail::ReadFromDeviceL1(
-        receiver_device->get_devices()[0],
+        receiver_device->impl().get_devices()[0],
         receiver_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -372,7 +373,7 @@ void run_mcast_sender_step(
     // Validate status of sender
     std::vector<uint32_t> sender_status;
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -483,7 +484,7 @@ void run_mcast_recv_step(
     for (auto& [dev, _] : recv_programs) {
         std::vector<uint32_t> receiver_status;
         tt_metal::detail::ReadFromDeviceL1(
-            dev->get_devices()[0],
+            dev->impl().get_devices()[0],
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,

--- a/tests/tt_metal/multihost/socket_pipeline/multiprocess/multi_host_pipeline.cpp
+++ b/tests/tt_metal/multihost/socket_pipeline/multiprocess/multi_host_pipeline.cpp
@@ -22,6 +22,7 @@
 #include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include "tt_metal/fabric/physical_system_discovery.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -960,7 +961,7 @@ void run_single_galaxy_pipeline(
     barrier();
     if (is_pipeline_start) {
         const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-        auto start_device_id = mesh_device->get_device(start_coord)->id();
+        auto start_device_id = mesh_device->impl().get_device(start_coord)->id();
         auto start_core_coord = mesh_device->worker_core_from_logical_core(logical_coord);
         std::vector<uint64_t> latencies = std::vector<uint64_t>(num_iterations, 0);
         uint32_t base_addr = latency_measurement_address;

--- a/tests/tt_metal/multihost/socket_pipeline/multiprocess/single_host_pipeline_tests.cpp
+++ b/tests/tt_metal/multihost/socket_pipeline/multiprocess/single_host_pipeline_tests.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -42,11 +43,11 @@ void run_single_host_loopback_pipeline(
     auto intermed_device_coord_3 = MeshCoordinate(0, 1);
     auto end_device_coord = MeshCoordinate(0, 0);
 
-    log_info(tt::LogTest, "Start Device ID: {}", mesh_device->get_device(start_device_coord)->id());
-    log_info(tt::LogTest, "Intermed Device ID: {}", mesh_device->get_device(intermed_device_coord)->id());
-    log_info(tt::LogTest, "Intermed Device 2 ID: {}", mesh_device->get_device(intermed_device_coord_2)->id());
-    log_info(tt::LogTest, "Intermed Device 3 ID: {}", mesh_device->get_device(intermed_device_coord_3)->id());
-    log_info(tt::LogTest, "End Device ID: {}", mesh_device->get_device(end_device_coord)->id());
+    log_info(tt::LogTest, "Start Device ID: {}", mesh_device->impl().get_device(start_device_coord)->id());
+    log_info(tt::LogTest, "Intermed Device ID: {}", mesh_device->impl().get_device(intermed_device_coord)->id());
+    log_info(tt::LogTest, "Intermed Device 2 ID: {}", mesh_device->impl().get_device(intermed_device_coord_2)->id());
+    log_info(tt::LogTest, "Intermed Device 3 ID: {}", mesh_device->impl().get_device(intermed_device_coord_3)->id());
+    log_info(tt::LogTest, "End Device ID: {}", mesh_device->impl().get_device(end_device_coord)->id());
 
     // Create connections for:
     // Stage 0 -> 1
@@ -157,7 +158,7 @@ void run_single_host_loopback_pipeline(
     Synchronize(mesh_device.get(), std::nullopt);
 
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    auto start_device_id = mesh_device->get_device(start_device_coord)->id();
+    auto start_device_id = mesh_device->impl().get_device(start_device_coord)->id();
     auto start_core_coord = mesh_device->worker_core_from_logical_core(sender_logical_coord);
     std::vector<uint64_t> latencies = std::vector<uint64_t>(NUM_ITERATIONS, 0);
     cluster.read_core(
@@ -209,10 +210,10 @@ void run_single_host_rate_pipeline(
     auto fwd_device_coord_2 = MeshCoordinate(1, 1);
     auto recv_device_coord = MeshCoordinate(0, 1);
 
-    log_info(tt::LogTest, "Sender Device ID: {}", mesh_device->get_device(sender_device_coord)->id());
-    log_info(tt::LogTest, "Fwd 1 Device ID: {}", mesh_device->get_device(fwd_device_coord_1)->id());
-    log_info(tt::LogTest, "Fwd 2 Device ID: {}", mesh_device->get_device(fwd_device_coord_2)->id());
-    log_info(tt::LogTest, "Recv Device ID: {}", mesh_device->get_device(recv_device_coord)->id());
+    log_info(tt::LogTest, "Sender Device ID: {}", mesh_device->impl().get_device(sender_device_coord)->id());
+    log_info(tt::LogTest, "Fwd 1 Device ID: {}", mesh_device->impl().get_device(fwd_device_coord_1)->id());
+    log_info(tt::LogTest, "Fwd 2 Device ID: {}", mesh_device->impl().get_device(fwd_device_coord_2)->id());
+    log_info(tt::LogTest, "Recv Device ID: {}", mesh_device->impl().get_device(recv_device_coord)->id());
 
     // Socket connections for linear pipeline
     SocketConnection socket_connection_01 = SocketConnection(

--- a/tests/tt_metal/multihost/socket_pipeline/multiprocess/utils/mesh_socket_forward.cpp
+++ b/tests/tt_metal/multihost/socket_pipeline/multiprocess/utils/mesh_socket_forward.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/sockets/mesh_socket.hpp>
 #include <tt-metalium/cluster.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -161,7 +162,7 @@ void socket_forward(
     const auto& device_coord = send_socket_connections[0].sender_core.device_coord;
 
     // Check if this device coordinate is local to this mesh device
-    auto* target_device = mesh_device->get_device(device_coord);
+    auto* target_device = mesh_device->impl().get_device(device_coord);
     TT_FATAL(target_device != nullptr, "SocketForward device coordinate not found in mesh device");
 
     distributed::MeshWorkload workload;

--- a/tests/tt_metal/multihost/socket_pipeline/multiprocess/utils/mesh_socket_rate.cpp
+++ b/tests/tt_metal/multihost/socket_pipeline/multiprocess/utils/mesh_socket_rate.cpp
@@ -21,6 +21,7 @@
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/cluster.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt::constants;
 
@@ -372,7 +373,7 @@ void send_async_rate(
 
     const auto& device_coord = socket_connections[0].sender_core.device_coord;
     TT_FATAL(
-        mesh_device->get_device(device_coord) != nullptr,
+        mesh_device->impl().get_device(device_coord) != nullptr,
         "Sender device for socket connection is not local to this mesh device");
 
     distributed::MeshWorkload workload;
@@ -396,7 +397,7 @@ void socket_forward_rate(
     TT_FATAL(recv_socket_connections.size() == 1, "SocketForward only supports one sender and one receiver core.");
 
     const auto& device_coord = send_socket_connections[0].sender_core.device_coord;
-    auto* target_device = mesh_device->get_device(device_coord);
+    auto* target_device = mesh_device->impl().get_device(device_coord);
     TT_FATAL(target_device != nullptr, "SocketForward device coordinate not found in mesh device");
 
     distributed::MeshWorkload workload;
@@ -416,7 +417,7 @@ void recv_async_rate(
     TT_FATAL(recv_socket_connections.size() == 1, "recv_async_rate only supports one connection.");
 
     const auto& device_coord = recv_socket_connections[0].receiver_core.device_coord;
-    auto* target_device = mesh_device->get_device(device_coord);
+    auto* target_device = mesh_device->impl().get_device(device_coord);
     TT_FATAL(target_device != nullptr, "Receiver device coordinate not found in mesh device");
 
     distributed::MeshWorkload workload;

--- a/tests/tt_metal/multihost/socket_pipeline/multiprocess/utils/mesh_socket_send_recv.cpp
+++ b/tests/tt_metal/multihost/socket_pipeline/multiprocess/utils/mesh_socket_send_recv.cpp
@@ -21,6 +21,7 @@
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/cluster.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt::constants;
 
@@ -190,7 +191,7 @@ void send_async(
 
     const auto& device_coord = socket_connections[0].sender_core.device_coord;
     TT_FATAL(
-        mesh_device->get_device(device_coord) != nullptr,
+        mesh_device->impl().get_device(device_coord) != nullptr,
         "Sender device for socket connection is not local to this mesh device");
 
     distributed::MeshWorkload workload;

--- a/tests/tt_metal/tools/profiler/test_full_buffer.cpp
+++ b/tests/tt_metal/tools/profiler/test_full_buffer.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/impl/kernels/kernel.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -21,7 +22,7 @@ constexpr uint32_t FULL_L1_MARKER_COUNT = 256;
 
 void RunFillUpAllBuffers(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, int loop_count, bool fast_dispatch) {
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     CoreCoord compute_with_storage_size = mesh_device->compute_with_storage_grid_size();
     CoreCoord start_core = {0, 0};

--- a/tests/tt_metal/tools/profiler/test_timestamped_events.cpp
+++ b/tests/tt_metal/tools/profiler/test_timestamped_events.cpp
@@ -11,13 +11,14 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/impl/kernels/kernel.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
 
 void RunFillUpAllBuffers(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, int loop_count, bool fast_dispatch) {
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     CoreCoord compute_with_storage_size = mesh_device->compute_with_storage_grid_size();
     CoreCoord start_core = {0, 0};

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -20,6 +20,7 @@
 #include <llrt/tt_cluster.hpp>
 #include <tt-metalium/allocator.hpp>
 #include "test_host_kernel_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_fabric::fabric_router_tests {
 
@@ -135,7 +136,7 @@ public:
     void RunProgramNonblocking(
         const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& device, tt::tt_metal::Program& program) {
         if (this->slow_dispatch_) {
-            tt::tt_metal::detail::LaunchProgram(device->get_devices()[0], program, false);
+            tt::tt_metal::detail::LaunchProgram(device->impl().get_devices()[0], program, false);
         } else {
             tt::tt_metal::distributed::MeshCommandQueue& cq = device->mesh_command_queue();
             // Create a mesh workload from the program
@@ -154,7 +155,7 @@ public:
         const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& device, tt::tt_metal::Program& program) {
         if (this->slow_dispatch_) {
             // Wait for the program to finish
-            tt::tt_metal::detail::WaitProgramDone(device->get_devices()[0], program);
+            tt::tt_metal::detail::WaitProgramDone(device->impl().get_devices()[0], program);
         } else {
             // Wait for all programs on cq to finish
             tt::tt_metal::distributed::MeshCommandQueue& cq = device->mesh_command_queue();

--- a/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.cpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.cpp
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <llrt/tt_cluster.hpp>
 #include "tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_fabric::test_utils {
 
@@ -55,7 +56,7 @@ std::shared_ptr<tt_metal::Program> create_traffic_generator_program(
     auto program = std::make_shared<tt_metal::Program>();
 
     // Use first device
-    auto* src_physical_device = device->get_devices()[0];
+    auto* src_physical_device = device->impl().get_devices()[0];
     // Get source fabric node ID from logical first device
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     FabricNodeId src_fabric_node = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device->id());
@@ -130,7 +131,7 @@ void signal_worker_teardown(
     std::vector<uint32_t> data = {WORKER_TEARDOWN};
 
     // Get the actual device where the kernel is running (first device in mesh)
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     auto virtual_core = mesh_device->virtual_core_from_logical_core(logical_core, CoreType::WORKER);
 

--- a/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
+++ b/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
@@ -40,6 +40,7 @@
 #include <limits>
 
 #include <tt_metal/fabric/ccl/ccl_common.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -140,7 +141,7 @@ static void build_and_enqueue(
         futures.emplace_back(tt::tt_metal::detail::async([&devices, &programs, i, enqueue_only]() {
             if constexpr (std::is_same_v<ProgramContainer, std::vector<Program*>>) {
                 if (!enqueue_only) {
-                    tt::tt_metal::detail::CompileProgram(devices[i]->get_devices()[0], *programs[i]);
+                    tt::tt_metal::detail::CompileProgram(devices[i]->impl().get_devices()[0], *programs[i]);
                 }
                 MeshWorkload mesh_workload;
                 MeshCoordinateRange device_range = MeshCoordinateRange({0, 0}, {0, 0});  // Single device range
@@ -148,7 +149,7 @@ static void build_and_enqueue(
                 tt::tt_metal::distributed::EnqueueMeshWorkload(devices[i]->mesh_command_queue(), mesh_workload, false);
             } else {
                 if (!enqueue_only) {
-                    tt::tt_metal::detail::CompileProgram(devices[i]->get_devices()[0], programs[i]);
+                    tt::tt_metal::detail::CompileProgram(devices[i]->impl().get_devices()[0], programs[i]);
                 }
                 MeshWorkload mesh_workload;
                 MeshCoordinateRange device_range = MeshCoordinateRange({0, 0}, {0, 0});  // Single device range

--- a/tests/tt_metal/tt_fabric/common/utils.cpp
+++ b/tests/tt_metal/tt_fabric/common/utils.cpp
@@ -31,6 +31,7 @@
 #include <utility>
 #include <vector>
 #include <unordered_map>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_fabric::fabric_router_tests {
 
@@ -49,7 +50,8 @@ bool find_device_with_neighbor_in_multi_direction(
     // Find a device with enough neighbours in the specified direction
     bool connection_found = false;
     for (const auto& device : devices) {
-        src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->get_devices()[0]->id());
+        src_fabric_node_id =
+            control_plane.get_fabric_node_id_from_physical_chip_id(device->impl().get_devices()[0]->id());
         if (incoming_direction.has_value()) {
             if (control_plane.get_intra_chip_neighbors(src_fabric_node_id, incoming_direction.value()).empty()) {
                 // This potential source will not have the requested incoming direction, skip
@@ -82,7 +84,7 @@ bool find_device_with_neighbor_in_multi_direction(
             }
         }
         if (connection_found) {
-            src_physical_device_id = device->get_devices()[0]->id();
+            src_physical_device_id = device->impl().get_devices()[0]->id();
             dst_fabric_node_ids_by_dir = std::move(temp_end_fabric_node_ids_by_dir);
             dst_physical_device_ids_by_dir = std::move(temp_physical_end_device_ids_by_dir);
             break;
@@ -101,12 +103,13 @@ bool find_device_with_neighbor_in_direction(
     auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     auto devices = fixture->get_devices();
     for (const auto& device : devices) {
-        src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->get_devices()[0]->id());
+        src_fabric_node_id =
+            control_plane.get_fabric_node_id_from_physical_chip_id(device->impl().get_devices()[0]->id());
 
         // Get neighbours within a mesh in the given direction
         auto neighbors = control_plane.get_intra_chip_neighbors(src_fabric_node_id, direction);
         if (!neighbors.empty()) {
-            src_physical_device_id = device->get_devices()[0]->id();
+            src_physical_device_id = device->impl().get_devices()[0]->id();
             dst_fabric_node_id = FabricNodeId(src_fabric_node_id.mesh_id, neighbors[0]);
             dst_physical_device_id = control_plane.get_physical_chip_id_from_fabric_node_id(dst_fabric_node_id);
             return true;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -39,6 +39,7 @@
 #include "tt_metal/fabric/fabric_builder_context.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include "test_host_kernel_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_fabric::fabric_router_tests {
 std::random_device rd;  // Non-deterministic seed source
@@ -302,10 +303,10 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
     // Launch sender and receiver programs and wait for them to finish
     // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, recv_program] : recv_programs) {
-        log_info(tt::LogTest, "Run receiver on: {}", dev->get_devices()[0]->id());
+        log_info(tt::LogTest, "Run receiver on: {}", dev->impl().get_devices()[0]->id());
         fixture->RunProgramNonblocking(dev, *recv_program);
     }
-    log_info(tt::LogTest, "Run Sender on: {}", sender_device->get_devices()[0]->id());
+    log_info(tt::LogTest, "Run Sender on: {}", sender_device->impl().get_devices()[0]->id());
     fixture->RunProgramNonblocking(sender_device, sender_program);
 
     // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
@@ -316,7 +317,7 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
 
     std::vector<uint32_t> sender_status;
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -331,7 +332,7 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
     for (auto& [dev, _] : recv_programs) {
         std::vector<uint32_t> receiver_status;
         tt_metal::detail::ReadFromDeviceL1(
-            dev->get_devices()[0],
+            dev->impl().get_devices()[0],
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,
@@ -397,8 +398,8 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
         auto random_dev_list = get_random_numbers_from_range(0, devices.size() - 1, devices.size());
 
         // pick the first two in the list to be src and dst devices for the test.
-        src_physical_device_id = devices[random_dev_list[0]]->get_devices()[0]->id();
-        dst_physical_device_id = devices[random_dev_list[1]]->get_devices()[0]->id();
+        src_physical_device_id = devices[random_dev_list[0]]->impl().get_devices()[0]->id();
+        dst_physical_device_id = devices[random_dev_list[1]]->impl().get_devices()[0]->id();
         src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
         dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_physical_device_id);
         mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
@@ -514,7 +515,7 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
     std::vector<uint32_t> receiver_status;
 
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -522,7 +523,7 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
         CoreType::WORKER);
 
     tt_metal::detail::ReadFromDeviceL1(
-        receiver_device->get_devices()[0],
+        receiver_device->impl().get_devices()[0],
         receiver_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -636,12 +637,12 @@ void run_unicast_test_bw_chips(
     if (use_dram_dst) {
         std::vector<uint32_t> zeros(tt::tt_metal::hal::get_l1_alignment() / sizeof(uint32_t), 0);  // zero out mailbox
         tt_metal::detail::WriteToDeviceL1(
-            receiver_device->get_devices()[0],
+            receiver_device->impl().get_devices()[0],
             receiver_logical_core,
             worker_mem_map.notification_mailbox_address,
             zeros,
             CoreType::WORKER);
-        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(receiver_device->get_devices()[0]->id());
+        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(receiver_device->impl().get_devices()[0]->id());
     }
 
     std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
@@ -677,7 +678,7 @@ void run_unicast_test_bw_chips(
     std::vector<uint32_t> receiver_status;
 
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -685,7 +686,7 @@ void run_unicast_test_bw_chips(
         CoreType::WORKER);
 
     tt_metal::detail::ReadFromDeviceL1(
-        receiver_device->get_devices()[0],
+        receiver_device->impl().get_devices()[0],
         receiver_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -741,8 +742,8 @@ void RunTestUnicastConnAPIRandom(BaseFabricFixture* fixture) {
     // In 2D routing the source and desitnation devices can be anywhere on the mesh.
     auto random_dev_list = get_random_numbers_from_range(0, devices.size() - 1, 2);
 
-    const auto src_physical_device_id = devices[random_dev_list[0]]->get_devices()[0]->id();
-    const auto dst_physical_device_id = devices[random_dev_list[1]]->get_devices()[0]->id();
+    const auto src_physical_device_id = devices[random_dev_list[0]]->impl().get_devices()[0]->id();
+    const auto dst_physical_device_id = devices[random_dev_list[1]]->impl().get_devices()[0]->id();
 
     log_info(tt::LogTest, "Src Phys ChipId {}", src_physical_device_id);
     log_info(tt::LogTest, "Dst Phys ChipId {}", dst_physical_device_id);
@@ -1078,7 +1079,7 @@ void RunTestMCastConnAPI(
     std::vector<uint32_t> right_recv_status;
 
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -1098,7 +1099,7 @@ void RunTestMCastConnAPI(
             std::vector<uint32_t> recv_status;
 
             tt_metal::detail::ReadFromDeviceL1(
-                receiver_device->get_devices()[0],
+                receiver_device->impl().get_devices()[0],
                 receiver_logical_core,
                 worker_mem_map.test_results_address,
                 worker_mem_map.test_results_size_bytes,
@@ -1619,7 +1620,7 @@ void RunTest2DMCastConnAPI(
     std::vector<uint32_t> right_recv_status;
 
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -1638,7 +1639,7 @@ void RunTest2DMCastConnAPI(
         std::vector<uint32_t> recv_status;
 
         tt_metal::detail::ReadFromDeviceL1(
-            receiver_device->get_devices()[0],
+            receiver_device->impl().get_devices()[0],
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,
@@ -1840,7 +1841,7 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
     std::vector<uint32_t> right_recv_status;
 
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -1867,7 +1868,7 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
             std::vector<uint32_t> recv_status;
 
             tt_metal::detail::ReadFromDeviceL1(
-                receiver_device->get_devices()[0],
+                receiver_device->impl().get_devices()[0],
                 receiver_logical_core,
                 worker_mem_map.test_results_address,
                 worker_mem_map.test_results_size_bytes,
@@ -2045,10 +2046,10 @@ void RunEDMConnectionStressTest(
                 worker_args.push_back(i % packet_sizes.size());
                 worker_args.push_back(i % message_counts.size());
 
-                const auto sender_fabric_node_id =
-                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->get_devices()[0]->id());
-                const auto receiver_fabric_node_id =
-                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(receiver_device->get_devices()[0]->id());
+                const auto sender_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(
+                    sender_device->impl().get_devices()[0]->id());
+                const auto receiver_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(
+                    receiver_device->impl().get_devices()[0]->id());
                 append_fabric_connection_rt_args(
                     sender_fabric_node_id,
                     receiver_fabric_node_id,
@@ -2263,7 +2264,7 @@ void FabricUnicastCommon(
 
     std::vector<uint32_t> sender_status;
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -2274,7 +2275,7 @@ void FabricUnicastCommon(
     std::vector<uint32_t> receiver_status;
     for (const auto& recv_dev : receiver_devices) {
         tt_metal::detail::ReadFromDeviceL1(
-            recv_dev->get_devices()[0],
+            recv_dev->impl().get_devices()[0],
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,
@@ -2573,7 +2574,7 @@ void UDMFabricUnicastCommon(
             uint32_t total_size_to_clear = num_packets * worker_mem_map.packet_payload_size_bytes;
             std::vector<uint32_t> zeros(total_size_to_clear / sizeof(uint32_t), 0);
             tt_metal::detail::WriteToDeviceL1(
-                receiver_device->get_devices()[0],
+                receiver_device->impl().get_devices()[0],
                 receiver_logical_core,
                 worker_mem_map.target_address,
                 zeros,
@@ -2581,7 +2582,7 @@ void UDMFabricUnicastCommon(
             // Clear RISC1 target memory as well
             if (dual_risc) {
                 tt_metal::detail::WriteToDeviceL1(
-                    receiver_device->get_devices()[0],
+                    receiver_device->impl().get_devices()[0],
                     receiver_logical_core,
                     worker_mem_map_risc1.target_address,
                     zeros,
@@ -2603,7 +2604,7 @@ void UDMFabricUnicastCommon(
                                   const std::string& risc_name) {
         std::vector<uint32_t> sender_status;
         tt_metal::detail::ReadFromDeviceL1(
-            sender_device->get_devices()[0],
+            sender_device->impl().get_devices()[0],
             sender_core,
             mem_map.test_results_address,
             mem_map.test_results_size_bytes,
@@ -2614,7 +2615,7 @@ void UDMFabricUnicastCommon(
 
         std::vector<uint32_t> receiver_status;
         tt_metal::detail::ReadFromDeviceL1(
-            receiver_device->get_devices()[0],
+            receiver_device->impl().get_devices()[0],
             receiver_core,
             mem_map.test_results_address,
             mem_map.test_results_size_bytes,
@@ -2687,7 +2688,7 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
 
     // Calculate number of sender/receiver cores per device (all cores in top/bottom half)
     // Split grid into top half (senders) and bottom half (receivers)
-    auto grid_size = devices[0]->get_devices()[0]->compute_with_storage_grid_size();
+    auto grid_size = devices[0]->impl().get_devices()[0]->compute_with_storage_grid_size();
     uint32_t receiver_y_start = grid_size.y / 2;
     uint32_t receiver_y_end = grid_size.y;
     uint32_t sender_rows = receiver_y_start;                  // Number of rows in top half
@@ -2987,14 +2988,14 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
                 tt::tt_metal::CoreCoord receiver_logical_core = receiver_logical_cores[core_idx];
                 std::vector<uint32_t> zeros(total_l1_to_clear / sizeof(uint32_t), 0);
                 tt_metal::detail::WriteToDeviceL1(
-                    device_ptr->get_devices()[0],
+                    device_ptr->impl().get_devices()[0],
                     receiver_logical_core,
                     worker_mem_map.target_address,
                     zeros,
                     CoreType::WORKER);
                 if (dual_risc) {
                     tt_metal::detail::WriteToDeviceL1(
-                        device_ptr->get_devices()[0],
+                        device_ptr->impl().get_devices()[0],
                         receiver_logical_core,
                         worker_mem_map_risc1.target_address,
                         zeros,
@@ -3034,7 +3035,7 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
                 // Check sender status
                 std::vector<uint32_t> sender_status;
                 tt_metal::detail::ReadFromDeviceL1(
-                    device_ptr->get_devices()[0],
+                    device_ptr->impl().get_devices()[0],
                     sender_logical_core,
                     mem_map.test_results_address,
                     mem_map.test_results_size_bytes,
@@ -3051,7 +3052,7 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
                 // Check receiver status
                 std::vector<uint32_t> receiver_status;
                 tt_metal::detail::ReadFromDeviceL1(
-                    device_ptr->get_devices()[0],
+                    device_ptr->impl().get_devices()[0],
                     receiver_logical_core,
                     mem_map.test_results_address,
                     mem_map.test_results_size_bytes,
@@ -3364,7 +3365,7 @@ void Fabric2DMulticastCommon(
 
     std::vector<uint32_t> sender_status;
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -3377,7 +3378,7 @@ void Fabric2DMulticastCommon(
     for (auto& [dev, _] : receiver_programs) {
         std::vector<uint32_t> recv_status;
         tt_metal::detail::ReadFromDeviceL1(
-            dev->get_devices()[0],
+            dev->impl().get_devices()[0],
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,
@@ -3546,7 +3547,7 @@ void FabricMulticastCommon(
 
     std::vector<uint32_t> sender_status;
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -3559,7 +3560,7 @@ void FabricMulticastCommon(
     for (auto& [dev, _] : receiver_programs) {
         std::vector<uint32_t> recv_status;
         tt_metal::detail::ReadFromDeviceL1(
-            dev->get_devices()[0],
+            dev->impl().get_devices()[0],
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,
@@ -3833,7 +3834,7 @@ void FabricSparseMulticastCommon(
 
     std::vector<uint32_t> sender_status;
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -3844,7 +3845,7 @@ void FabricSparseMulticastCommon(
     for (auto& [dev, _] : receiver_programs) {
         std::vector<uint32_t> recv_status;
         tt_metal::detail::ReadFromDeviceL1(
-            dev->get_devices()[0],
+            dev->impl().get_devices()[0],
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -43,6 +43,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "test_host_kernel_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_fabric::fabric_router_tests {
 
@@ -94,7 +95,7 @@ void RunGetNextHopRouterDirectionTest(BaseFabricFixture* fixture, bool is_multi_
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
         const auto& src_device = devices[src_idx];
         auto src_fabric_node_id =
-            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->get_devices()[0]->id());
+            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->impl().get_devices()[0]->id());
         uint32_t src_fabric_chip_id = src_fabric_node_id.chip_id;
 
         uint32_t result_size = NUM_DEVICES * sizeof(uint32_t);
@@ -114,7 +115,7 @@ void RunGetNextHopRouterDirectionTest(BaseFabricFixture* fixture, bool is_multi_
         // Add mesh_id and chip_id pairs for all destinations
         for (size_t dst_idx = 0; dst_idx < NUM_DEVICES; dst_idx++) {
             auto dst_fabric_node_id =
-                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->get_devices()[0]->id());
+                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->impl().get_devices()[0]->id());
             runtime_args.push_back(*dst_fabric_node_id.mesh_id);  // dst_mesh_id
             runtime_args.push_back(dst_fabric_node_id.chip_id);   // dst_chip_id
         }
@@ -138,7 +139,7 @@ void RunGetNextHopRouterDirectionTest(BaseFabricFixture* fixture, bool is_multi_
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
         const auto& src_device = devices[src_idx];
         auto src_fabric_node_id =
-            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->get_devices()[0]->id());
+            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->impl().get_devices()[0]->id());
 
         std::vector<uint32_t> result_data;
         tt::tt_metal::distributed::ReadShard(
@@ -148,7 +149,7 @@ void RunGetNextHopRouterDirectionTest(BaseFabricFixture* fixture, bool is_multi_
             tt::tt_metal::distributed::MeshCoordinate({0, 0}));
         for (size_t dst_idx = 0; dst_idx < NUM_DEVICES; dst_idx++) {
             auto dst_fabric_node_id =
-                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->get_devices()[0]->id());
+                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->impl().get_devices()[0]->id());
             uint32_t actual_direction = result_data[dst_idx];
             if (src_fabric_node_id == dst_fabric_node_id) {
                 // Self-routing should return INVALID_DIRECTION
@@ -185,7 +186,7 @@ void RunSetUnicastRouteTest(
     for (size_t dev_idx = 0; dev_idx < NUM_DEVICES; dev_idx++) {
         if (core_type == HalProgrammableCoreType::IDLE_ETH) {
             // Use first available IDLE_ETH core for each device
-            auto idle_eth_cores = devices[dev_idx]->get_devices()[0]->get_inactive_ethernet_cores();
+            auto idle_eth_cores = devices[dev_idx]->impl().get_devices()[0]->get_inactive_ethernet_cores();
             if (idle_eth_cores.empty()) {
                 GTEST_SKIP() << "No IDLE_ETH cores available on device " << dev_idx;
             }
@@ -204,7 +205,7 @@ void RunSetUnicastRouteTest(
 
     // Get mesh shape to determine if it's 2D fabric
     auto src_fabric_node_id =
-        control_plane.get_fabric_node_id_from_physical_chip_id(devices[0]->get_devices()[0]->id());
+        control_plane.get_fabric_node_id_from_physical_chip_id(devices[0]->impl().get_devices()[0]->id());
     auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
     const auto& fabric_context = control_plane.get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
@@ -225,7 +226,7 @@ void RunSetUnicastRouteTest(
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
         const auto& src_device = devices[src_idx];
         auto src_fabric_node_id =
-            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->get_devices()[0]->id());
+            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->impl().get_devices()[0]->id());
         uint32_t src_fabric_chip_id = src_fabric_node_id.chip_id;
 
         uint32_t result_size = NUM_DEVICES * RESULT_SIZE_PER_DEVICE * sizeof(uint32_t);
@@ -247,7 +248,7 @@ void RunSetUnicastRouteTest(
         // Add mesh_id and chip_id pairs for all destinations
         for (size_t dst_idx = 0; dst_idx < NUM_DEVICES; dst_idx++) {
             auto dst_fabric_node_id =
-                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->get_devices()[0]->id());
+                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->impl().get_devices()[0]->id());
             runtime_args.push_back(*dst_fabric_node_id.mesh_id);  // dst_mesh_id
             runtime_args.push_back(dst_fabric_node_id.chip_id);   // dst_chip_id
         }
@@ -289,7 +290,7 @@ void RunSetUnicastRouteTest(
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
         const auto& src_device = devices[src_idx];
         auto src_fabric_node_id =
-            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->get_devices()[0]->id());
+            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->impl().get_devices()[0]->id());
 
         uint32_t result_size = NUM_DEVICES * RESULT_SIZE_PER_DEVICE * sizeof(uint32_t);
         std::vector<uint32_t> result_data;
@@ -298,7 +299,7 @@ void RunSetUnicastRouteTest(
         // Note: This is experimental and bypasses safety checks
         CoreType read_core_type = (core_type == HalProgrammableCoreType::IDLE_ETH) ? CoreType::ETH : CoreType::WORKER;
         tt::tt_metal::detail::ReadFromDeviceL1(
-            src_device->get_devices()[0],
+            src_device->impl().get_devices()[0],
             logical_cores[src_idx],
             result_addrs[src_idx],
             result_size,
@@ -307,7 +308,7 @@ void RunSetUnicastRouteTest(
 
         for (size_t dst_idx = 0; dst_idx < NUM_DEVICES; dst_idx++) {
             auto dst_fabric_node_id =
-                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->get_devices()[0]->id());
+                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->impl().get_devices()[0]->id());
             if (!is_2d_fabric && std::abs(
                                      static_cast<long>(src_fabric_node_id.chip_id) -
                                      static_cast<long>(dst_fabric_node_id.chip_id)) >= MAX_CHIPS_LOWLAT_1D) {
@@ -345,7 +346,7 @@ std::vector<std::tuple<uint32_t, uint32_t, uint32_t, uint32_t>> GenerateAllValid
 
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto src_fabric_node_id =
-        control_plane.get_fabric_node_id_from_physical_chip_id(devices[0]->get_devices()[0]->id());
+        control_plane.get_fabric_node_id_from_physical_chip_id(devices[0]->impl().get_devices()[0]->id());
     auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
 
     uint32_t ns_dim = mesh_shape[0];
@@ -939,7 +940,7 @@ std::vector<std::pair<tt::tt_metal::CoreCoord, tt::tt_metal::CoreCoord>> GetAllW
 
 // UDM Mode Worker Coordinate Tests - test fabric communication with all workers simultaneously
 TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteAllWorkerCoords) {
-    auto grid_size = get_devices()[0]->get_devices()[0]->compute_with_storage_grid_size();
+    auto grid_size = get_devices()[0]->impl().get_devices()[0]->compute_with_storage_grid_size();
     auto all_worker_pairs = GetAllWorkerCoordPairs(grid_size);
     log_info(tt::LogTest, "Testing {} worker pairs for write operations", all_worker_pairs.size());
     for (uint32_t dst : {5u, 6u, 7u}) {
@@ -950,7 +951,7 @@ TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteAllWorkerCoords) 
 }
 
 TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadAllWorkerCoords) {
-    auto grid_size = get_devices()[0]->get_devices()[0]->compute_with_storage_grid_size();
+    auto grid_size = get_devices()[0]->impl().get_devices()[0]->compute_with_storage_grid_size();
     auto all_worker_pairs = GetAllWorkerCoordPairs(grid_size);
     log_info(tt::LogTest, "Testing {} worker pairs for read operations", all_worker_pairs.size());
     for (uint32_t dst : {5u, 6u, 7u}) {
@@ -964,7 +965,7 @@ TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteAllWorkerCoordsDu
     if (arch_ == tt::ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "Dual RISC test does not support wormhole";
     }
-    auto grid_size = get_devices()[0]->get_devices()[0]->compute_with_storage_grid_size();
+    auto grid_size = get_devices()[0]->impl().get_devices()[0]->compute_with_storage_grid_size();
     auto all_worker_pairs = GetAllWorkerCoordPairs(grid_size);
     log_info(tt::LogTest, "Testing {} worker pairs for write operations", all_worker_pairs.size());
     for (uint32_t dst : {5u, 6u, 7u}) {
@@ -978,7 +979,7 @@ TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadAllWorkerCoordsDua
     if (arch_ == tt::ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "Dual RISC test does not support wormhole";
     }
-    auto grid_size = get_devices()[0]->get_devices()[0]->compute_with_storage_grid_size();
+    auto grid_size = get_devices()[0]->impl().get_devices()[0]->compute_with_storage_grid_size();
     auto all_worker_pairs = GetAllWorkerCoordPairs(grid_size);
     log_info(tt::LogTest, "Testing {} worker pairs for read operations", all_worker_pairs.size());
     for (uint32_t dst : {5u, 6u, 7u}) {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -25,6 +25,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_fabric::fabric_router_tests::fabric_mux_tests {
 
@@ -267,9 +268,10 @@ void create_mux_kernel(
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& device,
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& dest_device,
     tt::tt_metal::Program& program_handle) {
-    const auto src_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->get_devices()[0]->id());
+    const auto src_node_id =
+        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->impl().get_devices()[0]->id());
     const auto dst_node_id =
-        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dest_device->get_devices()[0]->id());
+        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dest_device->impl().get_devices()[0]->id());
     const auto& available_links = get_forwarding_link_indices(src_node_id, dst_node_id);
     TT_FATAL(
         !available_links.empty(),
@@ -283,7 +285,7 @@ void create_mux_kernel(
 
     std::vector<std::pair<size_t, size_t>> addresses_to_clear = {};
     create_kernel(
-        device->get_devices()[0],
+        device->impl().get_devices()[0],
         program_handle,
         mux_kernel_src,
         mux_logical_core,
@@ -360,9 +362,9 @@ void create_worker_kernel(
     if (test_config.is_2d_fabric) {
         const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
         const auto src_fabric_node_id =
-            control_plane.get_fabric_node_id_from_physical_chip_id(device->get_devices()[0]->id());
+            control_plane.get_fabric_node_id_from_physical_chip_id(device->impl().get_devices()[0]->id());
         const auto dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(
-            worker_test_config.dest_device->get_devices()[0]->id());
+            worker_test_config.dest_device->impl().get_devices()[0]->id());
         const auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
         const auto forwarding_direction =
             control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
@@ -398,7 +400,7 @@ void create_worker_kernel(
     }
 
     create_kernel(
-        device->get_devices()[0],
+        device->impl().get_devices()[0],
         program_handle,
         std::string(worker_test_config.kernel_src),
         worker_logical_core,
@@ -613,14 +615,14 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
         log_info(LogTest, "Waiting for senders to complete");
         for (const auto& device : devices) {
             for (const auto& [core, _] : device_senders_map[device]) {
-                wait_for_worker_completion(device->get_devices()[0], core);
+                wait_for_worker_completion(device->impl().get_devices()[0], core);
             }
         }
 
         log_info(LogTest, "Senders done, waiting for receivers to complete");
         for (const auto& device : devices) {
             for (const auto& [core, _] : device_receivers_map[device]) {
-                wait_for_worker_completion(device->get_devices()[0], core);
+                wait_for_worker_completion(device->impl().get_devices()[0], core);
             }
         }
 
@@ -628,7 +630,7 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
         std::vector<uint32_t> mux_termination_signal(1, tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
         for (auto i = 0; i < devices.size(); i++) {
             tt::tt_metal::detail::WriteToDeviceL1(
-                devices[i]->get_devices()[0],
+                devices[i]->impl().get_devices()[0],
                 worker_logical_cores[0],
                 mux_termination_signal_addresses[i],
                 mux_termination_signal);
@@ -650,11 +652,11 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
     log_info(LogTest, "Programs done, validating results");
     for (const auto& device : devices) {
         for (const auto& [core, _] : device_senders_map[device]) {
-            validate_worker_results(device->get_devices()[0], core);
+            validate_worker_results(device->impl().get_devices()[0], core);
         }
 
         for (const auto& [core, _] : device_receivers_map[device]) {
-            validate_worker_results(device->get_devices()[0], core);
+            validate_worker_results(device->impl().get_devices()[0], core);
         }
     }
 }

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux_v2.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux_v2.cpp
@@ -26,6 +26,7 @@
 #include "fabric_fixture.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_fabric::fabric_router_tests::fabric_mux_v2_tests {
 
@@ -156,7 +157,7 @@ struct ReceiverDeviceContext {
     MuxDeployment receiver_mux_deployment;
 };
 
-ChipId get_physical_device_id(const MeshDevicePtr& device) { return device->get_devices()[0]->id(); }
+ChipId get_physical_device_id(const MeshDevicePtr& device) { return device->impl().get_devices()[0]->id(); }
 
 uint32_t align_up(uint32_t value, uint32_t alignment) { return ((value + alignment - 1) / alignment) * alignment; }
 
@@ -671,7 +672,7 @@ std::vector<uint32_t> read_worker_status(
     const MeshDevicePtr& device, const tt::tt_metal::CoreCoord& logical_core, uint32_t test_results_address) {
     std::vector<uint32_t> worker_status;
     tt::tt_metal::detail::ReadFromDeviceL1(
-        device->get_devices()[0],
+        device->impl().get_devices()[0],
         logical_core,
         test_results_address,
         kTestResultsSizeBytes,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
@@ -30,6 +30,7 @@
 #include <tt-metalium/tt_metal_profiler.hpp>
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include <umd/device/types/core_coordinates.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_fabric::fabric_router_tests {
 
@@ -49,8 +50,8 @@ void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
     auto sender_device = devices[0];
     auto receiver_device = devices[1];
 
-    auto src_physical_device_id = sender_device->get_devices()[0]->id();
-    auto dst_physical_device_id = receiver_device->get_devices()[0]->id();
+    auto src_physical_device_id = sender_device->impl().get_devices()[0]->id();
+    auto dst_physical_device_id = receiver_device->impl().get_devices()[0]->id();
 
     auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
     auto dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_physical_device_id);
@@ -147,7 +148,7 @@ void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
     std::vector<uint32_t> receiver_status;
 
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -155,7 +156,7 @@ void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
         CoreType::WORKER);
 
     tt_metal::detail::ReadFromDeviceL1(
-        receiver_device->get_devices()[0],
+        receiver_device->impl().get_devices()[0],
         receiver_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_sparse_mcast_perpage.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_sparse_mcast_perpage.cpp
@@ -29,6 +29,7 @@
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include "fabric_fixture.hpp"
 #include "utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_fabric::fabric_router_tests {
 
@@ -150,7 +151,7 @@ void RunSparseMcastPerPage(BaseFabricFixture* fixture, RoutingDirection dir, uin
 
     std::vector<uint32_t> sender_status;
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -161,7 +162,7 @@ void RunSparseMcastPerPage(BaseFabricFixture* fixture, RoutingDirection dir, uin
     for (auto& [dev, _] : receiver_programs) {
         std::vector<uint32_t> recv_status;
         tt_metal::detail::ReadFromDeviceL1(
-            dev->get_devices()[0],
+            dev->impl().get_devices()[0],
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -53,6 +53,7 @@
 #include "fabric_fixture.hpp"
 #include "t3k_mesh_descriptor_chip_mappings.hpp"
 #include "utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_fabric::fabric_router_tests {
 
@@ -118,7 +119,7 @@ std::vector<EthCoreCaptureResult> read_capture_from_all_eth_cores(
     for (const auto& [logical_core, channel_id] : capture_cores) {
         std::vector<uint32_t> raw_data;
         tt_metal::detail::ReadFromDeviceL1(
-            device->get_devices()[0], logical_core, capture_addr, capture_size, raw_data, CoreType::ETH);
+            device->impl().get_devices()[0], logical_core, capture_addr, capture_size, raw_data, CoreType::ETH);
 
         CaptureResults capture{};
         std::memcpy(static_cast<void*>(&capture), raw_data.data(), std::min(capture_size, raw_data.size() * sizeof(uint32_t)));
@@ -156,7 +157,7 @@ void clear_capture_on_device(BaseFabricFixture* fixture, ChipId physical_chip_id
     const auto& device = fixture->get_device(physical_chip_id);
     for (const auto& [logical_core, _] : capture_cores) {
         tt_metal::detail::WriteToDeviceL1(
-            device->get_devices()[0], logical_core, capture_addr, raw, CoreType::ETH);
+            device->impl().get_devices()[0], logical_core, capture_addr, raw, CoreType::ETH);
     }
 }
 
@@ -356,7 +357,7 @@ UnicastTrafficResult run_unicast_traffic_bw_nodes(
     std::vector<uint32_t> receiver_status;
 
     tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -364,7 +365,7 @@ UnicastTrafficResult run_unicast_traffic_bw_nodes(
         CoreType::WORKER);
 
     tt_metal::detail::ReadFromDeviceL1(
-        receiver_device->get_devices()[0],
+        receiver_device->impl().get_devices()[0],
         receiver_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,

--- a/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
@@ -21,12 +21,13 @@
 #include <tt-metalium/hal_types.hpp>
 #include "llrt/metal_soc_descriptor.hpp"
 #include "impl/context/metal_context.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt::tt_metal;
 namespace unit_tests::test_l1_banking_allocator {
 
 uint64_t get_alloc_limit(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     const metal_SocDescriptor& soc_desc =
         tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
     uint32_t l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);

--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include "tests/tt_metal/tt_metal/common/device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -53,7 +54,7 @@ protected:
 static constexpr DeviceAddr PAGE_SIZE = 1024;
 
 TEST_F(PerCoreAllocationTest, BasicPerCoreAllocation) {
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     auto compute_grid = device->compute_with_storage_grid_size();
     uint32_t num_cores = static_cast<uint32_t>(std::min<size_t>(4, compute_grid.x));
     ASSERT_GE(num_cores, 2u) << "Need at least 2 compute cores";
@@ -85,7 +86,7 @@ TEST_F(PerCoreAllocationTest, BasicPerCoreAllocation) {
 }
 
 TEST_F(PerCoreAllocationTest, PerCoreAndLockstepCoexist) {
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     auto compute_grid = device->compute_with_storage_grid_size();
     uint32_t num_cores = static_cast<uint32_t>(std::min<size_t>(4, compute_grid.x));
     ASSERT_GE(num_cores, 2u);
@@ -123,7 +124,7 @@ TEST_F(PerCoreAllocationTest, PerCoreAndLockstepCoexist) {
 }
 
 TEST_F(PerCoreAllocationTest, DeallocationFreesPerCoreSpace) {
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     auto compute_grid = device->compute_with_storage_grid_size();
     uint32_t num_cores = static_cast<uint32_t>(std::min<size_t>(4, compute_grid.x));
     ASSERT_GE(num_cores, 2u);

--- a/tests/tt_metal/tt_metal/api/buffer_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/api/buffer_test_utils.hpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::test::buffer::detail {
 inline void writeL1Backdoor(
@@ -23,7 +24,7 @@ inline void writeL1Backdoor(
     uint32_t address,
     std::vector<uint32_t>& data) {
     log_info(tt::LogTest, "{} -- coord={} address={}", __FUNCTION__, coord.str(), address);
-    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], coord, address, data);
+    tt_metal::detail::WriteToDeviceL1(mesh_device->impl().get_devices()[0], coord, address, data);
 }
 inline void writeL1Backdoor(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
@@ -31,7 +32,7 @@ inline void writeL1Backdoor(
     uint32_t address,
     std::span<const uint8_t> data) {
     log_info(tt::LogTest, "{} -- coord={} address={}", __FUNCTION__, coord.str(), address);
-    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], coord, address, data);
+    tt_metal::detail::WriteToDeviceL1(mesh_device->impl().get_devices()[0], coord, address, data);
 }
 inline void readL1Backdoor(
     tt::tt_metal::IDevice* device, tt::tt_metal::CoreCoord coord, uint32_t address, uint32_t byte_size, std::vector<uint32_t>& data) {
@@ -45,7 +46,7 @@ inline void readL1Backdoor(
     uint32_t byte_size,
     std::vector<uint32_t>& data) {
     log_info(tt::LogTest, "{} -- coord={} address={} byte_size={}", __FUNCTION__, coord.str(), address, byte_size);
-    tt_metal::detail::ReadFromDeviceL1(mesh_device->get_devices()[0], coord, address, byte_size, data);
+    tt_metal::detail::ReadFromDeviceL1(mesh_device->impl().get_devices()[0], coord, address, byte_size, data);
 }
 inline void readL1Backdoor(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
@@ -53,7 +54,7 @@ inline void readL1Backdoor(
     uint32_t address,
     std::span<uint8_t> data) {
     log_info(tt::LogTest, "{} -- coord={} address={} byte_size={}", __FUNCTION__, coord.str(), address, data.size());
-    tt_metal::detail::ReadFromDeviceL1(mesh_device->get_devices()[0], coord, address, data);
+    tt_metal::detail::ReadFromDeviceL1(mesh_device->impl().get_devices()[0], coord, address, data);
 }
 inline void writeDramBackdoor(
     tt::tt_metal::IDevice* device, uint32_t channel, uint32_t address, std::vector<uint32_t>& data) {
@@ -66,7 +67,7 @@ inline void writeDramBackdoor(
     uint32_t address,
     std::vector<uint32_t>& data) {
     log_info(tt::LogTest, "{} -- channel={} address={}", __FUNCTION__, channel, address);
-    tt_metal::detail::WriteToDeviceDRAMChannel(mesh_device->get_devices()[0], channel, address, data);
+    tt_metal::detail::WriteToDeviceDRAMChannel(mesh_device->impl().get_devices()[0], channel, address, data);
 }
 inline void writeDramBackdoor(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
@@ -74,7 +75,7 @@ inline void writeDramBackdoor(
     uint32_t address,
     std::span<const uint8_t> data) {
     log_info(tt::LogTest, "{} -- channel={} address={}", __FUNCTION__, channel, address);
-    tt_metal::detail::WriteToDeviceDRAMChannel(mesh_device->get_devices()[0], channel, address, data);
+    tt_metal::detail::WriteToDeviceDRAMChannel(mesh_device->impl().get_devices()[0], channel, address, data);
 }
 inline void readDramBackdoor(
     tt::tt_metal::IDevice* device, uint32_t channel, uint32_t address, uint32_t byte_size, std::vector<uint32_t>& data) {
@@ -88,7 +89,8 @@ inline void readDramBackdoor(
     uint32_t byte_size,
     std::vector<uint32_t>& data) {
     log_info(tt::LogTest, "{} -- channel={} address={} byte_size={}", __FUNCTION__, channel, address, byte_size);
-    tt_metal::detail::ReadFromDeviceDRAMChannel(mesh_device->get_devices()[0], channel, address, byte_size, data);
+    tt_metal::detail::ReadFromDeviceDRAMChannel(
+        mesh_device->impl().get_devices()[0], channel, address, byte_size, data);
 }
 inline void readDramBackdoor(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
@@ -96,6 +98,6 @@ inline void readDramBackdoor(
     uint32_t address,
     std::span<uint8_t> data) {
     log_info(tt::LogTest, "{} -- channel={} address={} byte_size={}", __FUNCTION__, channel, address, data.size());
-    tt_metal::detail::ReadFromDeviceDRAMChannel(mesh_device->get_devices()[0], channel, address, data);
+    tt_metal::detail::ReadFromDeviceDRAMChannel(mesh_device->impl().get_devices()[0], channel, address, data);
 }
 }  // namespace tt::test::buffer::detail

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -38,6 +38,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 // Access to internal API: ProgramImpl::get_cb_base_addr, circular_buffers_unique_coreranges, etc.
 #include "impl/program/program_impl.hpp"
@@ -68,10 +69,10 @@ void validate_cb_address(
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 CoreCoord core_coord(x, y);
-                auto address =
-                    program.impl().get_cb_base_addr(mesh_device->get_devices()[0], core_coord, tt::CoreType::WORKER);
+                auto address = program.impl().get_cb_base_addr(
+                    mesh_device->impl().get_devices()[0], core_coord, tt::CoreType::WORKER);
                 tt::tt_metal::detail::ReadFromDeviceL1(
-                    mesh_device->get_devices()[0], core_coord, address, cb_config_buffer_size, cb_config_vector);
+                    mesh_device->impl().get_devices()[0], core_coord, address, cb_config_buffer_size, cb_config_vector);
 
                 std::map<uint8_t, uint32_t> address_per_buffer_index = core_to_address_per_buffer_index.at(core_coord);
 
@@ -180,7 +181,7 @@ TEST_F(MeshDeviceFixture, TensixTestValidCircularBufferAddress) {
 
         auto buffer_size = cb_config.page_size;
         tt::tt_metal::InterleavedBufferConfig buff_config{
-            .device = device->get_devices()[0],
+            .device = device->impl().get_devices()[0],
             .size = buffer_size,
             .page_size = buffer_size,
             .buffer_type = tt::tt_metal::BufferType::L1};
@@ -229,7 +230,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBuffersAndL1BuffersCollision) {
         uint32_t page_size = tt::tile_size(tt::DataFormat::Float16_b);
 
         DeviceAddr l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
-        DeviceAddr l1_max_size = mesh_device->get_devices()[0]->l1_size_per_core();
+        DeviceAddr l1_max_size = mesh_device->impl().get_devices()[0]->l1_size_per_core();
         DeviceAddr l1_bank_size = l1_max_size - l1_unreserved_base;
 
         // Allocate a MeshBuffer that consumes most of L1 bank 0 (top-down), leaving room for
@@ -358,7 +359,7 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddress) {
 
         auto buffer_size = cb_config.page_size;
         tt::tt_metal::InterleavedBufferConfig buff_config{
-            .device = device->get_devices()[0],
+            .device = device->impl().get_devices()[0],
             .size = buffer_size,
             .page_size = buffer_size,
             .buffer_type = tt::tt_metal::BufferType::L1};
@@ -538,10 +539,10 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferPageSize) {
             for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                 for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord core_coord(x, y);
-                    auto address =
-                        program_.impl().get_cb_base_addr(device->get_devices()[0], core_coord, tt::CoreType::WORKER);
+                    auto address = program_.impl().get_cb_base_addr(
+                        device->impl().get_devices()[0], core_coord, tt::CoreType::WORKER);
                     tt::tt_metal::detail::ReadFromDeviceL1(
-                        device->get_devices()[0], core_coord, address, cb_config_buffer_size, cb_config_vector);
+                        device->impl().get_devices()[0], core_coord, address, cb_config_buffer_size, cb_config_vector);
 
                     std::map<uint8_t, uint32_t> address_per_buffer_index = golden_addresses_per_core.at(core_coord);
                     const std::map<uint8_t, uint32_t>& num_pages_per_buffer_index =
@@ -569,10 +570,10 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferPageSize) {
             for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                 for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord core_coord(x, y);
-                    auto address =
-                        program_.impl().get_cb_base_addr(device->get_devices()[0], core_coord, tt::CoreType::WORKER);
+                    auto address = program_.impl().get_cb_base_addr(
+                        device->impl().get_devices()[0], core_coord, tt::CoreType::WORKER);
                     tt::tt_metal::detail::ReadFromDeviceL1(
-                        device->get_devices()[0], core_coord, address, cb_config_buffer_size, cb_config_vector);
+                        device->impl().get_devices()[0], core_coord, address, cb_config_buffer_size, cb_config_vector);
 
                     std::map<uint8_t, uint32_t> address_per_buffer_index = golden_addresses_per_core.at(core_coord);
                     const std::map<uint8_t, uint32_t>& num_pages_per_buffer_index =
@@ -608,13 +609,13 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
         uint32_t buffer_size = single_tile_size * num_tiles;
 
         tt::tt_metal::InterleavedBufferConfig dram_config{
-            .device = device->get_devices()[0],
+            .device = device->impl().get_devices()[0],
             .size = buffer_size,
             .page_size = buffer_size,
             .buffer_type = tt::tt_metal::BufferType::DRAM};
 
         tt::tt_metal::InterleavedBufferConfig l1_config{
-            .device = device->get_devices()[0],
+            .device = device->impl().get_devices()[0],
             .size = buffer_size,
             .page_size = buffer_size,
             .buffer_type = tt::tt_metal::BufferType::L1};
@@ -683,7 +684,7 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
 
         std::vector<uint32_t> input_cb_data;
         detail::ReadFromDeviceL1(
-            device->get_devices()[0],
+            device->impl().get_devices()[0],
             core,
             device->allocator()->get_base_allocator_addr(HalMemType::L1),
             buffer_size,
@@ -707,7 +708,7 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
 
         std::vector<uint32_t> second_cb_data;
         detail::ReadFromDeviceL1(
-            device->get_devices()[0], core, global_cb_buffer->address(), buffer_size, second_cb_data);
+            device->impl().get_devices()[0], core, global_cb_buffer->address(), buffer_size, second_cb_data);
         EXPECT_EQ(src_vec, second_cb_data);
     }
 }

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -25,6 +25,7 @@
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-metalium/program.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 // Access to internal API: ProgramImpl::get_sem_base_addr, ProgramImpl::get_cb_size
 #include "impl/program/program_impl.hpp"
@@ -48,7 +49,7 @@ bool test_cb_config_written_to_core(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     auto& program = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
 
     vector<uint32_t> cb_config_vector;

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
@@ -26,6 +26,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt::tt_metal;
 
@@ -39,7 +40,7 @@ std::vector<std::shared_ptr<Buffer>> create_output_buffers(
     distributed::MeshWorkload& /*workload*/, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     std::vector<std::shared_ptr<Buffer>> output_buffers;
     output_buffers.reserve(n_cbs);

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_wrapping.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_wrapping.cpp
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "host_api.hpp"
 #include "tt_metal.hpp"
+#include <distributed/mesh_device_impl.hpp>
 namespace tt::tt_metal {
 
 /**
@@ -100,7 +101,7 @@ static const std::vector<DataT> EXPECTED_RESULT = {WRAP_WRITE_VALUE, WRAP_WRITE_
  */
 TEST_F(MeshDeviceFixture, TensixTestCircularBufferWrappingBlockingToWriter) {
     auto mesh_device = devices_.at(0);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -142,7 +143,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferWrappingBlockingToWriter) {
  */
 TEST_F(MeshDeviceFixture, TensixTestCircularBufferWrappingBlockingToCompute) {
     auto mesh_device = devices_.at(0);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -206,7 +207,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferWrappingNonBlockingFront) {
     static constexpr DataT SUCCESS_TOKEN = 0xC0FFEE;
 
     auto mesh_device = devices_.at(0);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -261,7 +262,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferWrappingNonBlockingBack) {
     static constexpr DataT SUCCESS_TOKEN = 0xBABE;
 
     auto mesh_device = devices_.at(0);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
@@ -46,6 +46,7 @@
 #include "impl/program/program_impl.hpp"
 #include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 #include "tt_metal/impl/host_api/temp_quasar_api.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -81,7 +82,7 @@ DfbInitTimingBenchContext create_dfb_init_timing_bench_context() {
 
     DfbInitTimingBenchContext ctx;
     ctx.mesh_device = id_to_device.begin()->second;
-    ctx.device = ctx.mesh_device->get_devices()[0];
+    ctx.device = ctx.mesh_device->impl().get_devices()[0];
     return ctx;
 }
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -46,6 +46,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -204,7 +205,7 @@ inline void run_single_dfb_program_2_0(
     // path is arch-agnostic (only the implicit async_read/write<TXN_ID> path is #ifdef ARCH_QUASAR).
     // So the simple 1x1 explicit-sync cases run on WH/BH too; only implicit-sync and multi-core
     // are Quasar-only (mirrors the legacy DFB_SKIP_IF_UNSUPPORTED gate).
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR &&
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR &&
         (p.implicit_sync || p.num_producers > 1 || p.num_consumers > 1)) {
         GTEST_SKIP() << "M2 non-Quasar: only 1x1 explicit-sync DFB runs on WH/BH "
                         "(implicit-sync + multi-core are Quasar-only)";
@@ -224,7 +225,7 @@ inline void run_single_dfb_program_2_0(
         GTEST_SKIP() << "ALL DM consumer with implicit_sync not supported (legacy parity)";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     const m2::NodeCoord node{0, 0};
     const uint32_t entries_per_core = p.num_entries_in_buffer.value_or(p.num_entries);
     const bool is_all = (p.cap == m2::DFBAccessPattern::ALL);
@@ -310,7 +311,7 @@ inline void run_single_dfb_program_2_0(
     // a Gen2 config, so mirror the legacy driver -- DM producer -> RISCV_0, DM consumer ->
     // RISCV_1/NOC_1, Tensix -> ComputeGen1. The make_*_kernel helpers default to Gen2; override
     // to Gen1 on WH/BH here (only 1x1 explicit-sync cases reach WH/BH per the skip gate above).
-    if (mesh_device->get_devices()[0]->arch() == ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() == ARCH::QUASAR) {
         // Gen2 implicit-sync opt-out (#45160): only DM endpoints carry the per-kernel flag; for
         // ImplicitSyncFalse it keeps the host from programming implicit ISR/txn metadata over the
         // kernels' explicit credit-flow path. Tensix endpoints have no DM side.

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -34,6 +34,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "impl/program/program_impl.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -281,7 +282,7 @@ void run_alias_dfb_program(
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
@@ -445,7 +446,7 @@ TEST_F(MeshDeviceFixture, AliasDFBAddressEquality1Sx1S) {
 
     Program program = MakeProgramFromSpec(*devices_.at(0), spec);
 
-    IDevice* device = devices_.at(0)->get_devices()[0];
+    IDevice* device = devices_.at(0)->impl().get_devices()[0];
     detail::CompileProgram(device, program);
     program.impl().finalize_dataflow_buffer_configs();
     program.impl().allocate_dataflow_buffers(device);
@@ -494,7 +495,7 @@ TEST_F(MeshDeviceFixture, AliasDFBDataFlow4Sx2S) {
 }
 
 TEST_F(MeshDeviceFixture, AliasDFBAllocSecondarySkipped) {
-    IDevice* device = devices_.at(0)->get_devices()[0];
+    IDevice* device = devices_.at(0)->impl().get_devices()[0];
     const CoreCoord core{0, 0};
 
     const auto cfg_a = make_1sx1s_config(512, 8);
@@ -525,7 +526,7 @@ TEST_F(MeshDeviceFixture, AliasDFBAllocSecondarySkipped) {
 }
 
 TEST_F(MeshDeviceFixture, AliasDFBAlloc3Way) {
-    IDevice* device = devices_.at(0)->get_devices()[0];
+    IDevice* device = devices_.at(0)->impl().get_devices()[0];
     const CoreCoord core{0, 0};
 
     const auto cfg_a = make_1sx1s_config(512,  8);
@@ -556,7 +557,7 @@ TEST_F(MeshDeviceFixture, AliasDFBAlloc3Way) {
 }
 
 TEST_F(MeshDeviceFixture, AliasDFBAgreedGroupResize) {
-    IDevice* device = devices_.at(0)->get_devices()[0];
+    IDevice* device = devices_.at(0)->impl().get_devices()[0];
     const CoreCoord core{0, 0};
 
     // Two aliased DFBs starting at equal total size (4096 B), plus a trailing non-aliased DFB to
@@ -609,7 +610,7 @@ TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryAddressEquality) {
 
     Program program = MakeProgramFromSpec(*devices_.at(0), spec);
 
-    IDevice* device = devices_.at(0)->get_devices()[0];
+    IDevice* device = devices_.at(0)->impl().get_devices()[0];
     detail::CompileProgram(device, program);
     program.impl().finalize_dataflow_buffer_configs();
     program.impl().allocate_dataflow_buffers(device);
@@ -714,7 +715,7 @@ TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    IDevice* device = devices_.at(0)->get_devices()[0];
+    IDevice* device = devices_.at(0)->impl().get_devices()[0];
     detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -30,6 +30,7 @@
 #include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "impl/program/program_impl.hpp"
 #include "metal2_host_api/test_helpers.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -88,8 +89,7 @@ void run_borrowed_memory_dfb_program(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const NodeCoord& node,
     const BorrowedDFBTestConfig& cfg) {
-
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     const ARCH arch = device->arch();
     const bool is_all = (cfg.cap == DFBAccessPattern::ALL);
 
@@ -289,7 +289,7 @@ void run_update_address_test(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const NodeCoord& node,
     std::optional<uint32_t> reentry_num_entries_override = std::nullopt) {
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     const ARCH arch = device->arch();
 
     constexpr uint32_t num_entries  = 16;

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
@@ -35,6 +35,7 @@
 #include "llrt/rtoptions.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "umd/device/driver_atomics.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -44,7 +45,7 @@ TEST_F(MeshDeviceFixture, DataflowBufferReadTileValue) {
     using DataT = std::uint32_t;
 
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     if (device->arch() == ARCH::QUASAR) {
         GTEST_SKIP() << "Quasar read_tile_value / get_tile_address on DFB is under debug; run on WH/BH";
     }
@@ -373,7 +374,7 @@ struct ExtentProbeParams {
 void run_extent_probe(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const ExtentProbeParams& params) {
     constexpr uint32_t extent_record_bytes = 8 * sizeof(uint32_t);
 
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     const bool is_quasar = device->arch() == ARCH::QUASAR;
 
     if (!is_quasar && (params.num_producers > 1 || params.num_consumers > 1)) {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -35,6 +35,7 @@
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "../metal2_host_api/test_helpers.hpp"
 #include "dfb_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -293,7 +294,7 @@ TEST_F(MeshDeviceFixture, DfbSerializeGlobalHeader1Sx1S) {
     CoreCoord logical_core = CoreCoord(0, 0);
     experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(this->devices_.at(0)->get_devices()[0]);
+    program.impl().allocate_dataflow_buffers(this->devices_.at(0)->impl().get_devices()[0]);
 
     const auto& dfbs = program.impl().dataflow_buffers_on_core(logical_core);
     ASSERT_EQ(dfbs.size(), 1u);
@@ -386,7 +387,7 @@ TEST_F(MeshDeviceFixture, DfbSerializeTxnCentricImplicitSync1Sx1S) {
     CoreCoord logical_core = CoreCoord(0, 0);
     experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(this->devices_.at(0)->get_devices()[0]);
+    program.impl().allocate_dataflow_buffers(this->devices_.at(0)->impl().get_devices()[0]);
 
     const auto& dfbs = program.impl().dataflow_buffers_on_core(logical_core);
     ASSERT_EQ(dfbs.size(), 1u);
@@ -1591,12 +1592,12 @@ static inline void validate_multicore_dfb_groups_2_0(
 
 TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_NoImplicitSync_2_0) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only";
     }
     // 2-core test (nodes (0,0)..(1,0)): the Quasar 1x3 emu reports a 1x1
     // compute grid, so skip there.
-    CoreCoord grid = mesh_device->get_devices()[0]->compute_with_storage_grid_size();
+    CoreCoord grid = mesh_device->impl().get_devices()[0]->compute_with_storage_grid_size();
     if (grid.x < 2) {
         GTEST_SKIP() << "2-core test requires grid.x >= 2 (got " << grid.x << "x" << grid.y << ")";
     }
@@ -1638,12 +1639,12 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_NoImplicitSync_2_0) {
 
 TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_ImplicitSync_2_0) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only";
     }
     // 2-core test (nodes (0,0)..(1,0)): the Quasar 1x3 emu reports a 1x1
     // compute grid, so skip there.
-    CoreCoord grid = mesh_device->get_devices()[0]->compute_with_storage_grid_size();
+    CoreCoord grid = mesh_device->impl().get_devices()[0]->compute_with_storage_grid_size();
     if (grid.x < 2) {
         GTEST_SKIP() << "2-core test requires grid.x >= 2 (got " << grid.x << "x" << grid.y << ")";
     }
@@ -1681,7 +1682,7 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_ImplicitSync_2_0) {
 #define CONFIG_TC_TEST_2_0(name, prod, cons, num_p, num_c, pap_kind, cap_kind, exp_prod_tc, exp_cons_tc) \
     TEST_F(MeshDeviceFixture, name##_2_0) {                                                              \
         auto& mesh_device = this->devices_.at(0);                                                        \
-        if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {                                     \
+        if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {                              \
             GTEST_SKIP() << "M2 path is Quasar-only";                                                    \
         }                                                                                                \
         using namespace m2_config_test_helpers;                                                          \
@@ -1772,7 +1773,7 @@ TEST(TxnIdAllocatorTest, AllocatesTopDownFromDfbPool) {
 // land on {2, 3, 1} (divisibility-based selection).
 TEST_F(MeshDeviceFixture, B2_TxnIdAllocator_Boundaries_Config_2_0) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Implicit sync (and therefore the txn-id allocator) is Quasar-only";
     }
     using namespace m2_config_test_helpers;
@@ -1830,7 +1831,7 @@ TEST_F(MeshDeviceFixture, B2_TxnIdAllocator_Boundaries_Config_2_0) {
 //   ALL:     threshold = num_consumers * (num_entries / num_txn_ids)
 TEST_F(MeshDeviceFixture, B4_CachedThreshold_Config_2_0) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Implicit sync (and therefore threshold caching) is Quasar-only";
     }
     using namespace m2_config_test_helpers;
@@ -1885,7 +1886,7 @@ TEST_F(MeshDeviceFixture, B4_CachedThreshold_Config_2_0) {
 // (b) barely-divisible (only n=1 works) should succeed.
 TEST_F(MeshDeviceFixture, B10_NumEntriesDivisibility_2_0) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Txn-id allocator is Quasar-only";
     }
     using namespace m2_config_test_helpers;
@@ -1944,7 +1945,7 @@ TEST_F(MeshDeviceFixture, B10_NumEntriesDivisibility_2_0) {
 // INTRA self-loop config probe (legacy: TensixIntraTest1xDFB1Sx1SConfig).
 TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1SConfig_2_0) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "INTRA scope is Quasar-only";
     }
     const m2::DFBSpecName DFB{"intra_dfb"};
@@ -1993,7 +1994,7 @@ TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1SConfig_2_0) {
 // B6 — Producer access pattern = ALL is rejected.
 TEST_F(MeshDeviceFixture, B6_AllProducer_Rejected_2_0) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "DFB validation tested on Quasar";
     }
     using namespace m2_config_test_helpers;
@@ -2026,7 +2027,7 @@ TEST_F(MeshDeviceFixture, B7_CB_DFB_Mix_Rejected_2_0) {
 // B8 — ALL consumer with num_consumers > 4 is rejected (Remapper has 4 clientR slots).
 TEST_F(MeshDeviceFixture, B8_FiveAllConsumers_Rejected_2_0) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Remapper limit tested on Quasar";
     }
     using namespace m2_config_test_helpers;

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
@@ -5,6 +5,7 @@
 // Edge-case coverage: counter-wrap, ring-pressure, decoy, long-run (Metal 2.0).
 
 #include "dfb_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -13,11 +14,11 @@ namespace tt::tt_metal {
 enum class A1Transform { Identity, Relu };
 
 static void run_a1_pipeline(const std::shared_ptr<distributed::MeshDevice>& mesh_device, A1Transform transform) {
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only (Gen2Config)";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     constexpr uint32_t entry_size = 2 * 32 * 32;  // bf16 tile = 2048 B
     constexpr uint32_t num_entries = 4;
     const m2::NodeCoord node{0, 0};
@@ -156,11 +157,11 @@ static void run_dm_dfb_dm_implicit_sync_2_0(
     uint32_t entry_size = 1024,
     uint32_t num_entries = 16,
     uint32_t total_tiles = 16) {
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Implicit sync is Quasar-only";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     const m2::NodeCoord node{0, 0};
 
     const m2::DFBSpecName DFB{"dfb"};
@@ -259,11 +260,11 @@ TEST_F(MeshDeviceFixture, B3_2_0_TailCreditRace_RepeatedImplicitSync_DMDM) {
 // D1: long implicit-sync run past counter wrap
 TEST_F(MeshDeviceFixture, D1_2_0_LongImplicitSync_PostCounterWrap) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Implicit sync is Quasar-only";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     constexpr uint32_t kPreloadValue = 65528;
     constexpr uint32_t kPushTiles = 32;
     constexpr uint32_t kEntrySize = 1024;
@@ -441,11 +442,11 @@ TEST_F(MeshDeviceFixture, D2_2_0_AllDMsConcurrent_6Sx2S_ImplicitOn) {
 // D3: multi-core two-groups-via-decoy
 TEST_F(MeshDeviceFixture, D3_2_0_MultiCoreDFB_TwoGroupsViaDecoy) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "TC-based grouping is Quasar-only";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
     const uint32_t num_workers = grid.x * grid.y;
     if (num_workers < 2) {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
@@ -5,6 +5,7 @@
 // Intra-scope (self-loop) DFB tests.
 
 #include "dfb_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -14,7 +15,7 @@ static void run_intra_tensix_dfb_program(
     uint32_t entry_size,
     uint32_t num_entries,
     uint32_t num_threads) {
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     experimental::dfb::DataflowBufferConfig dfb_config{
         .entry_size = entry_size,
@@ -130,11 +131,11 @@ TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB4Sx4S) {
 // Metal 2.0 intra: DM->Trisc self-loop double-relu
 TEST_F(MeshDeviceFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "C2 INTRA-scope DFB self-loop requires Quasar";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     constexpr uint32_t entry_size = 2 * 32 * 32;  // bf16 tile = 2048 B
     constexpr uint32_t num_entries = 4;
     const m2::NodeCoord node{0, 0};
@@ -256,10 +257,10 @@ TEST_F(MeshDeviceFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
 // Metal 2.0 intra-Tensix self-loop harness + test
 static void run_intra_tensix_dfb_program_2_0(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t entry_size, uint32_t num_threads) {
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 INTRA test is Quasar-only";
     }
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t num_entries = 16;  // matches legacy
     TT_FATAL(num_entries % num_threads == 0, "num_entries must be divisible by num_threads");
@@ -341,10 +342,10 @@ TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1S_2_0) {
 // Metal 2.0 intra + remapper coexistence
 TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only (Gen2Config)";
     }
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;
     constexpr uint32_t num_entries = 16;

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
@@ -5,6 +5,7 @@
 // Multi-core and multi-DFB (concurrent/sequential) tests (Metal 2.0).
 
 #include "dfb_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -17,10 +18,10 @@ static void run_single_dfb_multicore_2_0(
     m2::DFBAccessPattern pap,
     m2::DFBAccessPattern cap,
     bool implicit_sync) {
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only";
     }
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
     if (grid.x * grid.y < 2) {
         GTEST_SKIP() << "Multi-core test requires >= 2 Tensix cores";
@@ -124,14 +125,14 @@ static void run_concurrent_dfbs_program_2_0(
     uint32_t entry_size,
     uint32_t entries_per_dfb,
     bool implicit_sync) {
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Concurrent DFB tests require Quasar";
     }
     if (2 * num_dfbs > 6) {
         GTEST_SKIP() << "2*num_dfbs must fit in 6 Quasar DM threads";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     const m2::NodeCoord node{0, 0};
 
     // One big DRAM tensor sliced num_dfbs ways for input + same for output.
@@ -235,13 +236,13 @@ static void run_sequential_4_dfbs_2_0(
     uint32_t num_producers,
     uint32_t num_consumers,
     bool implicit_sync) {
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Sequential 4-DFB test requires Quasar";
     }
     if (num_producers + num_consumers > 6) {
         GTEST_SKIP() << "num_p + num_c must fit in 6 Quasar DM threads";
     }
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;
     // num_entries must be divisible by both num_producers and num_consumers.
@@ -422,11 +423,11 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, DMTest4xDFB_Mixed_2_0) {
 
 TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only";
     }
     const bool implicit_sync = GetParam();
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t num_dfbs = 4;
     constexpr uint32_t entry_size = 1024;
@@ -570,10 +571,10 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
 // homogeneous-grid multi-core group test
 TEST_F(MeshDeviceFixture, MultiCoreDFB_HomogeneousGrid_SingleGroup_2_0) {
     auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device->impl().get_devices()[0]->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only (Gen2Config)";
     }
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
     if (grid.x < 2 || grid.y < 2) {
         GTEST_SKIP() << "Homogeneous-grid test requires >= 2x2 Tensix grid";

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
@@ -5,6 +5,7 @@
 // DFB re-entry / entry-size / num-entries override runtime tests (legacy-only).
 
 #include "dfb_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -24,7 +25,7 @@ static void run_dfb_size_override_test(
     const std::vector<DfbSizeOverride>& launches,
     uint8_t num_producers = 1,
     uint8_t num_consumers = 1) {
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     const bool implicit_sync = (device->arch() == ARCH::QUASAR) && implicit_sync_param;
 
     // Per-thread compile-time loop bounds; the strided kernels split `workload` across the threads

--- a/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/mesh_buffer.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -38,7 +39,7 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, NocRead_L1_Misaligned_SanityCheck) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -71,7 +72,7 @@ TEST_F(MeshDeviceFixture, NocRead_L1_Misaligned_SanityCheck) {
 TEST_F(MeshDeviceFixture, NocWrite_L1_Misaligned_SanityCheck) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -106,7 +107,7 @@ TEST_F(MeshDeviceFixture, NocWrite_L1_Misaligned_SanityCheck) {
 TEST_F(MeshDeviceFixture, NocRead_L1_Misaligned_Source_SanityCheck) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -141,7 +142,7 @@ TEST_F(MeshDeviceFixture, NocRead_L1_Misaligned_Source_SanityCheck) {
 TEST_F(MeshDeviceFixture, NocWrite_L1_Misaligned_Dest_SanityCheck) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -177,7 +178,7 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Misaligned_SanityCheck_WH) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
     auto& mesh = this->devices_.at(0);
-    auto* device = mesh->get_devices()[0];
+    auto* device = mesh->impl().get_devices()[0];
     // WH-only: the 32 B DRAM-read rule is compiled into the JIT kernel only under
     // a wormhole cluster. Under blackhole the same offset aborts with the 64 B
     // message (regex mismatch), so gate to WH and SKIP elsewhere rather than fail
@@ -236,7 +237,7 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Misaligned_SanityCheck_BH) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
     auto& mesh = this->devices_.at(0);
-    auto* device = mesh->get_devices()[0];
+    auto* device = mesh->impl().get_devices()[0];
     // BH-only: the 64 B DRAM-read rule is compiled into the JIT kernel only under
     // a blackhole cluster. Under wormhole the 32 B rule accepts this 32-aligned
     // offset, so the read proceeds and aborts as an OOB write instead — gate to
@@ -290,7 +291,7 @@ TEST_F(MeshDeviceFixture, NocWrite_DRAM_Misaligned_SanityCheck) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
     auto& mesh = this->devices_.at(0);
-    auto* device = mesh->get_devices()[0];
+    auto* device = mesh->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -345,7 +346,7 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_WH) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
     auto& mesh = this->devices_.at(0);
-    auto* device = mesh->get_devices()[0];
+    auto* device = mesh->impl().get_devices()[0];
     // WH-only positive control (guards the 32 B / 0x1F mask). Skip on other arches.
     if (device->arch() != tt::ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "WH-only positive control; device arch is not wormhole.";
@@ -416,7 +417,7 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_BH) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
     auto& mesh = this->devices_.at(0);
-    auto* device = mesh->get_devices()[0];
+    auto* device = mesh->impl().get_devices()[0];
     // BH-only positive control (guards the 64 B / 0x3F mask). Skip on other arches.
     if (device->arch() != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "BH-only positive control; device arch is not blackhole.";
@@ -483,7 +484,7 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_BH) {
 TEST_F(MeshDeviceFixture, NocRead_L1_Aligned_NoViolation) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 

--- a/tests/tt_metal/tt_metal/api/emule/test_cb_leak.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_cb_leak.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -37,7 +38,7 @@ TEST_F(MeshDeviceFixture, Dirty_CB_ReserveWithoutPush) {
     // regression run may have exported to skip the check elsewhere.
     ::unsetenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB");
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -75,7 +76,7 @@ TEST_F(MeshDeviceFixture, Dirty_CB_WaitWithoutPop) {
     // regression run may have exported to skip the check elsewhere.
     ::unsetenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB");
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -119,7 +120,7 @@ TEST_F(MeshDeviceFixture, Dirty_CB_LookaheadReserve_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
     ::unsetenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB");
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -168,7 +169,7 @@ TEST_F(MeshDeviceFixture, Dirty_CB_Balanced_NoViolation) {
     // regression run may have exported to skip the check elsewhere.
     ::unsetenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB");
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -210,7 +211,7 @@ TEST_F(MeshDeviceFixture, Dirty_CB_SkipEnv_Suppresses) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
     ::setenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 

--- a/tests/tt_metal/tt_metal/api/emule/test_cb_pages.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_cb_pages.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -20,7 +21,7 @@ using namespace tt::tt_metal;
 namespace tt::tt_metal {
 
 TEST_F(MeshDeviceFixture, CB_Reservation_Overflow_SanityCheck) {
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     Program program = CreateProgram();
@@ -55,7 +56,7 @@ TEST_F(MeshDeviceFixture, CB_Reservation_Overflow_SanityCheck) {
 TEST_F(MeshDeviceFixture, CB_Reservation_Overflow_AlwaysOn) {
     ::unsetenv("TT_METAL_EMULE_ASAN");  // master switch OFF — check must still fire
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     Program program = CreateProgram();
@@ -98,7 +99,7 @@ TEST_F(MeshDeviceFixture, CB_Reservation_Overflow_AlwaysOn) {
 TEST_F(MeshDeviceFixture, CB_Reservation_ExactCapacity_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     Program program = CreateProgram();

--- a/tests/tt_metal/tt_metal/api/emule/test_host_alignment.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_host_alignment.cpp
@@ -29,6 +29,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -40,7 +41,7 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, Host_Alignment_L1_Unaligned_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     // Allocate an L1 buffer so the poke targets a valid, non-reserved address.
@@ -70,7 +71,7 @@ TEST_F(MeshDeviceFixture, Host_Alignment_L1_Unaligned_NoViolation) {
 TEST_F(MeshDeviceFixture, Host_Alignment_DRAM_Unaligned_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
 
     // Allocate a DRAM buffer to obtain a valid, non-reserved DRAM address.
     constexpr uint32_t buf_size = 256;

--- a/tests/tt_metal/tt_metal/api/emule/test_metadata_size.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_metadata_size.cpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/allocator.hpp>
 #include "impl/context/metal_context.hpp"
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -35,7 +36,7 @@ TEST_F(MeshDeviceFixture, Metadata_CB_Tensor_Clash_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
     auto& mesh_device = this->devices_.at(0);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     // Pin a low lowest_occupied_compute_l1_address by allocating a 1 MB L1
@@ -89,7 +90,7 @@ TEST_F(MeshDeviceFixture, Metadata_CB_Tensor_Clash_SanityCheck) {
 TEST_F(MeshDeviceFixture, Metadata_KernelConfigWindow_Overflow_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     const auto& hal = MetalContext::instance().hal();
@@ -170,7 +171,7 @@ TEST_F(MeshDeviceFixture, Metadata_KernelConfigWindow_Overflow_SanityCheck) {
 TEST_F(MeshDeviceFixture, Metadata_CB_Tensor_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     // A tiny 2-page CB leaves the vast majority of L1 free; no clash possible.

--- a/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -23,7 +24,7 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -75,7 +76,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_SanityCheck) {
 TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -128,7 +129,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
 TEST_F(MeshDeviceFixture, NoC_Barrier_Present_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -179,7 +180,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Present_NoViolation) {
 TEST_F(MeshDeviceFixture, NoC_Barrier_MultiRead_SingleBarrier_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 

--- a/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
 #include "impl/emulation/host_sanitizers.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -24,7 +25,7 @@ TEST_F(MeshDeviceFixture, Tensor_Padding_Violation_SanityCheck) {
     GTEST_SKIP() << "Temporarily disabled. See SANITIZER_CHECKS.md for details.";
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 

--- a/tests/tt_metal/tt_metal/api/emule/test_pointer_size.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_pointer_size.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -22,7 +23,7 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, Local_L1_Alignment_SanityCheck) {
     GTEST_SKIP() << "Temporarily disabled.";
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 

--- a/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -20,7 +21,7 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, Semaphore_Direct_Write_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -55,7 +56,7 @@ TEST_F(MeshDeviceFixture, Semaphore_Direct_Write_SanityCheck) {
 TEST_F(MeshDeviceFixture, Semaphore_OutsideRegion_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 

--- a/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/experimental/core_subset_write/buffer_write.hpp>
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -30,7 +31,7 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
 
     auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
@@ -42,7 +43,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SanityCheck) {
 TEST_F(MeshDeviceFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
 
     auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
@@ -52,7 +53,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
 }
 
 TEST_F(MeshDeviceFixture, Host_UAF_ReadShard_SanityCheck) {
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
 
     // ReadShard's sanitizer check runs before its is_sharded() assertion, so a
     // plain interleaved buffer still drives the UAF path under test here.
@@ -66,7 +67,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_ReadShard_SanityCheck) {
 TEST_F(MeshDeviceFixture, Host_UAF_CoreSubsetWriteToBuffer_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
 
     auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
@@ -88,7 +89,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_CoreSubsetWriteToBuffer_SanityCheck) {
 TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
 
     auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
     DeallocateBuffer(*buffer);
@@ -103,7 +104,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) 
 TEST_F(MeshDeviceFixture, Host_UAF_Allocated_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
 
     auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);  // left allocated
 

--- a/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -29,7 +30,7 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, Object_Intent_Provenance_Violation_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -112,7 +113,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_Violation_SanityCheck) {
 TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NonAdjacent_Violation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -173,7 +174,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NonAdjacent_Violation) {
 TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NoViolation_Control) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -220,7 +221,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NoViolation_Control) {
 TEST_F(MeshDeviceFixture, Object_Intent_IOArg_Exempt_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -270,7 +271,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_IOArg_Exempt_NoViolation) {
 TEST_F(MeshDeviceFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -331,7 +332,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) 
 TEST_F(MeshDeviceFixture, Object_Intent_MultiKernel_Core_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 

--- a/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -29,7 +30,7 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, CB_Boundary_Violation_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -76,7 +77,7 @@ TEST_F(MeshDeviceFixture, CB_Boundary_Violation_SanityCheck) {
 TEST_F(MeshDeviceFixture, CB_Boundary_Violation_Read_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -129,7 +130,7 @@ TEST_F(MeshDeviceFixture, CB_Boundary_Violation_Read_SanityCheck) {
 TEST_F(MeshDeviceFixture, CB_Boundary_Wraparound_Violation_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -185,7 +186,7 @@ TEST_F(MeshDeviceFixture, CB_Boundary_Wraparound_Violation_SanityCheck) {
 TEST_F(MeshDeviceFixture, CB_Boundary_Wraparound_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -238,7 +239,7 @@ TEST_F(MeshDeviceFixture, CB_Boundary_Wraparound_NoViolation) {
 TEST_F(MeshDeviceFixture, CB_Boundary_NoActiveWindow_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -281,7 +282,7 @@ TEST_F(MeshDeviceFixture, CB_Boundary_NoActiveWindow_NoViolation) {
 TEST_F(MeshDeviceFixture, CB_Boundary_ProducedRegionReuse_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -335,7 +336,7 @@ TEST_F(MeshDeviceFixture, CB_Boundary_ProducedRegionReuse_NoViolation) {
 TEST_F(MeshDeviceFixture, CB_Boundary_GloballyAllocated_Exempt_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 

--- a/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -28,7 +29,7 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_L1_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -72,7 +73,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_L1_SanityCheck) {
 TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_DRAM_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -117,7 +118,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_DRAM_SanityCheck) {
 TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_JustPast_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -159,7 +160,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_JustPast_SanityCheck) {
 TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_L1_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -195,7 +196,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_L1_NoViolation) {
 TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -236,7 +237,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
 TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_Accept_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
+    auto* device = this->devices_.at(0)->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
@@ -26,6 +26,7 @@
 #include "device_fixture.hpp"
 #include "multi_device_fixture.hpp"
 #include "test_helpers.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::experimental {
 namespace {
@@ -52,7 +53,7 @@ protected:
             return;
         }
         auto mesh_device = devices_.at(0);
-        IDevice* device = mesh_device->get_devices()[0];
+        IDevice* device = mesh_device->impl().get_devices()[0];
         if (device->arch() != tt::ARCH::WORMHOLE_B0 && device->arch() != tt::ARCH::BLACKHOLE) {
             GTEST_SKIP() << "Skipping: test requires Wormhole B0 or Blackhole hardware";
         }
@@ -67,7 +68,7 @@ protected:
             return;
         }
         auto mesh_device = devices_.at(0);
-        IDevice* device = mesh_device->get_devices()[0];
+        IDevice* device = mesh_device->impl().get_devices()[0];
         if (device->arch() != tt::ARCH::WORMHOLE_B0 && device->arch() != tt::ARCH::BLACKHOLE) {
             GTEST_SKIP() << "Skipping: test requires Wormhole B0 or Blackhole hardware";
         }
@@ -265,7 +266,7 @@ TEST_F(MeshWorkloadFactorySlowDispatchHWTest, FactoryMethodsSupportSlowDispatch)
 
 TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecSupportsDfbResizeBetweenEnqueues) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     // Build a workload with a producer-consumer DFB loopback.
     distributed::MeshWorkload workload = MakeMeshWorkloadFromSpec(*mesh_device, MakeLoopbackSpec());

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
@@ -82,7 +82,7 @@ protected:
         if (this->IsSkipped()) {
             return;
         }
-        IDevice* device = mesh_device_->get_devices().at(0);
+        IDevice* device = mesh_device_->impl().get_devices().at(0);
         if (device->arch() != tt::ARCH::WORMHOLE_B0 && device->arch() != tt::ARCH::BLACKHOLE) {
             GTEST_SKIP() << "Skipping: test requires Wormhole B0 or Blackhole hardware";
         }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -48,6 +48,7 @@
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
 
 #include "test_helpers.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::experimental {
 namespace {
@@ -3903,7 +3904,7 @@ void kernel_main() {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
+    IDevice* device = mesh_device_->impl().get_devices()[0];
     EXPECT_NO_THROW(detail::CompileProgram(device, program));
 }
 
@@ -3940,7 +3941,7 @@ void kernel_main() {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
+    IDevice* device = mesh_device_->impl().get_devices()[0];
     EXPECT_NO_THROW(detail::CompileProgram(device, program));
 }
 
@@ -3968,7 +3969,7 @@ void kernel_main() {
         .scratchpad_spec_name = ScratchpadSpecName{"scratch"}, .accessor_name = "scratch"});
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
+    IDevice* device = mesh_device_->impl().get_devices()[0];
     EXPECT_NO_THROW(detail::CompileProgram(device, program));
 }
 
@@ -4002,7 +4003,7 @@ void kernel_main() {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
+    IDevice* device = mesh_device_->impl().get_devices()[0];
     EXPECT_NO_THROW(detail::CompileProgram(device, program));
 }
 
@@ -4063,7 +4064,7 @@ TEST_F(ProgramSpecTestGen1, TtKernelComputeShimCompiles) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("wu", node, {"compute", "consumer"})};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
+    IDevice* device = mesh_device_->impl().get_devices()[0];
     EXPECT_NO_THROW(detail::CompileProgram(device, program));
 }
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -30,6 +30,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "test_helpers.hpp"
 #include "impl/program/program_impl.hpp"  // ScratchpadBaseReDeliveredAfterDfbResize: DFB allocated-address query
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::experimental {
 namespace {
@@ -76,7 +77,7 @@ protected:
 
 TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     // Test parameters
     constexpr uint32_t entry_size = 1024;  // bytes per DFB entry
@@ -218,7 +219,7 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
 
 TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;
     constexpr uint32_t num_entries_in_dfb = 4;
@@ -338,7 +339,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
 
 TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;  // CTA value folded into the XOR (not a DFB size)
     constexpr uint32_t num_tiles = 8;      // CRTA value folded into the XOR
@@ -412,7 +413,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
 
 TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;
     constexpr uint32_t num_entries_in_dfb = 4;
@@ -501,7 +502,7 @@ TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopback) {
 
 TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopbackCompute) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;  // CTA value folded into the XOR (not a DFB size)
     constexpr uint32_t num_tiles = 8;      // CRTA value folded into the XOR
@@ -566,7 +567,7 @@ TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopbackCompute) {
 
 TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     const NodeCoord node{0, 0};
 
@@ -649,7 +650,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
 
 TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     // Tensor: 8 pages × 1024 bytes (BFLOAT16, ROW_MAJOR, shape {8, 512} → page = row = 1024 B)
     constexpr uint32_t num_pages = 8;
@@ -783,7 +784,7 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
 
 TEST_F(ProgramSpecHWTest, LocalTensorAccessorBindingCompileComputeKernel) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t kReportAddr = 100 * 1024;  // host-known fixed L1 addr (same idiom as ScratchpadWriteReadback)
     constexpr uint32_t kNumReportWords = 4;
@@ -894,7 +895,7 @@ TEST_F(ProgramSpecHWTest, MultiBindingProducerMaskMismatchFails) {
 // real, writable, node-local L1" and "the framework delivered its base address to the kernel".
 TEST_F(ProgramSpecHWTest, ScratchpadWriteReadback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t kScratchpadBytes = 64;                            // 16 x uint32_t
     constexpr uint32_t kNumElems = kScratchpadBytes / sizeof(uint32_t);  // 16
@@ -995,7 +996,7 @@ TEST_F(ProgramSpecHWTest, ScratchpadWriteReadback) {
 //            MULTI-WORD binding in the middle (River's original had named=0, binding=0).
 TEST_F(ProgramSpecHWTest, CrtaAllFourSectionsSetAndPartialUpdate) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;  // bytes per DFB entry
     constexpr uint32_t num_entries = 4;    // DFB depth
@@ -1214,7 +1215,7 @@ void kernel_main() {
 // (base_B == base_A → the NE check fails) and its pattern write lands inside the grown DFB's region.
 TEST_F(ProgramSpecHWTest, ScratchpadBaseReDeliveredAfterDfbResize) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;      // bytes per DFB entry (constant)
     constexpr uint32_t num_entries_small = 2;  // initial DFB depth

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_scratchpad_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_scratchpad_hw.cpp
@@ -38,13 +38,14 @@
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 #include "command_queue_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 namespace {
 
 TEST_F(UnitMeshCQSingleCardFixture, ScratchpadWriteReadback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     // Gen1 only (mirrors test_program_spec_hw.cpp's guard). The scratchpad feature works on both
     // gens, but the device-side kernel here uses the Gen1 L1-readback idiom (plain volatile L1

--- a/tests/tt_metal/tt_metal/api/test_blaze_named_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_blaze_named_runtime_args.cpp
@@ -26,6 +26,7 @@
 
 #include "device_fixture.hpp"
 #include "multi_device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -33,7 +34,7 @@ using NamedArgsTest = GenericMeshDeviceFixture;
 
 TEST_F(NamedArgsTest, TensixTestNamedCommonAndPerCoreRuntimeArgs) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
@@ -78,7 +79,7 @@ TEST_F(NamedArgsTest, TensixTestNamedCommonAndPerCoreRuntimeArgs) {
 
 TEST_F(NamedArgsTest, TensixTestNamedArrayRuntimeArgs) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
@@ -129,7 +130,7 @@ TEST_F(NamedArgsTest, TensixTestNamedArrayRuntimeArgs) {
 
 TEST_F(NamedArgsTest, TensixTestNamedCompileTimeArgs) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
@@ -168,7 +169,7 @@ TEST_F(NamedArgsTest, TensixTestNamedCompileTimeArgs) {
 
 TEST_F(NamedArgsTest, TensixTestNamedPerCoreArrayRuntimeArgs) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
@@ -233,7 +234,7 @@ TEST_F(NamedArgsTest, TensixTestNamedPerCoreArrayRuntimeArgs) {
 // exercises the relocated, presence-gated prolog #include on the compute path.
 TEST_F(NamedArgsTest, TensixTestNamedCompileTimeArgsComputeKernel) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
@@ -273,7 +274,7 @@ TEST_F(NamedArgsTest, TensixTestNamedCompileTimeArgsComputeKernel) {
 // is correct: positional at [0..N-1], named at [N..].
 TEST_F(NamedArgsTest, TensixTestMixedPositionalAndNamedRuntimeArgs) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
@@ -323,7 +324,7 @@ TEST_F(NamedArgsTest, TensixTestMixedPositionalAndNamedRuntimeArgs) {
 // Two entries with the same name and value should be silently deduplicated.
 TEST_F(NamedArgsTest, TensixTestCTArgDedupSameValue) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 

--- a/tests/tt_metal/tt_metal/api/test_compile_time_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_compile_time_args.cpp
@@ -21,6 +21,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/program.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -40,7 +41,7 @@ TEST_F(MeshDeviceFixture, TensixTestTwentyThousandCompileTimeArgs) {
         Program program;
         workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
 
         const uint32_t write_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
 
@@ -81,7 +82,7 @@ TEST_F(CompileTimeArgsTest, TensixTestNamedCompileTimeArgs) {
     Program program;
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     const uint32_t write_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
 

--- a/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
+++ b/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
@@ -24,6 +24,7 @@
 #include "jit_build/build.hpp"
 #include "jit_build/build_env_manager.hpp"
 #include "multi_device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -60,7 +61,7 @@ void kernel_main() {
 )";
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     Program program = CreateProgram();
 
     DataMovementConfig config{
@@ -109,7 +110,7 @@ void kernel_main() {
 )";
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     Program program = CreateProgram();
 
     DataMovementConfig config{
@@ -211,7 +212,7 @@ void kernel_main() {
 )";
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     auto compile_and_get_elf_path = [&]() -> fs::path {
         Program program = CreateProgram();

--- a/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
@@ -23,6 +23,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace {
 
@@ -80,7 +81,7 @@ void RunTest(tt::tt_metal::distributed::MeshDevice* mesh_device) {
     tt::tt_metal::distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, true);
 
     uint64_t cycles_elapsed = 0;
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto virtual_core = device->worker_core_from_logical_core(core);
     mc.get_cluster().read_core(&cycles_elapsed, sizeof(uint64_t), tt_cxy_pair(device->id(), virtual_core), cycles_addr);
 

--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -39,6 +39,7 @@
 #include <tt_stl/assert.hpp>
 
 #include "multi_device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -176,7 +177,7 @@ TEST(DescriptorPatching, ResolvedBindings_EmptyAfterAddingCb_IsFalse) {
 
 class DescriptorPatchingDeviceTest : public GenericMeshDeviceFixture {
 protected:
-    IDevice* device() { return get_mesh_device()->get_devices()[0]; }
+    IDevice* device() { return get_mesh_device()->impl().get_devices()[0]; }
 };
 
 // resolve_bindings correctly maps a single per-core buffer arg.

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -35,6 +35,7 @@
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using std::vector;
 using namespace tt;
@@ -63,7 +64,7 @@ bool reader_only(
     tt_metal::Program program = tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     tt::tt_metal::InterleavedBufferConfig dram_config{
         .device = device, .size = byte_size, .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM};
@@ -133,7 +134,7 @@ bool writer_only(
     tt_metal::Program program = tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     tt_metal::InterleavedBufferConfig dram_config{
         .device = device, .size = byte_size, .page_size = byte_size, .buffer_type = tt_metal::BufferType::DRAM};
@@ -197,7 +198,7 @@ struct ReaderWriterConfig {
 /// @return
 bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const ReaderWriterConfig& test_config) {
     const size_t byte_size = test_config.num_tiles * test_config.tile_byte_size;
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     tt::tt_metal::InterleavedBufferConfig dram_config{
         .device = device, .size = byte_size, .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM};
@@ -344,7 +345,7 @@ static ReaderDatacopyWriterContext setup_reader_datacopy_writer_context(
     ReaderDatacopyWriterContext ctx;
     ctx.byte_size = test_config.num_tiles * test_config.tile_byte_size;
 
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     tt::tt_metal::InterleavedBufferConfig dram_config{
         .device = device,
         .size = ctx.byte_size,
@@ -384,7 +385,7 @@ static bool verify_reader_datacopy_writer_output(const ReaderDatacopyWriterConte
 bool reader_datacopy_writer(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const ReaderDatacopyWriterConfig& test_config) {
     auto ctx = setup_reader_datacopy_writer_context(mesh_device, test_config);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     const bool is_quasar = device->arch() == ARCH::QUASAR;
     // On Quasar we can split work across two DM threads when num_tiles > 1;

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -35,6 +35,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 
@@ -302,7 +303,7 @@ TEST_F(MeshDispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
     };
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         for (auto active_eth_core : device->get_active_ethernet_cores(true)) {
             log_info(tt::LogTest, "Active Eth Loopback. Logical core {}", active_eth_core.str());
             dram_test_config.core_range = {active_eth_core, active_eth_core};
@@ -339,7 +340,7 @@ TEST_F(MeshDispatchFixture, IdleEthDRAMLoopbackSingleCore) {
     };
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         for (auto idle_eth_core : device->get_inactive_ethernet_cores()) {
             log_info(tt::LogTest, "Single Idle Eth Loopback. Logical core {}", idle_eth_core.str());
             dram_test_config.core_range = {idle_eth_core, idle_eth_core};

--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -19,6 +19,7 @@
 #include "impl/kernels/kernel.hpp"
 #include "llrt/hal.hpp"
 #include "llrt/tt_cluster.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -56,7 +57,7 @@ protected:
             GTEST_SKIP() << "DRAM programmable cores not enabled";
         }
         mesh_device_ = devices_[0].get();
-        device_ = mesh_device_->get_devices()[0];
+        device_ = mesh_device_->impl().get_devices()[0];
         device_range_ = distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0));
         drisc_l1_base_ = hal.get_dev_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
         drisc_l1_noc_addr_ = hal.get_dev_noc_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);

--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -35,6 +35,7 @@
 #include "impl/context/metal_context.hpp"
 #include "llrt/hal.hpp"
 #include "llrt/tt_cluster.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -50,7 +51,7 @@ protected:
             GTEST_SKIP() << "DRAM programmable cores not enabled";
         }
         mesh_device_ = devices_[0].get();
-        device_ = mesh_device_->get_devices()[0];
+        device_ = mesh_device_->impl().get_devices()[0];
     }
 
     distributed::MeshDevice* mesh_device_{};

--- a/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
@@ -15,6 +15,7 @@
 #include "distributed/mesh_device_impl.hpp"
 #include "impl/context/metal_context.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -22,7 +23,7 @@ class DramSubchannelHelperFixture : public BlackholeSingleCardFixture {};
 
 TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
     auto mesh_device = devices_[0];
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device->id());
 
     const uint32_t num_banks = soc_desc.get_num_dram_views();
@@ -68,7 +69,7 @@ TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
 
 TEST_F(DramSubchannelHelperFixture, RejectsOutOfRangeBank) {
     auto mesh_device = devices_[0];
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device->id());
     const uint32_t num_banks = soc_desc.get_num_dram_views();
     EXPECT_ANY_THROW(mesh_device->impl().pick_unused_dram_logical_core(num_banks));

--- a/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
@@ -27,6 +27,7 @@
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <umd/device/types/arch.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 
@@ -48,7 +49,7 @@ bool dram_to_l1_multicast(
     const DRAMtoL1MulticastConfig& cfg) {
     bool pass = true;
 
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     distributed::MeshWorkload workload;
     distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);

--- a/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
@@ -17,6 +17,7 @@
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -25,7 +26,7 @@ TEST_F(MeshDispatchFixture, InitializeGlobalSemaphores) {
 
     auto cores_vec = corerange_to_cores(cores);
     for (const auto& mesh_device : devices_) {
-        auto device_id = mesh_device->get_devices()[0]->id();
+        auto device_id = mesh_device->impl().get_devices()[0]->id();
         {
             uint32_t initial_value = 1;
             auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(mesh_device.get(), cores, initial_value);
@@ -61,7 +62,7 @@ TEST_F(MeshDispatchFixture, CreateMultipleGlobalSemaphoresOnSameCore) {
         cores_vecs.push_back(corerange_to_cores(crs));
     }
     for (const auto& mesh_device : devices_) {
-        auto device_id = mesh_device->get_devices()[0]->id();
+        auto device_id = mesh_device->impl().get_devices()[0]->id();
         {
             std::vector<tt::tt_metal::GlobalSemaphore> global_semaphores;
             global_semaphores.reserve(cores.size());
@@ -94,7 +95,7 @@ TEST_F(MeshDispatchFixture, ResetGlobalSemaphores) {
 
     auto cores_vec = corerange_to_cores(cores);
     for (const auto& mesh_device : devices_) {
-        auto device_id = mesh_device->get_devices()[0]->id();
+        auto device_id = mesh_device->impl().get_devices()[0]->id();
         {
             uint32_t initial_value = 1;
             uint32_t reset_value = 2;

--- a/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
@@ -23,6 +23,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "impl/kernels/kernel.hpp"
+#include <distributed/mesh_device_impl.hpp>
 // Access to internal API: ProgramImpl::get_kernels
 #include "impl/program/program_impl.hpp"
 
@@ -32,7 +33,7 @@ TEST_F(MeshDeviceFixture, TensixTestEquivalentDataMovementKernelsWithDifferentPr
     const std::string kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_4.cpp";
 
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         jit_build_cache_clear();
 
         DataMovementConfig config_riscv_0 = {.processor = DataMovementProcessor::RISCV_0};

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -26,6 +26,7 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -57,7 +58,7 @@ TEST_F(MeshDispatchFixture, DISABLED_TensixIdleEthCreateKernelsOnDispatchCores) 
         GTEST_SKIP() << "This test is only supported in fast dispatch mode";
     }
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
 
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -20,6 +20,7 @@
 #include "impl/context/metal_context.hpp"
 #include "device_fixture.hpp"
 #include "metal2_host_api/test_helpers.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::experimental {
 namespace {
@@ -75,7 +76,7 @@ class KernelThreadSyncTest : public tt::tt_metal::MeshDeviceFixture {};
 
 TEST_F(KernelThreadSyncTest, BarrierSynchronizesThreads) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     NodeCoord node{0, 0};
 
     // Arch-specific config: kernels to launch, one scratch layout per kernel,

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -34,6 +34,7 @@
 #include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"
 #include "llrt/hal.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::test_utils;
@@ -48,10 +49,10 @@ uint32_t ReadRegFromDevice(
     const CoreCoord& logical_core,
     uint32_t address,
     uint32_t& regval) {
-    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->get_devices()[0]->id());
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->impl().get_devices()[0]->id());
     auto worker_core = device->worker_core_from_logical_core(logical_core);
     tt::tt_metal::MetalContext::instance().get_cluster().read_reg(
-        &regval, tt_cxy_pair(device->get_devices()[0]->id(), worker_core), address);
+        &regval, tt_cxy_pair(device->impl().get_devices()[0]->id(), worker_core), address);
     return regval;
 }
 
@@ -216,7 +217,7 @@ TEST_F(MeshDeviceFixture, TensixDirectedStreamRegWriteRead) {
         tt_metal::Program program = tt_metal::CreateProgram();
         workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
 
         CoreCoord logical_grid_size = mesh_device->compute_with_storage_grid_size();
         CoreCoord end_core{logical_grid_size.x - 1, logical_grid_size.y - 1};
@@ -335,7 +336,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWrite4BAlignment) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         distributed::MeshWorkload workload;
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         uint32_t receiver_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1) + 4;
         EXPECT_EQ(receiver_addr % 4, 0)
             << "Expected dest address to be 4B aligned to test noc_inline_dw_write alignment rule";
@@ -379,7 +380,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDedicatedNoc) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         distributed::MeshWorkload workload;
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         uint32_t first_receiver_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
         uint32_t second_receiver_addr =
             first_receiver_addr + MetalContext::instance().hal().get_alignment(HalMemType::L1);
@@ -437,7 +438,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDedicatedNocMisaligned) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         distributed::MeshWorkload workload;
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         uint32_t base_receiver_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1) + 4;
         std::vector<uint32_t> readback(num_writes * sizeof(uint32_t), 0);
         tt_metal::detail::WriteToDeviceL1(device, receiver_core, base_receiver_addr, readback);
@@ -492,7 +493,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDynamicNoc) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         distributed::MeshWorkload workload;
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         uint32_t receiver_addr0 = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
         uint32_t receiver_addr2 = receiver_addr0 + (num_writes_per_risc * l1_alignment);
         std::vector<uint32_t> readback(num_writes_total * l1_alignment / sizeof(uint32_t), 0);
@@ -566,7 +567,7 @@ void run_local_noc_stream_reg_inc(
     const CoreCoord& core,
     const HalProgrammableCoreType& hal_programmable_core_type) {
     auto& cq = mesh_device->mesh_command_queue();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     // Set up program and command queue
     distributed::MeshWorkload workload;
@@ -663,7 +664,7 @@ TEST_F(MeshDeviceFixture, TensixTestNocStreamRegs) {
 
 TEST_F(MeshDeviceFixture, ActiveEthTestNocStreamRegs) {
     auto mesh_device = this->devices_[0];
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     // Skip if no active ethernet cores on this device
     if (device->get_active_ethernet_cores(true).empty()) {
@@ -678,7 +679,7 @@ TEST_F(MeshDeviceFixture, ActiveEthTestNocStreamRegs) {
 
 TEST_F(MeshDeviceFixture, IdleEthTestNocStreamRegs) {
     auto mesh_device = this->devices_[0];
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     // Skip if no idle ethernet cores on this device
     if (device->get_inactive_ethernet_cores().empty()) {
@@ -717,7 +718,7 @@ TEST_F(BlackholeSingleCardFixture, DramKernelTensixWritesDriscStreamReg) {
     constexpr uint32_t kStreamReg = 10;
 
     auto mesh_device = this->devices_[0];
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto device_range = distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0));
 
     // Subchannel 0 is the syseng-owned NOC0 DRAM endpoint (no DRISC firmware); use subchannel 1.
@@ -763,7 +764,7 @@ TEST_F(BlackholeSingleCardFixture, DramKernelDriscWritesTensixStreamReg) {
     constexpr uint32_t kStreamReg = 10;
 
     auto mesh_device = this->devices_[0];
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto device_range = distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0));
 
     // Subchannel 0 is the syseng-owned NOC0 DRAM endpoint (no DRISC firmware); use subchannel 1.

--- a/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
+++ b/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
@@ -25,6 +25,7 @@
 #include "jit_build/build.hpp"
 #include "llrt/rtoptions.hpp"
 #include "tt_metal/jit_build/build_cache_telemetry.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -245,7 +246,7 @@ TEST_F(MeshDeviceFixture, RuntimePrecompiledHitLoadsWithoutJit) {
         GTEST_SKIP() << "CompileKernelOffline has no precompiled firmware for the simulator build_key "
                         "(multi-erisc disabled); skipping under TT_METAL_SIMULATOR.";
     }
-    auto* device = this->devices_.at(0)->get_devices().at(0);
+    auto* device = this->devices_.at(0)->impl().get_devices().at(0);
 
     ScopedTempDir precompiled_root("tt_metal_precompiled_seed_hit");
     seed_precompiled_root(precompiled_root.path_, kReaderKernelPath, kReaderDmConfig);
@@ -270,7 +271,7 @@ TEST_F(MeshDeviceFixture, RuntimePrecompiledHitWithCbMetadataLoadsWithoutJit) {
     // hlk_desc contributions diverge, this test fails as `jit_srcs.delta() > 0` (runtime
     // falls through to JIT) rather than as a layout assertion, which is exactly the
     // failure mode that justifies surfacing CBCompileConfigsFromProgram in the public API.
-    auto* device = this->devices_.at(0)->get_devices().at(0);
+    auto* device = this->devices_.at(0)->impl().get_devices().at(0);
 
     constexpr uint32_t kPageSize = 2048;
     constexpr DataFormat kCbFormat = DataFormat::Float16_b;
@@ -310,7 +311,7 @@ TEST_F(MeshDeviceFixture, RuntimePrecompiledHitWithCbMetadataLoadsWithoutJit) {
 TEST_F(MeshDeviceFixture, RuntimeMissingPrecompiledFallsBackToJit) {
     const auto precompiled_config = make_precompiled_config(kMissingPrecompiledRoot, BinaryPolicy::JitCompile);
     Program program = create_precompiled_program(precompiled_config);
-    auto* device = this->devices_.at(0)->get_devices().at(0);
+    auto* device = this->devices_.at(0)->impl().get_devices().at(0);
 
     jit_build_cache_clear();
     JitSrcsBaseline jit_srcs;
@@ -321,7 +322,7 @@ TEST_F(MeshDeviceFixture, RuntimeMissingPrecompiledFallsBackToJit) {
 TEST_F(MeshDeviceFixture, RuntimeMissingPrecompiledErrorsOnPolicyError) {
     const auto precompiled_config = make_precompiled_config(kMissingPrecompiledRoot, BinaryPolicy::Error);
     Program program = create_precompiled_program(precompiled_config);
-    auto* device = this->devices_.at(0)->get_devices().at(0);
+    auto* device = this->devices_.at(0)->impl().get_devices().at(0);
 
     jit_build_cache_clear();
     JitSrcsBaseline jit_srcs;

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -32,6 +32,7 @@
 
 #include "device_fixture.hpp"
 #include <umd/device/types/xy_pair.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 // Access to internal API: ProgramImpl::num_kernel, get_kernel
 #include "impl/program/program_impl.hpp"
@@ -339,7 +340,7 @@ void verify_core_rt_args(
     const std::vector<uint32_t>& written_args,
     const uint32_t incr_val) {
     std::vector<uint32_t> observed_args;
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     tt_metal::detail::ReadFromDeviceL1(device, core, base_addr, written_args.size() * sizeof(uint32_t), observed_args);
 
     for (size_t i = 0; i < written_args.size(); i++) {
@@ -370,7 +371,7 @@ void verify_results(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     const auto& program = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     for (size_t kernel_id = 0; kernel_id < program.impl().num_kernels(); kernel_id++) {
         const auto kernel = program.impl().get_kernel(kernel_id);
@@ -426,7 +427,7 @@ void verify_quasar_crtas(
     const CoreCoord& core,
     const std::vector<std::vector<uint32_t>>& per_user_dm_crtas,
     bool expect_shared_address) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     uint32_t l1_base = mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     uint32_t results_base = get_runtime_arg_addr(l1_base, tt::tt_metal::HalProcessorClassType::DM, 0, true);
     uint32_t max_dms = MetalContext::instance().hal().get_processor_types_count(
@@ -496,7 +497,7 @@ TEST_F(MeshDeviceFixture, TensixLegallyModifyRTArgsDataMovement) {
         CoreRange second_core_range(CoreCoord(3, 3), CoreCoord(5, 5));
         CoreRangeSet core_range_set(std::vector{first_core_range, second_core_range});
         auto& cq = mesh_device->mesh_command_queue();
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto workload = unit_tests::runtime_args::initialize_program_data_movement_rta(mesh_device, core_range_set, 2);
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -752,7 +753,7 @@ TEST_F(MeshDeviceFixture, TensixIllegallyModifyRTArgs) {
         auto& cq = mesh_device->mesh_command_queue();
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         // First run the program with the initial runtime args
         CoreRange first_core_range(CoreCoord(0, 0), CoreCoord(1, 1));
         CoreRange second_core_range(CoreCoord(3, 3), CoreCoord(5, 5));
@@ -871,7 +872,7 @@ TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
         hal.get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t) -
         watcher_reserved_count_words;
     for (auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto active_eth_cores = device->get_active_ethernet_cores(true);
 
         // Skip test if no active ethernet cores available
@@ -956,7 +957,7 @@ TEST_F(MeshDeviceFixture, IdleEthIllegalTooManyRuntimeArgs) {
         hal.get_dev_size(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t) -
         watcher_reserved_count_words;
     for (auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto idle_eth_cores = device->get_inactive_ethernet_cores();
 
         // Skip test if no idle ethernet cores available
@@ -1134,7 +1135,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMergeProgramRunArgs) {
 
     // Zero-init both output slots.
     std::vector<uint32_t> zeros(2, 0);
-    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node, address_1, zeros);
+    tt_metal::detail::WriteToDeviceL1(mesh_device->impl().get_devices()[0], node, address_1, zeros);
 
     // Two kernels, each using one DM thread, writing to distinct L1 addresses.
     const experimental::KernelSpecName K1{"k1"}, K2{"k2"};
@@ -1176,7 +1177,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMergeProgramRunArgs) {
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     std::vector<uint32_t> out(2, 0);
-    tt_metal::detail::ReadFromDeviceL1(mesh_device->get_devices()[0], node, address_1, 2 * sizeof(uint32_t), out);
+    tt_metal::detail::ReadFromDeviceL1(
+        mesh_device->impl().get_devices()[0], node, address_1, 2 * sizeof(uint32_t), out);
     ASSERT_EQ(out, std::vector<uint32_t>({value_1, value_2}));
 }
 
@@ -1213,7 +1215,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarUpdateProgramRunArgs) {
     Program& prog = workload.get_programs().at(device_range);
 
     std::vector<uint32_t> zeros(2, 0);
-    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node, address_1, zeros);
+    tt_metal::detail::WriteToDeviceL1(mesh_device->impl().get_devices()[0], node, address_1, zeros);
 
     // First enqueue: write value_1 to address_1.
     experimental::ProgramRunArgs params1;
@@ -1236,7 +1238,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarUpdateProgramRunArgs) {
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     std::vector<uint32_t> outputs(2, 0);
-    tt_metal::detail::ReadFromDeviceL1(mesh_device->get_devices()[0], node, address_1, 2 * sizeof(uint32_t), outputs);
+    tt_metal::detail::ReadFromDeviceL1(
+        mesh_device->impl().get_devices()[0], node, address_1, 2 * sizeof(uint32_t), outputs);
     ASSERT_EQ(outputs, std::vector<uint32_t>({value_1, value_2}));
 }
 

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -25,6 +25,7 @@
 #include "impl/buffers/semaphore.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -95,7 +96,7 @@ void create_and_read_max_num_semaphores(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     auto& program = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     std::vector<uint32_t> golden;
     for (uint32_t i = 0; i < tt::tt_metal::NUM_SEMAPHORES; i++) {
         uint32_t initial_value = i;

--- a/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
@@ -26,6 +26,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/xy_pair.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt::tt_metal;
 
@@ -88,7 +89,7 @@ namespace local_test_functions {
 template <typename T>
 std::pair<std::shared_ptr<Buffer>, std::vector<uint32_t>> l1_buffer_write_wait(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const L1Config<T>& test_config) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto buffer = test_config.sharded ? CreateBuffer(tt::tt_metal::ShardedBufferConfig{
                                             .device = device,
                                             .size = test_config.size_bytes,
@@ -150,7 +151,7 @@ bool l1_buffer_read_write(const std::shared_ptr<distributed::MeshDevice>& mesh_d
 template <typename T>
 std::shared_ptr<Buffer> make_height_sharded_l1_buffer(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const L1Config<T>& test_config) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     return CreateBuffer(tt::tt_metal::ShardedBufferConfig{
         .device = device,
         .size = test_config.size_bytes,
@@ -215,7 +216,7 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_WritesOnlyFilteredCores) 
             ttsl::Span<const uint8_t>(
                 reinterpret_cast<const uint8_t*>(newest.data()), newest.size() * sizeof(uint32_t)),
             filter);
-        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_devices()[0]->id());
+        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->impl().get_devices()[0]->id());
         std::vector<uint32_t> output;
         tt::tt_metal::detail::ReadFromBuffer(buffer, output);
         auto expected =
@@ -239,7 +240,7 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_EmptyFilterIsNoop) {
             ttsl::Span<const uint8_t>(
                 reinterpret_cast<const uint8_t*>(newest.data()), newest.size() * sizeof(uint32_t)),
             empty_filter);
-        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_devices()[0]->id());
+        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->impl().get_devices()[0]->id());
         std::vector<uint32_t> output;
         tt::tt_metal::detail::ReadFromBuffer(buffer, output);
         EXPECT_EQ(output, sentinel);
@@ -265,7 +266,7 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_FullFilterMatchesUnfilter
             *buffer_b,
             ttsl::Span<const uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size() * sizeof(uint32_t)),
             full_filter);
-        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_devices()[0]->id());
+        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->impl().get_devices()[0]->id());
         std::vector<uint32_t> out_a;
         std::vector<uint32_t> out_b;
         tt::tt_metal::detail::ReadFromBuffer(buffer_a, out_a);
@@ -336,7 +337,7 @@ TEST_F(MeshDeviceFixture, TestUnorderedHeightShardReadWrite) {
         for (const auto& core : cores) {
             physical_cores.push_back(mesh_device->worker_core_from_logical_core(core));
         }
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         uint32_t page_size = tt::constants::TILE_HW * sizeof(uint32_t);
         uint32_t total_size = cores.size() * page_size;
         auto buffer = CreateBuffer(tt::tt_metal::ShardedBufferConfig{

--- a/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
+++ b/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "impl/kernels/kernel.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -41,7 +42,7 @@ TEST_F(MeshDeviceSingleCardFixture, StreamScratchRegisterTensixCores) {
 TEST_F(MeshDeviceSingleCardFixture, StreamScratchRegisterEriscCores) {
     // Get device from fixture
     auto mesh_device = this->devices_[0];
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     // Check if device has active ethernet cores
     if (device->get_active_ethernet_cores(true).empty()) {

--- a/tests/tt_metal/tt_metal/api/test_tensor_accessor_default_page_size.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tensor_accessor_default_page_size.cpp
@@ -32,6 +32,7 @@
 #include <tt-metalium/tt_metal.hpp>
 
 #include "device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -69,7 +70,7 @@ constexpr uint32_t TILE_NUM_PAGES = 1;
 constexpr uint32_t TILE_TOTAL_SIZE = TILE_NUM_PAGES * TILE_PAGE_SIZE;
 
 void verify_default_page_size(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const Buffer* input_buffer) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
 
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -122,7 +123,7 @@ void verify_runtime_page_size(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const Buffer* input_buffer,
     uint32_t sentinel_page_size) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
 
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -248,7 +249,7 @@ namespace tt::tt_metal {
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedDramRowMajor) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto buffer = create_interleaved_buffer(device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::DRAM);
         verify_default_page_size(mesh_device, buffer.get());
     }
@@ -256,7 +257,7 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedDramRo
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedDramTilized) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto buffer = create_interleaved_buffer(device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::DRAM);
         verify_default_page_size(mesh_device, buffer.get());
     }
@@ -264,7 +265,7 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedDramTi
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedL1RowMajor) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto buffer = create_interleaved_buffer(device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::L1);
         verify_default_page_size(mesh_device, buffer.get());
     }
@@ -272,7 +273,7 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedL1RowM
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedL1Tilized) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto buffer = create_interleaved_buffer(device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::L1);
         verify_default_page_size(mesh_device, buffer.get());
     }
@@ -282,7 +283,7 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedL1Tili
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorRuntimePageSizeInterleavedDram) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         // Input is a real interleaved row-major DRAM buffer; its address is passed to the kernel but
         // its page size is NOT -- the accessor must read the page size from the runtime sentinel.
         auto input = create_interleaved_buffer(device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::DRAM);
@@ -294,7 +295,7 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorRuntimePageSizeInterleavedDram) 
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedDramRowMajor) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto buffer = create_legacy_sharded_buffer(
             device,
             RM_PAGE_SIZE,
@@ -309,7 +310,7 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedDram
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedDramTilized) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto buffer = create_legacy_sharded_buffer(
             device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::DRAM, {TILE_H, TILE_W}, {TILE_H, TILE_W}, {1, 1});
         verify_default_page_size(mesh_device, buffer.get());
@@ -318,7 +319,7 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedDram
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedL1RowMajor) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto buffer = create_legacy_sharded_buffer(
             device,
             RM_PAGE_SIZE,
@@ -333,7 +334,7 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedL1Ro
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedL1Tilized) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto buffer = create_legacy_sharded_buffer(
             device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::L1, {TILE_H, TILE_W}, {TILE_H, TILE_W}, {1, 1});
         verify_default_page_size(mesh_device, buffer.get());

--- a/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
@@ -46,6 +46,7 @@
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 
 #include "gtest/gtest.h"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -86,7 +87,7 @@ namespace tt::tt_metal {
 
 TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApi) {
     auto& mesh_device = *devices_[0];
-    IDevice* dev = mesh_device.get_devices()[0];
+    IDevice* dev = mesh_device.impl().get_devices()[0];
 
     constexpr uint32_t scratch_bytes = 8 * 1024;
     constexpr uint32_t num_pages = 4;
@@ -207,7 +208,7 @@ TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApi) {
 // chunks of one DFB entry and then barriers once.
 TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApiBatchedL1) {
     auto& mesh_device = *devices_[0];
-    IDevice* dev = mesh_device.get_devices()[0];
+    IDevice* dev = mesh_device.impl().get_devices()[0];
 
     constexpr uint32_t scratch_bytes = 32 * 1024;
     constexpr uint32_t num_chunks = 4;  // 4 disjoint 8 KB L1 zeros, then a single barrier

--- a/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
@@ -20,6 +20,7 @@
 #include "llrt.hpp"
 #include "common/tt_backend_api_types.hpp"
 #include <llrt/tt_cluster.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -166,7 +167,7 @@ protected:
 
     void RunTestOnDevice(
         const std::function<void()>& run_function, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running test on device {}.", device->id());
         run_function();
         log_info(tt::LogTest, "Finished running test on device {}.", device->id());

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -268,7 +268,7 @@ void ExpectDeviceProfilerSkippedOnMock(distributed::MeshDevice& mock_mesh_device
         << "getDeviceProfilerState() must be false for a mock context even when profiling is requested";
     const auto& profiler_state_manager = MetalContext::instance(mock_context_id).profiler_state_manager();
     ASSERT_NE(profiler_state_manager, nullptr);
-    for (auto* dev : mock_mesh_device.get_devices()) {
+    for (auto* dev : mock_mesh_device.impl().get_devices()) {
         EXPECT_FALSE(profiler_state_manager->device_profiler_map.contains(dev->id()))
             << "Device profiler was started on mock device " << dev->id()
             << " -- it must be skipped for mock/emulated clusters";
@@ -305,8 +305,8 @@ void RunCoexistingMockAndSiliconDevice(bool expect_profiler) {
     auto mock_mesh_device_2 = mock_env_2.create_mesh_device(mock_mesh_device_config_2);
     log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_2->shape().dims());
 
-    ASSERT_EQ(mock_mesh_device_1->get_devices().size(), 1);
-    ASSERT_EQ(mock_mesh_device_2->get_devices().size(), 2);
+    ASSERT_EQ(mock_mesh_device_1->impl().get_devices().size(), 1);
+    ASSERT_EQ(mock_mesh_device_2->impl().get_devices().size(), 2);
 
     if (expect_profiler) {
         ExpectDeviceProfilerSkippedOnMock(*mock_mesh_device_1);
@@ -359,8 +359,8 @@ void RunCoexistingSiliconAndMockDevice(bool expect_profiler) {
     std::shared_ptr<distributed::MeshDevice> mesh_device = env.create_mesh_device(mesh_device_config);
     log_info(tt::LogTest, "Created silicon mesh device with shape {}", mesh_device->shape().dims());
 
-    ASSERT_EQ(mock_mesh_device_1->get_devices().size(), 1);
-    ASSERT_EQ(mock_mesh_device_2->get_devices().size(), 2);
+    ASSERT_EQ(mock_mesh_device_1->impl().get_devices().size(), 1);
+    ASSERT_EQ(mock_mesh_device_2->impl().get_devices().size(), 2);
 
     if (expect_profiler) {
         ExpectDeviceProfilerActiveOnSilicon(*mesh_device);
@@ -551,7 +551,7 @@ TEST(MetalContextIntegrationTest, ForkMockAndRealDevice) {
 
         auto mock_mesh_shape = mock_env.get_system_mesh().shape();
         auto mock_mesh_device = mock_env.create_mesh_device(distributed::MeshDeviceConfig(mock_mesh_shape));
-        if (mock_mesh_device->get_devices().size() != 2) {
+        if (mock_mesh_device->impl().get_devices().size() != 2) {
             _exit(3);
         }
 

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -626,7 +626,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllCustom) {
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes2_0) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     uint32_t test_case_id = 329;
 
@@ -652,7 +652,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllDirectedIdeal_2_0) 
     uint32_t test_id = 330;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
     auto arch_ = device->arch();
 
     auto [bytes_per_page, max_reservable_bytes, max_reservable_pages] =
@@ -737,7 +737,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From2x2DirectedI
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllGridSweepPacketSizes2_0) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
     auto grid = device->compute_with_storage_grid_size();
 
     uint32_t test_case_id = 336;

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -622,7 +622,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllPacketSizes2_0) {
     uint32_t test_id = 309;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
@@ -646,7 +646,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllDirectedIdeal_2_0) {
     uint32_t test_id = 310;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
     auto arch_ = device->arch();
 
     auto [bytes_per_page, max_reservable_bytes, max_reservable_pages] =
@@ -731,7 +731,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll2x2To2x2DirectedIdeal
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllGridSweepPacketSizes2_0) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
     auto grid = device->compute_with_storage_grid_size();
 
     uint32_t test_case_id = 316;

--- a/tests/tt_metal/tt_metal/data_movement/atomics/test_atomic_semaphore_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/atomics/test_atomic_semaphore_bandwidth.cpp
@@ -7,6 +7,7 @@
 #include "../dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -34,7 +35,7 @@ struct AtomicSemaphoreConfig {
 bool run_atomic_semaphore_test(
     const shared_ptr<distributed::MeshDevice>& mesh_device, const AtomicSemaphoreConfig& test_config) {
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
 
     std::cerr << "Sender core location X,Y: " << test_config.sender_core_coord.x << ","
               << test_config.sender_core_coord.y << std::endl;

--- a/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/test_conv_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/test_conv_hardcoded.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -38,7 +39,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const C
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = CreateProgram();
     auto& cq = mesh_device->mesh_command_queue();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     // Kernels
     auto receiver_kernel = CreateKernel(

--- a/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/test_deinterleave_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/test_deinterleave_hardcoded.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -37,7 +38,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const D
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = CreateProgram();
     auto& cq = mesh_device->mesh_command_queue();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     for (int k = 0; k < test_config.dest_core_set.size(); k++) {
         // Kernels

--- a/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
@@ -24,6 +24,7 @@
 
 #include <chrono>
 #include <thread>
+#include <distributed/mesh_device_impl.hpp>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -65,7 +66,7 @@ void sync_debug_servers_before_teardown() {
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     TT_FATAL(device->is_mmio_capable(), "Host hugepage test requires an MMIO-capable device");
 
     auto& cluster = MetalContext::instance().get_cluster();

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -37,7 +38,7 @@ struct MulticastAtomicConfig {
 /// @param test_config - Configuration of the test
 /// @return true if test passes, false otherwise
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MulticastAtomicConfig& test_config) {
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
 
     uint32_t num_senders = test_config.sender_cores.size();
     uint32_t num_dests = test_config.dst_grid_size.x * test_config.dst_grid_size.y;
@@ -218,7 +219,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSource) {
     uint32_t test_id = 342;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     auto grid_size = device->compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
@@ -241,7 +242,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSource) {
     uint32_t test_id = 343;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     auto grid_size = device->compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
@@ -264,7 +265,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSourceNOC1) {
     uint32_t test_id = 344;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     auto grid_size = device->compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
@@ -287,7 +288,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSourceNOC1) {
     uint32_t test_id = 345;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     auto grid_size = device->compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
@@ -310,7 +311,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrement) {
     uint32_t test_id = 346;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     auto grid_size = device->compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
@@ -335,7 +336,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrementNOC1) {
     uint32_t test_id = 347;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     auto grid_size = device->compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
@@ -362,7 +363,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSource_2_0) {
     uint32_t test_id = 348;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     auto grid_size = device->compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
@@ -386,7 +387,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrement_2_0) {
     uint32_t test_id = 349;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     auto grid_size = device->compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
@@ -412,7 +413,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSource_2_0) {
     uint32_t test_id = 350;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     auto grid_size = device->compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
@@ -436,7 +437,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSourceNOC1_2_0) {
     uint32_t test_id = 351;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     auto grid_size = device->compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
@@ -460,7 +461,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSourceNOC1_2_0) {
     uint32_t test_id = 352;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     auto grid_size = device->compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
@@ -484,7 +485,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrementNOC1_2_0) {
     uint32_t test_id = 353;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     auto grid_size = device->compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -50,7 +51,7 @@ struct NocApiLatencyConfig {
 bool run_noc_api_latency_test(
     const shared_ptr<distributed::MeshDevice>& mesh_device, const NocApiLatencyConfig& test_config) {
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
 
     /* ================ SETUP ================ */
 
@@ -182,7 +183,7 @@ bool run_noc_api_latency_test(
 // Sweep test for unicast write and read
 void unicast_sweep_test(
     const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id, KernelType kernel_type) {
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
     for (uint32_t transaction_size = 32; transaction_size <= 4096; transaction_size *= 2) {
         for (uint32_t num_transactions = 1; num_transactions <= 256; num_transactions *= 2) {
             NocApiLatencyConfig test_config = {
@@ -273,7 +274,7 @@ TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyMulticastWrite5x5) {
 TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyMulticastWriteAll) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 706;
-    auto* device = this->mesh_device_->get_device(0);
+    auto* device = this->mesh_device_->impl().get_device(0);
     CoreCoord grid_size = device->compute_with_storage_grid_size();
     tt::tt_metal::unit_tests::dm::noc_api_latency::multicast_write_sweep_test(
         this->mesh_device_, test_case_id, {0, 0}, {grid_size.x - 1, grid_size.y - 1}, true);

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -10,6 +10,7 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -39,8 +40,7 @@ struct L2FlushTestConfig {
 bool run_l2_flush_test(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const L2FlushTestConfig& config) {
-
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     constexpr CoreCoord core = {0, 0};
     const experimental::NodeCoord node{0, 0};
 
@@ -126,8 +126,7 @@ struct L1DCacheTestConfig {
 bool run_l1_dcache_test(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const L1DCacheTestConfig& config) {
-
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     constexpr CoreCoord core = {0, 0};
     const experimental::NodeCoord node{0, 0};
 

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <cstdint>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -30,7 +31,7 @@ bool should_skip_test() { return std::getenv("TT_METAL_SIMULATOR") == nullptr; }
 // on a single DM core, then reads back and verifies the byte pattern landed.
 bool run_cache_write(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, std::uint32_t size_bytes, std::uint32_t write_path) {
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     constexpr CoreCoord core = {0, 0};
     const experimental::NodeCoord node{0, 0};
 

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -94,7 +95,7 @@ bool run_idma_basic_test(const std::shared_ptr<distributed::MeshDevice>& mesh_de
     constexpr uint32_t total_bytes = num_elements * elem_size;
     constexpr uint32_t num_words = total_bytes / sizeof(uint32_t);
 
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
     auto buffers = make_idma_src_dst_buffers(mesh_device, total_bytes);
     const uint32_t src_base = buffers.src->address();
     const uint32_t dst_base = buffers.dst->address();
@@ -142,7 +143,7 @@ bool run_idma_1d_strided_test(const std::shared_ptr<distributed::MeshDevice>& me
     constexpr uint32_t src_num_words = (num_elements * src_stride) / sizeof(uint32_t);
     constexpr uint32_t dst_num_words = (num_elements * elem_size) / sizeof(uint32_t);
 
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     std::vector<uint32_t> src_data(src_num_words);
     for (uint32_t i = 0; i < src_num_words; i++) {

--- a/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/test_reshard_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/test_reshard_hardcoded.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -38,7 +39,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const R
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = CreateProgram();
     auto& cq = mesh_device->mesh_command_queue();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     // Kernels
     auto receiver_kernel = CreateKernel(

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -17,6 +17,7 @@
 #include <cerrno>
 #include "tt_stl/assert.hpp"
 #include "fmt/format.h"
+#include <distributed/mesh_device_impl.hpp>
 
 // Access to internal API: BuildEnvManager, CompileProgram, get_kernel
 #include "jit_build/build_env_manager.hpp"
@@ -59,11 +60,11 @@ protected:
         // and a hung core will fail that check. Tensix/DRAM cores don't need this.
         auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
         for (auto& [device_id, device] : id_to_device_) {
-            for (const auto& logical_core : device->get_devices()[0]->get_inactive_ethernet_cores()) {
+            for (const auto& logical_core : device->impl().get_devices()[0]->get_inactive_ethernet_cores()) {
                 CoreCoord virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(
-                    device->get_devices()[0]->id(), logical_core, CoreType::ETH);
+                    device->impl().get_devices()[0]->id(), logical_core, CoreType::ETH);
                 cluster.assert_risc_reset_at_core(
-                    tt_cxy_pair(device->get_devices()[0]->id(), virtual_core), tt::umd::RiscType::ALL);
+                    tt_cxy_pair(device->impl().get_devices()[0]->id(), virtual_core), tt::umd::RiscType::ALL);
             }
         }
 
@@ -339,7 +340,7 @@ public:
         KernelHandle kernel_handle = CreateKernel(program_, kernel_path, core, config);
 
         SetRuntimeArgs(program_, kernel_handle, core, runtime_args);
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         detail::CompileProgram(device, program_);
 
         // Find compiled kernel and extract format string from it to compare with expected_format_message

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
@@ -26,6 +26,7 @@
 #include "debug_tools_test_utils.hpp"
 #include "gtest/gtest.h"
 #include "tt_metal/test_utils/stimulus.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -191,7 +192,7 @@ TEST_F(DevicePrintCheckpointTest, CheckpointLoopAndDumpDest) {
 static void run_global_checkpoint(
     DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     using namespace dp_ckpt;
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     size_t tile_size = tt::tile_size(FMT);
     size_t buf_sz = NUM_TILES * tile_size;
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_eth_cores.cpp
@@ -22,6 +22,7 @@
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "tests/tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////
 // A test for printing from ethernet cores.
@@ -37,7 +38,7 @@ void RunTest(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     bool active,
     DataMovementProcessor processor = DataMovementProcessor::RISCV_0) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     // Try printing on all ethernet cores on this device
     std::unordered_set<CoreCoord> test_cores;
     tt_metal::EthernetConfig config = {.noc = static_cast<tt_metal::NOC>(processor), .processor = processor};
@@ -77,7 +78,7 @@ void RunTest(
 
 TEST_F(DevicePrintFixture, ActiveEthTestPrint) {
     for (auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         // Skip if no ethernet cores on this device
         if (device->get_active_ethernet_cores(true).empty()) {
             log_info(tt::LogTest, "Skipping device {} due to no ethernet cores...", device->id());
@@ -103,7 +104,7 @@ TEST_F(DevicePrintFixture, IdleEthTestPrint) {
         GTEST_SKIP();
     }
     for (auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         // Skip if no ethernet cores on this device
         if (device->get_inactive_ethernet_cores().empty()) {
             log_info(tt::LogTest, "Skipping device {} due to no ethernet cores...", device->id());

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
@@ -21,6 +21,7 @@
 #include "debug_tools_fixture.hpp"
 #include "debug_tools_test_utils.hpp"
 #include "impl/context/metal_context.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -115,7 +116,7 @@ void RunFilteringTest(
         << log;
 
     for (const auto& mesh_device : all_devices) {
-        auto [row, col] = GetGlobalCoord(mesh_device->get_devices()[0]->id());
+        auto [row, col] = GetGlobalCoord(mesh_device->impl().get_devices()[0]->id());
         if (std::make_pair(row, col) == fixture->target_coord) {
             continue;
         }
@@ -130,7 +131,7 @@ void RunFilteringTest(
 void RunAllChipsVerificationTest(
     DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     constexpr auto kDprint = tt::llrt::RunTimeDebugFeatureDprint;
-    ChipId chip_id = mesh_device->get_devices()[0]->id();
+    ChipId chip_id = mesh_device->impl().get_devices()[0]->id();
     auto [row, col] = GetGlobalCoord(chip_id);
 
     auto workload = BuildMeshCoordWorkload(mesh_device);

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
@@ -85,7 +85,7 @@ distributed::MeshWorkload BuildMeshCoordWorkload(const std::shared_ptr<distribut
     distributed::MeshWorkload workload;
     constexpr CoreCoord kCore = {0, 0};
     for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
-        auto [row, col] = GetGlobalCoord(mesh_device->get_device(coord)->id());
+        auto [row, col] = GetGlobalCoord(mesh_device->impl().get_device(coord)->id());
         Program program;
         CreateKernel(
             program,

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_multi_kernel_print.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_multi_kernel_print.cpp
@@ -25,6 +25,7 @@
 #include "debug_tools_test_utils.hpp"
 #include "gtest/gtest.h"
 #include "tests/tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -82,7 +83,7 @@ TEST_F(DevicePrintFixture, TwoWorkerKernelsSameProgram) {
 // Single program, two active ETH kernels (DM0) on two different ETH cores.
 TEST_F(DevicePrintFixture, TwoActiveEthKernelsSameProgram) {
     for (auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const auto eth_cores = device->get_active_ethernet_cores(true);
         if (eth_cores.size() < 2) {
             log_info(
@@ -125,7 +126,7 @@ TEST_F(DevicePrintFixture, TwoWorkerProgramsBackToBack) {
 // Two programs run back-to-back on the same active ETH core / RISC.
 TEST_F(DevicePrintFixture, TwoActiveEthProgramsBackToBack) {
     for (auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const auto eth_cores = device->get_active_ethernet_cores(true);
         if (eth_cores.empty()) {
             log_info(tt::LogTest, "Skipping device {} (no active ETH cores)", device->id());

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_before_finish.cpp
@@ -19,6 +19,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking that the finish command can wait for the last dprint.
@@ -39,7 +40,7 @@ void RunTest(DevicePrintFixture* fixture, const std::shared_ptr<distributed::Mes
     Program program = Program();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     // This tests prints only on a single core
     CoreCoord xy_start = {0, 0};

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
@@ -23,6 +23,7 @@
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////
 // A test for checking that prints are prepended with their corresponding device, core and RISC.
@@ -38,7 +39,8 @@ void UpdateGoldenOutput(
     const std::string& risc) {
     // Using wildcard characters in lieu of actual values for the virtual coordinates as virtual coordinates can vary
     // by machine. CoreCoord::str() formats as "x-y".
-    const std::string& device_core_risc = std::to_string(mesh_device->get_devices()[0]->id()) + ":?-?:" + risc + ": ";
+    const std::string& device_core_risc =
+        std::to_string(mesh_device->impl().get_devices()[0]->id()) + ":?-?:" + risc + ": ";
 
     const std::string& output_line_all_riscs = device_core_risc + "Printing on a RISC.";
     golden_output.push_back(output_line_all_riscs);
@@ -62,7 +64,7 @@ void RunTest(
     Program program = Program();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     CreateKernel(
         program_,
@@ -130,11 +132,11 @@ TEST_F(DevicePrintFixture, TensixActiveEthTestPrintPrependDeviceCoreRisc) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
         tt::llrt::RunTimeDebugFeatureDprint, true);
     for (auto& mesh_device : this->devices_) {
-        if (mesh_device->get_devices()[0]->get_active_ethernet_cores(true).empty()) {
+        if (mesh_device->impl().get_devices()[0]->get_active_ethernet_cores(true).empty()) {
             log_info(
                 tt::LogTest,
                 "Skipping device {} due to no active ethernet cores...",
-                mesh_device->get_devices()[0]->id());
+                mesh_device->impl().get_devices()[0]->id());
             continue;
         }
         this->RunTestOnDevice(

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -32,6 +32,7 @@
 #include "impl/dispatch/dispatch_engine_cores.hpp"
 #include "host_api/temp_quasar_api.hpp"
 #include <umd/device/types/core_coordinates.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher asserts.
@@ -62,7 +63,7 @@ static void RunTest(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
     // TENSIX cores use the Metal 2.0 host API and the *_2_0.cpp kernel; ETH/DRAM cores remain on the legacy

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -23,6 +23,7 @@
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "impl/kernels/kernel.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher polling the eth link training counter.
@@ -38,7 +39,7 @@ static void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distribut
     Program program = Program();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     CoreCoord logical_core, virtual_core;
     if (device->get_active_ethernet_cores(true).empty()) {
@@ -88,7 +89,7 @@ TEST_F(MeshWatcherFixture, ActiveEthTestWatcherEthLinkCheck) {
 
     // Just try forcing an eth retrain on Device 0
     auto mesh_device = this->devices_[0];
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     vector<uint32_t> reset_val = {0x1};
     uint32_t retrain_force_addr = tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
         tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::RETRAIN_FORCE);

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_mcast_wrap_around.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_mcast_wrap_around.cpp
@@ -21,6 +21,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -42,7 +43,7 @@ void DoHostMcastWrite(ChipId chip_id, CoreCoord core_start, CoreCoord core_end) 
 }  // namespace
 
 TEST_F(MeshWatcherFixture, HostMcastWrapAroundY_Down) {
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     ChipId chip_id = device->id();
     CoreCoord grid = device->compute_with_storage_grid_size();
 
@@ -59,7 +60,7 @@ TEST_F(MeshWatcherFixture, HostMcastWrapAroundY_Down) {
 }
 
 TEST_F(MeshWatcherFixture, HostMcastWrapAroundY_Up) {
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     ChipId chip_id = device->id();
     CoreCoord grid = device->compute_with_storage_grid_size();
 
@@ -76,7 +77,7 @@ TEST_F(MeshWatcherFixture, HostMcastWrapAroundY_Up) {
 }
 
 TEST_F(MeshWatcherFixture, HostMcastWrapAroundX_Right) {
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     ChipId chip_id = device->id();
     CoreCoord grid = device->compute_with_storage_grid_size();
 
@@ -93,7 +94,7 @@ TEST_F(MeshWatcherFixture, HostMcastWrapAroundX_Right) {
 }
 
 TEST_F(MeshWatcherFixture, HostMcastWrapAroundX_Left) {
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     ChipId chip_id = device->id();
     CoreCoord grid = device->compute_with_storage_grid_size();
 
@@ -110,7 +111,7 @@ TEST_F(MeshWatcherFixture, HostMcastWrapAroundX_Left) {
 }
 
 TEST_F(MeshWatcherFixture, HostMcastWrapAroundXY_DownRight) {
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     ChipId chip_id = device->id();
     CoreCoord grid = device->compute_with_storage_grid_size();
 
@@ -127,7 +128,7 @@ TEST_F(MeshWatcherFixture, HostMcastWrapAroundXY_DownRight) {
 }
 
 TEST_F(MeshWatcherFixture, HostMcastWrapAroundXY_UpLeft) {
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     ChipId chip_id = device->id();
     CoreCoord grid = device->compute_with_storage_grid_size();
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_mcast_wrap_around_device.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_mcast_wrap_around_device.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "debug_tools_fixture.hpp"
 #include <tt-logger/tt-logger.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -148,7 +149,7 @@ TEST_F(MeshWatcherFixture, DeviceMcastWrapAroundY_Down_Noc0_SingleCol) {
     if (!this->IsSlowDispatch()) {
         GTEST_SKIP() << "Wrap-around multicast device tests require Slow Dispatch mode";
     }
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.y < 2) {
@@ -178,7 +179,7 @@ TEST_F(MeshWatcherFixture, DeviceMcastWrapAroundY_Down_Noc0_MultiCol_S4) {
     if (!this->IsSlowDispatch()) {
         GTEST_SKIP() << "Wrap-around multicast device tests require Slow Dispatch mode";
     }
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.y < 2 || grid.x < 5) {
@@ -208,7 +209,7 @@ TEST_F(MeshWatcherFixture, DeviceMcastWrapAroundY_Down_Noc1_MultiCol_S8) {
     if (!this->IsSlowDispatch()) {
         GTEST_SKIP() << "Wrap-around multicast device tests require Slow Dispatch mode";
     }
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.y < 2 || grid.x < 12) {
@@ -238,7 +239,7 @@ TEST_F(MeshWatcherFixture, DeviceMcastWrapAroundY_Down_Noc1_SingleCol) {
     if (!this->IsSlowDispatch()) {
         GTEST_SKIP() << "Wrap-around multicast device tests require Slow Dispatch mode";
     }
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.y < 2) {
@@ -268,7 +269,7 @@ TEST_F(MeshWatcherFixture, DeviceMcastWrapAroundX_Right_Noc0) {
     if (!this->IsSlowDispatch()) {
         GTEST_SKIP() << "Wrap-around multicast device tests require Slow Dispatch mode";
     }
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.x < 2) {
@@ -292,7 +293,7 @@ TEST_F(MeshWatcherFixture, DeviceMcastWrapAroundX_Right_Noc1) {
     if (!this->IsSlowDispatch()) {
         GTEST_SKIP() << "Wrap-around multicast device tests require Slow Dispatch mode";
     }
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.x < 2) {
@@ -316,7 +317,7 @@ TEST_F(MeshWatcherFixture, DeviceMcastMixedWrap_XWrapYNormal_Noc0) {
     if (!this->IsSlowDispatch()) {
         GTEST_SKIP() << "Wrap-around multicast device tests require Slow Dispatch mode";
     }
-    auto* device = this->devices_[0]->get_devices()[0];
+    auto* device = this->devices_[0]->impl().get_devices()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.x < 2 || grid.y < 3) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -31,6 +31,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher NOC sanitization.
@@ -60,7 +61,7 @@ void RunDelayTestOnCore(
     tt_metal::Program program = tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
 
     const uint32_t SINGLE_TILE_SIZE = 2 * 1024;

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -26,6 +26,7 @@
 #include "impl/kernels/kernel.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher pause feature.
@@ -41,7 +42,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     const auto& hal = MetalContext::instance().hal();
     const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
     // Watcher pause kernels use Metal 2.0 on all architectures.
@@ -154,7 +155,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
 }
 
 void RunEthTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     if (MetalContext::instance().hal().get_arch() == tt::ARCH::QUASAR) {
         GTEST_SKIP() << "Metal 2.0 does not yet support ETH KernelSpecs";
     }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -23,6 +23,7 @@
 #include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"
 #include <umd/device/types/core_coordinates.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking debug ring buffer feature.
@@ -51,7 +52,7 @@ void RunTest(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     workload.add_program(device_range, {});
     auto& program = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     // Depending on riscv type, choose one core to run the test on
     // and set up the kernel on the correct risc

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "debug_tools_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -38,7 +39,7 @@ protected:
         }
         MeshWatcherFixture::SetUp();
         mesh_device = devices_[0];
-        device = mesh_device->get_devices()[0];
+        device = mesh_device->impl().get_devices()[0];
         num_dms_ = MetalContext::instance().hal().get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);
         is_quasar = arch_ == tt::ARCH::QUASAR;
         // On Quasar, DM0/DM1 are reserved for internal use; user kernels can only land on DM2..DM7.

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/hal_types.hpp>
+#include <distributed/mesh_device_impl.hpp>
 // Do we really want to expose Hal like this?
 // This looks like an API level test
 #include "impl/context/metal_context.hpp"
@@ -155,7 +156,7 @@ void RunTestOnCore(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
 
     CoreCoord virtual_core;
@@ -796,7 +797,7 @@ void RunTestEth(
     MeshWatcherFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     watcher_features_t feature) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     if (fixture->IsSlowDispatch()) {
         GTEST_SKIP();
     }
@@ -813,7 +814,7 @@ void RunTestIEth(
     MeshWatcherFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     watcher_features_t feature) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     // Run on the first ethernet core (if there are any).
     if (device->get_inactive_ethernet_cores().empty()) {
         log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
@@ -825,7 +826,7 @@ void RunTestIEth(
 
 // Run tests for host-side sanitization (uses functions that are from watcher_server.hpp).
 void CheckHostSanitization(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     // Try reading from a core that doesn't exist
     constexpr CoreCoord core = {99, 99};
     uint64_t addr = 0;

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 #include <optional>
 #include "impl/kernels/kernel.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -39,7 +40,7 @@ void RunOneTest(
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     CoreCoord coord = {0, 0};
     std::vector<uint32_t> compile_args{free};

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -17,6 +17,7 @@
 #include "debug_tools_fixture.hpp"
 #include "debug_tools_test_utils.hpp"
 #include "impl/context/metal_context.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher tile counter log feature.
@@ -43,7 +44,7 @@ void RunTest(
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     CoreCoord logical_core = {0, 0};
     CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
     const experimental::NodeCoord node{static_cast<uint32_t>(logical_core.x), static_cast<uint32_t>(logical_core.y)};

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -26,6 +26,7 @@
 #include <umd/device/types/arch.hpp>
 #include "impl/kernels/kernel.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher waypoints.
@@ -56,7 +57,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     const auto& hal = MetalContext::instance().hal();
     const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
     // Watcher waypoint kernels use Metal 2.0 on all architectures.
@@ -221,7 +222,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
 }
 
 void RunEthTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     const auto& hal = MetalContext::instance().hal();
     if (hal.get_arch() == tt::ARCH::QUASAR) {
         GTEST_SKIP() << "Metal 2.0 does not yet support ETH KernelSpecs";

--- a/tests/tt_metal/tt_metal/deployment/dram/dram_base.cpp
+++ b/tests/tt_metal/tt_metal/deployment/dram/dram_base.cpp
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <string>
 #include <umd/device/types/telemetry.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 static bool get_dram_inject_tensix_heartbeat_stall_from_env_once() {
     const char* env = std::getenv("DRAM_TEST_INJECT_TENSIX_HEARTBEAT_STALL");
@@ -214,7 +215,7 @@ static void log_verbose_dram_work_item(
 
 std::vector<DramBankWorkerAssignment> get_optimal_dram_bank_worker_assignments(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device, tt_metal::NOC noc) {
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
 
     const uint32_t num_dram_channels = device->num_dram_channels();
 
@@ -330,7 +331,7 @@ DramRunSummary run_dram_base_test(
     uint32_t repeat_index,
     DataMovementProcessor processor) {
     /* ======================== */
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
 
     TT_FATAL(cfg.bank_id < 8, "bank_id must not exceed the total number of controllers");
     TT_FATAL(cfg.total_bytes <= DRAM_TEST_EFFECTIVE_MAX_BANK_BYTES, "total_bytes must be under (4GB-16MB-2KB)");
@@ -448,7 +449,7 @@ DramRunSummary run_dram_multi_core_single_controller_test(
     uint32_t repeat_index,
     DataMovementProcessor processor) {
     /* ======================== */
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
 
     TT_FATAL(!cores.empty(), "No cores provided");
     TT_FATAL(cfg.bank_id < 8, "bank_id must not exceed the total number of controllers");
@@ -579,7 +580,7 @@ DramRunSummary run_dram_multi_core_all_controllers_test(
     uint32_t repeat_index,
     DataMovementProcessor processor) {
     /* ======================== */
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t num_controllers = 8u;
 
@@ -731,7 +732,7 @@ DramRunSummary run_dram_eight_single_core_single_controller_test(
     uint32_t repeat_index,
     DataMovementProcessor processor) {
     /* ======================== */
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t num_controllers = 8u;
 
@@ -858,7 +859,7 @@ DramMultiInstanceSummary run_dram_eight_single_core_single_controller_test_verbo
     uint32_t repeat_index,
     DataMovementProcessor processor) {
     /* ======================== */
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
 
     constexpr uint32_t num_controllers = 8u;
 
@@ -985,7 +986,7 @@ DramMultiInstanceSummary run_dram_persistent_jobs_test_verbose(
     uint32_t chunk_bytes,
     DataMovementProcessor processor) {
     /* ======================== */
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
 
     TT_FATAL(!worker_cores.empty(), "No worker cores provided");
     TT_FATAL(!jobs_per_core.empty(), "No per-core jobs provided");

--- a/tests/tt_metal/tt_metal/deployment/dram/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/deployment/dram/test_dram.cpp
@@ -29,6 +29,7 @@
 
 #include <iomanip>
 #include <array>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -893,7 +894,7 @@ TEST_F(MeshDispatchFixture, DramDeployment_PersistentOptimalWorkersAllDramBanks)
         bool chip_pass = true;
 
         const auto& mesh_device = devices_[chip_index];
-        auto* const device = mesh_device->get_devices()[0];
+        auto* const device = mesh_device->impl().get_devices()[0];
 
         chip_summary.chips_tested = 1;
 
@@ -1172,7 +1173,7 @@ TEST_F(MeshDispatchFixture, DramDeployment_PersistentAllWorkersSingleDramSequent
         bool chip_pass = true;
 
         const auto& mesh_device = devices_[chip_index];
-        auto* const device = mesh_device->get_devices()[0];
+        auto* const device = mesh_device->impl().get_devices()[0];
 
         chip_summary.chips_tested = 1;
 
@@ -1510,7 +1511,7 @@ TEST_F(MeshDispatchFixture, DramDeployment_PersistentPartitionedWorkersAllDramBa
         bool chip_pass = true;
 
         const auto& mesh_device = devices_[chip_index];
-        auto* const device = mesh_device->get_devices()[0];
+        auto* const device = mesh_device->impl().get_devices()[0];
 
         chip_summary.chips_tested = 1;
 

--- a/tests/tt_metal/tt_metal/deployment/eth/common.hpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/common.hpp
@@ -13,6 +13,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "command_queue_fixture.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 /* Performance debug helpers */
 #define NOW() std::chrono::high_resolution_clock::now()
@@ -260,7 +261,7 @@ static void track_eth_progress_timeout_cores(std::span<struct core_setup> cores)
             continue;
         }
         threads.emplace_back([&] {
-            auto* const device = c.mesh_device->get_devices()[0];
+            auto* const device = c.mesh_device->impl().get_devices()[0];
             track_eth_progress_timeout(device, nullptr, c.core, c.core, c.iter_l1_addr, c.expected_count);
         });
     }
@@ -286,7 +287,7 @@ static void wait_to_finish_eth_timeout_cores(
     }
 
     for (const auto& [dev, workload] : devices) {
-        detail::CompileProgram(dev->get_devices()[0], *programs[dev]);
+        detail::CompileProgram(dev->impl().get_devices()[0], *programs[dev]);
         devices[dev]->add_program(device_range, std::move(*programs[dev]));
     }
 
@@ -331,8 +332,8 @@ static void wait_to_finish_eth_timeout(
         fixture->RunProgram(recv_mesh_device, recv_workload, true);
     }
 
-    auto* const send_device = send_mesh_device->get_devices()[0];
-    auto* const recv_device = recv_mesh_device->get_devices()[0];
+    auto* const send_device = send_mesh_device->impl().get_devices()[0];
+    auto* const recv_device = recv_mesh_device->impl().get_devices()[0];
     track_eth_progress_timeout(send_device, recv_device, send_core, recv_core, iter_l1_addr, expected_count);
 
     fixture->FinishCommands(send_mesh_device);
@@ -454,7 +455,7 @@ static void tensix_zero_dram(
     TT_FATAL(dram_start_addr < dram_end_addr, "start addr must be less than end addr");
     tt_metal::Program zero_program = tt_metal::Program();
 
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
     CoreCoord core_grid = device->compute_with_storage_grid_size();
     uint32_t total_bytes = dram_end_addr - dram_start_addr;
     uint32_t core_count = core_grid.x * core_grid.y;
@@ -531,7 +532,7 @@ static void tensix_counter_dram(
     TT_FATAL(dram_start_addr < dram_end_addr, "start addr must be less than end addr");
     tt_metal::Program zero_program = tt_metal::Program();
 
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
     CoreCoord core_grid = device->compute_with_storage_grid_size();
     uint32_t total_bytes = dram_end_addr - dram_start_addr;
     uint32_t core_count = core_grid.x * core_grid.y;
@@ -612,7 +613,7 @@ static bool tensix_compare_dram_banks(
 
     tt_metal::Program cmp_program = tt_metal::Program();
 
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
     CoreCoord core_grid = device->compute_with_storage_grid_size();
     uint32_t total_bytes = dram_end_addr - dram_start_addr;
     uint32_t core_count = core_grid.x * core_grid.y;
@@ -734,7 +735,7 @@ static bool test_check_cores(std::span<struct core_setup> cores) {
             log_info(tt::LogTest, "core_check: {}", cs.locinfo);
         }
         prev = cs.locinfo;
-        auto* const dev = cs.mesh_device->get_devices()[0];
+        auto* const dev = cs.mesh_device->impl().get_devices()[0];
         pass &= bandwidth_check(dev, cs.core, cs.delta_time_addr, cs.total_transferred, cs.bw_threshold);
         pass &= data_check(dev, cs.core, cs.recv_l1_address, cs.inp);
 
@@ -917,7 +918,7 @@ static bool ensure_links(std::span<std::shared_ptr<distributed::MeshDevice>> dev
     }
 
     for (const auto& device : devices) {
-        auto* const dev = device->get_devices()[0];
+        auto* const dev = device->impl().get_devices()[0];
         int numlinks = dev->get_active_ethernet_cores().size();
         if (numlinks != expected_links) {
             pass = false;

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth.cpp
@@ -12,6 +12,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "command_queue_fixture.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -28,8 +29,8 @@ static bool run_test_bandwidth(
     const CoreCoord& recv_core,
     DataMovementProcessor processor = DataMovementProcessor::RISCV_0) {
     /* ======================= */
-    auto* const send_device = send_mesh_device->get_devices()[0];
-    auto* const recv_device = recv_mesh_device->get_devices()[0];
+    auto* const send_device = send_mesh_device->impl().get_devices()[0];
+    auto* const recv_device = recv_mesh_device->impl().get_devices()[0];
 
     TEST_PARAM(uint32_t, transfer_size, 160 * 1024, "ETH_TEST_TRANSFER_SIZE");
     TEST_PARAM(uint32_t, transfer_count, 10 << 10, "ETH_TEST_TRANSFER_COUNT");
@@ -116,9 +117,9 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet01Bandwidth) {
     ASSERT_TRUE(ensure_links(devices_));
 
     for (const auto& sender_mesh_device : devices_) {
-        auto* const sender_device = sender_mesh_device->get_devices()[0];
+        auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+            auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
 
             log_info(
                 tt::LogTest,

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth_bidir.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth_bidir.cpp
@@ -13,6 +13,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "command_queue_fixture.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -30,8 +31,8 @@ static bool run_test_bandwidth_bidir(
     DataMovementProcessor processor0,
     span<uint32_t> inputs) {
     /* =================== */
-    auto* const send_device = send_mesh_device->get_devices()[0];
-    auto* const recv_device = recv_mesh_device->get_devices()[0];
+    auto* const send_device = send_mesh_device->impl().get_devices()[0];
+    auto* const recv_device = recv_mesh_device->impl().get_devices()[0];
 
     TEST_PARAM(uint32_t, transfer_size, 160 * 1024, "ETH_TEST_TRANSFER_SIZE");
     TEST_PARAM(uint32_t, transfer_count, 20 << 10, "ETH_TEST_TRANSFER_COUNT");
@@ -127,9 +128,9 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet02BandwidthBidir) {
     ASSERT_TRUE(ensure_links(devices_));
 
     for (const auto& sender_mesh_device : devices_) {
-        auto* const sender_device = sender_mesh_device->get_devices()[0];
+        auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+            auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
 
             log_info(
                 tt::LogTest,

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram.cpp
@@ -13,6 +13,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "command_queue_fixture.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -228,7 +229,7 @@ static bool run_test_integrity_dram(
     };
     wait_to_finish_eth_timeout_cores(fixture, cores, programs);
 
-    auto* const send_device = send_mesh_device->get_devices()[0];
+    auto* const send_device = send_mesh_device->impl().get_devices()[0];
     double threshold = get_eth_bw() * 0.5;
 
     bool pass = true;
@@ -252,9 +253,9 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet03DataIntegrityDram) {
     ASSERT_TRUE(ensure_links(devices_));
 
     for (const auto& sender_mesh_device : devices_) {
-        auto* const sender_device = sender_mesh_device->get_devices()[0];
+        auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+            auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
 
             log_info(
                 tt::LogTest,

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram_bidir.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram_bidir.cpp
@@ -13,6 +13,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "command_queue_fixture.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -91,8 +92,8 @@ static bool run_test_integrity_dram_bidir(
     const CoreCoord& recv_core,
     DataMovementProcessor processor0 = DataMovementProcessor::RISCV_0) {
     /* ============= */
-    auto* const send_device = send_mesh_device->get_devices()[0];
-    auto* const recv_device = recv_mesh_device->get_devices()[0];
+    auto* const send_device = send_mesh_device->impl().get_devices()[0];
+    auto* const recv_device = recv_mesh_device->impl().get_devices()[0];
 
     TEST_PARAM(uint32_t, dram_start_addr, 0x500000, "ETH_TEST_START_ADDR");
     TEST_PARAM(uint32_t, dram_end_addr, 0xfe000000u, "ETH_TEST_END_ADDR");
@@ -214,9 +215,9 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet04DataIntegrityDramBidir) {
     ASSERT_TRUE(ensure_links(devices_));
 
     for (const auto& sender_mesh_device : devices_) {
-        auto* const sender_device = sender_mesh_device->get_devices()[0];
+        auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+            auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
 
             log_info(
                 tt::LogTest,

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_link_up.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_link_up.cpp
@@ -12,6 +12,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "command_queue_fixture.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -28,8 +29,8 @@ static bool run_test(
     const CoreCoord& recv_core,
     DataMovementProcessor processor = DataMovementProcessor::RISCV_0) {
     /* =================== */
-    auto* const send_device = send_mesh_device->get_devices()[0];
-    auto* const recv_device = recv_mesh_device->get_devices()[0];
+    auto* const send_device = send_mesh_device->impl().get_devices()[0];
+    auto* const recv_device = recv_mesh_device->impl().get_devices()[0];
     uint32_t num_bytes_per_send = 16;
     uint32_t transfer_size = 1024;
     uint32_t transfer_count = 1;
@@ -111,9 +112,9 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet00LinkUp) {
     ASSERT_TRUE(ensure_links(devices_));
 
     for (const auto& sender_mesh_device : devices_) {
-        auto* const sender_device = sender_mesh_device->get_devices()[0];
+        auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+            auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
 
             log_info(
                 tt::LogTest,

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_stress_test.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_stress_test.cpp
@@ -13,6 +13,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "command_queue_fixture.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -34,8 +35,8 @@ static void run_test_stress(
     map<shared_ptr<distributed::MeshDevice>, shared_ptr<tt_metal::Program>> programs) {
     /* =================== */
     (void)fixture;
-    auto* const send_device = send_mesh_device->get_devices()[0];
-    auto* const recv_device = recv_mesh_device->get_devices()[0];
+    auto* const send_device = send_mesh_device->impl().get_devices()[0];
+    auto* const recv_device = recv_mesh_device->impl().get_devices()[0];
 
     TEST_PARAM(uint32_t, transfer_size, 160 * 1024, "ETH_TEST_TRANSFER_SIZE");
     TEST_PARAM(uint32_t, transfer_count, 2 << 20, "ETH_TEST_TRANSFER_COUNT");
@@ -128,11 +129,11 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet05StressTest) {
 
     for (int i = 0; i < devices_.size(); i++) {
         const auto& sender_mesh_device = devices_[i];
-        auto* const sender_device = sender_mesh_device->get_devices()[0];
+        auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
 
         for (int j = i; j < devices_.size(); j++) {
             const auto& receiver_mesh_device = devices_[j];
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+            auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
 
             log_info(
                 tt::LogTest,

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -41,7 +41,6 @@
 #include "math.hpp"
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include <distributed/mesh_device_impl.hpp>
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -570,7 +569,7 @@ TEST_F(MeshDeviceFixture, SlowDispatchFullGridAccess) {
 
     for (const auto& mesh_device : devices_) {
         for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
-            auto* device = mesh_device->get_device(coord[0], coord[1]);
+            auto* device = mesh_device->impl().get_device(coord[0], coord[1]);
             auto compute_grid = device->compute_with_storage_grid_size();
             auto logical_grid = device->logical_grid_size();
 

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -41,6 +41,7 @@
 #include "math.hpp"
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include <distributed/mesh_device_impl.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -60,7 +61,7 @@ bool l1_ping(
     const size_t& byte_size,
     const size_t& l1_byte_address,
     const CoreCoord& grid_size) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     bool pass = true;
     auto inputs = generate_uniform_random_vector<uint32_t>(0, UINT32_MAX, byte_size / sizeof(uint32_t));
     for (int y = 0; y < grid_size.y; y++) {
@@ -95,7 +96,7 @@ bool dram_ping(
     const size_t& byte_size,
     const size_t& dram_byte_address,
     const unsigned int& num_channels) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     bool pass = true;
     auto inputs = generate_uniform_random_vector<uint32_t>(0, UINT32_MAX, byte_size / sizeof(uint32_t));
     for (unsigned int channel = 0; channel < num_channels; channel++) {
@@ -209,7 +210,7 @@ TEST_F(MeshDeviceFixture, TensixPingIllegalL1Cores) {
 // Purpose of this test is to ensure that L1 reader/writer APIs do not target harvested cores
 TEST_F(MeshDeviceFixture, TensixValidateKernelDoesNotTargetHarvestedCores) {
     for (auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         uint32_t num_l1_banks = mesh_device->allocator()->get_num_banks(BufferType::L1);
         std::vector<uint32_t> host_input(1);
         std::map<uint32_t, uint32_t> bank_id_to_value;
@@ -285,7 +286,7 @@ TEST_F(MeshDeviceFixture, TestDeviceToHostMemChannelAssignment) {
 // Test to ensure writing from 16B aligned L1 address to 16B aligned PCIe address works
 TEST_F(MeshDeviceFixture, TensixTestL1ToPCIeAt16BAlignedAddress) {
     auto mesh_device = this->devices_.at(0);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -341,7 +342,7 @@ TEST_F(MeshDeviceFixture, TensixTestL1ToPCIeAt16BAlignedAddress) {
 TEST_F(BlackholeSingleCardFixture, TensixL1DataCache) {
     CoreCoord core{0, 0};
     const auto& mesh_device = devices_.at(0);
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
 
     uint32_t l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
     std::vector<uint32_t> random_vec(1, 0xDEADBEEF);
@@ -390,7 +391,7 @@ TEST_F(MeshDeviceFixture, VerifyLogicalToVirtualMap) {
     std::map<CoreCoord, CoreCoord> logical_to_virtual_map;
 
     auto mesh_device = this->devices_.at(0);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);

--- a/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
@@ -17,6 +17,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::unit_tests::multichip::cluster {
 
@@ -29,8 +30,8 @@ using namespace tt::test_utils;
 TEST_F(N300MeshDeviceFixture, EthValidateEthernetConnectivity) {
     const auto& mesh_device_0 = this->devices_.at(0);
     const auto& mesh_device_1 = this->devices_.at(1);
-    auto* device_0 = mesh_device_0->get_devices()[0];
-    auto* device_1 = mesh_device_1->get_devices()[0];
+    auto* device_0 = mesh_device_0->impl().get_devices()[0];
+    auto* device_1 = mesh_device_1->impl().get_devices()[0];
 
     // Check active and inactive core counts
     const auto& device_0_active_eth_cores = device_0->get_active_ethernet_cores();
@@ -92,7 +93,7 @@ TEST_F(N300MeshDeviceFixture, EthValidateEthernetConnectivity) {
 
 TEST_F(N300MeshDeviceFixture, EthInvalidLogicalEthernetCore) {
     const auto& mesh_device_0 = this->devices_.at(0);
-    auto* device_0 = mesh_device_0->get_devices()[0];
+    auto* device_0 = mesh_device_0->impl().get_devices()[0];
     EXPECT_ANY_THROW(device_0->ethernet_core_from_logical_core(CoreCoord(1, 0)));
     EXPECT_ANY_THROW(device_0->ethernet_core_from_logical_core(CoreCoord(0, 16)));
 }
@@ -117,7 +118,7 @@ TEST_F(N300MeshDeviceFixture, EthValidateAllEthernetCoreMapping) {
         {CoreCoord(0, 15), CoreCoord(21, 17)},
     };
     const auto& mesh_device_0 = this->devices_.at(0);
-    auto* device_0 = mesh_device_0->get_devices()[0];
+    auto* device_0 = mesh_device_0->impl().get_devices()[0];
     for (const auto& logical_core : device_0->ethernet_cores()) {
         ASSERT_TRUE(
             device_0->ethernet_core_from_logical_core(logical_core) ==
@@ -145,7 +146,7 @@ TEST_F(N300MeshDeviceFixture, EthValidatePhysicalCoreConversion) {
         {CoreCoord(0, 15), CoreCoord(21, 17)},
     };
     const auto& mesh_device_0 = this->devices_.at(0);
-    auto* device_0 = mesh_device_0->get_devices()[0];
+    auto* device_0 = mesh_device_0->impl().get_devices()[0];
     for (const auto& logical_core : device_0->ethernet_cores()) {
         ASSERT_TRUE(
             device_0->virtual_core_from_logical_core(logical_core, CoreType::ETH) ==
@@ -158,8 +159,8 @@ TEST_F(N300MeshDeviceFixture, EthValidatePhysicalCoreConversion) {
 TEST_F(N300MeshDeviceFixture, ActiveEthValidateEthernetSockets) {
     const auto& mesh_device_0 = this->devices_.at(0);
     const auto& mesh_device_1 = this->devices_.at(1);
-    auto* device_0 = mesh_device_0->get_devices()[0];
-    auto* device_1 = mesh_device_1->get_devices()[0];
+    auto* device_0 = mesh_device_0->impl().get_devices()[0];
+    auto* device_1 = mesh_device_1->impl().get_devices()[0];
 
     std::vector<CoreCoord> device_0_sockets = device_0->get_ethernet_sockets(1);
     std::vector<CoreCoord> device_1_sockets = device_1->get_ethernet_sockets(0);

--- a/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
@@ -19,6 +19,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -71,7 +72,7 @@ TEST_F(GalaxyFixture, Initialize) {
 // which shelf a particular Galaxy chip is on.
 TEST_F(TGFixture, ActiveEthValidateNumLinksBetweenAdjacentGalaxyChips) {
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const ChipId device_id = device->id();
         if (is_galaxy_device(device_id)) {
             std::unordered_map<ChipId, uint32_t> connected_devices_to_num_links_found;
@@ -108,7 +109,7 @@ TEST_F(TGFixture, ActiveEthValidateNumLinksBetweenAdjacentGalaxyChips) {
 // and that each Galaxy chip links to at most one MMIO chip
 TEST_F(GalaxyFixture, DISABLED_ActiveEthValidateLinksBetweenMMIOAndGalaxyChips) {
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const ChipId device_id = device->id();
         const std::unordered_set<ChipId>& connected_device_ids = get_ethernet_connected_device_ids(device_id);
         if (is_galaxy_device(device_id)) {
@@ -144,7 +145,7 @@ TEST_F(GalaxyFixture, DISABLED_ActiveEthValidateLinksBetweenMMIOAndGalaxyChips) 
 // Validate that all galaxy chips are unharvested
 TEST_F(GalaxyFixture, ValidateAllGalaxyChipsAreUnharvested) {
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const ChipId device_id = device->id();
         if (is_galaxy_device(device_id)) {
             const uint32_t harvest_mask =
@@ -158,7 +159,7 @@ TEST_F(GalaxyFixture, ValidateAllGalaxyChipsAreUnharvested) {
 // Validate that all MMIO chips have a single row harvested
 TEST_F(GalaxyFixture, DISABLED_ValidateAllMMIOChipsHaveSingleRowHarvested) {
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const ChipId device_id = device->id();
         if (!is_galaxy_device(device_id)) {
             uint32_t num_rows_harvested = 0;
@@ -190,7 +191,7 @@ TEST_F(TGFixture, ValidateChipBoardTypes) {
     uint32_t num_n150_chips = 0;
     uint32_t num_galaxy_chips = 0;
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const ChipId device_id = device->id();
         if (is_galaxy_device(device_id)) {
             num_galaxy_chips++;

--- a/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
@@ -34,6 +34,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/pcie/tlb_window.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -98,7 +99,7 @@ TEST_F(AnyDispatchSimulatorFixture, QuasarStaticTlbReadWrite) {
     constexpr uint32_t value32 = 0xDEADBEEF;
 
     for (auto& mesh_device : this->devices_) {
-        const ChipId chip_id = mesh_device->get_devices()[0]->id();
+        const ChipId chip_id = mesh_device->impl().get_devices()[0]->id();
         const auto& sdesc = cluster.get_soc_desc(chip_id);
 
         const std::vector<tt::umd::CoreCoord> tensix_cores =

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -50,6 +50,7 @@
 
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -234,7 +235,7 @@ void WriteToUnitMeshBuffer(
     const std::vector<uint32_t>& src,
     const std::shared_ptr<distributed::MeshBuffer>& buf,
     const std::optional<BufferShardingArgs>& sharding_args) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     std::shared_ptr<Buffer> slow_dispatch_buffer;
     if (sharding_args.has_value()) {
         slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype, sharding_args.value());
@@ -250,7 +251,7 @@ void ReadFromUnitMeshBuffer(
     std::vector<uint32_t>& dst,
     const std::shared_ptr<distributed::MeshBuffer>& buf,
     const std::optional<BufferShardingArgs>& sharding_args) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     std::shared_ptr<Buffer> slow_dispatch_buffer;
     if (sharding_args.has_value()) {
         slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype, sharding_args.value());
@@ -291,7 +292,7 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     distributed::MeshCommandQueue& cq,
     const TestBufferConfig& config) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     // Clear out command queue
     uint16_t channel =
         tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
@@ -465,7 +466,7 @@ void stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_sharded(
     srand(config.seed);
 
     auto device_coord = distributed::MeshCoordinate(0, 0);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     for (const bool cq_write : {true, false}) {
         for (const bool cq_read : {true, false}) {
@@ -814,7 +815,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestSinglePageLargerThanMaxPrefe
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeShardedBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 2048;
     for (const auto& mesh_device : devices_) {
-        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_devices()[0]->id());
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->impl().get_devices()[0]->id());
         CoreCoord start(0, 0);
         CoreCoord end(3, 0);
         CoreRange cores(start, end);
@@ -860,7 +861,7 @@ TEST_F(
 
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeSubBuffer) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
 
         const uint32_t max_prefetch_command_size =
@@ -908,7 +909,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleUnalignedPagesLarger
 
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeSubBuffer) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
 
         const uint32_t max_prefetch_command_size =
@@ -938,7 +939,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPr
     const uint32_t region_size = 5 * page_size;
     const uint32_t region_offset = 9 * page_size;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         CoreCoord start(0, 0);
         CoreCoord end(4, 0);
@@ -983,7 +984,7 @@ TEST_F(
     const uint32_t region_size = 5 * page_size;
     const uint32_t region_offset = 9 * page_size;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         CoreCoord start(0, 0);
         CoreCoord end(4, 0);
@@ -1040,7 +1041,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestNon32BAlignedPageSizeForDram
 // Requires enqueue write buffer
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapHostHugepageOnEnqueueReadBuffer) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         uint32_t page_size = 2048;
         uint32_t command_issue_region_size = device->sysmem_manager().get_issue_queue_size(0);
@@ -1060,7 +1061,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapHostHugepageOnEnqueueRea
 
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
         uint32_t page_size = 2048;
         uint32_t command_queue_size = device->sysmem_manager().get_cq_size();
@@ -1079,7 +1080,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficien
     uint32_t small_page_size = 2048;  // page size for second read
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         uint32_t command_completion_region_size = device->sysmem_manager().get_completion_queue_size(0);
 
@@ -1139,7 +1140,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteShardedSubBuffer) {
     const uint32_t buffer_size = 64 * page_size;
     const BufferRegion region(256, 512);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         CoreCoord start(0, 0);
         CoreCoord end(5, 0);
@@ -1178,7 +1179,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteSubBuffer) {
     const uint32_t buffer_size = 64 * page_size;
     const BufferRegion region(256, 512);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
 
         distributed::DeviceLocalBufferConfig dram_config{
@@ -1204,7 +1205,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteSubBufferLargeOffse
     const uint32_t buffer_size = (0xFFFF + 50000) * 2 * page_size;
     const BufferRegion region(((2 * 0xFFFF) + 25000) * page_size, 32);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::DeviceLocalBufferConfig dram_config{
             .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
@@ -1230,7 +1231,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadBufferWriteSubBuffer) {
     const uint32_t buffer_region_size = 128;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::DeviceLocalBufferConfig dram_config{
             .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
@@ -1262,7 +1263,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadSubBufferWriteBuffer) {
     const uint32_t buffer_region_size = 128;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::DeviceLocalBufferConfig dram_config{
             .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
@@ -1291,7 +1292,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadSubBufferInvalidRegion) 
     const uint32_t buffer_region_size = buffer_size;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::DeviceLocalBufferConfig dram_config{
             .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
@@ -1310,7 +1311,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWriteSubBufferInvalidRegion)
     const uint32_t buffer_region_size = buffer_size;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::DeviceLocalBufferConfig dram_config{
             .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
@@ -1327,7 +1328,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWriteSubBufferInvalidRegion)
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficientSpace2) {
     // Using default 75-25 issue and completion queue split
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         uint32_t command_completion_region_size = device->sysmem_manager().get_completion_queue_size(0);
 
@@ -1372,7 +1373,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficien
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToDramBank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
@@ -1384,7 +1385,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToDramBank0) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllDramBanks) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {
             .num_pages = uint32_t(mesh_device->allocator()->get_num_banks(BufferType::DRAM)),
@@ -1403,7 +1404,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllDramBanks) {
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
     constexpr uint32_t num_round_robins = 2;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {
             .num_pages = num_round_robins * (mesh_device->allocator()->get_num_banks(BufferType::DRAM)),
@@ -1422,7 +1423,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileAcrossAllDramBanksTw
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, Sending131072Pages) {
     TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
@@ -1435,7 +1436,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, Sending131072Pages) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::DRAM};
 
@@ -1450,7 +1451,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram2) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
@@ -1465,7 +1466,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         uint32_t page_size = 2048;
         uint32_t command_queue_size = device->sysmem_manager().get_cq_size();
@@ -1486,7 +1487,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram
     constexpr uint32_t page_size = 200;
     const uint32_t max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         const uint32_t num_banks = mesh_device->allocator()->get_num_banks(BufferType::DRAM);
         const uint32_t num_pages = std::max(4 * num_banks, (max_prefetch_command_size / page_size) + num_banks);
@@ -1509,7 +1510,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestSubBufferReadCrossesRelayPag
         relay_page_boundary - 1, relay_page_boundary, relay_page_boundary + 1};
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
@@ -1527,7 +1528,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestLargeSubBufferReadPastRebase
     constexpr uint32_t region_num_pages = 64;
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running on Device {}", device->id());
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
@@ -1550,7 +1551,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToDramBank0) {
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToAllDramBanks) {
     auto mesh_device = this->device_;
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     TestBufferConfig config = {
         .num_pages = uint32_t(device->allocator()->get_num_banks(BufferType::DRAM)),
         .page_size = 2048,
@@ -1565,7 +1566,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToAllDramBanks) {
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
     auto mesh_device = this->device_;
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     constexpr uint32_t num_round_robins = 2;
     TestBufferConfig config = {
         .num_pages = num_round_robins * (device->allocator()->get_num_banks(BufferType::DRAM)),
@@ -1617,7 +1618,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForDra
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
     auto mesh_device = this->device_;
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     uint32_t page_size = 2048;
     uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
     uint32_t command_queue_size =
@@ -1635,7 +1636,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestIssueMultipleReadWriteComma
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForDramWrapsAcrossBanksAndTransactions) {
     auto mesh_device = this->device_;
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     constexpr uint32_t page_size = 200;
     const uint32_t max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
     const uint32_t num_banks = device->allocator()->get_num_banks(BufferType::DRAM);
@@ -1682,7 +1683,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestLargeSubBufferReadPastRebas
 
 TEST_F(UnitMeshCQMultiDeviceBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSize) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -1705,7 +1706,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteShardedSubBufferFor
     const std::vector<ShardedSubBufferStressTestConfig>& configs =
         local_test_functions::generate_sharded_sub_buffer_test_configs(max_buffer_size);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running on Device {}", device->id());
         for (const ShardedSubBufferStressTestConfig& config : configs) {
             log_debug(
@@ -1758,7 +1759,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleNonOverlappingWrites
     const uint32_t buffer_size = 16 * page_size;
     const uint32_t buffer_region_size = 4 * page_size;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running on Device {}", device->id());
         CoreCoord start_coord = {0, 0};
         CoreCoord end_coord = {5, 5};
@@ -1903,7 +1904,7 @@ TEST_F(
     const uint32_t region_offset = 16 * page_size;
     const uint32_t region_size = 16 * page_size;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         CoreCoord start(0, 0);
         CoreCoord end(3, 3);
@@ -1941,7 +1942,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleNonOverlappingReadsS
     const uint32_t buffer_size = 16 * page_size;
     const uint32_t buffer_region_size = buffer_size / 4;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running on Device {}", device->id());
         CoreCoord start_coord = {0, 0};
         CoreCoord end_coord = {5, 5};
@@ -2006,7 +2007,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteShardedSubBufferMul
     const uint32_t buffer_region_size = page_size * 7;
     vector<uint32_t> src = local_test_functions::generate_arange_vector(buffer_region_size);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running on Device {}", device->id());
         CoreCoord start_coord = {0, 0};
         CoreCoord end_coord = {3, 3};
@@ -2039,7 +2040,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteSubBufferForL1) {
     const uint32_t buffer_size = 128 * page_size;
     const BufferRegion region(2 * page_size, 2048);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
 
         distributed::DeviceLocalBufferConfig l1_config{
@@ -2059,7 +2060,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteSubBufferLargeOffse
     const uint32_t buffer_size = 512 * page_size;
     const BufferRegion region(400 * page_size, 2048);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
 
         distributed::DeviceLocalBufferConfig l1_config{
@@ -2112,7 +2113,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestNon32BAlignedPageSizeForL1) 
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::L1};
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         if (device->is_mmio_capable()) {
             continue;
         }
@@ -2215,7 +2216,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForL1)
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToL1Bank0) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::L1};
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
@@ -2228,7 +2229,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToL1Bank0) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1Banks) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
         TestBufferConfig config = {
@@ -2246,7 +2247,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1Banks) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
 
@@ -2265,7 +2266,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceRou
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForL1) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::L1};
 
@@ -2367,7 +2368,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, WritesToRandomBufferTypeAndThenR
         .seed = 0, .num_pages_total = 50000, .page_size = 2048, .max_num_pages_per_buffer = 16};
 
     for (const auto& mesh_device : devices_) {
-        if (not mesh_device->get_devices()[0]->is_mmio_capable()) {
+        if (not mesh_device->impl().get_devices()[0]->is_mmio_capable()) {
             continue;
         }
         EXPECT_TRUE(local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer<true>(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
@@ -28,6 +28,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -113,7 +114,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceAllocations) {
     auto input_1_it = input_1.begin();
     for (const auto& physical_core : physical_cores_1) {
         auto readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            mesh_device->get_devices()[0]->id(), physical_core, buffer_1->address(), page_size_1);
+            mesh_device->impl().get_devices()[0]->id(), physical_core, buffer_1->address(), page_size_1);
         EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
         input_1_it += page_size_1 / sizeof(uint32_t);
     }
@@ -138,7 +139,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceAllocations) {
     auto input_2_it = input_2.begin();
     for (const auto& physical_core : physical_cores_2) {
         auto readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            mesh_device->get_devices()[0]->id(), physical_core, buffer_3->address(), page_size_2);
+            mesh_device->impl().get_devices()[0]->id(), physical_core, buffer_3->address(), page_size_2);
         EXPECT_TRUE(std::equal(input_2_it, input_2_it + page_size_2 / sizeof(uint32_t), readback.begin()));
         input_2_it += page_size_2 / sizeof(uint32_t);
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
@@ -10,6 +10,7 @@
 #include "tt_metal/distributed/fd_mesh_command_queue.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt::tt_metal;
 
@@ -22,7 +23,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestBasicReadWriteL1) {
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
 
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
         const CoreCoord virtual_core = mesh_device->worker_core_from_logical_core(logical_core);
 
@@ -52,7 +53,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestBasicReadL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(device->id(), virtual_core, src_data, address);
         const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
@@ -79,7 +80,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestBasicWriteL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
         const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
         const distributed::DeviceMemoryAddress device_memory_address = {
@@ -109,7 +110,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestInvalidReadWriteAddressL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
         const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
         const distributed::DeviceMemoryAddress device_memory_address = {
@@ -135,7 +136,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestReadWriteMultipleCoresL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         for (uint32_t core_x = 0; core_x < device->compute_with_storage_grid_size().x; ++core_x) {
             for (uint32_t core_y = 0; core_y < device->compute_with_storage_grid_size().y; ++core_y) {
                 const CoreCoord core = device->worker_core_from_logical_core({core_x, core_y});
@@ -179,7 +180,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestReadWriteZeroElementsL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
         const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
         const distributed::DeviceMemoryAddress device_memory_address = {
@@ -206,7 +207,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestReadWriteEntireL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
         const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
         const distributed::DeviceMemoryAddress device_memory_address = {
@@ -232,7 +233,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, ActiveEthTestReadWriteEntireL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         if (!does_device_have_active_eth_cores(device)) {
             GTEST_SKIP() << "No active ethernet cores found";
         }
@@ -262,7 +263,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, ActiveEthTestReadWriteMultipleCoresL1)
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         if (!does_device_have_active_eth_cores(device)) {
             GTEST_SKIP() << "No active ethernet cores found";
         }
@@ -310,7 +311,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, IdleEthTestReadWriteEntireL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         if (!does_device_have_idle_eth_cores(device)) {
             GTEST_SKIP() << "No idle ethernet cores found";
         }
@@ -347,7 +348,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, IdleEthTestInvalidReadWriteAddressL1) 
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         if (!does_device_have_idle_eth_cores(device)) {
             GTEST_SKIP() << "No idle ethernet cores found";
         }
@@ -382,7 +383,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, IdleEthTestReadWriteMultipleCoresL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         if (!does_device_have_idle_eth_cores(device)) {
             GTEST_SKIP() << "No idle ethernet cores found";
         }
@@ -431,7 +432,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, IdleEthTestReadWriteMultipleCoresL1) {
 TEST_F(UnitMeshCQSingleCardSharedFixture, TestInvalidReadWriteAddressDRAM) {
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const uint32_t num_elements = 1010;
         const std::vector<uint32_t> src_data = generate_arange_vector(num_elements * sizeof(uint32_t));
 
@@ -463,7 +464,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TestInvalidReadWriteAddressDRAM) {
 TEST_F(UnitMeshCQSingleCardSharedFixture, TestReadWriteMultipleCoresDRAM) {
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         const DeviceAddr address = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);
         const uint32_t num_elements = 1000;
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -26,6 +26,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include <umd/device/types/arch.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -222,7 +223,7 @@ namespace basic_tests {
 // wrap issue queue)
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsEventSynchronizeSanity) {
     for (auto& mesh_device : devices_) {
-        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_devices()[0]->id());
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->impl().get_devices()[0]->id());
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
             mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
         vector<uint32_t> cmds_issued_per_cq = {0, 0};
@@ -441,7 +442,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 // Ensure read back data is correct, data is different for each write.
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQs) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
         auto start = std::chrono::system_clock::now();
@@ -462,7 +463,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsDeterministic) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
@@ -478,7 +479,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsHostVisibleControl) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
@@ -494,7 +495,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsBurstWritesThenSingleCrossCqEvent) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunBurstWritesThenSingleCrossCqEvent(
@@ -505,7 +506,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsBurstWritesThenSingleCr
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsDeviceOnlyEventChainWithPerIterationValidation) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunDeviceOnlyEventChainWithPerIterationValidation(
@@ -516,7 +517,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsDeviceOnlyEventChainWit
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsHeavyBurstWritesThenDeviceOnlyEvent) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running on Device {}", device->id());
         bool pass =
             local_test_functions::RunHeavyBurstWritesThenDeviceOnlyEvent(mesh_device, zero_coord_, /*num_buffers=*/12);
@@ -529,7 +530,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsHeavyBurstWritesThenDev
 // write and write after read before checking correct data read at the end after all cmds finished on device.
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsPingPong) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 16, .buftype = BufferType::DRAM};
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
@@ -22,6 +22,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -55,7 +56,7 @@ TEST_F(UnitMeshCQEventFixture, TestEventsDataMovementWrittenToCompletionQueueInO
     uint32_t last_read_address = 0;
     auto mesh_device = this->devices_[0];
     auto& cq = mesh_device->mesh_command_queue();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     for (const DataMovementMode data_movement_mode : {DataMovementMode::READ, DataMovementMode::WRITE}) {
         auto start = std::chrono::system_clock::now();
@@ -241,7 +242,7 @@ TEST_F(UnitMeshCQEventFixture, TestEventsEventsQueryBasic) {
 TEST_F(UnitMeshCQEventFixture, TestEventsMixedWriteBufferRecordWaitSynchronize) {
     auto mesh_device = this->devices_[0];
     auto& cq = mesh_device->mesh_command_queue();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     const size_t num_buffers = 2;
     const uint32_t page_size = 2048;
     vector<uint32_t> page(page_size / sizeof(uint32_t));

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/program_with_kernel_created_from_string_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/program_with_kernel_created_from_string_fixture.hpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 #include "mesh_dispatch_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt::tt_metal;
 
@@ -14,7 +15,7 @@ protected:
     void SetUp() override {
         MeshDispatchFixture::SetUp();
         for (const auto& mesh_device : this->devices_) {
-            auto device = mesh_device->get_devices()[0];
+            auto device = mesh_device->impl().get_devices()[0];
             const ChipId device_id = device->id();
             this->device_ids_to_devices_[device_id] = mesh_device;
         }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -2379,7 +2379,7 @@ TEST_F(UnitMeshRandomProgramFixture, TensixTestSimplePrograms) {
 }
 
 TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestSimplePrograms) {
-    for (const auto& device : device_->get_devices()) {
+    for (const auto& device : device_->impl().get_devices()) {
         if (!does_device_have_active_eth_cores(device)) {
             GTEST_SKIP() << "Skipping test because device " << device->id()
                          << " does not have any active ethernet cores";
@@ -2411,7 +2411,7 @@ TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestSimplePrograms) {
 }
 
 TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestPrograms) {
-    for (const auto& device : device_->get_devices()) {
+    for (const auto& device : device_->impl().get_devices()) {
         if (!does_device_have_active_eth_cores(device)) {
             GTEST_SKIP() << "Skipping test because device " << device->id()
                          << " does not have any active ethernet cores";
@@ -2439,7 +2439,7 @@ TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestPrograms) {
 }
 
 TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestPrograms) {
-    for (const auto& device : device_->get_devices()) {
+    for (const auto& device : device_->impl().get_devices()) {
         if (!does_device_have_active_eth_cores(device)) {
             GTEST_SKIP() << "Skipping test because device " << device->id()
                          << " does not have any active ethernet cores";

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -53,6 +53,7 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 // Access to internal API: ProgramImpl::get_cb_base_addr, get_kernel
 #include "impl/program/program_impl.hpp"
@@ -197,7 +198,7 @@ bool cb_config_successful(
     // to read from
     vector<uint32_t> cb_config_vector;
     uint32_t cb_config_buffer_size = max_cbs * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
     for (const CoreRange& core_range : program_config.cr_set.ranges()) {
         for (const CoreCoord& core_coord : core_range) {
@@ -232,7 +233,7 @@ void test_dummy_EnqueueProgram_with_runtime_args(
     distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program;
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto eth_noc_xy = mesh_device->ethernet_core_from_logical_core(eth_core_coord);
 
     constexpr uint32_t num_runtime_args0 = 9;
@@ -350,7 +351,7 @@ bool test_dummy_EnqueueProgram_with_sems(
     distributed::EnqueueMeshWorkload(cq, workload, is_blocking_op);
     Finish(cq);
 
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     uint32_t expected_semaphore_vals_idx = 0;
     for (const CoreRange& core_range : program_config.cr_set.ranges()) {
         const vector<uint32_t>& expected_semaphore_vals_for_core = expected_semaphore_vals[expected_semaphore_vals_idx];
@@ -417,7 +418,7 @@ bool test_dummy_EnqueueProgram_with_runtime_args(
     distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
 
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     Program program;
     bool pass = true;
 
@@ -529,7 +530,7 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
     distributed::MeshWorkload workload;
     distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     Program program;
     bool pass = true;
 
@@ -780,7 +781,7 @@ bool test_increment_runtime_args_sanity(
     distributed::MeshWorkload workload;
     distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     Program program;
     bool pass = true;
 
@@ -907,7 +908,7 @@ void test_basic_dispatch_functions(const std::shared_ptr<distributed::MeshDevice
     constexpr uint32_t k_LoopPerDev = 100;
 
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     log_info(tt::LogTest, "Running On Device {} CQ{}", mesh_device->id(), cq_id);
 
     log_info(tt::LogTest, "Running On Device {} CQ{}", device->id(), cq_id);
@@ -1077,9 +1078,9 @@ TEST_F(UnitMeshCQFixture, TensixTestMultiCBSharedAddressSpaceSentSingleCore) {
 
         vector<uint32_t> cb_config_vector;
 
-        auto address = program_.impl().get_cb_base_addr(device->get_devices()[0], core_coord, CoreType::WORKER);
+        auto address = program_.impl().get_cb_base_addr(device->impl().get_devices()[0], core_coord, CoreType::WORKER);
         tt::tt_metal::detail::ReadFromDeviceL1(
-            device->get_devices()[0], core_coord, address, cb_config_buffer_size, cb_config_vector);
+            device->impl().get_devices()[0], core_coord, address, cb_config_buffer_size, cb_config_vector);
         uint32_t cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
         uint32_t intermediate_index = intermediate_cb * sizeof(uint32_t);
 
@@ -1185,7 +1186,7 @@ TEST_F(UnitMeshCQFixture, ActiveEthEnqueueDummyProgram) {
         GTEST_SKIP() << "Skipping test as this test requires 2 active ethernet cores";
     }
     for (const auto& device : devices_) {
-        for (const auto& eth_core : device->get_devices()[0]->get_active_ethernet_cores(true)) {
+        for (const auto& eth_core : device->impl().get_devices()[0]->get_active_ethernet_cores(true)) {
             for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; erisc_idx++) {
                 log_info(
                     tt::LogTest,
@@ -1212,7 +1213,7 @@ TEST_F(UnitMeshCQFixture, ActiveEthTwoRiscsHandshake) {
         distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
 
-        for (const auto& eth_core : mesh_device->get_devices()[0]->get_active_ethernet_cores(true)) {
+        for (const auto& eth_core : mesh_device->impl().get_devices()[0]->get_active_ethernet_cores(true)) {
             auto program = tt::tt_metal::CreateProgram();
             auto primary = CreateKernel(
                 program,
@@ -1253,7 +1254,7 @@ TEST_F(UnitMeshCQFixture, ActiveEthTwoRiscsHandshake) {
 // 0 active eth cores, that's okay.
 TEST_F(UnitMeshCQFixture, ActiveEthIncrementRuntimeArgsSanitySingleCoreDataMovementErisc) {
     for (const auto& device : devices_) {
-        for (const auto& eth_core : device->get_devices()[0]->get_active_ethernet_cores(true)) {
+        for (const auto& eth_core : device->impl().get_devices()[0]->get_active_ethernet_cores(true)) {
             CoreRange cr0(eth_core);
             CoreRangeSet cr_set({cr0});
             DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
@@ -1283,7 +1284,7 @@ TEST_F(UnitMeshCQFixture, ActiveEthIncrementRuntimeArgsSanitySingleCoreDataMovem
 // FIXME - Re-enable when FD-on-idle-eth is supported
 TEST_F(UnitMeshCQFixture, DISABLED_ActiveEthIncrementRuntimeArgsSanitySingleCoreDataMovementEriscIdle) {
     for (const auto& device : devices_) {
-        for (const auto& eth_core : device->get_devices()[0]->get_active_ethernet_cores(true)) {
+        for (const auto& eth_core : device->impl().get_devices()[0]->get_active_ethernet_cores(true)) {
             CoreRange cr0(eth_core);
             CoreRangeSet cr_set({cr0});
             DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
@@ -1303,7 +1304,7 @@ TEST_F(UnitMeshCQFixture, DISABLED_ActiveEthIncrementRuntimeArgsSanitySingleCore
 // FIXME - Re-enable when FD-on-idle-eth is supported
 TEST_F(UnitMeshCQFixture, DISABLED_IdleEthIncrementRuntimeArgsSanitySingleCoreDataMovementEriscInactive) {
     for (const auto& device : devices_) {
-        for (const auto& eth_core : device->get_devices()[0]->get_inactive_ethernet_cores()) {
+        for (const auto& eth_core : device->impl().get_devices()[0]->get_inactive_ethernet_cores()) {
             CoreRange cr0(eth_core);
             CoreRangeSet cr_set({cr0});
             DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
@@ -1686,7 +1687,7 @@ TEST_F(UnitMeshCQFixture, TensixLargeCommonRuntimeArgsLargeMulticast) {
 TEST_F(UnitMeshCQFixture, TensixLargeUniqueRuntimeArgsPatchedAcrossRuns) {
     constexpr uint32_t kNumArgs = 1100;  // > 1024 words → large-unicast path
     for (const auto& device : devices_) {
-        auto* dev = device->get_devices()[0];
+        auto* dev = device->impl().get_devices()[0];
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
         CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
         CoreRangeSet cr_set(cr);
@@ -1788,7 +1789,7 @@ TEST_F(UnitMeshCQFixture, TestLogicalCoordinatesCompute) {
 TEST_F(UnitMeshCQFixture, TestLogicalCoordinatesEth) {
     GTEST_SKIP() << "Mesh device does not support logical / relative coordinates on Eth";
     for (const auto& device : devices_) {
-        if (!does_device_have_active_eth_cores(device->get_devices()[0])) {
+        if (!does_device_have_active_eth_cores(device->impl().get_devices()[0])) {
             GTEST_SKIP() << "Skipping test because device " << device->id()
                          << " does not have any active ethernet cores";
         }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "impl/dataflow_buffer/dataflow_buffer.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -22,7 +23,7 @@ using namespace tt::tt_metal;
 // Validates data integrity: DRAM -> Reader -> CB -> Writer -> DRAM (src == dst)
 TEST_F(MeshDispatchFixture, DataflowCb) {
     auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
+    IDevice* dev = mesh_device->impl().get_devices()[0];
     if (dev->arch() == ARCH::QUASAR) {
         GTEST_SKIP() << "Quasar does not support CBs, skipping test";
     }
@@ -119,7 +120,7 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
 
 TEST_F(MeshDispatchFixture, DataflowDfb) {
     auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
+    IDevice* dev = mesh_device->impl().get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -544,7 +544,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarDispatchSInstantiatedAndRunning)
 
     const bool use_tensix_fallback = MetalContext::instance().rtoptions().get_use_quasar_tensix_dispatch_cores();
     auto mesh_device = devices_.front();
-    IDevice* device = mesh_device->get_devices().front();
+    IDevice* device = mesh_device->impl().get_devices().front();
     if (!use_tensix_fallback && detail::sd_cq_kernel_tests_should_skip(device)) {
         GTEST_SKIP() << "No dispatch-engine cores in soc descriptor";
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -36,6 +36,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 // Access to internal API: ProgramImpl::get_cb_base_addr, ProgramImpl::get_cb_size, Eth, EthernetConfig,
 // CreateSemaphore with CoreType
@@ -65,7 +66,7 @@ static void test_sems_across_core_types(
     }
 
     for (const auto& mesh_device : devices) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         if (not device->is_mmio_capable()) {
             continue;
         }
@@ -157,7 +158,7 @@ static void test_sems_across_core_types(
 
 TEST_F(MeshDispatchFixture, EthTestBlank) {
     auto mesh_device = devices_[0];
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
 
@@ -231,7 +232,7 @@ TEST_F(MeshDispatchFixture, EthTestInitLocalMemory) {
     }
 
     auto mesh_device = devices_[0];
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
 
@@ -296,7 +297,7 @@ TEST_F(MeshDispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
     uint32_t cb_config_buffer_size = max_cbs_ * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
 
         CoreCoord worker_grid_size = mesh_device->compute_with_storage_grid_size();
         bool found_overlapping_core = false;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_program_with_kernel_created_from_string.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_program_with_kernel_created_from_string.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/program.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "program_with_kernel_created_from_string_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -94,7 +95,7 @@ TEST_F(ProgramWithKernelCreatedFromStringFixture, ActiveEthEthernetKernel) {
     )";
 
     for (const auto& mesh_device : this->devices_) {
-        auto device = mesh_device->get_devices()[0];
+        auto device = mesh_device->impl().get_devices()[0];
         const std::unordered_set<CoreCoord>& active_ethernet_cores = device->get_active_ethernet_cores(true);
         if (active_ethernet_cores.empty()) {
             const ChipId device_id = device->id();

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_stress.cpp
@@ -25,6 +25,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/distributed.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -59,7 +60,7 @@ void RunTest(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     // Write runtime args
     auto get_first_arg =
         [](const std::shared_ptr<distributed::MeshDevice>& mesh_device, CoreCoord& core, uint32_t multiplier) {
-            return (uint32_t)mesh_device->get_devices()[0]->id() + ((uint32_t)core.x * 10 * multiplier);
+            return (uint32_t)mesh_device->impl().get_devices()[0]->id() + ((uint32_t)core.x * 10 * multiplier);
         };
     auto get_second_arg = [](const std::shared_ptr<distributed::MeshDevice>& /*mesh_device*/,
                              CoreCoord& core,
@@ -82,7 +83,7 @@ void RunTest(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     // Check results
     for (CoreCoord core : core_range) {
         std::vector<uint32_t> brisc_result;
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         tt_metal::detail::ReadFromDeviceL1(device, core, l1_unreserved_base, sizeof(uint32_t), brisc_result);
         std::vector<uint32_t> ncrisc_result;
         tt_metal::detail::ReadFromDeviceL1(device, core, l1_unreserved_base + 4, sizeof(uint32_t), ncrisc_result);
@@ -136,7 +137,7 @@ TEST(DispatchStress, TensixRunManyTimes) {
 
         // Run the test on each device
         for (auto& device : devices_) {
-            log_info(LogTest, "Running on device {}", device->get_devices()[0]->id());
+            log_info(LogTest, "Running on device {}", device->impl().get_devices()[0]->id());
             RunTest(device);
         }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
@@ -26,6 +26,7 @@
 
 #include "impl/program/program_impl.hpp"
 #include "tt_metal/impl/context/metal_context.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -152,7 +153,7 @@ TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) 
     constexpr tt::DataFormat tile_format = tt::DataFormat::Float16_b;
 
     auto mesh_device = devices_[0];
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_kernel_config_buffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_kernel_config_buffer.cpp
@@ -58,7 +58,7 @@ protected:
     // determines where unreserved_base_ is positioned and thus the kernel config buffer size.
     // Larger worker_l1_size -> higher unreserved_base_ -> smaller kernel config buffer and vice versa
     void compute_memory_layout() {
-        TT_FATAL(!devices_.empty() && !devices_[0]->get_devices().empty(), "No devices available for testing");
+        TT_FATAL(!devices_.empty() && !devices_[0]->impl().get_devices().empty(), "No devices available for testing");
 
         auto* single_device = devices_[0]->impl().get_devices()[0];
         unreserved_base_ = single_device->allocator()->get_base_allocator_addr(HalMemType::L1);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_kernel_config_buffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_kernel_config_buffer.cpp
@@ -16,6 +16,7 @@
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/dispatch/util/size_literals.hpp"
 #include "tt_metal/common/env_lib.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::kernel_size_tests {
 
@@ -59,7 +60,7 @@ protected:
     void compute_memory_layout() {
         TT_FATAL(!devices_.empty() && !devices_[0]->get_devices().empty(), "No devices available for testing");
 
-        auto* single_device = devices_[0]->get_devices()[0];
+        auto* single_device = devices_[0]->impl().get_devices()[0];
         unreserved_base_ = single_device->allocator()->get_base_allocator_addr(HalMemType::L1);
         auto l1_base = hal_.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE);
         auto l1_size = hal_.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE);
@@ -265,7 +266,7 @@ TEST_F(KernelSizeTestBigBuffer, BigKernelExecutionCorrectness) {
     distributed::Finish(device->mesh_command_queue());
 
     // Read the result back directly from L1 using device API
-    auto* single_device = device->get_devices()[0];
+    auto* single_device = device->impl().get_devices()[0];
     std::vector<uint32_t> result;
     tt::tt_metal::detail::ReadFromDeviceL1(
         single_device,

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -44,6 +44,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <tt-metalium/distributed.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 // Access to internal API: ProgramImpl::validate_circular_buffer_region
 #include "tt_metal/impl/program/program_impl.hpp"
@@ -59,7 +60,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceCBAllocation) {
     SubDevice sub_device_1(std::array{sharded_cores_1});
     auto sub_device_manager_1 = mesh_device->create_sub_device_manager({sub_device_1}, k_local_l1_size);
     DeviceAddr l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
-    DeviceAddr l1_max_size = mesh_device->get_devices()[0]->l1_size_per_core();
+    DeviceAddr l1_max_size = mesh_device->impl().get_devices()[0]->l1_size_per_core();
     DeviceAddr l1_total_size = l1_max_size - l1_unreserved_base;
     mesh_device->load_sub_device_manager(sub_device_manager_1);
     uint32_t global_buffer_size = l1_total_size - (k_local_l1_size * 2);
@@ -169,14 +170,14 @@ void test_sub_device_synchronization(distributed::MeshDevice* device) {
     auto input_1_it = input_1.begin();
     for (const auto& physical_core : physical_cores_1) {
         auto readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            device->get_devices()[0]->id(), physical_core, buffer_1->address(), page_size_1);
+            device->impl().get_devices()[0]->id(), physical_core, buffer_1->address(), page_size_1);
         EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
         input_1_it += page_size_1 / sizeof(uint32_t);
     }
     auto sem_addr = global_semaphore.address();
     auto physical_syncer_core = device->worker_core_from_logical_core(syncer_core);
     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        device->get_devices()[0]->id(), physical_syncer_core, std::vector<uint32_t>{1}, sem_addr);
+        device->impl().get_devices()[0]->id(), physical_syncer_core, std::vector<uint32_t>{1}, sem_addr);
 
     // Full synchronization
     device->reset_sub_device_stall_group();
@@ -462,7 +463,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceProgramReuseRtas) {
             distributed::Synchronize(mesh_device.get(), std::nullopt);
             std::vector<uint32_t> kernel_result;
             tt_metal::detail::ReadFromDeviceL1(
-                mesh_device->get_devices()[0], core, l1_unreserved_base, sizeof(int), kernel_result);
+                mesh_device->impl().get_devices()[0], core, l1_unreserved_base, sizeof(int), kernel_result);
             EXPECT_EQ(kernel_result[0], unique_runtime_args[0] + common_runtime_args[0]);
         }
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
@@ -12,6 +12,7 @@
 #include "impl/context/metal_context.hpp"
 #include "mesh_device.hpp"
 #include <llrt/tt_cluster.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -112,7 +113,7 @@ inline void verify_kernel_coordinates(
     const tt::tt_metal::distributed::MeshDevice* mesh_device,
     tt::tt_metal::SubDeviceId sub_device_id,
     uint32_t cb_addr) {
-    for (const auto& device : mesh_device->get_devices()) {
+    for (const auto& device : mesh_device->impl().get_devices()) {
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
     }
 
@@ -130,7 +131,7 @@ inline void verify_kernel_coordinates(
         for (const auto& logical_coord : cr) {
             const auto& virtual_coord = mesh_device->virtual_core_from_logical_core(logical_coord, core_type);
             CoreCoord relative_coord{logical_coord.x - sub_device_origin.x, logical_coord.y - sub_device_origin.y};
-            for (const auto& device : mesh_device->get_devices()) {
+            for (const auto& device : mesh_device->impl().get_devices()) {
                 auto read_coords_raw = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                     device->id(), virtual_coord, cb_addr, sizeof(tt::tt_metal::CoreCoordsL1));
                 auto* read_coords = reinterpret_cast<volatile tt::tt_metal::CoreCoordsL1*>(read_coords_raw.data());

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -38,6 +38,7 @@
 #include "tt_metal/common/scoped_timer.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include "distributed/mesh_trace.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 // Access to internal API: ProgramImpl::get_id
 #include "impl/program/program_impl.hpp"
@@ -657,8 +658,8 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixTestSimpleProgramsTrace) {
 }
 
 TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestSimpleProgramsTrace) {
-    if (!does_device_have_active_eth_cores(this->device_->get_devices()[0])) {
-        GTEST_SKIP() << "Skipping test because device " << this->device_->get_devices()[0]->id()
+    if (!does_device_have_active_eth_cores(this->device_->impl().get_devices()[0])) {
+        GTEST_SKIP() << "Skipping test because device " << this->device_->impl().get_devices()[0]->id()
                      << " does not have any active ethernet cores";
     }
 
@@ -681,8 +682,8 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestSimpleProgramsTrace) {
 }
 
 TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestSimpleProgramsTrace) {
-    if (!does_device_have_active_eth_cores(this->device_->get_devices()[0])) {
-        GTEST_SKIP() << "Skipping test because device " << this->device_->get_devices()[0]->id()
+    if (!does_device_have_active_eth_cores(this->device_->impl().get_devices()[0])) {
+        GTEST_SKIP() << "Skipping test because device " << this->device_->impl().get_devices()[0]->id()
                      << " does not have any active ethernet cores";
     }
 
@@ -733,8 +734,8 @@ TEST_F(UnitMeshRandomProgramTraceFixture, NIGHTLY_TensixTestProgramsTrace) {
 }
 
 TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTrace) {
-    if (!does_device_have_active_eth_cores(this->device_->get_devices()[0])) {
-        GTEST_SKIP() << "Skipping test because device " << this->device_->get_devices()[0]->id()
+    if (!does_device_have_active_eth_cores(this->device_->impl().get_devices()[0])) {
+        GTEST_SKIP() << "Skipping test because device " << this->device_->impl().get_devices()[0]->id()
                      << " does not have any active ethernet cores";
     }
 
@@ -762,8 +763,8 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTrace) {
 }
 
 TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTrace) {
-    if (!does_device_have_active_eth_cores(this->device_->get_devices()[0])) {
-        GTEST_SKIP() << "Skipping test because device " << this->device_->get_devices()[0]->id()
+    if (!does_device_have_active_eth_cores(this->device_->impl().get_devices()[0])) {
+        GTEST_SKIP() << "Skipping test because device " << this->device_->impl().get_devices()[0]->id()
                      << " does not have any active ethernet cores";
     }
 
@@ -928,8 +929,8 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixTestProgramsTraceAndNoTrace) {
 }
 
 TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTraceAndNoTrace) {
-    if (!does_device_have_active_eth_cores(this->device_->get_devices()[0])) {
-        GTEST_SKIP() << "Skipping test because device " << this->device_->get_devices()[0]->id()
+    if (!does_device_have_active_eth_cores(this->device_->impl().get_devices()[0])) {
+        GTEST_SKIP() << "Skipping test because device " << this->device_->impl().get_devices()[0]->id()
                      << " does not have any active ethernet cores";
     }
 
@@ -983,8 +984,8 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTraceAndNoTrace) 
 }
 
 TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTraceAndNoTrace) {
-    if (!does_device_have_active_eth_cores(this->device_->get_devices()[0])) {
-        GTEST_SKIP() << "Skipping test because device " << this->device_->get_devices()[0]->id()
+    if (!does_device_have_active_eth_cores(this->device_->impl().get_devices()[0])) {
+        GTEST_SKIP() << "Skipping test because device " << this->device_->impl().get_devices()[0]->id()
                      << " does not have any active ethernet cores";
     }
 
@@ -1108,7 +1109,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceTraceFixture, TensixEnqueueDFBProgramTrace) {
 
     CreateDevice(dfb_total_size * 4);
 
-    IDevice* device = this->device_->get_devices()[0];
+    IDevice* device = this->device_->impl().get_devices()[0];
     CoreCoord worker = {0, 0};
 
     // Each execution writes 1 uint32 (entry_size).  Pick addresses after the

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
@@ -26,6 +26,7 @@
 #include <umd/device/pcie/pci_device.hpp>
 #include <umd/device/tt_device/tt_device.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "command_queue_fixture.hpp"
 #include "multi_command_queue_fixture.hpp"
@@ -100,7 +101,7 @@ protected:
         }
     }
 
-    IDevice* device() const { return devices_.at(0)->get_devices().front(); }
+    IDevice* device() const { return devices_.at(0)->impl().get_devices().front(); }
 
     tt::umd::TTDevice& tt_device() const {
         return *MetalContext::instance().get_cluster().get_driver()->get_tt_device(device()->id());
@@ -192,7 +193,7 @@ protected:
         }
     }
 
-    IDevice* device() const { return device_->get_devices().front(); }
+    IDevice* device() const { return device_->impl().get_devices().front(); }
 
     tt::umd::TTDevice& tt_device() const {
         return *MetalContext::instance().get_cluster().get_driver()->get_tt_device(device()->id());
@@ -262,7 +263,7 @@ protected:
         }
     }
 
-    IDevice* device() const { return mesh_device_->get_devices().front(); }
+    IDevice* device() const { return mesh_device_->impl().get_devices().front(); }
 
     tt::umd::TTDevice& tt_device() const {
         return *MetalContext::instance().get_cluster().get_driver()->get_tt_device(device()->id());

--- a/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
@@ -17,6 +17,7 @@
 #include "impl/kernels/kernel.hpp"
 #include "dispatch_test_utils.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -330,7 +331,7 @@ private:
             TT_FATAL(core_type == CoreType::ETH, "Unsupported core type");
             std::set<CoreRange> core_ranges;
             const std::unordered_set<CoreCoord> active_eth_cores =
-                this->device_->get_devices()[0]->get_active_ethernet_cores(true);
+                this->device_->impl().get_devices()[0]->get_active_ethernet_cores(true);
             TT_FATAL(!active_eth_cores.empty(), "No active ethernet cores detected");
             for (CoreCoord eth_core : active_eth_cores) {
                 core_ranges.emplace(eth_core);

--- a/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
@@ -26,6 +26,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "impl/context/metal_context.hpp"
 #include "llrt/llrt.hpp"
@@ -102,7 +103,7 @@ protected:
 //   2. allocate_l1 / deallocate_l1 / bytes_available on an unclaimed core
 TEST_F(ServiceCoreSdFixture, ServiceCoreFatalGuards) {
     auto& mesh_device = this->devices_[0];
-    IDevice* device = mesh_device->get_device(MeshCoordinate(0, 0));
+    IDevice* device = mesh_device->impl().get_device(MeshCoordinate(0, 0));
 
     // Before FD is active, both query and claim must fatal
     EXPECT_THROW(MetalContext::instance().get_service_core_manager().get_claimable_cores(device), std::exception);
@@ -131,7 +132,7 @@ TEST_F(ServiceCoreSdFixture, ServiceCoreFatalGuards) {
 //   2. leaves no idle dispatch cores when FD is re-initialized.
 TEST_F(ServiceCoreSdFixture, ServiceCoreGridCap) {
     auto& mesh_device = this->devices_[0];
-    IDevice* device = mesh_device->get_device(MeshCoordinate(0, 0));
+    IDevice* device = mesh_device->impl().get_device(MeshCoordinate(0, 0));
 
     // Phase 1: record full SD grid (no services active)
     const CoreCoord sd_grid = device->compute_with_storage_grid_size();
@@ -177,7 +178,7 @@ TEST_F(ServiceCoreSdFixture, ServiceCoreGridCap) {
 // We verify the counter is still incrementing after each FD lifecycle transition
 TEST_F(ServiceCoreSdFixture, PersistentServiceMultiCycle) {
     auto& mesh_device = this->devices_[0];
-    IDevice* device = mesh_device->get_device(MeshCoordinate(0, 0));
+    IDevice* device = mesh_device->impl().get_device(MeshCoordinate(0, 0));
     const auto& cluster = MetalContext::instance().get_cluster();
 
     uint32_t single_tile_size = ::tt::tile_size(DataFormat::UInt32);
@@ -295,7 +296,7 @@ TEST_F(ServiceCoreSdFixture, PersistentServiceMultiCycle) {
 // Per-core Allocator sanity check: verify alignment, non-overlap, bytes_available accounting, and deallocation
 TEST_F(ServiceCoreFdFixture, ServiceCoreAllocatorCorrectness) {
     auto& mesh_device = this->devices_[0];
-    IDevice* device = mesh_device->get_device(MeshCoordinate(0, 0));
+    IDevice* device = mesh_device->impl().get_device(MeshCoordinate(0, 0));
 
     auto claimable = MetalContext::instance().get_service_core_manager().get_claimable_cores(device);
     CoreCoord core = claimable[0];
@@ -342,7 +343,7 @@ TEST_F(ServiceCoreFdFixture, ServiceCoreAllocatorCorrectness) {
 // independent. Needed for prefill in Blitz.
 TEST_F(ServiceCoreFdFixture, FDWorkloadAndServiceKernelConcurrent) {
     auto& mesh_device = this->devices_[0];
-    IDevice* device = mesh_device->get_device(MeshCoordinate(0, 0));
+    IDevice* device = mesh_device->impl().get_device(MeshCoordinate(0, 0));
     const auto& cluster = MetalContext::instance().get_cluster();
 
     auto claimable = MetalContext::instance().get_service_core_manager().get_claimable_cores(device);
@@ -442,7 +443,7 @@ TEST_F(ServiceCoreFdFixture, FDWorkloadAndServiceKernelConcurrent) {
 // a second TT_FATALs until the core is released and re-claimed, after which a fresh enqueue succeeds.
 TEST_F(ServiceCoreFdFixture, ServiceWorkloadReenqueueRequiresRelease) {
     auto& mesh_device = this->devices_[0];
-    IDevice* device = mesh_device->get_device(MeshCoordinate(0, 0));
+    IDevice* device = mesh_device->impl().get_device(MeshCoordinate(0, 0));
 
     auto claimable = MetalContext::instance().get_service_core_manager().get_claimable_cores(device);
     ASSERT_GE(claimable.size(), 1u) << "Need at least one claimable service core for this test.";
@@ -483,7 +484,7 @@ TEST_F(ServiceCoreFdFixture, ServiceWorkloadReenqueueRequiresRelease) {
 // a claimed service core and an unclaimed worker core.
 TEST_F(ServiceCoreFdFixture, ServiceWorkloadMixingFatal) {
     auto& mesh_device = this->devices_[0];
-    IDevice* device = mesh_device->get_device(MeshCoordinate(0, 0));
+    IDevice* device = mesh_device->impl().get_device(MeshCoordinate(0, 0));
 
     auto claimable = MetalContext::instance().get_service_core_manager().get_claimable_cores(device);
     ASSERT_GE(claimable.size(), 1u) << "Need at least one claimable service core for this test.";

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -35,6 +35,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
 #include "eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -73,7 +74,7 @@ bool reader_kernel_no_send(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::Program();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     distributed::DeviceLocalBufferConfig dram_config{
         .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM};
@@ -150,7 +151,7 @@ bool writer_kernel_no_receive(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::Program();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     distributed::DeviceLocalBufferConfig dram_config{
         .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM};
@@ -224,7 +225,7 @@ bool noc_reader_and_writer_kernels(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::Program();
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
 
     distributed::DeviceLocalBufferConfig dram_config{.page_size = byte_size, .buffer_type = tt_metal::BufferType::DRAM};
@@ -338,7 +339,7 @@ TEST_F(UnitMeshCQSingleCardProgramFixture, ActiveEthKernelsNocReadNoSend) {
         tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(HalProgrammableCoreType::ACTIVE_ETH);
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         for (const auto& eth_core : device->get_active_ethernet_cores(true)) {
             for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; ++erisc_idx) {
                 const auto ethernet_config = tt_metal::EthernetConfig{
@@ -380,7 +381,7 @@ TEST_F(UnitMeshCQSingleCardProgramFixture, ActiveEthKernelsNocWriteNoReceive) {
         tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(HalProgrammableCoreType::ACTIVE_ETH);
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         for (const auto& eth_core : device->get_active_ethernet_cores(true)) {
             for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; ++erisc_idx) {
                 const auto ethernet_config = tt_metal::EthernetConfig{
@@ -406,8 +407,8 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsNocReadNoSend) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
-    auto* const device_0 = mesh_device_0->get_devices()[0];
-    auto* const device_1 = mesh_device_1->get_devices()[0];
+    auto* const device_0 = mesh_device_0->impl().get_devices()[0];
+    auto* const device_1 = mesh_device_1->impl().get_devices()[0];
 
     const size_t src_eth_l1_byte_address = tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
@@ -451,8 +452,8 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsNocWriteNoReceive) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
-    auto* const device_0 = mesh_device_0->get_devices()[0];
-    auto* const device_1 = mesh_device_1->get_devices()[0];
+    auto* const device_0 = mesh_device_0->impl().get_devices()[0];
+    auto* const device_1 = mesh_device_1->impl().get_devices()[0];
 
     const size_t src_eth_l1_byte_address = tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
@@ -505,7 +506,7 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsNocWriteNoReceive) {
 // TODO #14640: Run this on WH when i$ flush issue is addressed
 TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnIdleErisc0) {
     const auto& mesh_device = devices_.at(0);
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
 
     using namespace CMAKE_UNIQUE_NAMESPACE;
     uint32_t eth_l1_address =
@@ -549,7 +550,7 @@ TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnIdleErisc0) {
 
 TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnIdleErisc1) {
     const auto& mesh_device = devices_.at(0);
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
 
     using namespace CMAKE_UNIQUE_NAMESPACE;
     uint32_t eth_l1_address =
@@ -593,7 +594,7 @@ TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnIdleErisc1) {
 
 TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnBothIdleEriscs) {
     const auto& mesh_device = devices_.at(0);
-    auto* const device = mesh_device->get_devices()[0];
+    auto* const device = mesh_device->impl().get_devices()[0];
 
     using namespace CMAKE_UNIQUE_NAMESPACE;
     uint32_t read_write_size_bytes = WORD_SIZE * 2048;

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -41,6 +41,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::test_utils;
@@ -72,8 +73,8 @@ bool chip_to_chip_dram_buffer_transfer(
     const DataMovementProcessor& processor) {
     bool pass = true;
 
-    auto* sender_device = sender_mesh_device->get_devices()[0];
-    auto* receiver_device = receiver_mesh_device->get_devices()[0];
+    auto* sender_device = sender_mesh_device->impl().get_devices()[0];
+    auto* receiver_device = receiver_mesh_device->impl().get_devices()[0];
 
     distributed::DeviceLocalBufferConfig sender_dram_config{
         .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM, .bottom_up = false};
@@ -375,7 +376,7 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsSendDramBufferChip0ToChip1) {
     }
     const auto& sender_mesh_device = devices_.at(0);
     const auto& receiver_mesh_device = devices_.at(1);
-    auto* const sender_device = sender_mesh_device->get_devices()[0];
+    auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
 
     for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
         if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
@@ -425,7 +426,7 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsSendDramBufferChip1ToChip0) {
     }
     const auto& sender_mesh_device = devices_.at(1);
     const auto& receiver_mesh_device = devices_.at(0);
-    auto* const sender_device = sender_mesh_device->get_devices()[0];
+    auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
 
     for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
         if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
@@ -473,8 +474,8 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferChip0ToChip1)
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const auto& sender_mesh_device = devices_.at(0);
     const auto& receiver_mesh_device = devices_.at(1);
-    auto* const sender_device = sender_mesh_device->get_devices()[0];
-    auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+    auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
+    auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
     uint32_t MAX_BUFFER_SIZE =
         MetalContext::instance().hal().get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
 
@@ -560,9 +561,9 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferAllConnectedChips
     uint32_t page_size = 2 * 32 * 32;
     uint32_t num_pages = MAX_BUFFER_SIZE / page_size;
     for (const auto& sender_mesh_device : devices_) {
-        auto* const sender_device = sender_mesh_device->get_devices()[0];
+        auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+            auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
             if (sender_device->id() == receiver_device->id()) {
                 continue;
             }
@@ -650,9 +651,9 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendDramBufferAllCon
         tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(HalProgrammableCoreType::ACTIVE_ETH);
 
     for (const auto& sender_mesh_device : devices_) {
-        auto* const sender_device = sender_mesh_device->get_devices()[0];
+        auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+            auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
             if (sender_device->id() >= receiver_device->id()) {
                 continue;
             }
@@ -726,9 +727,9 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendInterleavedBuffe
         tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(HalProgrammableCoreType::ACTIVE_ETH);
 
     for (const auto& sender_mesh_device : devices_) {
-        auto* const sender_device = sender_mesh_device->get_devices()[0];
+        auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+            auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
             if (sender_device->id() >= receiver_device->id()) {
                 continue;
             }

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -40,6 +40,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include "eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
@@ -81,8 +82,8 @@ bool eth_direct_sender_receiver_kernels(
     const CoreCoord& eth_receiver_core,
     DataMovementProcessor processor = DataMovementProcessor::RISCV_0,
     uint32_t num_bytes_per_send = 16) {
-    auto* const sender_device = sender_mesh_device->get_devices()[0];
-    auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+    auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
+    auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
     bool pass = true;
     log_info(
         tt::LogTest,
@@ -192,8 +193,8 @@ bool send_over_eth(
     const CoreCoord& sender_core,
     const CoreCoord& receiver_core,
     const size_t& byte_size) {
-    auto* const sender_device = sender_mesh_device->get_devices()[0];
-    auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+    auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
+    auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
     log_debug(
         tt::LogTest,
         "Running direct send test with sender chip {} core {}, receiver chip {} core {}, sending {} bytes",
@@ -314,8 +315,8 @@ TEST_F(N300MeshDeviceFixture, ActiveEthSingleCoreDirectSendChip0ToChip1) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
-    auto* const device_0 = mesh_device_0->get_devices()[0];
-    auto* const device_1 = mesh_device_1->get_devices()[0];
+    auto* const device_0 = mesh_device_0->impl().get_devices()[0];
+    auto* const device_1 = mesh_device_1->impl().get_devices()[0];
 
     auto send_cores = device_0->get_ethernet_sockets(device_1->id());
     auto receiver_cores = device_1->get_ethernet_sockets(device_0->id());
@@ -356,8 +357,8 @@ TEST_F(N300MeshDeviceFixture, ActiveEthSingleCoreDirectSendChip1ToChip0) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
-    auto* const device_0 = mesh_device_0->get_devices()[0];
-    auto* const device_1 = mesh_device_1->get_devices()[0];
+    auto* const device_0 = mesh_device_0->impl().get_devices()[0];
+    auto* const device_1 = mesh_device_1->impl().get_devices()[0];
 
     auto send_cores = device_1->get_ethernet_sockets(device_0->id());
     auto receiver_cores = device_0->get_ethernet_sockets(device_1->id());
@@ -398,8 +399,8 @@ TEST_F(N300MeshDeviceFixture, ActiveEthBidirectionalCoreDirectSend) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
-    auto* const device_0 = mesh_device_0->get_devices()[0];
-    auto* const device_1 = mesh_device_1->get_devices()[0];
+    auto* const device_0 = mesh_device_0->impl().get_devices()[0];
+    auto* const device_1 = mesh_device_1->impl().get_devices()[0];
 
     auto send_cores = device_1->get_ethernet_sockets(device_0->id());
     auto receiver_cores = device_0->get_ethernet_sockets(device_1->id());
@@ -488,8 +489,8 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip0ToChip1) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
-    auto* const device_0 = mesh_device_0->get_devices()[0];
-    auto* const device_1 = mesh_device_1->get_devices()[0];
+    auto* const device_0 = mesh_device_0->impl().get_devices()[0];
+    auto* const device_1 = mesh_device_1->impl().get_devices()[0];
 
     const size_t src_eth_l1_byte_address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
@@ -547,8 +548,8 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip1ToChip0) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
-    auto* const device_0 = mesh_device_0->get_devices()[0];
-    auto* const device_1 = mesh_device_1->get_devices()[0];
+    auto* const device_0 = mesh_device_0->impl().get_devices()[0];
+    auto* const device_1 = mesh_device_1->impl().get_devices()[0];
 
     const size_t src_eth_l1_byte_address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
@@ -609,9 +610,9 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsDirectSendAllConnectedChips) {
     const size_t dst_eth_l1_byte_address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
     for (const auto& sender_mesh_device : devices_) {
-        auto* const sender_device = sender_mesh_device->get_devices()[0];
+        auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+            auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
             if (sender_device->id() == receiver_device->id()) {
                 continue;
             }
@@ -669,7 +670,7 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
-    auto* const device_0 = mesh_device_0->get_devices()[0];
+    auto* const device_0 = mesh_device_0->impl().get_devices()[0];
 
     const size_t src_eth_l1_byte_address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
@@ -782,7 +783,7 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsRepeatedDirectSends) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
-    auto* const device_0 = mesh_device_0->get_devices()[0];
+    auto* const device_0 = mesh_device_0->impl().get_devices()[0];
 
     const size_t src_eth_l1_byte_address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
@@ -824,8 +825,8 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsRandomDirectSendTests) {
     srand(0);
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
-    auto* const device_0 = mesh_device_0->get_devices()[0];
-    auto* const device_1 = mesh_device_1->get_devices()[0];
+    auto* const device_0 = mesh_device_0->impl().get_devices()[0];
+    auto* const device_1 = mesh_device_1->impl().get_devices()[0];
 
     std::map<std::tuple<int, CoreCoord>, std::tuple<int, CoreCoord>> connectivity = {};
     for (const auto& sender_core : device_0->get_active_ethernet_cores(true)) {
@@ -851,7 +852,7 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsRandomDirectSendTests) {
 
         // gotcha: devices_ are mesh devices. Mesh device IDs are not the same as actual device IDs needed in the
         // cluster
-        auto* send_device = send_chip->get_devices()[0];
+        auto* send_device = send_chip->impl().get_devices()[0];
         if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
                 send_device->id(), sender_core)) {
             continue;
@@ -889,8 +890,8 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsRandomEthPacketSizeDirectSendTests)
     srand(0);
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
-    auto* const device_0 = mesh_device_0->get_devices()[0];
-    auto* const device_1 = mesh_device_1->get_devices()[0];
+    auto* const device_0 = mesh_device_0->impl().get_devices()[0];
+    auto* const device_1 = mesh_device_1->impl().get_devices()[0];
 
     std::map<std::tuple<int, CoreCoord>, std::tuple<int, CoreCoord>> connectivity = {};
     for (const auto& sender_core : device_0->get_active_ethernet_cores(true)) {
@@ -960,9 +961,9 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsDirectSendAllConnect
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
     const auto num_eriscs = MetalContext::instance().hal().get_num_risc_processors(HalProgrammableCoreType::ACTIVE_ETH);
     for (const auto& sender_mesh_device : devices_) {
-        auto* const sender_device = sender_mesh_device->get_devices()[0];
+        auto* const sender_device = sender_mesh_device->impl().get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+            auto* const receiver_device = receiver_mesh_device->impl().get_devices()[0];
             if (sender_device->id() >= receiver_device->id()) {
                 continue;
             }

--- a/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
@@ -18,6 +18,7 @@
 #include "multi_device_fixture.hpp"
 #include <tt-metalium/program.hpp>
 #include "impl/context/metal_context.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -130,8 +131,8 @@ static void run_multi_txq_rxq_test(
     uint32_t data_txq_id,
     uint32_t ack_txq_id,
     uint32_t num_messages) {
-    auto* device_0 = mesh_device_0->get_devices()[0];
-    auto* device_1 = mesh_device_1->get_devices()[0];
+    auto* device_0 = mesh_device_0->impl().get_devices()[0];
+    auto* device_1 = mesh_device_1->impl().get_devices()[0];
     // Find ethernet cores that connect device_0 and device_1 using standard metal APIs
     std::optional<CoreCoord> sender_core_0;
     std::optional<CoreCoord> receiver_core_0;

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -38,6 +38,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include "eth_test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using std::vector;
 using namespace tt;
@@ -103,7 +104,7 @@ std::vector<std::shared_ptr<distributed::MeshDevice>> get_device_ring(
     std::vector<std::vector<int>> adj(mesh_devices.size(), std::vector<int>(mesh_devices.size(), 0));
     for (uint32_t i = 0; i < mesh_devices.size(); ++i) {
         const auto& mesh_device = mesh_devices[i];
-        auto* device = mesh_device->get_devices()[0];
+        auto* device = mesh_device->impl().get_devices()[0];
         auto ethernet_connected_device_ids =
             tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_connected_device_ids(device->id());
         for (const auto& connected_device_id : ethernet_connected_device_ids) {
@@ -139,9 +140,9 @@ get_sender_receiver_cores(std::vector<std::shared_ptr<distributed::MeshDevice>> 
     // Special case for 2 devices to ensure core pairs are not the same for send and receive
     if (device_ring.size() - 1 == 2) {
         const auto& first_mesh_device = device_ring[0];
-        auto* first_device = first_mesh_device->get_devices()[0];
+        auto* first_device = first_mesh_device->impl().get_devices()[0];
         const auto& second_mesh_device = device_ring[1];
-        auto* second_device = second_mesh_device->get_devices()[0];
+        auto* second_device = second_mesh_device->impl().get_devices()[0];
         uint32_t i = 0;
         for (const auto& first_eth_core : first_device->get_active_ethernet_cores(true)) {
             if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
@@ -159,8 +160,8 @@ get_sender_receiver_cores(std::vector<std::shared_ptr<distributed::MeshDevice>> 
                     sender_mesh_device = second_mesh_device, receiver_mesh_device = first_mesh_device;
                     sender_eth_core = second_eth_core, receiver_eth_core = first_eth_core;
                 }
-                auto* sender_device = sender_mesh_device->get_devices()[0];
-                auto* receiver_device = receiver_mesh_device->get_devices()[0];
+                auto* sender_device = sender_mesh_device->impl().get_devices()[0];
+                auto* receiver_device = receiver_mesh_device->impl().get_devices()[0];
                 sender_receivers.push_back(
                     {sender_mesh_device, receiver_mesh_device, sender_eth_core, receiver_eth_core});
                 log_info(
@@ -179,9 +180,9 @@ get_sender_receiver_cores(std::vector<std::shared_ptr<distributed::MeshDevice>> 
     } else {
         for (uint32_t i = 0; i < device_ring.size() - 1; ++i) {
             const auto& sender_mesh_device = device_ring[i];
-            auto* sender_device = sender_mesh_device->get_devices()[0];
+            auto* sender_device = sender_mesh_device->impl().get_devices()[0];
             const auto& receiver_mesh_device = device_ring[i + 1];
-            auto* receiver_device = receiver_mesh_device->get_devices()[0];
+            auto* receiver_device = receiver_mesh_device->impl().get_devices()[0];
             for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
                 if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
                         sender_device->id(), sender_eth_core)) {
@@ -249,13 +250,13 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
         ////////////////////////////////////////////////////////////////////////////
         const auto& [sender_mesh_device, receiver_mesh_device, eth_sender_core, eth_receiver_core] =
             sender_receivers[i];
-        auto* sender_device = sender_mesh_device->get_devices()[0];
-        auto* receiver_device = receiver_mesh_device->get_devices()[0];
+        auto* sender_device = sender_mesh_device->impl().get_devices()[0];
+        auto* receiver_device = receiver_mesh_device->impl().get_devices()[0];
         auto& sender_program = programs[sender_device->id()];
         auto& receiver_program = programs[receiver_device->id()];
         CoreCoord sender_receiver_core;
         for (const auto& sender_receiver : sender_receivers) {
-            if (std::get<1>(sender_receiver)->get_devices()[0]->id() == sender_device->id()) {
+            if (std::get<1>(sender_receiver)->impl().get_devices()[0]->id() == sender_device->id()) {
                 sender_receiver_core = sender_device->ethernet_core_from_logical_core(std::get<3>(sender_receiver));
             }
         }
@@ -302,7 +303,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
         // Clear expected value at ethernet L1 address
         CoreCoord receiver_sender_core;
         for (const auto& sender_receiver : sender_receivers) {
-            if (std::get<0>(sender_receiver)->get_devices()[0]->id() == receiver_device->id()) {
+            if (std::get<0>(sender_receiver)->impl().get_devices()[0]->id() == receiver_device->id()) {
                 receiver_sender_core = receiver_device->ethernet_core_from_logical_core(std::get<2>(sender_receiver));
             }
         }
@@ -342,11 +343,11 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
     ths.reserve(sender_receivers.size());
     for (const auto& sender_receiver : sender_receivers) {
         const auto& device = std::get<0>(sender_receiver);
-        workloads[device->get_devices()[0]->id()].add_program(
-            device_range, std::move(programs[device->get_devices()[0]->id()]));
+        workloads[device->impl().get_devices()[0]->id()].add_program(
+            device_range, std::move(programs[device->impl().get_devices()[0]->id()]));
         ths.emplace_back([&] {
             distributed::EnqueueMeshWorkload(
-                device->mesh_command_queue(), workloads[device->get_devices()[0]->id()], false);
+                device->mesh_command_queue(), workloads[device->impl().get_devices()[0]->id()], false);
         });
     }
     for (auto& th : ths) {
@@ -356,8 +357,8 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
         const auto& device = std::get<0>(sender_receivers[i]);
         const auto& core = std::get<2>(sender_receivers[i]);
         auto readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            device->get_devices()[0]->id(),
-            device->get_devices()[0]->ethernet_core_from_logical_core(core),
+            device->impl().get_devices()[0]->id(),
+            device->impl().get_devices()[0]->ethernet_core_from_logical_core(core),
             src_eth_l1_byte_address,
             byte_size_per_device * sender_receivers.size());
         auto a = std::mismatch(full_input.begin(), full_input.end(), readback_vec.begin());
@@ -413,13 +414,13 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
             }
         }
 
-        auto& program = programs[device->get_devices()[0]->id()];
+        auto& program = programs[device->impl().get_devices()[0]->id()];
 
-        auto input_buffer = CreateBuffer(
-            tt_metal::InterleavedBufferConfig{device->get_devices()[0], cfg.size_bytes, cfg.page_size_bytes, cfg.input_buffer_type});
+        auto input_buffer = CreateBuffer(tt_metal::InterleavedBufferConfig{
+            device->impl().get_devices()[0], cfg.size_bytes, cfg.page_size_bytes, cfg.input_buffer_type});
         tt_metal::detail::WriteToBuffer(input_buffer, inputs[i]);
         output_buffers.emplace_back(CreateBuffer(tt_metal::InterleavedBufferConfig{
-            device->get_devices()[0],
+            device->impl().get_devices()[0],
             cfg.size_bytes * sender_receivers.size(),
             cfg.page_size_bytes,
             cfg.output_buffer_type}));
@@ -434,8 +435,8 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
                 .compile_args = {
                     uint32_t(num_bytes_per_send),
                     uint32_t(num_bytes_per_send >> 4),
-                    uint32_t(device->get_devices()[0]->ethernet_core_from_logical_core(eth_receiver_core).x),
-                    uint32_t(device->get_devices()[0]->ethernet_core_from_logical_core(eth_receiver_core).y),
+                    uint32_t(device->impl().get_devices()[0]->ethernet_core_from_logical_core(eth_receiver_core).x),
+                    uint32_t(device->impl().get_devices()[0]->ethernet_core_from_logical_core(eth_receiver_core).y),
                     uint32_t(input_buffer->buffer_type() == tt_metal::BufferType::DRAM),
                     uint32_t(output_buffers[i]->buffer_type() == tt_metal::BufferType::DRAM)}});
 
@@ -454,14 +455,14 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
              (uint32_t)cfg.page_size_bytes,
              (uint32_t)sem_l1_byte_address});
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            device->get_devices()[0]->id(),
-            device->get_devices()[0]->ethernet_core_from_logical_core(eth_sender_core),
+            device->impl().get_devices()[0]->id(),
+            device->impl().get_devices()[0]->ethernet_core_from_logical_core(eth_sender_core),
             std::vector{INVALID},
             sem_l1_byte_address);
 
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            device->get_devices()[0]->id(),
-            device->get_devices()[0]->ethernet_core_from_logical_core(eth_receiver_core),
+            device->impl().get_devices()[0]->id(),
+            device->impl().get_devices()[0]->ethernet_core_from_logical_core(eth_receiver_core),
             std::vector{INVALID},
             sem_l1_byte_address);
 
@@ -499,11 +500,11 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
     ths.reserve(sender_receivers.size());
     for (const auto& sender_receiver : sender_receivers) {
         const auto& device = std::get<0>(sender_receiver);
-        workloads[device->get_devices()[0]->id()].add_program(
-            device_range, std::move(programs[device->get_devices()[0]->id()]));
+        workloads[device->impl().get_devices()[0]->id()].add_program(
+            device_range, std::move(programs[device->impl().get_devices()[0]->id()]));
         ths.emplace_back([&] {
             distributed::EnqueueMeshWorkload(
-                device->mesh_command_queue(), workloads[device->get_devices()[0]->id()], false);
+                device->mesh_command_queue(), workloads[device->impl().get_devices()[0]->id()], false);
         });
     }
     for (auto& th : ths) {

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
@@ -45,6 +45,7 @@
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <umd/device/types/arch.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -240,7 +241,7 @@ bool matmul_multi_core_single_dram(const std::shared_ptr<distributed::MeshDevice
             out_subblock_h,
             out_subblock_w);
 
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     auto& program_ = workload.get_programs().at(device_range);

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -41,6 +41,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -505,7 +506,7 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(const std::shared_ptr<dist
     auto activations_tile_layout =
         convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(activations_tilized));
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     pass &= move_tiles_to_dram(device, activations, M, K, in0_dram_addr);
 
     auto identity_tilized = tilize_swizzled(identity, K * 32, N * 32);

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
@@ -41,6 +41,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -376,7 +377,7 @@ bool matmul_multi_core_multi_dram_inX_mcast(
     auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bfloat16 identity
     auto golden = tt_metal::select_columns(tensor.get_values(), M, K, N);
 
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto
         [workload,
          mm_reader_kernel_sender,

--- a/tests/tt_metal/tt_metal/jit_build/test_compile_stress.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_compile_stress.cpp
@@ -67,6 +67,7 @@
 #include "common/env_lib.hpp"
 #include "common/tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -219,7 +220,7 @@ protected:
 TEST_F(CompileStressFixture, DISABLED_TensixCompileStress) {
     const auto target = MetalContext::instance().get_cluster().get_target_device_type();
 
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
 
     if (use_mock_mode()) {
         TT_FATAL(

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -37,6 +37,7 @@
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -238,7 +239,7 @@ void run_single_core_broadcast(
     auto dst_dram_buffer = CreateDramBufferForPageSize(mesh_device, single_tile_size, k_num_tiles_broadcast_test);
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
-    auto* device = mesh_device->get_devices().empty() ? nullptr : mesh_device->get_devices().front();
+    auto* device = mesh_device->impl().get_devices().empty() ? nullptr : mesh_device->impl().get_devices().front();
     TT_FATAL(device != nullptr, "mesh_device has no backing devices");
     const bool is_quasar = device->arch() == ARCH::QUASAR;
 

--- a/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
@@ -33,6 +33,7 @@
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -87,7 +88,7 @@ void run_single_core_cumsum(
     Program program = tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     CoreCoord core = {0, 0};
 

--- a/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
@@ -33,6 +33,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -115,7 +116,7 @@ bool test_dropout_standalone(
         Program program = CreateProgram();
         workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
-        auto* const device = mesh_device->get_devices()[0];
+        auto* const device = mesh_device->impl().get_devices()[0];
 
         constexpr CoreCoord core = {0, 0};
         constexpr uint32_t single_tile_size = 2 * 1024;

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -21,6 +21,7 @@
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/float8_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -39,7 +40,7 @@ static vector<uint32_t> run_fp8_typecast(
     const vector<uint32_t>& src_vec,
     uint32_t num_tiles,
     bool fp32_dest_acc_en) {
-    IDevice* dev = mesh_device.get_devices()[0];
+    IDevice* dev = mesh_device.impl().get_devices()[0];
     Program program = CreateProgram();
     CoreCoord core = {0, 0};
 

--- a/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
@@ -33,6 +33,7 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using std::vector;
 using namespace tt;
@@ -50,7 +51,7 @@ struct MulReduceScalarConfig {
 };
 
 bool run_mul_reduce_scalar_test(distributed::MeshDevice& mesh_device, const MulReduceScalarConfig& config) {
-    IDevice* device = mesh_device.get_devices()[0];
+    IDevice* device = mesh_device.impl().get_devices()[0];
     tt_metal::Program program = tt_metal::CreateProgram();
     CoreCoord core = {0, 0};
 

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -27,6 +27,7 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/float8_utils.hpp"
 #include "tt_metal/test_utils/mx_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -51,7 +52,7 @@ static vector<uint32_t> run_mxfp4_typecast(
     const vector<uint32_t>& src_vec,
     uint32_t num_tiles,
     bool fp32_dest_acc_en) {
-    IDevice* dev = mesh_device.get_devices()[0];
+    IDevice* dev = mesh_device.impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     uint32_t input_tile_size = tt::tile_size(input_fmt);

--- a/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
@@ -27,6 +27,7 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/float8_utils.hpp"
 #include "tt_metal/test_utils/mx_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -52,7 +53,7 @@ static vector<uint32_t> run_mxfp6_typecast(
     const vector<uint32_t>& src_vec,
     uint32_t num_tiles,
     bool fp32_dest_acc_en) {
-    IDevice* dev = mesh_device.get_devices()[0];
+    IDevice* dev = mesh_device.impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     uint32_t input_tile_size = tt::tile_size(input_fmt);

--- a/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
@@ -27,6 +27,7 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/float8_utils.hpp"
 #include "tt_metal/test_utils/mx_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -51,7 +52,7 @@ static vector<uint32_t> run_mxfp8_typecast(
     const vector<uint32_t>& src_vec,
     uint32_t num_tiles,
     bool fp32_dest_acc_en) {
-    IDevice* dev = mesh_device.get_devices()[0];
+    IDevice* dev = mesh_device.impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     uint32_t input_tile_size = tt::tile_size(input_fmt);

--- a/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
@@ -27,6 +27,7 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/float8_utils.hpp"
 #include "tt_metal/test_utils/mx_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -45,7 +46,7 @@ static vector<uint32_t> run_mxint_typecast(
     const vector<uint32_t>& src_vec,
     uint32_t num_tiles,
     bool fp32_dest_acc_en) {
-    IDevice* dev = mesh_device.get_devices()[0];
+    IDevice* dev = mesh_device.impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     uint32_t input_tile_size = tt::tile_size(input_fmt);

--- a/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
@@ -27,6 +27,7 @@
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include <umd/device/types/arch.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -56,7 +57,7 @@ void run_single_core_pack_rows_program(
     Program program = tt::tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     CoreCoord core = {0, 0};
 

--- a/tests/tt_metal/tt_metal/llk/test_quasar_cb_l1_read_api.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_quasar_cb_l1_read_api.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -38,7 +39,7 @@ const std::vector<DataT> EXPECTED_RESULT = {VAL0, VAL1, VAL2, VAL3, VAL2};
 // them back through both APIs. Reading tile_index 1 exercises the per-tile stride term.
 TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarCbL1ReadApi) {
     auto mesh_device = devices_.at(0);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -39,6 +39,7 @@
 #include <umd/device/types/arch.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -116,7 +117,7 @@ bool single_core_reconfig(
     tt_metal::Program program = tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     tt::tt_metal::InterleavedBufferConfig dram_config_bfp16b{
         .device = device,
@@ -622,7 +623,7 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
     };
     experimental::SetProgramRunArgs(program, params);
 
-    auto* dev = mesh_device->get_devices()[0];
+    auto* dev = mesh_device->impl().get_devices()[0];
     tt_metal::detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> dest_buffer_data;
@@ -977,7 +978,7 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
     };
     experimental::SetProgramRunArgs(program, params);
 
-    auto* dev = mesh_device->get_devices()[0];
+    auto* dev = mesh_device->impl().get_devices()[0];
     tt_metal::detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> out0_data;

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -46,6 +46,7 @@
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/int8.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -681,12 +682,12 @@ std::vector<uint32_t> run_sfpu_pipeline(
     const size_t out_bytes = test_config.num_tiles * tt::tile_size(test_config.l1_output_data_format);
 
     tt::tt_metal::InterleavedBufferConfig in_dram{
-        .device = mesh_device->get_devices()[0],
+        .device = mesh_device->impl().get_devices()[0],
         .size = in_bytes,
         .page_size = in_bytes,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
     tt::tt_metal::InterleavedBufferConfig out_dram{
-        .device = mesh_device->get_devices()[0],
+        .device = mesh_device->impl().get_devices()[0],
         .size = out_bytes,
         .page_size = out_bytes,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
@@ -967,7 +968,7 @@ std::vector<uint32_t> sfpu_quasar_run(
     const experimental::ProgramRunArgs& params,
     const std::vector<std::pair<std::shared_ptr<tt::tt_metal::Buffer>, const std::vector<uint32_t>*>>& inputs,
     const std::shared_ptr<tt::tt_metal::Buffer>& out_buf) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto program = experimental::MakeProgramFromSpec(*mesh_device, spec);
     experimental::SetProgramRunArgs(program, params);
     for (const auto& [buf, data] : inputs) {
@@ -993,7 +994,7 @@ std::vector<uint32_t> sfpu_quasar_run(
 /// @return
 bool run_sfpu_binary_two_input_buffer(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const SfpuConfig& test_config) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     const size_t per_buffer_byte_size_input = test_config.num_tiles * tt::tile_size(test_config.l1_input_data_format);
     const size_t per_buffer_byte_size_output = test_config.num_tiles * tt::tile_size(test_config.l1_output_data_format);
 
@@ -1177,7 +1178,7 @@ bool run_sfpu_binary_two_input_buffer(
 bool run_sfpu_ternary_three_input_buffer(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const SfpuConfig& test_config) {
     const size_t per_buffer_byte_size = test_config.num_tiles * test_config.tile_byte_size;
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     tt::tt_metal::InterleavedBufferConfig dram_config{
         .device = device,

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -38,6 +38,7 @@
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/distributed.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -451,7 +452,7 @@ bool single_core_binary(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    auto* dev = mesh_device->get_devices()[0];
+    auto* dev = mesh_device->impl().get_devices()[0];
     tt_metal::detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
 
     return read_and_validate_binary_result(cq, output_dram_buffer, zero_coord, stimulus);

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -44,6 +44,7 @@
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -364,7 +365,7 @@ bool single_tile_matmul(
     const uint32_t in1_tile_size = tt::tile_size(in1_fmt);
     const uint32_t out_tile_size = tt::tile_size(out_fmt);
 
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -525,7 +526,7 @@ bool single_block_matmul(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     tt::tt_metal::InterleavedBufferConfig dram_config_0{
         .device = device,
@@ -691,7 +692,7 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     tt::tt_metal::InterleavedBufferConfig dram_config_0{
         .device = device,

--- a/tests/tt_metal/tt_metal/llk/test_top32_rm_dev.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_top32_rm_dev.cpp
@@ -28,6 +28,7 @@
 #include <tt-metalium/distributed.hpp>
 
 #include "tt_metal/test_utils/packing.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -164,7 +165,7 @@ bool verify_top32_outputs(
 
 bool run_top32_rm_dev(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t row_elements, uint32_t seed) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -48,6 +48,7 @@
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/buffer.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -281,7 +282,7 @@ void get_packed_tilized_input_output_pair(
 
 void run_single_core_unary_broadcast_quasar(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const UnaryBroadcastConfig& test_config) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     constexpr uint32_t num_tiles = 32;

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -47,6 +47,7 @@
 #include "impl/data_format/bfloat16_utils.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -206,7 +207,7 @@ static void validate_result(
 void run_single_core_tilize_program(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const TestConfig& test_config) {
     auto& cq = mesh_device->mesh_command_queue();
-    auto* dev = mesh_device->get_devices()[0];
+    auto* dev = mesh_device->impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const std::uint32_t num_tiles = test_config.num_tiles_r * test_config.num_tiles_c;
@@ -455,7 +456,7 @@ void run_single_core_unpack_tilizeA_B_program(
     Program program = tt::tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     CoreCoord core = {0, 0};
 
@@ -958,7 +959,7 @@ static void run_quasar_tilize_untilize_test(
     std::uint32_t face_r_dim = tt::constants::FACE_HEIGHT) {
     bool is_tilize = (mode == QuasarTestMode::TILIZE);
 
-    IDevice* dev = mesh_device->get_devices()[0];
+    IDevice* dev = mesh_device->impl().get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 

--- a/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
+++ b/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
@@ -28,6 +28,7 @@
 #include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"
 #include "impl/buffers/semaphore.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -184,7 +185,7 @@ void build_and_run_program_ethernet(
     log_info(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
 
-    auto* device_0 = device->get_devices()[0];
+    auto* device_0 = device->impl().get_devices()[0];
 
     // Query the number of ethernet ERISCs
     const auto erisc_count = tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(

--- a/tests/tt_metal/tt_metal/noc_debugging/test_reads_writes.cpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/test_reads_writes.cpp
@@ -10,6 +10,7 @@
 
 #include "hal_types.hpp"
 #include "noc_debugging_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -29,7 +30,7 @@ void VerifyIssuesOnAllCores(
     bool expect_issue,
     const IssueChecker& has_issue,
     const std::string& issue_type) {
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto device_id = device->id();
 
     for (uint32_t x = grid_start.x; x <= grid_end.x; ++x) {
@@ -406,7 +407,7 @@ void RunMcastTest(
 
     ReadMeshDeviceProfilerResults(*mesh_device);
 
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     auto device_id = device->id();
     auto sender_core_virtual = mesh_device->worker_core_from_logical_core(sender_core);
 

--- a/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/hal_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "impl/context/metal_context.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 #include <vector>
 
@@ -100,7 +101,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessIssue) {
 
         // Writer core (source of the NOC writes) should have been flagged for writing to a locked buffer
         std::vector<NOCDebugIssueType> locked_issues;
-        for (IDevice* device : mesh_device->get_devices()) {
+        for (IDevice* device : mesh_device->impl().get_devices()) {
             auto issues = this->get_write_to_locked_issues(device->id(), writer_virtual_core, 0);
             locked_issues.insert(locked_issues.end(), issues.begin(), issues.end());
         }
@@ -203,7 +204,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockMultipleL1Issues) {
         ReadMeshDeviceProfilerResults(*mesh_device);
 
         std::vector<NOCDebugIssueType> locked_issues;
-        for (IDevice* device : mesh_device->get_devices()) {
+        for (IDevice* device : mesh_device->impl().get_devices()) {
             auto issues = this->get_write_to_locked_issues(device->id(), writer_virtual_core, 0);
             locked_issues.insert(locked_issues.end(), issues.begin(), issues.end());
         }
@@ -308,7 +309,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessNoIssue) {
         ReadMeshDeviceProfilerResults(*mesh_device);
 
         // No write-to-locked issues should be reported (writes happen only when buffer is not locked)
-        for (IDevice* device : mesh_device->get_devices()) {
+        for (IDevice* device : mesh_device->impl().get_devices()) {
             ChipId chip_id = device->id();
             EXPECT_FALSE(this->has_write_to_locked_issue(chip_id, writer_virtual_core, 0))
                 << "Unexpected write-to-locked-buffer issue on writer core; writes were outside lock scope.";
@@ -398,7 +399,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBIssue) {
         ReadMeshDeviceProfilerResults(*mesh_device);
 
         std::vector<NOCDebugIssueType> locked_issues;
-        for (IDevice* device : mesh_device->get_devices()) {
+        for (IDevice* device : mesh_device->impl().get_devices()) {
             auto issues = this->get_write_to_locked_issues(device->id(), writer_virtual_core, 0);
             locked_issues.insert(locked_issues.end(), issues.begin(), issues.end());
         }
@@ -496,7 +497,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBNoIssue) {
         distributed::Finish(mesh_device->mesh_command_queue());
         ReadMeshDeviceProfilerResults(*mesh_device);
 
-        for (IDevice* device : mesh_device->get_devices()) {
+        for (IDevice* device : mesh_device->impl().get_devices()) {
             ChipId chip_id = device->id();
             EXPECT_FALSE(this->has_write_to_locked_issue(chip_id, writer_virtual_core, 0))
                 << "Unexpected write-to-locked-CB issue on writer core; writes were outside lock scope.";
@@ -550,7 +551,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockSelfWriteToLockedIssue) {
         ReadMeshDeviceProfilerResults(*mesh_device);
 
         std::vector<NOCDebugIssueType> locked_issues;
-        for (IDevice* device : mesh_device->get_devices()) {
+        for (IDevice* device : mesh_device->impl().get_devices()) {
             auto issues = this->get_write_to_locked_issues(device->id(), virtual_core, 0);
             locked_issues.insert(locked_issues.end(), issues.begin(), issues.end());
         }
@@ -612,7 +613,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockSelfWriteToUnlockedNoIssue) {
 
         ReadMeshDeviceProfilerResults(*mesh_device);
 
-        for (IDevice* device : mesh_device->get_devices()) {
+        for (IDevice* device : mesh_device->impl().get_devices()) {
             EXPECT_FALSE(this->has_write_to_locked_issue(device->id(), virtual_core, 0))
                 << "Unexpected write-to-locked issue; NOC write targeted an unlocked region.";
         }
@@ -654,7 +655,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockNoWritesNoIssue) {
 
         ReadMeshDeviceProfilerResults(*mesh_device);
 
-        for (IDevice* device : mesh_device->get_devices()) {
+        for (IDevice* device : mesh_device->impl().get_devices()) {
             EXPECT_FALSE(this->has_write_to_locked_issue(device->id(), virtual_core, 0))
                 << "Unexpected write-to-locked issue; kernel only locked and unlocked with no NOC writes.";
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -57,6 +57,7 @@
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 #include <umd/device/types/arch.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using std::vector;
 using namespace tt;
@@ -588,7 +589,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         constexpr int giga_byte = 1000000;
         constexpr long long tera_byte = 1000000000000LL;
-        int tt_npu_clock = get_tt_npu_clock(device->get_devices()[0]);
+        int tt_npu_clock = get_tt_npu_clock(device->impl().get_devices()[0]);
         double rpeak_tflops = get_tt_npu_rpeak_tflops(arch, grid_size, tt_npu_clock);
         std::vector<double> rmax_tflops;
         uint64_t num_of_matmul_ops =
@@ -607,7 +608,7 @@ int main(int argc, char** argv) {
                 log_debug(LogTest, "EnqueueMeshWorkload done");
 
                 uint64_t t0_to_any_riscfw_end = get_t0_to_any_riscfw_end_cycle(
-                    device->get_devices()[0], mesh_workload.get_programs().begin()->second);
+                    device->impl().get_devices()[0], mesh_workload.get_programs().begin()->second);
                 double cycle_time = 1 / static_cast<double>(tt_npu_clock) / giga_byte;
                 auto execution_time = t0_to_any_riscfw_end * cycle_time;
                 rmax_tflops.push_back(static_cast<double>(num_of_matmul_ops) / execution_time / tera_byte);
@@ -1462,7 +1463,7 @@ void prepare_inputs(
 
             // copy in0, in1, in2 to L1
             CoreCoord core = {(std::size_t)c, (std::size_t)r};
-            auto* target_device = device->get_devices()[0];
+            auto* target_device = device->impl().get_devices()[0];
             pass &= tt_metal::detail::WriteToDeviceL1(target_device, core, in0_addr, in0);
             TT_FATAL(pass, "Failed to write in0 to device L1");
             pass &= tt_metal::detail::WriteToDeviceL1(target_device, core, in1_addr, in1);
@@ -1599,7 +1600,7 @@ bool validation(
             std::vector<uint32_t> result_vec;
             uint32_t num_r = (r == num_cores_y - 1) ? (last_block_h) : (per_core_Mt);
             uint32_t num_c = (c == num_cores_x - 1) ? (last_block_w) : (per_core_Nt);
-            auto* target_device = device->get_devices()[0];
+            auto* target_device = device->impl().get_devices()[0];
             tt_metal::detail::ReadFromDeviceL1(
                 target_device, core, out_addr, num_r * num_c * single_tile_size, result_vec);
             auto result_flat_layout = unpack_bfp8_tiles_into_float_vec(result_vec, true, false);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
@@ -36,6 +36,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 #include <tt-metalium/distributed.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -154,7 +155,7 @@ int main(int argc, char** argv) {
         int device_id = 0;
         auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
 
-        int clock_freq_mhz = get_tt_npu_clock(device->get_devices()[0]);
+        int clock_freq_mhz = get_tt_npu_clock(device->impl().get_devices()[0]);
         auto grid_coord = device->compute_with_storage_grid_size();
         num_cores_c = (num_cores_c == 0) ? grid_coord.x : num_cores_c;
         num_cores_r = (num_cores_r == 0) ? grid_coord.y : num_cores_r;
@@ -247,7 +248,7 @@ int main(int argc, char** argv) {
 
             if (use_device_profiler) {
                 elapsed_cc = get_t0_to_any_riscfw_end_cycle(
-                    device->get_devices()[0], mesh_workload.get_programs().begin()->second);
+                    device->impl().get_devices()[0], mesh_workload.get_programs().begin()->second);
                 elapsed_us = (double)elapsed_cc / clock_freq_mhz;
                 log_info(LogTest, "Time elapsed using device profiler: {}us ({}cycles)", elapsed_us, elapsed_cc);
             }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
@@ -35,6 +35,7 @@
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -132,7 +133,7 @@ int main(int argc, char** argv) {
         int device_id = 0;
         auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
 
-        int clock_freq_mhz = get_tt_npu_clock(device->get_devices()[0]);
+        int clock_freq_mhz = get_tt_npu_clock(device->impl().get_devices()[0]);
         auto grid_coord = device->compute_with_storage_grid_size();
         num_cores_c = (num_cores_c == 0) ? grid_coord.x : num_cores_c;
         num_cores_r = (num_cores_r == 0) ? grid_coord.y : num_cores_r;
@@ -212,7 +213,7 @@ int main(int argc, char** argv) {
 
             if (use_device_profiler) {
                 elapsed_cc = get_t0_to_any_riscfw_end_cycle(
-                    device->get_devices()[0], mesh_workload.get_programs().begin()->second);
+                    device->impl().get_devices()[0], mesh_workload.get_programs().begin()->second);
                 elapsed_us.push_back((double)elapsed_cc / clock_freq_mhz);
                 log_info(LogTest, "Time elapsed uisng device profiler: {}us ({}cycles)", elapsed_us[i], elapsed_cc);
             }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -43,6 +43,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -266,7 +267,7 @@ int main(int argc, char** argv) {
         std::vector<uint32_t> go_signal = {0};
         std::vector<uint32_t> done_signal = {1};
         uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-        tt_metal::detail::WriteToDeviceL1(device->get_devices()[0], logical_core, l1_unreserved_base, go_signal);
+        tt_metal::detail::WriteToDeviceL1(device->impl().get_devices()[0], logical_core, l1_unreserved_base, go_signal);
 
         // Application setup
         tt_metal::Program program = tt_metal::Program();
@@ -398,7 +399,7 @@ int main(int argc, char** argv) {
                     uint32_t num_write_ptr_updates = write_size_bytes / (32 * 1024);
                     for (int i = 0; i < num_write_ptr_updates; i++) {
                         tt::tt_metal::MetalContext::instance().get_cluster().write_reg(
-                            &val_to_write, tt_cxy_pair(device->get_devices()[0]->id(), physical_core), reg_addr);
+                            &val_to_write, tt_cxy_pair(device->impl().get_devices()[0]->id(), physical_core), reg_addr);
                         reg_addr += sizeof(uint32_t);
                         num_reg_writes = (reg_addr - prefetch_q_base) / sizeof(uint32_t);
                         if (num_reg_writes == num_reg_entries) {
@@ -412,7 +413,7 @@ int main(int argc, char** argv) {
                     tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                         read_hex_vec.data(),
                         sizeof(uint32_t),
-                        tt_cxy_pair(device->get_devices()[0]->id(), physical_core),
+                        tt_cxy_pair(device->impl().get_devices()[0]->id(), physical_core),
                         reg_addr);
                 }
 
@@ -421,7 +422,8 @@ int main(int argc, char** argv) {
             }
 
             auto t_end = std::chrono::steady_clock::now();
-            tt_metal::detail::WriteToDeviceL1(device->get_devices()[0], logical_core, l1_unreserved_base, done_signal);
+            tt_metal::detail::WriteToDeviceL1(
+                device->impl().get_devices()[0], logical_core, l1_unreserved_base, done_signal);
 
             t1.join();
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
@@ -29,6 +29,7 @@
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -111,7 +112,7 @@ int main(int argc, char** argv) {
         }
 
         auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
-        device_is_mmio = device->get_devices()[0]->is_mmio_capable();
+        device_is_mmio = device->impl().get_devices()[0]->is_mmio_capable();
 
         if (!tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
             log_info(LogTest, "Skip! This test needs to be run with fast dispatch enabled");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -45,6 +45,7 @@
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using std::chrono::duration_cast;
@@ -185,7 +186,7 @@ int main(int argc, char** argv) {
         auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
         dram_bandwidth_spec = get_dram_bandwidth(device->arch());
 
-        int clock_freq_mhz = get_tt_npu_clock(device->get_devices()[0]);
+        int clock_freq_mhz = get_tt_npu_clock(device->impl().get_devices()[0]);
 
         uint32_t num_tiles = static_cast<uint32_t>((input_size + single_tile_size - 1) / single_tile_size);
         auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -259,7 +260,7 @@ int main(int argc, char** argv) {
                 }
                 auto write_size = num_reqs_at_a_time * 512;
                 auto sliced_input = slice_vec(input_vec, input_offset, input_offset + write_size - 1);
-                tt_metal::detail::WriteToDeviceL1(device->get_devices()[0], core, cb_addr, sliced_input);
+                tt_metal::detail::WriteToDeviceL1(device->impl().get_devices()[0], core, cb_addr, sliced_input);
                 input_offset += (num_tiles_per_core) * 512;
             }
         }
@@ -286,7 +287,7 @@ int main(int argc, char** argv) {
 
             if (use_device_profiler) {
                 unsigned long elapsed_cc = get_t0_to_any_riscfw_end_cycle(
-                    device->get_devices()[0], mesh_workload.get_programs().begin()->second);
+                    device->impl().get_devices()[0], mesh_workload.get_programs().begin()->second);
                 elapsed_us = (double)elapsed_cc / clock_freq_mhz;
                 dram_bandwidth.push_back((input_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));
                 log_info(
@@ -487,7 +488,7 @@ bool validation(
 
             std::vector<uint32_t> result_vec;
             tt_metal::detail::ReadFromDeviceL1(
-                device->get_devices()[0], core, cb_addr, num_reqs_at_a_time * single_tile_size, result_vec);
+                device->impl().get_devices()[0], core, cb_addr, num_reqs_at_a_time * single_tile_size, result_vec);
             auto result_bf16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
             auto sliced_input = slice_vec(
                 input_bf16,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -46,6 +46,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using std::chrono::duration_cast;
@@ -214,7 +215,7 @@ bool validation(
     for (auto core : all_cores) {
         std::vector<uint32_t> result_vec;
         tt_metal::detail::ReadFromDeviceL1(
-            device->get_devices()[0], core, cb_addr, num_tiles_cb * single_tile_size, result_vec);
+            device->impl().get_devices()[0], core, cb_addr, num_tiles_cb * single_tile_size, result_vec);
 
         uint32_t num_datum_per_block = block_h * block_w * num_datum_per_slice;
         uint32_t tensor_slice_stride = core_id * num_datum_per_slice;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -47,6 +47,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using std::chrono::duration_cast;
@@ -297,7 +298,7 @@ bool validation(
 
         std::vector<uint32_t> result_vec;
         tt_metal::detail::ReadFromDeviceL1(
-            device->get_devices()[0], core, cb_addr, num_tiles_cb / 2 * single_tile_size, result_vec);
+            device->impl().get_devices()[0], core, cb_addr, num_tiles_cb / 2 * single_tile_size, result_vec);
 
         if (df == 0) {  // BFP4
             auto result_bfp4 = unpack_bfp4_tiles_into_float_vec(result_vec, true, true);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -37,6 +37,7 @@
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "impl/dispatch/dispatch_engine_cores.hpp"
 #include "host_api/temp_quasar_api.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::tt_dispatch_tests::Common {
 
@@ -1144,7 +1145,7 @@ protected:
         // Initialize common pointers
         auto& mcq = mesh_device_->mesh_command_queue();
         fdcq_ = &dynamic_cast<distributed::FDMeshCommandQueue&>(mcq);
-        device_ = mesh_device_->get_devices()[0];
+        device_ = mesh_device_->impl().get_devices()[0];
         mgr_ = &device_->sysmem_manager();  // Use Chip 0's SystemMemoryManager
 
         if (Common::is_quasar_sim()) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -42,6 +42,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 constexpr uint32_t DEFAULT_ITERATIONS = 1000;
 constexpr uint32_t DEFAULT_WARMUP_ITERATIONS = 2;
@@ -221,7 +222,7 @@ int main(int argc, char** argv) {
     try {
         auto mesh_device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(0 /*device_id*/);
         auto& cq = mesh_device->mesh_command_queue();
-        auto device_id = mesh_device->get_devices()[0]->id();
+        auto device_id = mesh_device->impl().get_devices()[0]->id();
 
         auto mesh_workload = tt::tt_metal::distributed::MeshWorkload();
         tt_metal::Program program = tt_metal::CreateProgram();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -20,6 +20,7 @@
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h"
 #include <impl/dispatch/dispatch_query_manager.hpp>
 #include "tt_metal/impl/dispatch/memcpy.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 #include <umd/device/pcie/tlb_window.hpp>
 
@@ -2010,7 +2011,7 @@ protected:
         const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
 
         // Identify the MMIO device in the mesh
-        for (auto* dev : mesh_device_->get_devices()) {
+        for (auto* dev : mesh_device_->impl().get_devices()) {
             if (cluster.get_associated_mmio_device(dev->id()) == dev->id()) {
                 mmio_device_ = dev;
                 break;
@@ -2022,7 +2023,7 @@ protected:
         }
 
         // Next, identify a remote device associated with the MMIO device
-        for (auto* dev : mesh_device_->get_devices()) {
+        for (auto* dev : mesh_device_->impl().get_devices()) {
             if (dev != mmio_device_ && (cluster.get_associated_mmio_device(dev->id()) == mmio_device_->id())) {
                 remote_device_ = dev;
                 break;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -38,6 +38,7 @@
 
 #include <enchantum/enchantum.hpp>
 #include <llrt/tt_cluster.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::test_utils;
@@ -110,7 +111,7 @@ struct SenderReceiverPair {
 tt_metal::distributed::MeshDevice* find_device_with_id(
     const std::vector<std::shared_ptr<tt_metal::distributed::MeshDevice>>& devices, ChipId chip_id) {
     for (const auto& device : devices) {
-        if (device->get_devices()[0]->id() == chip_id) {
+        if (device->impl().get_devices()[0]->id() == chip_id) {
             return device.get();
         }
     }
@@ -238,8 +239,8 @@ private:
         bool slow_dispath_mode = (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr);
 
         std::queue<ChipId> chip_q;
-        chip_q.push(this->devices[0]->get_devices()[0]->id());  // Start with the first device's chip ID
-        sender_chips.insert(this->devices[0]->get_devices()[0]->id());
+        chip_q.push(this->devices[0]->impl().get_devices()[0]->id());  // Start with the first device's chip ID
+        sender_chips.insert(this->devices[0]->impl().get_devices()[0]->id());
         std::unordered_set<ChipId> visited_chips;
 
         // Need sender and receiver chips to be disjoint because we profile wrt. sender and don't want devices to be out
@@ -275,10 +276,10 @@ private:
 
             // Handle other unconnected device clusters
             for (auto& device : this->devices) {
-                if (!visited_chips.contains(device->get_devices()[0]->id())) {
+                if (!visited_chips.contains(device->impl().get_devices()[0]->id())) {
                     // This device is not connected others visited above, mark it as a sender for its connected cluster
-                    chip_q.push(device->get_devices()[0]->id());
-                    sender_chips.insert(device->get_devices()[0]->id());
+                    chip_q.push(device->impl().get_devices()[0]->id());
+                    sender_chips.insert(device->impl().get_devices()[0]->id());
                     break;
                 }
             }
@@ -330,8 +331,8 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
     // Create a mapping from chip ID to vector index
     std::map<ChipId, size_t> chip_to_index;
     for (size_t i = 0; i < device_helper.devices.size(); i++) {
-        chip_to_index[device_helper.devices[i]->get_devices()[0]->id()] = i;
-        log_info(tt::LogTest, "Device {} index {}", device_helper.devices[i]->get_devices()[0]->id(), i);
+        chip_to_index[device_helper.devices[i]->impl().get_devices()[0]->id()] = i;
+        log_info(tt::LogTest, "Device {} index {}", device_helper.devices[i]->impl().get_devices()[0]->id(), i);
     }
 
     uint32_t measurement_type = (uint32_t)(params.test_latency ? MeasurementType::Latency : MeasurementType::Bandwidth);
@@ -438,8 +439,8 @@ void validation(
     auto* sender_device = find_device_with_id(device_helper.devices, link.sender.chip);
     auto* receiver_device = find_device_with_id(device_helper.devices, link.receiver.chip);
     TT_FATAL(
-        sender_device->get_devices()[0]->id() == link.sender.chip and
-            receiver_device->get_devices()[0]->id() == link.receiver.chip,
+        sender_device->impl().get_devices()[0]->id() == link.sender.chip and
+            receiver_device->impl().get_devices()[0]->id() == link.receiver.chip,
         "Mismatch between chips");
 
     auto sender_virtual =

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
@@ -36,6 +36,7 @@
 #include <tt-metalium/distributed.hpp>
 #include "common/tt_backend_api_types.hpp"
 #include "impl/kernels/kernel.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::test_utils;
@@ -228,12 +229,13 @@ int main(int argc, char** argv) {
     N300TestDevice test_fixture;
 
     const auto& device_0 = test_fixture.devices_.at(2);
-    const auto& active_eth_cores = device_0->get_devices()[0]->get_active_ethernet_cores(true);
+    const auto& active_eth_cores = device_0->impl().get_devices()[0]->get_active_ethernet_cores(true);
     auto eth_sender_core_iter = active_eth_cores.begin();
     TT_FATAL(eth_sender_core_iter != active_eth_cores.end(), "No active ethernet cores found");
     auto eth_sender_core = *eth_sender_core_iter;
 
-    auto [device_id, eth_receiver_core] = device_0->get_devices()[0]->get_connected_ethernet_core(eth_sender_core);
+    auto [device_id, eth_receiver_core] =
+        device_0->impl().get_devices()[0]->get_connected_ethernet_core(eth_sender_core);
     const auto& device_1 = test_fixture.devices_.at(device_id);
     bool success = false;
     success = true;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -39,6 +39,7 @@
 #include "common/tt_backend_api_types.hpp"
 #include <llrt/tt_cluster.hpp>
 #include "tt_metal/impl/kernels/kernel.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::test_utils;
@@ -243,7 +244,7 @@ int main(int argc, char** argv) {
     std::cout << "done setting up test fixture" << std::endl;
 
     const auto& device_0 = test_fixture.devices_.at(0);
-    const auto& active_eth_cores = device_0->get_devices()[0]->get_active_ethernet_cores(true);
+    const auto& active_eth_cores = device_0->impl().get_devices()[0]->get_active_ethernet_cores(true);
     auto eth_sender_core_iter = active_eth_cores.begin();
     auto eth_sender_core_iter_end = active_eth_cores.end();
     ChipId device_id = std::numeric_limits<ChipId>::max();
@@ -252,16 +253,16 @@ int main(int argc, char** argv) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     do {
         TT_FATAL(eth_sender_core_iter != eth_sender_core_iter_end, "No active ethernet core found for device 0");
-        if (cluster.is_ethernet_link_up(device_0->get_devices()[0]->id(), *eth_sender_core_iter)) {
+        if (cluster.is_ethernet_link_up(device_0->impl().get_devices()[0]->id(), *eth_sender_core_iter)) {
             std::tie(device_id, eth_receiver_core) =
-                device_0->get_devices()[0]->get_connected_ethernet_core(*eth_sender_core_iter);
+                device_0->impl().get_devices()[0]->get_connected_ethernet_core(*eth_sender_core_iter);
             eth_sender_core = *eth_sender_core_iter;
         }
         eth_sender_core_iter++;
     } while (device_id == std::numeric_limits<ChipId>::max() ||
-             !test_fixture.devices_.at(device_id)->get_devices()[0]->is_mmio_capable());
+             !test_fixture.devices_.at(device_id)->impl().get_devices()[0]->is_mmio_capable());
     TT_FATAL(device_id != std::numeric_limits<ChipId>::max(), "No valid receiver device found to connect to");
-    auto* receiver_device = test_fixture.devices_.at(device_id)->get_devices()[0];
+    auto* receiver_device = test_fixture.devices_.at(device_id)->impl().get_devices()[0];
     TT_FATAL(receiver_device->is_mmio_capable(), "Receiver device is not mmio capable");
     const auto& device_1 = test_fixture.devices_.at(device_id);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
@@ -43,6 +43,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 #define LAUNCH
 
@@ -252,8 +253,8 @@ int main(int argc, char** argv) {
                 auto activations_tile_layout =
                     convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(activations_tilized));
                 auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-                pass &=
-                    tt_metal::detail::WriteToDeviceL1(device->get_devices()[0], core, activations_addr, activations);
+                pass &= tt_metal::detail::WriteToDeviceL1(
+                    device->impl().get_devices()[0], core, activations_addr, activations);
                 TT_FATAL(pass, "Error");
 
                 auto identity_tilized = tilize_swizzled(weights_slice, Kt * 32, per_core_Nt * 32);
@@ -262,7 +263,7 @@ int main(int argc, char** argv) {
                 auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
                 auto weights_tile_transposed = transpose_tiles(weights, Kt, per_core_Nt, 1);
                 pass &= tt_metal::detail::WriteToDeviceL1(
-                    device->get_devices()[0], core, weights_addr, weights_tile_transposed);
+                    device->impl().get_devices()[0], core, weights_addr, weights_tile_transposed);
                 TT_FATAL(pass, "Error");
             }
         }
@@ -352,7 +353,11 @@ int main(int argc, char** argv) {
 
                     std::vector<uint32_t> result_vec;
                     tt_metal::detail::ReadFromDeviceL1(
-                        device->get_devices()[0], core, output_addr, cb_output_tiles * single_tile_size, result_vec);
+                        device->impl().get_devices()[0],
+                        core,
+                        output_addr,
+                        cb_output_tiles * single_tile_size,
+                        result_vec);
                     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
                     auto result_flat_layout =
                         convert_layout_tile_nfaces_to_tile_swizzled(ttsl::make_const_span(result_bfp16));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -39,6 +39,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using std::chrono::duration_cast;
@@ -329,7 +330,7 @@ int main(int argc, char** argv) {
                     std::vector<uint32_t> result_vec;
                     CoreCoord core = {(size_t)c, (size_t)r};
                     tt_metal::detail::ReadFromDeviceL1(
-                        device->get_devices()[0], core, dst_cb_addr, cb_tiles * single_tile_size, result_vec);
+                        device->impl().get_devices()[0], core, dst_cb_addr, cb_tiles * single_tile_size, result_vec);
                     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
 
                     int tensors_idx = (single_read || one_buffer_share) ? (0) : ((r * num_cores_c) + c);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
@@ -37,6 +37,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using std::chrono::duration_cast;
@@ -182,7 +183,7 @@ int main(int argc, char** argv) {
             for (int c = 0; c < num_cores_c; ++c) {
                 CoreCoord core = {(size_t)c, (size_t)r};
                 tt_metal::detail::WriteToDeviceL1(
-                    device->get_devices()[0], core, activations_addr, packed_tensors[(r * num_cores_c) + c]);
+                    device->impl().get_devices()[0], core, activations_addr, packed_tensors[(r * num_cores_c) + c]);
             }
         }
 
@@ -192,7 +193,7 @@ int main(int argc, char** argv) {
                 CoreCoord core = {(size_t)c, (size_t)r};
                 std::vector<uint32_t> result_vec;
                 tt_metal::detail::ReadFromDeviceL1(
-                    device->get_devices()[0], core, activations_addr, total_tiles_size_bytes, result_vec);
+                    device->impl().get_devices()[0], core, activations_addr, total_tiles_size_bytes, result_vec);
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
                 if (tensors[(r * num_cores_c) + c].get_values() != result_bfp16) {
                     log_error(LogTest, "{}/{} - value read from l1 is wrong", r, c);
@@ -250,7 +251,7 @@ int main(int argc, char** argv) {
                     std::vector<uint32_t> result_vec;
                     CoreCoord core = {(size_t)c, (size_t)r};
                     tt_metal::detail::ReadFromDeviceL1(
-                        device->get_devices()[0], core, dst_cb_addr, cb_tiles * single_tile_size, result_vec);
+                        device->impl().get_devices()[0], core, dst_cb_addr, cb_tiles * single_tile_size, result_vec);
                     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
                     auto sliced_tensor =
                         slice_vec(tensors[(r * num_cores_c) + c].get_values(), (Nt - cb_tiles) * 1024, (Nt * 1024) - 1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
@@ -25,6 +25,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -80,7 +81,7 @@ int main(int argc, char** argv) {
             for (int i = 0; i < iter; i++) {
                 begin = std::chrono::steady_clock::now();
                 pass &= tt_metal::detail::WriteToDeviceDRAMChannel(
-                    device->get_devices()[0], dram_channel, dram_addr, src_vec);
+                    device->impl().get_devices()[0], dram_channel, dram_addr, src_vec);
                 end = std::chrono::steady_clock::now();
                 elapsed_sum += end - begin;
             }
@@ -99,7 +100,7 @@ int main(int argc, char** argv) {
             for (int i = 0; i < iter; i++) {
                 begin = std::chrono::steady_clock::now();
                 tt_metal::detail::ReadFromDeviceDRAMChannel(
-                    device->get_devices()[0], dram_channel, dram_addr, buffer_size, result_vec);
+                    device->impl().get_devices()[0], dram_channel, dram_addr, buffer_size, result_vec);
                 end = std::chrono::steady_clock::now();
                 elapsed_sum += end - begin;
             }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
@@ -23,6 +23,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -67,7 +68,7 @@ int main(int argc, char** argv) {
 
         {
             auto begin = std::chrono::steady_clock::now();
-            pass &= tt_metal::detail::WriteToDeviceL1(device->get_devices()[0], core, target_cb_addr, src_vec);
+            pass &= tt_metal::detail::WriteToDeviceL1(device->impl().get_devices()[0], core, target_cb_addr, src_vec);
             auto end = std::chrono::steady_clock::now();
             auto elapsed_us = duration_cast<microseconds>(end - begin).count();
             auto bw = (buffer_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
@@ -77,7 +78,8 @@ int main(int argc, char** argv) {
         std::vector<uint32_t> result_vec;
         {
             auto begin = std::chrono::steady_clock::now();
-            tt_metal::detail::ReadFromDeviceL1(device->get_devices()[0], core, target_cb_addr, buffer_size, result_vec);
+            tt_metal::detail::ReadFromDeviceL1(
+                device->impl().get_devices()[0], core, target_cb_addr, buffer_size, result_vec);
             auto end = std::chrono::steady_clock::now();
 
             auto elapsed_us = duration_cast<microseconds>(end - begin).count();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -102,6 +102,7 @@
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 
 #include "test_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -679,7 +680,7 @@ BuiltProgram build_program(
         core_list.assign(full_order.begin() + off, full_order.begin() + off + want);
     }
     if (cfg.log_core_map) {
-        const auto did = mesh_device->get_devices()[0]->id();
+        const auto did = mesh_device->impl().get_devices()[0]->id();
         const auto& sd = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(did);
         for (const auto& c : core_list) {
             const auto p = sd.get_physical_tensix_core_from_logical(c);  // matches profiler core_x/core_y
@@ -1001,7 +1002,7 @@ int main(int argc, char** argv) {
         auto mesh_device =
             distributed::MeshDevice::create_unit_mesh(cfg.device_id, DEFAULT_L1_SMALL_SIZE, trace_region_size);
 
-        log_info(LogTest, "Clock: {} MHz", get_tt_npu_clock(mesh_device->get_devices()[0]));
+        log_info(LogTest, "Clock: {} MHz", get_tt_npu_clock(mesh_device->impl().get_devices()[0]));
 
         const auto grid = mesh_device->compute_with_storage_grid_size();
         uint32_t effective_cores = grid.x * grid.y;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/fabric_mux_v2_benchmark_program.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/fabric_mux_v2_benchmark_program.cpp
@@ -19,6 +19,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "context/metal_context.hpp"
 #include "llrt/tt_cluster.hpp"
@@ -535,7 +536,7 @@ void FabricMuxV2BenchmarkContext::initialize() {
     TT_FATAL(mesh_device_ != nullptr, "Failed to create full mesh device for mux-v2 standalone benchmark");
 
     device_ = nullptr;
-    for (auto* device : mesh_device_->get_devices()) {
+    for (auto* device : mesh_device_->impl().get_devices()) {
         if (device != nullptr && device->id() == 0) {
             device_ = device;
             break;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -27,6 +27,7 @@
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/profiler/profiler_paths.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 const std::string mux_kernel_src = "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp";
 const std::string drainer_kernel_src =
@@ -380,7 +381,7 @@ int main(int argc, char** argv) {
 
     std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device = mesh_device_map.at(0 /* chip_id */);
     // need device handle to do L1 read/writes
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
     distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt::tt_metal::distributed::MeshWorkload mesh_workload;

--- a/tests/tt_metal/tt_metal/sfpi/test_sfpi.cpp
+++ b/tests/tt_metal/tt_metal/sfpi/test_sfpi.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include <tt-metalium/distributed.hpp>
 #include "impl/context/metal_context.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace {
 
@@ -49,7 +50,7 @@ bool runTest(
 
     distributed::Finish(mesh_device->mesh_command_queue());
 
-    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_devices()[0]->id());
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->impl().get_devices()[0]->id());
     auto noc_xy = mesh_device->worker_core_from_logical_core(coord);
     unsigned expected = 0;
     // If path ends in -[digits], extract the expected value
@@ -67,7 +68,7 @@ bool runTest(
         expected |= 0x4000;
     }
     std::vector<uint32_t> args = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-        mesh_device->get_devices()[0]->id(), noc_xy, args_addr, sizeof(uint32_t));
+        mesh_device->impl().get_devices()[0]->id(), noc_xy, args_addr, sizeof(uint32_t));
     unsigned result = args[0];
     bool pass = result == expected;
     if (pass) {

--- a/tests/tt_metal/tt_metal/test_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_add_two_ints.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -22,7 +23,7 @@ using namespace tt::tt_metal;
 // Result is read from L1
 ////////////////////////////////////////////////////////////////////////////
 TEST_F(MeshDeviceSingleCardFixture, AddTwoInts) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     uint32_t l1_unreserved_base = dev->allocator()->get_base_allocator_addr(HalMemType::L1);
 
     Program program = CreateProgram();

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -22,6 +22,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using std::vector;
 using namespace tt;
@@ -286,31 +287,31 @@ void run_bcast_test(IDevice* dev, BcastDim::Enum bcast_dim, BcastOp::Enum bcast_
 }  // namespace
 
 TEST_F(MeshDeviceSingleCardFixture, BcastHAdd) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::H, BcastOp::ADD);
+    run_bcast_test(devices_[0]->impl().get_devices()[0], BcastDim::H, BcastOp::ADD);
 }
 TEST_F(MeshDeviceSingleCardFixture, BcastHSub) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::H, BcastOp::SUB);
+    run_bcast_test(devices_[0]->impl().get_devices()[0], BcastDim::H, BcastOp::SUB);
 }
 TEST_F(MeshDeviceSingleCardFixture, BcastHMul) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::H, BcastOp::MUL);
+    run_bcast_test(devices_[0]->impl().get_devices()[0], BcastDim::H, BcastOp::MUL);
 }
 
 TEST_F(MeshDeviceSingleCardFixture, BcastWAdd) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::W, BcastOp::ADD);
+    run_bcast_test(devices_[0]->impl().get_devices()[0], BcastDim::W, BcastOp::ADD);
 }
 TEST_F(MeshDeviceSingleCardFixture, BcastWSub) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::W, BcastOp::SUB);
+    run_bcast_test(devices_[0]->impl().get_devices()[0], BcastDim::W, BcastOp::SUB);
 }
 TEST_F(MeshDeviceSingleCardFixture, BcastWMul) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::W, BcastOp::MUL);
+    run_bcast_test(devices_[0]->impl().get_devices()[0], BcastDim::W, BcastOp::MUL);
 }
 
 TEST_F(MeshDeviceSingleCardFixture, BcastHWAdd) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::HW, BcastOp::ADD);
+    run_bcast_test(devices_[0]->impl().get_devices()[0], BcastDim::HW, BcastOp::ADD);
 }
 TEST_F(MeshDeviceSingleCardFixture, BcastHWSub) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::HW, BcastOp::SUB);
+    run_bcast_test(devices_[0]->impl().get_devices()[0], BcastDim::HW, BcastOp::SUB);
 }
 TEST_F(MeshDeviceSingleCardFixture, BcastHWMul) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::HW, BcastOp::MUL);
+    run_bcast_test(devices_[0]->impl().get_devices()[0], BcastDim::HW, BcastOp::MUL);
 }

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using std::vector;
 using namespace tt;
@@ -201,7 +202,7 @@ bool validate_bmm_result(
 
 TEST_F(AnyDispatchMeshDeviceSingleCardFixture, Bmm) {
     auto& mesh_device = *devices_[0];
-    IDevice* dev = mesh_device.get_devices()[0];
+    IDevice* dev = mesh_device.impl().get_devices()[0];
 
     BmmParams p;
     if (dev->arch() != ARCH::QUASAR) {
@@ -279,7 +280,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, BmmMultinode) {
         GTEST_SKIP() << "This test requires at least 2 worker nodes.";
     }
 
-    IDevice* dev = mesh_device.get_devices()[0];
+    IDevice* dev = mesh_device.impl().get_devices()[0];
 
     BmmParams p;
     p.Mt = 2; p.Kt = 2; p.Nt = 2;

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -18,6 +18,7 @@
 #include "jit_build/build.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include <umd/device/types/arch.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 // Access to internal API: ProgramImpl::num_kernel, get_kernel
 #include "impl/program/program_impl.hpp"
@@ -248,7 +249,7 @@ std::unordered_map<std::string, std::string> compile_program_with_modified_kerne
 }  // namespace
 
 TEST_F(MeshDispatchFixture, CompileProgramInLoop) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
 
     ClearKernelCache(BuildEnvManager::get_instance(extract_context_id(dev))
                          .get_device_build_env(dev->build_id())
@@ -277,7 +278,7 @@ TEST_F(MeshDispatchFixture, CompileProgramInLoop) {
 }
 
 TEST_F(MeshDispatchFixture, CompileProgramAfterCleanKernelBinaryDirectory) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
 
     ClearKernelCache(BuildEnvManager::get_instance(extract_context_id(dev))
                          .get_device_build_env(dev->build_id())
@@ -307,7 +308,7 @@ TEST_F(MeshDispatchFixture, CompileProgramAfterCleanKernelBinaryDirectory) {
 }
 
 TEST_F(MeshDispatchFixture, CompileProgramWithModifiedProgram) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
 
     const static std::unordered_map<HalProcessorClassType, bool> compute_miss_data_movement_hit = {
         {HalProcessorClassType::COMPUTE, false}, {HalProcessorClassType::DM, true}};

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -21,6 +21,7 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 // Access to internal API: ProgramImpl::get_sem_base_addr, get_sem_size, num_kernels, get_kernel
 #include "impl/program/program_impl.hpp"
@@ -91,7 +92,7 @@ void check_semaphores_are_initialized(
 }  // namespace
 
 TEST_F(MeshDeviceSingleCardFixture, CoreRangeSet) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     Program program = CreateProgram();
 
     CoreRange core_range_one({0, 0}, {1, 1});

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -13,12 +13,13 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include <distributed/mesh_device_impl.hpp>
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, Datacopy) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -14,13 +14,14 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, DatacopyBfp8b) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -15,13 +15,14 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, DatacopyOutputInL1) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "impl/context/metal_context.hpp"
 #include "llrt/tt_cluster.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -34,7 +35,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
         std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
     }
 
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     auto mesh_device = devices_[0];
     const experimental::NodeCoord node{0, 0};
 

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -29,6 +29,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does
@@ -46,7 +47,7 @@ struct hlk_args_t {
 
 TEST_F(MeshDeviceSingleCardFixture, DramCopySticksMultiCore) {
     bool pass = true;
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
 
     try {
         tt_metal::Program program = tt_metal::CreateProgram();

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
+#include <distributed/mesh_device_impl.hpp>
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -22,7 +23,7 @@ using namespace tt::tt_metal;
 // 4. Host reads from buffer written to in step 2.
 //////////////////////////////////////////////////////////////////////////////////////////
 TEST_F(MeshDeviceSingleCardFixture, DramLoopbackSingleCore) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -41,6 +41,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // This test is similar to test_matmul_large_block.
@@ -99,7 +100,7 @@ std::vector<std::uint32_t> transpose_tiles(
 }  // namespace
 
 TEST_F(MeshDeviceSingleCardFixture, GenericBinaryReaderMatmulLargeBlock) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     bool pass = true;
 
     try {

--- a/tests/tt_metal/tt_metal/test_globals_tls.cpp
+++ b/tests/tt_metal/tt_metal/test_globals_tls.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -32,7 +33,7 @@ constexpr uint32_t TOTAL_RESULT_BYTES = NUM_DM_CORES * TLS_CHECK_RESULT_SLOT_BYT
 // This test requires simulator environment
 TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
     auto mesh_device = devices_[0];
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     const uint32_t signal_address = 100 * 1024;
     const uint32_t l1_result_addr = 200 * 1024;
@@ -278,7 +279,7 @@ static constexpr uint32_t QUASAR_FIRST_COMPUTE_HARTID = 8;  // DM 0-7, compute 8
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelTLS) {
     auto mesh_device = devices_[0];
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = mesh_device->impl().get_devices()[0];
 
     char* env_var = std::getenv("TT_METAL_SIMULATOR");
     if (env_var == nullptr) {

--- a/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
+#include <distributed/mesh_device_impl.hpp>
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -59,5 +60,6 @@ TEST_F(MeshDeviceSingleCardFixture, InterleavedL1Buffer) {
     int num_bank_pages_one = 258;
     int num_bank_pages_two = 378;
 
-    test_interleaved_l1_buffer_impl(devices_[0]->get_devices()[0], num_bank_pages_one, num_bank_pages_two, page_size);
+    test_interleaved_l1_buffer_impl(
+        devices_[0]->impl().get_devices()[0], num_bank_pages_one, num_bank_pages_two, page_size);
 }

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -14,13 +14,14 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileBfp8b) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -17,13 +17,14 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <umd/device/types/core_coordinates.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileOutputInL1) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include <distributed/mesh_device_impl.hpp>
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
@@ -84,7 +85,7 @@ void set_rt_args(
 }  // namespace
 
 TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelSameRuntimeArgs) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
 
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {2, 2};
@@ -124,7 +125,7 @@ TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelSameRuntimeArgs) {
 }
 
 TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelUniqueRuntimeArgs) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
 
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {1, 1};

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -13,6 +13,7 @@
 #include "hw/inc/internal/tt-2xx/quasar/dev_mem_map.h"
 #include "impl/context/metal_context.hpp"
 #include "llrt/rtoptions.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -40,7 +41,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
         log_error(tt::LogTest, "For example, export TT_METAL_DPRINT_CORES=(0,0),(1,0)");
     }
 
-    IDevice* dev = mesh_device->get_devices()[0];
+    IDevice* dev = mesh_device->impl().get_devices()[0];
 
     distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
     distributed::MeshWorkload workload;

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using std::vector;
 using namespace tt;
@@ -176,7 +177,7 @@ void write_program_runtime_args_to_device(
 // 3. Second program runs matmul, using results from step 2 as input activation
 //////////////////////////////////////////////////////////////////////////////////////////
 TEST_F(MeshDeviceSingleCardFixture, MultiplePrograms) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     CoreCoord core = {0, 0};
     uint32_t single_tile_size = 2 * 1024;
     uint32_t num_tiles = 1;

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -40,7 +41,7 @@ static void run_pack_relu_test(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t relu_config,
     const std::function<float(float)>& golden_fn) {
-    IDevice* dev = mesh_device->get_devices()[0];
+    IDevice* dev = mesh_device->impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     uint32_t single_tile_size = 2 * 1024;

--- a/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "llrt/rtoptions.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -46,7 +47,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelMultipleThreads) {
     const uint32_t l1_address = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     std::vector<uint32_t> init_values(16, 0);
-    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node, l1_address, init_values);
+    tt_metal::detail::WriteToDeviceL1(mesh_device->impl().get_devices()[0], node, l1_address, init_values);
 
     const experimental::KernelSpecName COMPUTE_KERNEL{"risc_math"};
 
@@ -88,7 +89,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelMultipleThreads) {
 
     std::vector<uint32_t> actual_values(16, 0);
     tt_metal::detail::ReadFromDeviceL1(
-        mesh_device->get_devices()[0], node, l1_address, 16 * sizeof(uint32_t), actual_values);
+        mesh_device->impl().get_devices()[0], node, l1_address, 16 * sizeof(uint32_t), actual_values);
 
     const std::vector<uint32_t> expected_values = {4, 6, 5, 9, 8, 10, 9, 13, 12, 14, 13, 17, 16, 18, 17, 21};
 
@@ -123,7 +124,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelSingleThread) {
     const uint32_t l1_address = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     std::vector<uint32_t> init_values(4, 0);
-    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node, l1_address, init_values);
+    tt_metal::detail::WriteToDeviceL1(mesh_device->impl().get_devices()[0], node, l1_address, init_values);
 
     const experimental::KernelSpecName COMPUTE_KERNEL{"risc_math"};
 
@@ -165,7 +166,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelSingleThread) {
 
     std::vector<uint32_t> actual_values(4, 0);
     tt_metal::detail::ReadFromDeviceL1(
-        mesh_device->get_devices()[0], node, l1_address, 4 * sizeof(uint32_t), actual_values);
+        mesh_device->impl().get_devices()[0], node, l1_address, 4 * sizeof(uint32_t), actual_values);
 
     const std::vector<uint32_t> expected_values = {4, 6, 5, 9};
 

--- a/tests/tt_metal/tt_metal/test_quasar_events.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_events.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <distributed/mesh_device_impl.hpp>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -55,7 +56,7 @@ distributed::MeshWorkload make_l1_write_workload(
 
 void run_cross_cq_handoff(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint8_t producer_cq, uint8_t consumer_cq) {
-    IDevice* dev = mesh_device->get_devices()[0];
+    IDevice* dev = mesh_device->impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t producer_address = MetalContext::instance().hal().get_dev_addr(
@@ -100,7 +101,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, EventSynchronize) {
     }
 
     auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
+    IDevice* dev = mesh_device->impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t address = MetalContext::instance().hal().get_dev_addr(
@@ -147,7 +148,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, EventBetweenWorkloads) {
     }
 
     auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
+    IDevice* dev = mesh_device->impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t address_1 = MetalContext::instance().hal().get_dev_addr(
@@ -209,7 +210,7 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, RecordEventToHostFromBothCQs) {
     }
 
     auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
+    IDevice* dev = mesh_device->impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t address_0 = MetalContext::instance().hal().get_dev_addr(

--- a/tests/tt_metal/tt_metal/test_quasar_mesh_workloads.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_mesh_workloads.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -116,7 +117,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestSingleWorkloadNonBlockingEnqueueFi
     }
 
     auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
+    IDevice* dev = mesh_device->impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t base_address = MetalContext::instance().hal().get_dev_addr(
@@ -154,7 +155,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestMultipleWorkloadsNonBlockingEnqueu
     }
 
     auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
+    IDevice* dev = mesh_device->impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t base_address = MetalContext::instance().hal().get_dev_addr(
@@ -209,7 +210,7 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, TestInterleavedWorkloadsAcrossT
     }
 
     auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
+    IDevice* dev = mesh_device->impl().get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t base_address = MetalContext::instance().hal().get_dev_addr(

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "hal.hpp"
 #include "llrt/rtoptions.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -48,7 +49,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
     for (uint32_t i = 0; i < num_elements; i++) {
         initial_data[i] = i;
     }
-    tt_metal::detail::WriteToDeviceDRAMChannel(mesh_device->get_devices()[0], 0, dram_src_addr, initial_data);
+    tt_metal::detail::WriteToDeviceDRAMChannel(mesh_device->impl().get_devices()[0], 0, dram_src_addr, initial_data);
 
     const experimental::KernelSpecName DM_READER{"dm_reader"};
     const experimental::KernelSpecName DM_TRANSFORM{"dm_transform"};
@@ -157,7 +158,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
 
     std::vector<uint32_t> actual_data(num_elements, 0);
     tt_metal::detail::ReadFromDeviceDRAMChannel(
-        mesh_device->get_devices()[0], 0, dram_dst_addr, num_elements * sizeof(uint32_t), actual_data);
+        mesh_device->impl().get_devices()[0], 0, dram_dst_addr, num_elements * sizeof(uint32_t), actual_data);
 
     const std::vector<uint32_t> expected_data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
@@ -197,7 +198,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     for (uint32_t i = 0; i < num_elements; i++) {
         initial_data[i] = i;
     }
-    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node_0, buf_a_addr, initial_data);
+    tt_metal::detail::WriteToDeviceL1(mesh_device->impl().get_devices()[0], node_0, buf_a_addr, initial_data);
 
     const CoreCoord core_1_virtual = mesh_device->worker_core_from_logical_core(node_1);
 
@@ -377,7 +378,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
 
     std::vector<uint32_t> actual_data(num_elements, 0);
     tt_metal::detail::ReadFromDeviceDRAMChannel(
-        mesh_device->get_devices()[0], 0, dram_dst_addr, num_elements * sizeof(uint32_t), actual_data);
+        mesh_device->impl().get_devices()[0], 0, dram_dst_addr, num_elements * sizeof(uint32_t), actual_data);
 
     const std::vector<uint32_t> expected_data = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
 

--- a/tests/tt_metal/tt_metal/test_quasar_trace.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_trace.cpp
@@ -15,6 +15,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <distributed/mesh_device_impl.hpp>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -29,7 +30,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTraceSingleReplay) {
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     auto mesh_device = devices_[0];
     const experimental::NodeCoord node{0, 0};
 
@@ -92,7 +93,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTraceMultipleReplays) {
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     auto mesh_device = devices_[0];
     const experimental::NodeCoord node{0, 0};
 
@@ -162,7 +163,7 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, QuasarTraceMultipleReplaysAcros
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     auto mesh_device = devices_[0];
     const experimental::NodeCoord node{0, 0};
 

--- a/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
@@ -22,6 +22,7 @@
 #include "impl/context/metal_context.hpp"
 #include "common/mesh_dispatch_fixture.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -49,7 +50,7 @@ protected:
             GTEST_SKIP() << "RISCV Atomics not supported on Wormhole";
         }
         mesh_device_ = devices_[0];
-        device_ = mesh_device_->get_devices()[0];
+        device_ = mesh_device_->impl().get_devices()[0];
         num_dms_ = MetalContext::instance().hal().get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);
         l1_unreserved_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
         is_quasar = arch_ == tt::ARCH::QUASAR;

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <tt-metalium/tilize_utils.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using std::vector;
 using namespace tt;
@@ -181,7 +182,7 @@ static bool test_sdpa_reduce_c(
         num_faces);
 
     // Get device and command queue from mesh
-    tt_metal::IDevice* device = mesh_device->get_devices().at(0);
+    tt_metal::IDevice* device = mesh_device->impl().get_devices().at(0);
     tt_metal::distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue(0);
 
     tt_metal::Program program = tt_metal::CreateProgram();

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -26,7 +27,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
         GTEST_SKIP() << "This test can only be run using a simulator. Set TT_METAL_SIMULATOR environment variable.";
     }
 
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     auto mesh_device = devices_[0];
 
     const uint32_t address = MetalContext::instance().hal().get_dev_addr(

--- a/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
@@ -36,6 +36,7 @@
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <llrt/tt_cluster.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -52,7 +53,7 @@ const uint32_t N_RANDS = 512;
 // Disabled because this test can hang the NoC due to hardware issues.
 // Uses detail::LaunchProgram which requires slow dispatch mode
 TEST_F(MeshDeviceSingleCardFixture, DISABLED_StressNocMcast) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
 
     // Use default test parameters
     uint32_t time_secs = DEFAULT_SECONDS;

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -20,12 +20,13 @@
 #include <tt-metalium/tilize_utils.hpp>
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, TransposeHC) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     Program program = CreateProgram();
     constexpr bool multibank = true;
 

--- a/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/span.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // This test verifies that the slow dispatch path can perform device reads and writes when the page size is not a
@@ -41,7 +42,7 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+    IDevice* dev = devices_[0]->impl().get_devices()[0];
     bool pass = true;
 
     try {

--- a/tests/ttnn/benchmark/cpp/benchmark_d2h_stream_service.cpp
+++ b/tests/ttnn/benchmark/cpp/benchmark_d2h_stream_service.cpp
@@ -29,6 +29,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "impl/context/metal_context.hpp"
 #include "llrt/tt_cluster.hpp"
@@ -277,7 +278,7 @@ MeshWorkload build_producer_workload(
 
     MeshWorkload producer_workload;
     for (const auto& coord : coords) {
-        auto* device = mesh_device->get_device(coord);
+        auto* device = mesh_device->impl().get_device(coord);
         const CoreCoord service_logical = service.get_service_core(coord);
         const CoreCoord service_phys = device->worker_core_from_logical_core(service_logical);
         const uint32_t write_ack_counter_addr = static_cast<uint32_t>(service.get_write_ack_counter_addr(coord));
@@ -438,7 +439,7 @@ void run_d2h_stream_service_benchmark(benchmark::State& state, const BenchmarkCa
     std::vector<uint32_t> latency_gate_word{1};
     auto release_latency_gate = [&]() {
         for (const auto& coord : coords) {
-            auto* device = g_mesh_device->get_device(coord);
+            auto* device = g_mesh_device->impl().get_device(coord);
             for (uint32_t y = kProducerCores.start_coord.y; y <= kProducerCores.end_coord.y; ++y) {
                 for (uint32_t x = kProducerCores.start_coord.x; x <= kProducerCores.end_coord.x; ++x) {
                     tt::tt_metal::detail::WriteToDeviceL1(

--- a/tests/ttnn/benchmark/cpp/benchmark_h2d_stream_service.cpp
+++ b/tests/ttnn/benchmark/cpp/benchmark_h2d_stream_service.cpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "impl/context/metal_context.hpp"
 #include "llrt/tt_cluster.hpp"
@@ -154,7 +155,7 @@ MeshWorkload build_drain_workload(
 
     MeshWorkload worker_workload;
     for (const auto& coord : coords) {
-        auto* device = mesh_device->get_device(coord);
+        auto* device = mesh_device->impl().get_device(coord);
         const CoreCoord service_logical = service.get_service_core(coord);
         const CoreCoord service_phys = device->worker_core_from_logical_core(service_logical);
         const uint32_t consumed_counter_addr = static_cast<uint32_t>(service.get_consumed_counter_addr(coord));

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/api/ttnn/distributed/api.hpp"
@@ -832,7 +833,7 @@ TEST_P(InterleavedAccessorTestsCopyOnDevice, MultiCoreCopyAllPages) {
     const auto& params = GetParam();
 
     // Use all available cores for multi-core testing
-    auto* device = mesh_device_->get_devices().at(0);
+    auto* device = mesh_device_->impl().get_devices().at(0);
     auto grid_size = device->compute_with_storage_grid_size();
     CoreRangeSet cores = CoreRangeSet(CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1}));
 
@@ -848,7 +849,7 @@ TEST_P(InterleavedAccessorTestsCopyOnDevice, MultiCoreCopyAllPagesBigStep) {
     const auto& params = GetParam();
 
     // Use all available cores for multi-core testing
-    auto* device = mesh_device_->get_devices().at(0);
+    auto* device = mesh_device_->impl().get_devices().at(0);
     auto grid_size = device->compute_with_storage_grid_size();
     CoreRangeSet cores = CoreRangeSet(CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1}));
 

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -25,6 +25,7 @@
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "tests/tt_metal/tt_metal/common/device_fixture.hpp"
 #include "tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp"
@@ -116,7 +117,7 @@ void run_strided_dfb_copy_test(
     tt::tt_metal::distributed::MeshDevice* mesh_device,
     uint32_t num_dfb_entries,
     KernelBuilderFn kernel_builder_fn) {
-    auto* device = mesh_device->get_devices().at(0);
+    auto* device = mesh_device->impl().get_devices().at(0);
 
     MemoryConfig mem_config(TensorMemoryLayout::INTERLEAVED, params.buffer_type);
     tt::tt_metal::TensorSpec tensor_spec(

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -5,6 +5,7 @@
 
 #include <fmt/base.h>
 #include <cstdint>
+#include <distributed/mesh_device_impl.hpp>
 // #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
@@ -148,7 +149,7 @@ void generate_receiver_worker_kernels(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     auto& program = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     // Just want a dummy DF
     uint32_t src0_cb_index = CBIndex::c_0;
@@ -240,7 +241,7 @@ void generate_sender_worker_kernels(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     auto& program = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
+    auto* device = mesh_device->impl().get_devices()[0];
 
     std::vector<uint32_t> sender_worker_reader_compile_args{
         num_pages_total,  //
@@ -597,7 +598,7 @@ bool RunWriteBWTest(
     ////////////////////////////////////////////////////////////////////////////
     auto local_edm_kernel = ttnn::ccl::generate_edm_kernel(
         sender_program,
-        sender_mesh_device->get_devices()[0],
+        sender_mesh_device->impl().get_devices()[0],
         local_chip_edm_builder,
         eth_sender_core,
         tt_metal::DataMovementProcessor::RISCV_0,
@@ -606,7 +607,7 @@ bool RunWriteBWTest(
 
     auto remote_edm_kernel = ttnn::ccl::generate_edm_kernel(
         receiver_program,
-        receiver_mesh_device->get_devices()[0],
+        receiver_mesh_device->impl().get_devices()[0],
         remote_chip_edm_builder,
         eth_receiver_core,
         tt_metal::DataMovementProcessor::RISCV_0,
@@ -712,7 +713,7 @@ int TestEntrypoint(
     N300TestDevice test_fixture;
 
     const auto& mesh_device_0 = test_fixture.devices_.at(0);
-    auto* device_0 = mesh_device_0->get_devices()[0];
+    auto* device_0 = mesh_device_0->impl().get_devices()[0];
 
     const auto& active_eth_cores = device_0->get_active_ethernet_cores(true);
     auto eth_sender_core_iter = active_eth_cores.begin();

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -43,6 +43,7 @@
 #include <functional>
 #include <limits>
 #include <unordered_set>
+#include <distributed/mesh_device_impl.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -608,7 +609,7 @@ bool RunPipelinedWorkersTest(
                 reader_kernels[stage],
                 {&device_tensors[stage]},
                 {page_size_bytes},
-                mesh_device->get_devices()[0],
+                mesh_device->impl().get_devices()[0],
                 0,  // link = 0, don't care, since we aren't specifying connections
                 cb_packet_size_in_pages,
                 {worker_cores.at(worker)},
@@ -621,7 +622,7 @@ bool RunPipelinedWorkersTest(
                 writer_kernels[stage],
                 {&device_tensors[stage + 1]},
                 {page_size_bytes},
-                mesh_device->get_devices()[0],
+                mesh_device->impl().get_devices()[0],
                 0,  // link = 0, don't care, since we aren't specifying connections
                 cb_packet_size_in_pages,
                 {worker_cores.at(worker)},

--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_cross_process_d2d_stream_service.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_cross_process_d2d_stream_service.cpp
@@ -85,6 +85,7 @@
 
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 #include <ttnn/api/ttnn/distributed/distributed_configs.hpp>
 #include "ttnn/distributed/distributed_tensor.hpp"
@@ -365,7 +366,7 @@ MeshWorkload make_relay_like_workload(
             DataMovementConfig{
                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = ct_args});
 
-        auto* device = mesh->get_device(coord);
+        auto* device = mesh->impl().get_device(coord);
         const auto up_svc_phys = device->worker_core_from_logical_core(inbound->get_service_core(coord));
         CoreCoord down_svc_phys{0, 0};
         uint32_t down_counter_addr = 0;
@@ -454,7 +455,7 @@ MeshWorkload make_d2h_relay_workload(
             DataMovementConfig{
                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = ct_args});
 
-        auto* device = mesh->get_device(coord);
+        auto* device = mesh->impl().get_device(coord);
         const auto up_svc_phys = device->worker_core_from_logical_core(inbound->get_service_core(coord));
 
         const auto d2h_svc_phys = device->worker_core_from_logical_core(d2h_service->get_service_core(coord));
@@ -547,7 +548,7 @@ MeshWorkload make_stress_compute_workload(
                 .compile_args = ct_args,
                 .defines = {{"STRESS_MODE", "0"}}});
 
-        auto* device = mesh->get_device(coord);
+        auto* device = mesh->impl().get_device(coord);
         const auto up_svc_phys = device->worker_core_from_logical_core(inbound->get_service_core(coord));
         // Outbound D2D sender's metadata buffer (service-core L1) + its physical NoC —
         // the propagate target, producing stages only.
@@ -647,7 +648,7 @@ MeshWorkload make_stress_d2h_compute_workload(
                 .compile_args = ct_args,
                 .defines = {{"STRESS_MODE", "0"}}});
 
-        auto* device = mesh->get_device(coord);
+        auto* device = mesh->impl().get_device(coord);
         const auto up_svc_phys = device->worker_core_from_logical_core(inbound->get_service_core(coord));
         const auto d2h_svc_phys = device->worker_core_from_logical_core(d2h_service->get_service_core(coord));
         const uint32_t write_ack_addr = static_cast<uint32_t>(d2h_service->get_write_ack_counter_addr(coord));
@@ -697,7 +698,7 @@ MeshWorkload make_stress_signal_workload(D2DStreamServiceSender* outbound, const
                 .noc = NOC::RISCV_0_default,
                 .defines = {{"STRESS_MODE", "1"}}});
 
-        auto* device = mesh->get_device(coord);
+        auto* device = mesh->impl().get_device(coord);
         const auto down_svc_phys = device->worker_core_from_logical_core(outbound->get_service_core(coord));
         const uint32_t down_counter_addr = static_cast<uint32_t>(outbound->get_data_ready_counter_addr(coord));
         for (const auto& wc : worker_cores) {
@@ -803,7 +804,7 @@ MeshWorkload make_stress_fabric_workload(
     MeshWorkload workload;
     for (const auto& coord : MeshCoordinateRange(mesh->shape())) {
         auto program = CreateProgram();
-        auto* device = mesh->get_device(coord);
+        auto* device = mesh->impl().get_device(coord);
         const auto sender_node = mesh->get_fabric_node_id(coord);
         const auto fabric_core_phys = device->worker_core_from_logical_core(fabric_core);
 

--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_cross_process_d2h_stream_service.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_cross_process_d2h_stream_service.cpp
@@ -24,6 +24,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
@@ -89,7 +90,7 @@ void write_worker_metadata(
     const std::vector<uint8_t>& metadata) {
     const uint32_t worker_metadata_addr = static_cast<uint32_t>(service.get_worker_metadata_addr());
     for (const auto& coord : service.get_backing_tensor().tensor_topology().mesh_coords()) {
-        auto* device = mesh_device->get_device(coord);
+        auto* device = mesh_device->impl().get_device(coord);
         for (uint32_t y = worker_cores.start_coord.y; y <= worker_cores.end_coord.y; ++y) {
             for (uint32_t x = worker_cores.start_coord.x; x <= worker_cores.end_coord.x; ++x) {
                 tt::tt_metal::detail::WriteToDeviceL1(
@@ -127,7 +128,7 @@ tt::tt_metal::distributed::MeshWorkload build_d2h_metadata_worker_workload(
 
     tt::tt_metal::distributed::MeshWorkload workloads;
     for (const auto& coord : coords) {
-        auto* device = mesh_device->get_device(coord);
+        auto* device = mesh_device->impl().get_device(coord);
         const tt::tt_metal::CoreCoord service_logical = service.get_service_core(coord);
         const tt::tt_metal::CoreCoord service_phys = device->worker_core_from_logical_core(service_logical);
         const uint32_t write_ack_counter_addr = static_cast<uint32_t>(service.get_write_ack_counter_addr(coord));

--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_cross_process_h2d_stream_service.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_cross_process_h2d_stream_service.cpp
@@ -23,6 +23,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
@@ -99,7 +100,7 @@ tt::tt_metal::distributed::MeshWorkload build_worker_workload(
 
     tt::tt_metal::distributed::MeshWorkload worker_workload;
     for (const auto& coord : coords) {
-        auto* device = mesh_device->get_device(coord);
+        auto* device = mesh_device->impl().get_device(coord);
 
         const CoreCoord service_logical = service.get_service_core(coord);
         const CoreCoord service_phys = device->worker_core_from_logical_core(service_logical);

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
@@ -10,6 +10,7 @@
 
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 #include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -48,7 +49,7 @@ TEST_F(MultiDeviceTensorCreationTest, Empty) {
 TEST_F(MultiDeviceTensorCreationTest, EmptyLike) {
     MeshDevice* mesh_device = this->mesh_device_.get();
 
-    ASSERT_FALSE(mesh_device->get_devices().empty());
+    ASSERT_FALSE(mesh_device->impl().get_devices().empty());
 
     const Tensor tensor = ttnn::empty(
         ttnn::Shape({32, 32}),
@@ -96,7 +97,7 @@ TEST_F(MultiDeviceTensorCreationTest, Full) {
 TEST_F(MultiDeviceTensorCreationTest, FullLike) {
     MeshDevice* mesh_device = this->mesh_device_.get();
 
-    ASSERT_FALSE(mesh_device->get_devices().empty());
+    ASSERT_FALSE(mesh_device->impl().get_devices().empty());
 
     Tensor tensor = ttnn::empty(
         ttnn::Shape({32, 32}),
@@ -129,7 +130,7 @@ TEST_F(MultiDeviceTensorCreationTest, FullLike) {
 TEST_F(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
     MeshDevice* mesh_device = this->mesh_device_.get();
 
-    ASSERT_FALSE(mesh_device->get_devices().empty());
+    ASSERT_FALSE(mesh_device->impl().get_devices().empty());
 
     Tensor tensor = ttnn::empty(
         ttnn::Shape({32, 32}),

--- a/tests/ttnn/unit_tests/gtests/tensor/test_d2d_stream_service.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_d2d_stream_service.cpp
@@ -54,6 +54,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt_stl/small_vector.hpp>
 #include <umd/device/types/arch.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
@@ -265,7 +266,7 @@ void verify_transfer(
     std::vector<uint32_t> trigger{num_workers};
     for (const auto& coord : coords) {
         tt::tt_metal::detail::WriteToDeviceL1(
-            sender_mesh->get_device(coord),
+            sender_mesh->impl().get_device(coord),
             sender->get_service_core(coord),
             static_cast<uint32_t>(sender->get_data_ready_counter_addr(coord)),
             trigger);
@@ -345,7 +346,7 @@ MeshWorkload make_sender_worker_workload(
             DataMovementConfig{
                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = ct_args});
 
-        auto* device = mesh->get_device(coord);
+        auto* device = mesh->impl().get_device(coord);
         const auto service_phys = device->worker_core_from_logical_core(sender->get_service_core(coord));
         const uint32_t md_addr = metadata_enabled ? static_cast<uint32_t>(sender->get_metadata_addr(coord)) : 0u;
         for (const auto& wc : worker_cores) {
@@ -386,7 +387,7 @@ MeshWorkload make_receiver_worker_workload(
             DataMovementConfig{
                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = ct_args});
 
-        auto* device = mesh->get_device(coord);
+        auto* device = mesh->impl().get_device(coord);
         const auto service_phys = device->worker_core_from_logical_core(receiver->get_service_core(coord));
         const std::vector<uint32_t> rt_args = {
             static_cast<uint32_t>(receiver->get_consumed_counter_addr(coord)),
@@ -428,7 +429,7 @@ void verify_metadata_sender_write(
     for (const auto& coord : sender->get_backing_tensor().tensor_topology().mesh_coords()) {
         readback.clear();
         tt::tt_metal::detail::ReadFromDeviceL1(
-            sender_mesh->get_device(coord),
+            sender_mesh->impl().get_device(coord),
             sender->get_service_core(coord),
             static_cast<uint32_t>(sender->get_metadata_addr(coord)),
             md_bytes,
@@ -624,7 +625,7 @@ void expect_metadata_on_receiver_workers(
     const CoreRange recv_workers = receiver->get_worker_cores();
     std::vector<uint32_t> rb;
     for (const auto& coord : receiver->get_backing_tensor().tensor_topology().mesh_coords()) {
-        auto* device = receiver_mesh->get_device(coord);
+        auto* device = receiver_mesh->impl().get_device(coord);
         for (const auto& wc : recv_workers) {
             rb.clear();
             tt::tt_metal::detail::ReadFromDeviceL1(device, wc, recv_md_addr, md_bytes, rb);
@@ -649,7 +650,7 @@ void expect_metadata_everywhere(
     for (const auto& coord : sender->get_backing_tensor().tensor_topology().mesh_coords()) {
         rb.clear();
         tt::tt_metal::detail::ReadFromDeviceL1(
-            sender_mesh->get_device(coord),
+            sender_mesh->impl().get_device(coord),
             sender->get_service_core(coord),
             static_cast<uint32_t>(sender->get_metadata_addr(coord)),
             md_bytes,
@@ -783,7 +784,7 @@ MeshWorkload make_receiver_consumer_workload(
             DataMovementConfig{
                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = ct_args});
 
-        auto* device = mesh->get_device(coord);
+        auto* device = mesh->impl().get_device(coord);
         const auto service_phys = device->worker_core_from_logical_core(receiver->get_service_core(coord));
         for (const auto& wc : worker_cores) {
             const auto [start_page, end_page] =
@@ -891,7 +892,7 @@ MeshWorkload make_bridge_workload(
             DataMovementConfig{
                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = ct_args});
 
-        auto* device = mesh->get_device(coord);
+        auto* device = mesh->impl().get_device(coord);
         const auto h2d_service_phys = device->worker_core_from_logical_core(upstream.get_service_core(coord));
         const auto d2d_service_phys = device->worker_core_from_logical_core(d2d_sender->get_service_core(coord));
         const uint32_t d2d_md_addr =

--- a/tests/ttnn/unit_tests/gtests/tensor/test_d2h_stream_service.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_d2h_stream_service.cpp
@@ -19,6 +19,7 @@
 #include <ttnn/distributed/distributed_configs.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
@@ -85,7 +86,7 @@ void write_worker_metadata(
     const std::vector<uint8_t>& metadata) {
     const uint32_t worker_metadata_addr = static_cast<uint32_t>(service.get_worker_metadata_addr());
     for (const auto& coord : service.get_backing_tensor().tensor_topology().mesh_coords()) {
-        auto* device = mesh_device->get_device(coord);
+        auto* device = mesh_device->impl().get_device(coord);
         for (uint32_t y = worker_cores.start_coord.y; y <= worker_cores.end_coord.y; ++y) {
             for (uint32_t x = worker_cores.start_coord.x; x <= worker_cores.end_coord.x; ++x) {
                 tt::tt_metal::detail::WriteToDeviceL1(
@@ -127,7 +128,7 @@ tt::tt_metal::distributed::MeshWorkload build_d2h_worker_workload(
 
     tt::tt_metal::distributed::MeshWorkload workloads;
     for (const auto& coord : coords) {
-        auto* device = mesh_device->get_device(coord);
+        auto* device = mesh_device->impl().get_device(coord);
         const tt::tt_metal::CoreCoord service_logical = service.get_service_core(coord);
         const tt::tt_metal::CoreCoord service_phys = device->worker_core_from_logical_core(service_logical);
         const uint32_t write_ack_counter_addr = static_cast<uint32_t>(service.get_write_ack_counter_addr(coord));

--- a/tests/ttnn/unit_tests/gtests/tensor/test_h2d_stream_service.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_h2d_stream_service.cpp
@@ -28,6 +28,7 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include <tt_stl/small_vector.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
@@ -116,7 +117,7 @@ tt::tt_metal::distributed::MeshWorkload build_worker_workload(
 
     tt::tt_metal::distributed::MeshWorkload worker_workload;
     for (const auto& coord : coords) {
-        auto* device = mesh_device->get_device(coord);
+        auto* device = mesh_device->impl().get_device(coord);
 
         // Service-core physical NoC coords and consumed-counter address both vary per device.
         const tt::tt_metal::CoreCoord service_logical = service.get_service_core(coord);
@@ -313,7 +314,7 @@ void run_h2d_stream_service_case(
             EXPECT_EQ(readback, expected) << "contents mismatch at coord " << coord;
 
             if (cs.metadata_size_bytes > 0) {
-                auto* d = mesh_device->get_device(coord);
+                auto* d = mesh_device->impl().get_device(coord);
                 const auto* exp_meta_u8 = reinterpret_cast<const uint8_t*>(expected_meta.data());
                 const std::vector<uint8_t> expected_meta_u8(exp_meta_u8, exp_meta_u8 + expected_meta.size());
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_stream_pipeline.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_stream_pipeline.cpp
@@ -59,6 +59,7 @@
 #include <tt_stl/small_vector.hpp>
 #include <tt_stl/span.hpp>
 #include <umd/device/types/arch.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
@@ -236,7 +237,7 @@ MeshWorkload build_relay_workload(
             DataMovementConfig{
                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = ct_args});
 
-        auto* device = stage.get_device(coord);
+        auto* device = stage.impl().get_device(coord);
         const auto up_svc_phys = device->worker_core_from_logical_core(up.service_core(coord));
         CoreCoord down_svc_phys{0, 0};
         uint32_t down_counter_addr = 0;
@@ -444,7 +445,7 @@ void run_pipeline(
         const CoreRange recv_workers = last_recv.get_worker_cores();
         std::vector<uint32_t> rb;
         for (const auto& coord : last_recv.get_backing_tensor().tensor_topology().mesh_coords()) {
-            auto* device = stages[num_stages - 1]->get_device(coord);
+            auto* device = stages[num_stages - 1]->impl().get_device(coord);
             for (const auto& wc : recv_workers) {
                 rb.clear();
                 tt::tt_metal::detail::ReadFromDeviceL1(device, wc, recv_md_addr, metadata_size_bytes, rb);

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -44,6 +44,7 @@
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include "tests/tt_metal/tt_fabric/common/fabric_fixture.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace ttnn::operations::generic::test {
 
@@ -1632,7 +1633,7 @@ TEST_F(Fabric1DFixtureGeneric, TestLinearFabricUnicastNocUnicastWrite) {
 
     std::vector<uint32_t> sender_status;
     tt::tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+        sender_device->impl().get_devices()[0],
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -1643,7 +1644,7 @@ TEST_F(Fabric1DFixtureGeneric, TestLinearFabricUnicastNocUnicastWrite) {
     std::vector<uint32_t> receiver_status;
 
     tt::tt_metal::detail::ReadFromDeviceL1(
-        receiver_device->get_devices()[0],
+        receiver_device->impl().get_devices()[0],
         receiver_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -216,6 +216,9 @@ public:
     // The type parameter allows the caller to specify how to linearize the devices in the mesh.
 
     // Returns the devices in the mesh in row-major order.
+    [[deprecated(
+        "Deprecated, retrieving physical devices can fail in distributed contexts. This will be removed after "
+        "03-09-2026.")]]
     std::vector<IDevice*> get_devices() const;
     [[deprecated(
         "Deprecated, retrieving physical devices can fail in distributed contexts. This will be removed after "

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -13,6 +13,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"
 #include "tt_metal/llrt/tt_cluster.hpp"
+#include <distributed/mesh_device_impl.hpp>
 #ifdef TT_METAL_USE_EMULE
 #include "tt_metal/impl/emulation/emulated_program_runner.hpp"  // emule::pump_device (host-interleaved socket)
 #endif
@@ -65,7 +66,7 @@ void advance_d2h_simulator_socket_device(MeshDevice* mesh_device, const MeshCoor
         return;
     }
 
-    cluster.advance_device_execution(mesh_device->get_device(device_coord)->id());
+    cluster.advance_device_execution(mesh_device->impl().get_device(device_coord)->id());
 }
 
 }  // namespace
@@ -113,10 +114,11 @@ D2HSocket::PinnedBufferInfo D2HSocket::init_host_buffer(
     pinned_memory_ =
         tt::tt_metal::experimental::PinnedMemory::Create(*mesh_device, device_range, host_buffer_view, true);
 
-    const auto& noc_addr = pinned_memory_->get_noc_addr(mesh_device->get_device(sender_core_.device_coord)->id());
+    const auto& noc_addr =
+        pinned_memory_->get_noc_addr(mesh_device->impl().get_device(sender_core_.device_coord)->id());
     TT_FATAL(noc_addr.has_value(), "Failed to get NOC address for D2H socket pinned memory.");
     TT_FATAL(
-        noc_addr.value().device_id == mesh_device->get_device(sender_core_.device_coord)->id(),
+        noc_addr.value().device_id == mesh_device->impl().get_device(sender_core_.device_coord)->id(),
         "Pinned Memory used for D2H sockets must be mapped to the same device as the sender core. D2H Sockets cannot "
         "communicate with remote devices.");
 
@@ -136,7 +138,7 @@ D2HSocket::PinnedBufferInfo D2HSocket::init_host_buffer_hugepage(const std::shar
 #endif
     using_hugepage_ = true;
 
-    auto* device = mesh_device->get_device(sender_core_.device_coord);
+    auto* device = mesh_device->impl().get_device(sender_core_.device_coord);
     auto device_id = device->id();
     auto& sysmem_mgr = device->sysmem_manager();
 
@@ -185,7 +187,7 @@ void D2HSocket::init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_devic
 
     std::optional<DeviceAddr> preallocated_addr;
     auto& svc = tt::tt_metal::MetalContext::instance().get_service_core_manager();
-    auto* sender_device = mesh_device->get_device(sender_core_.device_coord);
+    auto* sender_device = mesh_device->impl().get_device(sender_core_.device_coord);
     if (svc.claimed_cores(sender_device->id()).contains(sender_core_.core_coord)) {
         svc_config_l1_addr_ = svc.allocate_l1(sender_device, sender_core_.core_coord, config_buffer_size);
         preallocated_addr = svc_config_l1_addr_;
@@ -224,7 +226,7 @@ void D2HSocket::write_socket_metadata(
         distributed::WriteShard(
             mesh_device->mesh_command_queue(0), config_buffer_, config_data, sender_core_.device_coord, true);
     } else {
-        IDevice* device = mesh_device->get_device(sender_core_.device_coord);
+        IDevice* device = mesh_device->impl().get_device(sender_core_.device_coord);
         tt::tt_metal::detail::WriteToDeviceL1(
             device, sender_core_.core_coord, config_buffer_address_, config_data, CoreType::WORKER);
     }
@@ -245,7 +247,7 @@ void D2HSocket::init_sender_tlb(const std::shared_ptr<MeshDevice>& mesh_device, 
     // installed writer is harmless there.
 
     if (mesh_device) {
-        sender_device_id = mesh_device->get_device(sender_core_.device_coord)->id();
+        sender_device_id = mesh_device->impl().get_device(sender_core_.device_coord)->id();
         sender_virtual_core = mesh_device->worker_core_from_logical_core(sender_core_.core_coord);
         if (!cluster.is_mock_or_emulated()) {
             sender_core_tlb_ = cluster.get_driver()
@@ -313,7 +315,7 @@ void D2HSocket::init_common(const std::shared_ptr<MeshDevice>& mesh_device) {
     } else {
         data_info = init_host_buffer_hugepage(mesh_device);
 
-        auto* device = mesh_device->get_device(sender_core_.device_coord);
+        auto* device = mesh_device->impl().get_device(sender_core_.device_coord);
         auto& sysmem_mgr = device->sysmem_manager();
         auto [bs_host_ptr, bs_dev_addr] = sysmem_mgr.allocate_region(sizeof(uint32_t));
         hugepage_bytes_sent_host_ptr_ = static_cast<volatile uint32_t*>(bs_host_ptr);
@@ -386,7 +388,7 @@ D2HSocket::~D2HSocket() noexcept {
         try {
             config_buffer_.reset();
             auto& svc = tt::tt_metal::MetalContext::instance().get_service_core_manager();
-            auto* sender_device = mesh_device_->get_device(sender_core_.device_coord);
+            auto* sender_device = mesh_device_->impl().get_device(sender_core_.device_coord);
             svc.deallocate_l1(sender_device, sender_core_.core_coord, svc_config_l1_addr_.value());
         } catch (const std::exception& e) {
             log_warning(LogMetal, "D2HSocket destructor: service-core L1 release failed: {}", e.what());

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -199,7 +199,7 @@ FDMeshCommandQueue::FDMeshCommandQueue(
         mesh_device_->allocator_impl()->get_config().l1_unreserved_base);
     this->populate_virtual_program_dispatch_core();
 
-    for (auto* device : mesh_device_->get_devices()) {
+    for (auto* device : mesh_device_->impl().get_devices()) {
         if (auto* physical_device = dynamic_cast<Device*>(device)) {
             physical_device->update_smc_dispatch_telemetry_for_fast_dispatch(
                 this->id_, build_smc_dispatch_core_coords(*physical_device, this->id_));
@@ -270,7 +270,7 @@ FDMeshCommandQueue::~FDMeshCommandQueue() {
 }
 
 void FDMeshCommandQueue::populate_read_descriptor_queue() {
-    for (const auto* device : mesh_device_->get_devices()) {
+    for (const auto* device : mesh_device_->impl().get_devices()) {
         read_descriptors_.emplace(
             device->id(), std::make_unique<MultiProducerSingleConsumerQueue<CompletionReaderVariant>>());
     }
@@ -284,7 +284,7 @@ void FDMeshCommandQueue::populate_virtual_program_dispatch_core() {
     }
 
     int device_idx = 0;
-    for (auto* device : mesh_device_->get_devices()) {
+    for (auto* device : mesh_device_->impl().get_devices()) {
         if (device_idx) {
             TT_FATAL(
                 this->dispatch_core_ == device->virtual_program_dispatch_core(this->id_),
@@ -328,7 +328,7 @@ void FDMeshCommandQueue::wait_for_outstanding_reads(std::unique_lock<std::mutex>
 
     const auto& rtoptions = MetalContext::instance(mesh_device_->impl().get_context_id()).rtoptions();
     if (rtoptions.get_watcher_enabled() && rtoptions.get_test_mode_enabled()) {
-        const ChipId device_id = mesh_device_->get_devices().at(0)->id();
+        const ChipId device_id = mesh_device_->impl().get_devices().at(0)->id();
         constexpr auto poll_interval = std::chrono::milliseconds(100);
         while (num_outstanding_reads_.load() != 0 && !thread_exception_state_.load()) {
             if (record_watcher_error_in_test_mode(device_id)) {
@@ -353,7 +353,7 @@ void FDMeshCommandQueue::clear_expected_num_workers_completed() {
         MeshEvent(sysmem_manager.get_next_event(id_), mesh_device_, id_, MeshCoordinateRange(mesh_device_->shape()));
 
     // Issue commands to clear expected_num_workers_completed counter(s) on the dispatcher
-    for (auto* device : mesh_device_->get_devices()) {
+    for (auto* device : mesh_device_->impl().get_devices()) {
         event_dispatch::issue_record_event_commands(
             mesh_device_,
             device->id(),
@@ -449,7 +449,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     // Need to stall and reset counters if host wraps
     if (updated_worker_counts.wrapped) [[unlikely]] {
         get_config_buffer_mgr(*sub_device_id).mark_completely_full(0);
-        for (auto* device : mesh_device_->get_devices()) {
+        for (auto* device : mesh_device_->impl().get_devices()) {
             program_dispatch::reset_expected_num_workers_completed_on_device(
                 static_cast<Device*>(device),  // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
                 sub_device_id,
@@ -694,7 +694,7 @@ void FDMeshCommandQueue::finish_nolock(ttsl::Span<const SubDeviceId> sub_device_
     if (tt::IsProgramRealtimeProfilerActive()) {
         for (const auto& sub_device_id : buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids)) {
             const uint32_t wait_count = expected_num_workers_completed_[*sub_device_id];
-            for (auto* device : mesh_device_->get_devices()) {
+            for (auto* device : mesh_device_->impl().get_devices()) {
                 write_rt_profiler_flush(id_, sub_device_id, device->sysmem_manager(), wait_count);
             }
         }
@@ -1137,13 +1137,13 @@ void FDMeshCommandQueue::reset_worker_state(
     const vector_aligned<uint32_t>& go_signal_noc_data,
     const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping,
     ttsl::Span<const uint32_t> workers_per_sub_device) {
-    for (auto* device : mesh_device_->get_devices()) {
+    for (auto* device : mesh_device_->impl().get_devices()) {
         TT_FATAL(!device->sysmem_manager().get_bypass_mode(), "Cannot reset worker state during trace capture");
     }
     cq_shared_state_->sub_device_cq_owner.clear();
     cq_shared_state_->sub_device_cq_owner.resize(num_sub_devices);
     in_use_ = true;
-    for (auto* device : mesh_device_->get_devices()) {
+    for (auto* device : mesh_device_->impl().get_devices()) {
         program_dispatch::reset_worker_dispatch_state_on_device(
             mesh_device_,
             device->sysmem_manager(),
@@ -1197,7 +1197,7 @@ void FDMeshCommandQueue::write_go_signal_to_unused_sub_grids(
     bool mcast_go_signals,
     bool unicast_go_signals,
     const program_dispatch::ProgramDispatchMetadata& dispatch_md) {
-    for (auto& device : mesh_device_->get_devices()) {
+    for (auto& device : mesh_device_->impl().get_devices()) {
         if (!chip_ids_in_workload.contains(device->id())) {
             write_go_signal(
                 id_,
@@ -1236,7 +1236,7 @@ void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blockin
         buffer->num_pages(),
         buffer->address());
 
-    for (auto* device : mesh_device_->get_devices()) {
+    for (auto* device : mesh_device_->impl().get_devices()) {
         trace_dispatch::issue_trace_commands(
             mesh_device_, device->sysmem_manager(), dispatch_md, id_, expected_num_workers_completed_, dispatch_core_);
     }
@@ -1269,7 +1269,7 @@ void FDMeshCommandQueue::record_begin(const MeshTraceId& trace_id, const std::sh
 
     trace_id_ = trace_id;
     trace_ctx_ = ctx;
-    for (auto* device : mesh_device_->get_devices()) {
+    for (auto* device : mesh_device_->impl().get_devices()) {
         device->sysmem_manager().set_bypass_mode(/*enable*/ true, /*clear*/ true);
     }
 
@@ -1423,7 +1423,7 @@ void FDMeshCommandQueue::record_end() {
         // cache manager to give each range a clean slate.
         this->reset_prefetcher_cache_manager();
 
-        auto& sysmem_manager_for_trace = mesh_device_->get_device(range.start_coord())->sysmem_manager();
+        auto& sysmem_manager_for_trace = mesh_device_->impl().get_device(range.start_coord())->sysmem_manager();
         auto& worker_launch_message_buffer_state = cq_shared_state_->worker_launch_message_buffer_state;
         for (uint32_t sub_device_id = 0; sub_device_id < mesh_device_->num_sub_devices(); sub_device_id++) {
             worker_launch_message_buffer_state[sub_device_id].reset();
@@ -1610,7 +1610,7 @@ void FDMeshCommandQueue::record_end() {
         expected_num_workers_completed_reset_,
         config_buffer_mgr_reset_);
 
-    for (auto* device : mesh_device_->get_devices()) {
+    for (auto* device : mesh_device_->impl().get_devices()) {
         device->sysmem_manager().set_bypass_mode(/*enable*/ false, /*clear*/ true);
     }
 
@@ -1621,7 +1621,7 @@ void FDMeshCommandQueue::record_end() {
 }
 
 SystemMemoryManager& FDMeshCommandQueue::reference_sysmem_manager() {
-    auto local_devices = mesh_device_->get_devices();
+    auto local_devices = mesh_device_->impl().get_devices();
     return local_devices.at(0)->sysmem_manager();
 }
 
@@ -1646,12 +1646,12 @@ int FDMeshCommandQueue::get_prefetcher_cache_sizeB() const {
 void FDMeshCommandQueue::wait_for_completion(bool reset_launch_msg_state) {
     if (in_use_) {
         size_t num_sub_devices = mesh_device_->num_sub_devices();
-        for (auto* device : mesh_device_->get_devices()) {
+        for (auto* device : mesh_device_->impl().get_devices()) {
             TT_FATAL(!device->sysmem_manager().get_bypass_mode(), "Cannot reset worker state during trace capture");
         }
         cq_shared_state_->sub_device_cq_owner.clear();
         cq_shared_state_->sub_device_cq_owner.resize(num_sub_devices);
-        for (auto* device : mesh_device_->get_devices()) {
+        for (auto* device : mesh_device_->impl().get_devices()) {
             program_dispatch::reset_worker_dispatch_state_on_device(
                 mesh_device_,
                 device->sysmem_manager(),
@@ -1680,7 +1680,7 @@ void FDMeshCommandQueue::finish_and_reset_in_use() {
     if (in_use_) {
         auto lock = lock_api_function_();
         uint32_t current_event = reference_sysmem_manager().get_current_event(id_);
-        for (auto* device : mesh_device_->get_devices()) {
+        for (auto* device : mesh_device_->impl().get_devices()) {
             TT_ASSERT(
                 device->sysmem_manager().get_last_completed_event(id_) == current_event,
                 "Current event must be equal to last completed event");

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -21,6 +21,7 @@
 #include <tt-metalium/tt_align.hpp>
 #include <umd/device/chip_helpers/tlb_manager.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include <distributed/mesh_device_impl.hpp>
 #include <cstdlib>
 #include <cstring>
 #include <sys/mman.h>
@@ -48,7 +49,7 @@ void advance_h2d_simulator_socket_device(MeshDevice* mesh_device, const MeshCoor
         return;
     }
 
-    cluster.advance_device_execution(mesh_device->get_device(device_coord)->id());
+    cluster.advance_device_execution(mesh_device->impl().get_device(device_coord)->id());
 }
 
 }  // namespace
@@ -81,10 +82,10 @@ H2DSocket::PinnedBufferInfo H2DSocket::init_bytes_acked_buffer(
     pinned_memory_ =
         tt::tt_metal::experimental::PinnedMemory::Create(*mesh_device, device_range, bytes_acked_buffer_view, true);
 
-    const auto& noc_addr = pinned_memory_->get_noc_addr(mesh_device->get_device(recv_core_.device_coord)->id());
+    const auto& noc_addr = pinned_memory_->get_noc_addr(mesh_device->impl().get_device(recv_core_.device_coord)->id());
     TT_FATAL(noc_addr.has_value(), "Failed to get NOC address for bytes_acked pinned memory.");
     TT_FATAL(
-        noc_addr.value().device_id == mesh_device->get_device(recv_core_.device_coord)->id(),
+        noc_addr.value().device_id == mesh_device->impl().get_device(recv_core_.device_coord)->id(),
         "Pinned Memory used for H2D sockets must be mapped to the same device as the receiver core. H2D Sockets cannot "
         "communicate with remote devices");
     return PinnedBufferInfo{
@@ -119,7 +120,7 @@ H2DSocket::PinnedBufferInfo H2DSocket::init_host_data_buffer(
     pinned_memory_ =
         tt::tt_metal::experimental::PinnedMemory::Create(*mesh_device, device_range, host_buffer_view, true);
 
-    const auto& noc_addr = pinned_memory_->get_noc_addr(mesh_device->get_device(recv_core_.device_coord)->id());
+    const auto& noc_addr = pinned_memory_->get_noc_addr(mesh_device->impl().get_device(recv_core_.device_coord)->id());
     TT_FATAL(noc_addr.has_value(), "Failed to get NOC address for data pinned memory.");
 
     return PinnedBufferInfo{
@@ -153,7 +154,7 @@ void H2DSocket::init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_devic
     // On a claimed service core the worker-grid BankManager can't reach L1; allocate from the service-core allocator.
     std::optional<DeviceAddr> preallocated_addr;
     auto& svc = tt::tt_metal::MetalContext::instance().get_service_core_manager();
-    auto* recv_device = mesh_device->get_device(recv_core_.device_coord);
+    auto* recv_device = mesh_device->impl().get_device(recv_core_.device_coord);
     if (svc.claimed_cores(recv_device->id()).contains(recv_core_.core_coord)) {
         svc_config_l1_addr_ = svc.allocate_l1(recv_device, recv_core_.core_coord, config_buffer_size);
         preallocated_addr = svc_config_l1_addr_;
@@ -172,7 +173,7 @@ void H2DSocket::init_data_buffer(const std::shared_ptr<MeshDevice>& mesh_device,
     }
 
     auto& svc = tt::tt_metal::MetalContext::instance().get_service_core_manager();
-    auto* recv_device = mesh_device->get_device(recv_core_.device_coord);
+    auto* recv_device = mesh_device->impl().get_device(recv_core_.device_coord);
     if (svc.claimed_cores(recv_device->id()).contains(recv_core_.core_coord)) {
         const uint64_t alloc_size = fifo_size_ + pcie_alignment;
         DeviceAddr raw_addr = svc.allocate_l1(recv_device, recv_core_.core_coord, alloc_size);
@@ -241,7 +242,7 @@ void H2DSocket::write_socket_metadata(
 
     if (svc_config_l1_addr_.has_value()) {
         // WriteShard can't reach service cores, so write L1 directly. config_buffer_address_ isn't assigned yet.
-        auto* device = mesh_device->get_device(recv_core_.device_coord);
+        auto* device = mesh_device->impl().get_device(recv_core_.device_coord);
         std::span<const uint8_t> bytes(reinterpret_cast<const uint8_t*>(&md), sizeof(md));
         tt::tt_metal::detail::WriteToDeviceL1(
             device, recv_core_.core_coord, static_cast<uint32_t>(config_buffer_->address()), bytes);
@@ -273,7 +274,7 @@ void H2DSocket::init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device
     const CoreType recv_umd_core_type = (recv_core_type_ == RecvCoreType::Dram) ? CoreType::DRAM : CoreType::TENSIX;
 
     if (mesh_device) {
-        recv_device_id = mesh_device->get_device(recv_core_.device_coord)->id();
+        recv_device_id = mesh_device->impl().get_device(recv_core_.device_coord)->id();
         recv_virtual_core = mesh_device->virtual_core_from_logical_core(recv_core_.core_coord, recv_umd_core_type);
     } else {
         recv_device_id = device_id.value();
@@ -435,13 +436,14 @@ H2DSocket::H2DSocket(
     md.h2d.data_addr_hi = 0;
     md.h2d.pcie_xy_enc = bytes_acked_info.pcie_xy_enc;
 
-    const CoreCoord virtual_core = mesh_device->get_device(recv_core_.device_coord)
+    const CoreCoord virtual_core = mesh_device->impl()
+                                       .get_device(recv_core_.device_coord)
                                        ->virtual_core_from_logical_core(recv_core_.core_coord, CoreType::DRAM);
     MetalContext::instance(extract_context_id(mesh_device.get()))
         .get_cluster()
         .write_core(
-            mesh_device->get_device(recv_core_.device_coord)->id(),
-            tt_cxy_pair(mesh_device->get_device(recv_core_.device_coord)->id(), virtual_core),
+            mesh_device->impl().get_device(recv_core_.device_coord)->id(),
+            tt_cxy_pair(mesh_device->impl().get_device(recv_core_.device_coord)->id(), virtual_core),
             std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(&md), sizeof(md)),
             static_cast<uint64_t>(config_buffer_address_) + dram_l1_noc_offset_);
 }
@@ -460,7 +462,7 @@ H2DSocket::~H2DSocket() noexcept {
             config_buffer_.reset();
             data_buffer_.reset();
             auto& svc = tt::tt_metal::MetalContext::instance().get_service_core_manager();
-            auto* recv_device = mesh_device_->get_device(recv_core_.device_coord);
+            auto* recv_device = mesh_device_->impl().get_device(recv_core_.device_coord);
             if (svc_config_l1_addr_.has_value()) {
                 svc.deallocate_l1(recv_device, recv_core_.core_coord, svc_config_l1_addr_.value());
             }

--- a/tt_metal/distributed/hd_socket_descriptor.cpp
+++ b/tt_metal/distributed/hd_socket_descriptor.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/distributed.hpp>
 #include "impl/context/metal_context.hpp"
 #include <umd/device/pcie/pci_device.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #include <cerrno>
 #include <chrono>
@@ -41,7 +42,7 @@ void HDSocketDescriptor::populate_from_owner(
     // does not would disagree on what a given logical id refers to. The physical
     // device number is identical in every process on the host, so the connector can
     // translate it back to its own local logical id (see PCIeCoreWriter).
-    uint32_t logical_device_id = static_cast<uint32_t>(mesh_device->get_device(core.device_coord)->id());
+    uint32_t logical_device_id = static_cast<uint32_t>(mesh_device->impl().get_device(core.device_coord)->id());
     auto physical_device_num = tt::umd::PCIDevice::get_pci_device_id(static_cast<int>(logical_device_id));
     TT_FATAL(
         physical_device_num.has_value(),

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -539,7 +539,7 @@ void RealtimeProfilerManager::initialize_devices(const std::shared_ptr<MeshDevic
             continue;
         }
 
-        IDevice* device = mesh_device->get_device(coord);
+        IDevice* device = mesh_device->impl().get_device(coord);
         auto device_id = device->id();
 
         auto eligibility = evaluate_realtime_profiler_eligibility(device, context_id_);

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -69,7 +69,7 @@ SDMeshCommandQueue::SDMeshCommandQueue(
     active_distributed_context_(std::move(distributed_context)) {
     // Init thread pool with all local devices for parallel dispatch.
     // One thread per device enables NUMA-aware CPU binding.
-    auto local_devices = mesh_device_->get_devices();
+    auto local_devices = mesh_device_->impl().get_devices();
     if (local_devices.size() > 1) {
         launch_thread_pool_ = create_device_bound_thread_pool(mesh_device_->impl().get_context_id(), local_devices);
     }
@@ -376,7 +376,7 @@ void SDMeshCommandQueue::finish(ttsl::Span<const SubDeviceId>) {
     }
     auto lock = lock_api_function_();
     wait_for_cores_idle();
-    for (const auto& device : mesh_device_->get_devices()) {
+    for (const auto& device : mesh_device_->impl().get_devices()) {
         tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id())
             .get_cluster()
             .dram_barrier(device->id());

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -253,7 +253,7 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
     const uint64_t dram_l1_noc_offset = metal_ctx.hal().get_l1_noc_offset(HalProgrammableCoreType::DRAM);
     const uint64_t write_addr = dram_l1_noc_offset + static_cast<uint64_t>(sender_state_drisc_l1_base_);
 
-    const auto& devices = mesh_device->get_devices();
+    const auto& devices = mesh_device->impl().get_devices();
     const std::vector<uint8_t> pages_sent_zero_bytes(2 * sizeof(uint32_t) * max_num_receivers_per_sender, 0);
     const uint64_t pages_sent_write_addr = dram_l1_noc_offset + static_cast<uint64_t>(pages_sent_drisc_l1_base_);
     auto& cluster = metal_ctx.get_cluster();

--- a/tt_metal/impl/device/experimental/device.cpp
+++ b/tt_metal/impl/device/experimental/device.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt_stl/assert.hpp>
 #include "tt_metal/impl/device/device_impl.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::experimental::Device {
 
@@ -18,7 +19,7 @@ uint32_t get_worker_noc_hop_distance(
     if (auto* mesh = dynamic_cast<distributed::MeshDevice*>(device)) {
         TT_FATAL(mesh->num_devices() == 1, "get_worker_noc_hop_distance() is only supported on unit MeshDevice.");
         // Delegate to the underlying device
-        return get_worker_noc_hop_distance(mesh->get_devices().front(), logical_src, logical_dst, noc);
+        return get_worker_noc_hop_distance(mesh->impl().get_devices().front(), logical_src, logical_dst, noc);
     }
 
     // Handle regular Device - cast to access internal physical_worker_core_from_logical_core
@@ -49,7 +50,8 @@ uint32_t get_worker_noc_hop_distance(
     NOC noc) {
     TT_FATAL(mesh_device != nullptr, "MeshDevice pointer cannot be null");
     const auto linear_index = mesh_coord.to_linear_index(mesh_device->shape());
-    return get_worker_noc_hop_distance(mesh_device->get_devices().at(linear_index), logical_src, logical_dst, noc);
+    return get_worker_noc_hop_distance(
+        mesh_device->impl().get_devices().at(linear_index), logical_src, logical_dst, noc);
 }
 
 }  // namespace tt::tt_metal::experimental::Device

--- a/tt_metal/impl/experimental/udm/mesh_builder.cpp
+++ b/tt_metal/impl/experimental/udm/mesh_builder.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/experimental/udm/mesh_builder.hpp>
 #include <tt-metalium/experimental/udm/mesh_utils.hpp>
+#include <distributed/mesh_device_impl.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/fmt.hpp>
 #include <tt-metalium/mesh_coord.hpp>
@@ -330,7 +331,7 @@ public:
         // This maps linearized worker core index (row-major) to packed NOC (x,y) coordinates
         // The mapping is the same for all devices in the mesh
         // Get any device to query the core mapping (all devices have the same mapping)
-        auto* device = mesh_device_->get_devices()[0];
+        auto* device = mesh_device_->impl().get_devices()[0];
 
         // Compute total number of cores in grid
         uint32_t num_cores = 1;

--- a/tt_metal/impl/memory_tracking/shm_tracking_processor.cpp
+++ b/tt_metal/impl/memory_tracking/shm_tracking_processor.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <unistd.h>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -45,7 +46,7 @@ void ShmTrackingProcessor::track_allocate(const Buffer* buffer) {
         // buffer->size() is already the correct per-device size in both layouts.
         std::lock_guard<std::mutex> tracking_lock(tracking_mutex_);
 
-        auto underlying_devices = mesh_device->get_devices();
+        auto underlying_devices = mesh_device->impl().get_devices();
         size_t num_tracked = 0;
         uint64_t size_per_device = buffer->size();
 
@@ -180,7 +181,7 @@ void ShmTrackingProcessor::track_deallocate(Buffer* buffer) {
         // sharded and replicated). No double-counting — see track_allocate comment.
         std::lock_guard<std::mutex> tracking_lock(tracking_mutex_);
 
-        auto underlying_devices = mesh_device->get_devices();
+        auto underlying_devices = mesh_device->impl().get_devices();
         uint64_t size_per_device = buffer->size();
 
         // Track deallocation on all underlying Devices that have SHM provider

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -63,6 +63,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <impl/debug/noc_debugging.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 #if !defined(TRACY_ENABLE) && defined(__clang__)
 #pragma clang diagnostic push
@@ -1200,7 +1201,7 @@ void ReadMeshDeviceProfilerResults(
         MetalContext::instance(context_id).profiler_state_manager();
 
     if (useFastDispatch(&mesh_device, &mesh_device, context_id)) {
-        for (IDevice* device : mesh_device.get_devices()) {
+        for (IDevice* device : mesh_device.impl().get_devices()) {
             auto profiler_it = profiler_state_manager->device_profiler_map.find(device->id());
             TT_ASSERT(profiler_it != profiler_state_manager->device_profiler_map.end());
             DeviceProfiler& profiler = profiler_it->second;
@@ -1237,12 +1238,12 @@ void ReadMeshDeviceProfilerResults(
         return;
     }
 
-    for (IDevice* device : mesh_device.get_devices()) {
+    for (IDevice* device : mesh_device.impl().get_devices()) {
         const std::vector<CoreCoord> virtual_cores = detail::getVirtualCoresForProfiling(device, state);
         detail::ReadDeviceProfilerResults(&mesh_device, device, virtual_cores, state, metadata);
     }
 
-    for (IDevice* device : mesh_device.get_devices()) {
+    for (IDevice* device : mesh_device.impl().get_devices()) {
         mesh_device.enqueue_to_thread_pool([device, state, &metadata]() {
             const std::vector<CoreCoord> virtual_cores = detail::getVirtualCoresForProfiling(device, state);
             detail::ProcessDeviceProfilerResults(device, virtual_cores, state, metadata);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -91,6 +91,7 @@
 #include <internal/service/service_core_manager.hpp>
 #include "impl/internal/service/service_core_manager_impl.hpp"
 #include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt {
 enum CBIndex : std::uint8_t;
@@ -1496,7 +1497,7 @@ void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
         dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device);
     if (mesh_device != nullptr) {
         // Mesh device: track all sub-devices
-        for (IDevice* sub_device : mesh_device->get_devices()) {
+        for (IDevice* sub_device : mesh_device->impl().get_devices()) {
             devices_to_track.push_back(sub_device);
         }
     } else {
@@ -1670,7 +1671,7 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
     std::vector<AllocatorImpl*> physical_allocators;
     if (hybrid_mode) {
         if (const auto* mesh = dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device)) {
-            for (IDevice* dev : mesh->get_devices()) {
+            for (IDevice* dev : mesh->impl().get_devices()) {
                 physical_allocators.push_back(dev->allocator_impl().get());
             }
         } else {
@@ -1684,7 +1685,7 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
     std::vector<const IDevice*> devices_for_svc_check;
     if (svc.has_any_claims()) {
         if (const auto* mesh = dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device)) {
-            for (IDevice* dev : mesh->get_devices()) {
+            for (IDevice* dev : mesh->impl().get_devices()) {
                 devices_for_svc_check.push_back(dev);
             }
         } else {
@@ -1773,7 +1774,7 @@ void detail::ProgramImpl::validate_circular_buffer_core_ranges(const IDevice* de
     std::unordered_set<CoreCoord> claimed;
     if (svc.has_any_claims()) {
         if (const auto* mesh = dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device)) {
-            for (IDevice* dev : mesh->get_devices()) {
+            for (IDevice* dev : mesh->impl().get_devices()) {
                 auto chip_claimed = svc.claimed_cores(dev->id());
                 claimed.insert(chip_claimed.begin(), chip_claimed.end());
             }


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
