### PR TITLE
[skip ci] [Cleanup] tt_transformers: remove unreachable per_core_M arm in prefill QKV config

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1667,16 +1667,12 @@ class ModelArgs:
                     in0_block_w=1,  # FIXME: optimize this config for prefill, careful use DI_DT_WORKAROUND if necessary
                     out_subblock_h=1,  # Must be divisible by per_core_M
                     out_subblock_w=1,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
-                    per_core_M=1  # workaround for issue #50656
-                    if self.device_name == "P100"
-                    else (
-                        max(  # NOTE: P100 runs OOM in L1 with 8 per_core_M
-                            1,
-                            8
-                            if seq_len >= self.MAX_QKV_MM_SEQ_LEN
-                            else math.ceil(seq_len / ttnn.TILE_SIZE / 8),  # 8 rows
-                        )
-                    ),  # M / TILE_HEIGHT / Grid_Size (dynamic based on seqlen)
+                    # This branch is only reached when use_minimal_qkv_prefill_matmul() is False,
+                    # i.e. seq_len <= 128, so the former `8 if seq_len >= MAX_QKV_MM_SEQ_LEN` arm
+                    # (MAX_QKV_MM_SEQ_LEN == 2048) was unreachable and has been removed. At every
+                    # reachable seq_len the max(1, ...) floor makes this 1.
+                    # NOTE: P100 runs OOM in L1 with a larger per_core_M (workaround for issue #50656).
+                    per_core_M=1 if self.device_name == "P100" else max(1, math.ceil(seq_len / ttnn.TILE_SIZE / 8)),
                     per_core_N=math.ceil(
                         self.qkv_size / self.cluster_shape[1] / 32 / self.dram_shard_grid_width
                     ),  # N / TILE_WIDTH / grid width


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
`get_attn_qkv_program_config(Mode.PREFILL, ...)` builds the dense
`MatmulMultiCoreReuseMultiCastProgramConfig` only in the `else` of
`if self.use_minimal_qkv_prefill_matmul(seq_len)`. That predicate returns `True` for every
`seq_len > 128`, so the dense branch is reachable only for `seq_len <= 128`.

Inside it, `per_core_M` was computed as:

```python
max(1, 8 if seq_len >= self.MAX_QKV_MM_SEQ_LEN         # MAX_QKV_MM_SEQ_LEN == 2048
        else math.ceil(seq_len / ttnn.TILE_SIZE / 8))
```

The `seq_len >= 2048` arm can never be taken. The gate lives **inside the same method**, so no
caller can reach this config with `seq_len >= 2048` regardless of call site. It is a leftover from
before `minimal_matmul` took over long prefill (#33149 / #37739).

This drops the dead arm and the now-misleading `# 8 rows` / `Grid_Size` trailing comments, and adds
a short note recording why the branch is `seq_len <= 128`-only.

**No functional change.** The two expressions agree for every `seq_len <= 2048`, which strictly
contains the reachable domain. In practice the reachable domain is a single value: prefill lengths
are quantized by `get_padded_prefill_len()` to `{128, 1024, 2048, 4096, ...}` and chunked prefill
emits only multiples of 2048 (`get_max_prefill_chunk_size`, `MIN_CHUNK_SIZE = 2048`), so
intersecting with `<= 128` leaves exactly `seq_len == 128`, where `per_core_M == 1` either way.

### Notes for reviewers

- **The one place the old and new expressions differ is above 2048** (e.g. 4096: old `8`, new `16`).
  That region is unreachable here today, which is the whole basis for the removal — but if a future
  change routes long prefill back to this config, `per_core_M` would need revisiting. That is why
  the reachability constraint is now written down in a comment rather than left implicit.
- The `device_name == "P100"` special case and its `#50656` workaround value are preserved
  unchanged; only the non-P100 arm was touched.
- Incidental observation, deliberately **not** changed in this PR: on this branch `fuse_batch=seq_len
  <= self.MAX_QKV_MM_SEQ_LEN` is likewise always `True`, and the P100 `per_core_M=1` now coincides
  with what the general expression yields at `seq_len <= 128`. Both are constant-folding
  opportunities rather than dead code, and both still document real intent, so they are left alone
  to keep this diff minimal.
- Verified locally: `black` (23.10.1, the pinned pre-commit version) clean, full pre-commit suite
  passes. No device run — the change is provably behaviour-preserving over the reachable domain, as
  argued above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
