### PR TITLE
[Bug fix] seeded on-device sampling fix

### DIFF
--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -949,8 +949,12 @@ class SeedManager:
         self._seed_active = any(s is not None for s in self.seeds)
         self._reseted = True
 
-    def reset_seed_from_slots_if_needed(self, seeds, user_ids) -> None:
-        """Reset only active slots whose slot-indexed seed changed."""
+    def reset_seed_from_slots_if_needed(self, seeds, user_ids) -> list[int]:
+        """Reset only active slots whose slot-indexed seed changed.
+
+        Returns the reset slots: they hold newly admitted requests, so their host
+        position is authoritative even when the rest of the batch's is not.
+        """
         if user_ids is None:
             user_ids = range(self.max_batch_size)
         reset_slots = []
@@ -960,6 +964,7 @@ class SeedManager:
                 reset_slots.append(slot)
         if reset_slots:
             self.reset_seed_from_slots(seeds, reset_slots)
+        return reset_slots
 
     def align_seed_counters_to_positions(self, seeds, user_ids, positions, offset: int = 1):
         """Make explicit-seed decode independent of persistent slot lifetime.
@@ -969,6 +974,10 @@ class SeedManager:
         slots. For explicit request seeds, deriving the per-token device seed
         from the absolute decode position keeps the stream reproducible even
         when the Python-side slot counter was reset or moved.
+
+        ``positions`` MUST be authoritative for the slots being aligned: the
+        counter self-advances per token, so aligning to a position that lags
+        under async scheduling makes the stream timing-dependent (#51981).
         """
         if positions is None:
             return

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -665,8 +665,12 @@ class SeedManager:
         self._seed_active = any(s is not None for s in self.seeds)
         self._reseted = True
 
-    def reset_seed_from_slots_if_needed(self, seeds, user_ids) -> None:
-        """Reset only active slots whose slot-indexed seed changed."""
+    def reset_seed_from_slots_if_needed(self, seeds, user_ids) -> list[int]:
+        """Reset only active slots whose slot-indexed seed changed.
+
+        Returns the reset slots: they hold newly admitted requests, so their host
+        position is authoritative even when the rest of the batch's is not.
+        """
         if user_ids is None:
             user_ids = range(self.max_batch_size)
         reset_slots = []
@@ -676,6 +680,7 @@ class SeedManager:
                 reset_slots.append(slot)
         if reset_slots:
             self.reset_seed_from_slots(seeds, reset_slots)
+        return reset_slots
 
     def align_seed_counters_to_positions(self, seeds, user_ids, positions, offset: int = 1):
         """Make explicit-seed decode independent of persistent slot lifetime.
@@ -685,6 +690,10 @@ class SeedManager:
         slots. For explicit request seeds, deriving the per-token device seed
         from the absolute decode position keeps the stream reproducible even
         when the Python-side slot counter was reset or moved.
+
+        ``positions`` MUST be authoritative for the slots being aligned: the
+        counter self-advances per token, so aligning to a position that lags
+        under async scheduling makes the stream timing-dependent (#51981).
         """
         if positions is None:
             return
@@ -831,8 +840,13 @@ class SeedManager:
                 assert len(empty_slots) == 1, "Cannot replicate seeds if empty_slots is not length 1"
                 new_seeds = self.max_batch_size * [new_seeds[empty_slots[0]]]
 
+        self._copy_seeds_to_device(new_seeds)
+        self._reseted = False
+
+    def _copy_seeds_to_device(self, new_seeds):
+        """Push one step's per-slot device seeds. Split out so host-only tests
+        can drive the seed bookkeeping without a device."""
         new_seed_tt = ttnn.from_torch(
             torch.tensor(new_seeds), dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, mesh_mapper=self._seed_mapper
         )
         ttnn.copy_host_to_device_tensor(new_seed_tt, self.tt_sampling.seeds_tt_tensor)
-        self._reseted = False

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -18,7 +18,7 @@ from models.common.sampling import (
     format_sampling_params,
     scatter_sampling_params_to_slots,
 )
-from models.common.sampling.generator import _mark_trace_buffers_corruptible
+from models.common.sampling.generator import _hash_request_seed_to_device_seed, _mark_trace_buffers_corruptible
 from models.common.sampling.tt_log_probs import MAX_TOP_LOGPROBS, LogProbsResult
 from models.common.utility_functions import comp_pcc
 
@@ -350,6 +350,136 @@ def test_scatter_sampling_params_to_slots_is_identity_for_dense_slots():
 
     assert scattered.temperature[:2] == params.temperature[:2]
     assert scattered.top_k[:2] == params.top_k[:2]
+
+
+# ---------------------------------------------------------------------------
+# Seeded decode reproducibility under async scheduling (#51981).
+# Host-only: the generator is built with __new__ and driven with stub modules.
+# ---------------------------------------------------------------------------
+SEED_TEST_BATCH = 32  # format_sampling_params requires a multiple of 32
+
+
+class _RecordingSeedManager(SeedManager):
+    """SeedManager that records each step's device seed vector instead of pushing it."""
+
+    def __init__(self, max_batch_size=SEED_TEST_BATCH):
+        super().__init__(SimpleNamespace(_sampling_dp=1), max_batch_size=max_batch_size)
+        self.pushed = []
+
+    def write_device_seed_values(self, new_seeds):
+        self.pushed.append(list(new_seeds))
+
+
+class _StubSamplingModule:
+    def __init__(self, max_batch_size=SEED_TEST_BATCH):
+        self.seed_manager = _RecordingSeedManager(max_batch_size)
+        self.tt_sampling = SimpleNamespace(max_batch_size=max_batch_size)
+
+    def apply_decode_state(self, sampling_params_chunks, *, reset_batch=False, prompt_tokens=None, output_tokens=None):
+        pass
+
+    def sample(self, logits=None, tt_out_tok=None, enable_trace=False):
+        return logits
+
+
+def _make_stub_generator(max_batch_size=SEED_TEST_BATCH):
+    from models.tt_transformers.tt.generator import Generator
+
+    generator = Generator.__new__(Generator)
+    generator.data_parallel = 1
+    sampling = _StubSamplingModule(max_batch_size)
+    generator.model = [SimpleNamespace(sampling=sampling, sampling_dp=1)]
+    return generator, sampling
+
+
+def _decode_sampling_step(generator, seeds, positions, reload_inputs, max_batch_size=SEED_TEST_BATCH):
+    """Run one device-sampling decode step; return the per-slot device seeds pushed."""
+    seeds = list(seeds) + [None] * (max_batch_size - len(seeds))
+    positions = list(positions) + [-1] * (max_batch_size - len(positions))
+    params = SamplingParams(
+        temperature=[1.0] * max_batch_size,
+        top_k=[32] * max_batch_size,
+        top_p=[1.0] * max_batch_size,
+        seed=seeds,
+    )
+    generator.sample_decode_on_device(
+        [None],
+        sampling_params=params,
+        start_pos=[torch.tensor(positions, dtype=torch.int32)],
+        reload_inputs=reload_inputs,
+    )
+    return generator.model[0].sampling.seed_manager.pushed[-1]
+
+
+def _expected_seed_stream(request_seed, first_position, num_steps):
+    """Device seeds for `num_steps` consecutive tokens starting at `first_position`."""
+    positions = range(first_position, first_position + num_steps)
+    return [_hash_request_seed_to_device_seed(request_seed, pos + 1) for pos in positions]
+
+
+def test_seed_stream_is_independent_of_host_position_lag():
+    """The counter must self-advance from the last authoritative anchor; re-anchoring
+    to a lagging host position replays device seeds (#51981)."""
+    generator, sampling = _make_stub_generator()
+
+    pushed = [_decode_sampling_step(generator, [7], [100], reload_inputs=True)[0]]
+    # Device is at 101, 102, 103; the host reports the previous position and
+    # stalls entirely when a readback is late.
+    for lagging_host_pos in (100, 101, 101):
+        pushed.append(_decode_sampling_step(generator, [7], [lagging_host_pos], reload_inputs=False)[0])
+
+    assert pushed == _expected_seed_stream(7, 100, 4)
+    assert len(set(pushed)) == 4  # no replayed seed
+    assert sampling.seed_manager.seed_counters[0] == 105  # anchored at 101, one per token
+
+
+def test_seed_stream_matches_across_different_host_lags():
+    """Same seed and true positions, but one run has async overlap engaged (host
+    lags) and the other does not. Equal streams is what `seed=` promises."""
+    lagged, _ = _make_stub_generator()
+    exact, _ = _make_stub_generator()
+
+    lagged_stream = [_decode_sampling_step(lagged, [7], [100], reload_inputs=True)[0]]
+    exact_stream = [_decode_sampling_step(exact, [7], [100], reload_inputs=True)[0]]
+    for true_pos in (101, 102, 103):
+        lagged_stream.append(_decode_sampling_step(lagged, [7], [true_pos - 1], reload_inputs=False)[0])
+        exact_stream.append(_decode_sampling_step(exact, [7], [true_pos], reload_inputs=False)[0])
+
+    assert lagged_stream == exact_stream
+
+
+def test_seed_counters_realign_when_host_inputs_are_authoritative():
+    """A batch reset re-anchors every active slot: vLLM may have evicted and
+    re-admitted the request elsewhere, so the resident counter is untrustworthy."""
+    generator, sampling = _make_stub_generator()
+
+    _decode_sampling_step(generator, [7], [100], reload_inputs=True)
+    sampling.seed_manager.seed_counters[0] = 0  # state moved behind our back
+    pushed = _decode_sampling_step(generator, [7], [200], reload_inputs=True)
+
+    assert pushed[0] == _hash_request_seed_to_device_seed(7, 201)
+
+
+def test_newly_seeded_slot_is_aligned_even_on_a_non_authoritative_step():
+    """A freshly admitted slot's position comes from its prefill, so it is
+    authoritative even when the rest of the batch's host inputs are stale;
+    otherwise its reset-to-zero counter starts the stream at the wrong offset."""
+    generator, _ = _make_stub_generator()
+
+    _decode_sampling_step(generator, [7], [100], reload_inputs=True)
+    # Slot 1 admitted mid-flight at position 5; slot 0 keeps decoding with a lag.
+    pushed = _decode_sampling_step(generator, [7, 11], [100, 5], reload_inputs=False)
+
+    assert pushed[0] == _hash_request_seed_to_device_seed(7, 102)  # unmoved, self-advanced
+    assert pushed[1] == _hash_request_seed_to_device_seed(11, 6)  # anchored to its prefill position
+
+
+def test_reset_seed_from_slots_if_needed_reports_the_slots_it_reset():
+    seed_manager = _make_host_only_seed_manager()
+    seed_manager.reset_seed_from_slots([42, 43, None, None], [0, 1, 2, 3])
+
+    assert seed_manager.reset_seed_from_slots_if_needed([42, 43, None, None], [0, 1, 2, 3]) == []
+    assert seed_manager.reset_seed_from_slots_if_needed([42, 99, None, None], [0, 1, 2, 3]) == [1]
 
 
 def _skip_if_not_galaxy(mesh_device):

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -324,34 +324,6 @@ def test_format_sampling_params_uses_device_argmax_sentinel_for_greedy_rows():
     assert params.top_p[0] == 0.0
 
 
-def test_scatter_sampling_params_to_slots_moves_params_to_their_slot_row():
-    """A batched prefill samples slot row s with the params of the request there."""
-    params = SamplingParams(temperature=[0.1, 0.2, 0.3], top_k=[1, 2, 3], top_p=[0.5, 0.6, 0.7], seed=[7, 8, 9])
-
-    scattered = scatter_sampling_params_to_slots(params, [2, 0, 5], slot_len=8)
-
-    assert scattered.temperature[2] == 0.1 and scattered.temperature[0] == 0.2
-    assert scattered.temperature[5] == 0.3
-    assert scattered.top_k[2] == 1 and scattered.top_k[0] == 2 and scattered.top_k[5] == 3
-    assert scattered.top_p[2] == 0.5 and scattered.top_p[0] == 0.6 and scattered.top_p[5] == 0.7
-    # Unoccupied rows carry the last request's values, so they stay valid instead of
-    # sampling from a formatter default.
-    assert scattered.temperature[1] == 0.3
-    # SeedManager.reset_seed is given the slot list separately and maps seeds itself.
-    assert scattered.seed == [7, 8, 9]
-    # The input is never mutated.
-    assert params.temperature == [0.1, 0.2, 0.3]
-
-
-def test_scatter_sampling_params_to_slots_is_identity_for_dense_slots():
-    params = format_sampling_params(SamplingParams(temperature=[0.5, 0.5], top_k=[4, 4], top_p=[0.9, 0.9]), 32)
-
-    scattered = scatter_sampling_params_to_slots(params, list(range(2)), slot_len=32)
-
-    assert scattered.temperature[:2] == params.temperature[:2]
-    assert scattered.top_k[:2] == params.top_k[:2]
-
-
 # ---------------------------------------------------------------------------
 # Seeded decode reproducibility under async scheduling (#51981).
 # Host-only: the generator is built with __new__ and driven with stub modules.
@@ -366,8 +338,8 @@ class _RecordingSeedManager(SeedManager):
         super().__init__(SimpleNamespace(_sampling_dp=1), max_batch_size=max_batch_size)
         self.pushed = []
 
-    def write_device_seed_values(self, new_seeds):
-        self.pushed.append(list(new_seeds))
+    def write_device_seed_values(self, seed_values):
+        self.pushed.append(list(seed_values))
 
 
 class _StubSamplingModule:
@@ -375,10 +347,10 @@ class _StubSamplingModule:
         self.seed_manager = _RecordingSeedManager(max_batch_size)
         self.tt_sampling = SimpleNamespace(max_batch_size=max_batch_size)
 
-    def apply_decode_state(self, sampling_params_chunks, *, reset_batch=False, prompt_tokens=None, output_tokens=None):
+    def apply_decode_state(self, sampling_params_chunks, **kwargs):
         pass
 
-    def sample(self, logits=None, tt_out_tok=None, enable_trace=False):
+    def sample(self, logits=None, **kwargs):
         return logits
 
 
@@ -480,6 +452,34 @@ def test_reset_seed_from_slots_if_needed_reports_the_slots_it_reset():
 
     assert seed_manager.reset_seed_from_slots_if_needed([42, 43, None, None], [0, 1, 2, 3]) == []
     assert seed_manager.reset_seed_from_slots_if_needed([42, 99, None, None], [0, 1, 2, 3]) == [1]
+
+
+def test_scatter_sampling_params_to_slots_moves_params_to_their_slot_row():
+    """A batched prefill samples slot row s with the params of the request there."""
+    params = SamplingParams(temperature=[0.1, 0.2, 0.3], top_k=[1, 2, 3], top_p=[0.5, 0.6, 0.7], seed=[7, 8, 9])
+
+    scattered = scatter_sampling_params_to_slots(params, [2, 0, 5], slot_len=8)
+
+    assert scattered.temperature[2] == 0.1 and scattered.temperature[0] == 0.2
+    assert scattered.temperature[5] == 0.3
+    assert scattered.top_k[2] == 1 and scattered.top_k[0] == 2 and scattered.top_k[5] == 3
+    assert scattered.top_p[2] == 0.5 and scattered.top_p[0] == 0.6 and scattered.top_p[5] == 0.7
+    # Unoccupied rows carry the last request's values, so they stay valid instead of
+    # sampling from a formatter default.
+    assert scattered.temperature[1] == 0.3
+    # SeedManager.reset_seed is given the slot list separately and maps seeds itself.
+    assert scattered.seed == [7, 8, 9]
+    # The input is never mutated.
+    assert params.temperature == [0.1, 0.2, 0.3]
+
+
+def test_scatter_sampling_params_to_slots_is_identity_for_dense_slots():
+    params = format_sampling_params(SamplingParams(temperature=[0.5, 0.5], top_k=[4, 4], top_p=[0.9, 0.9]), 32)
+
+    scattered = scatter_sampling_params_to_slots(params, list(range(2)), slot_len=32)
+
+    assert scattered.temperature[:2] == params.temperature[:2]
+    assert scattered.top_k[:2] == params.top_k[:2]
 
 
 def _skip_if_not_galaxy(mesh_device):

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -15,6 +15,7 @@ from models.common.sampling import (
     broadcast_sampling_params,
     format_sampling_params,
 )
+from models.common.sampling.generator import _hash_request_seed_to_device_seed
 from models.common.sampling.tt_log_probs import MAX_TOP_LOGPROBS, LogProbsResult
 from models.common.utility_functions import comp_pcc
 
@@ -145,6 +146,136 @@ def test_format_sampling_params_uses_device_argmax_sentinel_for_greedy_rows():
     assert params.temperature[0] == 1.0
     assert params.top_k[0] == 1
     assert params.top_p[0] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Seeded decode reproducibility under async scheduling (#51981).
+# Host-only: the generator is built with __new__ and driven with stub modules.
+# ---------------------------------------------------------------------------
+SEED_TEST_BATCH = 32  # format_sampling_params requires a multiple of 32
+
+
+class _RecordingSeedManager(SeedManager):
+    """SeedManager that records each step's device seed vector instead of pushing it."""
+
+    def __init__(self, max_batch_size=SEED_TEST_BATCH):
+        super().__init__(SimpleNamespace(_sampling_dp=1), max_batch_size=max_batch_size)
+        self.pushed = []
+
+    def _copy_seeds_to_device(self, new_seeds):
+        self.pushed.append(list(new_seeds))
+
+
+class _StubSamplingModule:
+    def __init__(self, max_batch_size=SEED_TEST_BATCH):
+        self.seed_manager = _RecordingSeedManager(max_batch_size)
+        self.tt_sampling = SimpleNamespace(max_batch_size=max_batch_size)
+
+    def apply_decode_state(self, sampling_params_chunks, *, reset_batch=False, prompt_tokens=None, output_tokens=None):
+        pass
+
+    def sample(self, logits=None, tt_out_tok=None, enable_trace=False):
+        return logits
+
+
+def _make_stub_generator(max_batch_size=SEED_TEST_BATCH):
+    from models.tt_transformers.tt.generator import Generator
+
+    generator = Generator.__new__(Generator)
+    generator.data_parallel = 1
+    sampling = _StubSamplingModule(max_batch_size)
+    generator.model = [SimpleNamespace(sampling=sampling, sampling_dp=1)]
+    return generator, sampling
+
+
+def _decode_sampling_step(generator, seeds, positions, reload_inputs, max_batch_size=SEED_TEST_BATCH):
+    """Run one device-sampling decode step; return the per-slot device seeds pushed."""
+    seeds = list(seeds) + [None] * (max_batch_size - len(seeds))
+    positions = list(positions) + [-1] * (max_batch_size - len(positions))
+    params = SamplingParams(
+        temperature=[1.0] * max_batch_size,
+        top_k=[32] * max_batch_size,
+        top_p=[1.0] * max_batch_size,
+        seed=seeds,
+    )
+    generator.sample_decode_on_device(
+        [None],
+        sampling_params=params,
+        start_pos=[torch.tensor(positions, dtype=torch.int32)],
+        reload_inputs=reload_inputs,
+    )
+    return generator.model[0].sampling.seed_manager.pushed[-1]
+
+
+def _expected_seed_stream(request_seed, first_position, num_steps):
+    """Device seeds for `num_steps` consecutive tokens starting at `first_position`."""
+    positions = range(first_position, first_position + num_steps)
+    return [_hash_request_seed_to_device_seed(request_seed, pos + 1) for pos in positions]
+
+
+def test_seed_stream_is_independent_of_host_position_lag():
+    """The counter must self-advance from the last authoritative anchor; re-anchoring
+    to a lagging host position replays device seeds (#51981)."""
+    generator, sampling = _make_stub_generator()
+
+    pushed = [_decode_sampling_step(generator, [7], [100], reload_inputs=True)[0]]
+    # Device is at 101, 102, 103; the host reports the previous position and
+    # stalls entirely when a readback is late.
+    for lagging_host_pos in (100, 101, 101):
+        pushed.append(_decode_sampling_step(generator, [7], [lagging_host_pos], reload_inputs=False)[0])
+
+    assert pushed == _expected_seed_stream(7, 100, 4)
+    assert len(set(pushed)) == 4  # no replayed seed
+    assert sampling.seed_manager.seed_counters[0] == 105  # anchored at 101, one per token
+
+
+def test_seed_stream_matches_across_different_host_lags():
+    """Same seed and true positions, but one run has async overlap engaged (host
+    lags) and the other does not. Equal streams is what `seed=` promises."""
+    lagged, _ = _make_stub_generator()
+    exact, _ = _make_stub_generator()
+
+    lagged_stream = [_decode_sampling_step(lagged, [7], [100], reload_inputs=True)[0]]
+    exact_stream = [_decode_sampling_step(exact, [7], [100], reload_inputs=True)[0]]
+    for true_pos in (101, 102, 103):
+        lagged_stream.append(_decode_sampling_step(lagged, [7], [true_pos - 1], reload_inputs=False)[0])
+        exact_stream.append(_decode_sampling_step(exact, [7], [true_pos], reload_inputs=False)[0])
+
+    assert lagged_stream == exact_stream
+
+
+def test_seed_counters_realign_when_host_inputs_are_authoritative():
+    """A batch reset re-anchors every active slot: vLLM may have evicted and
+    re-admitted the request elsewhere, so the resident counter is untrustworthy."""
+    generator, sampling = _make_stub_generator()
+
+    _decode_sampling_step(generator, [7], [100], reload_inputs=True)
+    sampling.seed_manager.seed_counters[0] = 0  # state moved behind our back
+    pushed = _decode_sampling_step(generator, [7], [200], reload_inputs=True)
+
+    assert pushed[0] == _hash_request_seed_to_device_seed(7, 201)
+
+
+def test_newly_seeded_slot_is_aligned_even_on_a_non_authoritative_step():
+    """A freshly admitted slot's position comes from its prefill, so it is
+    authoritative even when the rest of the batch's host inputs are stale;
+    otherwise its reset-to-zero counter starts the stream at the wrong offset."""
+    generator, _ = _make_stub_generator()
+
+    _decode_sampling_step(generator, [7], [100], reload_inputs=True)
+    # Slot 1 admitted mid-flight at position 5; slot 0 keeps decoding with a lag.
+    pushed = _decode_sampling_step(generator, [7, 11], [100, 5], reload_inputs=False)
+
+    assert pushed[0] == _hash_request_seed_to_device_seed(7, 102)  # unmoved, self-advanced
+    assert pushed[1] == _hash_request_seed_to_device_seed(11, 6)  # anchored to its prefill position
+
+
+def test_reset_seed_from_slots_if_needed_reports_the_slots_it_reset():
+    seed_manager = _make_host_only_seed_manager()
+    seed_manager.reset_seed_from_slots([42, 43, None, None], [0, 1, 2, 3])
+
+    assert seed_manager.reset_seed_from_slots_if_needed([42, 43, None, None], [0, 1, 2, 3]) == []
+    assert seed_manager.reset_seed_from_slots_if_needed([42, 99, None, None], [0, 1, 2, 3]) == [1]
 
 
 def _skip_if_not_galaxy(mesh_device):

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1605,6 +1605,32 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         on_device_sampling = (sampling_params is not None) or defer_device_sampling
         B = tokens.shape[0]
 
+        # Are the host tokens/positions authoritative this step, or is the device
+        # copy ahead? Trace reload and seed alignment must agree, so compute it
+        # once here instead of privately in the trace path (#51981).
+        prev_on_device_sampling = getattr(self, "_prev_on_device_sampling", None)
+        self._prev_on_device_sampling = on_device_sampling
+        sampling_mode_changed = prev_on_device_sampling is not None and prev_on_device_sampling != on_device_sampling
+        reload_inputs = (
+            not enable_trace
+            or not self.trace_ids_decode[on_device_sampling]
+            or not on_device_sampling
+            or reset_batch
+            or mode_switched
+            or sampling_mode_changed
+            or any(
+                getattr(self.model[i], "_tt_vllm_always_refresh_decode_trace_inputs", False)
+                for i in range(self.data_parallel)
+            )
+        )
+        # vLLM sees re-admissions the model cannot (tenstorrent/vllm#456), so
+        # either side asserting authority is enough.
+        if kwargs.get("reload_inputs"):
+            reload_inputs = True
+        # Deferred sampling calls sample_decode_on_device() out of band; stash the
+        # flag so that call need not thread it.
+        self._decode_reload_inputs = reload_inputs
+
         tokens = torch.chunk(tokens, self.data_parallel, 0)
         start_pos = torch.chunk(start_pos, self.data_parallel, 0)
         page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
@@ -1698,12 +1724,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         }
 
         if enable_trace:
-            # A real batch reset / slot remap (reset_batch) also makes the device
-            # token/current_pos trace buffers stale, not just a prefill->decode
-            # mode switch, so both must force a full traced-input reset.
+            # reset_batch (real reset / slot remap) and a prefill->decode switch
+            # both stale the device buffers; both are folded into reload_inputs.
             tt_decode_output = self._decode_forward_trace_text(
                 **decode_kwargs,
-                reset_batch=reset_batch or mode_switched,
+                reload_inputs=reload_inputs,
                 skip_precompile=skip_trace_precompile,
             )
         else:
@@ -1726,6 +1751,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 slot_remap=slot_remap,
                 enable_trace=enable_trace,
                 skip_precompile=skip_trace_precompile,
+                reload_inputs=reload_inputs,
             )
         # Host sampling
         if read_from_device:
@@ -1946,11 +1972,14 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         page_table=None,
         kv_cache=None,
         on_device_sampling=False,
-        reset_batch=False,
+        reload_inputs=False,
         skip_precompile=False,
     ):
         """
         Run decode forward text with tracing
+
+        ``reload_inputs`` (from decode_forward): host token/position inputs are
+        authoritative this step and must overwrite the device-resident ones.
         """
         # The trace is different depending on whether we are doing device sampling or not
         if not self.trace_ids_decode[on_device_sampling]:
@@ -1966,19 +1995,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             self.trace_inputs_decode[on_device_sampling] = device_inputs
             self.trace_output_decode[on_device_sampling] = tt_out_trace
 
-        # reset inputs when mode switches from prefill to decode,
-        # or when sampling mode changes (different trace has stale inputs)
-        prev_on_device_sampling = getattr(self, "_prev_on_device_sampling", None)
-        self._prev_on_device_sampling = on_device_sampling
-        sampling_mode_changed = prev_on_device_sampling is not None and prev_on_device_sampling != on_device_sampling
-        reset_inputs = reset_batch or not on_device_sampling or sampling_mode_changed
         page_table_changed = page_table is not None and (
             self.prev_page_table is None
             or any(not torch.equal(prev, curr) for prev, curr in zip(self.prev_page_table, page_table))
         )
 
         for i in range(self.data_parallel):
-            refresh_trace_inputs = reset_inputs or getattr(
+            refresh_trace_inputs = reload_inputs or getattr(
                 self.model[i], "_tt_vllm_always_refresh_decode_trace_inputs", False
             )
             user_page_table = page_table[i] if page_table is not None else None
@@ -2021,7 +2044,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         slot_remap=None,
         enable_trace=False,
         skip_precompile=False,
+        reload_inputs=None,
     ):
+        """Sample this decode step's tokens on device.
+
+        ``reload_inputs``: host inputs are authoritative, so ``start_pos`` may
+        re-anchor the seed counters. ``None`` takes the last decode_forward's
+        value (the deferred path calls this out of band).
+        """
+        if reload_inputs is None:
+            reload_inputs = getattr(self, "_decode_reload_inputs", True)
         # sampling_dp may differ from data_parallel for models that internally
         # shard users across mesh rows (users_row_sharded) — each row samples
         # 32 users independently, so sampling params must be chunked by the
@@ -2092,6 +2124,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # flow). Position alignment then keeps the stream reproducible even
             # when vLLM evicts a running request and re-admits it in a different
             # slot under async scheduling. Mirrors the llama3_70b_galaxy decode path.
+            #
+            # Align only from a trustworthy position (#51981): the counter
+            # self-advances per token, so re-anchoring to a lagging host start_pos
+            # is what breaks reproducibility. Trustworthy = reload_inputs, or a
+            # slot just reseeded (freshly admitted, position from its prefill).
             if active_seed_slots:
                 seed_bs = sampling_module.tt_sampling.max_batch_size
                 if len(model_chunks) == 1:
@@ -2106,11 +2143,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 # path matches the manager's initial None, early-returns, and replays one draw.
                 if reset_batch:
                     sampling_module.seed_manager.reset_seed_from_slots(seed_values, active_seed_slots)
+                    reseeded_slots = list(active_seed_slots)
                 else:
-                    sampling_module.seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
-                sampling_module.seed_manager.align_seed_counters_to_positions(
-                    seed_values, active_seed_slots, start_values
-                )
+                    reseeded_slots = sampling_module.seed_manager.reset_seed_from_slots_if_needed(
+                        seed_values, active_seed_slots
+                    )
+                align_slots = active_seed_slots if reload_inputs else reseeded_slots
+                if align_slots:
+                    sampling_module.seed_manager.align_seed_counters_to_positions(
+                        seed_values, align_slots, start_values
+                    )
             sampling_module.seed_manager.get_new_values(active_seed_slots)
 
         sampled_outputs = []

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1283,6 +1283,32 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         on_device_sampling = (sampling_params is not None) or defer_device_sampling
         B = tokens.shape[0]
 
+        # Are the host tokens/positions authoritative this step, or is the device
+        # copy ahead? Trace reload and seed alignment must agree, so compute it
+        # once here instead of privately in the trace path (#51981).
+        prev_on_device_sampling = getattr(self, "_prev_on_device_sampling", None)
+        self._prev_on_device_sampling = on_device_sampling
+        sampling_mode_changed = prev_on_device_sampling is not None and prev_on_device_sampling != on_device_sampling
+        reload_inputs = (
+            not enable_trace
+            or not self.trace_ids_decode[on_device_sampling]
+            or not on_device_sampling
+            or reset_batch
+            or mode_switched
+            or sampling_mode_changed
+            or any(
+                getattr(self.model[i], "_tt_vllm_always_refresh_decode_trace_inputs", False)
+                for i in range(self.data_parallel)
+            )
+        )
+        # vLLM sees re-admissions the model cannot (tenstorrent/vllm#456), so
+        # either side asserting authority is enough.
+        if kwargs.get("reload_inputs"):
+            reload_inputs = True
+        # Deferred sampling calls sample_decode_on_device() out of band; stash the
+        # flag so that call need not thread it.
+        self._decode_reload_inputs = reload_inputs
+
         tokens = torch.chunk(tokens, self.data_parallel, 0)
         start_pos = torch.chunk(start_pos, self.data_parallel, 0)
         page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
@@ -1376,12 +1402,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         }
 
         if enable_trace:
-            # A real batch reset / slot remap (reset_batch) also makes the device
-            # token/current_pos trace buffers stale, not just a prefill->decode
-            # mode switch, so both must force a full traced-input reset.
+            # reset_batch (real reset / slot remap) and a prefill->decode switch
+            # both stale the device buffers; both are folded into reload_inputs.
             tt_decode_output = self._decode_forward_trace_text(
                 **decode_kwargs,
-                reset_batch=reset_batch or mode_switched,
+                reload_inputs=reload_inputs,
             )
         else:
             tt_decode_output = self._decode_forward_no_trace_text(
@@ -1402,6 +1427,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 output_tokens=output_tokens,
                 slot_remap=slot_remap,
                 enable_trace=enable_trace,
+                reload_inputs=reload_inputs,
             )
         # Host sampling
         if read_from_device:
@@ -1552,10 +1578,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         page_table=None,
         kv_cache=None,
         on_device_sampling=False,
-        reset_batch=False,
+        reload_inputs=False,
     ):
         """
         Run decode forward text with tracing
+
+        ``reload_inputs`` (from decode_forward): host token/position inputs are
+        authoritative this step and must overwrite the device-resident ones.
         """
         # The trace is different depending on whether we are doing device sampling or not
         if not self.trace_ids_decode[on_device_sampling]:
@@ -1566,19 +1595,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             self.trace_inputs_decode[on_device_sampling] = device_inputs
             self.trace_output_decode[on_device_sampling] = tt_out_trace
 
-        # reset inputs when mode switches from prefill to decode,
-        # or when sampling mode changes (different trace has stale inputs)
-        prev_on_device_sampling = getattr(self, "_prev_on_device_sampling", None)
-        self._prev_on_device_sampling = on_device_sampling
-        sampling_mode_changed = prev_on_device_sampling is not None and prev_on_device_sampling != on_device_sampling
-        reset_inputs = reset_batch or not on_device_sampling or sampling_mode_changed
         page_table_changed = page_table is not None and (
             self.prev_page_table is None
             or any(not torch.equal(prev, curr) for prev, curr in zip(self.prev_page_table, page_table))
         )
 
         for i in range(self.data_parallel):
-            refresh_trace_inputs = reset_inputs or getattr(
+            refresh_trace_inputs = reload_inputs or getattr(
                 self.model[i], "_tt_vllm_always_refresh_decode_trace_inputs", False
             )
             user_page_table = page_table[i] if page_table is not None else None
@@ -1620,7 +1643,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         enable_trace=False,
+        reload_inputs=None,
     ):
+        """Sample this decode step's tokens on device.
+
+        ``reload_inputs``: host inputs are authoritative, so ``start_pos`` may
+        re-anchor the seed counters. ``None`` takes the last decode_forward's
+        value (the deferred path calls this out of band).
+        """
+        if reload_inputs is None:
+            reload_inputs = getattr(self, "_decode_reload_inputs", True)
         # sampling_dp may differ from data_parallel for models that internally
         # shard users across mesh rows (users_row_sharded) — each row samples
         # 32 users independently, so sampling params must be chunked by the
@@ -1686,6 +1718,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # flow). Position alignment then keeps the stream reproducible even
             # when vLLM evicts a running request and re-admits it in a different
             # slot under async scheduling. Mirrors the llama3_70b_galaxy decode path.
+            #
+            # Align only from a trustworthy position (#51981): the counter
+            # self-advances per token, so re-anchoring to a lagging host start_pos
+            # is what breaks reproducibility. Trustworthy = reload_inputs, or a
+            # slot just reseeded (freshly admitted, position from its prefill).
             if active_seed_slots:
                 seed_bs = sampling_module.tt_sampling.max_batch_size
                 if len(model_chunks) == 1:
@@ -1695,10 +1732,14 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     for chunk in model_chunks:
                         s = format_sampling_params(chunk, seed_bs).seed
                         seed_values += s if isinstance(s, list) else [s] * seed_bs
-                sampling_module.seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
-                sampling_module.seed_manager.align_seed_counters_to_positions(
-                    seed_values, active_seed_slots, start_values
+                reseeded_slots = sampling_module.seed_manager.reset_seed_from_slots_if_needed(
+                    seed_values, active_seed_slots
                 )
+                align_slots = active_seed_slots if reload_inputs else reseeded_slots
+                if align_slots:
+                    sampling_module.seed_manager.align_seed_counters_to_positions(
+                        seed_values, align_slots, start_values
+                    )
             sampling_module.seed_manager.get_new_values(active_seed_slots)
 
         sampled_outputs = []


### PR DESCRIPTION
### Summary
Fix for #51981.

`tt_transformers`' shared generator re-anchored the per-request device seed
counter to the host `start_pos` on **every** device-sampling decode
(the unconditional `align_seed_counters_to_positions` call in
`sample_decode_on_device`). Under vLLM async scheduling the host position is
deliberately behind the device, and by how much depends on when the readback
landed, so a seeded request's device-seed stream became timing-dependent. The
same prompt with the same `seed=` could produce different tokens depending on
unrelated concurrent traffic (overlap is disabled when any *other* request in the
batch asks for logprobs, penalties or structured output).

`align_seed_counters_to_positions` sets `seed_counters[slot] = position + 1`, and
the device seed is `_hash_request_seed_to_device_seed(request_seed,
seed_counters[slot])` and the counter *is* the stream position. It also
self-advances one per token, so alignment is only needed to *re-anchor* after a
slot move, not on every step.

`decode_forward` already knew the host position was untrustworthy: it substitutes
device-read positions, but only on a reset step. On a steady decode the stale host
value flowed straight into `sample_decode_on_device`.

**The fix** gates alignment on whether host inputs are authoritative for the step,
the way `llama3_70b_galaxy` does with `reset_inputs`. That signal already existed
here and `_decode_forward_trace_text` computed it privately as
`reset_batch or not on_device_sampling or sampling_mode_changed` and threw it
away. It is now hoisted into `decode_forward` as `reload_inputs` and shared, so
the trace-reload decision and the seed-alignment decision cannot drift.

NOTE: due to lack of Galaxy machine this fix was tested very sparingly (only Llama 70B batch-1 test) so more testing should be done on different models before merging the change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vllm_seeded_on_device_sampling_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vllm_seeded_on_device_sampling_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vllm_seeded_on_device_sampling_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vllm_seeded_on_device_sampling_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vllm_seeded_on_device_sampling_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vllm_seeded_on_device_sampling_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vllm_seeded_on_device_sampling_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vllm_seeded_on_device_sampling_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vllm_seeded_on_device_sampling_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vllm_seeded_on_device_sampling_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vllm_seeded_on_device_sampling_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vllm_seeded_on_device_sampling_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vllm_seeded_on_device_sampling_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vllm_seeded_on_device_sampling_fix)