### PR TITLE
Kimi prefill runner CI: opt out of the dispatch-hang triage

### DIFF
--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -518,7 +518,7 @@
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      export TT_METAL_OPERATION_TIMEOUT_SECONDS=0
+      export TT_METAL_OPERATION_TIMEOUT_SECONDS=300  # 5 min; the runner idles up to 111s in the H2D recv
       python3 -m pytest models/demos/common/prefill/tests/test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth -vvv --tb=short --timeout=1800
     '
   test_type: prefill_runner

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -518,11 +518,6 @@
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      # No dispatch-hang watchdog for this leg. The runner publishes readiness and then parks in the H2D
-      # recv (inbound_socket_service_sync), a device op with no timeout by design, until the producer --
-      # minutes of weight load away -- pushes its first chunk. dispatch_progress only advances when a
-      # command RETIRES, so that healthy idle wait is indistinguishable from a hang: tt-triage fires and
-      # TT_THROWs, killing the runner mid-serve. 0 is the runtime default, i.e. pre-#51679 behaviour.
       export TT_METAL_OPERATION_TIMEOUT_SECONDS=0
       python3 -m pytest models/demos/common/prefill/tests/test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth -vvv --tb=short --timeout=1800
     '

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -518,6 +518,12 @@
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
+      # No dispatch-hang watchdog for this leg. The runner publishes readiness and then parks in the H2D
+      # recv (inbound_socket_service_sync), a device op with no timeout by design, until the producer --
+      # minutes of weight load away -- pushes its first chunk. dispatch_progress only advances when a
+      # command RETIRES, so that healthy idle wait is indistinguishable from a hang: tt-triage fires and
+      # TT_THROWs, killing the runner mid-serve. 0 is the runtime default, i.e. pre-#51679 behaviour.
+      export TT_METAL_OPERATION_TIMEOUT_SECONDS=0
       python3 -m pytest models/demos/common/prefill/tests/test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth -vvv --tb=short --timeout=1800
     '
   test_type: prefill_runner


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/52060

### PR Category

Bug fix / CI

### Summary

The Kimi prefill runner leg in Blaze went back to burning its whole 30-minute step budget and getting killed on the 08-04 nightly, a day after hang diagnostics were wired into this pipeline (#51679). This is not the old timeout returning: the two nightlies before it were green at 14:55 and 21:28, and the difference is that tt-triage is now armed. The leg is a serving loop, and the dispatch-hang watchdog cannot tell a serving loop that is waiting for work from one that has died. One line, in one leg's `cmd`, turns the watchdog off for that leg.

```yaml
mpirun --bind-to none --pernode --tag-output bash -lc '
  export OMP_NUM_THREADS=$(nproc)
  export TT_METAL_OPERATION_TIMEOUT_SECONDS=0     # <-- this PR
  python3 -m pytest ...test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth ...
'
```

It goes inside the `mpirun` shell rather than up with the other exports because only `OMPI_`-prefixed variables are forwarded to remote ranks; the leg is single-rank today, so the outer position would work, but the inner one keeps working when it isn't. The two pytest children inherit it, since the test hands its environment down verbatim.

### Prefill CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=nbabin/runner_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:nbabin/runner_triage)


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/runner_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/runner_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nbabin/runner_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nbabin/runner_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nbabin/runner_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nbabin/runner_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nbabin/runner_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nbabin/runner_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nbabin/runner_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nbabin/runner_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nbabin/runner_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nbabin/runner_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nbabin/runner_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nbabin/runner_triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nbabin/runner_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nbabin/runner_triage)