### PR TITLE
fix(perf): regenerate catalog for formats.sfpu_math — unbreak main gate

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_test_schemas.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_test_schemas.py
@@ -14,7 +14,7 @@ live columns and fails, per test, on any drift from this catalog.
 
 PERF_TEST_SCHEMAS = {
     "perf_eltwise_bcast_col_custom": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "broadcast_type",
             "ct_dim",
@@ -24,6 +24,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "loop_factor",
             "marker",
             "math_fidelity",
@@ -34,7 +35,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_eltwise_binary_fpu": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "formats.input_A",
@@ -42,6 +43,8 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
+            "loop_factor",
             "marker",
             "math_fidelity",
             "mathop",
@@ -51,7 +54,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_eltwise_binary_sfpu": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "approx_mode",
             "dest_acc",
@@ -60,6 +63,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "iterations",
             "loop_factor",
             "marker",
@@ -75,7 +79,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_eltwise_typecast": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "approx_mode",
             "dest_acc",
@@ -85,6 +89,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "input_format",
             "iterations",
             "loop_factor",
@@ -103,7 +108,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_eltwise_unary_sfpu": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "approx_mode",
             "clamp_negative",
@@ -114,6 +119,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "iterations",
             "loop_factor",
             "marker",
@@ -130,7 +136,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_eltwise_unary_sfpu_int32": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "approx_mode",
             "clamp_negative",
@@ -141,6 +147,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "iterations",
             "loop_factor",
             "marker",
@@ -157,7 +164,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_fast_tilize": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "formats.input_A",
@@ -165,6 +172,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "loop_factor",
             "marker",
             "num_faces",
@@ -176,7 +184,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_fast_tilize_full": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "formats.input_A",
@@ -184,6 +192,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "loop_factor",
             "marker",
             "num_faces",
@@ -195,7 +204,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_fast_untilize": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "dest_sync",
@@ -204,6 +213,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "loop_factor",
             "marker",
             "tile_cnt",
@@ -212,7 +222,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_fast_untilize_baseline_compare": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "formats.input_A",
@@ -220,6 +230,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "loop_factor",
             "marker",
             "tile_cnt",
@@ -228,7 +239,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_math_matmul": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "c_dimm",
             "dest_acc",
@@ -239,6 +250,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "in0_c_dim",
             "in0_r_dim",
             "in1_c_dim",
@@ -264,7 +276,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_math_transpose": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "formats.input_A",
@@ -272,6 +284,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "marker",
             "math_transpose_faces",
             "tile_cnt",
@@ -281,7 +294,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_matmul": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "c_dimm",
             "dest_acc",
@@ -291,6 +304,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "k_dimm",
             "loop_factor",
             "marker",
@@ -307,7 +321,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_pack_dest_bank": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "dst_index",
@@ -316,6 +330,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "l1_acc",
             "loop_factor",
             "marker",
@@ -331,7 +346,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_pack_untilize": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "formats.input_A",
@@ -339,6 +354,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "loop_factor",
             "marker",
             "tile_cnt",
@@ -347,7 +363,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_reduce": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "formats.input_A",
@@ -355,6 +371,8 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
+            "loop_factor",
             "marker",
             "mathop",
             "reduce_pool_type",
@@ -364,7 +382,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_sfpu_binop_scalar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "approx_mode",
             "dest_acc",
@@ -373,6 +391,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "iterations",
             "loop_factor",
             "marker",
@@ -389,7 +408,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_sfpu_comp": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "approx_mode",
             "clamp_negative",
@@ -400,6 +419,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "iterations",
             "loop_factor",
             "marker",
@@ -416,7 +436,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_sfpu_div_wh": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "approx_mode",
             "dest_acc",
@@ -425,6 +445,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "iterations",
             "loop_factor",
             "marker",
@@ -440,7 +461,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_sfpu_erfinv_wh": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "approx_mode",
             "clamp_negative",
@@ -451,6 +472,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "iterations",
             "loop_factor",
             "marker",
@@ -467,7 +489,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_sfpu_reduce_row_max": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "approx_mode",
             "dest_acc",
@@ -476,6 +498,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "loop_factor",
             "marker",
             "mathop",
@@ -486,7 +509,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_sfpu_reduce_sdpa": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "formats.input_A",
@@ -494,6 +517,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "loop_factor",
             "marker",
             "mathop",
@@ -504,7 +528,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_sfpu_ternary": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "approx_mode",
             "dest_acc",
@@ -513,6 +537,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "iterations",
             "loop_factor",
             "marker",
@@ -529,7 +554,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_unpack_a_bcast_eltwise": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "dest_sync",
@@ -538,6 +563,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "marker",
             "math_fidelity",
             "mathop",
@@ -548,7 +574,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_unpack_tilize": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "formats.input_A",
@@ -556,6 +582,7 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "loop_factor",
             "marker",
             "tile_cnt",
@@ -564,7 +591,7 @@ PERF_TEST_SCHEMAS = {
         "aliases": {},
     },
     "perf_unpack_transpose": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "formats.input_A",
@@ -572,6 +599,8 @@ PERF_TEST_SCHEMAS = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
+            "loop_factor",
             "marker",
             "tile_cnt",
             "unpack_to_dest",
@@ -583,14 +612,9 @@ PERF_TEST_SCHEMAS = {
 }
 
 
-# Quasar per-perf-test CSV schema catalog.
-#
-# Same shape and rules as PERF_TEST_SCHEMAS above, derived statically from the
-# sibling test_*_quasar.py sources (see perf_schema_derive). One entry per Quasar
-# perf test: version + columns + aliases.
 PERF_TEST_SCHEMAS_QSR = {
     "perf_eltwise_binary_broadcast_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "broadcast_type",
             "dest_acc",
@@ -602,6 +626,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "loop_factor",
             "marker",
@@ -616,7 +641,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_eltwise_binary_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "acc_to_dest",
             "dest_acc",
@@ -628,6 +653,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "input_tile_cnt",
             "loop_factor",
@@ -644,7 +670,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_eltwise_binary_reuse_dest_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "dest_sync",
@@ -655,6 +681,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "input_num_blocks",
             "input_tile_cnt",
@@ -675,7 +702,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_eltwise_unary_datacopy_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "data_copy_type",
             "dest_acc",
@@ -688,6 +715,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "loop_factor",
             "marker",
@@ -705,7 +733,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_matmul_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "c_dimm",
             "dest_acc",
@@ -717,6 +745,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "k_dimm",
             "loop_factor",
@@ -733,7 +762,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_pack_l1_acc_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "dest_sync",
@@ -744,6 +773,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "input_num_blocks",
             "loop_factor",
@@ -761,7 +791,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_pack_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "dest_sync",
@@ -772,6 +802,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "loop_factor",
             "marker",
@@ -789,7 +820,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_pack_untilize_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "dest_sync",
@@ -800,6 +831,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "loop_factor",
             "marker",
@@ -817,7 +849,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_reduce_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "dest_sync",
@@ -828,6 +860,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "loop_factor",
             "marker",
@@ -848,7 +881,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_transpose_dest_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "data_copy_type",
             "dest_acc",
@@ -861,6 +894,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "loop_factor",
             "marker",
@@ -875,7 +909,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_unary_broadcast_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "broadcast_type",
             "dest_acc",
@@ -887,6 +921,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "input_num_blocks",
             "loop_factor",
@@ -908,7 +943,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_unpack_reduce_col_tilizeA_strided_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "dest_acc",
             "dest_sync",
@@ -919,6 +954,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "loop_factor",
             "marker",
@@ -934,7 +970,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_unpack_tilize_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "data_copy_type",
             "dest_acc",
@@ -946,6 +982,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "loop_factor",
             "marker",
@@ -963,7 +1000,7 @@ PERF_TEST_SCHEMAS_QSR = {
         "aliases": {},
     },
     "perf_unpack_unary_operand_quasar": {
-        "version": 1,
+        "version": 2,
         "columns": [
             "data_copy_type",
             "dest_acc",
@@ -975,6 +1012,7 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.output",
             "formats.register_A",
             "formats.register_B",
+            "formats.sfpu_math",
             "implied_math_format",
             "loop_factor",
             "marker",


### PR DESCRIPTION
### Problem
`test_perf_header_gate.py::test_perf_test_schemas_match` fails on every PR gate.
#51484 (catalog) and #51949 (sfpu_math) merged into main independently:
`FORMAT_HEADERS` gained `formats.sfpu_math`, but the recorded catalog did not.
The gate derives 6 live headers vs 5 in the catalog → drift → red on main.

### Fix
Regenerate `helpers/perf_test_schemas.py` against current source. Adds
`formats.sfpu_math` (and `loop_factor` where tests grew it), bumps the changed
tests v1→v2. One file, no logic change.

### Verification
All per-test + vocabulary gate tests pass locally:
`test_perf_test_schemas_match`, `test_perf_test_schemas_match_qsr`,
`test_run_type_names_match_source`, `test_metric_bases_match_source`.

The gate did its job it caught a real cross PR inconsistency on main.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstojictt/perf-catalog-sfpu-hotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstojictt/perf-catalog-sfpu-hotfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-catalog-sfpu-hotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstojictt/perf-catalog-sfpu-hotfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-catalog-sfpu-hotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nstojictt/perf-catalog-sfpu-hotfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstojictt/perf-catalog-sfpu-hotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstojictt/perf-catalog-sfpu-hotfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstojictt/perf-catalog-sfpu-hotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstojictt/perf-catalog-sfpu-hotfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstojictt/perf-catalog-sfpu-hotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstojictt/perf-catalog-sfpu-hotfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstojictt/perf-catalog-sfpu-hotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstojictt/perf-catalog-sfpu-hotfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstojictt/perf-catalog-sfpu-hotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstojictt/perf-catalog-sfpu-hotfix)