### PR TITLE
[gpt_oss_d_p] Top-1 / logits functional sign-off harness (PREFILL_TOP1)

### DIFF
--- a/models/demos/gpt_oss_d_p/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/gpt_oss_d_p/tests/galaxy_prefill_kv_pcc.py
@@ -16,6 +16,8 @@ Env:
   PREFILL_CHUNKED     "1" -> chunked (SP ring cache-read for chunks 1+); "0" -> one-shot            [default 0]
   PREFILL_CHUNK_SIZE  chunk size in tokens (chunked mode only)                             [default 5120]
   PREFILL_TPS_ITERS   prefill repetitions for the throughput measurement                   [default 1]
+  PREFILL_TOP1        "1" -> also run the top-1 / logits sign-off vs golden (one-shot only)  [default 0]
+  GPT_OSS_TOP1_MIN    fail if top-1 agreement < this fraction (CI gate; needs reference_top1) [default unset]
   PREFILL_NUM_LAYERS  build/run only the first N decoder layers (faster partial-model runs) [default: all]
   EXPERT_DTYPE        MoE routed-expert weight dtype: "bf4" or "bf8"                        [default bf4]
   GPT_OSS_WEIGHTS_FROM_CACHE  "1" -> pass an empty state_dict (load tilized weights from the TTNN cache)
@@ -200,6 +202,49 @@ def main():
         if _pcc_min is not None and min_pcc < float(_pcc_min):
             print(f"[prefill-pcc] FAIL: min KV PCC {min_pcc:.5f} < GPT_OSS_KV_PCC_MIN={_pcc_min}", flush=True)
             return 1
+
+        # --- functional sign-off: top-1 / logits agreement vs golden (one-shot only) ---
+        # PREFILL_TOP1=1 runs one extra forward with the LM head, gathers the SP-seq + TP-vocab sharded
+        # logits, argmaxes per position, and compares to the golden's reference_top1 (HF argmax). This
+        # is the definitive "does prefill predict the right tokens" check (KV PCC is only a proxy).
+        # Gate on GPT_OSS_TOP1_MIN when set (CI); needs the golden to carry reference_top1.safetensors.
+        if os.getenv("PREFILL_TOP1", "0") == "1":
+            if n_chunks != 1:
+                print("[prefill-pcc] TOP1 needs one-shot (PREFILL_CHUNKED=0); skipping top-1", flush=True)
+            else:
+                inp = runtime.make_chunk_input(padded[:chunk])
+                out = runtime.prefill_chunk(inp, slot_id=0, actual_start=0, actual_end=n_tokens, skip_lm_head=False)
+                our_top1 = runtime.logits_top1_oneshot(out, n_tokens)
+                out.deallocate(True)
+                try:
+                    agree, ncmp, first = runtime.top1_check(our_top1, golden_dir)
+                    print(
+                        f"[prefill-pcc] TOP-1 agreement vs golden: {agree * 100:.2f}% over {ncmp} positions "
+                        f"(first-token match={first})",
+                        flush=True,
+                    )
+                    _top1_min = os.environ.get("GPT_OSS_TOP1_MIN")
+                    if _top1_min is not None and agree < float(_top1_min):
+                        print(f"[prefill-pcc] FAIL: TOP-1 {agree:.4f} < GPT_OSS_TOP1_MIN={_top1_min}", flush=True)
+                        return 1
+                except FileNotFoundError as e:
+                    # No reference yet: report our own prediction so the device path is still validated.
+                    tok0, gen = int(our_top1[0]), int(our_top1[-1])
+                    dec0 = dec_gen = ""
+                    try:
+                        from transformers import AutoTokenizer
+
+                        _tk = AutoTokenizer.from_pretrained(os.environ["HF_MODEL"])
+                        dec0, dec_gen = repr(_tk.decode([tok0])), repr(_tk.decode([gen]))
+                    except Exception:
+                        pass
+                    print(
+                        f"[prefill-pcc] TOP1: no golden reference ({e}); device path OK "
+                        f"({our_top1.numel()} positions). pos0 pred id={tok0} {dec0}; "
+                        f"generation (after prompt) id={gen} {dec_gen}",
+                        flush=True,
+                    )
+
         print("[prefill-pcc] DONE", flush=True)
     finally:
         ttnn.close_mesh_device(mesh)

--- a/models/demos/gpt_oss_d_p/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/gpt_oss_d_p/tests/galaxy_prefill_kv_pcc.py
@@ -209,41 +209,54 @@ def main():
         # is the definitive "does prefill predict the right tokens" check (KV PCC is only a proxy).
         # Gate on GPT_OSS_TOP1_MIN when set (CI); needs the golden to carry reference_top1.safetensors.
         if os.getenv("PREFILL_TOP1", "0") == "1":
+            _top1_min = os.environ.get("GPT_OSS_TOP1_MIN")
             if n_chunks != 1:
-                print("[prefill-pcc] TOP1 needs one-shot (PREFILL_CHUNKED=0); skipping top-1", flush=True)
-            else:
-                inp = runtime.make_chunk_input(padded[:chunk])
-                out = runtime.prefill_chunk(inp, slot_id=0, actual_start=0, actual_end=n_tokens, skip_lm_head=False)
-                our_top1 = runtime.logits_top1_oneshot(out, n_tokens)
-                out.deallocate(True)
+                # Top-1 is one-shot only; a chunked run can't exercise it. Fail loudly rather than
+                # silently no-op, so a CI job that asked for the sign-off can't go green without it.
+                print(
+                    f"[prefill-pcc] FAIL: PREFILL_TOP1 is one-shot only — set PREFILL_CHUNKED=0 "
+                    f"(got n_chunks={n_chunks})",
+                    flush=True,
+                )
+                return 1
+            inp = runtime.make_chunk_input(padded[:chunk])
+            out = runtime.prefill_chunk(inp, slot_id=0, actual_start=0, actual_end=n_tokens, skip_lm_head=False)
+            our_top1 = runtime.logits_top1_oneshot(out, n_tokens)
+            out.deallocate(True)
+            try:
+                agree, ncmp, gen_match = runtime.top1_check(our_top1, golden_dir)
+                print(
+                    f"[prefill-pcc] TOP-1 agreement vs golden: {agree * 100:.2f}% over {ncmp} positions "
+                    f"(gen-token match={gen_match})",
+                    flush=True,
+                )
+                if _top1_min is not None and agree < float(_top1_min):
+                    print(f"[prefill-pcc] FAIL: TOP-1 {agree:.4f} < GPT_OSS_TOP1_MIN={_top1_min}", flush=True)
+                    return 1
+            except FileNotFoundError as e:
+                # A configured gate must not pass without an HF comparison.
+                if _top1_min is not None:
+                    print(
+                        f"[prefill-pcc] FAIL: GPT_OSS_TOP1_MIN={_top1_min} set but no golden reference ({e})",
+                        flush=True,
+                    )
+                    return 1
+                # Ungated bring-up: report our own prediction so the device path is still validated.
+                tok0, gen = int(our_top1[0]), int(our_top1[-1])
+                dec0 = dec_gen = ""
                 try:
-                    agree, ncmp, first = runtime.top1_check(our_top1, golden_dir)
-                    print(
-                        f"[prefill-pcc] TOP-1 agreement vs golden: {agree * 100:.2f}% over {ncmp} positions "
-                        f"(first-token match={first})",
-                        flush=True,
-                    )
-                    _top1_min = os.environ.get("GPT_OSS_TOP1_MIN")
-                    if _top1_min is not None and agree < float(_top1_min):
-                        print(f"[prefill-pcc] FAIL: TOP-1 {agree:.4f} < GPT_OSS_TOP1_MIN={_top1_min}", flush=True)
-                        return 1
-                except FileNotFoundError as e:
-                    # No reference yet: report our own prediction so the device path is still validated.
-                    tok0, gen = int(our_top1[0]), int(our_top1[-1])
-                    dec0 = dec_gen = ""
-                    try:
-                        from transformers import AutoTokenizer
+                    from transformers import AutoTokenizer
 
-                        _tk = AutoTokenizer.from_pretrained(os.environ["HF_MODEL"])
-                        dec0, dec_gen = repr(_tk.decode([tok0])), repr(_tk.decode([gen]))
-                    except Exception:
-                        pass
-                    print(
-                        f"[prefill-pcc] TOP1: no golden reference ({e}); device path OK "
-                        f"({our_top1.numel()} positions). pos0 pred id={tok0} {dec0}; "
-                        f"generation (after prompt) id={gen} {dec_gen}",
-                        flush=True,
-                    )
+                    _tk = AutoTokenizer.from_pretrained(os.environ["HF_MODEL"])
+                    dec0, dec_gen = repr(_tk.decode([tok0])), repr(_tk.decode([gen]))
+                except Exception:
+                    pass
+                print(
+                    f"[prefill-pcc] TOP1: no golden reference ({e}); device path OK "
+                    f"({our_top1.numel()} positions). pos0 pred id={tok0} {dec0}; "
+                    f"generation (after prompt) id={gen} {dec_gen}",
+                    flush=True,
+                )
 
         print("[prefill-pcc] DONE", flush=True)
     finally:

--- a/models/demos/gpt_oss_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/gpt_oss_d_p/tt/tt_prefill_runtime.py
@@ -337,7 +337,13 @@ class TtPrefillRuntime:
 
     def top1_check(self, our_top1, trace_dir):
         """Compare our per-position top-1 to the golden reference (reference_top1.safetensors, key
-        top1_token_ids [n_tokens]). Returns (agreement_fraction, n_compared, first_token_match)."""
+        top1_token_ids [n_tokens]). Returns (agreement_fraction, n_positions, gen_token_match).
+
+        gen_token_match is the FIRST GENERATED token — the argmax at the LAST prompt position
+        (our_top1[-1]), i.e. the token the model would emit after the prompt. (Position 0 is a
+        teacher-forced next-token, not the generation.) Requires a FULL-length reference: a truncated /
+        mismatched golden is rejected, not silently partially compared, since this is the definitive
+        full-prompt sign-off."""
         from safetensors import safe_open
 
         ref_path = Path(trace_dir) / "reference_top1.safetensors"
@@ -348,10 +354,15 @@ class TtPrefillRuntime:
             )
         with safe_open(str(ref_path), framework="pt") as h:
             ref = h.get_tensor("top1_token_ids").reshape(-1).long()
-        n = min(ref.numel(), our_top1.numel())
-        agree = float((our_top1[:n].long() == ref[:n]).float().mean())
-        first = bool(our_top1[0].long() == ref[0].long()) if n else False
-        return agree, n, first
+        our = our_top1.long()
+        if ref.numel() != our.numel():
+            raise ValueError(
+                f"reference_top1 has {ref.numel()} positions but prefill produced {our.numel()}; the "
+                f"sign-off needs a full-prompt reference — regenerate the golden for this exact prompt."
+            )
+        agree = float((our == ref).float().mean())
+        gen_match = bool(our[-1] == ref[-1])  # first generated token = argmax at the last prompt position
+        return agree, our.numel(), gen_match
 
     def kv_cache_pcc_check(
         self, kv_caches=None, *, slot_id: int, n_chunks: int, trace_dir=None, first_layer_idx: int = 0

--- a/models/demos/gpt_oss_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/gpt_oss_d_p/tt/tt_prefill_runtime.py
@@ -307,6 +307,52 @@ class TtPrefillRuntime:
         logger.info(f"[kv-diag L{gL}] K per-head:     {heads}")
         logger.info(f"[kv-diag L{gL}] dumped -> {out_dir / f'layer_{gL}.pt'}")
 
+    def logits_top1_oneshot(self, out, n_tokens):
+        """One-shot: convert SP-seq + TP-vocab sharded prefill logits to per-position GLOBAL top-1
+        token id in natural token order, first ``n_tokens``.
+
+        out: per-device [1,1,chunk_local,vocab_shard].
+        - SEQUENCE is sharded CONTIGUOUSLY across SP rows (prepare_inputs_prefill uses a
+          ShardTensor2dMesh split on the seq dim: row r = positions [r*cl:(r+1)*cl]). This is the
+          ACTIVATION layout and is NOT block-cyclic -- block-cyclic is only the KV-CACHE storage
+          layout (gather_layer un-rotates that; the logits are a plain activation, so no un-rotation).
+          => concatenating the rows in mesh order already gives natural token order.
+        - VOCAB is col-parallel: col c holds a contiguous shard, and lm_head is PADDED to a pow2
+          padded_vocab_size with ZEROS (model.py). => concat the col shards in order, then SLICE to the
+          real vocab_size before argmax, else a zero-padded index can win when all real logits are < 0.
+
+        Bring-up hook for the top-1 functional sign-off (galaxy_prefill_kv_pcc TOP1 mode). One-shot only
+        (single chunk == whole seq). Validated end-to-end vs reference_top1 when the golden carries it."""
+        sp = self.config.sp_factor
+        cols = self.config.tp_factor
+        vocab = self.hf_config.vocab_size
+        dts = ttnn.get_device_tensors(out)
+        rows = []
+        for r in range(sp):
+            shards = [ttnn.to_torch(dts[r * cols + c])[0, 0].float() for c in range(cols)]  # [cl, vshard]
+            full = torch.cat(shards, dim=-1)[:, :vocab]  # [chunk_local, vocab] (drop pow2 zero-padding)
+            rows.append(full.argmax(dim=-1))  # [chunk_local] global vocab id
+        dev = torch.cat(rows, dim=0)  # contiguous SP-row order == natural token order (no un-rotation)
+        return dev[:n_tokens]  # [n_tokens] argmax token ids
+
+    def top1_check(self, our_top1, trace_dir):
+        """Compare our per-position top-1 to the golden reference (reference_top1.safetensors, key
+        top1_token_ids [n_tokens]). Returns (agreement_fraction, n_compared, first_token_match)."""
+        from safetensors import safe_open
+
+        ref_path = Path(trace_dir) / "reference_top1.safetensors"
+        if not ref_path.exists():
+            raise FileNotFoundError(
+                f"{ref_path} missing - golden has no reference top-1 yet (ask the golden generator to "
+                f"save logits.argmax(-1) as top1_token_ids)."
+            )
+        with safe_open(str(ref_path), framework="pt") as h:
+            ref = h.get_tensor("top1_token_ids").reshape(-1).long()
+        n = min(ref.numel(), our_top1.numel())
+        agree = float((our_top1[:n].long() == ref[:n]).float().mean())
+        first = bool(our_top1[0].long() == ref[0].long()) if n else False
+        return agree, n, first
+
     def kv_cache_pcc_check(
         self, kv_caches=None, *, slot_id: int, n_chunks: int, trace_dir=None, first_layer_idx: int = 0
     ) -> float:


### PR DESCRIPTION
## What

Adds the **top-1 / logits functional sign-off** harness for GPT-OSS prefill — the definitive accuracy
check that KV-cache PCC only proxies. Follow-up to #51992; implements the harness side of #52002.

## Why

Prefill has been validated via **KV-cache PCC** (min ~0.80–0.86 at depth). That's a proxy — it doesn't
answer the real question: **does prefill predict the same tokens as HF at each position?** Top-1 /
logits agreement does.

## This PR

- `runtime.logits_top1_oneshot()` — gathers the SP-seq + TP-vocab sharded prefill logits, drops the
  pow2 vocab zero-padding, argmaxes per position → `[n_tokens]` global token ids. One-shot only
  (single chunk == whole seq); contiguous SP-row order is already natural token order.
- `runtime.top1_check()` — compares to the golden's `reference_top1.safetensors` (key
  `top1_token_ids`) → `(agreement, n_compared, first_token_match)`.
- Harness `PREFILL_TOP1=1` (one-shot): one extra forward with the LM head, compares, and **gates on
  `GPT_OSS_TOP1_MIN`** when set — a CI gate parallel to `GPT_OSS_KV_PCC_MIN`. Absent a reference it
  reports our own prediction so the device path is still exercised.

## Golden dependency

The golden currently has no `reference_top1`. The generator **already runs the full HF forward**
(metadata: `forward_time_seconds`, HF `AutoModelForCausalLM`), so producing it is a ~2-line add:

```python
save_file({"top1_token_ids": logits[0].argmax(-1).to(torch.int32).contiguous()},
          out_dir / "reference_top1.safetensors")  # same token_ids/prompt as the KV golden
```

Once the golden carries it, set `GPT_OSS_TOP1_MIN` and register the galaxy job (#52003).

## Validation

Galaxy 4×8, 36L, real bf16 weights, one-shot 5k: **5000 positions computed**, KV PCC 0.859; device
path OK (reference pending, so agreement is not yet numeric).

## Not in this PR

- Chunked (multi-chunk) top-1 — follow-up.
- The `ATTN_WEIGHT_DTYPE` diagnostic knob — separate follow-up.

Refs: #51992, #52002, #52003

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-top1-signoff)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/gpt-oss-top1-signoff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-top1-signoff)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/gpt-oss-top1-signoff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-top1-signoff)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mdragula/gpt-oss-top1-signoff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/gpt-oss-top1-signoff)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/gpt-oss-top1-signoff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/gpt-oss-top1-signoff)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/gpt-oss-top1-signoff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/gpt-oss-top1-signoff)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/gpt-oss-top1-signoff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/gpt-oss-top1-signoff)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/gpt-oss-top1-signoff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/gpt-oss-top1-signoff)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/gpt-oss-top1-signoff)