### PR TITLE
[Bug fix] RingJointSDPA: restore non-sliding multi-batch support

### DIFF
--- a/tests/nightly/t3000/ccl/test_ring_joint_attention.py
+++ b/tests/nightly/t3000/ccl/test_ring_joint_attention.py
@@ -197,6 +197,44 @@ def test_ring_joint_sdpa(
 
 
 @pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        (
+            {"worker_l1_size": 1344544, "trace_region_size": 200000, "fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            ttnn.Topology.Linear,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["line"],
+)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+def test_ring_joint_sdpa_multi_batch_wh_t3k(mesh_device, all_gather_topology, reset_seeds):
+    """Non-sliding RingJointSDPA supports B>1 without cross-batch K/V chaining."""
+    submesh = create_ring_joint_sdpa_submesh(mesh_device, rp_axis=0, rp_factor=2, up_axis=1, up_factor=2)
+
+    run_ring_joint_sdpa(
+        submesh,
+        b=2,
+        nh=8,
+        base_seq_len=1024,
+        padded_seq_len=1024,
+        joint_seq_len=0,
+        d=64,
+        q_chunk_size=128,
+        k_chunk_size=128,
+        dtype=ttnn.bfloat16,
+        n_iters=1,
+        trace_enabled=False,
+        num_links=1,
+        rp_axis=0,
+        up_axis=1,
+        all_gather_topology=all_gather_topology,
+        skip_check=False,
+        pcc_threshold=0.994,
+    )
+
+
+@pytest.mark.parametrize(
     "dtype, pcc_threshold",
     [
         (ttnn.bfloat16, 0.994),

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -497,8 +497,6 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
             "Chunked GPT-OSS halo {} exceeds the per-device Q slab {}",
             halo_tokens,
             N_local_q);
-    } else {
-        TT_FATAL(B == 1, "Non-sliding RingJointSDPA supports batch size 1, got B={}", B);
     }
 
     TT_FATAL(!(L != 0 && args.is_causal), "Causality is enabled only for ring attention");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -893,6 +893,10 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const bool gqa_grouped_kv = ring_joint::is_gqa_grouped_kv_head_mode(v_shares_k_buffer, NH, NHK, NHV);
     const bool k_uses_batch_chain = ring_joint::uses_shared_k_batch_chain(gqa_grouped_kv, NHK);
     const bool use_head_chain = enable_kv_chains && !gqa_grouped_kv;
+    // The store-and-forward chains are scheduled per head, not per (batch, head).
+    // Until their batch-aware scheduling is restored, multi-batch requests read K/V
+    // independently on each core. This preserves the established B>1 functional path.
+    const bool build_kv_chains = enable_kv_chains && B == 1;
 
     const uint32_t q_local_padded_Nt = q_local_padded_N / tt::constants::TILE_HEIGHT;
     const uint32_t kv_local_padded_Nt = kv_local_padded_N / tt::constants::TILE_HEIGHT;
@@ -1968,7 +1972,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     };
 
     // Build head chains for MHA and separate-V shared-K. GQA uses KV-head-grouped chains instead.
-    if (use_head_chain) {
+    if (use_head_chain && build_kv_chains) {
         for (uint32_t head_id = 0; head_id < static_cast<uint32_t>(head_segments.size()); ++head_id) {
             const auto& segs = head_segments[head_id];
             if (segs.size() < 2) {
@@ -1986,7 +1990,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
 
     // Check query-head chain multicast eligibility and configure mcast for eligible chains.
     uint32_t mcast_chains = 0;
-    if (use_head_chain) {
+    if (use_head_chain && build_kv_chains) {
         struct McastCandidate {
             std::vector<uint32_t> core_indices;
             uint32_t ref_q_chunks;
@@ -2175,7 +2179,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     bool gqa_mcast_enabled = false;
     std::string gqa_mcast_fallback_reason;
     std::vector<uint32_t> gqa_chain_max_q(gqa_chain_configs.size(), 0);  // per-core loop-padding count
-    if (gqa_grouped_kv && enable_kv_chains) {
+    if (gqa_grouped_kv && build_kv_chains) {
         std::vector<std::vector<ChainSegment>> kv_group_segments(NHK);
 
         for (uint32_t ci = 0; ci < num_cores; ++ci) {
@@ -2261,7 +2265,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     // Build the shared-K chain for separate-V/latent cases.
     // K is shared across all heads, so all active cores form one chain.
     // Sorted by physical position for a stable unicast ordering (overwritten by mcast pass if eligible).
-    if (k_uses_batch_chain && enable_kv_chains) {
+    if (k_uses_batch_chain && build_kv_chains) {
         std::vector<uint32_t> core_indices;
         for (uint32_t i = 0; i < num_cores; ++i) {
             if (core_work[i].global_q_count == 0) {


### PR DESCRIPTION
## Summary

Fixes the T3K Motif regression reported in #52033.

The GPT-OSS sliding-prefill change added a blanket `B == 1` validation to non-sliding RingJointSDPA. The associated cross-core K/V chain scheduling is not batch-aware, so this change removes the invalid rejection and limits those chains to batch-1 requests. Multi-batch requests correctly use independent per-core K/V reads.

Adds a focused T3K op-level `B=2` regression test for non-sliding RingJointSDPA.

Fixes #52033

### Manually triggered CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)](https://github.com/tenstorrent/tt-metal/actions/runs/30916536919)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-multi-batch-regression)