### PR TITLE
Port sum_reduce_scalar from blaze to metal

### DIFF
--- a/tests/tt_metal/tt_metal/llk/sources.cmake
+++ b/tests/tt_metal/tt_metal/llk/sources.cmake
@@ -23,6 +23,7 @@ set(UNIT_TESTS_LLK_SRC
     test_single_core_binary_compute.cpp
     test_single_core_matmul_compute.cpp
     test_stochastic_rounding.cpp
+    test_sum_reduce_scalar.cpp
     test_single_core_matmul_int8.cpp
     test_top32_rm_dev.cpp
     test_transpose.cpp

--- a/tests/tt_metal/tt_metal/llk/test_sum_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sum_reduce_scalar.cpp
@@ -201,41 +201,44 @@ using namespace tt::tt_metal::unit_tests::compute::sum_reduce_scalar;
 
 // Runs on any single card (Wormhole or Blackhole): sum_reduce_scalar builds on
 // mul_reduce_scalar's reduce tail, which is supported on both architectures.
-class SumReduceScalarTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<int> {};
+//
+// Match Blaze LayerNorm's interpreted-tile selection exactly. It picks the tallest
+// legal height in {32, 16, 8, 4, 2, 1} that covers the width with at most eight
+// whole tiles, so only the height/count pairs below are generated today.
+class SumReduceScalarBlazeShapeTest : public LLKMeshDeviceSingleCardFixture,
+                                      public testing::WithParamInterface<SumReduceScalarConfig> {};
 
-// Standard 32x32-tile suite parametrized by tile count. One tile skips the accumulate
-// loop entirely; 8 is the DEST half-sync bf16 capacity, so every copied tile must still
-// be resident when the reduce consumes it.
-TEST_P(SumReduceScalarTest, SumReduceScalar) {
+TEST_P(SumReduceScalarBlazeShapeTest, SumReduceScalarBlazeShape) {
     auto& mesh_device = *devices_[0];
-    int num_tiles = GetParam();
-    ASSERT_TRUE(run_sum_reduce_scalar_test(mesh_device, {.num_tiles = num_tiles, .tile_height = 32}));
+    ASSERT_TRUE(run_sum_reduce_scalar_test(mesh_device, GetParam()));
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    SumReduceScalarTests, SumReduceScalarTest, testing::Values(1, 3, 8), [](const testing::TestParamInfo<int>& info) {
-        return "SumReduceScalar_" + std::to_string(info.param) + "_Tiles";
-    });
-
-// Tile geometry suite parametrized by tile height. 16x32 halves num_faces to 2 while
-// face_r_dim stays 16; heights below 16 shrink face_r_dim itself, which reconfigures the
-// packer and GAPOOL. blaze reaches all of (32, 16, 8, 4, 2, 1) by picking the tallest
-// tile dividing the width, so bracket the sub-16 range at 8 and 1 rather than
-// enumerating 4 and 2 as well.
-class SumReduceScalarTileHeightTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<int> {};
-
-TEST_P(SumReduceScalarTileHeightTest, SumReduceScalarTileHeight) {
-    auto& mesh_device = *devices_[0];
-    int tile_height = GetParam();
-    ASSERT_TRUE(run_sum_reduce_scalar_test(mesh_device, {.num_tiles = 8, .tile_height = tile_height}));
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    SumReduceScalarTileHeightTests,
-    SumReduceScalarTileHeightTest,
-    testing::Values(16, 8, 1),
-    [](const testing::TestParamInfo<int>& info) {
-        return "SumReduceScalar_" + std::to_string(info.param) + "x32_8_Tiles";
+    SumReduceScalarBlazeShapes,
+    SumReduceScalarBlazeShapeTest,
+    testing::Values(
+        SumReduceScalarConfig{.num_tiles = 1, .tile_height = 1},
+        SumReduceScalarConfig{.num_tiles = 1, .tile_height = 2},
+        SumReduceScalarConfig{.num_tiles = 3, .tile_height = 2},
+        SumReduceScalarConfig{.num_tiles = 5, .tile_height = 2},
+        SumReduceScalarConfig{.num_tiles = 7, .tile_height = 2},
+        SumReduceScalarConfig{.num_tiles = 1, .tile_height = 4},
+        SumReduceScalarConfig{.num_tiles = 3, .tile_height = 4},
+        SumReduceScalarConfig{.num_tiles = 5, .tile_height = 4},
+        SumReduceScalarConfig{.num_tiles = 7, .tile_height = 4},
+        SumReduceScalarConfig{.num_tiles = 1, .tile_height = 8},
+        SumReduceScalarConfig{.num_tiles = 3, .tile_height = 8},
+        SumReduceScalarConfig{.num_tiles = 5, .tile_height = 8},
+        SumReduceScalarConfig{.num_tiles = 7, .tile_height = 8},
+        SumReduceScalarConfig{.num_tiles = 1, .tile_height = 16},
+        SumReduceScalarConfig{.num_tiles = 3, .tile_height = 16},
+        SumReduceScalarConfig{.num_tiles = 1, .tile_height = 32},
+        SumReduceScalarConfig{.num_tiles = 2, .tile_height = 32},
+        SumReduceScalarConfig{.num_tiles = 4, .tile_height = 32},
+        SumReduceScalarConfig{.num_tiles = 8, .tile_height = 32}),
+    [](const testing::TestParamInfo<SumReduceScalarConfig>& info) {
+        return "SumReduceScalar_" + std::to_string(info.param.tile_height) + "x32_" +
+               std::to_string(info.param.num_tiles) + "_Tiles";
     });
 
 // Native fp32 DEST with full sync, parametrized by tile count. A separate instantiation

--- a/tests/tt_metal/tt_metal/llk/test_sum_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sum_reduce_scalar.cpp
@@ -1,0 +1,310 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-logger/tt-logger.hpp>
+
+#include "llk_device_fixture.hpp"
+#include "tt_metal/impl/data_format/bfloat16_utils.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace tt::tt_metal::unit_tests::compute::sum_reduce_scalar {
+
+struct SumReduceScalarConfig {
+    uint32_t num_tiles = 1;
+    // Tile row height. 32 -> standard 32x32 tiles (4 faces); 16 -> 16x32 "tiny
+    // tiles" (2 faces, one face-row). Column dimension is always 32.
+    uint32_t tile_height = 32;
+    float scaler = 1.0f;
+    // Native fp32 DEST. The reduce tail is templated on DST_ACCUM_MODE, so this
+    // selects a different instantiation of the whole op. Inputs stay bfloat16; only
+    // DEST and the output CB widen, matching mul_reduce_scalar's own fp32 coverage.
+    bool fp32_dest_acc = false;
+    // Full-sync DEST doubles the tile budget (8 fp32 / 16 bf16 instead of 4 / 8) and
+    // changes DST_SYNC_MODE, which the op threads into its SFPU fills. blaze couples
+    // this to fp32 (compiler.py: dst_full_sync_en=fp32_dest_acc_en), so the fp32
+    // suites below set both together to reproduce its real configuration.
+    bool dst_full_sync = false;
+    MathFidelity math_fidelity = MathFidelity::HiFi4;
+    uint32_t seed = 12345;
+};
+
+bool run_sum_reduce_scalar_test(distributed::MeshDevice& mesh_device, const SumReduceScalarConfig& config) {
+    IDevice* device = mesh_device.get_devices()[0];
+    tt_metal::Program program = tt_metal::CreateProgram();
+    CoreCoord core = {0, 0};
+
+    // bfloat16: 2 bytes per element; a 16x32 tiny tile is half a full tile.
+    const uint32_t tile_byte_size = 2 * config.tile_height * tt::constants::TILE_WIDTH;
+    const tt::DataFormat out_format = config.fp32_dest_acc ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    const uint32_t out_tile_byte_size = config.fp32_dest_acc ? 2 * tile_byte_size : tile_byte_size;
+    const tt::tt_metal::Tile cb_tile({config.tile_height, tt::constants::TILE_WIDTH});
+    const bool tiny_tile = (config.tile_height != tt::constants::TILE_HEIGHT);
+
+    // One page for the whole input, so it lands contiguously in a single DRAM bank:
+    // reader_unary_push_n walks a bank linearly, which would otherwise stride across
+    // interleaved banks and hand the compute kernel the wrong tiles.
+    const uint32_t input_byte_size = config.num_tiles * tile_byte_size;
+    tt_metal::InterleavedBufferConfig dram_config = {
+        .device = device,
+        .size = input_byte_size,
+        .page_size = input_byte_size,
+        .buffer_type = tt_metal::BufferType::DRAM};
+    auto src_dram_buffer = CreateBuffer(dram_config);
+
+    dram_config.size = out_tile_byte_size;
+    dram_config.page_size = out_tile_byte_size;
+    auto dst_dram_buffer = CreateBuffer(dram_config);
+
+    uint32_t cb_tiles = std::max(8u, config.num_tiles);
+    tt_metal::CircularBufferConfig cb_src_config =
+        tt_metal::CircularBufferConfig(cb_tiles * tile_byte_size, {{tt::CBIndex::c_0, tt::DataFormat::Float16_b}})
+            .set_page_size(tt::CBIndex::c_0, tile_byte_size);
+    tt_metal::CircularBufferConfig cb_out_config =
+        tt_metal::CircularBufferConfig(cb_tiles * out_tile_byte_size, {{tt::CBIndex::c_16, out_format}})
+            .set_page_size(tt::CBIndex::c_16, out_tile_byte_size);
+    if (tiny_tile) {
+        // Advertise the 16x32 tile geometry so the compute kernel derives
+        // num_faces=2 from the operand CBs via get_operand_num_faces().
+        cb_src_config.set_tile_dims(tt::CBIndex::c_0, cb_tile);
+        cb_out_config.set_tile_dims(tt::CBIndex::c_16, cb_tile);
+    }
+    tt_metal::CreateCircularBuffer(program, core, cb_src_config);
+    tt_metal::CreateCircularBuffer(program, core, cb_out_config);
+
+    auto unary_reader_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+
+    auto unary_writer_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+
+    auto sum_reduce_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/sum_reduce_scalar.cpp",
+        core,
+        tt_metal::ComputeConfig{
+            .math_fidelity = config.math_fidelity,
+            .fp32_dest_acc_en = config.fp32_dest_acc,
+            .dst_full_sync_en = config.dst_full_sync});
+
+    SetRuntimeArgs(
+        program,
+        unary_reader_kernel,
+        core,
+        {src_dram_buffer->address(),
+         0,
+         config.num_tiles,
+         tt::CBIndex::c_0,
+         1 /*ublock_size_tiles*/,
+         0 /*reader_only*/});
+
+    SetRuntimeArgs(program, unary_writer_kernel, core, {dst_dram_buffer->address(), 0, 1});
+
+    SetRuntimeArgs(program, sum_reduce_kernel, core, {config.num_tiles, std::bit_cast<uint32_t>(config.scaler)});
+
+    uint32_t byte_size = config.num_tiles * tile_byte_size;
+    auto packed_input = test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+        0, 1.0f, byte_size / sizeof(bfloat16), config.seed);
+
+    tt_metal::detail::WriteToBuffer(*src_dram_buffer, packed_input);
+
+    // Wrap the program into a MeshWorkload and dispatch via the mesh command queue.
+    // This path works under both fast dispatch and slow dispatch, unlike detail::LaunchProgram.
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    workload.add_program(device_range, std::move(program));
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
+
+    std::vector<uint32_t> result_vec;
+    tt_metal::detail::ReadFromBuffer(*dst_dram_buffer, result_vec);
+
+    auto u16_src_vec = u16_from_u32_vector(packed_input);
+
+    float golden_scalar = 0.0f;
+    for (uint16_t packed : u16_src_vec) {
+        golden_scalar += static_cast<float>(std::bit_cast<bfloat16>(packed));
+    }
+    // The scaler sits in SrcB for both GAPOOL passes (column accumulate and final
+    // collapse), so it multiplies the result twice.
+    golden_scalar *= config.scaler * config.scaler;
+
+    // The reduced scalar lives in element [0] of the output tile, in the output CB's
+    // format: raw fp32 with native fp32 DEST, otherwise the low bfloat16 of word 0.
+    float device_scalar = config.fp32_dest_acc
+                              ? std::bit_cast<float>(result_vec[0])
+                              : static_cast<float>(std::bit_cast<bfloat16>(u16_from_u32_vector(result_vec)[0]));
+
+    log_info(
+        LogTest,
+        "num_tiles={}, tile_height={}, fp32_dest_acc={}, full_sync={}, fidelity={}, scaler={}: "
+        "Golden={}, Device={}, Diff={}",
+        config.num_tiles,
+        config.tile_height,
+        config.fp32_dest_acc,
+        config.dst_full_sync,
+        static_cast<int>(config.math_fidelity),
+        config.scaler,
+        golden_scalar,
+        device_scalar,
+        std::abs(device_scalar - golden_scalar));
+
+    // LoFi truncates the SrcA/SrcB mantissas feeding both GAPOOL passes. With
+    // all-positive stimuli that truncation is one-directional, so the reduced scalar
+    // comes out ~3% low no matter how many tiles are summed -- a per-element precision
+    // effect, not accumulation drift. Budget for it rather than asserting HiFi
+    // precision at LoFi; the tile-count-independence is what rules out a real bug, and
+    // blaze absorbs the bias because layernorm subtracts the mean and divides by the
+    // variance, so a common scale error largely cancels.
+    const float rel_tol = (config.math_fidelity == MathFidelity::LoFi) ? 0.05f : 0.01f;
+    const float abs_tol = 0.01f;
+    const float tolerance = std::max(rel_tol * std::abs(golden_scalar), abs_tol);
+    return std::abs(device_scalar - golden_scalar) < tolerance;
+}
+
+}  // namespace tt::tt_metal::unit_tests::compute::sum_reduce_scalar
+
+using namespace tt::tt_metal::unit_tests::compute::sum_reduce_scalar;
+
+// Runs on any single card (Wormhole or Blackhole): sum_reduce_scalar builds on
+// mul_reduce_scalar's reduce tail, which is supported on both architectures.
+class SumReduceScalarTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<int> {};
+
+// Standard 32x32-tile suite parametrized by tile count. One tile skips the accumulate
+// loop entirely; 8 is the DEST half-sync bf16 capacity, so every copied tile must still
+// be resident when the reduce consumes it.
+TEST_P(SumReduceScalarTest, SumReduceScalar) {
+    auto& mesh_device = *devices_[0];
+    int num_tiles = GetParam();
+    ASSERT_TRUE(run_sum_reduce_scalar_test(mesh_device, {.num_tiles = num_tiles, .tile_height = 32}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SumReduceScalarTests, SumReduceScalarTest, testing::Values(1, 3, 8), [](const testing::TestParamInfo<int>& info) {
+        return "SumReduceScalar_" + std::to_string(info.param) + "_Tiles";
+    });
+
+// Tile geometry suite parametrized by tile height. 16x32 halves num_faces to 2 while
+// face_r_dim stays 16; heights below 16 shrink face_r_dim itself, which reconfigures the
+// packer and GAPOOL. blaze reaches all of (32, 16, 8, 4, 2, 1) by picking the tallest
+// tile dividing the width, so bracket the sub-16 range at 8 and 1 rather than
+// enumerating 4 and 2 as well.
+class SumReduceScalarTileHeightTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<int> {};
+
+TEST_P(SumReduceScalarTileHeightTest, SumReduceScalarTileHeight) {
+    auto& mesh_device = *devices_[0];
+    int tile_height = GetParam();
+    ASSERT_TRUE(run_sum_reduce_scalar_test(mesh_device, {.num_tiles = 8, .tile_height = tile_height}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SumReduceScalarTileHeightTests,
+    SumReduceScalarTileHeightTest,
+    testing::Values(16, 8, 1),
+    [](const testing::TestParamInfo<int>& info) {
+        return "SumReduceScalar_" + std::to_string(info.param) + "x32_8_Tiles";
+    });
+
+// Native fp32 DEST with full sync, parametrized by tile count. A separate instantiation
+// of the op: DST_ACCUM_MODE and DST_SYNC_MODE are both threaded into the reduce init and
+// the SFPU fills. blaze couples the two flags (compiler.py:
+// dst_full_sync_en=fp32_dest_acc_en) and never uses the other diagonal. Full-sync 32-bit
+// DEST holds 8 tiles, which is what blaze's widest layernorm asks for (width 8192, one
+// 32x32 tile per 1024 elements).
+class SumReduceScalarFp32DestTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<int> {};
+
+TEST_P(SumReduceScalarFp32DestTest, SumReduceScalarFp32Dest) {
+    auto& mesh_device = *devices_[0];
+    int num_tiles = GetParam();
+    ASSERT_TRUE(run_sum_reduce_scalar_test(
+        mesh_device, {.num_tiles = num_tiles, .tile_height = 32, .fp32_dest_acc = true, .dst_full_sync = true}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SumReduceScalarFp32DestTests,
+    SumReduceScalarFp32DestTest,
+    testing::Values(1, 8),
+    [](const testing::TestParamInfo<int>& info) {
+        return "SumReduceScalar_fp32dest_" + std::to_string(info.param) + "_Tiles";
+    });
+
+// LoFi is what blaze runs this op at (LayerNorm.math_fidelity = "LoFi"), and
+// MATH_FIDELITY parametrizes both GAPOOL passes, so it is its own instantiation. Run it
+// on both DEST widths; the fp32 case is blaze's exact layernorm configuration.
+class SumReduceScalarLoFiTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<bool> {};
+
+TEST_P(SumReduceScalarLoFiTest, SumReduceScalarLoFi) {
+    auto& mesh_device = *devices_[0];
+    bool fp32_dest_acc = GetParam();
+    ASSERT_TRUE(run_sum_reduce_scalar_test(
+        mesh_device,
+        {.num_tiles = 8,
+         .tile_height = 32,
+         .fp32_dest_acc = fp32_dest_acc,
+         .dst_full_sync = fp32_dest_acc,
+         .math_fidelity = MathFidelity::LoFi}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SumReduceScalarLoFiTests, SumReduceScalarLoFiTest, testing::Bool(), [](const testing::TestParamInfo<bool>& info) {
+        return std::string("SumReduceScalar_LoFi_8_Tiles_") + (info.param ? "fp32dest" : "bf16dest");
+    });
+
+// The scaler is what separates this from a plain sum, and it lands on the result twice.
+// One value either side of 1.0 pins the square. The doubling case also runs on fp32
+// DEST, since the scaler arrives through an SFPU fill whose access width is selected by
+// DST_ACCUM_MODE.
+class SumReduceScalarScalerTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<bool> {};
+
+TEST_P(SumReduceScalarScalerTest, SumReduceScalarScaler) {
+    auto& mesh_device = *devices_[0];
+    bool doubling = GetParam();
+    ASSERT_TRUE(run_sum_reduce_scalar_test(
+        mesh_device,
+        {.num_tiles = 4,
+         .tile_height = 32,
+         .scaler = doubling ? 2.0f : 0.5f,
+         .fp32_dest_acc = doubling,
+         .dst_full_sync = doubling}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SumReduceScalarScalerTests,
+    SumReduceScalarScalerTest,
+    testing::Bool(),
+    [](const testing::TestParamInfo<bool>& info) {
+        return info.param ? "SumReduceScalar_Scaler_2_fp32dest" : "SumReduceScalar_Scaler_0p5";
+    });

--- a/tests/tt_metal/tt_metal/test_kernels/compute/sum_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/sum_reduce_scalar.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/experimental/sum_reduce_scalar.h"
+#include "api/dataflow/circular_buffer.h"
+
+void kernel_main() {
+    const uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    const float scaler = __builtin_bit_cast(float, get_arg_val<uint32_t>(1));
+
+    CircularBuffer cb0(tt::CBIndex::c_0);    // Input
+    CircularBuffer cb16(tt::CBIndex::c_16);  // Output (reduced)
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+
+    cb0.wait_front(num_tiles);
+    cb16.reserve_back(1);
+
+    ckernel::sum_reduce_scalar_init(tt::CBIndex::c_0);
+
+    tile_regs_acquire();
+
+    ckernel::sum_reduce_scalar_tile(tt::CBIndex::c_0, tt::CBIndex::c_16, num_tiles, scaler);
+
+    tile_regs_commit();
+    tile_regs_wait();
+
+    // The reduced scalar lands in tile index 0.
+    pack_tile(0, tt::CBIndex::c_16);
+
+    tile_regs_release();
+
+    cb0.pop_front(num_tiles);
+    cb16.push_back(1);
+
+    // sum_reduce_scalar shares the reduce tail, and therefore the teardown, with mul_reduce_scalar.
+    ckernel::mul_reduce_scalar_uninit();
+}

--- a/tt_metal/hw/inc/api/compute/experimental/sum_reduce_scalar.h
+++ b/tt_metal/hw/inc/api/compute/experimental/sum_reduce_scalar.h
@@ -14,7 +14,7 @@ namespace ckernel {
  * Initializes the sum-reduce-scalar operation.
  *
  * Configures UNPACK and MATH for the datacopy phase. The reduce phase reconfigures
- * both itself, so only the datacopy needs setting up here.
+ * both of those threads itself, so only the datacopy needs setting up here.
  *
  * Must be called before sum_reduce_scalar_tile().
  *
@@ -40,6 +40,14 @@ ALWI void sum_reduce_scalar_init(uint32_t icb) { copy_tile_to_dst_init_short(icb
  * The result is stored in dest[0] at element position [0]; every other lane is
  * unspecified. Slots 0..num_tiles-1 of DEST are clobbered.
  *
+ * num_tiles is bounded twice. The hard ceiling is 8: the shared reduce tail moves
+ * dest[i] to SrcA through a switch that only covers i in 0..7 and no-ops above that,
+ * so a 9th tile would be silently dropped from the sum. Below that, the acquired DEST
+ * must also hold every copied tile until the reduce consumes it, which caps num_tiles
+ * at get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>() --
+ * 8 for half-sync/16-bit, 4 for half-sync/32-bit, 8 for full-sync/32-bit. Callers
+ * pairing fp32 DEST with half-sync therefore get 4, not 8.
+ *
  * This is the sum-only counterpart to mul_reduce_scalar_tile(): it reaches the same
  * reduction without an all-ones second operand or an identity ELWMUL. Phase 1 copies
  * each tile into DEST via datacopy (A2D); the reduce tail is the same DEST-only
@@ -52,7 +60,7 @@ ALWI void sum_reduce_scalar_init(uint32_t icb) { copy_tile_to_dst_init_short(icb
  * |----------------|---------------------------------------------------------------|----------|-------------|----------|
  * | icb            | Input circular buffer                                         | uint32_t | 0 to 31     | True     |
  * | ocb            | Output circular buffer (used to program packer face_r_dim)    | uint32_t | 0 to 31     | True     |
- * | num_tiles      | Number of tiles to reduce                                     | uint32_t | 1 to 8      | True     |
+ * | num_tiles      | Number of tiles to reduce (see the DEST note above)           | uint32_t | 1 to 8      | True     |
  * | scaler         | Per-GAPOOL multiplier; applied twice (default: 1.0)           | float    | Any float   | False    |
  *
  * Return value: None

--- a/tt_metal/hw/inc/api/compute/experimental/sum_reduce_scalar.h
+++ b/tt_metal/hw/inc/api/compute/experimental/sum_reduce_scalar.h
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/experimental/mul_reduce_scalar.h"
+#include "api/compute/tile_move_copy.h"
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Initializes the sum-reduce-scalar operation.
+ *
+ * Configures UNPACK and MATH for the datacopy phase. The reduce phase reconfigures
+ * both itself, so only the datacopy needs setting up here.
+ *
+ * Must be called before sum_reduce_scalar_tile().
+ *
+ * | Argument       | Description                                                   | Type     | Valid Range | Required |
+ * |----------------|---------------------------------------------------------------|----------|-------------|----------|
+ * | icb            | Input circular buffer                                         | uint32_t | 0 to 31     | True     |
+ *
+ * Return value: None
+ */
+// clang-format on
+ALWI void sum_reduce_scalar_init(uint32_t icb) { copy_tile_to_dst_init_short(icb); }
+
+// clang-format off
+/**
+ * Reduces num_tiles tiles of icb to a single scalar:
+ *
+ *     result = sum(all elements of all tiles) * scaler^2
+ *
+ * NOTE the square: scaler is loaded into SrcB once and both GAPOOL passes (the
+ * per-tile column accumulate and the final scalar collapse) multiply by it, so it
+ * lands on the result twice. To scale the sum by 1/N, pass 1/sqrt(N).
+ *
+ * The result is stored in dest[0] at element position [0]; every other lane is
+ * unspecified. Slots 0..num_tiles-1 of DEST are clobbered.
+ *
+ * This is the sum-only counterpart to mul_reduce_scalar_tile(): it reaches the same
+ * reduction without an all-ones second operand or an identity ELWMUL. Phase 1 copies
+ * each tile into DEST via datacopy (A2D); the reduce tail is the same DEST-only
+ * column-accumulate plus scalar collapse, which is what keeps SrcB (the scaler) valid
+ * across tiles — a mid-reduce unpack_A path does not.
+ *
+ * Pair with mul_reduce_scalar_uninit().
+ *
+ * | Argument       | Description                                                   | Type     | Valid Range | Required |
+ * |----------------|---------------------------------------------------------------|----------|-------------|----------|
+ * | icb            | Input circular buffer                                         | uint32_t | 0 to 31     | True     |
+ * | ocb            | Output circular buffer (used to program packer face_r_dim)    | uint32_t | 0 to 31     | True     |
+ * | num_tiles      | Number of tiles to reduce                                     | uint32_t | 1 to 8      | True     |
+ * | scaler         | Per-GAPOOL multiplier; applied twice (default: 1.0)           | float    | Any float   | False    |
+ *
+ * Return value: None
+ */
+// clang-format on
+ALWI void sum_reduce_scalar_tile(uint32_t icb, uint32_t ocb, uint32_t num_tiles, float scaler = 1.0f) {
+    // Step 1: Copy each input tile into its own DEST slot
+    for (uint32_t i = 0; i < num_tiles; i++) {
+        copy_tile(icb, i, i);
+    }
+
+    // Step 2: Switch UNPACK state for reduce phase (reset counters, set DVALID)
+    UNPACK((llk_unpack_mul_reduce_scalar_switch_to_reduce()));
+
+    // Step 3: Initialize reduce operation
+    MATH((llk_math_mul_reduce_scalar_reduce_init<DST_ACCUM_MODE, MATH_FIDELITY>()));
+
+    // Step 4: Move dest[0] (first copied tile) to srcA
+    MATH((llk_math_mul_reduce_scalar_move_dest_to_src<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(0)));
+
+    // Populate srcB with the scaler value
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _calculate_fill_,
+        (APPROX, 2 /*ITERATIONS*/),
+        0 /*dst_index*/,
+        VectorMode::RC_custom,
+        scaler));
+    MATH((llk_math_mul_reduce_scalar_move_dest_to_src<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(0)));
+
+    // Clear dest[0] - this will accumulate scalar reduction results from all tiles
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _calculate_fill_,
+        (APPROX, 2 /*ITERATIONS*/),
+        0 /*dst_index*/,
+        VectorMode::RC_custom,
+        0.0f));
+
+    // Step 5: Configure packer for scalar reduction
+    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_SCALAR, PackMode::Default>(ocb)));
+
+    // Step 6: Column-reduce each tile, accumulating into dest[0]
+    MATH((llk_math_mul_reduce_column<MATH_FIDELITY>(0, icb)));
+    for (uint32_t i = 1; i < num_tiles; i++) {
+        MATH((llk_math_mul_reduce_scalar_move_dest_to_src<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(i)));
+        MATH((llk_math_mul_reduce_column<MATH_FIDELITY>(0, icb)));
+    }
+
+    // Step 7: Perform final scalar reduction
+    MATH((llk_math_mul_reduce_scalar<MATH_FIDELITY>()));
+
+    // Step 8: Clear data valid flags
+    MATH((llk_math_mul_reduce_scalar_clear_dvalid()));
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -103,6 +103,7 @@ set(HW_JIT_API_HEADERS
     inc/api/compute/experimental/fast_untilize.h
     inc/api/compute/experimental/mul_reduce_scalar.h
     inc/api/compute/experimental/semaphore.h
+    inc/api/compute/experimental/sum_reduce_scalar.h
     inc/api/compute/binary_fmod.h
     inc/api/compute/gcd.h
     inc/api/compute/isclose.h


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Adds `sum_reduce_scalar` to `experimental/` — the sum-only counterpart to the existing `mul_reduce_scalar`, reaching the same reduction by datacopying each tile into DEST instead of requiring an all-ones second operand and an identity ELWMUL. Relates to tt-blaze#2002.

### Notes for reviewers

- One code change relative to blaze's copy: blaze calls `SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM`, a compat macro local to blaze that restores a macro tt-metal deleted. This uses `SFPU_UNARY_CALL` instead — the same expansion, and the form `mul_reduce_scalar.h` already uses. Everything else is dentical apart from comments.
- The `scaler` lands on the result **twice** (`sum * scaler^2`): it sits in SrcB for both GAPOOL passes. blaze documented that only at its layernorm call site, which passes `1/sqrt(width)` to divide by width; it's now in the header contract.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch2)