### PR TITLE
[Cleanup] Break DispatchCoreManager/ServiceCoreManager MetalContext::instance() cycle

### DIFF
--- a/tt_metal/api/internal/service/service_core_manager.hpp
+++ b/tt_metal/api/internal/service/service_core_manager.hpp
@@ -14,6 +14,7 @@
 
 namespace tt::tt_metal {
 class IDevice;
+class MetalContext;
 class MetalEnvImpl;
 using DeviceAddr = uint64_t;
 }  // namespace tt::tt_metal
@@ -86,9 +87,9 @@ class ServiceCoreManagerImpl;
 //
 class ServiceCoreManager {
 public:
-    // Constructed by MetalContext. Stores a reference to the MetalEnvImpl that owns the cluster,
-    // rtoptions and hal it queries (mirrors dispatch_core_manager).
-    explicit ServiceCoreManager(MetalEnvImpl& env);
+    // Constructed by MetalContext. Stores MetalEnvImpl (cluster/rtoptions/hal) and the owning
+    // MetalContext (for sibling accessors such as get_dispatch_core_manager).
+    ServiceCoreManager(MetalEnvImpl& env, MetalContext& ctx);
     ~ServiceCoreManager();
 
     // Returns dispatch-column cores not yet allocated to FD infra or claimed as service cores.

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -229,7 +229,7 @@ void MetalContext::initialize(
 
     // Initialize dispatch state
     dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(
-        dispatch_core_config_, num_hw_cqs, MetalEnvAccessor(*this->env_).impl());
+        dispatch_core_config_, num_hw_cqs, MetalEnvAccessor(*this->env_).impl(), *this);
     dispatch_query_manager_ =
         std::make_unique<DispatchQueryManager>(*this->env_, *dispatch_core_manager_, dispatch_core_config_, num_hw_cqs);
     const bool is_galaxy_cluster = get_cluster().is_galaxy_cluster();
@@ -320,7 +320,7 @@ void MetalContext::reinitialize_dispatch_managers() {
     // Reinitialize dispatch core manager and query manager to pick up current dispatch mode
     // This refreshes cached dispatch/compute core allocations when transitioning SD<->FD
     dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(
-        dispatch_core_config_, num_hw_cqs_, MetalEnvAccessor(*this->env_).impl());
+        dispatch_core_config_, num_hw_cqs_, MetalEnvAccessor(*this->env_).impl(), *this);
     dispatch_query_manager_ = std::make_unique<DispatchQueryManager>(
         *this->env_, *dispatch_core_manager_, dispatch_core_config_, num_hw_cqs_);
 }
@@ -521,7 +521,7 @@ MetalContext::MetalContext(ContextId context_id, tt::tt_metal::MetalEnv& metal_e
     check_context_id(context_id);
     // Construct before the dispatch managers: dispatch core (re)initialization queries it to exclude
     // claimed service cores from the FD pool.
-    service_core_manager_ = std::make_unique<internal::ServiceCoreManager>(MetalEnvAccessor(*this->env_).impl());
+    service_core_manager_ = std::make_unique<internal::ServiceCoreManager>(MetalEnvAccessor(*this->env_).impl(), *this);
     device_manager_ = std::make_unique<DeviceManager>(metal_env, *this);
 }
 

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -240,8 +240,8 @@ std::optional<tt_cxy_pair> dispatch_core_manager::get_reserved_realtime_profiler
 // private methods
 
 dispatch_core_manager::dispatch_core_manager(
-    const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, MetalEnvImpl& env) :
-    env_(env) {
+    const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, MetalEnvImpl& env, MetalContext& ctx) :
+    env_(env), ctx_(ctx) {
     this->reset_dispatch_core_manager(dispatch_core_config, num_hw_cqs, env);
 }
 
@@ -296,7 +296,7 @@ void dispatch_core_manager::reset_dispatch_core_manager(
         }
 
         // Remove service-owned cores so FD never allocates them.
-        auto claimed = MetalContext::instance().get_service_core_manager().claimed_cores(device_id);
+        auto claimed = ctx_.get_service_core_manager().claimed_cores(device_id);
         if (!claimed.empty()) {
             logical_dispatch_cores.remove_if([&claimed](const CoreCoord& c) { return claimed.contains(c); });
         }

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -24,6 +24,8 @@
 
 namespace tt::tt_metal {
 
+class MetalContext;
+
 // Dispatch core manager APIs track which cores are assigned to which dispatch functionality
 
 // A command queue is split into an issue queue and completion queue
@@ -66,7 +68,9 @@ public:
     ///         This list contains dispatch cores that have not been assigned to a particular dispatch function
     /// @param num_hw_cqs is used to get the correct collection of dispatch cores for a particular device
     /// @param dispatch_core_config specifies the core type that is designated for dispatch functionality
-    dispatch_core_manager(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, MetalEnvImpl& env);
+    /// @param ctx owning MetalContext (for sibling accessors such as get_service_core_manager)
+    dispatch_core_manager(
+        const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, MetalEnvImpl& env, MetalContext& ctx);
 
     static constexpr uint8_t MAX_NUM_HW_CQS = ::MAX_NUM_HW_CQS;
 
@@ -213,6 +217,9 @@ private:
     DispatchCoreConfig dispatch_core_config_;
     uint8_t num_hw_cqs{};
     MetalEnvImpl& env_;
+    // Owning context; used for context-level siblings (e.g. service_core_manager). Keep env_
+    // for env-level cluster/HAL access — do not reach env state through ctx_.
+    MetalContext& ctx_;
     static dispatch_core_manager* _inst;
 };
 

--- a/tt_metal/impl/internal/service/service_core_manager.cpp
+++ b/tt_metal/impl/internal/service/service_core_manager.cpp
@@ -41,7 +41,7 @@ std::pair<DeviceAddr, DeviceAddr> l1_service_range(const Hal& hal) {
 
 // ServiceCoreManagerImpl
 
-ServiceCoreManagerImpl::ServiceCoreManagerImpl(MetalEnvImpl& env) : env_(env) {}
+ServiceCoreManagerImpl::ServiceCoreManagerImpl(MetalEnvImpl& env, MetalContext& ctx) : env_(env), ctx_(ctx) {}
 
 void ServiceCoreManagerImpl::claim(IDevice* device, const std::vector<CoreCoord>& cores) {
     const auto& cluster = env_.get_cluster();
@@ -123,7 +123,7 @@ std::vector<CoreCoord> ServiceCoreManagerImpl::get_claimable_cores(IDevice* devi
         env_.get_rtoptions().get_fast_dispatch(),
         "get_claimable_cores() requires Fast Dispatch to be active. "
         "Call initialize_fast_dispatch() first.");
-    auto available = MetalContext::instance().get_dispatch_core_manager().get_available_dispatch_cores(device->id());
+    auto available = ctx_.get_dispatch_core_manager().get_available_dispatch_cores(device->id());
     // Filter out cores already claimed in this session so consecutive calls reflect current state.
     const auto claimed = claimed_cores(device->id());
     std::erase_if(available, [&claimed](const CoreCoord& c) { return claimed.contains(c); });
@@ -252,7 +252,8 @@ std::optional<DeviceAddr> ServiceCoreManagerImpl::lowest_allocated_address(ChipI
 
 // ServiceCoreManager Public interface
 
-ServiceCoreManager::ServiceCoreManager(MetalEnvImpl& env) : pimpl_(std::make_unique<ServiceCoreManagerImpl>(env)) {}
+ServiceCoreManager::ServiceCoreManager(MetalEnvImpl& env, MetalContext& ctx) :
+    pimpl_(std::make_unique<ServiceCoreManagerImpl>(env, ctx)) {}
 ServiceCoreManager::~ServiceCoreManager() = default;
 
 std::vector<CoreCoord> ServiceCoreManager::get_claimable_cores(IDevice* device) const {

--- a/tt_metal/impl/internal/service/service_core_manager_impl.hpp
+++ b/tt_metal/impl/internal/service/service_core_manager_impl.hpp
@@ -18,6 +18,7 @@
 
 namespace tt::tt_metal {
 class IDevice;
+class MetalContext;
 class MetalEnvImpl;
 using DeviceAddr = uint64_t;
 }  // namespace tt::tt_metal
@@ -34,9 +35,10 @@ namespace tt::tt_metal::internal {
 // 3. If a core already has a service launched on it
 class ServiceCoreManagerImpl {
 public:
-    // Stores a reference to the MetalEnvImpl that owns the cluster, rtoptions and hal we query
-    // (mirrors dispatch_core_manager). The env outlives the MetalContext that owns us.
-    explicit ServiceCoreManagerImpl(MetalEnvImpl& env);
+    // Stores MetalEnvImpl (cluster/rtoptions/hal) and the owning MetalContext (for sibling
+    // accessors such as get_dispatch_core_manager). Env-level queries go through env_;
+    // context-level through ctx_.
+    ServiceCoreManagerImpl(MetalEnvImpl& env, MetalContext& ctx);
 
     // ── User-facing surface (forwarded by ServiceCoreManager) ──────────────────────────────────
     std::vector<CoreCoord> get_claimable_cores(IDevice* device) const;
@@ -94,6 +96,7 @@ private:
     };
 
     MetalEnvImpl& env_;
+    MetalContext& ctx_;
     std::unordered_map<ChipId, DeviceServiceState> devices_;
 };
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Relates to #52020.

There is a recently-introduced interdependency between DCM and SCM.  Pass MetalContext& (similar to what DeviceManager already does) and resolve siblings through ctx_, keeping MetalEnvImpl& for env-level access.

This allows removal of MetalContext::instance() in these objects.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
Both DCM and SCM are MetalContext-owned objects whose lifespan is tied to the MetalContext instance.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/dispatch_core_manager_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/dispatch_core_manager_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/dispatch_core_manager_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/dispatch_core_manager_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ruizhang/dispatch_core_manager_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ruizhang/dispatch_core_manager_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/dispatch_core_manager_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/dispatch_core_manager_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/dispatch_core_manager_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/dispatch_core_manager_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/dispatch_core_manager_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/dispatch_core_manager_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/dispatch_core_manager_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/dispatch_core_manager_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/dispatch_core_manager_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/dispatch_core_manager_context)