### PR TITLE
prevent parametrize expansion for skipped tests

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -471,6 +471,23 @@ def pytest_ignore_collect(collection_path, config):
     return None
 
 
+def _statically_skipped(definition) -> bool:
+    conds = [m.args[0] for m in definition.iter_markers(name="skipif") if m.args]
+    return (
+        bool(conds)
+        and not any(isinstance(c, str) for c in conds)
+        and any(c for c in conds)
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_generate_tests(metafunc):
+    if _statically_skipped(metafunc.definition):
+        metafunc.definition.own_markers = [
+            m for m in metafunc.definition.own_markers if m.name != "parametrize"
+        ]
+
+
 def _collapse_runtime_only_variants(config, items):
     """Keep only one test per unique compile key, dropping runtime only duplicates.
 
@@ -486,7 +503,7 @@ def _collapse_runtime_only_variants(config, items):
     deselected = []
     for item in items:
         marker = item.get_closest_marker(RUNTIME_AXES_MARK)
-        if marker is None:
+        if marker is None or not getattr(item, "callspec", None):
             keep.append(item)
             continue
         compile_key_fn = marker.kwargs["compile_key_fn"]

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -472,12 +472,11 @@ def pytest_ignore_collect(collection_path, config):
 
 
 def _statically_skipped(definition) -> bool:
-    conds = [m.args[0] for m in definition.iter_markers(name="skipif") if m.args]
-    return (
-        bool(conds)
-        and not any(isinstance(c, str) for c in conds)
-        and any(c for c in conds)
-    )
+    conds = []
+    for m in definition.iter_markers(name="skipif"):
+        conds.extend(m.args)
+        conds.append(m.kwargs.get("condition"))
+    return any(c for c in conds if c is not None and not isinstance(c, str))
 
 
 @pytest.hookimpl(tryfirst=True)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Skip parametrize expansion for arch unsupported tests via a tryfirst `pytest_generate_tests hook`, so the whole function skips as one test instead of generating 1000 variants.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=marko/skip-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:marko/skip-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=marko/skip-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:marko/skip-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=marko/skip-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:marko/skip-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=marko/skip-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:marko/skip-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=marko/skip-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:marko/skip-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=marko/skip-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:marko/skip-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=marko/skip-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:marko/skip-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=marko/skip-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:marko/skip-skips)