### PR TITLE
[Cleanup] Device 2.0 Migration for Experimental SSM Ops

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/writer_ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/writer_ssm_1d_sum_reduce.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
+#include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -31,6 +32,12 @@ void kernel_main() {
     CircularBuffer cb_intermed2(intermed_cb_id2);
     CircularBuffer cb_output(output_cb_id);
 
+    // Faces are gathered from cb_intermed1 into cb_intermed2 L1->L1 via a NoC loopback to this
+    // core's own coordinates.
+    UnicastEndpoint local_src;
+    const uint32_t local_noc_x = my_x[noc.get_noc_id()];
+    const uint32_t local_noc_y = my_y[noc.get_noc_id()];
+
     constexpr uint32_t onetile = 1;
     constexpr auto dst_args = TensorAccessorArgs<3>();
     const auto s = TensorAccessor(dst_args, dst_addr);
@@ -40,39 +47,55 @@ void kernel_main() {
     for (uint32_t block_h_id = 0; block_h_id < out_num_blocks_h; block_h_id++) {
         for (uint32_t i = start_id; i < end_id; ++i) {
             cb_intermed2.reserve_back(onetile);
-            uint32_t dst = cb_intermed2.get_write_ptr();
+            uint32_t dst_offset = 0;
 
             // Manually unroll copying into destination face 1+2 and 3+4 to avoid conditional inside loop
             for (uint32_t j = 0; j < FACE_WIDTH; ++j) {
                 cb_intermed1.wait_front(onetile);
-                uint64_t src = get_noc_addr(cb_intermed1.get_read_ptr());
+                const uint32_t src_addr = cb_intermed1.get_read_ptr();
 
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-                noc_async_read(src, dst, FACE_WIDTH_BYTES);
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-                noc_async_read(src + FACE_SIZE_BYTES, dst + FACE_SIZE_BYTES, FACE_WIDTH_BYTES);
+                noc.async_read(
+                    local_src,
+                    cb_intermed2,
+                    FACE_WIDTH_BYTES,
+                    {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = src_addr},
+                    {.offset_bytes = dst_offset});
+                noc.async_read(
+                    local_src,
+                    cb_intermed2,
+                    FACE_WIDTH_BYTES,
+                    {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = src_addr + FACE_SIZE_BYTES},
+                    {.offset_bytes = dst_offset + FACE_SIZE_BYTES});
                 noc.async_read_barrier();
 
                 cb_intermed1.pop_front(onetile);
 
-                dst += FACE_WIDTH_BYTES;
+                dst_offset += FACE_WIDTH_BYTES;
             }
-            dst += FACE_SIZE_BYTES;
+            dst_offset += FACE_SIZE_BYTES;
 
             // Copy face 3/4 into the destination
             for (uint32_t j = 0; j < FACE_WIDTH; ++j) {
                 cb_intermed1.wait_front(onetile);
-                uint64_t src = get_noc_addr(cb_intermed1.get_read_ptr());
+                const uint32_t src_addr = cb_intermed1.get_read_ptr();
 
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-                noc_async_read(src, dst, FACE_WIDTH_BYTES);
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-                noc_async_read(src + FACE_SIZE_BYTES, dst + FACE_SIZE_BYTES, FACE_WIDTH_BYTES);
+                noc.async_read(
+                    local_src,
+                    cb_intermed2,
+                    FACE_WIDTH_BYTES,
+                    {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = src_addr},
+                    {.offset_bytes = dst_offset});
+                noc.async_read(
+                    local_src,
+                    cb_intermed2,
+                    FACE_WIDTH_BYTES,
+                    {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = src_addr + FACE_SIZE_BYTES},
+                    {.offset_bytes = dst_offset + FACE_SIZE_BYTES});
                 noc.async_read_barrier();
 
                 cb_intermed1.pop_front(onetile);
 
-                dst += FACE_WIDTH_BYTES;
+                dst_offset += FACE_WIDTH_BYTES;
             }
             cb_intermed2.push_back(onetile);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/reader_ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/reader_ssm_eltwise_mul.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -34,6 +35,13 @@ void kernel_main() {
     CircularBuffer cb_in1(cb_id_in1);
     CircularBuffer cb_in1_transposed_buf(cb_in1_transposed);
     CircularBuffer cb_in1_bcast_row_buf(cb_in1_bcast_row);
+
+#ifdef REPEAT_INTERLEAVE_IN1
+    // The transposed rows are copied L1->L1 via a NoC loopback to this core's own coordinates.
+    UnicastEndpoint local_src;
+    const uint32_t local_noc_x = my_x[noc.get_noc_id()];
+    const uint32_t local_noc_y = my_y[noc.get_noc_id()];
+#endif
 
     const uint32_t in0_tile_bytes = get_tile_size(cb_id_in0);
     const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
@@ -67,14 +75,12 @@ void kernel_main() {
 
 #ifdef REPEAT_INTERLEAVE_IN1
             cb_in1_transposed_buf.wait_front(onetile);
-            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-            uint64_t cb_in1_transposed_read_ptr = get_noc_addr(cb_in1_transposed_buf.get_read_ptr());
+            uint32_t cb_in1_transposed_read_addr = cb_in1_transposed_buf.get_read_ptr();
 
             // Manually unroll iterating across the tile to eliminate unnecessary conditional checking
             // First + second face
             for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_face; tile_row_id++) {
                 cb_in1_bcast_row_buf.reserve_back(onetile);
-                uint32_t cb_in1_bcast_row_write_ptr = cb_in1_bcast_row_buf.get_write_ptr();
 
 #ifndef REPEAT_IN0
                 cb_in0.reserve_back(onetile);
@@ -86,13 +92,20 @@ void kernel_main() {
                      .offset_bytes = 0},
                     {.offset_bytes = 0});
 #endif
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-                noc_async_read(cb_in1_transposed_read_ptr, cb_in1_bcast_row_write_ptr, bfloat16_one_row_in_face_bytes);
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-                noc_async_read(
-                    cb_in1_transposed_read_ptr + bfloat16_one_face_bytes,
-                    cb_in1_bcast_row_write_ptr + bfloat16_one_face_bytes,
-                    bfloat16_one_row_in_face_bytes);
+                noc.async_read(
+                    local_src,
+                    cb_in1_bcast_row_buf,
+                    bfloat16_one_row_in_face_bytes,
+                    {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = cb_in1_transposed_read_addr},
+                    {.offset_bytes = 0});
+                noc.async_read(
+                    local_src,
+                    cb_in1_bcast_row_buf,
+                    bfloat16_one_row_in_face_bytes,
+                    {.noc_x = local_noc_x,
+                     .noc_y = local_noc_y,
+                     .addr = cb_in1_transposed_read_addr + bfloat16_one_face_bytes},
+                    {.offset_bytes = bfloat16_one_face_bytes});
                 noc.async_read_barrier();
 
 #ifndef REPEAT_IN0
@@ -100,14 +113,13 @@ void kernel_main() {
 #endif
                 cb_in1_bcast_row_buf.push_back(onetile);
 
-                cb_in1_transposed_read_ptr += bfloat16_one_row_in_face_bytes;
+                cb_in1_transposed_read_addr += bfloat16_one_row_in_face_bytes;
             }
 
-            cb_in1_transposed_read_ptr += bfloat16_one_face_bytes;
+            cb_in1_transposed_read_addr += bfloat16_one_face_bytes;
             // Third + fourth face
             for (uint32_t tile_row_id = num_rows_in_face; tile_row_id < 2 * num_rows_in_face; tile_row_id++) {
                 cb_in1_bcast_row_buf.reserve_back(onetile);
-                uint32_t cb_in1_bcast_row_write_ptr = cb_in1_bcast_row_buf.get_write_ptr();
 
 #ifndef REPEAT_IN0
                 cb_in0.reserve_back(onetile);
@@ -118,13 +130,20 @@ void kernel_main() {
                     {.page_id = block_h_id * 5120 + (i * in0_blocks_per_in1_block + tile_row_id), .offset_bytes = 0},
                     {.offset_bytes = 0});
 #endif
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-                noc_async_read(cb_in1_transposed_read_ptr, cb_in1_bcast_row_write_ptr, bfloat16_one_row_in_face_bytes);
-                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-                noc_async_read(
-                    cb_in1_transposed_read_ptr + bfloat16_one_face_bytes,
-                    cb_in1_bcast_row_write_ptr + bfloat16_one_face_bytes,
-                    bfloat16_one_row_in_face_bytes);
+                noc.async_read(
+                    local_src,
+                    cb_in1_bcast_row_buf,
+                    bfloat16_one_row_in_face_bytes,
+                    {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = cb_in1_transposed_read_addr},
+                    {.offset_bytes = 0});
+                noc.async_read(
+                    local_src,
+                    cb_in1_bcast_row_buf,
+                    bfloat16_one_row_in_face_bytes,
+                    {.noc_x = local_noc_x,
+                     .noc_y = local_noc_y,
+                     .addr = cb_in1_transposed_read_addr + bfloat16_one_face_bytes},
+                    {.offset_bytes = bfloat16_one_face_bytes});
                 noc.async_read_barrier();
 
 #ifndef REPEAT_IN0
@@ -132,7 +151,7 @@ void kernel_main() {
 #endif
                 cb_in1_bcast_row_buf.push_back(onetile);
 
-                cb_in1_transposed_read_ptr += bfloat16_one_row_in_face_bytes;
+                cb_in1_transposed_read_addr += bfloat16_one_row_in_face_bytes;
             }
             cb_in1_transposed_buf.pop_front(onetile);
 


### PR DESCRIPTION
### Summary
Device 2.0 migration required to enable the Metal 2.0 port of the SSM Eltwise Matmul op. 
This PR migrates both ops under `experimental/ssm` to Device 2.0 together.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/Device2.0_EltwiseMul)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/Device2.0_EltwiseMul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/Device2.0_EltwiseMul)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/Device2.0_EltwiseMul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=edwinlee/Device2.0_EltwiseMul)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:edwinlee/Device2.0_EltwiseMul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/Device2.0_EltwiseMul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/Device2.0_EltwiseMul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/Device2.0_EltwiseMul)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/Device2.0_EltwiseMul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/Device2.0_EltwiseMul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/Device2.0_EltwiseMul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/Device2.0_EltwiseMul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/Device2.0_EltwiseMul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/Device2.0_EltwiseMul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/Device2.0_EltwiseMul)