### PR TITLE
[gpt_oss_d_p] Warm the SP ring cache-read path in prefill compile()

### DIFF
--- a/models/demos/gpt_oss_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/gpt_oss_d_p/tt/tt_prefill_runtime.py
@@ -177,12 +177,28 @@ class TtPrefillRuntime:
         return x_embd
 
     def compile(self, kv_caches=None) -> None:
-        """Warm up the kernels by running one zero-token chunk through prefill_chunk (JIT-compiles)."""
+        """Warm up the kernels by running zero-token chunks through prefill_chunk (JIT-compiles).
+
+        Two warmups: the first chunk (actual_start=0, the gather-Q path) AND — when the config is
+        multi-chunk (max_seq_len > chunk_size) — a second chunk (actual_start>0), which is the ONLY
+        path that fires the SP ring cache-read (attention/dense_sp.py). Without the second warmup the
+        ring kernels JIT-compile inside the first *served/timed* chunk, which dominates TTFT (a cold
+        first request measured ~10s vs ~1.3s warm). One-shot (max_seq_len == chunk_size) never reaches
+        the ring path and uses FABRIC_1D, so it skips the second warmup."""
         assert self.model_built
         chunk = self.config.chunk_size
-        logger.info(f"GPT-OSS TtPrefillRuntime.compile() — warming up one {chunk}-token chunk")
-        tt_input = self.make_chunk_input([0] * chunk)
-        self.prefill_chunk(tt_input, kv_caches, slot_id=0, actual_start=0, actual_end=chunk)
+        ring = self.config.max_seq_len > chunk
+        logger.info(
+            f"GPT-OSS TtPrefillRuntime.compile() — warming up {'2 chunks (gather-Q + ring cache-read)' if ring else 'one chunk'} "
+            f"of {chunk} tokens"
+        )
+        # prefill_chunk consumes (deallocates) its input tensor, so build a fresh input per call.
+        self.prefill_chunk(self.make_chunk_input([0] * chunk), kv_caches, slot_id=0, actual_start=0, actual_end=chunk)
+        if ring:
+            # actual_start>0 drives the ring cache-read; it reads the prefix we just wrote at [0, chunk).
+            self.prefill_chunk(
+                self.make_chunk_input([0] * chunk), kv_caches, slot_id=0, actual_start=chunk, actual_end=2 * chunk
+            )
         ttnn.synchronize_device(self.mesh_device)
         self.compiled = True
 

--- a/models/demos/gpt_oss_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/gpt_oss_d_p/tt/tt_prefill_runtime.py
@@ -182,9 +182,10 @@ class TtPrefillRuntime:
         Two warmups: the first chunk (actual_start=0, the gather-Q path) AND — when the config is
         multi-chunk (max_seq_len > chunk_size) — a second chunk (actual_start>0), which is the ONLY
         path that fires the SP ring cache-read (attention/dense_sp.py). Without the second warmup the
-        ring kernels JIT-compile inside the first *served/timed* chunk, which dominates TTFT (a cold
-        first request measured ~10s vs ~1.3s warm). One-shot (max_seq_len == chunk_size) never reaches
-        the ring path and uses FABRIC_1D, so it skips the second warmup."""
+        ring kernels JIT-compile inside the first *served/timed* chunk, adding ~0.9s to it (first served
+        chunk ~2.16s vs ~1.28s warm, at 5k). (Separately, the very first run ever also pays a one-time
+        ~10.6s empty-disk kernel-cache compile — orthogonal to this warmup.) One-shot
+        (max_seq_len == chunk_size) never reaches the ring path and uses FABRIC_1D, so it skips it."""
         assert self.model_built
         chunk = self.config.chunk_size
         ring = self.config.max_seq_len > chunk

--- a/models/demos/gpt_oss_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/gpt_oss_d_p/tt/tt_prefill_runtime.py
@@ -182,10 +182,10 @@ class TtPrefillRuntime:
         Two warmups: the first chunk (actual_start=0, the gather-Q path) AND — when the config is
         multi-chunk (max_seq_len > chunk_size) — a second chunk (actual_start>0), which is the ONLY
         path that fires the SP ring cache-read (attention/dense_sp.py). Without the second warmup the
-        ring kernels JIT-compile inside the first *served/timed* chunk, adding ~0.9s to it (first served
-        chunk ~2.16s vs ~1.28s warm, at 5k). (Separately, the very first run ever also pays a one-time
-        ~10.6s empty-disk kernel-cache compile — orthogonal to this warmup.) One-shot
-        (max_seq_len == chunk_size) never reaches the ring path and uses FABRIC_1D, so it skips it."""
+        ring kernels JIT-compile inside the first *served/timed* chunk, inflating first-request TTFT.
+        (This is separate from the one-time empty-disk kernel-cache compile that only the very first run
+        ever pays.) One-shot (max_seq_len == chunk_size) never reaches the ring path and uses FABRIC_1D,
+        so it skips the second warmup."""
         assert self.model_built
         chunk = self.config.chunk_size
         ring = self.config.max_seq_len > chunk


### PR DESCRIPTION
## What

Follow-up to #51992. Fixes first-request TTFT of the chunked prefill path by warming the SP ring
cache-read kernels during `compile()` instead of inside the first *served* chunk.

## Context

`TtPrefillRuntime.compile()` warmed only the `actual_start=0` chunk (the gather-Q / one-shot path).
The SP **ring cache-read** (chunks 1+, `actual_start>0`, `tt/attention/dense_sp.py`) is a *different*
set of kernels and was never warmed, so it JIT-compiled inside the first served/timed chunk. That made
the chunked path look far slower than it is:

| measurement (5k, 36L, 2×2560, single 4×8 Blackhole galaxy) | wall |
|---|---|
| first-ever run, empty on-disk kernel cache | ~10.6 s (one-time full compile) |
| cold process, warm disk cache, first served chunk (before) | ~2.16 s |
| warm steady-state | ~1.28 s (~2× one-shot 0.64 s) |

The ~16× "slowdown" noted in #51992 / #52000 was these caching + JIT artifacts, **not** a steady-state
cost. The genuine overhead is the ~2× warm ring-op cost, tracked for profiling in #52000.

## This PR

- `compile()` warms a second `actual_start>0` chunk (the ring cache-read) when the config is multi-chunk
  (`max_seq_len > chunk_size`). One-shot (`max_seq_len == chunk_size`) skips it — it never hits the ring
  and uses `FABRIC_1D`.
- Fresh `make_chunk_input` per warmup call: `prefill_chunk` consumes (deallocates) its input tensor.

## Validation

Galaxy 4×8, 36L, real bf16 weights, chunked 5k (2×2560), `PREFILL_TPS_ITERS=3`:

| iter | before | after |
|---|---|---|
| 0 (first served chunk) | 2156 ms | **1258 ms** |
| 1 | 1267 ms | 1282 ms |
| 2 | 1287 ms | 1282 ms |

First served chunk now matches warm steady-state; min KV-cache PCC unchanged (0.806).

Refs: #51992, #52000

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-prefill-ring-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/gpt-oss-prefill-ring-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-prefill-ring-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/gpt-oss-prefill-ring-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-prefill-ring-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mdragula/gpt-oss-prefill-ring-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/gpt-oss-prefill-ring-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/gpt-oss-prefill-ring-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/gpt-oss-prefill-ring-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/gpt-oss-prefill-ring-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/gpt-oss-prefill-ring-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/gpt-oss-prefill-ring-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/gpt-oss-prefill-ring-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/gpt-oss-prefill-ring-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/gpt-oss-prefill-ring-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/gpt-oss-prefill-ring-warmup)