### PR TITLE
Replace transformers fx-availability shim with direct torch.fx import

### DIFF
--- a/models/demos/deepseek_v3/reference/modeling_deepseek.py
+++ b/models/demos/deepseek_v3/reference/modeling_deepseek.py
@@ -42,6 +42,7 @@ from typing import List, Optional, Tuple, Union
 import numpy as np
 import torch
 import torch.distributed as dist
+import torch.fx
 import torch.nn.functional as F
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
@@ -55,7 +56,7 @@ from transformers.modeling_outputs import (
     SequenceClassifierOutputWithPast,
 )
 from transformers.modeling_utils import PreTrainedModel
-from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS, is_torch_greater_or_equal_than_1_13
+from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS
 from transformers.utils import (
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
@@ -63,22 +64,12 @@ from transformers.utils import (
     replace_return_docstrings,
 )
 
-# transformers >= 5.x removed is_torch_fx_available (it was just `is_torch_available()`).
-try:
-    from transformers.utils.import_utils import is_torch_fx_available
-except ImportError:
-    from transformers.utils import is_torch_available as is_torch_fx_available
-
 from .configuration_deepseek import DeepseekV3Config
 from .reference_utils import topk_bitonic
 
 # This makes `_prepare_4d_causal_attention_mask` a leaf function in the FX graph.
 # It means that the function will not be traced through and simply appear as a node in the graph.
-if is_torch_fx_available():
-    if not is_torch_greater_or_equal_than_1_13:
-        import torch.fx
-
-    _prepare_4d_causal_attention_mask = torch.fx.wrap(_prepare_4d_causal_attention_mask)
+_prepare_4d_causal_attention_mask = torch.fx.wrap(_prepare_4d_causal_attention_mask)
 
 
 logger = logging.get_logger(__name__)


### PR DESCRIPTION
### Summary
`models/demos/deepseek_v3/reference/modeling_deepseek.py` guards the `torch.fx.wrap(...)` of `_prepare_4d_causal_attention_mask` behind `is_torch_fx_available()`, which transformers 5.x removed (it was just `is_torch_available()`). Main currently works around this by probing the private `transformers.utils.import_utils` module with a fallback shim (added in #47218), and still carries a dead `is_torch_greater_or_equal_than_1_13` branch for torch < 1.13 (transformers 5.x requires torch >= 2.x, so that path can never trigger).

Import `torch.fx` directly instead: it is part of torch itself, so the FX-wrap guard no longer depends on transformers' internal availability helpers at all, and the obsolete version check goes away. The change is version-agnostic across transformers 4.x and 5.x.

Relates to #47974 (transformers 5.12.1 bump). Downstream tracking: tt-blaze#1835.

### Notes for reviewers
- Single file, ~20 lines, Python-only. No functional change: whenever torch is installed (required by this module anyway), `torch_fx is not None` is true and `_prepare_4d_causal_attention_mask` is wrapped exactly as before.
- Verified: `import models.demos.deepseek_v3.reference.modeling_deepseek` succeeds under the repo's pinned transformers 5.12.1.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmal/deepseek-v3-transformers5-fx-compat)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/deepseek-v3-transformers5-fx-compat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=esmal/deepseek-v3-transformers5-fx-compat)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:esmal/deepseek-v3-transformers5-fx-compat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=esmal/deepseek-v3-transformers5-fx-compat)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:esmal/deepseek-v3-transformers5-fx-compat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/deepseek-v3-transformers5-fx-compat)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/deepseek-v3-transformers5-fx-compat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=esmal/deepseek-v3-transformers5-fx-compat)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:esmal/deepseek-v3-transformers5-fx-compat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/deepseek-v3-transformers5-fx-compat)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/deepseek-v3-transformers5-fx-compat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/deepseek-v3-transformers5-fx-compat)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/deepseek-v3-transformers5-fx-compat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/deepseek-v3-transformers5-fx-compat)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/deepseek-v3-transformers5-fx-compat)