### PR TITLE
[Bug fix] Add back the sfpu_math value so the perf report headers match again

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
@@ -736,6 +736,7 @@ class PerfConfig(TestConfig):
                 self.formats_config[0].unpack_A_dst,
                 self.formats_config[0].unpack_B_dst,
                 self.formats_config[0].output_format,
+                self.formats_config[0].sfpu_math,
             ]
             if has_formats
             else []


### PR DESCRIPTION
### Ticket

N/A, this is breaking the LLK perf workflow on main.

### Problem description

Any perf test that has a formats config currently blows up while building its report:

```
perf report header/value drift: 6 names vs 5 values
```

`FORMAT_HEADERS` has six entries but `PerfConfig.run()` only builds five values, and those two lists become the columns and the single row of the `sweep` DataFrame, so they have to be the same length.

This is a merge conflict that git couldn't see. Two PRs fixed the same drift from opposite ends:

* #51949 added the sixth header `formats.sfpu_math` to match the value that was already being emitted, so six headers paired with six values.
* #51912 then landed a `perf.py` that predated #51949 and had fixed the same thing the other way round, by dropping the value. That left the header with nothing to pair with.

Both are fine on their own. They touch different files, so git merged them cleanly and the result is inconsistent.

### What's changed

Added `self.formats_config[0].sfpu_math` back to the format value list.

I put the value back instead of removing the header because #51949 published `formats.sfpu_math` as part of the CSV schema on purpose, and taking it out again would quietly change that schema for anything reading these reports.

The assert from #51912 stays, since it's what pointed at this in the first place. Without it you get `ValueError: 6 columns passed, passed data had 5 columns` from inside the DataFrame constructor instead, which fires after the kernel has already run and doesn't tell you which list is wrong.

### Verification

* `FORMAT_HEADERS` and the value list are both 6, so the assert passes.
* Every value attribute resolves on `FormatConfig`: `unpack_A_src`, `unpack_B_src`, `unpack_A_dst`, `unpack_B_dst` and `sfpu_math` are dataclass fields, `output_format` is a property.
* The order lines up as well as the count: `input_A` to `unpack_A_src`, `input_B` to `unpack_B_src`, `register_A` to `unpack_A_dst`, `register_B` to `unpack_B_dst`, `output` to `output_format`, `sfpu_math` to `sfpu_math`.
* The DataFrame that used to raise now builds, 8 columns and 8 values once `FLAG_HEADERS` is included.
* Checked the pre-fix tree still reproduces the exact message from CI, `6 names vs 5 values`, so this is the right cause and not just a symptom that moved.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist

- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Sanity](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml) CI passes (not required, this only touches the Python test harness)
- [x] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) no assert changes, the existing one is kept
