### PR TITLE
Per-fiber my_logical_x_/y_ globals + build_core_map stale-SWEmuleChip cache invalidation

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -171,6 +171,24 @@ thread_local uint8_t my_x[NUM_NOCS] = {};
 thread_local uint8_t my_y[NUM_NOCS] = {};
 thread_local uint32_t __emule_logical_x = 0;
 thread_local uint32_t __emule_logical_y = 0;
+////////////////////////////////////////////////////////////
+// Blaze-only experimental firmware-global shim
+// Removal is tracked by issue #50953
+// Silicon-named per-core LOGICAL coords (firmware globals `my_logical_x_/y_`,
+// mirroring hw/firmware/src/tt-1xx/brisc.cc; declared extern by
+// blaze/kernels/kernel_utils.hpp). Defined here so compute (TRISC) kernels that
+// reference them link; restored per fiber swap-in by the scheduler's
+// install_fiber. The dataflow (NCRISC/BRISC) senders that must read a CORRECT
+// per-fiber value instead resolve `my_logical_x_/y_` through the
+// dataflow_utils.hpp shadow's per-fiber accessor (__emule_self->core->logical_*),
+// so this definition is only a link/fallback anchor on other RISCs.
+// These MUST stay at global scope with these exact unmangled names (NOT inside a
+// namespace): under emule there is no firmware, and JIT'd kernels are x86-compiled
+// and resolve these symbols against libtt_metal via dlopen(-rdynamic) — any
+// mangling/rename breaks that lookup.
+thread_local uint8_t my_logical_x_ = 0;
+thread_local uint8_t my_logical_y_ = 0;
+////////////////////////////////////////////////////////////
 
 // NOC encoding constants (matching firmware for Blackhole/Wormhole).
 static constexpr uint32_t NOC_LOCAL_BITS = 36;

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2066,12 +2066,23 @@ static void jit_compile_pending(
 static std::mutex g_core_map_mutex;
 static std::unordered_map<uint32_t, std::shared_ptr<std::unordered_map<uint64_t, tt_emule::Core*>>>
     g_core_map_cache;
+// The SWEmuleChip each cached core_map was built against. A device close+reopen mints
+// a NEW SWEmuleChip with fresh per-core L1 mmaps (single-process-galaxy L1 model), so a
+// core_map cached from the prior chip holds Core* into a now-disjoint L1 region. The NOC
+// path (this map) would then resolve a worker's semaphore to a different L1 backing than
+// that worker's own fiber (built from the CURRENT chip in setup_core_state) reads —
+// cross-core sems never observed → deadlock. Rebuild when the chip identity changes.
+static std::unordered_map<uint32_t, tt::umd::SWEmuleChip*> g_core_map_sw_emu;
 
 static std::unordered_map<uint64_t, tt_emule::Core*>* build_core_map(
     tt::umd::SWEmuleChip* sw_emu, IDevice* device, ChipId device_id) {
     std::lock_guard<std::mutex> lock(g_core_map_mutex);
     auto& core_map = g_core_map_cache[device_id];
+    if (core_map && g_core_map_sw_emu[device_id] != sw_emu) {
+        core_map.reset();  // stale: built against a different (now-replaced) SWEmuleChip
+    }
     if (!core_map && sw_emu) {
+        g_core_map_sw_emu[device_id] = sw_emu;
         core_map = std::make_shared<std::unordered_map<uint64_t, tt_emule::Core*>>();
         // Add ALL worker cores from the device grid
         auto grid = device->compute_with_storage_grid_size();

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -31,6 +31,10 @@
 // since one worker hosts many fibers. See tt-emule docs/fiber-engine.md.
 extern thread_local uint8_t my_x[2];
 extern thread_local uint8_t my_y[2];
+// Blaze-only experimental firmware-global shim (issue #50953) — global-scope,
+// unmangled names required by dlopen(-rdynamic) JIT-kernel symbol resolution.
+extern thread_local uint8_t my_logical_x_;
+extern thread_local uint8_t my_logical_y_;
 
 namespace tt::tt_metal::emule_fiber {
 
@@ -181,8 +185,10 @@ void FiberSchedulerImpl::install_fiber(Fiber* f) {
     __emule_self = f->owned_ctx.get();       // the single thread_local repoint
     my_x[0] = my_x[1] = f->id.phys_x;        // restore the silicon-named coords
     my_y[0] = my_y[1] = f->id.phys_y;
+    my_logical_x_ = static_cast<uint8_t>(f->id.logical_x);  // firmware LOGICAL coords (issue #50953)
+    my_logical_y_ = static_cast<uint8_t>(f->id.logical_y);
     // Per-fiber ASAN state (e.g. the Object-Intent resolved-range log) lives in the ctx
-    // above, so it swaps in with __emule_self — nothing else to restore here. See tt-emule #241.
+    // above, so it swaps in with __emule_self — no separate restore needed here. See tt-emule #241.
 }
 
 void FiberSchedulerImpl::worker_main(unsigned w) {


### PR DESCRIPTION
### Summary

Upstreams two small tt-emule fixes currently carried on the tt-blaze branch, so the tt-blaze tt-metal submodule can track upstream main (tenstorrent/tt-blaze#1835). Both reached the blaze branch via #50283 but never landed on main.

**Fix 1 — per-fiber `my_logical_x_`/`my_logical_y_` thread-locals.**
Silicon firmware defines per-core logical-coordinate globals `my_logical_x_`/`my_logical_y_` (`hw/firmware/src/tt-1xx/brisc.cc`), declared `extern` by kernel-facing headers — upstream `dataflow_api.h`'s `get_absolute_logical_x()/y()` and Blaze's `blaze/kernels/kernel_utils.hpp` (used by the `create_q_heads` family). Under emule there is no firmware: JIT'd kernels are x86-compiled and resolve these symbols against `libtt_metal` via `dlopen(-rdynamic)`, so any kernel referencing them fails to link at `dlopen` time (`undefined symbol: my_logical_y_` — reproduced below). This PR defines `thread_local uint8_t my_logical_x_/my_logical_y_` at global scope in `emulated_program_runner.cpp` and restores them per fiber swap-in in `FiberSchedulerImpl::install_fiber` (alongside the existing `my_x`/`my_y` restore), so each fiber observes its own core's logical coords.

**Fix 2 — `build_core_map` stale-`SWEmuleChip` cache invalidation.**
`build_core_map` caches the physical{x,y}→`Core*` map keyed only by `device_id`. On device close+reopen within one process a NEW `SWEmuleChip` is minted with fresh per-core L1 mmaps (single-process-galaxy L1 model), so a map cached from the prior chip holds `Core*` into a now-disjoint L1 region. The NOC path would then resolve a worker's semaphore to a different L1 backing than that worker's own fiber (built from the CURRENT chip in `setup_core_state`) reads — cross-core semaphores never observed → deadlock. (The existing `g_pcie_base_cache` comment already notes the core_map cache can go stale this way.) Fix: track the `SWEmuleChip*` each cached map was built against (`g_core_map_sw_emu`) and rebuild on identity mismatch.

### Triggered CI runs

- [Static checks (all-static-checks.yaml)](https://github.com/tenstorrent/tt-metal/actions/runs/30915062963) — triggered on this branch
- [Sanity tests (sanity-tests.yaml)](https://github.com/tenstorrent/tt-metal/actions/runs/30915065862) — triggered on this branch

There is no upstream emule CI workflow (and these files build only under `TT_METAL_USE_EMULE=ON`), so hardware/silicon suites cannot exercise this change; the runs above are the applicable general gates. Emule validation was run manually (x86, `TT_METAL_EMULE_MODE=1`): smoke test PASS incl. the dlopen negative control — details in commit messages.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=emule/my-logical-globals-core-map-stale-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:emule/my-logical-globals-core-map-stale-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=emule/my-logical-globals-core-map-stale-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:emule/my-logical-globals-core-map-stale-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=emule/my-logical-globals-core-map-stale-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:emule/my-logical-globals-core-map-stale-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=emule/my-logical-globals-core-map-stale-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:emule/my-logical-globals-core-map-stale-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=emule/my-logical-globals-core-map-stale-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:emule/my-logical-globals-core-map-stale-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=emule/my-logical-globals-core-map-stale-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:emule/my-logical-globals-core-map-stale-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=emule/my-logical-globals-core-map-stale-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:emule/my-logical-globals-core-map-stale-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=emule/my-logical-globals-core-map-stale-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:emule/my-logical-globals-core-map-stale-cache)
