### PR TITLE
Add Gemma-2 TTNN bring-up scaffolding

### DIFF
--- a/models/tt_transformers/tests/test_lm_head.py
+++ b/models/tt_transformers/tests/test_lm_head.py
@@ -17,6 +17,19 @@ from models.tt_transformers.tt.model_config import ModelArgs
 from models.tt_transformers.tt.prefetcher import Prefetcher
 
 
+def test_softcap_logits_matches_gemma_formula(monkeypatch):
+    monkeypatch.setattr("models.tt_transformers.tt.lm_head.ttnn.mul", torch.mul)
+    monkeypatch.setattr("models.tt_transformers.tt.lm_head.ttnn.tanh", torch.tanh)
+
+    logits = torch.tensor([[-120.0, -30.0, 0.0, 30.0, 120.0]])
+    cap = 30.0
+
+    actual = LMHead.softcap_logits(logits, cap)
+    expected = cap * torch.tanh(logits / cap)
+
+    torch.testing.assert_close(actual, expected)
+
+
 @torch.no_grad()
 @pytest.mark.parametrize(
     "use_prefetcher",

--- a/models/tt_transformers/tests/test_model_config_utils.py
+++ b/models/tt_transformers/tests/test_model_config_utils.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+from models.tt_transformers.tt.common import get_base_model_name
 from models.tt_transformers.tt.model_config import compute_padded_vocab_size, should_pad_sampling_logits_to_power_of_2
 
 
@@ -46,3 +47,15 @@ def test_should_pad_sampling_logits_to_power_of_2(base_model_name, padded_vocab_
 def test_should_pad_sampling_logits_to_power_of_2_rejects_invalid_sampling_splits():
     with pytest.raises(ValueError, match="sampling_splits must be >= 1"):
         should_pad_sampling_logits_to_power_of_2("Llama-3.1-70B", 128256, 0)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        ("gemma-2-2b-it", "gemma-2-2b"),
+        ("gemma-2-9b-it", "gemma-2-9b"),
+        ("google/gemma-2-2b-it", "google/gemma-2-2b"),
+    ],
+)
+def test_get_base_model_name_gemma2(model_name, expected):
+    assert get_base_model_name(model_name) == expected

--- a/models/tt_transformers/tt/lm_head.py
+++ b/models/tt_transformers/tt/lm_head.py
@@ -139,6 +139,14 @@ class LMHead(LightweightModule):
             packer_l1_acc=True,
         )
 
+    @staticmethod
+    def softcap_logits(logits, cap):
+        if cap is None or cap <= 0:
+            return logits
+        logits = ttnn.mul(logits, 1.0 / cap)
+        logits = ttnn.tanh(logits)
+        return ttnn.mul(logits, cap)
+
     def forward(self, x: ttnn.Tensor, debug_input_torch=None, debug_weight_torch=None):
         outputs = []
         use_prefetcher = self.prefetcher is not None and self.prefetcher.mode == Mode.DECODE
@@ -204,4 +212,4 @@ class LMHead(LightweightModule):
             subdevice_id=self.prefetcher.worker_sub_device_id if use_prefetcher else None,
         )
 
-        return output
+        return self.softcap_logits(output, self.args.final_logit_softcapping)

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -108,8 +108,7 @@ def should_pad_sampling_logits_to_power_of_2(
 ) -> bool:
     # Enable optional sampling padding for models that regress to single-core TopK. More info at issue #40399
     if sampling_splits < 1:
-        logger.warning(f"Sampling_splits must be >= 1, got {sampling_splits}")
-        return False
+        raise ValueError(f"sampling_splits must be >= 1, got {sampling_splits}")
 
     per_device_vocab = padded_vocab_size // sampling_splits
     return per_device_vocab > 0 and (per_device_vocab & (per_device_vocab - 1)) != 0
@@ -505,6 +504,8 @@ class ModelArgs:
             "Qwen2.5-32B-Instruct": "models/tt_transformers/model_params/Qwen2.5-32B-Instruct",
             "Meta-Llama-3-8B": "models/tt_transformers/model_params/Meta-Llama-3-8B",
             "Meta-Llama-3-8B-Instruct": "models/tt_transformers/model_params/Meta-Llama-3-8B",
+            "gemma-2-2b-it": "models/tt_transformers/model_params/gemma-2-2b-it",
+            "gemma-2-9b-it": "models/tt_transformers/model_params/gemma-2-9b-it",
             "Qwen3.6-27B": "models/tt_transformers/model_params/Qwen3.6-27B",
         }.items()
     }
@@ -561,6 +562,8 @@ class ModelArgs:
 
         self.rms_norm_add_unit_offset = False
         self.embed_scale = None
+        self.attn_logit_softcapping = None
+        self.final_logit_softcapping = None
         self.use_hf_rope = use_hf_rope
 
         assert not os.getenv(
@@ -634,9 +637,20 @@ class ModelArgs:
 
         if (
             self.base_model_name
-            in ["Llama-3.1-8B", "Llama-3.2-11B", "Mistral-7B", "gemma-3-27b", "gemma-3-4b", "Phi-4"]
+            in [
+                "Llama-3.1-8B",
+                "Llama-3.2-11B",
+                "Mistral-7B",
+                "gemma-2-2b",
+                "gemma-3-27b",
+                "gemma-3-4b",
+                "Phi-4",
+            ]
             and self.device_name == "N150"
-        ) or (self.base_model_name in ["Qwen2.5-7B", "Qwen2.5-VL-7B", "Phi-4"] and self.device_name == "N300"):
+        ) or (
+            self.base_model_name in ["Qwen2.5-7B", "Qwen2.5-VL-7B", "Phi-4", "gemma-2-2b"]
+            and self.device_name == "N300"
+        ):
             logger.info(f"Reducing prefill_len_cutoff to 512 for {self.model_name} on {self.device_name}")
             self.prefill_len_cutoff = 512
         elif self.base_model_name in ["Mixtral-8x7B"] and self.device_name == "T3K":
@@ -2412,6 +2426,8 @@ class ModelArgs:
                 "Qwen3-Embedding-8B": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128, "P150x4": 128},
                 "Phi-4": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128, "P150x4": 128},
                 "Mistral-Small-3.1-24B": {"N150": 8, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
+                "gemma-2-2b": {"N150": 32, "N300": 64, "T3K": 128, "TG": 128, "P150x4": 128},
+                "gemma-2-9b": {"N150": None, "N300": 32, "T3K": 64, "TG": 128, "P150x4": 128},
                 "gemma-3-1b": {"N150": 32, "N300": 32, "T3K": 32, "TG": 32, "P150x4": 32},
                 "gemma-3-4b": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
                 "medgemma-4b": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
@@ -2666,9 +2682,16 @@ class ModelArgs:
         self.n_layers -= len(text_config.get("cross_attention_layers", ()))
         self.vision_num_cross_attention_layers = len(text_config.get("cross_attention_layers", ()))
 
-        self.sliding_window_pattern = (
-            [lt == "sliding_attention" for lt in layer_types] if layer_types is not None else [False] * self.n_layers
-        )
+        if layer_types is not None:
+            self.sliding_window_pattern = [lt == "sliding_attention" for lt in layer_types]
+        elif self.base_model_name.startswith("gemma-2"):
+            # Gemma-2 alternates local sliding-window and global attention layers.
+            # HF configs for this family do not always serialize layer_types, so we
+            # reconstruct the pattern here when needed.
+            self.sliding_window_pattern = [i % 2 == 0 for i in range(self.n_layers)]
+            layer_types = ["sliding_attention" if is_sliding else "full_attention" for is_sliding in self.sliding_window_pattern]
+        else:
+            self.sliding_window_pattern = [False] * self.n_layers
 
         self.full_model_n_layers = self.n_layers
         self.norm_eps = text_config.get("norm_eps", text_config.get("rms_norm_eps"))
@@ -2761,6 +2784,8 @@ class ModelArgs:
                     self.hidden_dim = padded_hidden_dim
 
         self.layer_types = text_config.get("layer_types", None)
+        if self.layer_types is None and self.base_model_name.startswith("gemma-2"):
+            self.layer_types = ["sliding_attention" if i % 2 == 0 else "full_attention" for i in range(self.n_layers)]
 
         # Sliding window attention
         self.sliding_window = text_config.get("sliding_window", None)
@@ -2785,6 +2810,17 @@ class ModelArgs:
         )
 
         self.query_pre_attn_scalar = text_config.get("query_pre_attn_scalar", None)
+        self.attn_logit_softcapping = text_config.get("attn_logit_softcapping", None)
+        self.final_logit_softcapping = text_config.get("final_logit_softcapping", None)
+
+        is_gemma = self.base_model_name.startswith("gemma-")
+        if is_gemma:
+            self.rms_norm_add_unit_offset = True
+            self.embed_scale = self.dim**0.5
+            if self.attn_logit_softcapping:
+                raise NotImplementedError(
+                    "Gemma attention logit soft-capping is not supported by the shared TTNN fused SDPA path yet"
+                )
 
         # Configurable MLP activation type
         self.mlp_activation_type = self._get_hidden_activation_type(text_config)
@@ -3536,6 +3572,8 @@ class ModelArgs:
             "Mistral-7B": "mistralai/Mistral-7B-Instruct-v0.3",
             "Mistral-Small-3.1-24B": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
             "Phi-3-mini-128k-instruct": "microsoft/Phi-3-mini-128k-instruct",
+            "gemma-2-2b": "google/gemma-2-2b-it",
+            "gemma-2-9b": "google/gemma-2-9b-it",
             "gemma-3-4b": "google/gemma-3-4b-it",
             "gemma-3-27b": "google/gemma-3-27b-it",
             "Qwen3.6-27B": "Qwen/Qwen3.6-27B",


### PR DESCRIPTION
**Title**
#51398
Gemma-2 TTNN bring-up scaffolding in tt_transformers
**Description**
This change adds the first shared-framework wiring for Gemma-2 text models in models/tt_transformers:
Adds Gemma-2 HF/model aliases and cache path mappings.
Adds Gemma-2 prefill chunk-size entries for the supported device matrix.
Enables Gemma-2 defaults that the architecture expects:RMSNorm unit offset
embedding scale by sqrt(hidden_size)
alternating sliding-window / global attention layer pattern

Adds final logit soft-capping in the shared LMHead.
Adds targeted unit coverage for:Gemma-2 base model name normalization
final-logit softcap formula

**What this does not yet fully solve:**
Attention-logit soft-capping is still not implemented in the shared fused TTNN SDPA path.
I left that as an explicit NotImplementedError rather than silently producing incorrect outputs.