### PR TITLE
[Bug fix] Return Metal logical DRAM coords from get_metal_dram_cores, unbreaking watcher on Blackhole

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
@@ -66,6 +66,54 @@ TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
     }
 }
 
+// get_metal_dram_cores(LOGICAL) must name the same cores as get_metal_dram_cores(TRANSLATED), which is
+// the set firmware init and watcher's mailbox init write to. Resolving the logical coords back through
+// the same path a caller uses is what catches a coordinate-space mismatch: UMD's logical DRAM coord is
+// {channel, raw subchannel} while Metal's is {dram_view, dram_bank_endpoint_coords index}, and the
+// table orders each view's NOC0 worker endpoint first, so returning the UMD coord resolved onto the
+// syseng-owned NOC0 endpoint for every view whose worker_endpoint[0] is not subchannel 0.
+TEST_F(DramSubchannelHelperFixture, MetalDramCoresLogicalResolvesToTranslatedSet) {
+    auto mesh_device = devices_[0];
+    auto* device = mesh_device->get_devices()[0];
+    const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device->id());
+    const auto& cluster = MetalContext::instance().get_cluster();
+
+    const auto translated_cores = soc_desc.get_metal_dram_cores(tt::CoordSystem::TRANSLATED);
+    const auto logical_cores = soc_desc.get_metal_dram_cores(tt::CoordSystem::LOGICAL);
+    ASSERT_FALSE(translated_cores.empty());
+    ASSERT_EQ(logical_cores.size(), translated_cores.size());
+
+    // Every DRAM view's NOC0 worker endpoint is syseng-owned on Blackhole and runs no DRISC firmware,
+    // so no returned core may land on one.
+    std::set<std::pair<size_t, size_t>> noc0_endpoints;
+    for (uint32_t view = 0; view < soc_desc.get_num_dram_views(); ++view) {
+        const auto& noc0_endpoint = soc_desc.dram_view_worker_cores.at(view).at(0);
+        noc0_endpoints.emplace(noc0_endpoint.x, noc0_endpoint.y);
+    }
+
+    std::set<std::pair<size_t, size_t>> expected;
+    for (const auto& c : translated_cores) {
+        expected.emplace(c.x, c.y);
+        EXPECT_FALSE(noc0_endpoints.contains({c.x, c.y}))
+            << "TRANSLATED core (" << c.x << ", " << c.y << ") is a NOC0 worker endpoint";
+    }
+
+    std::set<std::pair<size_t, size_t>> resolved;
+    for (const auto& logical_core : logical_cores) {
+        // The conversion watcher and any other logical-coord consumer goes through.
+        const CoreCoord virtual_core =
+            cluster.get_virtual_coordinate_from_logical_coordinates(device->id(), logical_core, CoreType::DRAM);
+        EXPECT_FALSE(noc0_endpoints.contains({virtual_core.x, virtual_core.y}))
+            << "LOGICAL core " << logical_core.str() << " resolved to NOC0 worker endpoint (" << virtual_core.x << ", "
+            << virtual_core.y << ")";
+        resolved.emplace(virtual_core.x, virtual_core.y);
+    }
+
+    EXPECT_EQ(resolved, expected) << "LOGICAL and TRANSLATED requests named different DRAM cores";
+    // No two logical coords may collapse onto one core, or a core would go unvisited.
+    EXPECT_EQ(resolved.size(), logical_cores.size()) << "LOGICAL DRAM coords are not distinct after resolution";
+}
+
 TEST_F(DramSubchannelHelperFixture, RejectsOutOfRangeBank) {
     auto mesh_device = devices_[0];
     auto* device = mesh_device->get_devices()[0];

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -60,15 +60,46 @@ std::vector<tt::tt_metal::CoreCoord> metal_SocDescriptor::get_metal_dram_cores(t
     const auto& umd_dram_cores = get_cores(tt::CoreType::DRAM, coord_system);
     dram_cores.reserve(umd_dram_cores.size());
     for (const tt::umd::CoreCoord& core : umd_dram_cores) {
-        if (exclude_noc0_endpoints) {
-            const tt::umd::CoreCoord translated = translate_coord_to(core, tt::CoordSystem::TRANSLATED);
-            if (is_noc0_dram_endpoint({translated.x, translated.y})) {
-                continue;
-            }
+        const tt::umd::CoreCoord translated = translate_coord_to(core, tt::CoordSystem::TRANSLATED);
+        if (exclude_noc0_endpoints && is_noc0_dram_endpoint({translated.x, translated.y})) {
+            continue;
         }
-        dram_cores.push_back({core.x, core.y});
+        // UMD's LOGICAL DRAM coord is {channel, raw subchannel}, but Metal's logical DRAM space is
+        // {dram_view, index into dram_bank_endpoint_coords}, which orders the NOC0 worker endpoint
+        // first rather than by subchannel id. Handing back the UMD coord would make a caller that
+        // resolves it through get_physical_dram_core_from_logical land on a different core -- and for
+        // any view whose worker_endpoint[0] is not subchannel 0, that core is the syseng-owned NOC0
+        // endpoint this loop just excluded, whose mailbox is never initialized.
+        if (coord_system == tt::CoordSystem::LOGICAL) {
+            dram_cores.push_back(get_logical_dram_core_from_translated({translated.x, translated.y}));
+        } else {
+            dram_cores.push_back({core.x, core.y});
+        }
     }
     return dram_cores;
+}
+
+tt::tt_metal::CoreCoord metal_SocDescriptor::get_logical_dram_core_from_translated(
+    const tt::tt_metal::CoreCoord& translated_coord) const {
+    // A view can share its NOC endpoints with the other views carved out of the same channel, so this
+    // returns the lowest view index that reaches translated_coord. Every such coord resolves back to
+    // translated_coord through get_physical_dram_core_from_logical, which is what callers rely on; use
+    // get_logical_dram_core_for_subchannel instead when a specific view is wanted.
+    for (size_t dram_view = 0; dram_view < this->dram_bank_endpoint_coords.size(); ++dram_view) {
+        const auto& endpoints = this->dram_bank_endpoint_coords[dram_view];
+        for (size_t idx = 0; idx < endpoints.size(); ++idx) {
+            if (endpoints[idx] == translated_coord) {
+                return tt::tt_metal::CoreCoord{static_cast<uint32_t>(dram_view), static_cast<uint32_t>(idx)};
+            }
+        }
+    }
+    TT_THROW(
+        "Translated DRAM core ({}, {}) is not a NOC endpoint of any of the {} DRAM views, so it has no logical "
+        "DRAM coordinate. Every DRAM core Metal can address is reachable through some view, so this coord is "
+        "either not a DRAM core or belongs to a harvested channel",
+        translated_coord.x,
+        translated_coord.y,
+        this->dram_bank_endpoint_coords.size());
 }
 
 tt::tt_metal::CoreCoord metal_SocDescriptor::get_preferred_eth_core_for_dram_view(int dram_view, uint8_t noc) const {

--- a/tt_metal/llrt/metal_soc_descriptor.hpp
+++ b/tt_metal/llrt/metal_soc_descriptor.hpp
@@ -50,6 +50,9 @@ public:
     // endpoint, which is owned by the syseng firmware (CMFW DRAM telemetry, SYS-1419) and runs no
     // DRISC firmware. Hardware without that restriction returns all DRAM cores -- callers never need
     // to special-case it.
+    // A LOGICAL request returns Metal logical DRAM coords ({dram_view, dram_bank_endpoint_coords
+    // index}, the space get_physical_dram_core_from_logical and CreateKernel(DramConfig) use), not
+    // UMD's {channel, raw subchannel}.
     std::vector<tt::tt_metal::CoreCoord> get_metal_dram_cores(tt::CoordSystem coord_system) const;
     tt::tt_metal::CoreCoord get_logical_core_for_dram_view(int dram_view) const;
     size_t get_address_offset(int dram_view) const;
@@ -65,6 +68,13 @@ public:
     // Map a DRAM view + hardware subchannel to the logical CoreCoord used by CreateKernel(DramConfig).
     // logical.y indexes dram_bank_endpoint_coords (worker endpoint first), not the raw subchannel id.
     tt::tt_metal::CoreCoord get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const;
+    // Same logical space as get_logical_dram_core_for_subchannel, keyed by a TRANSLATED coord. Inverse
+    // of get_physical_dram_core_from_logical. A DRAM view is a dram_view_size window of one hardware
+    // channel -- what Metal allocates against as a DRAM bank -- so a channel split into several views
+    // (Wormhole: two 1 GB views per channel) has one set of NOC endpoints serving all of them. This
+    // returns the lowest view reaching the coord; it round-trips, but is not the only answer.
+    tt::tt_metal::CoreCoord get_logical_dram_core_from_translated(
+        const tt::tt_metal::CoreCoord& translated_coord) const;
     tt::tt_metal::CoreCoord get_physical_dispatch_engine_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const;
     uint32_t get_num_dispatch_engine_cores() const;
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`TT_METAL_WATCHER=1` is unusable on Blackhole boards that have DRAM programmable cores enabled. Watcher aborts on its very first poll, during device init, before any test body runs:

```
Watcher data corruption, unexpected drisc kernel id on Device 0 core 18-14: 37091 (last valid 1)
```

The cause is a coordinate-space mismatch. `get_metal_dram_cores(LOGICAL)` handed back UMD's logical DRAM coord, `{channel, raw subchannel}`, but Metal's logical DRAM space is `{dram_view, index into dram_bank_endpoint_coords}` — and that table is built preferred-endpoint-first, so index 0 is `worker_endpoint[0]` (the NOC0 endpoint) rather than subchannel 0. A caller resolving the returned coord through `get_physical_dram_core_from_logical` therefore landed on a different core than the one the filter had selected.

For any DRAM view whose `worker_endpoint[0]` is not subchannel 0 — channels 0, 4, 5, 6 and 7 in `blackhole_140_arch.yaml` — index 0 of the reordered table is the syseng-owned NOC0 endpoint that `get_metal_dram_cores` exists to exclude. So the mismatch undid the exclusion: the filter dropped the NOC0 endpoint, then the conversion resolved a survivor straight back onto it. That core runs no DRISC firmware and its launch message is never initialized, so watcher read a garbage `watcher_kernel_id` and threw.

Worked through on the p100a this reproduced on, which has one DRAM bank harvested (so UMD maps the west column to `dram_translated_coordinate_start_x + 1`):

| step | value |
|---|---|
| view 0, subchannels 0/1/2 | translated (18,12) / (18,13) / **(18,14)** |
| channel 0 `worker_endpoint[0]` | 2, so `dram_bank_endpoint_coords[0]` = [(18,14), (18,12), (18,13)] |
| filter drops the NOC0 endpoint | (18,14) |
| first surviving UMD logical coord | (0,0) |
| watcher resolved (0,0) to | `dram_bank_endpoint_coords[0][0]` = **(18,14)**, the excluded endpoint |

Because that is the first DRAM core dumped, it failed immediately rather than partway through.

**Harvesting is not required to trigger this**, and neither is the p100a specifically. The reorder comes from the descriptor's `worker_endpoint` values, which are the same on every Blackhole board; harvesting only shifts which column the affected view sits in. On an unharvested 8-bank board view 0 sits at `x=17` instead, so the first bad read is (17,14) rather than (18,14), and the abort is identical.

`get_metal_dram_cores` now returns Metal logical coords for a `LOGICAL` request, via a new `get_logical_dram_core_from_translated` — the inverse of `get_physical_dram_core_from_logical`. Watcher itself needs no change, and its log lines now print `{view, endpoint index}`, the same space `CreateKernel(DramConfig)` takes.

### Notes for reviewers

**Blast radius is one code path.** The watcher reader (`watcher_device_reader.cpp:442`) was the only caller passing `LOGICAL`. Every other caller passes `TRANSLATED` and is untouched by this change: firmware L1 zeroing and reset (`risc_firmware_initializer.cpp:316`, `:410`), launch-message reset (`:1480`), `device.cpp:449`, the inspector RPC that feeds tt-triage (`inspector/data.cpp:404`), and — the telling one — watcher's *own* mailbox initializer (`watcher_server.cpp:531`). Watcher wrote its init values to the right set of cores and then read a different set.

**Why it hid for so long.** When `worker_endpoint[0]` is subchannel 0 the reorder is the identity and the two coordinate spaces coincide, which is the case for channels 1, 2 and 3. It also only bites where DRAM programmable cores are enabled at all, so it needs a Blackhole board above the firmware floor.

**I checked for the same bug class elsewhere and found none.** Every other holder of a Metal-logical DRAM coord gets it from `get_logical_dram_core_for_subchannel` (`mesh_device.cpp:1559`, `:1586`, `test_dram_subchannel_helper.cpp:58`), which already searches `dram_bank_endpoint_coords` and so is in the correct space. `get_dram_channel_from_logical_core` likewise treats `.x` as the view index. The watcher reader was unique in taking a UMD-logical coord from `get_metal_dram_cores` and feeding it to the Metal-logical resolver.

**The new reverse lookup is not injective, by construction.** A DRAM view is a `dram_view_size` window of one hardware channel — what Metal allocates against as a bank — so a channel carved into several views has one set of NOC endpoints serving all of them. Blackhole has one view per channel (8, or 7 with a bank harvested), but Wormhole has two 1 GB views per channel, 12 in total, where a given translated core is an endpoint of two views. `get_logical_dram_core_from_translated` returns the lowest such view. That round-trips correctly through `get_physical_dram_core_from_logical`, which is all any caller here relies on, and `get_logical_dram_core_for_subchannel` remains the way to name a specific view. Both are documented at the declaration. It is moot on today's hardware — Wormhole has no DRAM programmable cores, so nothing requests `LOGICAL` there — but it is the one place a future caller could be surprised.

**tt-triage was already defended against this, deliberately.** It consumes the inspector's `dramCores` as TRANSLATED (`tools/triage/run_checks.py:222`), with a comment stating that TRANSLATED "avoid[s] the UMD-vs-metal logical-DRAM numbering mismatch". So the hazard was known in the triage path; the watcher reader is the one place it was missed. Triage does have a separate, milder gap — its exalens fallback list is not NOC0-filtered, so a device the inspector does not cover gets the NOC0-inclusive enumeration — but that is unrelated to this change and produces spurious findings rather than an abort, so it is left alone here.

**Harvesting is handled by delegation, not by arithmetic.** #47895 fixed a family of bugs where a *physical* DRAM channel was passed somewhere a *compacted/logical* index is required, which on a mid-grid-harvested board indexes the wrong core and can select a syseng GDDR telemetry endpoint. The new reverse lookup is structurally immune: it performs no channel arithmetic at all, only a search of `dram_bank_endpoint_coords` keyed by a TRANSLATED coord. Both sides are already harvesting-resolved — the table is built through the post-#47895 `logical_channel = channel - harvested_before(mask, channel)` path, and the coord being looked up comes from UMD, whose `translate_dram_coords` skips harvested banks and compacts `logical_x`. The board this was developed and tested on is a mid-grid-harvested p100a (7 views), which is exactly the configuration #47895 was about.

**Testing.** A regression test, `DramSubchannelHelperFixture.MetalDramCoresLogicalResolvesToTranslatedSet`, asserts the property the bug violated: the LOGICAL and TRANSLATED requests name the same cores, resolution is injective so no core goes unvisited, and nothing lands on a view's NOC0 worker endpoint. It resolves through `get_virtual_coordinate_from_logical_coordinates`, the path watcher uses, rather than restating the descriptor's internals. Verified to have teeth — with the remap reverted it fails on this board with 5 of the 7 views resolving onto a NOC0 endpoint:

```
LOGICAL core 0-0 resolved to NOC0 worker endpoint (18, 14)
LOGICAL core 3-0 resolved to NOC0 worker endpoint (17, 14)
LOGICAL core 4-0 resolved to NOC0 worker endpoint (17, 17)
LOGICAL core 5-0 resolved to NOC0 worker endpoint (17, 20)
LOGICAL core 6-0 resolved to NOC0 worker endpoint (17, 23)
```

Five is the count you would predict: channels 0, 4, 5, 6 and 7 are the ones with `worker_endpoint[0] == 2`. `unit_tests_api DramSubchannelHelperFixture.*` is 3/3 with the fix (needs `TT_METAL_SLOW_DISPATCH_MODE=1`, or `BlackholeSingleCardFixture` skips).

Blackhole p100a (one DRAM bank harvested, so 7 DRAM views), `TT_METAL_WATCHER=1`, `unit_tests_dispatch --gtest_filter='*Buffer*'`:

| | before | after |
|---|---|---|
| result | aborted at watcher's first poll, 0 device tests reached | 154 run / 110 passed / 0 failed |
| NoC sanitizer hits | — | 0 |

Watcher now reads 14 DRAM cores (7 views x 2 non-NOC0 endpoints), endpoint index 0 is never touched, and (18,14) never appears. Every DRAM line reads `GW ... rmsg:H0D|dr h_id: 0` with `k_ids: 0`, uniform across all 14 — a DRISC parked in its go-message wait with no kernel resident, which is what an idle DRAM core should look like, against the 37091 garbage before.

**What this does not cover.** I could not observe watcher reporting a *non-zero* DRISC kernel id, because DRAM-core kernel tests cannot run under watcher on this board for an unrelated reason: `unit_tests_api --gtest_filter='*DramKernel*'` aborts on a device-side NOC sanitizer verdict, reproducibly and from a freshly reset device:

```
BRISC using noc0 tried to unicast read 4 bytes to local L1[0x000000] from DRAM core
w/ virtual coords 18-12 DRAM[addr=0xffb4f028]
(NOC target address did not map to any known Tensix/Ethernet/DRAM/PCIE core)
```

That is `DebugSanitizeNocTargetInvalidXY`, a `dev_msgs` code raised by the kernel-side sanitizer and merely formatted by the host, so it is independent of this change — the sanitizer's own core-type lookup uses `get_cores(DRAM, TRANSLATED)`, not `get_metal_dram_cores`. It reads as the device-side XY/address validation not accepting a DRISC L1-window address on a DRAM core. The same 20 tests pass 20/20 with watcher off. Worth a separate issue; it means watcher still cannot be used on the DRISC kernel path even with this fix, though it can now be used on everything else.

This also unblocked the watcher-enabled leg of #51272's test plan, which could not be run on this board before: with both changes applied locally, `UnitMeshCQSingleCard*BufferFixture*` is 57/57 under watcher with no sanitizer hits.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/watcher-dram-logical-coord-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/watcher-dram-logical-coord-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/watcher-dram-logical-coord-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/watcher-dram-logical-coord-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/watcher-dram-logical-coord-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/watcher-dram-logical-coord-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/watcher-dram-logical-coord-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/watcher-dram-logical-coord-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/watcher-dram-logical-coord-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/watcher-dram-logical-coord-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/watcher-dram-logical-coord-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/watcher-dram-logical-coord-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/watcher-dram-logical-coord-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/watcher-dram-logical-coord-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/watcher-dram-logical-coord-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/watcher-dram-logical-coord-fix)