### PR TITLE
[fuser] add unary broadcast kernel to fuser

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/unary_broadcast.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/unary_broadcast.py
@@ -12,19 +12,11 @@ from fuser.fused_loop import FusedLoop, LoopTileByTile
 from fuser.fused_operation import FusedOperation
 from fuser.fuser_config import GlobalConfig
 from helpers.golden_generators import BroadcastGolden, get_golden_generator
-from helpers.llk_params import BroadcastType
 from helpers.tilize_untilize import tilize_block, untilize_block
 
 
 class UnaryBroadcastFpu(Fpu):
     loop: FusedLoop = LoopTileByTile()
-
-    def __init__(self, broadcast_type: BroadcastType):
-        if broadcast_type == BroadcastType.None_:
-            raise ValueError(
-                f"Broadcast type {broadcast_type} is not valid for unary broadcast."
-            )
-        self.broadcast_type = broadcast_type
 
     def get_headers(self) -> List[str]:
         return [
@@ -55,7 +47,7 @@ class UnaryBroadcastFpu(Fpu):
         )
         broadcast_golden = get_golden_generator(BroadcastGolden)
         broadcast_result = broadcast_golden(
-            self.broadcast_type,
+            compute_unit.broadcast_type,
             tilized_b,
             compute_unit.src_b.data_format,
             num_faces,
@@ -79,7 +71,7 @@ class UnaryBroadcastFpu(Fpu):
         block: BlockData,
     ) -> str:
         stage = operation.stage_id
-        broadcast_type = self.broadcast_type.cpp_enum_value
+        broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         tensor_shape = operation.tile_shape.cpp_value
         return (
             f"// Operation {stage}: Unary Broadcast FPU\n"
@@ -104,6 +96,3 @@ class UnaryBroadcastFpu(Fpu):
         block: BlockData,
     ) -> str:
         return ""
-
-    def __str__(self) -> str:
-        return f"UnaryBroadcastFpu({self.broadcast_type})"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/unary_broadcast.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/unary_broadcast.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Tuple
+
+import torch
+from fuser.block_data import BlockData
+from fuser.fpu_node import FpuNode
+from fuser.fused_fpu import Fpu
+from fuser.fused_loop import FusedLoop, LoopTileByTile
+from fuser.fused_operation import FusedOperation
+from fuser.fuser_config import GlobalConfig
+from helpers.golden_generators import BroadcastGolden, get_golden_generator
+from helpers.llk_params import BroadcastType
+from helpers.tilize_untilize import tilize_block, untilize_block
+
+
+class UnaryBroadcastFpu(Fpu):
+    loop: FusedLoop = LoopTileByTile()
+
+    def __init__(self, broadcast_type: BroadcastType):
+        if broadcast_type == BroadcastType.None_:
+            raise ValueError(
+                f"Broadcast type {broadcast_type} is not valid for unary broadcast."
+            )
+        self.broadcast_type = broadcast_type
+
+    def get_headers(self) -> List[str]:
+        return [
+            "llk_math_common.h",
+            "llk_math_unary_broadcast.h",
+        ]
+
+    def golden(
+        self,
+        tensor_a: torch.Tensor,
+        tensor_b: torch.Tensor,
+        tensor_dst: torch.Tensor,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tile_dims = (
+            operation.tile_shape.total_row_dim(),
+            operation.tile_shape.total_col_dim(),
+        )
+        num_faces = operation.tile_shape.total_num_faces()
+        tilized_b = tilize_block(
+            tensor_b,
+            compute_unit.src_b.dimensions,
+            compute_unit.src_b.data_format,
+            num_faces=num_faces,
+            tile_dimensions=tile_dims,
+        )
+        broadcast_golden = get_golden_generator(BroadcastGolden)
+        broadcast_result = broadcast_golden(
+            self.broadcast_type,
+            tilized_b,
+            compute_unit.src_b.data_format,
+            num_faces,
+            compute_unit.src_b.tile_count,
+            operation.tile_shape.face_r_dim,
+        )
+        golden_tensor = untilize_block(
+            broadcast_result,
+            compute_unit.src_b.data_format,
+            compute_unit.src_b.dimensions,
+            tile_dimensions=tile_dims,
+            num_faces=num_faces,
+        )
+        return tensor_a, tensor_b, golden_tensor
+
+    def init(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        stage = operation.stage_id
+        broadcast_type = self.broadcast_type.cpp_enum_value
+        tensor_shape = operation.tile_shape.cpp_value
+        return (
+            f"// Operation {stage}: Unary Broadcast FPU\n"
+            f"_llk_math_eltwise_unary_broadcast_init_<{broadcast_type}, false>"
+            f"({tensor_shape});\n"
+        )
+
+    def calculate(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        return f"_llk_math_eltwise_unary_broadcast_({block.tile_id_block});\n"
+
+    def uninit(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        return ""
+
+    def __str__(self) -> str:
+        return f"UnaryBroadcastFpu({self.broadcast_type})"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
@@ -19,6 +19,7 @@ from fuser.validator import (
     OperationSchemaBase,
     PackSchema,
     UnarySfpuMathSchema,
+    _tile_dims,
 )
 from helpers.llk_params import (
     AccToDest,
@@ -161,6 +162,11 @@ _reduce_params = (
     "Reduce requires both reduce_pool and reduce_dim",
 )
 
+_only_32x32_tile = (
+    lambda s, a, b: _tile_dims(a.tile_shape) != (32, 32),
+    "Only (32, 32) tiles are supported for this operation",
+)
+
 UNPACKER_MAP = {
     "UnpackerA": (
         lambda s: UnpackerA(reuse_dest=s.reuse_dest),
@@ -183,7 +189,7 @@ UNPACKER_MAP = {
         [_no_transpose],
     ),
     "UnaryBroadcastUnpacker": (
-        lambda s: UnaryBroadcastUnpacker(s.broadcast_type),
+        lambda s: UnaryBroadcastUnpacker(),
         [_broadcast_required, _no_transpose, _no_unpack_to_dest],
     ),
 }
@@ -231,12 +237,13 @@ FPU_MAP = {
         ],
     ),
     "UnaryBroadcast": (
-        lambda s: UnaryBroadcastFpu(s.broadcast_type),
+        lambda s: UnaryBroadcastFpu(),
         [
             _broadcast_required,
             _no_reuse_dest,
             _no_broadcast_acc_to_dest,
             _no_unpack_to_dest,
+            _only_32x32_tile,
             _forced_unpacker("UnaryBroadcastUnpacker"),
         ],
     ),

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
@@ -5,7 +5,8 @@
 """Quasar fuser config parser.
 
 Supports: eltwise binary (Elwadd/Elwmul/Elwsub), datacopy, matmul, reduce,
-unary SFPU, binary SFPU, eltwise broadcast (COL/ROW/SCALAR).
+unary SFPU, binary SFPU, eltwise broadcast (COL/ROW/SCALAR),
+unary broadcast (COL/ROW/SCALAR).
 Unsupported on Quasar: MatmulNoMop, ReduceBlockMax, ReduceBlockMaxRuntime,
 SubBcastColCustom.
 """
@@ -35,6 +36,7 @@ from .fpu.datacopy import DatacopyFpu
 from .fpu.eltwise import EltwiseFpu
 from .fpu.matmul import MatmulFpu
 from .fpu.reduce import ReduceFpu
+from .fpu.unary_broadcast import UnaryBroadcastFpu
 from .packer.matmul import MatmulPacker
 from .packer.packer import Packer
 from .sfpu.binary import BinarySfpu
@@ -42,6 +44,7 @@ from .sfpu.unary import UnarySfpu
 from .unpacker.matmul import MatmulUnpacker
 from .unpacker.reduce import ReduceUnpacker
 from .unpacker.tilize_a import UnpackerTilizeA
+from .unpacker.unary_broadcast import UnaryBroadcastUnpacker
 from .unpacker.unpack_a import UnpackerA
 from .unpacker.unpack_ab import UnpackerAB
 
@@ -53,6 +56,11 @@ _no_broadcast = (
 _no_unpack_to_dest = (
     lambda s, a, b: s.unpack_to_dest == UnpackToDest.Yes,
     "unpack_to_dest is not supported for this kernel",
+)
+
+_broadcast_required = (
+    lambda s, a, b: s.broadcast_type == BroadcastType.None_,
+    "UnaryBroadcast requires a broadcast_type",
 )
 
 _no_transpose_unpack_to_dest = (
@@ -174,6 +182,10 @@ UNPACKER_MAP = {
         lambda s: ReduceUnpacker(s.reduce_dim, s.reduce_pool),
         [_no_transpose],
     ),
+    "UnaryBroadcastUnpacker": (
+        lambda s: UnaryBroadcastUnpacker(s.broadcast_type),
+        [_broadcast_required, _no_transpose, _no_unpack_to_dest],
+    ),
 }
 
 FPU_MAP = {
@@ -218,6 +230,16 @@ FPU_MAP = {
             _forced_unpacker("ReduceUnpacker"),
         ],
     ),
+    "UnaryBroadcast": (
+        lambda s: UnaryBroadcastFpu(s.broadcast_type),
+        [
+            _broadcast_required,
+            _no_reuse_dest,
+            _no_broadcast_acc_to_dest,
+            _no_unpack_to_dest,
+            _forced_unpacker("UnaryBroadcastUnpacker"),
+        ],
+    ),
 }
 
 _l1_acc_format = (
@@ -234,6 +256,7 @@ PACKER_MAP = {
 _eltwise_dims = lambda a, b: (min(a[0], b[0]), min(a[1], b[1]))
 _matmul_dims = lambda a, b: (a[0], b[1])
 _src_a_dims = lambda a, b: a
+_src_b_dims = lambda a, b: b
 
 OUTPUT_DIMS = {
     "Elwadd": _eltwise_dims,
@@ -242,6 +265,7 @@ OUTPUT_DIMS = {
     "Datacopy": _src_a_dims,
     "Matmul": _matmul_dims,
     "Reduce": _src_a_dims,
+    "UnaryBroadcast": _src_b_dims,
 }
 
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/common.py
@@ -14,12 +14,24 @@ def is_unary_unpacker(compute_node: FpuNode) -> bool:
     return isinstance(compute_node.unpacker, (UnpackerA, UnpackerTilizeA))
 
 
+def _is_unary_broadcast_unpacker(compute_node: FpuNode) -> bool:
+    from fuser.quasar.unpacker.unary_broadcast import UnaryBroadcastUnpacker
+
+    return isinstance(compute_node.unpacker, UnaryBroadcastUnpacker)
+
+
 def _emit_configure(
     compute_node: FpuNode,
     dest_acc: str,
     unpack_A_dst: DataFormat,
     unpack_B_dst: DataFormat,
 ) -> str:
+    if _is_unary_broadcast_unpacker(compute_node):
+        desc_b = compute_node.src_b.cpp_desc_name
+        code = f"{desc_b}.reg_data_format = static_cast<std::uint8_t>({unpack_B_dst.cpp_underlying_value});\n"
+        code += f"_llk_unpack_configure_unary_<p_unpacr::UNP_B>({desc_b});\n"
+        return code
+
     is_unary = is_unary_unpacker(compute_node)
     has_reuse_dest = compute_node.reuse_dest != EltwiseBinaryReuseDestType.NONE
     unpack_to_dest = compute_node.unpack_to_dest.value

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unary_broadcast.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unary_broadcast.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Tuple
+
+import torch
+from fuser.block_data import BlockData
+from fuser.fpu_node import FpuNode
+from fuser.fused_loop import FusedLoop, LoopTileByTile
+from fuser.fused_operation import FusedOperation
+from fuser.fused_unpacker import Unpacker
+from fuser.fuser_config import GlobalConfig
+from helpers.llk_params import BroadcastType
+
+
+class UnaryBroadcastUnpacker(Unpacker):
+    loop: FusedLoop = LoopTileByTile()
+
+    def __init__(self, broadcast_type: BroadcastType):
+        if broadcast_type == BroadcastType.None_:
+            raise ValueError(
+                f"Broadcast type {broadcast_type} is not valid for unary broadcast."
+            )
+        self.broadcast_type = broadcast_type
+
+    def get_headers(self) -> List[str]:
+        return [
+            "llk_unpack_common.h",
+            "llk_unpack_unary_broadcast_operands.h",
+        ]
+
+    def golden(
+        self,
+        tensor_a: torch.Tensor,
+        tensor_b: torch.Tensor,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return tensor_a.flatten(), tensor_b.flatten()
+
+    def init(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        buf_desc_id = compute_unit.src_b.buf_desc_id
+        broadcast_type = self.broadcast_type.cpp_enum_value
+        return (
+            f"_llk_unpack_unary_broadcast_operands_init_<p_unpacr::UNP_B, {broadcast_type}, false>"
+            f"({buf_desc_id}, 1);\n"
+        )
+
+    def unpack(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        return (
+            f"_llk_unpack_unary_broadcast_operands_<p_unpacr::UNP_B, false>"
+            f"({block.tile_id_global});\n"
+        )
+
+    def uninit(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        return ""
+
+    def __str__(self) -> str:
+        return f"UnaryBroadcastUnpacker({self.broadcast_type})"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unary_broadcast.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unary_broadcast.py
@@ -11,18 +11,10 @@ from fuser.fused_loop import FusedLoop, LoopTileByTile
 from fuser.fused_operation import FusedOperation
 from fuser.fused_unpacker import Unpacker
 from fuser.fuser_config import GlobalConfig
-from helpers.llk_params import BroadcastType
 
 
 class UnaryBroadcastUnpacker(Unpacker):
     loop: FusedLoop = LoopTileByTile()
-
-    def __init__(self, broadcast_type: BroadcastType):
-        if broadcast_type == BroadcastType.None_:
-            raise ValueError(
-                f"Broadcast type {broadcast_type} is not valid for unary broadcast."
-            )
-        self.broadcast_type = broadcast_type
 
     def get_headers(self) -> List[str]:
         return [
@@ -48,7 +40,7 @@ class UnaryBroadcastUnpacker(Unpacker):
         block: BlockData,
     ) -> str:
         buf_desc_id = compute_unit.src_b.buf_desc_id
-        broadcast_type = self.broadcast_type.cpp_enum_value
+        broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         return (
             f"_llk_unpack_unary_broadcast_operands_init_<p_unpacr::UNP_B, {broadcast_type}, false>"
             f"({buf_desc_id}, 1);\n"
@@ -74,6 +66,3 @@ class UnaryBroadcastUnpacker(Unpacker):
         block: BlockData,
     ) -> str:
         return ""
-
-    def __str__(self) -> str:
-        return f"UnaryBroadcastUnpacker({self.broadcast_type})"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/eltwise_unary_broadcast.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/eltwise_unary_broadcast.yaml
@@ -1,3 +1,6 @@
+# Test for Quasar unary broadcast, one stage per broadcast type (COL/ROW/SCALAR),
+# each packed to its own output.
+
 operands:
   - name: "input_A"
     dims: [256, 256]
@@ -5,7 +8,13 @@ operands:
   - name: "input_B"
     dims: [256, 256]
     format: "Float16_b"
-  - name: "output_A"
+  - name: "output_col"
+    dims: [256, 256]
+    format: "Float16_b"
+  - name: "output_row"
+    dims: [256, 256]
+    format: "Float16_b"
+  - name: "output_scalar"
     dims: [256, 256]
     format: "Float16_b"
 
@@ -20,5 +29,31 @@ operations:
         math_fidelity: "LoFi"
     block_size: [64, 64]
     pack:
-      - output: "output_A"
+      - output: "output_col"
+        packer: "Packer"
+
+  - math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "UnaryBroadcast"
+        unpacker: "UnaryBroadcastUnpacker"
+        broadcast_type: "ROW"
+        math_fidelity: "LoFi"
+    block_size: [64, 64]
+    pack:
+      - output: "output_row"
+        packer: "Packer"
+
+  - math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "UnaryBroadcast"
+        unpacker: "UnaryBroadcastUnpacker"
+        broadcast_type: "SCALAR"
+        math_fidelity: "LoFi"
+    block_size: [64, 64]
+    pack:
+      - output: "output_scalar"
         packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/eltwise_unary_broadcast.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/eltwise_unary_broadcast.yaml
@@ -1,0 +1,24 @@
+operands:
+  - name: "input_A"
+    dims: [256, 256]
+    format: "Float16_b"
+  - name: "input_B"
+    dims: [256, 256]
+    format: "Float16_b"
+  - name: "output_A"
+    dims: [256, 256]
+    format: "Float16_b"
+
+operations:
+  - math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "UnaryBroadcast"
+        unpacker: "UnaryBroadcastUnpacker"
+        broadcast_type: "COL"
+        math_fidelity: "LoFi"
+    block_size: [64, 64]
+    pack:
+      - output: "output_A"
+        packer: "Packer"


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Relates to https://github.com/tenstorrent/tt-metal/issues/51480

Add Quasar `UnaryBroadcast` support to the fuser.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=marko/unary-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:marko/unary-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=marko/unary-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:marko/unary-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=marko/unary-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:marko/unary-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=marko/unary-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:marko/unary-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=marko/unary-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:marko/unary-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=marko/unary-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:marko/unary-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=marko/unary-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:marko/unary-broadcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=marko/unary-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:marko/unary-broadcast)