### PR TITLE
[#46523] Fix BH layernorm-welford non-deterministic FP32 output (SrcB dest-reuse race)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -31,6 +31,10 @@ inline void llk_math_set_fp32_dest_acc(bool enable) { _llk_math_set_fp32_dest_ac
 
 inline void llk_math_reconfig_remap(const bool remap_enable) { _llk_math_reconfig_remap_(remap_enable); }
 
+// Release a stale (MatrixUnit-owned) SrcB bank before a DEST_TO_SRCB dest-reuse so its first SrcB load gates on
+// the current unpack. Only valid when the preceding op left SrcB stale; misaligns/deadlocks a clean entry. #46523.
+inline void llk_math_reset_srcb_bank_valid() { _llk_math_reset_srcb_bank_valid_(); }
+
 inline void llk_math_wait_for_dest_available() {
     WAYPOINT("MWDW");
     _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -31,6 +31,10 @@ inline void llk_math_set_fp32_dest_acc(bool enable) { _llk_math_set_fp32_dest_ac
 
 inline void llk_math_reconfig_remap(const bool /*remap_enable*/) {}
 
+// Release a stale (MatrixUnit-owned) SrcB bank before a DEST_TO_SRCB dest-reuse so its first SrcB load gates on
+// the current unpack. Only valid when the preceding op left SrcB stale; misaligns/deadlocks a clean entry. #46523.
+inline void llk_math_reset_srcb_bank_valid() { _llk_math_reset_srcb_bank_valid_(); }
+
 inline void llk_math_wait_for_dest_available() {
     WAYPOINT("MWDW");
     _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -358,6 +358,29 @@ ALWI void binary_dest_reuse_tiles_init(uint32_t icb0, uint32_t call_line = __bui
 
 // clang-format off
 /**
+ * Resets the SrcB register-bank handshake to Unpacker-owned so that a following
+ * binary_dest_reuse_tiles(..., DEST_TO_SRCB) gates its first SrcB load on the current unpack.
+ *
+ * Call on the compute thread immediately before binary_dest_reuse_tiles_init(...) when the op that produced the
+ * dest value kept SrcB — a COL/SCALAR broadcast such as sub_tiles_bcast_cols, whose MOP ends with CLR_A. That
+ * leaves SrcB stale-valid and lets the dest-reuse MOVD2B race the unpacker's SET_DVALID/ZEROSRC (tt-metal #46523).
+ *
+ * WARNING: valid ONLY when the preceding op left SrcB stale (MatrixUnit-owned). Calling it before an already-clean
+ * dest-reuse (e.g. one preceded by a NONE/ROW-broadcast op, or by another dest-reuse whose MOP ends with CLR_AB)
+ * misaligns the SrcB bank pointers and deadlocks. Do not call before every dest-reuse — only the first one after a
+ * SrcB-keeping producer. No-op on Quasar (different DEST_TO_SRCB bank model; out of scope for #46523, unvalidated).
+ *
+ * Return value: None
+ */
+// clang-format on
+ALWI void binary_dest_reuse_reset_srcb() {
+#ifndef ARCH_QUASAR
+    MATH((llk_math_reset_srcb_bank_valid()));
+#endif
+}
+
+// clang-format off
+/**
  * Performs element-wise binary operations, such as multiply, add, or sub of tiles.
  * If binary_reuse_dest = EltwiseBinaryReuseDestType::DEST_TO_SRCA, then the tile specified by idst will be loaded from
  * the DST register buffer into SRCA. The binary operation will operate on SRCA & SRCB inputs, and the result will be

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -28,6 +28,25 @@ inline void _llk_math_set_fp32_dest_acc_(bool enable)
 }
 
 /**
+ * @brief Release a stale SrcB bank to the Unpackers so a following DEST_TO_SRCB dest-reuse gates on the current unpack.
+ *
+ * A COL/SCALAR-broadcast eltwise binary ends its MOP with CLR_A (keeps SrcB), leaving SrcB[MatrixUnit.SrcBBank]
+ * MatrixUnit-owned. A subsequent binary_dest_reuse_tiles<..., DEST_TO_SRCB> then finds move_d2b_fixed_face's first
+ * STALLWAIT(SRCB_VLD) pre-satisfied by that stale ownership, so MOVD2B races the reuse-unpack's SET_DVALID/ZEROSRC
+ * (tt-metal #46523). SETRWC CLR_B releases the stale bank to the Unpackers and advances MatrixUnit.SrcBBank so it
+ * re-aligns with the reuse-unpack, restoring the SRCB_VLD wait's dependence on the current unpack.
+ *
+ * @note Call on the MATH thread after a SrcB-keeping producer op and before _llk_math_eltwise_binary_with_dest_reuse_init_.
+ * @note The CLR_B bank-pointer advance is UNCONDITIONAL: valid only when the SrcB entry is stale (MatrixUnit-owned).
+ *       On a clean (Unpacker-owned, aligned) entry the advance misaligns the pointers and DEADLOCKS the SRCB_VLD wait.
+ *       @ref clear_bank_valid.
+ */
+inline void _llk_math_reset_srcb_bank_valid_()
+{
+    clear_bank_valid<Srcs::SrcB>();
+}
+
+/**
  * @brief Configure the math (FPU) thread's ALU control registers for the given source data formats.
  *
  * Sets ZEROACC bank auto-detect, enables INT8 math when either source is Int8/Int32, and programs FP32 dest

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -27,6 +27,25 @@ inline void _llk_math_set_fp32_dest_acc_(bool enable)
 }
 
 /**
+ * @brief Release a stale SrcB bank to the Unpackers so a following DEST_TO_SRCB dest-reuse gates on the current unpack.
+ *
+ * A COL/SCALAR-broadcast eltwise binary ends its MOP with CLR_A (keeps SrcB), leaving SrcB[MatrixUnit.SrcBBank]
+ * MatrixUnit-owned. A subsequent binary_dest_reuse_tiles<..., DEST_TO_SRCB> then finds move_d2b_fixed_face's first
+ * STALLWAIT(SRCB_VLD) pre-satisfied by that stale ownership, so MOVD2B races the reuse-unpack's SET_DVALID/ZEROSRC
+ * (tt-metal #46523). SETRWC CLR_B releases the stale bank to the Unpackers and advances MatrixUnit.SrcBBank so it
+ * re-aligns with the reuse-unpack, restoring the SRCB_VLD wait's dependence on the current unpack.
+ *
+ * @note Call on the MATH thread after a SrcB-keeping producer op and before _llk_math_eltwise_binary_with_dest_reuse_init_.
+ * @note The CLR_B bank-pointer advance is UNCONDITIONAL: valid only when the SrcB entry is stale (MatrixUnit-owned).
+ *       On a clean (Unpacker-owned, aligned) entry the advance misaligns the pointers and DEADLOCKS the SRCB_VLD wait.
+ *       @ref clear_bank_valid.
+ */
+inline void _llk_math_reset_srcb_bank_valid_()
+{
+    clear_bank_valid<Srcs::SrcB>();
+}
+
+/**
  * @brief Configure the math (FPU) thread's ALU control registers for the given source data formats.
  *
  * Programs the source A/B ALU formats, enables INT8 math when either source is Int8/Int32, and sets FP32 dest

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
@@ -538,6 +538,13 @@ void kernel_main() {
                 dfb_x_welford_obj_eltwise.pop_front(block.full_block_size());
             }
 
+            // #46523: sub_tiles_bcast_cols above is a COL broadcast (its MOP ends with CLR_A), so it leaves SrcB
+            // MatrixUnit-owned (stale). Release it to the Unpackers so the first DEST_TO_SRCB dest-reuse below gates
+            // its MOVD2B on the current unpack instead of racing it. Runs once, before the first reuse only: the
+            // second reuse (ELWMUL after the fused ELWADD) sees a clean SrcB entry (the ELWADD reuse MOP ends with
+            // CLR_AB) and must NOT be reset, or the bank pointers misalign and deadlock.
+            binary_dest_reuse_reset_srcb();
+
             if constexpr (fuse_pre_add) {
                 // Fuse in = in + b
                 reconfig_data_format_srca(dfb_in, dfb_inb);


### PR DESCRIPTION
> **⚠️ DRAFT / UNTESTED PROTOTYPE.** Authored on a host without Blackhole hardware or a build toolchain, so it has **not been compiled or run**. It is written to be correct-by-construction against the ISA analysis in #46523, but must be validated on silicon before it can be trusted. See the test plan below.

Fixes #46523 (draft).

## Problem
`test_layer_norm_ulp_fp32_no_weight_bias[...use_welford=True-32x4096-Wsweep]` produces **non-deterministic** FP32 output on Blackhole — back-to-back runs differ, and the failure disappears under WATCHER (the signature of a timing race). Regression bisected (by @fplavecTT) to the commit that reverted the intermediate-CB workaround in favor of `binary_dest_reuse_tiles`.

## Root cause
A cross-thread **T0(unpack) ↔ T1(math) race on the SrcB bank** in `binary_dest_reuse_tiles<…, DEST_TO_SRCB>`:

- The reuse SrcB "producer" is `UNPACR_NOP(SrcB, SET_DVALID, ZEROSRC)` — a ZeroSrc NOP that zeros SrcB and, per the ISA, **skips** the `while(AllowedClient != Unpackers)` backpressure loop (no consumer→producer wait).
- `MOVD2B` (DEST→SrcB, `cmath_common.h`) doesn't auto-wait; its only gate is `STALLWAIT(SRCB_VLD)` = ISA condition **C8** = `SrcB[MatrixUnit.SrcBBank].AllowedClient != MatrixUnit` — a boolean ownership flag that can't tell *which* unpack set it.
- The op immediately before the reuse, `sub_tiles_bcast_cols`, is a **COL broadcast** whose MOP ends with `CLR_A` (keeps SrcB), so it leaves SrcB **MatrixUnit-owned (stale)**. The first reuse `STALLWAIT(SRCB_VLD)` is then pre-satisfied and `MOVD2B` races the unpacker's `ZEROSRC`. If `ZEROSRC` lands last → SrcB=0 → corrupted output. Winner varies run-to-run; WATCHER delays make the unpacker win, masking it.

## Fix — option 1: deterministic SrcB entry state at the call-site
Rather than clearing SrcB inside the shared dest-reuse init (unsafe — `SETRWC CLR_B` toggles the bank pointer **unconditionally**, so it *re-aligns* a stale entry but **deadlocks** a clean one, and entry-staleness is caller-dependent across the ~6 DEST_TO_SRCB call-sites), this adds an **additive, MATH-only primitive** the welford kernel calls once, exactly where the entry is provably stale:

| Layer | File | Change |
|---|---|---|
| LLK lib (BH+WH) | `llk_lib/llk_math_common.h` | `_llk_math_reset_srcb_bank_valid_()` → `clear_bank_valid<SrcB>()` |
| metal llk_api (BH+WH) | `metal/llk_api/llk_math_common_api.h` | `llk_math_reset_srcb_bank_valid()` wrapper |
| Compute API | `hw/inc/api/compute/eltwise_binary.h` | `binary_dest_reuse_reset_srcb()` (Quasar-guarded) |
| Kernel | `layernorm_large_tensor_welford.cpp` | one call at the stale seam |

`SETRWC CLR_B` releases the stale bank to the Unpackers and advances `MatrixUnit.SrcBBank` so it re-aligns with the reuse-unpack, restoring the `SRCB_VLD` wait's dependence on the current unpack.

### Why it can't affect the other callers
- The **shared** `binary_dest_reuse_tiles_init` / `_llk_math_eltwise_binary_with_dest_reuse_init_` are **untouched** — all changes are additive.
- The kernel calls the reset **once, before the first reuse only**. In the `fuse_pre_add` path the second reuse (ELWMUL after ELWADD) sees a clean entry (the ELWADD reuse MOP ends with `CLR_AB`) and is deliberately **not** reset — resetting a clean entry would misalign the pointers and deadlock.
- Every other DEST_TO_SRCB caller (conv1d, softmax, moe-gate, non-welford layernorm) never calls the new primitive → byte-for-byte unchanged.
- Mirrored to WH (report notes the identical latent gap); **no-op on Quasar** (different DEST_TO_SRCB bank model, out of scope for #46523, unvalidated).

## ⚠️ Open questions for an LLK reviewer (not yet confirmed on HW)
1. **Bank-pointer algebra** — that `CLR_B` at this exact seam *re-aligns* rather than *misaligns* (grounded on the public ISA docs; wants RTL/sage confirmation).
2. **Drain** — whether a `STALLWAIT(STALL_MATH)` is needed before the `CLR_B`. Kept minimal here (intra-thread program order should suffice); please confirm the preceding ELWSUB has retired.

## Test plan (Blackhole, WATCHER-off) — must pass before un-drafting
1. Lift the `#46523` skip in `test_layer_norm_ulp.py` (both occurrences).
2. `rm -rf ~/.cache/tt-metal-cache` after the header edits.
3. Run `distribution=normal-use_welford=True-32x4096-Wsweep` ~10× WATCHER-off (detector = the `_run_twice` `torch.equal` assert). Baseline ≈6/10 fail → **expect 0/10**. Also `centered_uniform`.
4. Regress the other DEST_TO_SRCB callers on **WH + BH** (conv depthwise-1d, softmax large-tensor, non-welford layernorm, deepseek moe-gate) — watch for `TENSIX TIMED OUT` (deadlock signature). Expected unchanged.
5. Before un-drafting: `race-audit-all` on the touched LLK + the metal-integration propagation checklist, and decide whether to keep the WH mirror or scope to BH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nvelickovicTT/46523-srcb-dest-reuse-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nvelickovicTT/46523-srcb-dest-reuse-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nvelickovicTT/46523-srcb-dest-reuse-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nvelickovicTT/46523-srcb-dest-reuse-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nvelickovicTT/46523-srcb-dest-reuse-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nvelickovicTT/46523-srcb-dest-reuse-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nvelickovicTT/46523-srcb-dest-reuse-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nvelickovicTT/46523-srcb-dest-reuse-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nvelickovicTT/46523-srcb-dest-reuse-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nvelickovicTT/46523-srcb-dest-reuse-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nvelickovicTT/46523-srcb-dest-reuse-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nvelickovicTT/46523-srcb-dest-reuse-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nvelickovicTT/46523-srcb-dest-reuse-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nvelickovicTT/46523-srcb-dest-reuse-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nvelickovicTT/46523-srcb-dest-reuse-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nvelickovicTT/46523-srcb-dest-reuse-race)