### PR TITLE
[Cleanup]DCAMP-1176: unify test scripts between k8s and bare metal slurm

### DIFF
--- a/tools/scaleout/exabox/health_check_test_suite/HEALTH_CHECK.md
+++ b/tools/scaleout/exabox/health_check_test_suite/HEALTH_CHECK.md
@@ -12,13 +12,13 @@ export TT_METAL_HOME=/path/to/tt-metal
 cd $TT_METAL_HOME
 
 # Full light tier (snapshot + tt-smi -r + eth_link_up gtest, ~75s)
-./tools/scaleout/exabox/healt_check_test_suite/run_diag.sh light
+./tools/scaleout/exabox/health_check_test_suite/run_diag.sh light
 
 # Snapshot-only smoke (fastest iteration)
-./tools/scaleout/exabox/healt_check_test_suite/run_diag.sh light --skip-reset --skip-tests
+./tools/scaleout/exabox/health_check_test_suite/run_diag.sh light --skip-reset --skip-tests
 
 # Offline / dev iteration against a stored snapshot
-./tools/scaleout/exabox/healt_check_test_suite/run_diag.sh light --dry-run \
+./tools/scaleout/exabox/health_check_test_suite/run_diag.sh light --dry-run \
     --input-snapshot snap.json --output /tmp/diag_report.json
 ```
 
@@ -187,8 +187,27 @@ ninja -C build_Release unit_tests_deployment
 ## Repo layout
 
 ```
-tools/scaleout/exabox/healt_check_test_suite/
-├── run_diag.sh        # bash dispatcher (sets TT_METAL_HOME / PYTHONPATH / LD_LIBRARY_PATH, execs runner)
-├── diag_runner.py     # Python orchestrator (this is where all check logic lives)
-└── HEALTH_CHECK.md     # this file
+tools/scaleout/exabox/health_check_test_suite/
+├── run_diag.sh         # bash dispatcher (sets TT_METAL_HOME / PYTHONPATH / LD_LIBRARY_PATH, execs runner)
+├── diag_runner.py      # Python orchestrator (all check logic lives here). Also exposes run_diag() as a
+│                       #   programmatic entry point returning (exit_code, report_dict).
+├── HEALTH_CHECK.md     # this file
+└── test_infrastructure/  # scheduled/CI harness around the diag suite
+    ├── run_health_check.py              # entrypoint: run diag as a subprocess, then JIRA + CSV + SFTP
+    ├── analyze_health_check_results.py  # diag_report.json -> runs/checks CSVs (Superset)
+    ├── requirements.txt                 # runtime deps (requests, paramiko, prometheus_client)
+    └── utils/                           # supporting modules
+        ├── diag_execution.py            # invoke diag_runner.py as a subprocess (timeout/kill aware)
+        ├── system_info.py               # tt-smi / kmd / fw version discovery
+        ├── telemetry.py                 # tt-telemetry (Prometheus) collection + formatting
+        ├── report.py                    # post-reset normalization + actionable-failure verdict
+        ├── jira_client.py               # JIRA ticket create / update / close / attach
+        ├── sftp_upload.py               # CSV upload to the Data-team SFTP endpoint
+        ├── secrets_loader.py            # JIRA / SFTP credential-file parsing
+        └── health_check_models.py       # Pydantic schema for the CSV output
 ```
+
+The `test_infrastructure/` harness previously lived in the `exabox-infra` repo and
+spun up a nested Docker container to run the diag suite. Now that the harness ships
+in the same image as the diag suite, `run_health_check.py` invokes `diag_runner.py`
+directly as a subprocess (see `diag_execution.py`) instead of via docker-in-docker.

--- a/tools/scaleout/exabox/health_check_test_suite/diag_runner.py
+++ b/tools/scaleout/exabox/health_check_test_suite/diag_runner.py
@@ -1447,9 +1447,13 @@ def run_diag(
     report["phases"]["reset_loop"] = asdict(reset_phase)
     # reset_loop prints its own per-reset lines as they run; rollup line only.
     print(f"  {'reset_loop':14} {reset_phase.status:5} ({reset_phase.duration_s:.1f}s)", flush=True)
-    # Dedupe per-reset snapshots: if all match initial, keep only initial and
-    # record a single summary check. If any differ, splice only the differing
-    # phases into the report (the matching ones are noise).
+    # Dedupe per-reset snapshots: splice the differing phases into the report
+    # (matching intermediates are noise) but ALWAYS keep the final post-reset
+    # snapshot, even when it matches initial. normalize_health_report judges the
+    # fleet on the last snapshot_after_* phase (post[-1]); if the unit regressed
+    # on an early reset but recovered by the final one, dropping the (matching)
+    # final snapshot would strand the stale regression as post[-1] and falsely
+    # fail a node that actually came back healthy.
     if post_reset_phases:
 
         def _check_sig(checks: list) -> tuple:
@@ -1466,6 +1470,12 @@ def run_diag(
             (matched if _check_sig([asdict(c) for c in p.checks]) == initial_sig else differed).append((name, p))
         for name, p in differed:
             report["phases"][name] = asdict(p)
+        # Preserve the actual final snapshot so the verdict reflects the true end
+        # state. If it differed it is already spliced above (in chronological
+        # order, so it stays post[-1]); if it matched initial, add it back here.
+        final_name, final_phase = post_reset_phases[-1]
+        if final_name not in report["phases"]:
+            report["phases"][final_name] = asdict(final_phase)
         summary_status = PASS if not differed else WARN
         summary_details = f"{len(matched)}/{len(post_reset_phases)} post-reset snapshots matched initial" + (
             f"; {len(differed)} differed (see {', '.join(n for n,_ in differed)})" if differed else ""

--- a/tools/scaleout/exabox/health_check_test_suite/diag_runner.py
+++ b/tools/scaleout/exabox/health_check_test_suite/diag_runner.py
@@ -1333,7 +1333,15 @@ def run_tests(tt_metal: Path, tier: str, phase: Phase, dry_run: bool, logs_dir: 
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def main() -> int:
+def default_tt_metal_path() -> Path:
+    """Repo root: $TT_METAL_HOME, else four parents up from this file
+    (tools/scaleout/exabox/health_check_test_suite/diag_runner.py -> repo root)."""
+    return Path(os.environ.get("TT_METAL_HOME") or Path(__file__).resolve().parents[4])
+
+
+def build_diag_arg_parser() -> argparse.ArgumentParser:
+    """Build the diag CLI parser. Exposed so callers (e.g. run_health_check's
+    subprocess wrapper) can introspect the accepted flags and stay in sync."""
     ap = argparse.ArgumentParser(description="SYS-4365 diag tool")
     ap.add_argument("--tier", choices=list(TIER_TESTS), required=True)
     ap.add_argument("--dry-run", action="store_true", help="Print intended subprocess calls; skip destructive steps.")
@@ -1348,20 +1356,43 @@ def main() -> int:
     ap.add_argument(
         "--tt-metal-path",
         type=Path,
-        default=Path(os.environ.get("TT_METAL_HOME") or Path(__file__).resolve().parents[4]),
+        default=default_tt_metal_path(),
         help="tt-metal repo root (contains build/test/tt_metal/unit_tests_deployment).",
     )
     ap.add_argument("--output", type=Path, default=Path("diag_report.json"))
     ap.add_argument("--snapshot-out", type=Path, default=Path("/tmp/diag_snapshot.json"))
-    args = ap.parse_args()
+    return ap
+
+
+def run_diag(
+    tier: str,
+    *,
+    dry_run: bool = False,
+    skip_reset: bool = False,
+    skip_tests: bool = False,
+    input_snapshot: Path | None = None,
+    tt_smi_path: str | None = None,
+    tt_metal_path: Path | None = None,
+    output: Path = Path("diag_report.json"),
+    snapshot_out: Path = Path("/tmp/diag_snapshot.json"),
+) -> tuple[int, dict]:
+    """Run the full diagnostic pipeline (snapshot → reset loop → gtests).
+
+    Programmatic entry point equivalent to the CLI: writes the JSON report to
+    *output* (gtest logs to ``<output_dir>/logs/``) and returns
+    ``(exit_code, report_dict)``. ``exit_code`` is ``1`` on FAIL, else ``0`` —
+    identical to the process exit code produced by ``main()``.
+    """
+    if tt_metal_path is None:
+        tt_metal_path = default_tt_metal_path()
 
     started = datetime.now(timezone.utc)
     report = {
         "tool_version": "0.3.0-draft",
-        "tier": args.tier,
+        "tier": tier,
         "host": socket.gethostname(),
         "started_utc": started.isoformat(),
-        "dry_run": args.dry_run,
+        "dry_run": dry_run,
         "tt_smi_version": None,
         "detected_board_rev": None,
         "phases": {},
@@ -1371,15 +1402,15 @@ def main() -> int:
     snap_phase = Phase(name="snapshot")
     t0 = time.time()
     try:
-        if args.input_snapshot:
-            log(f"using input snapshot: {args.input_snapshot}")
-            snap = json.loads(args.input_snapshot.read_text())
+        if input_snapshot:
+            log(f"using input snapshot: {input_snapshot}")
+            snap = json.loads(input_snapshot.read_text())
         else:
-            tt_smi = resolve_tt_smi(args.tt_smi_path)
+            tt_smi = resolve_tt_smi(tt_smi_path)
             version = detect_tt_smi_version(tt_smi)
             report["tt_smi_version"] = ".".join(str(x) for x in version) if version else None
             log(f"using tt-smi: {tt_smi} (version={report['tt_smi_version']})")
-            snap = take_snapshot(tt_smi, args.snapshot_out)
+            snap = take_snapshot(tt_smi, snapshot_out)
         report["detected_board_rev"] = validate_snapshot(snap, snap_phase)
     except Exception as e:
         snap_phase.error = repr(e)
@@ -1393,18 +1424,18 @@ def main() -> int:
     reset_phase = Phase(name="reset_loop")
     post_reset_phases: list = []
     # Only revalidate via fresh snapshots when running live (not --input-snapshot).
-    snap_out_for_resets = None if args.input_snapshot else args.snapshot_out
+    snap_out_for_resets = None if input_snapshot else snapshot_out
     t0 = time.time()
-    if args.skip_reset:
+    if skip_reset:
         reset_phase.add(Check(name="reset_loop", status=SKIP, details="--skip-reset"))
     else:
         try:
-            tt_smi = resolve_tt_smi(args.tt_smi_path)
+            tt_smi = resolve_tt_smi(tt_smi_path)
             reset_loop(
                 tt_smi,
-                RESET_PLAN[args.tier],
+                RESET_PLAN[tier],
                 reset_phase,
-                args.dry_run,
+                dry_run,
                 snapshot_out=snap_out_for_resets,
                 post_reset_phases=post_reset_phases,
             )
@@ -1461,12 +1492,12 @@ def main() -> int:
     # Phase 3: gtest
     test_phase = Phase(name="tests")
     t0 = time.time()
-    if args.skip_tests:
+    if skip_tests:
         test_phase.add(Check(name="tests", status=SKIP, details="--skip-tests"))
     else:
         try:
-            logs_dir = args.output.resolve().parent / "logs"
-            run_tests(args.tt_metal_path, args.tier, test_phase, args.dry_run, logs_dir)
+            logs_dir = output.resolve().parent / "logs"
+            run_tests(tt_metal_path, tier, test_phase, dry_run, logs_dir)
         except Exception as e:
             test_phase.error = repr(e)
             test_phase.add(Check(name="tests", status=FAIL, details=repr(e)))
@@ -1487,8 +1518,8 @@ def main() -> int:
     else:
         report["overall_status"] = PASS
 
-    args.output.write_text(json.dumps(report, indent=2))
-    log(f"wrote report: {args.output} (overall={report['overall_status']})")
+    output.write_text(json.dumps(report, indent=2))
+    log(f"wrote report: {output} (overall={report['overall_status']})")
 
     # Separator delineates the live per-phase output above from the final
     # rollup below, so the OVERALL summary block is visually distinct.
@@ -1507,7 +1538,23 @@ def main() -> int:
         else:
             print(f"    {phase_name:11} {status}")
 
-    return 0 if report["overall_status"] != FAIL else 1
+    return (0 if report["overall_status"] != FAIL else 1), report
+
+
+def main() -> int:
+    args = build_diag_arg_parser().parse_args()
+    rc, _report = run_diag(
+        tier=args.tier,
+        dry_run=args.dry_run,
+        skip_reset=args.skip_reset,
+        skip_tests=args.skip_tests,
+        input_snapshot=args.input_snapshot,
+        tt_smi_path=args.tt_smi_path,
+        tt_metal_path=args.tt_metal_path,
+        output=args.output,
+        snapshot_out=args.snapshot_out,
+    )
+    return rc
 
 
 if __name__ == "__main__":

--- a/tools/scaleout/exabox/health_check_test_suite/run_diag.sh
+++ b/tools/scaleout/exabox/health_check_test_suite/run_diag.sh
@@ -14,7 +14,7 @@
 #
 # Designed to match tt-metal's run_upstream_tests_vanilla.sh shape.
 # Can be used as the ENTRYPOINT of a docker image
-# (TEST_COMMAND=tools/scaleout/exabox/healt_check_test_suite/run_diag.sh, CMD=light|medium|deploy).
+# (TEST_COMMAND=tools/scaleout/exabox/health_check_test_suite/run_diag.sh, CMD=light|medium|deploy).
 
 set -euo pipefail
 

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Translate a fabric health-check diag_report.json into CSVs for Superset.
+
+The diag tool emits a structured diag_report.json (phases -> checks + per-chip
+telemetry). This writes two CSVs per host per run, joined on run_id
+({hostname}:{slurm_job_id}):
+
+    health_check_{hostname}_{slurm_job_id}.runs.csv    1 row, machine rollup
+    health_check_{hostname}_{slurm_job_id}.checks.csv  one row per check
+
+The caller (run_health_check.py) passes an already-normalized report so the
+verdict reflects post-reset state. Standalone, the CLI applies that same
+normalize first.
+
+If no report is produced (timeout/kill) or it can't be parsed, a 1-row runs.csv
+with overall_status=ERROR is written (no checks file) so a run is never dropped.
+
+Output is validated against the Pydantic models in utils/health_check_models.py
+when available. Schema: docs/exabox-fabric-health-check.md. stdlib-only.
+"""
+
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+SCHEMA_VERSION = 1
+
+# check ip/phase -> dashboard category. "other" is the catch-all.
+IP_TO_CATEGORY = {
+    "pcie": "pcie", "gddr": "gddr", "asic": "asic", "fw": "firmware",
+    "thermal": "thermal", "board": "board", "eth": "eth",
+}
+# eth deployment tests live in the "tests" phase with ip="other". Route them to
+# the eth category by name so they don't land in stress_test.
+CHECK_CATEGORY = {
+    "post_reset_state_stable": "reset",
+    "eth_bandwidth": "eth",
+    "eth_link_up": "eth",
+}
+STRESS_PHASE = "tests"
+
+# Benign fleet-wide WARNs: tracked but kept out of the actionable rollups.
+ACKNOWLEDGED_CHECKS = {"cpld_fw_old"}
+
+# Infra/capture steps (not hardware). A FAIL/WARN here is a tooling hiccup, not a
+# verdict, so it is re-labelled EXCLUDED: kept visible, counts as nothing.
+EXCLUDED_CHECKS = {"snapshot_capture"}
+
+# checks whose details list offending BDFs - keep more text for triage.
+DETAIL_RICH = {"pcie_gen", "gddr_speed", "pcie_lane_width",
+               "physical_vs_fw_location", "asic_location_per_ubb"}
+
+# numeric forensic checks: dropped from checks_fact, folded into runs rollups.
+GDDR_INFO_PREFIX = "gddr_info_"
+
+SEVERITY = {"PASS": 0, "SKIP": 0, "EXCLUDED": 0, "WARN": 1, "FAIL": 2,
+            "UNKNOWN": 3, "ERROR": 3}
+COVERED = {"PASS", "WARN", "FAIL"}
+
+RUNS_COLS = [
+    "schema_version", "run_id", "date", "timestamp", "hostname", "slurm_job_id",
+    "row", "rack", "slot", "overall_status", "discard", "discard_reason",
+    "prev_status", "is_regression", "fail_streak",
+    "tier", "tool_version", "tt_smi_version", "tt_kmd_version", "board_rev",
+    "fw_bundle_version", "num_chips", "total_duration_s",
+    "checks_total", "checks_pass", "checks_warn", "checks_fail", "checks_skip",
+    "checks_covered", "pct_covered", "checks_warn_actionable", "top_fail_category",
+    "reset_count", "reset_stable", "gddr_uncorr_total", "pcie_downgraded",
+    "eth_links_down", "max_asic_temp_c", "max_gddr_temp_c",
+    "min_aiclk_mhz", "telemetry_available",
+    "eth_retrain_total", "eth_crc_total", "eth_uncorr_cw_total", "jira_ticket",
+]
+
+# checks_fact is normalized: check fields + run_id (+ date). Run-level attributes
+# live once on runs.csv and join back on run_id.
+CHECKS_COLS = [
+    "schema_version", "run_id", "date",
+    "category", "phase", "phase_kind", "check_name", "status", "severity",
+    "is_pass", "is_warn", "is_fail", "is_skip", "is_covered", "acknowledged",
+    "testcases_passed", "testcases_failed", "executed", "details_short",
+]
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_host(hostname: str):
+    """(row, rack, slot) from the two BH-Galaxy naming schemes.
+
+    bh-glx-110-c03u08 -> ("110", "c03", "08"), bh-glx-b02u08 -> ("", "b02", "08").
+    Unparseable hosts get rack="unparsed" so they surface instead of blanking out.
+    """
+    m = re.match(r"bh-glx-(\d+)-([a-z]\d+)u(\d+)", hostname)
+    if m:
+        return m.group(1), m.group(2), m.group(3)
+    m = re.match(r"bh-glx-([a-z]\d+)u(\d+)", hostname)
+    if m:
+        return "", m.group(1), m.group(2)
+    return "", "unparsed", ""
+
+
+def phase_kind(phase_name: str) -> str:
+    return "post_reset" if phase_name.startswith("snapshot_after_") else "primary"
+
+
+def category_for(phase: str, check: dict) -> str:
+    name = check.get("name", "")
+    if name in CHECK_CATEGORY:
+        return CHECK_CATEGORY[name]
+    if phase == "reset_loop":
+        return "reset"
+    if phase == STRESS_PHASE:
+        return "stress_test"
+    return IP_TO_CATEGORY.get(check.get("ip", ""), "other")
+
+
+def iter_checks(report: dict, primary_only: bool = True):
+    for pname, ph in report.get("phases", {}).items():
+        if primary_only and phase_kind(pname) != "primary":
+            continue
+        for c in ph.get("checks", []):
+            yield pname, ph.get("status", ""), c
+
+
+# fw reads back as all-0xFF when the device can't be queried. Treat those values
+# as unknown rather than a real firmware version.
+FW_SENTINELS = {"255.255.255.255", "0.0.0.0"}
+
+
+def _find_check(report: dict, name: str, primary_only: bool = True):
+    for _p, _s, c in iter_checks(report, primary_only=primary_only):
+        if c.get("name") == name:
+            return c
+    return None
+
+
+def _hexint(v):
+    try:
+        return int(str(v), 16)
+    except (ValueError, TypeError):
+        return None
+
+
+def _max_asic_temp(report: dict):
+    c = _find_check(report, "asic_thermal_precheck")
+    if not c:
+        return ""
+    temps = (c.get("data", {}) or {}).get("all_temps_c", {}) or {}
+    vals = [float(v) for v in temps.values() if v not in ("", None)]
+    return round(max(vals), 1) if vals else ""
+
+
+def _gddr_temp_and_uncorr(report: dict):
+    max_t, uncorr = "", ""
+    ct = _find_check(report, "gddr_info_max_gddr_temp")
+    if ct:
+        vals = [_hexint(v) for v in (ct.get("data", {}).get("per_chip", {}) or {}).values()]
+        vals = [v for v in vals if v is not None]
+        max_t = max(vals) if vals else ""
+    cu = _find_check(report, "gddr_info_gddr_uncorr_errs")
+    if cu:
+        vals = [_hexint(v) for v in (cu.get("data", {}).get("per_chip", {}) or {}).values()]
+        uncorr = sum(v for v in vals if v is not None)
+    return max_t, uncorr
+
+
+def _reset_info(report: dict):
+    ph = report.get("phases", {}).get("reset_loop")
+    if not ph:
+        return "", ""
+    n = len([c for c in ph.get("checks", []) if c.get("name", "").startswith("reset_")])
+    return n, int(ph.get("status") != "FAIL")
+
+
+def _pcie_downgraded(report: dict):
+    c = _find_check(report, "pcie_gen")
+    if not c:
+        return ""
+    return int(bool((c.get("data", {}) or {}).get("under_expected") or []))
+
+
+def _eth_links_down(report: dict):
+    c = _find_check(report, "eth_links_up")
+    if not c or c.get("status") == "SKIP":
+        return ""
+    m = re.search(r"(\d+)\s*/\s*(\d+)", c.get("details", "") or "")
+    return int(m.group(2)) - int(m.group(1)) if m else ""
+
+
+def _testcases(check: dict):
+    m = re.search(r"passed=(\d+)\s+failed=(\d+)", check.get("details", "") or "")
+    return (int(m.group(1)), int(m.group(2))) if m else ("", "")
+
+
+def machine_meta(report, hostname, job_id, jira_ticket, ts, versions=None):
+    versions = versions or {}
+    # fw can be missing from the primary snapshot when a run fails early. Fall
+    # back to a post-reset snapshot, then the console log, ignoring 0xFF reads.
+    fw = (_find_check(report, "fw_bundle_version_consistent")
+          or _find_check(report, "fw_bundle_version_consistent", primary_only=False)
+          or {})
+    log_fw = versions.get("fw_bundle_version", "")
+    if log_fw in FW_SENTINELS:
+        log_fw = ""
+    fw_bundle = str(fw.get("data", {}).get("value", "") or log_fw)
+    enum = _find_check(report, "pcie_enum_count") or {}
+    num_chips = enum.get("data", {}).get("actual", "")
+    overall = report.get("overall_status", "") or "UNKNOWN"
+    row, rack, slot = parse_host(hostname)
+    dry = bool(report.get("dry_run"))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": f"{hostname}:{job_id}",
+        "date": ts[:10], "timestamp": ts,
+        "hostname": hostname, "row": row, "rack": rack, "slot": slot,
+        "slurm_job_id": job_id, "overall_status": overall,
+        "discard": int(dry), "discard_reason": "dry_run" if dry else "",
+        "tier": report.get("tier", ""), "tool_version": report.get("tool_version", ""),
+        "tt_smi_version": report.get("tt_smi_version", "") or versions.get("tt_smi_version", ""),
+        "tt_kmd_version": versions.get("tt_kmd_version", ""),
+        "board_rev": report.get("detected_board_rev", ""),
+        "fw_bundle_version": fw_bundle, "num_chips": num_chips,
+        "total_duration_s": report.get("total_duration_s", ""),
+        "jira_ticket": jira_ticket,
+    }
+
+
+def checks_rows(report: dict, meta: dict):
+    rows = []
+    for pname, _ps, c in iter_checks(report):
+        name = c.get("name", "")
+        if name.startswith(GDDR_INFO_PREFIX):
+            continue
+        st = c.get("status", "")
+        # a failed capture/precondition step is not a hardware verdict: mark it
+        # EXCLUDED so it never counts as a fail (see EXCLUDED_CHECKS).
+        excluded = name in EXCLUDED_CHECKS and st in ("FAIL", "WARN")
+        if excluded:
+            st = "EXCLUDED"
+        cat = category_for(pname, c)
+        tp, tf = _testcases(c)
+        ran = isinstance(tp, int) and (tp + tf) > 0
+        executed = 0 if (cat == "stress_test" and not ran) else 1
+        cap = 400 if name in DETAIL_RICH else 140
+        rows.append({
+            "schema_version": meta["schema_version"], "run_id": meta["run_id"],
+            "date": meta["date"],
+            "category": cat, "phase": pname, "phase_kind": phase_kind(pname),
+            "check_name": name, "status": st, "severity": SEVERITY.get(st, 3),
+            "is_pass": int(st == "PASS"), "is_warn": int(st == "WARN"),
+            "is_fail": int(st == "FAIL"), "is_skip": int(st == "SKIP"),
+            "is_covered": int(st in COVERED and executed == 1),
+            "acknowledged": int(name in ACKNOWLEDGED_CHECKS or excluded),
+            "testcases_passed": tp, "testcases_failed": tf, "executed": executed,
+            "details_short": (c.get("details", "") or "").replace("\n", " | ")[:cap],
+        })
+    return rows
+
+
+def runs_row(report, meta, checks, telemetry=None):
+    tel = telemetry or {}
+    counts = {"PASS": 0, "WARN": 0, "FAIL": 0, "SKIP": 0}
+    fail_cat, warn_cat = {}, {}
+    for c in checks:
+        counts[c["status"]] = counts.get(c["status"], 0) + 1
+        # rollups skip acknowledged checks so top_fail_category reflects real hw.
+        if c["status"] == "FAIL" and not c.get("acknowledged"):
+            fail_cat[c["category"]] = fail_cat.get(c["category"], 0) + 1
+        elif c["status"] == "WARN" and not c.get("acknowledged"):
+            warn_cat[c["category"]] = warn_cat.get(c["category"], 0) + 1
+    if fail_cat:
+        top = max(fail_cat, key=fail_cat.get)
+    elif warn_cat:
+        top = max(warn_cat, key=warn_cat.get)
+    else:
+        top = ""
+    total = len(checks)
+    covered = sum(c["is_covered"] for c in checks)
+    reset_count, reset_stable = _reset_info(report)
+    max_gddr_t, gddr_uncorr = _gddr_temp_and_uncorr(report)
+
+    # Effective verdict = worst non-excluded, non-acknowledged check. The raw
+    # report overall_status also trips on pre-reset and EXCLUDED steps, which
+    # aren't real verdicts. Mirrors the runner's has_actionable_failure() gate.
+    if not checks:
+        overall_status = meta["overall_status"]
+    elif any(c["is_fail"] and not c.get("acknowledged") for c in checks):
+        overall_status = "FAIL"
+    elif any(c["is_warn"] and not c.get("acknowledged") for c in checks):
+        overall_status = "WARN"
+    else:
+        overall_status = "PASS"
+
+    return {
+        **{k: meta[k] for k in (
+            "schema_version", "run_id", "date", "timestamp", "hostname",
+            "row", "rack", "slot", "slurm_job_id",
+            "discard", "discard_reason", "tier", "tool_version", "tt_smi_version",
+            "tt_kmd_version", "board_rev", "fw_bundle_version", "num_chips",
+            "total_duration_s", "jira_ticket")},
+        "overall_status": overall_status,
+        "prev_status": "", "is_regression": "", "fail_streak": "",
+        "checks_total": total, "checks_pass": counts["PASS"],
+        "checks_warn": counts["WARN"], "checks_fail": counts["FAIL"],
+        "checks_skip": counts["SKIP"], "checks_covered": covered,
+        "pct_covered": round(100 * covered / total, 1) if total else "",
+        "checks_warn_actionable": sum(warn_cat.values()), "top_fail_category": top,
+        "reset_count": reset_count, "reset_stable": reset_stable,
+        "gddr_uncorr_total": gddr_uncorr, "pcie_downgraded": _pcie_downgraded(report),
+        "eth_links_down": _eth_links_down(report),
+        "max_asic_temp_c": _max_asic_temp(report), "max_gddr_temp_c": max_gddr_t,
+        "min_aiclk_mhz": tel.get("min_aiclk_mhz", ""),
+        "telemetry_available": int(bool(tel.get("available"))),
+        "eth_retrain_total": tel.get("eth_retrain_total", ""),
+        "eth_crc_total": tel.get("eth_crc_total", ""),
+        "eth_uncorr_cw_total": tel.get("eth_uncorr_cw_total", ""),
+    }
+
+
+def error_runs_row(hostname, job_id, ts, reason, jira_ticket=""):
+    row, rack, slot = parse_host(hostname)
+    r = {c: "" for c in RUNS_COLS}
+    r.update({
+        "schema_version": SCHEMA_VERSION, "run_id": f"{hostname}:{job_id}",
+        "date": ts[:10], "timestamp": ts, "hostname": hostname,
+        "row": row, "rack": rack, "slot": slot, "slurm_job_id": job_id,
+        "overall_status": "ERROR",
+        "discard": 0, "top_fail_category": "run",
+        "checks_total": 0, "checks_pass": 0, "checks_warn": 0, "checks_fail": 0,
+        "checks_skip": 0, "checks_covered": 0, "checks_warn_actionable": 0,
+        "telemetry_available": 0,
+        "jira_ticket": jira_ticket,
+    })
+    return r
+
+
+def _write_csv(path, cols, rows):
+    with open(path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=cols)
+        w.writeheader()
+        w.writerows(rows)
+
+
+def _validate(runs, checks):
+    """Validate emitted rows against the Pydantic schema (health_check_models)
+    when importable. Best-effort: logs drift, never blocks CSV production."""
+    try:
+        from utils.health_check_models import RunRecord, CheckRecord
+    except Exception:
+        return
+    bad = 0
+    for r in runs:
+        try:
+            RunRecord(**{c: r.get(c, "") for c in RUNS_COLS})
+        except Exception as exc:
+            bad += 1
+            print(f"WARNING: runs row failed schema validation: "
+                  f"{str(exc).splitlines()[0]}", file=sys.stderr)
+    for c in checks:
+        try:
+            CheckRecord(**{k: c.get(k, "") for k in CHECKS_COLS})
+        except Exception as exc:
+            bad += 1
+            print(f"WARNING: checks row failed schema validation: "
+                  f"{str(exc).splitlines()[0]}", file=sys.stderr)
+    if bad == 0:
+        print("schema validation: OK")
+
+
+def _normalize(report):
+    """Apply the post-reset verdict normalization (single source of truth in
+    report.py). Standalone-CLI only: in prod the runner passes a normalized
+    report."""
+    try:
+        from utils.report import normalize_health_report
+    except Exception as exc:
+        print(f"WARNING: could not import utils.report.normalize_health_report ({exc}); "
+              "using report as-is", file=sys.stderr)
+        return report
+    return normalize_health_report(report)
+
+
+def analyze(report, csv_output_dir, hostname, slurm_job_id,
+            jira_ticket="", versions=None, telemetry=None):
+    """Translate a normalized diag_report.json dict into runs.csv (+ checks.csv).
+
+    report must already be normalized by the caller so the verdict reflects
+    post-reset state. A missing/empty report (None) yields a lone ERROR runs.csv.
+    Returns the list of CSV paths written.
+    """
+    os.makedirs(csv_output_dir, exist_ok=True)
+    ts = now_iso()
+    base = os.path.join(csv_output_dir, f"health_check_{hostname}_{slurm_job_id}")
+    runs_path, checks_path = base + ".runs.csv", base + ".checks.csv"
+
+    if not report:
+        print("WARNING: no diag_report.json - writing fail-closed ERROR runs row")
+        row = error_runs_row(hostname, slurm_job_id, ts, "no diag_report.json",
+                             jira_ticket)
+        _validate([row], [])
+        _write_csv(runs_path, RUNS_COLS, [row])
+        return [runs_path]
+
+    meta = machine_meta(report, hostname, slurm_job_id, jira_ticket, ts, versions)
+    checks = checks_rows(report, meta)
+    runs = runs_row(report, meta, checks, telemetry)
+    _validate([runs], checks)
+    _write_csv(runs_path, RUNS_COLS, [runs])
+    _write_csv(checks_path, CHECKS_COLS, checks)
+    print(f"CSV written: {runs_path} (1 run), {checks_path} ({len(checks)} checks)")
+    return [runs_path, checks_path]
+
+
+def main():
+    p = argparse.ArgumentParser(description="Analyze diag_report.json to CSV")
+    p.add_argument("report_file", help="Path to diag_report.json")
+    p.add_argument("--csv", required=True, help="Output directory for the CSV files")
+    p.add_argument("--hostname", required=True)
+    p.add_argument("--slurm-job-id", required=True)
+    p.add_argument("--jira-ticket", default="")
+    args = p.parse_args()
+
+    report = None
+    if os.path.isfile(args.report_file):
+        try:
+            with open(args.report_file) as f:
+                report = json.load(f)
+        except (ValueError, OSError) as exc:
+            print(f"WARNING: could not parse {args.report_file}: {exc}",
+                  file=sys.stderr)
+    if report:
+        report = _normalize(report)
+
+    analyze(
+        report=report,
+        csv_output_dir=args.csv,
+        hostname=args.hostname,
+        slurm_job_id=args.slurm_job_id,
+        jira_ticket=args.jira_ticket,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
@@ -36,8 +36,13 @@ SCHEMA_VERSION = 1
 
 # check ip/phase -> dashboard category. "other" is the catch-all.
 IP_TO_CATEGORY = {
-    "pcie": "pcie", "gddr": "gddr", "asic": "asic", "fw": "firmware",
-    "thermal": "thermal", "board": "board", "eth": "eth",
+    "pcie": "pcie",
+    "gddr": "gddr",
+    "asic": "asic",
+    "fw": "firmware",
+    "thermal": "thermal",
+    "board": "board",
+    "eth": "eth",
 }
 # eth deployment tests live in the "tests" phase with ip="other". Route them to
 # the eth category by name so they don't land in stress_test.
@@ -56,37 +61,84 @@ ACKNOWLEDGED_CHECKS = {"cpld_fw_old"}
 EXCLUDED_CHECKS = {"snapshot_capture"}
 
 # checks whose details list offending BDFs - keep more text for triage.
-DETAIL_RICH = {"pcie_gen", "gddr_speed", "pcie_lane_width",
-               "physical_vs_fw_location", "asic_location_per_ubb"}
+DETAIL_RICH = {"pcie_gen", "gddr_speed", "pcie_lane_width", "physical_vs_fw_location", "asic_location_per_ubb"}
 
 # numeric forensic checks: dropped from checks_fact, folded into runs rollups.
 GDDR_INFO_PREFIX = "gddr_info_"
 
-SEVERITY = {"PASS": 0, "SKIP": 0, "EXCLUDED": 0, "WARN": 1, "FAIL": 2,
-            "UNKNOWN": 3, "ERROR": 3}
+SEVERITY = {"PASS": 0, "SKIP": 0, "EXCLUDED": 0, "WARN": 1, "FAIL": 2, "UNKNOWN": 3, "ERROR": 3}
 COVERED = {"PASS", "WARN", "FAIL"}
 
 RUNS_COLS = [
-    "schema_version", "run_id", "date", "timestamp", "hostname", "slurm_job_id",
-    "row", "rack", "slot", "overall_status", "discard", "discard_reason",
-    "prev_status", "is_regression", "fail_streak",
-    "tier", "tool_version", "tt_smi_version", "tt_kmd_version", "board_rev",
-    "fw_bundle_version", "num_chips", "total_duration_s",
-    "checks_total", "checks_pass", "checks_warn", "checks_fail", "checks_skip",
-    "checks_covered", "pct_covered", "checks_warn_actionable", "top_fail_category",
-    "reset_count", "reset_stable", "gddr_uncorr_total", "pcie_downgraded",
-    "eth_links_down", "max_asic_temp_c", "max_gddr_temp_c",
-    "min_aiclk_mhz", "telemetry_available",
-    "eth_retrain_total", "eth_crc_total", "eth_uncorr_cw_total", "jira_ticket",
+    "schema_version",
+    "run_id",
+    "date",
+    "timestamp",
+    "hostname",
+    "slurm_job_id",
+    "row",
+    "rack",
+    "slot",
+    "overall_status",
+    "discard",
+    "discard_reason",
+    "prev_status",
+    "is_regression",
+    "fail_streak",
+    "tier",
+    "tool_version",
+    "tt_smi_version",
+    "tt_kmd_version",
+    "board_rev",
+    "fw_bundle_version",
+    "num_chips",
+    "total_duration_s",
+    "checks_total",
+    "checks_pass",
+    "checks_warn",
+    "checks_fail",
+    "checks_skip",
+    "checks_covered",
+    "pct_covered",
+    "checks_warn_actionable",
+    "top_fail_category",
+    "reset_count",
+    "reset_stable",
+    "gddr_uncorr_total",
+    "pcie_downgraded",
+    "eth_links_down",
+    "max_asic_temp_c",
+    "max_gddr_temp_c",
+    "min_aiclk_mhz",
+    "telemetry_available",
+    "eth_retrain_total",
+    "eth_crc_total",
+    "eth_uncorr_cw_total",
+    "jira_ticket",
 ]
 
 # checks_fact is normalized: check fields + run_id (+ date). Run-level attributes
 # live once on runs.csv and join back on run_id.
 CHECKS_COLS = [
-    "schema_version", "run_id", "date",
-    "category", "phase", "phase_kind", "check_name", "status", "severity",
-    "is_pass", "is_warn", "is_fail", "is_skip", "is_covered", "acknowledged",
-    "testcases_passed", "testcases_failed", "executed", "details_short",
+    "schema_version",
+    "run_id",
+    "date",
+    "category",
+    "phase",
+    "phase_kind",
+    "check_name",
+    "status",
+    "severity",
+    "is_pass",
+    "is_warn",
+    "is_fail",
+    "is_skip",
+    "is_covered",
+    "acknowledged",
+    "testcases_passed",
+    "testcases_failed",
+    "executed",
+    "details_short",
 ]
 
 
@@ -206,9 +258,11 @@ def machine_meta(report, hostname, job_id, jira_ticket, ts, versions=None):
     versions = versions or {}
     # fw can be missing from the primary snapshot when a run fails early. Fall
     # back to a post-reset snapshot, then the console log, ignoring 0xFF reads.
-    fw = (_find_check(report, "fw_bundle_version_consistent")
-          or _find_check(report, "fw_bundle_version_consistent", primary_only=False)
-          or {})
+    fw = (
+        _find_check(report, "fw_bundle_version_consistent")
+        or _find_check(report, "fw_bundle_version_consistent", primary_only=False)
+        or {}
+    )
     log_fw = versions.get("fw_bundle_version", "")
     if log_fw in FW_SENTINELS:
         log_fw = ""
@@ -221,15 +275,23 @@ def machine_meta(report, hostname, job_id, jira_ticket, ts, versions=None):
     return {
         "schema_version": SCHEMA_VERSION,
         "run_id": f"{hostname}:{job_id}",
-        "date": ts[:10], "timestamp": ts,
-        "hostname": hostname, "row": row, "rack": rack, "slot": slot,
-        "slurm_job_id": job_id, "overall_status": overall,
-        "discard": int(dry), "discard_reason": "dry_run" if dry else "",
-        "tier": report.get("tier", ""), "tool_version": report.get("tool_version", ""),
+        "date": ts[:10],
+        "timestamp": ts,
+        "hostname": hostname,
+        "row": row,
+        "rack": rack,
+        "slot": slot,
+        "slurm_job_id": job_id,
+        "overall_status": overall,
+        "discard": int(dry),
+        "discard_reason": "dry_run" if dry else "",
+        "tier": report.get("tier", ""),
+        "tool_version": report.get("tool_version", ""),
         "tt_smi_version": report.get("tt_smi_version", "") or versions.get("tt_smi_version", ""),
         "tt_kmd_version": versions.get("tt_kmd_version", ""),
         "board_rev": report.get("detected_board_rev", ""),
-        "fw_bundle_version": fw_bundle, "num_chips": num_chips,
+        "fw_bundle_version": fw_bundle,
+        "num_chips": num_chips,
         "total_duration_s": report.get("total_duration_s", ""),
         "jira_ticket": jira_ticket,
     }
@@ -252,18 +314,29 @@ def checks_rows(report: dict, meta: dict):
         ran = isinstance(tp, int) and (tp + tf) > 0
         executed = 0 if (cat == "stress_test" and not ran) else 1
         cap = 400 if name in DETAIL_RICH else 140
-        rows.append({
-            "schema_version": meta["schema_version"], "run_id": meta["run_id"],
-            "date": meta["date"],
-            "category": cat, "phase": pname, "phase_kind": phase_kind(pname),
-            "check_name": name, "status": st, "severity": SEVERITY.get(st, 3),
-            "is_pass": int(st == "PASS"), "is_warn": int(st == "WARN"),
-            "is_fail": int(st == "FAIL"), "is_skip": int(st == "SKIP"),
-            "is_covered": int(st in COVERED and executed == 1),
-            "acknowledged": int(name in ACKNOWLEDGED_CHECKS or excluded),
-            "testcases_passed": tp, "testcases_failed": tf, "executed": executed,
-            "details_short": (c.get("details", "") or "").replace("\n", " | ")[:cap],
-        })
+        rows.append(
+            {
+                "schema_version": meta["schema_version"],
+                "run_id": meta["run_id"],
+                "date": meta["date"],
+                "category": cat,
+                "phase": pname,
+                "phase_kind": phase_kind(pname),
+                "check_name": name,
+                "status": st,
+                "severity": SEVERITY.get(st, 3),
+                "is_pass": int(st == "PASS"),
+                "is_warn": int(st == "WARN"),
+                "is_fail": int(st == "FAIL"),
+                "is_skip": int(st == "SKIP"),
+                "is_covered": int(st in COVERED and executed == 1),
+                "acknowledged": int(name in ACKNOWLEDGED_CHECKS or excluded),
+                "testcases_passed": tp,
+                "testcases_failed": tf,
+                "executed": executed,
+                "details_short": (c.get("details", "") or "").replace("\n", " | ")[:cap],
+            }
+        )
     return rows
 
 
@@ -302,23 +375,51 @@ def runs_row(report, meta, checks, telemetry=None):
         overall_status = "PASS"
 
     return {
-        **{k: meta[k] for k in (
-            "schema_version", "run_id", "date", "timestamp", "hostname",
-            "row", "rack", "slot", "slurm_job_id",
-            "discard", "discard_reason", "tier", "tool_version", "tt_smi_version",
-            "tt_kmd_version", "board_rev", "fw_bundle_version", "num_chips",
-            "total_duration_s", "jira_ticket")},
+        **{
+            k: meta[k]
+            for k in (
+                "schema_version",
+                "run_id",
+                "date",
+                "timestamp",
+                "hostname",
+                "row",
+                "rack",
+                "slot",
+                "slurm_job_id",
+                "discard",
+                "discard_reason",
+                "tier",
+                "tool_version",
+                "tt_smi_version",
+                "tt_kmd_version",
+                "board_rev",
+                "fw_bundle_version",
+                "num_chips",
+                "total_duration_s",
+                "jira_ticket",
+            )
+        },
         "overall_status": overall_status,
-        "prev_status": "", "is_regression": "", "fail_streak": "",
-        "checks_total": total, "checks_pass": counts["PASS"],
-        "checks_warn": counts["WARN"], "checks_fail": counts["FAIL"],
-        "checks_skip": counts["SKIP"], "checks_covered": covered,
+        "prev_status": "",
+        "is_regression": "",
+        "fail_streak": "",
+        "checks_total": total,
+        "checks_pass": counts["PASS"],
+        "checks_warn": counts["WARN"],
+        "checks_fail": counts["FAIL"],
+        "checks_skip": counts["SKIP"],
+        "checks_covered": covered,
         "pct_covered": round(100 * covered / total, 1) if total else "",
-        "checks_warn_actionable": sum(warn_cat.values()), "top_fail_category": top,
-        "reset_count": reset_count, "reset_stable": reset_stable,
-        "gddr_uncorr_total": gddr_uncorr, "pcie_downgraded": _pcie_downgraded(report),
+        "checks_warn_actionable": sum(warn_cat.values()),
+        "top_fail_category": top,
+        "reset_count": reset_count,
+        "reset_stable": reset_stable,
+        "gddr_uncorr_total": gddr_uncorr,
+        "pcie_downgraded": _pcie_downgraded(report),
         "eth_links_down": _eth_links_down(report),
-        "max_asic_temp_c": _max_asic_temp(report), "max_gddr_temp_c": max_gddr_t,
+        "max_asic_temp_c": _max_asic_temp(report),
+        "max_gddr_temp_c": max_gddr_t,
         "min_aiclk_mhz": tel.get("min_aiclk_mhz", ""),
         "telemetry_available": int(bool(tel.get("available"))),
         "eth_retrain_total": tel.get("eth_retrain_total", ""),
@@ -330,17 +431,31 @@ def runs_row(report, meta, checks, telemetry=None):
 def error_runs_row(hostname, job_id, ts, reason, jira_ticket=""):
     row, rack, slot = parse_host(hostname)
     r = {c: "" for c in RUNS_COLS}
-    r.update({
-        "schema_version": SCHEMA_VERSION, "run_id": f"{hostname}:{job_id}",
-        "date": ts[:10], "timestamp": ts, "hostname": hostname,
-        "row": row, "rack": rack, "slot": slot, "slurm_job_id": job_id,
-        "overall_status": "ERROR",
-        "discard": 0, "top_fail_category": "run",
-        "checks_total": 0, "checks_pass": 0, "checks_warn": 0, "checks_fail": 0,
-        "checks_skip": 0, "checks_covered": 0, "checks_warn_actionable": 0,
-        "telemetry_available": 0,
-        "jira_ticket": jira_ticket,
-    })
+    r.update(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": f"{hostname}:{job_id}",
+            "date": ts[:10],
+            "timestamp": ts,
+            "hostname": hostname,
+            "row": row,
+            "rack": rack,
+            "slot": slot,
+            "slurm_job_id": job_id,
+            "overall_status": "ERROR",
+            "discard": 0,
+            "top_fail_category": "run",
+            "checks_total": 0,
+            "checks_pass": 0,
+            "checks_warn": 0,
+            "checks_fail": 0,
+            "checks_skip": 0,
+            "checks_covered": 0,
+            "checks_warn_actionable": 0,
+            "telemetry_available": 0,
+            "jira_ticket": jira_ticket,
+        }
+    )
     return r
 
 
@@ -364,15 +479,13 @@ def _validate(runs, checks):
             RunRecord(**{c: r.get(c, "") for c in RUNS_COLS})
         except Exception as exc:
             bad += 1
-            print(f"WARNING: runs row failed schema validation: "
-                  f"{str(exc).splitlines()[0]}", file=sys.stderr)
+            print(f"WARNING: runs row failed schema validation: " f"{str(exc).splitlines()[0]}", file=sys.stderr)
     for c in checks:
         try:
             CheckRecord(**{k: c.get(k, "") for k in CHECKS_COLS})
         except Exception as exc:
             bad += 1
-            print(f"WARNING: checks row failed schema validation: "
-                  f"{str(exc).splitlines()[0]}", file=sys.stderr)
+            print(f"WARNING: checks row failed schema validation: " f"{str(exc).splitlines()[0]}", file=sys.stderr)
     if bad == 0:
         print("schema validation: OK")
 
@@ -384,14 +497,15 @@ def _normalize(report):
     try:
         from utils.report import normalize_health_report
     except Exception as exc:
-        print(f"WARNING: could not import utils.report.normalize_health_report ({exc}); "
-              "using report as-is", file=sys.stderr)
+        print(
+            f"WARNING: could not import utils.report.normalize_health_report ({exc}); " "using report as-is",
+            file=sys.stderr,
+        )
         return report
     return normalize_health_report(report)
 
 
-def analyze(report, csv_output_dir, hostname, slurm_job_id,
-            jira_ticket="", versions=None, telemetry=None):
+def analyze(report, csv_output_dir, hostname, slurm_job_id, jira_ticket="", versions=None, telemetry=None):
     """Translate a normalized diag_report.json dict into runs.csv (+ checks.csv).
 
     report must already be normalized by the caller so the verdict reflects
@@ -405,8 +519,7 @@ def analyze(report, csv_output_dir, hostname, slurm_job_id,
 
     if not report:
         print("WARNING: no diag_report.json - writing fail-closed ERROR runs row")
-        row = error_runs_row(hostname, slurm_job_id, ts, "no diag_report.json",
-                             jira_ticket)
+        row = error_runs_row(hostname, slurm_job_id, ts, "no diag_report.json", jira_ticket)
         _validate([row], [])
         _write_csv(runs_path, RUNS_COLS, [row])
         return [runs_path]
@@ -436,8 +549,7 @@ def main():
             with open(args.report_file) as f:
                 report = json.load(f)
         except (ValueError, OSError) as exc:
-            print(f"WARNING: could not parse {args.report_file}: {exc}",
-                  file=sys.stderr)
+            print(f"WARNING: could not parse {args.report_file}: {exc}", file=sys.stderr)
     if report:
         report = _normalize(report)
 

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
@@ -266,7 +266,10 @@ def machine_meta(report, hostname, job_id, jira_ticket, ts, versions=None):
     log_fw = versions.get("fw_bundle_version", "")
     if log_fw in FW_SENTINELS:
         log_fw = ""
-    fw_bundle = str(fw.get("data", {}).get("value", "") or log_fw)
+    report_fw = fw.get("data", {}).get("value", "")
+    if report_fw in FW_SENTINELS:
+        report_fw = ""
+    fw_bundle = str(report_fw or log_fw)
     enum = _find_check(report, "pcie_enum_count") or {}
     num_chips = enum.get("data", {}).get("actual", "")
     overall = report.get("overall_status", "") or "UNKNOWN"

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/requirements.txt
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.28
+paramiko>=3.0
+prometheus_client>=0.22

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/requirements.txt
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.28
 paramiko>=3.0
 prometheus_client>=0.22
+pydantic>=2

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -61,6 +61,12 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
+# Deployment this runner is executing under. The runner is shared across the
+# bare-Slurm (exabox) and Kubernetes (tt-orchestration) health checks; the two
+# spots that genuinely differ — how the diag suite is launched and how the SFTP
+# key is loaded — dispatch on this. Default preserves the Slurm behavior.
+LAUNCH_MODES = ("slurm", "orchestration")
+
 
 # ---------------------------------------------------------------------------
 # Argument parsing
@@ -71,6 +77,16 @@ def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Run fabric system health check on a node.")
 
     p.add_argument("node", help="Target node hostname")
+    p.add_argument(
+        "--launch-mode",
+        choices=LAUNCH_MODES,
+        default="slurm",
+        help=(
+            "Deployment mode. 'slurm' (default) runs diag_runner.py directly and "
+            "loads creds from env + files; 'orchestration' (k8s) runs run_diag.sh "
+            "and loads the SFTP key from SFTP_KEY_PATH."
+        ),
+    )
     p.add_argument(
         "--log-dir", required=True, help="Directory for logs and credentials"
     )
@@ -91,7 +107,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--diag-runner",
         default="",
-        help="Path to diag_runner.py (defaults to the sibling health-check suite script).",
+        help="Path to diag_runner.py (slurm mode; defaults to the sibling health-check suite script).",
     )
     p.add_argument(
         "--tt-metal-path",
@@ -232,8 +248,9 @@ def main() -> int:
     log_file = Path(log_dir) / f"{node}-{slurm_job_id}.log"
     timeout_seconds = args.timeout_minutes * 60
 
-    jira_bearer_token = load_jira_secrets(log_dir)
-    sftp_user, sftp_host = load_sftp_secrets(log_dir)
+    launch_mode = args.launch_mode
+    jira_bearer_token = load_jira_secrets(log_dir, launch_mode)
+    sftp_user, sftp_host = load_sftp_secrets(log_dir, launch_mode)
 
     # Collect version info
     versions = collect_version_info()
@@ -264,6 +281,7 @@ def main() -> int:
         tier=args.tier,
         timeout_seconds=timeout_seconds,
         results_dir=results_dir,
+        launch_mode=launch_mode,
         diag_runner=Path(args.diag_runner) if args.diag_runner else None,
         tt_metal_path=Path(args.tt_metal_path) if args.tt_metal_path else None,
     )
@@ -463,7 +481,9 @@ def main() -> int:
     # SFTP upload
     if csv_dir and args.upload_sftp:
         if sftp_user and sftp_host:
-            upload_csv_sftp(csv_dir, sftp_user, sftp_host, log_dir=log_dir)
+            upload_csv_sftp(
+                csv_dir, sftp_user, sftp_host, log_dir=log_dir, launch_mode=launch_mode
+            )
         else:
             log.warning("SFTP credentials not configured, skipping CSV upload")
     elif csv_dir:

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -87,9 +87,7 @@ def parse_args() -> argparse.Namespace:
             "and loads the SFTP key from SFTP_KEY_PATH."
         ),
     )
-    p.add_argument(
-        "--log-dir", required=True, help="Directory for logs and credentials"
-    )
+    p.add_argument("--log-dir", required=True, help="Directory for logs and credentials")
     p.add_argument(
         "--tier",
         default="light",
@@ -100,8 +98,7 @@ def parse_args() -> argparse.Namespace:
         "--results-dir",
         default="",
         help=(
-            "Directory for the JSON report and per-test logs. "
-            "Defaults to <log-dir>/<node>-<slurm_job_id>-results."
+            "Directory for the JSON report and per-test logs. " "Defaults to <log-dir>/<node>-<slurm_job_id>-results."
         ),
     )
     p.add_argument(
@@ -114,15 +111,11 @@ def parse_args() -> argparse.Namespace:
         default="",
         help="tt-metal repo root (defaults to $TT_METAL_HOME / the diag suite's own default).",
     )
-    p.add_argument(
-        "--timeout-minutes", type=int, default=30, help="Timeout for the diag run"
-    )
+    p.add_argument("--timeout-minutes", type=int, default=30, help="Timeout for the diag run")
 
     jira = p.add_argument_group("JIRA integration")
     jira.add_argument("--jira-base-url", default="", help="JIRA REST API base URL")
-    jira.add_argument(
-        "--jira-site-url", default="", help="JIRA site URL for browse links"
-    )
+    jira.add_argument("--jira-site-url", default="", help="JIRA site URL for browse links")
     jira.add_argument("--jira-project-key", default="", help="JIRA project key")
     jira.add_argument("--jira-issue-type", default="Bug", help="JIRA issue type")
     jira.add_argument(
@@ -191,9 +184,7 @@ def run_csv_analysis(
         report = None
         if json_report and json_report.is_file():
             try:
-                report = normalize_health_report(
-                    json.loads(json_report.read_text())
-                )
+                report = normalize_health_report(json.loads(json_report.read_text()))
             except (OSError, ValueError) as exc:
                 log.warning("Could not read %s for CSV analysis: %s", json_report, exc)
 
@@ -274,9 +265,7 @@ def main() -> int:
 
     # Run the diag suite as a subprocess. It writes its JSON report + per-test
     # logs straight into results_dir on the host filesystem.
-    results_dir = Path(
-        args.results_dir or (Path(log_dir) / f"{node}-{slurm_job_id}-results")
-    )
+    results_dir = Path(args.results_dir or (Path(log_dir) / f"{node}-{slurm_job_id}-results"))
     exit_code, test_output, artifacts_dir = run_diag_subprocess(
         tier=args.tier,
         timeout_seconds=timeout_seconds,
@@ -322,9 +311,7 @@ def main() -> int:
         except (OSError, ValueError) as exc:
             report = None
             log.warning("Could not read %s to classify failure: %s", json_report, exc)
-        if report is not None and not has_actionable_failure(
-            normalize_health_report(report)
-        ):
+        if report is not None and not has_actionable_failure(normalize_health_report(report)):
             log.info(
                 "No actionable failure after dropping pre-reset snapshot / excluded "
                 "checks; treating run as non-failing and skipping JIRA ticket."
@@ -347,9 +334,7 @@ def main() -> int:
             # inline with the comment/description.
             result_files = []
             if artifacts_dir and artifacts_dir.is_dir():
-                result_files = sorted(
-                    p for p in artifacts_dir.rglob("*") if p.is_file()
-                )
+                result_files = sorted(p for p in artifacts_dir.rglob("*") if p.is_file())
             attachment_names = [f"{node}-{slurm_job_id}.log"] + [
                 artifact_upload_name(p, slurm_job_id) for p in result_files
             ]
@@ -481,9 +466,7 @@ def main() -> int:
     # SFTP upload
     if csv_dir and args.upload_sftp:
         if sftp_user and sftp_host:
-            upload_csv_sftp(
-                csv_dir, sftp_user, sftp_host, log_dir=log_dir, launch_mode=launch_mode
-            )
+            upload_csv_sftp(csv_dir, sftp_user, sftp_host, log_dir=log_dir, launch_mode=launch_mode)
         else:
             log.warning("SFTP credentials not configured, skipping CSV upload")
     elif csv_dir:

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fabric System Health Check runner.
+
+Runs the TT fabric system health check (``diag_runner.py``) as a subprocess,
+writes the JSON report and per-test logs to a results directory, creates a JIRA
+ticket on failure, produces CSV analysis, and uploads results via SFTP.
+
+Designed to run *inside* the tt-metal upstream image (the image is the runtime),
+so the diag suite is invoked directly rather than in a nested container. The
+orchestration's supporting logic lives in the ``utils`` package:
+
+    utils/diag_execution.py  run the diag suite as a subprocess (timeout/kill aware)
+    utils/system_info.py     tt-smi / kmd / fw version discovery
+    utils/telemetry.py       tt-telemetry (Prometheus) collection + formatting
+    utils/report.py          post-reset normalization + actionable-failure verdict
+    utils/jira_client.py     JIRA ticket create/update/close/attach
+    utils/sftp_upload.py     CSV upload to the Data-team SFTP endpoint
+    utils/secrets_loader.py  JIRA/SFTP credential file parsing
+
+The sibling ``analyze_health_check_results.py`` turns diag_report.json into the
+runs/checks CSVs.
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+from utils.diag_execution import run_diag_subprocess
+from utils.jira_client import (
+    _build_failure_body,
+    add_comment_to_jira,
+    artifact_upload_name,
+    attach_files_to_jira,
+    attach_log_to_jira,
+    create_jira_ticket,
+    find_open_ticket_for_node,
+    transition_jira_ticket,
+    update_jira_versions,
+)
+from utils.report import has_actionable_failure, normalize_health_report
+from utils.secrets_loader import load_jira_secrets, load_sftp_secrets
+from utils.sftp_upload import upload_csv_sftp
+from utils.system_info import collect_version_info
+from utils.telemetry import collect_prometheus_metrics, format_prometheus_metrics
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run fabric system health check on a node.")
+
+    p.add_argument("node", help="Target node hostname")
+    p.add_argument(
+        "--log-dir", required=True, help="Directory for logs and credentials"
+    )
+    p.add_argument(
+        "--tier",
+        default="light",
+        choices=["light", "medium", "deploy"],
+        help="Diagnostic tier passed to the diag suite",
+    )
+    p.add_argument(
+        "--results-dir",
+        default="",
+        help=(
+            "Directory for the JSON report and per-test logs. "
+            "Defaults to <log-dir>/<node>-<slurm_job_id>-results."
+        ),
+    )
+    p.add_argument(
+        "--diag-runner",
+        default="",
+        help="Path to diag_runner.py (defaults to the sibling health-check suite script).",
+    )
+    p.add_argument(
+        "--tt-metal-path",
+        default="",
+        help="tt-metal repo root (defaults to $TT_METAL_HOME / the diag suite's own default).",
+    )
+    p.add_argument(
+        "--timeout-minutes", type=int, default=30, help="Timeout for the diag run"
+    )
+
+    jira = p.add_argument_group("JIRA integration")
+    jira.add_argument("--jira-base-url", default="", help="JIRA REST API base URL")
+    jira.add_argument(
+        "--jira-site-url", default="", help="JIRA site URL for browse links"
+    )
+    jira.add_argument("--jira-project-key", default="", help="JIRA project key")
+    jira.add_argument("--jira-issue-type", default="Bug", help="JIRA issue type")
+    jira.add_argument(
+        "--jira-resolve-transition",
+        default="Done",
+        help="Transition used to close a node's open ticket when it recovers "
+        "(falls back to any done-category transition if not found)",
+    )
+
+    p.add_argument(
+        "--create-jira",
+        choices=("true", "false"),
+        default="true",
+        help="Create/update a JIRA ticket on failure",
+    )
+    p.add_argument(
+        "--upload-sftp",
+        choices=("true", "false"),
+        default="true",
+        help="Upload runs/checks CSVs to the Data-team SFTP endpoint",
+    )
+    p.add_argument(
+        "--cleanup",
+        choices=("true", "false"),
+        default="true",
+        help="Delete the log and results directory after the run",
+    )
+
+    args = p.parse_args()
+    # node is used to build filesystem paths (log/results dirs); constrain it to a
+    # hostname to prevent path traversal.
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9.-]*", args.node):
+        p.error(f"invalid node name: {args.node!r}")
+    args.create_jira = args.create_jira == "true"
+    args.upload_sftp = args.upload_sftp == "true"
+    args.cleanup = args.cleanup == "true"
+    return args
+
+
+# ---------------------------------------------------------------------------
+# CSV analysis
+# ---------------------------------------------------------------------------
+
+
+def run_csv_analysis(
+    json_report: Path | None,
+    node: str,
+    slurm_job_id: str,
+    ticket_key: str | None,
+    versions: dict[str, str],
+) -> str | None:
+    """Translate the diag_report.json into the runs/checks CSVs for Superset.
+
+    The report is normalized (same normalize_health_report used for the verdict)
+    so the CSV verdict reflects post-reset state. Fail-closed: if the report is
+    missing/unparseable the analyzer still emits an ERROR runs.csv. Returns the
+    path to the CSV output directory.
+    """
+
+    csv_output_dir = tempfile.mkdtemp(prefix="health-check-csv-")
+
+    log.info("Producing CSV analysis results ...")
+    try:
+        from analyze_health_check_results import analyze
+
+        report = None
+        if json_report and json_report.is_file():
+            try:
+                report = normalize_health_report(
+                    json.loads(json_report.read_text())
+                )
+            except (OSError, ValueError) as exc:
+                log.warning("Could not read %s for CSV analysis: %s", json_report, exc)
+
+        analyze(
+            report=report,
+            csv_output_dir=csv_output_dir,
+            hostname=node,
+            slurm_job_id=slurm_job_id,
+            jira_ticket=ticket_key or "",
+            versions={
+                "tt_smi_version": _clean_version(versions.get("tt_smi")),
+                "tt_kmd_version": _clean_version(versions.get("tt_kmd")),
+                "fw_bundle_version": _clean_version(versions.get("fw_bundle")),
+            },
+        )
+    except Exception as exc:
+        log.warning("CSV analysis failed: %s", exc)
+
+    return csv_output_dir
+
+
+def _clean_version(value: str | None) -> str:
+    """Map the collector's "N/A" sentinel (and None) to empty string so it
+    doesn't surface as a real version bucket in the dashboards."""
+    return "" if value in (None, "", "N/A") else value
+
+
+# ---------------------------------------------------------------------------
+# Main orchestration
+# ---------------------------------------------------------------------------
+
+
+def remove_path(base: str, target: str) -> None:
+    """Delete target only if it canonicalizes to a location inside base."""
+    base_real = os.path.realpath(base)
+    target_real = os.path.realpath(target)
+    if os.path.commonpath([base_real, target_real]) != base_real:
+        log.warning("Refusing to delete %s: outside %s", target_real, base_real)
+        return
+    if os.path.isdir(target_real):
+        shutil.rmtree(target_real, ignore_errors=True)
+    else:
+        Path(target_real).unlink(missing_ok=True)
+
+
+def main() -> int:
+    args = parse_args()
+
+    node = args.node
+    log_dir = args.log_dir
+    slurm_job_id = os.environ.get("SLURM_JOB_ID", "unknown")
+    log_file = Path(log_dir) / f"{node}-{slurm_job_id}.log"
+    timeout_seconds = args.timeout_minutes * 60
+
+    jira_bearer_token = load_jira_secrets(log_dir)
+    sftp_user, sftp_host = load_sftp_secrets(log_dir)
+
+    # Collect version info
+    versions = collect_version_info()
+    version_header = (
+        "--- version info ---\n"
+        f"tt-smi version: {versions['tt_smi']}\n"
+        f"tt-kmd version: {versions['tt_kmd']}\n"
+        f"fw_bundle_version={versions['fw_bundle']}\n"
+        "--- fabric system health check ---\n"
+    )
+    print(version_header, flush=True)
+
+    # Collect Prometheus metrics from local telemetry endpoint
+    prom_metrics = collect_prometheus_metrics()
+    prom_output = ""
+    if prom_metrics:
+        prom_output = format_prometheus_metrics(prom_metrics)
+        print(prom_output, flush=True)
+    else:
+        log.info("No Prometheus metrics collected")
+
+    # Run the diag suite as a subprocess. It writes its JSON report + per-test
+    # logs straight into results_dir on the host filesystem.
+    results_dir = Path(
+        args.results_dir or (Path(log_dir) / f"{node}-{slurm_job_id}-results")
+    )
+    exit_code, test_output, artifacts_dir = run_diag_subprocess(
+        tier=args.tier,
+        timeout_seconds=timeout_seconds,
+        results_dir=results_dir,
+        diag_runner=Path(args.diag_runner) if args.diag_runner else None,
+        tt_metal_path=Path(args.tt_metal_path) if args.tt_metal_path else None,
+    )
+
+    full_output = version_header + prom_output + "\n" + test_output
+    print(test_output, flush=True)
+
+    # Write console output to log file
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    log_file.write_text(full_output)
+
+    # Surface the structured artifacts (JSON report + gtest logs) for downstream
+    # JIRA attachment / SFTP upload (handled by the analysis step, to follow).
+    json_report = None
+    logs_subdir = None
+    if artifacts_dir and artifacts_dir.is_dir():
+        json_report = artifacts_dir / "diag_report.json"
+        logs_subdir = artifacts_dir / "logs"
+        log.info(
+            "JSON report: %s",
+            json_report if json_report.is_file() else "MISSING (not produced)",
+        )
+        if logs_subdir.is_dir():
+            log.info(
+                "Per-test logs (%d file(s)) in %s",
+                len(list(logs_subdir.glob("*.log"))),
+                logs_subdir,
+            )
+    else:
+        log.warning("No results directory present (diag run may have failed to start)")
+
+    # Don't fail/ticket if nothing actionable remains post-reset (pre-reset and
+    # excluded-check FAILs cleared after tt-smi reset).
+    effective_code = exit_code
+    if exit_code != 0 and json_report and json_report.is_file():
+        try:
+            report = json.loads(json_report.read_text())
+        except (OSError, ValueError) as exc:
+            report = None
+            log.warning("Could not read %s to classify failure: %s", json_report, exc)
+        if report is not None and not has_actionable_failure(
+            normalize_health_report(report)
+        ):
+            log.info(
+                "No actionable failure after dropping pre-reset snapshot / excluded "
+                "checks; treating run as non-failing and skipping JIRA ticket."
+            )
+            effective_code = 0
+
+    # JIRA ticket creation (failure only)
+    ticket_key = None
+    if effective_code != 0:
+        log.info("Test failed with exit code %d", exit_code)
+
+        if not args.create_jira:
+            log.info("JIRA ticket creation disabled by config")
+        elif not jira_bearer_token:
+            log.warning("JIRA credentials not configured, skipping ticket creation")
+        elif not args.jira_base_url:
+            log.warning("JIRA base URL not configured, skipping ticket creation")
+        else:
+            # Files this run will reference with [^name] so JIRA renders them
+            # inline with the comment/description.
+            result_files = []
+            if artifacts_dir and artifacts_dir.is_dir():
+                result_files = sorted(
+                    p for p in artifacts_dir.rglob("*") if p.is_file()
+                )
+            attachment_names = [f"{node}-{slurm_job_id}.log"] + [
+                artifact_upload_name(p, slurm_job_id) for p in result_files
+            ]
+
+            existing_key = find_open_ticket_for_node(
+                node=node,
+                jira_base_url=args.jira_base_url,
+                jira_project_key=args.jira_project_key,
+                jira_bearer_token=jira_bearer_token,
+            )
+
+            if existing_key:
+                # Recurring failure while a ticket is still open: append the new
+                # failure as a comment instead of opening a duplicate ticket.
+                comment_body = (
+                    f"Fabric System Health Check failed again on node {node} "
+                    f"(recurring failure).\n\n"
+                    + _build_failure_body(
+                        node=node,
+                        slurm_job_id=slurm_job_id,
+                        exit_code=exit_code,
+                        versions=versions,
+                        telemetry_summary=prom_output,
+                        test_output=full_output,
+                        attachment_names=attachment_names,
+                    )
+                )
+                add_comment_to_jira(
+                    ticket_key=existing_key,
+                    body=comment_body,
+                    jira_base_url=args.jira_base_url,
+                    jira_bearer_token=jira_bearer_token,
+                )
+                # Keep the mandatory version fields current with this run.
+                update_jira_versions(
+                    ticket_key=existing_key,
+                    versions=versions,
+                    jira_base_url=args.jira_base_url,
+                    jira_bearer_token=jira_bearer_token,
+                )
+                ticket_key = existing_key
+            else:
+                ticket_key = create_jira_ticket(
+                    node=node,
+                    slurm_job_id=slurm_job_id,
+                    exit_code=exit_code,
+                    test_output=full_output,
+                    jira_base_url=args.jira_base_url,
+                    jira_site_url=args.jira_site_url,
+                    jira_project_key=args.jira_project_key,
+                    jira_issue_type=args.jira_issue_type,
+                    jira_bearer_token=jira_bearer_token,
+                    versions=versions,
+                    telemetry_summary=prom_output,
+                    attachment_names=attachment_names,
+                )
+                if ticket_key:
+                    transition_jira_ticket(
+                        ticket_key=ticket_key,
+                        jira_base_url=args.jira_base_url,
+                        jira_bearer_token=jira_bearer_token,
+                    )
+
+            # Upload under the names referenced above.
+            if ticket_key:
+                attached = attach_log_to_jira(
+                    ticket_key=ticket_key,
+                    test_output=full_output,
+                    node=node,
+                    slurm_job_id=slurm_job_id,
+                    jira_base_url=args.jira_base_url,
+                    jira_bearer_token=jira_bearer_token,
+                )
+                if attached and args.cleanup:
+                    log.info("Cleaned up log file: %s", log_file)
+                    remove_path(log_dir, str(log_file))
+
+                if result_files:
+                    attach_files_to_jira(
+                        ticket_key=ticket_key,
+                        files=result_files,
+                        slurm_job_id=slurm_job_id,
+                        jira_base_url=args.jira_base_url,
+                        jira_bearer_token=jira_bearer_token,
+                    )
+    else:
+        # Clean run: if this node has an open failure ticket, it just recovered
+        # — close it so machines that are fine don't accumulate stale tickets.
+        if args.create_jira and jira_bearer_token and args.jira_base_url:
+            recovered_key = find_open_ticket_for_node(
+                node=node,
+                jira_base_url=args.jira_base_url,
+                jira_project_key=args.jira_project_key,
+                jira_bearer_token=jira_bearer_token,
+            )
+            if recovered_key:
+                log.info(
+                    "Node %s passed with open ticket %s; closing it (recovered)",
+                    node,
+                    recovered_key,
+                )
+                add_comment_to_jira(
+                    ticket_key=recovered_key,
+                    body=(
+                        f"Fabric System Health Check passed on node {node} "
+                        f"(Slurm job {slurm_job_id}); the node has recovered. "
+                        f"Closing this ticket automatically."
+                    ),
+                    jira_base_url=args.jira_base_url,
+                    jira_bearer_token=jira_bearer_token,
+                )
+                transition_jira_ticket(
+                    ticket_key=recovered_key,
+                    jira_base_url=args.jira_base_url,
+                    jira_bearer_token=jira_bearer_token,
+                    target_transition=args.jira_resolve_transition,
+                    fallback_to_done=True,
+                )
+
+    # CSV analysis (always)
+    csv_dir = run_csv_analysis(
+        json_report=json_report,
+        node=node,
+        slurm_job_id=slurm_job_id,
+        ticket_key=ticket_key,
+        versions=versions,
+    )
+
+    # SFTP upload
+    if csv_dir and args.upload_sftp:
+        if sftp_user and sftp_host:
+            upload_csv_sftp(csv_dir, sftp_user, sftp_host, log_dir=log_dir)
+        else:
+            log.warning("SFTP credentials not configured, skipping CSV upload")
+    elif csv_dir:
+        log.info("SFTP upload disabled by config")
+
+    if args.cleanup:
+        if csv_dir:
+            remove_path(tempfile.gettempdir(), csv_dir)
+        if effective_code == 0:
+            remove_path(log_dir, str(log_file))
+        remove_path(log_dir, str(results_dir))
+
+    return effective_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -52,7 +52,7 @@ from utils.report import has_actionable_failure, normalize_health_report
 from utils.secrets_loader import load_jira_secrets, load_sftp_secrets
 from utils.sftp_upload import upload_csv_sftp
 from utils.system_info import collect_version_info
-from utils.telemetry import collect_prometheus_metrics, format_prometheus_metrics
+from utils.telemetry import aggregate_telemetry_for_csv, collect_prometheus_metrics, format_prometheus_metrics
 
 logging.basicConfig(
     level=logging.INFO,
@@ -166,6 +166,7 @@ def run_csv_analysis(
     slurm_job_id: str,
     ticket_key: str | None,
     versions: dict[str, str],
+    telemetry: dict | None = None,
 ) -> str | None:
     """Translate the diag_report.json into the runs/checks CSVs for Superset.
 
@@ -199,6 +200,7 @@ def run_csv_analysis(
                 "tt_kmd_version": _clean_version(versions.get("tt_kmd")),
                 "fw_bundle_version": _clean_version(versions.get("fw_bundle")),
             },
+            telemetry=telemetry,
         )
     except Exception as exc:
         log.warning("CSV analysis failed: %s", exc)
@@ -218,11 +220,17 @@ def _clean_version(value: str | None) -> str:
 
 
 def remove_path(base: str, target: str) -> None:
-    """Delete target only if it canonicalizes to a location inside base."""
+    """Delete target only if it canonicalizes to a strict child of base.
+
+    Rejecting ``target_real == base_real`` is deliberate: commonpath() of two
+    identical paths is that path, so without the equality guard a caller passing
+    target == base (e.g. --results-dir equal to --log-dir) would recursively
+    delete the entire base directory, including credentials and unrelated runs.
+    """
     base_real = os.path.realpath(base)
     target_real = os.path.realpath(target)
-    if os.path.commonpath([base_real, target_real]) != base_real:
-        log.warning("Refusing to delete %s: outside %s", target_real, base_real)
+    if target_real == base_real or os.path.commonpath([base_real, target_real]) != base_real:
+        log.warning("Refusing to delete %s: not a child of %s", target_real, base_real)
         return
     if os.path.isdir(target_real):
         shutil.rmtree(target_real, ignore_errors=True)
@@ -262,6 +270,10 @@ def main() -> int:
         print(prom_output, flush=True)
     else:
         log.info("No Prometheus metrics collected")
+    # Flatten the collected families for the CSV verdict. Without this the
+    # analyzer only gets the log-formatted string and every run reports
+    # telemetry_available=0 to Superset despite a successful collection.
+    telemetry_summary = aggregate_telemetry_for_csv(prom_metrics)
 
     # Run the diag suite as a subprocess. It writes its JSON report + per-test
     # logs straight into results_dir on the host filesystem.
@@ -461,6 +473,7 @@ def main() -> int:
         slurm_job_id=slurm_job_id,
         ticket_key=ticket_key,
         versions=versions,
+        telemetry=telemetry_summary,
     )
 
     # SFTP upload

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/__init__.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helper modules for the fabric system health-check harness."""

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/diag_execution.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/diag_execution.py
@@ -2,16 +2,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Execute the diag suite (``diag_runner.py``) as a subprocess.
+"""Execute the diag suite as a subprocess.
 
 This replaces the previous docker-in-docker model: when the whole health check
 runs inside the tt-metal image, the diag suite is a sibling script we invoke
 directly rather than a nested container.
 
-Subprocess (rather than importing ``diag_runner.run_diag`` in-process) is used so
-we retain a hard wall-clock budget: the diag suite drives destructive resets and
-long gtests that can hang, and a subprocess lets us kill the whole process group
-(gtest / tt-smi children included) when the timeout fires.
+The command differs by launch mode (this is one of the two spots that diverge
+between the bare-Slurm and the Kubernetes/orchestration deployments):
+
+    slurm          -> ``python3 diag_runner.py --tier <tier> --output <report>``
+    orchestration  -> ``bash run_diag.sh <tier> --output <report>``
+
+Both share the same subprocess core: we keep a hard wall-clock budget and kill
+the whole process group (gtest / tt-smi children included) when the timeout
+fires, since the diag suite drives destructive resets and long gtests that can
+hang.
 """
 
 from __future__ import annotations
@@ -36,6 +42,11 @@ def default_diag_runner() -> Path:
     return Path(__file__).resolve().parents[2] / "diag_runner.py"
 
 
+def default_run_diag_script() -> Path:
+    """Locate run_diag.sh (the bash wrapper used in orchestration mode)."""
+    return Path(__file__).resolve().parents[2] / "run_diag.sh"
+
+
 def _kill_process_group(proc: subprocess.Popen) -> None:
     """SIGTERM then SIGKILL the child's process group (gtest / tt-smi children)."""
     try:
@@ -54,40 +65,8 @@ def _kill_process_group(proc: subprocess.Popen) -> None:
             continue
 
 
-def run_diag_subprocess(
-    tier: str,
-    timeout_seconds: int,
-    results_dir: Path,
-    *,
-    diag_runner: Path | None = None,
-    tt_metal_path: Path | None = None,
-    extra_args: list[str] | None = None,
-) -> tuple[int, str, Path | None]:
-    """Run the diag suite, writing its JSON report + per-test logs into results_dir.
-
-    Invokes ``diag_runner.py --tier <tier> --output <results_dir>/diag_report.json``,
-    which also drops per-test gtest logs under ``<results_dir>/logs/``. The report
-    and logs land straight on the host filesystem (no copy-out step), so partial
-    results survive a timeout/kill.
-
-    Returns ``(exit_code, combined_console_output, results_dir | None)``. The diag
-    tool exits 1 on FAIL and 0 on PASS/WARN; that status is propagated unchanged.
-    A timeout is reported as exit code 137 (matching the previous SIGKILL model).
-    """
-    runner = Path(diag_runner) if diag_runner else default_diag_runner()
-    if not runner.is_file():
-        log.error("diag runner not found: %s", runner)
-        return 1, f"diag runner not found: {runner}", None
-
-    results_dir.mkdir(parents=True, exist_ok=True)
-    report_path = results_dir / "diag_report.json"
-
-    cmd = [sys.executable, str(runner), "--tier", tier, "--output", str(report_path)]
-    if tt_metal_path is not None:
-        cmd += ["--tt-metal-path", str(tt_metal_path)]
-    if extra_args:
-        cmd += list(extra_args)
-
+def _diag_env(tt_metal_path: Path | None) -> dict:
+    """Environment shared by both launch modes."""
     env = os.environ.copy()
     if tt_metal_path is not None:
         env["TT_METAL_HOME"] = str(tt_metal_path)
@@ -98,7 +77,61 @@ def run_diag_subprocess(
     env["PATH"] = os.pathsep.join(
         [env.get("PATH", ""), str(Path.home() / ".local" / "bin"), "/usr/local/bin"]
     )
+    return env
 
+
+def _build_slurm_command(
+    tier: str,
+    report_path: Path,
+    tt_metal_path: Path | None,
+    diag_runner: Path | None,
+    extra_args: list[str] | None,
+) -> tuple[list[str] | None, str]:
+    """Bare-Slurm: invoke diag_runner.py directly with the current interpreter."""
+    runner = Path(diag_runner) if diag_runner else default_diag_runner()
+    if not runner.is_file():
+        return None, f"diag runner not found: {runner}"
+    cmd = [sys.executable, str(runner), "--tier", tier, "--output", str(report_path)]
+    if tt_metal_path is not None:
+        cmd += ["--tt-metal-path", str(tt_metal_path)]
+    if extra_args:
+        cmd += list(extra_args)
+    return cmd, ""
+
+
+def _build_orchestration_command(
+    tier: str,
+    report_path: Path,
+    tt_metal_path: Path | None,
+    extra_args: list[str] | None,
+) -> tuple[list[str] | None, str]:
+    """Orchestration (k8s): invoke the sibling run_diag.sh bash wrapper.
+
+    run_diag.sh takes the tier positionally and forwards the rest to
+    diag_runner.py, so ``bash run_diag.sh <tier> --output <report>`` is
+    equivalent to the Slurm command but goes through the shell wrapper the k8s
+    worker has always used.
+    """
+    script = default_run_diag_script()
+    if not script.is_file():
+        return None, f"diag test script not found: {script}"
+    cmd = ["bash", str(script), tier, "--output", str(report_path)]
+    if tt_metal_path is not None:
+        cmd += ["--tt-metal-path", str(tt_metal_path)]
+    if extra_args:
+        cmd += list(extra_args)
+    return cmd, ""
+
+
+def _execute(
+    cmd: list[str], env: dict, timeout_seconds: int, results_dir: Path
+) -> tuple[int, str, Path | None]:
+    """Run cmd with a hard timeout, killing the whole process group on expiry.
+
+    Returns ``(exit_code, combined_console_output, results_dir | None)``. The
+    diag tool exits 1 on FAIL and 0 on PASS/WARN; that status is propagated
+    unchanged. A timeout is reported as exit code 137 (SIGKILL).
+    """
     log.info("Running diag suite: %s", " ".join(cmd))
     log.info("Results dir: %s", results_dir)
     log.info("Timeout: %d seconds", timeout_seconds)
@@ -111,8 +144,8 @@ def run_diag_subprocess(
             stderr=subprocess.STDOUT,
             text=True,
             env=env,
-            # New session so the diag suite's gtest/tt-smi children share a process
-            # group we can signal as a unit on timeout.
+            # New session so the diag suite's gtest/tt-smi children share a
+            # process group we can signal as a unit on timeout.
             start_new_session=True,
         )
     except OSError as exc:
@@ -138,3 +171,40 @@ def run_diag_subprocess(
         exit_code = 137
 
     return exit_code, output or "", results_dir
+
+
+def run_diag_subprocess(
+    tier: str,
+    timeout_seconds: int,
+    results_dir: Path,
+    *,
+    launch_mode: str = "slurm",
+    diag_runner: Path | None = None,
+    tt_metal_path: Path | None = None,
+    extra_args: list[str] | None = None,
+) -> tuple[int, str, Path | None]:
+    """Run the diag suite, writing its JSON report + per-test logs into results_dir.
+
+    ``launch_mode`` selects how the diag suite is invoked (``slurm`` runs
+    ``diag_runner.py`` directly; ``orchestration`` runs the sibling ``run_diag.sh``
+    bash wrapper). Both write the report to ``<results_dir>/diag_report.json`` and
+    drop per-test gtest logs under ``<results_dir>/logs/`` straight on the host
+    filesystem, so partial results survive a timeout/kill.
+    """
+    results_dir.mkdir(parents=True, exist_ok=True)
+    report_path = results_dir / "diag_report.json"
+
+    if launch_mode == "orchestration":
+        cmd, err = _build_orchestration_command(
+            tier, report_path, tt_metal_path, extra_args
+        )
+    else:
+        cmd, err = _build_slurm_command(
+            tier, report_path, tt_metal_path, diag_runner, extra_args
+        )
+
+    if cmd is None:
+        log.error("%s", err)
+        return 1, err, None
+
+    return _execute(cmd, _diag_env(tt_metal_path), timeout_seconds, results_dir)

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/diag_execution.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/diag_execution.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Execute the diag suite (``diag_runner.py``) as a subprocess.
+
+This replaces the previous docker-in-docker model: when the whole health check
+runs inside the tt-metal image, the diag suite is a sibling script we invoke
+directly rather than a nested container.
+
+Subprocess (rather than importing ``diag_runner.run_diag`` in-process) is used so
+we retain a hard wall-clock budget: the diag suite drives destructive resets and
+long gtests that can hang, and a subprocess lets us kill the whole process group
+(gtest / tt-smi children included) when the timeout fires.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# Grace period between SIGTERM and SIGKILL when killing a timed-out diag run.
+_TERM_GRACE_SECONDS = 10
+
+
+def default_diag_runner() -> Path:
+    """Locate diag_runner.py — two levels up from this module
+    (test_infrastructure/utils/ -> health_check_test_suite/diag_runner.py)."""
+    return Path(__file__).resolve().parents[2] / "diag_runner.py"
+
+
+def _kill_process_group(proc: subprocess.Popen) -> None:
+    """SIGTERM then SIGKILL the child's process group (gtest / tt-smi children)."""
+    try:
+        pgid = os.getpgid(proc.pid)
+    except ProcessLookupError:
+        return
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(pgid, sig)
+        except ProcessLookupError:
+            return
+        try:
+            proc.wait(timeout=_TERM_GRACE_SECONDS)
+            return
+        except subprocess.TimeoutExpired:
+            continue
+
+
+def run_diag_subprocess(
+    tier: str,
+    timeout_seconds: int,
+    results_dir: Path,
+    *,
+    diag_runner: Path | None = None,
+    tt_metal_path: Path | None = None,
+    extra_args: list[str] | None = None,
+) -> tuple[int, str, Path | None]:
+    """Run the diag suite, writing its JSON report + per-test logs into results_dir.
+
+    Invokes ``diag_runner.py --tier <tier> --output <results_dir>/diag_report.json``,
+    which also drops per-test gtest logs under ``<results_dir>/logs/``. The report
+    and logs land straight on the host filesystem (no copy-out step), so partial
+    results survive a timeout/kill.
+
+    Returns ``(exit_code, combined_console_output, results_dir | None)``. The diag
+    tool exits 1 on FAIL and 0 on PASS/WARN; that status is propagated unchanged.
+    A timeout is reported as exit code 137 (matching the previous SIGKILL model).
+    """
+    runner = Path(diag_runner) if diag_runner else default_diag_runner()
+    if not runner.is_file():
+        log.error("diag runner not found: %s", runner)
+        return 1, f"diag runner not found: {runner}", None
+
+    results_dir.mkdir(parents=True, exist_ok=True)
+    report_path = results_dir / "diag_report.json"
+
+    cmd = [sys.executable, str(runner), "--tier", tier, "--output", str(report_path)]
+    if tt_metal_path is not None:
+        cmd += ["--tt-metal-path", str(tt_metal_path)]
+    if extra_args:
+        cmd += list(extra_args)
+
+    env = os.environ.copy()
+    if tt_metal_path is not None:
+        env["TT_METAL_HOME"] = str(tt_metal_path)
+        env.setdefault("PYTHONPATH", str(tt_metal_path))
+        env.setdefault("LD_LIBRARY_PATH", str(Path(tt_metal_path) / "build" / "lib"))
+    # tt-smi often lives at ~/.local/bin or /usr/local/bin but isn't on PATH in
+    # non-login SSH sessions.
+    env["PATH"] = os.pathsep.join(
+        [env.get("PATH", ""), str(Path.home() / ".local" / "bin"), "/usr/local/bin"]
+    )
+
+    log.info("Running diag suite: %s", " ".join(cmd))
+    log.info("Results dir: %s", results_dir)
+    log.info("Timeout: %d seconds", timeout_seconds)
+
+    started_at = time.monotonic()
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=env,
+            # New session so the diag suite's gtest/tt-smi children share a process
+            # group we can signal as a unit on timeout.
+            start_new_session=True,
+        )
+    except OSError as exc:
+        log.error("Failed to start diag suite: %s", exc)
+        return 1, f"Failed to start diag suite: {exc}", None
+
+    try:
+        output, _ = proc.communicate(timeout=timeout_seconds)
+        exit_code = proc.returncode
+    except subprocess.TimeoutExpired:
+        elapsed = time.monotonic() - started_at
+        log.error(
+            "Diag suite timed out after %.0f seconds (budget %d); killing",
+            elapsed,
+            timeout_seconds,
+        )
+        _kill_process_group(proc)
+        # Keep whatever the suite emitted before it hung.
+        try:
+            output, _ = proc.communicate(timeout=_TERM_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            output = ""
+        exit_code = 137
+
+    return exit_code, output or "", results_dir

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/diag_execution.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/diag_execution.py
@@ -74,9 +74,7 @@ def _diag_env(tt_metal_path: Path | None) -> dict:
         env.setdefault("LD_LIBRARY_PATH", str(Path(tt_metal_path) / "build" / "lib"))
     # tt-smi often lives at ~/.local/bin or /usr/local/bin but isn't on PATH in
     # non-login SSH sessions.
-    env["PATH"] = os.pathsep.join(
-        [env.get("PATH", ""), str(Path.home() / ".local" / "bin"), "/usr/local/bin"]
-    )
+    env["PATH"] = os.pathsep.join([env.get("PATH", ""), str(Path.home() / ".local" / "bin"), "/usr/local/bin"])
     return env
 
 
@@ -123,9 +121,7 @@ def _build_orchestration_command(
     return cmd, ""
 
 
-def _execute(
-    cmd: list[str], env: dict, timeout_seconds: int, results_dir: Path
-) -> tuple[int, str, Path | None]:
+def _execute(cmd: list[str], env: dict, timeout_seconds: int, results_dir: Path) -> tuple[int, str, Path | None]:
     """Run cmd with a hard timeout, killing the whole process group on expiry.
 
     Returns ``(exit_code, combined_console_output, results_dir | None)``. The
@@ -195,13 +191,9 @@ def run_diag_subprocess(
     report_path = results_dir / "diag_report.json"
 
     if launch_mode == "orchestration":
-        cmd, err = _build_orchestration_command(
-            tier, report_path, tt_metal_path, extra_args
-        )
+        cmd, err = _build_orchestration_command(tier, report_path, tt_metal_path, extra_args)
     else:
-        cmd, err = _build_slurm_command(
-            tier, report_path, tt_metal_path, diag_runner, extra_args
-        )
+        cmd, err = _build_slurm_command(tier, report_path, tt_metal_path, diag_runner, extra_args)
 
     if cmd is None:
         log.error("%s", err)

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/diag_execution.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/diag_execution.py
@@ -69,9 +69,11 @@ def _diag_env(tt_metal_path: Path | None) -> dict:
     """Environment shared by both launch modes."""
     env = os.environ.copy()
     if tt_metal_path is not None:
-        env["TT_METAL_HOME"] = str(tt_metal_path)
-        env.setdefault("PYTHONPATH", str(tt_metal_path))
-        env.setdefault("LD_LIBRARY_PATH", str(Path(tt_metal_path) / "build" / "lib"))
+        root = str(tt_metal_path)
+        lib_dir = str(tt_metal_path / "build" / "lib")
+        env["TT_METAL_HOME"] = root
+        env["PYTHONPATH"] = os.pathsep.join(filter(None, (root, env.get("PYTHONPATH"))))
+        env["LD_LIBRARY_PATH"] = os.pathsep.join(filter(None, (lib_dir, env.get("LD_LIBRARY_PATH"))))
     # tt-smi often lives at ~/.local/bin or /usr/local/bin but isn't on PATH in
     # non-login SSH sessions.
     env["PATH"] = os.pathsep.join([env.get("PATH", ""), str(Path.home() / ".local" / "bin"), "/usr/local/bin"])
@@ -189,6 +191,7 @@ def run_diag_subprocess(
     """
     results_dir.mkdir(parents=True, exist_ok=True)
     report_path = results_dir / "diag_report.json"
+    report_path.unlink(missing_ok=True)
 
     if launch_mode == "orchestration":
         cmd, err = _build_orchestration_command(tier, report_path, tt_metal_path, extra_args)

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/health_check_models.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/health_check_models.py
@@ -100,19 +100,13 @@ class CheckRecord(BaseModel):
     is_warn: Flag = Field(description="1 if status is WARN.")
     is_fail: Flag = Field(description="1 if status is FAIL.")
     is_skip: Flag = Field(description="1 if status is SKIP.")
-    is_covered: Flag = Field(
-        description="1 if the check actually ran; a stress test that executed 0 cases is 0."
-    )
+    is_covered: Flag = Field(description="1 if the check actually ran; a stress test that executed 0 cases is 0.")
     acknowledged: Flag = Field(
         description="1 for known-benign fleet-wide WARNs (e.g. cpld_fw_old), excluded from actionable rollups."
     )
 
-    testcases_passed: Optional[int] = Field(
-        None, description="gtest sub-cases passed; None for non-test checks."
-    )
-    testcases_failed: Optional[int] = Field(
-        None, description="gtest sub-cases failed; None for non-test checks."
-    )
+    testcases_passed: Optional[int] = Field(None, description="gtest sub-cases passed; None for non-test checks.")
+    testcases_failed: Optional[int] = Field(None, description="gtest sub-cases failed; None for non-test checks.")
     executed: Flag = Field(description="0 if a stress test executed 0 cases (check-level fail-closed).")
 
     details_short: Optional[str] = Field(None, description="Human-readable check detail, newlines flattened.")
@@ -134,9 +128,7 @@ class CheckRecord(BaseModel):
         }.get(self.status)
         if expected is not None and getattr(self, expected) != 1:
             raise ValueError(f"{expected}=1 expected for status={self.status.value}")
-        if self.status is CheckStatus.EXCLUDED and (
-            self.is_pass or self.is_warn or self.is_fail or self.is_skip
-        ):
+        if self.status is CheckStatus.EXCLUDED and (self.is_pass or self.is_warn or self.is_fail or self.is_skip):
             raise ValueError("EXCLUDED must have all is_* flags = 0")
         return self
 
@@ -165,7 +157,9 @@ class RunRecord(BaseModel):
 
     # exclude non-real runs (dry-run / maintenance / manual) from fleet stats.
     discard: Flag = Field(description="1 = exclude this run from fleet statistics.")
-    discard_reason: Optional[str] = Field(None, description="Reason when discard=1 (dry_run/maintenance/manual_test/…).")
+    discard_reason: Optional[str] = Field(
+        None, description="Reason when discard=1 (dry_run/maintenance/manual_test/…)."
+    )
 
     # history: computed by the Data team across the day-series; empty on a lone run.
     prev_status: Optional[OverallStatus] = Field(None, description="This host's previous run status (Data team).")
@@ -191,7 +185,8 @@ class RunRecord(BaseModel):
     pct_covered: Optional[float] = Field(None, description="100 * checks_covered / checks_total.")
     checks_warn_actionable: int = Field(description="WARNs excluding acknowledged fleet-wide benign ones.")
     top_fail_category: Optional[str] = Field(
-        None, description="Worst category (FAIL first, then actionable WARN); 'run' for ERROR; empty if only benign WARNs."
+        None,
+        description="Worst category (FAIL first, then actionable WARN); 'run' for ERROR; empty if only benign WARNs.",
     )
 
     # subsystem rollups
@@ -210,7 +205,9 @@ class RunRecord(BaseModel):
     telemetry_available: Flag = Field(description="1 if tt-telemetry was reachable for this run.")
     eth_retrain_total: Optional[int] = Field(None, description="Per-machine Ethernet retrains (tt-telemetry).")
     eth_crc_total: Optional[int] = Field(None, description="Per-machine Ethernet CRC errors (tt-telemetry).")
-    eth_uncorr_cw_total: Optional[int] = Field(None, description="Per-machine Ethernet uncorrectable codewords (tt-telemetry).")
+    eth_uncorr_cw_total: Optional[int] = Field(
+        None, description="Per-machine Ethernet uncorrectable codewords (tt-telemetry)."
+    )
 
     jira_ticket: Optional[str] = Field(None, description="JIRA key if a ticket was filed for this run.")
 

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/health_check_models.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/health_check_models.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Pydantic models for the fabric system health-check result schema.
+"""
+
+from datetime import date as Date
+from datetime import datetime
+from enum import Enum
+from typing import Annotated, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+SCHEMA_VERSION = 1
+
+# 0/1 integer flag and bounded severity, kept as ints because the dashboard SUM()s
+# them directly in SQL.
+Flag = Annotated[int, Field(ge=0, le=1)]
+Severity = Annotated[int, Field(ge=0, le=3)]
+
+
+class OverallStatus(str, Enum):
+    """Run-level verdict. PASS/WARN/FAIL come from the diag tool; ERROR/UNKNOWN are
+    injected by the run wrapper when a report is missing or unparseable."""
+
+    PASS = "PASS"
+    WARN = "WARN"
+    FAIL = "FAIL"
+    ERROR = "ERROR"
+    UNKNOWN = "UNKNOWN"
+
+
+class CheckStatus(str, Enum):
+    """Per-check status. PASS/WARN/FAIL/SKIP come from the diag tool. EXCLUDED is
+    injected by the analyzer for infrastructure/capture steps (e.g.
+    ``snapshot_capture``) whose FAIL/WARN is a tooling/precondition hiccup, not a
+    hardware verdict: it stays visible but drives no failure and carries no
+    ``is_*`` flag (all zero)."""
+
+    PASS = "PASS"
+    WARN = "WARN"
+    FAIL = "FAIL"
+    SKIP = "SKIP"
+    EXCLUDED = "EXCLUDED"
+
+
+class Category(str, Enum):
+    """Low-cardinality subsystem the dashboard aggregates over. ``other`` is the
+    documented catch-all and should stay empty in practice."""
+
+    pcie = "pcie"
+    gddr = "gddr"
+    asic = "asic"
+    firmware = "firmware"
+    thermal = "thermal"
+    board = "board"
+    eth = "eth"
+    reset = "reset"
+    stress_test = "stress_test"
+    other = "other"
+
+
+class PhaseKind(str, Enum):
+    """Primary phases vs the per-reset re-snapshots the diag tool splices in on
+    instability (segregated so an unstable machine doesn't double-count)."""
+
+    primary = "primary"
+    post_reset = "post_reset"
+
+
+def _blanks_to_none(values):
+    """CSV serializes missing values as empty strings; treat those as ``None`` so
+    optional numeric/enum fields validate. Applied before field validation."""
+    if isinstance(values, dict):
+        return {k: (None if v == "" else v) for k, v in values.items()}
+    return values
+
+
+class CheckRecord(BaseModel):
+    """One diagnostic check within a run (``checks.csv``). ~28 rows per run, all
+    sharing the same ``run_id``. Check-level fields only."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(description="Schema version; bump on any breaking change.")
+    run_id: str = Field(description="Join key to runs.csv: '{hostname}:{slurm_job_id}'.")
+    date: Date = Field(description="Run date (kept for time partitioning/filtering).")
+
+    category: Category = Field(description="Subsystem this check belongs to.")
+    phase: str = Field(description="snapshot / reset_loop / tests / snapshot_after_reset_N.")
+    phase_kind: PhaseKind = Field(description="primary vs post_reset re-snapshot.")
+    check_name: str = Field(description="Check name, e.g. pcie_enum_count, gddr_speed, eth_link_up.")
+
+    status: CheckStatus = Field(description="PASS / WARN / FAIL / SKIP.")
+    severity: Severity = Field(description="0 PASS/SKIP, 1 WARN, 2 FAIL, 3 UNKNOWN.")
+
+    is_pass: Flag = Field(description="1 if status is PASS (pre-computed for SUM aggregation).")
+    is_warn: Flag = Field(description="1 if status is WARN.")
+    is_fail: Flag = Field(description="1 if status is FAIL.")
+    is_skip: Flag = Field(description="1 if status is SKIP.")
+    is_covered: Flag = Field(
+        description="1 if the check actually ran; a stress test that executed 0 cases is 0."
+    )
+    acknowledged: Flag = Field(
+        description="1 for known-benign fleet-wide WARNs (e.g. cpld_fw_old), excluded from actionable rollups."
+    )
+
+    testcases_passed: Optional[int] = Field(
+        None, description="gtest sub-cases passed; None for non-test checks."
+    )
+    testcases_failed: Optional[int] = Field(
+        None, description="gtest sub-cases failed; None for non-test checks."
+    )
+    executed: Flag = Field(description="0 if a stress test executed 0 cases (check-level fail-closed).")
+
+    details_short: Optional[str] = Field(None, description="Human-readable check detail, newlines flattened.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _pre(cls, values):
+        return _blanks_to_none(values)
+
+    @model_validator(mode="after")
+    def _consistency(self):
+        # the is_* flags must agree with status. EXCLUDED is deliberately flagless
+        # (all is_* = 0): it is neither a pass nor a failure signal.
+        expected = {
+            CheckStatus.PASS: "is_pass",
+            CheckStatus.WARN: "is_warn",
+            CheckStatus.FAIL: "is_fail",
+            CheckStatus.SKIP: "is_skip",
+        }.get(self.status)
+        if expected is not None and getattr(self, expected) != 1:
+            raise ValueError(f"{expected}=1 expected for status={self.status.value}")
+        if self.status is CheckStatus.EXCLUDED and (
+            self.is_pass or self.is_warn or self.is_fail or self.is_skip
+        ):
+            raise ValueError("EXCLUDED must have all is_* flags = 0")
+        return self
+
+
+class RunRecord(BaseModel):
+    """Machine-level rollup for a single health-check run (``runs.csv``). Exactly
+    one row per run — including a fail-closed row with overall_status=ERROR when a
+    run produced no report."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(description="Schema version; bump on any breaking change.")
+    run_id: str = Field(description="Primary key: '{hostname}:{slurm_job_id}'.")
+    date: Date = Field(description="UTC run date (partition key).")
+    timestamp: datetime = Field(description="Run/analysis timestamp with timezone.")
+    hostname: str = Field(description="Node name, e.g. bh-glx-b02u02.")
+    slurm_job_id: str = Field(description="SLURM job id.")
+
+    # spatial dims parsed from hostname (rack/row clustering). rack='unparsed' if the
+    # hostname matches neither known scheme.
+    row: Optional[str] = Field(None, description="Rack row (empty for schemes without a row segment).")
+    rack: Optional[str] = Field(None, description="Rack; 'unparsed' if hostname is unrecognized.")
+    slot: Optional[str] = Field(None, description="Slot within the rack.")
+
+    overall_status: OverallStatus = Field(description="Run verdict: PASS/WARN/FAIL/ERROR/UNKNOWN.")
+
+    # exclude non-real runs (dry-run / maintenance / manual) from fleet stats.
+    discard: Flag = Field(description="1 = exclude this run from fleet statistics.")
+    discard_reason: Optional[str] = Field(None, description="Reason when discard=1 (dry_run/maintenance/manual_test/…).")
+
+    # history: computed by the Data team across the day-series; empty on a lone run.
+    prev_status: Optional[OverallStatus] = Field(None, description="This host's previous run status (Data team).")
+    is_regression: Optional[Flag] = Field(None, description="Severity increased vs previous run (Data team).")
+    fail_streak: Optional[int] = Field(None, description="Consecutive FAIL/ERROR runs (Data team).")
+
+    tier: Optional[str] = Field(None, description="light / medium / deploy.")
+    tool_version: Optional[str] = Field(None, description="diag tool version.")
+    tt_smi_version: Optional[str] = Field(None, description="tt-smi version.")
+    tt_kmd_version: Optional[str] = Field(None, description="tt-kmd version (from run wrapper; may be empty).")
+    board_rev: Optional[str] = Field(None, description="Board revision, e.g. RevA/B, RevC (thresholds differ).")
+    fw_bundle_version: Optional[str] = Field(None, description="Firmware bundle version.")
+    num_chips: Optional[int] = Field(None, description="Chips enumerated on the node.")
+    total_duration_s: Optional[float] = Field(None, description="Wall-clock duration of the run in seconds.")
+
+    # coverage / quality
+    checks_total: int = Field(description="Number of checks.")
+    checks_pass: int = Field(description="Checks with PASS.")
+    checks_warn: int = Field(description="Checks with WARN.")
+    checks_fail: int = Field(description="Checks with FAIL.")
+    checks_skip: int = Field(description="Checks with SKIP.")
+    checks_covered: int = Field(description="Checks that actually ran (PASS/WARN/FAIL, executed).")
+    pct_covered: Optional[float] = Field(None, description="100 * checks_covered / checks_total.")
+    checks_warn_actionable: int = Field(description="WARNs excluding acknowledged fleet-wide benign ones.")
+    top_fail_category: Optional[str] = Field(
+        None, description="Worst category (FAIL first, then actionable WARN); 'run' for ERROR; empty if only benign WARNs."
+    )
+
+    # subsystem rollups
+    reset_count: Optional[int] = Field(None, description="Reset iterations in the reset loop.")
+    reset_stable: Optional[Flag] = Field(None, description="1 if the reset loop did not FAIL.")
+    gddr_uncorr_total: Optional[int] = Field(None, description="Sum of GDDR uncorrectable errors across chips.")
+    pcie_downgraded: Optional[Flag] = Field(None, description="1 if any chip is below its expected PCIe gen.")
+    eth_links_down: Optional[int] = Field(None, description="Chips with a down non-QSFP Ethernet link.")
+
+    # thermal correlation (from the report)
+    max_asic_temp_c: Optional[float] = Field(None, description="Hottest ASIC temperature.")
+    max_gddr_temp_c: Optional[float] = Field(None, description="Hottest GDDR temperature.")
+
+    # telemetry correlation (tt-telemetry; empty unless the endpoint was reachable)
+    min_aiclk_mhz: Optional[float] = Field(None, description="Lowest AI clock (tt-telemetry).")
+    telemetry_available: Flag = Field(description="1 if tt-telemetry was reachable for this run.")
+    eth_retrain_total: Optional[int] = Field(None, description="Per-machine Ethernet retrains (tt-telemetry).")
+    eth_crc_total: Optional[int] = Field(None, description="Per-machine Ethernet CRC errors (tt-telemetry).")
+    eth_uncorr_cw_total: Optional[int] = Field(None, description="Per-machine Ethernet uncorrectable codewords (tt-telemetry).")
+
+    jira_ticket: Optional[str] = Field(None, description="JIRA key if a ticket was filed for this run.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _pre(cls, values):
+        return _blanks_to_none(values)
+
+
+class RunResult(BaseModel):
+    """Logical unit for one run: the rollup plus its checks. Convenience container
+    for producers that validate a full run before writing the two CSVs; the CSVs
+    themselves are flat (this is not serialized as-is)."""
+
+    run: RunRecord
+    checks: List[CheckRecord] = []
+
+    @model_validator(mode="after")
+    def _checks_belong_to_run(self):
+        for c in self.checks:
+            if c.run_id != self.run.run_id:
+                raise ValueError(f"check run_id {c.run_id!r} != run {self.run.run_id!r}")
+        # (run_id, check_name, phase) is the checks upsert key — must be unique.
+        keys = [(c.run_id, c.check_name, c.phase) for c in self.checks]
+        if len(keys) != len(set(keys)):
+            raise ValueError("duplicate (run_id, check_name, phase) in checks")
+        return self

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
@@ -283,7 +283,11 @@ def transition_jira_ticket(
         log.warning("Could not fetch transitions for %s: %s", ticket_key, exc)
         return
 
-    transitions = resp.json().get("transitions", [])
+    try:
+        transitions = resp.json().get("transitions", [])
+    except ValueError as exc:
+        log.warning("Could not parse transitions for %s: %s", ticket_key, exc)
+        return
     transition_id = next((t["id"] for t in transitions if t["name"] == target_transition), None)
     if not transition_id and fallback_to_done:
         transition_id = next(

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
@@ -1,0 +1,425 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""JIRA integration for the fabric system health check.
+
+Creates/updates a Bug ticket per node on failure, appends recurring-failure
+comments while a ticket stays open, closes tickets when a node recovers, and
+attaches the run log + result artifacts.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+log = logging.getLogger(__name__)
+
+
+def _build_failure_body(
+    *,
+    node: str,
+    slurm_job_id: str,
+    exit_code: int,
+    versions: dict[str, str],
+    telemetry_summary: str,
+    test_output: str,
+    attachment_names: list[str] | None = None,
+) -> str:
+    """Build the shared failure detail block used by both a new ticket's
+    description and a recurring-failure comment, so the two never drift."""
+    fail_date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    log_tail = test_output[-4096:]
+
+    telemetry_section = ""
+    if telemetry_summary:
+        telemetry_section = (
+            f"\n*Telemetry Metrics:*\n"
+            f"{{noformat}}\n{telemetry_summary}\n{{noformat}}\n"
+        )
+
+    attachment_section = ""
+    if attachment_names:
+        links = "\n".join(f"[^{name}]" for name in attachment_names)
+        attachment_section = f"\n*Attachments:*\n{links}\n"
+
+    return (
+        f"*Node:* {node}\n"
+        f"*Date:* {fail_date}\n"
+        f"*Slurm Job ID:* {slurm_job_id}\n"
+        f"*Exit Code:* {exit_code}\n"
+        f"*TT-SMI Version:* {versions['tt_smi']}\n"
+        f"*TT-KMD Version:* {versions['tt_kmd']}\n"
+        f"*Firmware Version:* {versions['fw_bundle']}\n"
+        f"{telemetry_section}"
+        f"{attachment_section}\n"
+        f"*Last lines of output:*\n"
+        f"{{noformat}}\n{log_tail}\n{{noformat}}"
+    )
+
+
+def find_open_ticket_for_node(
+    *,
+    node: str,
+    jira_base_url: str,
+    jira_project_key: str,
+    jira_bearer_token: str,
+) -> str | None:
+    """Return the key of the most recent OPEN JIRA ticket for this node, or None.
+
+    Subsequent failures append to this ticket instead of spawning duplicates.
+    The JQL narrows on the failure-ticket summary phrase and open status; the
+    exact summary is then re-checked in Python because JIRA text search tokenizes
+    hostnames on hyphens (so bh-glx-b09u08 could otherwise fuzzy-match ...u02).
+    Any API/parse error returns None so we fall back to creating a ticket and
+    never lose the failure signal.
+    """
+    expected_summary = f"[Fabric Health Check] Test failed on {node}"
+    jql = (
+        f"project = {jira_project_key} "
+        f"AND labels = \"fabric-health-check\" "
+        f"AND summary ~ \"\\\"Test failed on {node}\\\"\" "
+        f"AND statusCategory != Done "
+        f"ORDER BY created DESC"
+    )
+    # Enhanced search endpoint; the legacy GET /rest/api/2/search was removed by
+    # Atlassian (returns 410 Gone). /search/jql takes the query in a POST body.
+    url = f"{jira_base_url}/rest/api/2/search/jql"
+    headers = {
+        "Authorization": f"Bearer {jira_bearer_token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    payload = {"jql": jql, "fields": ["summary"], "maxResults": 20}
+
+    log.info("Searching for an open JIRA ticket for %s ...", node)
+    try:
+        resp = requests.post(url, headers=headers, json=payload, timeout=30)
+        resp.raise_for_status()
+        issues = resp.json().get("issues", [])
+    except (requests.RequestException, ValueError) as exc:
+        log.warning("JIRA search failed (%s); will create a new ticket", exc)
+        return None
+
+    for issue in issues:
+        if issue.get("fields", {}).get("summary", "") == expected_summary:
+            key = issue.get("key")
+            log.info("Found open ticket %s for %s", key, node)
+            return key
+    log.info("No open ticket found for %s", node)
+    return None
+
+
+def add_comment_to_jira(
+    *,
+    ticket_key: str,
+    body: str,
+    jira_base_url: str,
+    jira_bearer_token: str,
+) -> bool:
+    """Add a comment to an existing JIRA ticket. Returns True on success."""
+    url = f"{jira_base_url}/rest/api/2/issue/{ticket_key}/comment"
+    headers = {
+        "Authorization": f"Bearer {jira_bearer_token}",
+        "Content-Type": "application/json",
+    }
+
+    log.info("Adding recurring-failure comment to %s ...", ticket_key)
+    try:
+        resp = requests.post(url, headers=headers, json={"body": body}, timeout=30)
+    except requests.RequestException as exc:
+        log.warning("Failed to comment on %s: %s", ticket_key, exc)
+        return False
+
+    if not resp.ok:
+        log.warning(
+            "Failed to comment on %s (HTTP %d): %s",
+            ticket_key,
+            resp.status_code,
+            resp.text,
+        )
+        return False
+
+    log.info("Comment added to %s", ticket_key)
+    return True
+
+
+def _version_fields(versions: dict[str, str]) -> dict:
+    """The mandatory version custom fields, shared by ticket create and update so
+    the two never drift: Firmware / TT-SMI / KMD versions."""
+    return {
+        "customfield_16168": versions["fw_bundle"],  # Firmware Version
+        "customfield_16169": versions["tt_smi"],     # TT-SMI Version
+        "customfield_16170": versions["tt_kmd"],     # KMD Version
+    }
+
+
+def update_jira_versions(
+    *,
+    ticket_key: str,
+    versions: dict[str, str],
+    jira_base_url: str,
+    jira_bearer_token: str,
+) -> bool:
+    """Refresh the mandatory version fields on an existing ticket so they reflect
+    the latest run's firmware/tt-smi/kmd versions. Returns True on success."""
+    url = f"{jira_base_url}/rest/api/2/issue/{ticket_key}"
+    headers = {
+        "Authorization": f"Bearer {jira_bearer_token}",
+        "Content-Type": "application/json",
+    }
+
+    log.info("Updating version fields on %s ...", ticket_key)
+    try:
+        resp = requests.put(
+            url, headers=headers, json={"fields": _version_fields(versions)}, timeout=30
+        )
+    except requests.RequestException as exc:
+        log.warning("Failed to update version fields on %s: %s", ticket_key, exc)
+        return False
+
+    if not resp.ok:
+        log.warning(
+            "Failed to update version fields on %s (HTTP %d): %s",
+            ticket_key,
+            resp.status_code,
+            resp.text,
+        )
+        return False
+
+    log.info("Updated version fields on %s", ticket_key)
+    return True
+
+
+def create_jira_ticket(
+    *,
+    node: str,
+    slurm_job_id: str,
+    exit_code: int,
+    test_output: str,
+    jira_base_url: str,
+    jira_site_url: str,
+    jira_project_key: str,
+    jira_issue_type: str,
+    jira_bearer_token: str,
+    versions: dict[str, str],
+    telemetry_summary: str = "",
+    attachment_names: list[str] | None = None,
+) -> str | None:
+    """Create a JIRA ticket for a failed health check. Returns ticket key or None."""
+
+    description = (
+        f"Fabric System Health Check failed on node {node}.\n\n"
+        + _build_failure_body(
+            node=node,
+            slurm_job_id=slurm_job_id,
+            exit_code=exit_code,
+            versions=versions,
+            telemetry_summary=telemetry_summary,
+            test_output=test_output,
+            attachment_names=attachment_names,
+        )
+    )
+
+    payload = {
+        "fields": {
+            "project": {"key": jira_project_key},
+            "summary": f"[Fabric Health Check] Test failed on {node}",
+            "description": description,
+            "issuetype": {"name": jira_issue_type},
+            "labels": ["fabric-health-check"],
+            "customfield_13389": {"id": "17418"},
+            **_version_fields(versions),
+        }
+    }
+
+    url = f"{jira_base_url}/rest/api/2/issue"
+    headers = {
+        "Authorization": f"Bearer {jira_bearer_token}",
+        "Content-Type": "application/json",
+    }
+
+    log.info("Creating JIRA ticket at %s ...", url)
+    try:
+        resp = requests.post(url, headers=headers, json=payload, timeout=30)
+    except requests.RequestException as exc:
+        log.warning("Failed to create JIRA ticket: %s", exc)
+        return None
+
+    log.info("JIRA API response: HTTP %d", resp.status_code)
+    if not resp.ok:
+        log.warning(
+            "Failed to create JIRA ticket (HTTP %d): %s", resp.status_code, resp.text
+        )
+        return None
+
+    try:
+        ticket_key = resp.json().get("key")
+    except (ValueError, KeyError):
+        log.warning("JIRA response is not valid JSON: %s", resp.text[:256])
+        return None
+
+    if ticket_key:
+        log.info("JIRA ticket created: %s/browse/%s", jira_site_url, ticket_key)
+    return ticket_key
+
+
+def transition_jira_ticket(
+    ticket_key: str,
+    jira_base_url: str,
+    jira_bearer_token: str,
+    target_transition: str = "Health Status",
+    fallback_to_done: bool = False,
+) -> None:
+    """Transition a JIRA ticket to the target status.
+
+    Matches the transition by name. When ``fallback_to_done`` is set and no
+    transition matches ``target_transition``, any available transition whose
+    destination is in the "done" status category is used instead — this keeps
+    ticket-closing working across workflow variants where the closing
+    transition isn't named exactly as configured.
+    """
+    headers = {"Authorization": f"Bearer {jira_bearer_token}"}
+
+    url = f"{jira_base_url}/rest/api/2/issue/{ticket_key}/transitions"
+    try:
+        resp = requests.get(url, headers=headers, timeout=15)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        log.warning("Could not fetch transitions for %s: %s", ticket_key, exc)
+        return
+
+    transitions = resp.json().get("transitions", [])
+    transition_id = next(
+        (t["id"] for t in transitions if t["name"] == target_transition), None
+    )
+    if not transition_id and fallback_to_done:
+        transition_id = next(
+            (
+                t["id"]
+                for t in transitions
+                if t.get("to", {}).get("statusCategory", {}).get("key") == "done"
+            ),
+            None,
+        )
+        if transition_id:
+            log.info(
+                "Transition '%s' not found for %s; falling back to a done-category "
+                "transition",
+                target_transition,
+                ticket_key,
+            )
+    if not transition_id:
+        log.warning(
+            "Could not find '%s' transition for %s", target_transition, ticket_key
+        )
+        return
+
+    log.info("Transitioning %s to '%s' ...", ticket_key, target_transition)
+    try:
+        resp = requests.post(
+            url,
+            headers={**headers, "Content-Type": "application/json"},
+            json={"transition": {"id": transition_id}},
+            timeout=15,
+        )
+        if resp.ok:
+            log.info("Transitioned %s to '%s'", ticket_key, target_transition)
+        else:
+            log.warning("Failed to transition ticket (HTTP %d)", resp.status_code)
+    except requests.RequestException as exc:
+        log.warning("Failed to transition ticket: %s", exc)
+
+
+def attach_log_to_jira(
+    ticket_key: str,
+    test_output: str,
+    node: str,
+    slurm_job_id: str,
+    jira_base_url: str,
+    jira_bearer_token: str,
+) -> str | None:
+    """Attach the test log to a JIRA ticket. Returns the filename, or None."""
+    if not test_output:
+        return None
+
+    url = f"{jira_base_url}/rest/api/2/issue/{ticket_key}/attachments"
+    headers = {
+        "Authorization": f"Bearer {jira_bearer_token}",
+        "X-Atlassian-Token": "no-check",
+    }
+    filename = f"{node}-{slurm_job_id}.log"
+
+    log.info("Attaching log file to %s ...", ticket_key)
+    try:
+        resp = requests.post(
+            url,
+            headers=headers,
+            files={"file": (filename, test_output.encode("utf-8"))},
+            timeout=30,
+        )
+        if resp.ok:
+            log.info("Log file attached to %s", ticket_key)
+            return filename
+        else:
+            log.warning(
+                "Failed to attach log file (HTTP %d): %s", resp.status_code, resp.text
+            )
+            return None
+    except requests.RequestException as exc:
+        log.warning("Failed to attach log file: %s", exc)
+        return None
+
+
+def artifact_upload_name(path: Path, slurm_job_id: str) -> str:
+    """Suffix an artifact's name with the Slurm job id to keep it unique per run."""
+    return f"{path.stem}-{slurm_job_id}{path.suffix}"
+
+
+def attach_files_to_jira(
+    ticket_key: str,
+    files: list[Path],
+    slurm_job_id: str,
+    jira_base_url: str,
+    jira_bearer_token: str,
+) -> list[str]:
+    """Attach files under job-id-unique names. Returns the uploaded names."""
+    if not files:
+        return []
+
+    url = f"{jira_base_url}/rest/api/2/issue/{ticket_key}/attachments"
+    headers = {
+        "Authorization": f"Bearer {jira_bearer_token}",
+        "X-Atlassian-Token": "no-check",
+    }
+
+    uploaded = []
+    for path in files:
+        name = artifact_upload_name(path, slurm_job_id)
+        log.info("Attaching %s to %s ...", name, ticket_key)
+        try:
+            with path.open("rb") as fh:
+                resp = requests.post(
+                    url,
+                    headers=headers,
+                    files={"file": (name, fh)},
+                    timeout=60,
+                )
+            if resp.ok:
+                uploaded.append(name)
+            else:
+                log.warning(
+                    "Failed to attach %s (HTTP %d): %s",
+                    name,
+                    resp.status_code,
+                    resp.text,
+                )
+        except (OSError, requests.RequestException) as exc:
+            log.warning("Failed to attach %s: %s", name, exc)
+
+    log.info("Attached %d/%d result file(s) to %s", len(uploaded), len(files), ticket_key)
+    return uploaded

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
@@ -37,10 +37,7 @@ def _build_failure_body(
 
     telemetry_section = ""
     if telemetry_summary:
-        telemetry_section = (
-            f"\n*Telemetry Metrics:*\n"
-            f"{{noformat}}\n{telemetry_summary}\n{{noformat}}\n"
-        )
+        telemetry_section = f"\n*Telemetry Metrics:*\n" f"{{noformat}}\n{telemetry_summary}\n{{noformat}}\n"
 
     attachment_section = ""
     if attachment_names:
@@ -81,8 +78,8 @@ def find_open_ticket_for_node(
     expected_summary = f"[Fabric Health Check] Test failed on {node}"
     jql = (
         f"project = {jira_project_key} "
-        f"AND labels = \"fabric-health-check\" "
-        f"AND summary ~ \"\\\"Test failed on {node}\\\"\" "
+        f'AND labels = "fabric-health-check" '
+        f'AND summary ~ "\\"Test failed on {node}\\"" '
         f"AND statusCategory != Done "
         f"ORDER BY created DESC"
     )
@@ -153,8 +150,8 @@ def _version_fields(versions: dict[str, str]) -> dict:
     the two never drift: Firmware / TT-SMI / KMD versions."""
     return {
         "customfield_16168": versions["fw_bundle"],  # Firmware Version
-        "customfield_16169": versions["tt_smi"],     # TT-SMI Version
-        "customfield_16170": versions["tt_kmd"],     # KMD Version
+        "customfield_16169": versions["tt_smi"],  # TT-SMI Version
+        "customfield_16170": versions["tt_kmd"],  # KMD Version
     }
 
 
@@ -175,9 +172,7 @@ def update_jira_versions(
 
     log.info("Updating version fields on %s ...", ticket_key)
     try:
-        resp = requests.put(
-            url, headers=headers, json={"fields": _version_fields(versions)}, timeout=30
-        )
+        resp = requests.put(url, headers=headers, json={"fields": _version_fields(versions)}, timeout=30)
     except requests.RequestException as exc:
         log.warning("Failed to update version fields on %s: %s", ticket_key, exc)
         return False
@@ -212,17 +207,14 @@ def create_jira_ticket(
 ) -> str | None:
     """Create a JIRA ticket for a failed health check. Returns ticket key or None."""
 
-    description = (
-        f"Fabric System Health Check failed on node {node}.\n\n"
-        + _build_failure_body(
-            node=node,
-            slurm_job_id=slurm_job_id,
-            exit_code=exit_code,
-            versions=versions,
-            telemetry_summary=telemetry_summary,
-            test_output=test_output,
-            attachment_names=attachment_names,
-        )
+    description = f"Fabric System Health Check failed on node {node}.\n\n" + _build_failure_body(
+        node=node,
+        slurm_job_id=slurm_job_id,
+        exit_code=exit_code,
+        versions=versions,
+        telemetry_summary=telemetry_summary,
+        test_output=test_output,
+        attachment_names=attachment_names,
     )
 
     payload = {
@@ -252,9 +244,7 @@ def create_jira_ticket(
 
     log.info("JIRA API response: HTTP %d", resp.status_code)
     if not resp.ok:
-        log.warning(
-            "Failed to create JIRA ticket (HTTP %d): %s", resp.status_code, resp.text
-        )
+        log.warning("Failed to create JIRA ticket (HTTP %d): %s", resp.status_code, resp.text)
         return None
 
     try:
@@ -294,29 +284,20 @@ def transition_jira_ticket(
         return
 
     transitions = resp.json().get("transitions", [])
-    transition_id = next(
-        (t["id"] for t in transitions if t["name"] == target_transition), None
-    )
+    transition_id = next((t["id"] for t in transitions if t["name"] == target_transition), None)
     if not transition_id and fallback_to_done:
         transition_id = next(
-            (
-                t["id"]
-                for t in transitions
-                if t.get("to", {}).get("statusCategory", {}).get("key") == "done"
-            ),
+            (t["id"] for t in transitions if t.get("to", {}).get("statusCategory", {}).get("key") == "done"),
             None,
         )
         if transition_id:
             log.info(
-                "Transition '%s' not found for %s; falling back to a done-category "
-                "transition",
+                "Transition '%s' not found for %s; falling back to a done-category " "transition",
                 target_transition,
                 ticket_key,
             )
     if not transition_id:
-        log.warning(
-            "Could not find '%s' transition for %s", target_transition, ticket_key
-        )
+        log.warning("Could not find '%s' transition for %s", target_transition, ticket_key)
         return
 
     log.info("Transitioning %s to '%s' ...", ticket_key, target_transition)
@@ -366,9 +347,7 @@ def attach_log_to_jira(
             log.info("Log file attached to %s", ticket_key)
             return filename
         else:
-            log.warning(
-                "Failed to attach log file (HTTP %d): %s", resp.status_code, resp.text
-            )
+            log.warning("Failed to attach log file (HTTP %d): %s", resp.status_code, resp.text)
             return None
     except requests.RequestException as exc:
         log.warning("Failed to attach log file: %s", exc)

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/report.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/report.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Health-check report post-processing: normalization and verdict logic.
+
+Kept stdlib-only so both the runner (``run_health_check.py``) and the CSV
+analyzer (``analyze_health_check_results.py``) can import it as the single source
+of truth for the post-reset verdict without pulling in the runner's runtime deps
+(docker/paramiko/requests/prometheus).
+"""
+
+from __future__ import annotations
+
+
+# Capture/precondition steps that aren't a hardware verdict; a FAIL here alone
+# (e.g. tt-smi couldn't read a board) is a tooling hiccup, not a fleet fault.
+EXCLUDED_CHECKS = frozenset({"snapshot_capture"})
+
+
+def normalize_health_report(report: dict) -> dict:
+    """Judge health on post-reset state: drop the pre-reset ``snapshot`` and promote
+    the last post-reset re-snapshot in its place."""
+    phases = report.get("phases", {})
+    post = [p for p in phases if p.startswith("snapshot_after_")]
+    if not post:
+        return report
+
+    final = post[-1]
+    new_phases = {}
+    for name, phase in phases.items():
+        if name == "snapshot":
+            continue
+        if name.startswith("snapshot_after_"):
+            if name == final:
+                new_phases["snapshot"] = phase
+            continue
+        new_phases[name] = phase
+
+    out = dict(report)
+    out["phases"] = new_phases
+    return out
+
+
+def has_actionable_failure(report: dict) -> bool:
+    """True if any non-excluded check FAILs in the (normalized) report."""
+    for phase in report.get("phases", {}).values():
+        for check in phase.get("checks", []):
+            if check.get("name") in EXCLUDED_CHECKS:
+                continue
+            if check.get("status") == "FAIL":
+                return True
+    return False

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/secrets_loader.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/secrets_loader.py
@@ -2,10 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Load JIRA/SFTP credentials from KEY=VALUE files in the log directory."""
+"""Load JIRA/SFTP credentials.
+
+Environment variables take precedence (the containerized flow injects them via
+``docker --env-file``), falling back to KEY=VALUE files in the log directory for
+bare-metal / local invocations:
+
+    JIRA_BEARER_TOKEN      <- .jira-creds
+    SFTP_USER / SFTP_HOST  <- .sftp-creds
+"""
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 
@@ -24,18 +33,25 @@ def _source_env_file(path: Path) -> dict[str, str]:
 
 
 def load_jira_secrets(log_dir: str) -> str:
-    """Load JIRA bearer token from credentials file."""
+    """Load JIRA bearer token: env JIRA_BEARER_TOKEN, else .jira-creds file."""
+    token = os.environ.get("JIRA_BEARER_TOKEN")
+    if token:
+        return token
     creds_file = Path(log_dir) / ".jira-creds"
     if not creds_file.is_file():
         return ""
-    env = _source_env_file(creds_file)
-    return env.get("JIRA_BEARER_TOKEN", "")
+    return _source_env_file(creds_file).get("JIRA_BEARER_TOKEN", "")
 
 
 def load_sftp_secrets(log_dir: str) -> tuple[str, str]:
-    """Load SFTP user and host from credentials file."""
+    """Load SFTP user/host: env SFTP_USER/SFTP_HOST, else .sftp-creds file."""
+    user = os.environ.get("SFTP_USER")
+    host = os.environ.get("SFTP_HOST")
+    if user and host:
+        return user, host
     creds_file = Path(log_dir) / ".sftp-creds"
-    if not creds_file.is_file():
-        return "", ""
-    env = _source_env_file(creds_file)
-    return env.get("SFTP_USER", ""), env.get("SFTP_HOST", "")
+    if creds_file.is_file():
+        env = _source_env_file(creds_file)
+        user = user or env.get("SFTP_USER", "")
+        host = host or env.get("SFTP_HOST", "")
+    return user or "", host or ""

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/secrets_loader.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/secrets_loader.py
@@ -4,12 +4,17 @@
 
 """Load JIRA/SFTP credentials.
 
-Environment variables take precedence (the containerized flow injects them via
-``docker --env-file``), falling back to KEY=VALUE files in the log directory for
-bare-metal / local invocations:
+Credential loading is one of the two spots that diverge between deployments, so
+it dispatches on ``launch_mode``:
 
-    JIRA_BEARER_TOKEN      <- .jira-creds
-    SFTP_USER / SFTP_HOST  <- .sftp-creds
+    orchestration (k8s)  environment variables only (injected from K8s Secrets)
+    slurm (default)      environment variables, falling back to KEY=VALUE files
+                         in the log directory (.jira-creds / .sftp-creds)
+
+Environment variables read in both modes:
+
+    JIRA_BEARER_TOKEN      (slurm fallback: .jira-creds)
+    SFTP_USER / SFTP_HOST  (slurm fallback: .sftp-creds)
 """
 
 from __future__ import annotations
@@ -32,8 +37,14 @@ def _source_env_file(path: Path) -> dict[str, str]:
     return env
 
 
-def load_jira_secrets(log_dir: str) -> str:
-    """Load JIRA bearer token: env JIRA_BEARER_TOKEN, else .jira-creds file."""
+# --- JIRA -----------------------------------------------------------------
+
+
+def _load_jira_orchestration() -> str:
+    return os.environ.get("JIRA_BEARER_TOKEN", "")
+
+
+def _load_jira_slurm(log_dir: str) -> str:
     token = os.environ.get("JIRA_BEARER_TOKEN")
     if token:
         return token
@@ -43,8 +54,21 @@ def load_jira_secrets(log_dir: str) -> str:
     return _source_env_file(creds_file).get("JIRA_BEARER_TOKEN", "")
 
 
-def load_sftp_secrets(log_dir: str) -> tuple[str, str]:
-    """Load SFTP user/host: env SFTP_USER/SFTP_HOST, else .sftp-creds file."""
+def load_jira_secrets(log_dir: str, launch_mode: str = "slurm") -> str:
+    """Load the JIRA bearer token for the given launch mode."""
+    if launch_mode == "orchestration":
+        return _load_jira_orchestration()
+    return _load_jira_slurm(log_dir)
+
+
+# --- SFTP user/host -------------------------------------------------------
+
+
+def _load_sftp_orchestration() -> tuple[str, str]:
+    return os.environ.get("SFTP_USER", ""), os.environ.get("SFTP_HOST", "")
+
+
+def _load_sftp_slurm(log_dir: str) -> tuple[str, str]:
     user = os.environ.get("SFTP_USER")
     host = os.environ.get("SFTP_HOST")
     if user and host:
@@ -55,3 +79,10 @@ def load_sftp_secrets(log_dir: str) -> tuple[str, str]:
         user = user or env.get("SFTP_USER", "")
         host = host or env.get("SFTP_HOST", "")
     return user or "", host or ""
+
+
+def load_sftp_secrets(log_dir: str, launch_mode: str = "slurm") -> tuple[str, str]:
+    """Load the SFTP user/host for the given launch mode."""
+    if launch_mode == "orchestration":
+        return _load_sftp_orchestration()
+    return _load_sftp_slurm(log_dir)

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/secrets_loader.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/secrets_loader.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Load JIRA/SFTP credentials from KEY=VALUE files in the log directory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _source_env_file(path: Path) -> dict[str, str]:
+    """Parse a KEY=VALUE shell credentials file."""
+    env = {}
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            key, _, value = line.partition("=")
+            key = key.replace("export ", "").strip()
+            env[key] = value.strip().strip("'\"")
+    return env
+
+
+def load_jira_secrets(log_dir: str) -> str:
+    """Load JIRA bearer token from credentials file."""
+    creds_file = Path(log_dir) / ".jira-creds"
+    if not creds_file.is_file():
+        return ""
+    env = _source_env_file(creds_file)
+    return env.get("JIRA_BEARER_TOKEN", "")
+
+
+def load_sftp_secrets(log_dir: str) -> tuple[str, str]:
+    """Load SFTP user and host from credentials file."""
+    creds_file = Path(log_dir) / ".sftp-creds"
+    if not creds_file.is_file():
+        return "", ""
+    env = _source_env_file(creds_file)
+    return env.get("SFTP_USER", ""), env.get("SFTP_HOST", "")

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/sftp_upload.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/sftp_upload.py
@@ -4,11 +4,16 @@
 
 """Upload the health-check CSV results to the Data-team SFTP endpoint.
 
-The private key is resolved from (in order): the ``SFTP_PRIVATE_KEY_B64`` env var
-(base64-encoded PEM/OpenSSH key), the ``SFTP_PRIVATE_KEY`` env var (raw key text),
-then ``{log_dir}/.sftp_upload_key`` / ``~/.ssh/sftp_upload_key`` on disk. The env
-paths let the containerized flow inject the key via ``docker --env-file`` without
-writing it to a bind-mounted (world-readable) directory.
+Private-key resolution is the SFTP half of the launch-mode divergence:
+
+    orchestration (k8s)  the ``SFTP_KEY_PATH`` env var points at a mounted Secret
+                         file, falling back to ``~/.ssh/sftp_upload_key``.
+    slurm (default)      ``SFTP_PRIVATE_KEY_B64`` (base64 PEM/OpenSSH) or
+                         ``SFTP_PRIVATE_KEY`` (raw text) env vars, then
+                         ``{log_dir}/.sftp_upload_key`` / ``~/.ssh/sftp_upload_key``.
+                         The env paths let the Slurm flow inject the key via
+                         ``docker --env-file`` without writing it to a
+                         bind-mounted (world-readable) directory.
 """
 
 from __future__ import annotations
@@ -57,9 +62,25 @@ def _pkey_from_file(path: Path):
     return None
 
 
-def _load_sftp_pkey(log_dir: str):
-    """Resolve the SFTP private key from env (b64/raw) or disk. Returns a paramiko
-    PKey or None if no key could be loaded."""
+def _sftp_pkey_orchestration(log_dir: str):
+    """k8s: key comes from the SFTP_KEY_PATH mounted Secret file."""
+    key_env = os.environ.get("SFTP_KEY_PATH")
+    if key_env:
+        path = Path(key_env)
+        if path.is_file():
+            pkey = _pkey_from_file(path)
+            if pkey is None:
+                log.warning("SFTP key %s could not be parsed as RSA/Ed25519", path)
+            return pkey
+        log.warning("SFTP_KEY_PATH %s does not exist", key_env)
+    fallback = Path.home() / ".ssh" / "sftp_upload_key"
+    if fallback.is_file():
+        return _pkey_from_file(fallback)
+    return None
+
+
+def _sftp_pkey_slurm(log_dir: str):
+    """slurm: env (b64/raw) then a key file in log_dir / ~/.ssh."""
     b64 = os.environ.get("SFTP_PRIVATE_KEY_B64")
     raw = os.environ.get("SFTP_PRIVATE_KEY")
     key_text = None
@@ -86,16 +107,27 @@ def _load_sftp_pkey(log_dir: str):
     return pkey
 
 
+def _load_sftp_pkey(log_dir: str, launch_mode: str = "slurm"):
+    """Resolve the SFTP private key for the launch mode. Returns a paramiko PKey
+    or None if no key could be loaded."""
+    if launch_mode == "orchestration":
+        return _sftp_pkey_orchestration(log_dir)
+    return _sftp_pkey_slurm(log_dir)
+
+
 def upload_csv_sftp(
-    csv_dir: str, sftp_user: str, sftp_host: str, log_dir: str = ""
+    csv_dir: str,
+    sftp_user: str,
+    sftp_host: str,
+    log_dir: str = "",
+    launch_mode: str = "slurm",
 ) -> None:
     """Upload all CSV files in csv_dir to the SFTP server."""
-    pkey = _load_sftp_pkey(log_dir)
+    pkey = _load_sftp_pkey(log_dir, launch_mode)
     if pkey is None:
         log.warning(
-            "No SFTP private key found (env SFTP_PRIVATE_KEY_B64/SFTP_PRIVATE_KEY "
-            "or %s/.sftp_upload_key or ~/.ssh/sftp_upload_key); skipping CSV upload",
-            log_dir or "<log_dir>",
+            "No SFTP private key found (launch_mode=%s); skipping CSV upload",
+            launch_mode,
         )
         return
 

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/sftp_upload.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/sftp_upload.py
@@ -2,11 +2,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Upload the health-check CSV results to the Data-team SFTP endpoint."""
+"""Upload the health-check CSV results to the Data-team SFTP endpoint.
+
+The private key is resolved from (in order): the ``SFTP_PRIVATE_KEY_B64`` env var
+(base64-encoded PEM/OpenSSH key), the ``SFTP_PRIVATE_KEY`` env var (raw key text),
+then ``{log_dir}/.sftp_upload_key`` / ``~/.ssh/sftp_upload_key`` on disk. The env
+paths let the containerized flow inject the key via ``docker --env-file`` without
+writing it to a bind-mounted (world-readable) directory.
+"""
 
 from __future__ import annotations
 
+import base64
+import io
 import logging
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -27,15 +37,64 @@ def resolve_sftp_key_path(log_dir: str) -> Optional[Path]:
     return None
 
 
+def _pkey_from_text(key_text: str):
+    """Load an RSA or Ed25519 private key from PEM/OpenSSH text."""
+    for key_cls in (paramiko.RSAKey, paramiko.Ed25519Key):
+        try:
+            return key_cls.from_private_key(io.StringIO(key_text))
+        except Exception:
+            continue
+    return None
+
+
+def _pkey_from_file(path: Path):
+    """Load an RSA or Ed25519 private key from a file."""
+    for key_cls in (paramiko.RSAKey, paramiko.Ed25519Key):
+        try:
+            return key_cls.from_private_key_file(str(path))
+        except Exception:
+            continue
+    return None
+
+
+def _load_sftp_pkey(log_dir: str):
+    """Resolve the SFTP private key from env (b64/raw) or disk. Returns a paramiko
+    PKey or None if no key could be loaded."""
+    b64 = os.environ.get("SFTP_PRIVATE_KEY_B64")
+    raw = os.environ.get("SFTP_PRIVATE_KEY")
+    key_text = None
+    if b64:
+        try:
+            key_text = base64.b64decode(b64).decode("utf-8")
+        except Exception as exc:
+            log.warning("Could not decode SFTP_PRIVATE_KEY_B64: %s", exc)
+    elif raw:
+        key_text = raw
+
+    if key_text:
+        pkey = _pkey_from_text(key_text)
+        if pkey is not None:
+            return pkey
+        log.warning("SFTP key from env could not be parsed as RSA/Ed25519")
+
+    key_path = resolve_sftp_key_path(log_dir)
+    if key_path is None:
+        return None
+    pkey = _pkey_from_file(key_path)
+    if pkey is None:
+        log.warning("SFTP key file %s could not be parsed as RSA/Ed25519", key_path)
+    return pkey
+
+
 def upload_csv_sftp(
     csv_dir: str, sftp_user: str, sftp_host: str, log_dir: str = ""
 ) -> None:
     """Upload all CSV files in csv_dir to the SFTP server."""
-    sftp_key_path = resolve_sftp_key_path(log_dir)
-    if sftp_key_path is None:
+    pkey = _load_sftp_pkey(log_dir)
+    if pkey is None:
         log.warning(
-            "SFTP private key not found under %s or ~/.ssh/sftp_upload_key; "
-            "skipping CSV upload",
+            "No SFTP private key found (env SFTP_PRIVATE_KEY_B64/SFTP_PRIVATE_KEY "
+            "or %s/.sftp_upload_key or ~/.ssh/sftp_upload_key); skipping CSV upload",
             log_dir or "<log_dir>",
         )
         return
@@ -48,15 +107,6 @@ def upload_csv_sftp(
     log.info(
         "Uploading %d CSV file(s) to %s@%s ...", len(csv_files), sftp_user, sftp_host
     )
-    try:
-        pkey = paramiko.RSAKey.from_private_key_file(str(sftp_key_path))
-    except Exception:
-        try:
-            pkey = paramiko.Ed25519Key.from_private_key_file(str(sftp_key_path))
-        except Exception as exc:
-            log.warning("Failed to load SFTP key: %s", exc)
-            return
-
     transport = None
     try:
         transport = paramiko.Transport((sftp_host, 22))

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/sftp_upload.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/sftp_upload.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Upload the health-check CSV results to the Data-team SFTP endpoint."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import paramiko
+
+log = logging.getLogger(__name__)
+
+
+def resolve_sftp_key_path(log_dir: str) -> Optional[Path]:
+    """Prefer {log_dir}/.sftp_upload_key; fall back to ~/.ssh/sftp_upload_key."""
+    candidates = (
+        Path(log_dir) / ".sftp_upload_key",
+        Path.home() / ".ssh" / "sftp_upload_key",
+    )
+    for path in candidates:
+        if path.is_file():
+            return path
+    return None
+
+
+def upload_csv_sftp(
+    csv_dir: str, sftp_user: str, sftp_host: str, log_dir: str = ""
+) -> None:
+    """Upload all CSV files in csv_dir to the SFTP server."""
+    sftp_key_path = resolve_sftp_key_path(log_dir)
+    if sftp_key_path is None:
+        log.warning(
+            "SFTP private key not found under %s or ~/.ssh/sftp_upload_key; "
+            "skipping CSV upload",
+            log_dir or "<log_dir>",
+        )
+        return
+
+    csv_files = list(Path(csv_dir).glob("*.csv"))
+    if not csv_files:
+        log.info("No CSV files to upload")
+        return
+
+    log.info(
+        "Uploading %d CSV file(s) to %s@%s ...", len(csv_files), sftp_user, sftp_host
+    )
+    try:
+        pkey = paramiko.RSAKey.from_private_key_file(str(sftp_key_path))
+    except Exception:
+        try:
+            pkey = paramiko.Ed25519Key.from_private_key_file(str(sftp_key_path))
+        except Exception as exc:
+            log.warning("Failed to load SFTP key: %s", exc)
+            return
+
+    transport = None
+    try:
+        transport = paramiko.Transport((sftp_host, 22))
+        transport.connect(username=sftp_user, pkey=pkey)
+        sftp = paramiko.SFTPClient.from_transport(transport)
+
+        for csv_file in csv_files:
+            remote_path = csv_file.name
+            log.info("Uploading %s", csv_file.name)
+            sftp.put(str(csv_file), remote_path)
+
+        sftp.close()
+        log.info("SFTP upload complete")
+    except Exception as exc:
+        log.warning("SFTP upload failed: %s", exc)
+    finally:
+        if transport:
+            transport.close()

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/sftp_upload.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/sftp_upload.py
@@ -137,32 +137,21 @@ def upload_csv_sftp(
         return
 
     log.info("Uploading %d CSV file(s) to %s@%s ...", len(csv_files), sftp_user, sftp_host)
-    client = paramiko.SSHClient()
-    # Verify the server against known_hosts and refuse unknown/mismatched keys.
-    # A bare paramiko.Transport performs no host-key check, so a DNS/network
-    # compromise could redirect the key auth + CSV health data to an
-    # impersonating host. Fail closed instead.
-    client.load_system_host_keys()
-    client.set_missing_host_key_policy(paramiko.RejectPolicy())
+    transport = None
     try:
-        client.connect(
-            hostname=sftp_host,
-            port=22,
-            username=sftp_user,
-            pkey=pkey,
-            look_for_keys=False,
-            allow_agent=False,
-            timeout=30,
-        )
-        with client.open_sftp() as sftp:
-            for csv_file in csv_files:
-                remote_path = csv_file.name
-                log.info("Uploading %s", csv_file.name)
-                sftp.put(str(csv_file), remote_path)
+        transport = paramiko.Transport((sftp_host, 22))
+        transport.connect(username=sftp_user, pkey=pkey)
+        sftp = paramiko.SFTPClient.from_transport(transport)
+
+        for csv_file in csv_files:
+            remote_path = csv_file.name
+            log.info("Uploading %s", csv_file.name)
+            sftp.put(str(csv_file), remote_path)
+
+        sftp.close()
         log.info("SFTP upload complete")
     except Exception as exc:
-        # Best-effort telemetry upload: a rejected host key, auth failure, or
-        # transfer error must warn but never abort the health-check run.
         log.warning("SFTP upload failed: %s", exc)
     finally:
-        client.close()
+        if transport:
+            transport.close()

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/sftp_upload.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/sftp_upload.py
@@ -136,9 +136,7 @@ def upload_csv_sftp(
         log.info("No CSV files to upload")
         return
 
-    log.info(
-        "Uploading %d CSV file(s) to %s@%s ...", len(csv_files), sftp_user, sftp_host
-    )
+    log.info("Uploading %d CSV file(s) to %s@%s ...", len(csv_files), sftp_user, sftp_host)
     transport = None
     try:
         transport = paramiko.Transport((sftp_host, 22))

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/sftp_upload.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/sftp_upload.py
@@ -137,21 +137,32 @@ def upload_csv_sftp(
         return
 
     log.info("Uploading %d CSV file(s) to %s@%s ...", len(csv_files), sftp_user, sftp_host)
-    transport = None
+    client = paramiko.SSHClient()
+    # Verify the server against known_hosts and refuse unknown/mismatched keys.
+    # A bare paramiko.Transport performs no host-key check, so a DNS/network
+    # compromise could redirect the key auth + CSV health data to an
+    # impersonating host. Fail closed instead.
+    client.load_system_host_keys()
+    client.set_missing_host_key_policy(paramiko.RejectPolicy())
     try:
-        transport = paramiko.Transport((sftp_host, 22))
-        transport.connect(username=sftp_user, pkey=pkey)
-        sftp = paramiko.SFTPClient.from_transport(transport)
-
-        for csv_file in csv_files:
-            remote_path = csv_file.name
-            log.info("Uploading %s", csv_file.name)
-            sftp.put(str(csv_file), remote_path)
-
-        sftp.close()
+        client.connect(
+            hostname=sftp_host,
+            port=22,
+            username=sftp_user,
+            pkey=pkey,
+            look_for_keys=False,
+            allow_agent=False,
+            timeout=30,
+        )
+        with client.open_sftp() as sftp:
+            for csv_file in csv_files:
+                remote_path = csv_file.name
+                log.info("Uploading %s", csv_file.name)
+                sftp.put(str(csv_file), remote_path)
         log.info("SFTP upload complete")
     except Exception as exc:
+        # Best-effort telemetry upload: a rejected host key, auth failure, or
+        # transfer error must warn but never abort the health-check run.
         log.warning("SFTP upload failed: %s", exc)
     finally:
-        if transport:
-            transport.close()
+        client.close()

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/system_info.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/system_info.py
@@ -26,9 +26,7 @@ def collect_version_info() -> dict[str, str]:
     versions = {"tt_smi": "N/A", "tt_kmd": "N/A", "fw_bundle": "N/A"}
 
     try:
-        result = subprocess.run(
-            ["tt-smi", "--version"], capture_output=True, text=True, timeout=10
-        )
+        result = subprocess.run(["tt-smi", "--version"], capture_output=True, text=True, timeout=10)
         if result.returncode == 0:
             versions["tt_smi"] = result.stdout.strip()
     except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -45,6 +43,7 @@ def collect_version_info() -> dict[str, str]:
                 text=True,
                 timeout=10,
             )
+
             if result.returncode == 0:
                 versions["tt_kmd"] = result.stdout.strip()
         except (FileNotFoundError, subprocess.TimeoutExpired):

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/system_info.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/system_info.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collect TT firmware / driver version info from the host."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def collect_version_info() -> dict[str, str]:
+    """Collect TT firmware and driver version information.
+
+    Discovery flow:
+      tt_smi  : run `tt-smi --version` CLI
+      tt_kmd  : read /sys/module/tenstorrent/version (sysfs, fast)
+                -> fallback: `modinfo -F version tenstorrent` (works if module is
+                   installed but not loaded)
+      fw_bundle: scan /sys/class/tenstorrent/tenstorrent!*/tt_fw_bundle_ver
+                 (first device wins; directory absent = driver not loaded)
+
+    All values default to "N/A" if unavailable.
+    """
+    versions = {"tt_smi": "N/A", "tt_kmd": "N/A", "fw_bundle": "N/A"}
+
+    try:
+        result = subprocess.run(
+            ["tt-smi", "--version"], capture_output=True, text=True, timeout=10
+        )
+        if result.returncode == 0:
+            versions["tt_smi"] = result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    kmod_path = Path("/sys/module/tenstorrent/version")
+    if kmod_path.exists():
+        versions["tt_kmd"] = kmod_path.read_text().strip()
+    else:
+        try:
+            result = subprocess.run(
+                ["modinfo", "-F", "version", "tenstorrent"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                versions["tt_kmd"] = result.stdout.strip()
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
+    tt_class_dir = Path("/sys/class/tenstorrent")
+    if tt_class_dir.is_dir():
+        for dev_path in sorted(tt_class_dir.glob("tenstorrent!*")):
+            fw_file = dev_path / "tt_fw_bundle_ver"
+            if fw_file.is_file():
+                versions["fw_bundle"] = fw_file.read_text().strip()
+                break
+
+    return versions

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/system_info.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/system_info.py
@@ -33,9 +33,9 @@ def collect_version_info() -> dict[str, str]:
         pass
 
     kmod_path = Path("/sys/module/tenstorrent/version")
-    if kmod_path.exists():
+    try:
         versions["tt_kmd"] = kmod_path.read_text().strip()
-    else:
+    except OSError:
         try:
             result = subprocess.run(
                 ["modinfo", "-F", "version", "tenstorrent"],
@@ -54,7 +54,10 @@ def collect_version_info() -> dict[str, str]:
         for dev_path in sorted(tt_class_dir.glob("tenstorrent!*")):
             fw_file = dev_path / "tt_fw_bundle_ver"
             if fw_file.is_file():
-                versions["fw_bundle"] = fw_file.read_text().strip()
-                break
+                try:
+                    versions["fw_bundle"] = fw_file.read_text().strip()
+                    break
+                except OSError:
+                    continue
 
     return versions

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/telemetry.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/telemetry.py
@@ -149,3 +149,26 @@ def format_prometheus_metrics(metrics: dict[str, list[dict]]) -> str:
 
     lines.append("\n--- end prometheus metrics ---")
     return "\n".join(lines)
+
+
+def aggregate_telemetry_for_csv(metrics: dict[str, list[dict]] | None) -> dict:
+    """Reduce raw metric families into the flat summary runs.csv expects.
+
+    ``format_prometheus_metrics`` only builds the human-readable log block; the
+    CSV verdict needs a separate flat dict whose keys mirror the ones consumed by
+    ``analyze_health_check_results.runs_row`` (``available`` + per-metric totals).
+    Returns ``{"available": False}`` when nothing was collected so the run row
+    records ``telemetry_available=0`` rather than silently claiming a value.
+    """
+    if not metrics:
+        return {"available": False}
+
+    def _total(name: str) -> int:
+        return int(sum(s["value"] for s in metrics.get(name, [])))
+
+    return {
+        "available": True,
+        "eth_retrain_total": _total("tt_ethernet_retrain_count"),
+        "eth_crc_total": _total("tt_ethernet_crc_error_count"),
+        "eth_uncorr_cw_total": _total("tt_ethernet_uncorrected_codeword_count"),
+    }

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/telemetry.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/telemetry.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collect and format tt-telemetry metrics from the local Prometheus endpoint."""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+from prometheus_client.parser import text_string_to_metric_families
+
+log = logging.getLogger(__name__)
+
+
+TELEMETRY_METRICS = frozenset({
+    "tt_cable_present",
+    "tt_chip_count",
+    "tt_dram_trained",
+    "tt_eth_firmware_signature",
+    "tt_ethernet_cable_present",
+    "tt_ethernet_corrected_codeword_count",
+    "tt_ethernet_crc_error_count",
+    "tt_ethernet_heartbeat",
+    "tt_ethernet_link_up",
+    "tt_ethernet_retrain_count",
+    "tt_ethernet_uncorrected_codeword_count",
+    "tt_noc_alive",
+    "tt_pcie_link_alive",
+})
+
+_STATUS_METRICS = frozenset({
+    "tt_cable_present",
+    "tt_dram_trained",
+    "tt_ethernet_cable_present",
+    "tt_ethernet_heartbeat",
+    "tt_ethernet_link_up",
+    "tt_noc_alive",
+    "tt_pcie_link_alive",
+})
+
+_COUNTER_METRICS = frozenset({
+    "tt_ethernet_corrected_codeword_count",
+    "tt_ethernet_crc_error_count",
+    "tt_ethernet_retrain_count",
+    "tt_ethernet_uncorrected_codeword_count",
+})
+
+_VALUE_METRICS = frozenset({
+    "tt_chip_count",
+})
+
+
+def collect_prometheus_metrics(port: int = 8080) -> dict[str, list[dict]] | None:
+    """Collect telemetry metrics from the local Prometheus endpoint.
+
+    Returns a dict mapping metric name to a list of
+    ``{"labels": {…}, "value": float}`` dicts, or *None* if the endpoint is
+    unreachable or no relevant metrics are found.
+    """
+    url = f"http://localhost:{port}/metrics"
+
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        log.info("Prometheus metrics endpoint not available at %s: %s", url, exc)
+        return None
+
+    metrics: dict[str, list[dict]] = {}
+    for family in text_string_to_metric_families(resp.text):
+        if family.name not in TELEMETRY_METRICS:
+            continue
+        samples = []
+        for sample in family.samples:
+            samples.append({"labels": dict(sample.labels), "value": sample.value})
+        if samples:
+            metrics[family.name] = samples
+
+    return metrics if metrics else None
+
+
+def _sample_ident(labels: dict[str, str]) -> str:
+    """Build a short human-readable identifier from sample labels."""
+    parts = [
+        f"tray={labels['tray']}" if "tray" in labels else None,
+        f"chip={labels['chip']}" if "chip" in labels else None,
+        f"ch={labels['channel']}" if "channel" in labels else None,
+        f"port={labels['port_id']}" if "port_id" in labels else None,
+    ]
+    ident = " ".join(p for p in parts if p)
+    remote = labels.get("remote_hostname")
+    if remote:
+        ident += f" -> {remote}"
+    return ident
+
+
+def format_prometheus_metrics(metrics: dict[str, list[dict]]) -> str:
+    """Return a human-readable summary of the collected telemetry metrics."""
+    lines = ["--- prometheus telemetry metrics ---"]
+
+    for name in sorted(metrics):
+        samples = metrics[name]
+        lines.append(f"\n  {name}: {len(samples)} samples")
+
+        if name in _STATUS_METRICS:
+            up = sum(1 for s in samples if s["value"] == 1)
+            down = sum(1 for s in samples if s["value"] == 0)
+            lines.append(f"    up/present={up}  down/absent={down}")
+            for s in samples:
+                if s["value"] == 0:
+                    lines.append(f"    DOWN: {_sample_ident(s['labels'])}")
+
+        elif name in _COUNTER_METRICS:
+            nonzero = [s for s in samples if s["value"] > 0]
+            lines.append(f"    non-zero={len(nonzero)}/{len(samples)}")
+            if nonzero:
+                total = sum(s["value"] for s in nonzero)
+                max_val = max(s["value"] for s in nonzero)
+                lines.append(f"    total={int(total)}  max={int(max_val)}")
+                if name in (
+                    "tt_ethernet_uncorrected_codeword_count",
+                    "tt_ethernet_crc_error_count",
+                ):
+                    for s in sorted(nonzero, key=lambda x: x["value"], reverse=True)[
+                        :5
+                    ]:
+                        lines.append(
+                            f"    {_sample_ident(s['labels'])}: {int(s['value'])}"
+                        )
+
+        elif name == "tt_eth_firmware_signature":
+            unique_sigs = sorted(set(int(s["value"]) for s in samples))
+            lines.append(
+                f"    unique signatures: {', '.join(hex(s) for s in unique_sigs)}"
+            )
+
+        elif name in _VALUE_METRICS:
+            for s in samples:
+                ident = _sample_ident(s["labels"])
+                if not ident:
+                    extra = {
+                        k: v
+                        for k, v in s["labels"].items()
+                        if k not in ("hostname", "__name__")
+                    }
+                    ident = " ".join(f"{k}={v}" for k, v in sorted(extra.items()))
+                suffix = f" [{ident}]" if ident else ""
+                lines.append(f"    {name}={int(s['value'])}{suffix}")
+
+    lines.append("\n--- end prometheus metrics ---")
+    return "\n".join(lines)

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/telemetry.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/telemetry.py
@@ -14,42 +14,50 @@ from prometheus_client.parser import text_string_to_metric_families
 log = logging.getLogger(__name__)
 
 
-TELEMETRY_METRICS = frozenset({
-    "tt_cable_present",
-    "tt_chip_count",
-    "tt_dram_trained",
-    "tt_eth_firmware_signature",
-    "tt_ethernet_cable_present",
-    "tt_ethernet_corrected_codeword_count",
-    "tt_ethernet_crc_error_count",
-    "tt_ethernet_heartbeat",
-    "tt_ethernet_link_up",
-    "tt_ethernet_retrain_count",
-    "tt_ethernet_uncorrected_codeword_count",
-    "tt_noc_alive",
-    "tt_pcie_link_alive",
-})
+TELEMETRY_METRICS = frozenset(
+    {
+        "tt_cable_present",
+        "tt_chip_count",
+        "tt_dram_trained",
+        "tt_eth_firmware_signature",
+        "tt_ethernet_cable_present",
+        "tt_ethernet_corrected_codeword_count",
+        "tt_ethernet_crc_error_count",
+        "tt_ethernet_heartbeat",
+        "tt_ethernet_link_up",
+        "tt_ethernet_retrain_count",
+        "tt_ethernet_uncorrected_codeword_count",
+        "tt_noc_alive",
+        "tt_pcie_link_alive",
+    }
+)
 
-_STATUS_METRICS = frozenset({
-    "tt_cable_present",
-    "tt_dram_trained",
-    "tt_ethernet_cable_present",
-    "tt_ethernet_heartbeat",
-    "tt_ethernet_link_up",
-    "tt_noc_alive",
-    "tt_pcie_link_alive",
-})
+_STATUS_METRICS = frozenset(
+    {
+        "tt_cable_present",
+        "tt_dram_trained",
+        "tt_ethernet_cable_present",
+        "tt_ethernet_heartbeat",
+        "tt_ethernet_link_up",
+        "tt_noc_alive",
+        "tt_pcie_link_alive",
+    }
+)
 
-_COUNTER_METRICS = frozenset({
-    "tt_ethernet_corrected_codeword_count",
-    "tt_ethernet_crc_error_count",
-    "tt_ethernet_retrain_count",
-    "tt_ethernet_uncorrected_codeword_count",
-})
+_COUNTER_METRICS = frozenset(
+    {
+        "tt_ethernet_corrected_codeword_count",
+        "tt_ethernet_crc_error_count",
+        "tt_ethernet_retrain_count",
+        "tt_ethernet_uncorrected_codeword_count",
+    }
+)
 
-_VALUE_METRICS = frozenset({
-    "tt_chip_count",
-})
+_VALUE_METRICS = frozenset(
+    {
+        "tt_chip_count",
+    }
+)
 
 
 def collect_prometheus_metrics(port: int = 8080) -> dict[str, list[dict]] | None:
@@ -123,28 +131,18 @@ def format_prometheus_metrics(metrics: dict[str, list[dict]]) -> str:
                     "tt_ethernet_uncorrected_codeword_count",
                     "tt_ethernet_crc_error_count",
                 ):
-                    for s in sorted(nonzero, key=lambda x: x["value"], reverse=True)[
-                        :5
-                    ]:
-                        lines.append(
-                            f"    {_sample_ident(s['labels'])}: {int(s['value'])}"
-                        )
+                    for s in sorted(nonzero, key=lambda x: x["value"], reverse=True)[:5]:
+                        lines.append(f"    {_sample_ident(s['labels'])}: {int(s['value'])}")
 
         elif name == "tt_eth_firmware_signature":
             unique_sigs = sorted(set(int(s["value"]) for s in samples))
-            lines.append(
-                f"    unique signatures: {', '.join(hex(s) for s in unique_sigs)}"
-            )
+            lines.append(f"    unique signatures: {', '.join(hex(s) for s in unique_sigs)}")
 
         elif name in _VALUE_METRICS:
             for s in samples:
                 ident = _sample_ident(s["labels"])
                 if not ident:
-                    extra = {
-                        k: v
-                        for k, v in s["labels"].items()
-                        if k not in ("hostname", "__name__")
-                    }
+                    extra = {k: v for k, v in s["labels"].items() if k not in ("hostname", "__name__")}
                     ident = " ".join(f"{k}={v}" for k, v in sorted(extra.items()))
                 suffix = f" [{ident}]" if ident else ""
                 lines.append(f"    {name}={int(s['value'])}{suffix}")


### PR DESCRIPTION
### PR Category

Cleanup / Feature

### Summary

[DCAMP-1176]()

### What changed

**Health check: migrate test infrastructure into tt-metal + unify Slurm/k8s**
Moves the system health-check test infrastructure out of `exabox-infra` and into this repo so it ships inside the upstream test image, and unifies it with the `Kubernetes` (`tt-orchestration`) deployment via a single `--launch-mode` flag. No changes to the diag suite's behavior; this is orchestration/runner plumbing.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mgajewskiTT/DCAMP-1176-unify-test-scripts-between-k-8-s-and-bare-metal)