### PR TITLE
[Bug fix] Use per-core shard address for host data movement on per-core-allocated L1 buffers

### DIFF
--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation.py
@@ -456,7 +456,7 @@ def test_per_core_width_sharded_tiled_bfp4_round_trip(device):
         data, dtype=ttnn.bfloat4_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem_config
     )
 
-    addrs = {(c.x, c.y): tensor.experimental_per_core_buffer_address(c) for c in kv_cores}
+    addrs = {(c.x, c.y): _per_core_addr(tensor, c) for c in kv_cores}
     base = addrs[(1, 8)]
     relocated = [(c.x, c.y) for c in kv_cores if addrs[(c.x, c.y)] != base]
     print(f"\n[REPRO-KVA] distinct_addrs={len(set(addrs.values()))} relocated={relocated} base_addr={base}")
@@ -477,7 +477,7 @@ def test_per_core_width_sharded_tiled_bfp4_round_trip(device):
 
 # Inline data-movement kernel: copy `num_bytes` from a per-core SOURCE L1 address
 # (passed as a runtime arg, exactly how blaze wires weights via
-# experimental_per_core_buffer_address(core)) into a lockstep DESTINATION L1 address
+# experimental_per_core_buffer_address) into a lockstep DESTINATION L1 address
 # on the same core. A plain local L1->L1 word copy — no CB / NOC / TensorAccessor needed.
 _PER_CORE_READBACK_KERNEL = r"""
 #include "api/dataflow/dataflow_api.h"
@@ -503,7 +503,7 @@ def test_per_core_kernel_readback_honors_per_core_address(device):
 
     Unlike the host round-trip tests above, this introduces the asymmetry the bug
     needs: a kernel reads each core's shard at the per-core address
-    (``experimental_per_core_buffer_address(core)``, wired as a runtime arg exactly how
+    (``experimental_per_core_buffer_address``, wired as a runtime arg exactly how
     blaze's matmul reads weights), while ``from_torch`` writes via the host
     data-movement path.
 
@@ -556,7 +556,7 @@ def test_per_core_kernel_readback_honors_per_core_address(device):
 
     # Precondition: per-core addresses must be non-uniform, else scalar == per-core and
     # the bug is structurally invisible.
-    src_addrs = [src.experimental_per_core_buffer_address(c) for c in cores]
+    src_addrs = [_per_core_addr(src, c) for c in cores]
     assert len(set(src_addrs)) > 1, f"expected non-uniform per-core addresses; got {len(set(src_addrs))} distinct"
 
     # DESTINATION: a lockstep (uniform-address) uint8 tensor the kernel copies into,
@@ -575,7 +575,7 @@ def test_per_core_kernel_readback_honors_per_core_address(device):
     # destination = the lockstep base.
     rt_args = ttnn.RuntimeArgs()
     for c in cores:
-        rt_args[c.x][c.y] = [src.experimental_per_core_buffer_address(c), dst_base, SHARD_BYTES]
+        rt_args[c.x][c.y] = [_per_core_addr(src, c), dst_base, SHARD_BYTES]
 
     kernel = ttnn.KernelDescriptor(
         kernel_source=_PER_CORE_READBACK_KERNEL,

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation.py
@@ -417,6 +417,194 @@ def test_all_cores_lockstep_then_per_core_then_reverse(device):
 
 
 @requires_hybrid_allocator
+def test_per_core_width_sharded_tiled_bfp4_round_trip(device):
+    """FORMAT coverage: per-core allocation coexists with WIDTH_SHARDED + TILE_LAYOUT +
+    BFLOAT4_B for a (7168, 576) tensor on the 18-core grid (0,8)-(8,9), with a couple of
+    co-resident per-core tensors on (0,8)/(0,9) (so per-core addresses are non-uniform).
+
+    NOTE: this is a host ``from_torch``/``to_torch`` round-trip, which is SYMMETRIC (both
+    sides used the same buffer address), so it does NOT catch the per-core data-movement
+    address bug — it passed even while that bug was live, because the isolated co-resident
+    topology differs from the real dense run. The authoritative guard for that bug is
+    ``test_per_core_kernel_readback_honors_per_core_address`` (kernel reads at the per-core
+    address). This test only verifies that the BFP4/TILE/WIDTH-sharded per-core creation
+    path round-trips at all.
+    """
+    H, W = 7168, 576
+    kv_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(8, 9))])
+    kv_cores = list(ttnn.corerange_to_cores(kv_grid, row_wise=True))
+    num_cores = len(kv_cores)
+    assert num_cores == 18
+    shard_w = W // num_cores  # 32
+
+    # Phase 1: prior per-core alloc on (0,8) and (0,9) — the two cores that
+    # relocate in the real run (kv_norm gamma / k_rope co-residents).
+    relocate_cores = [ttnn.CoreCoord(0, 8), ttnn.CoreCoord(0, 9)]
+    prealloc = [_create_single_core_tensor(device, c, 2048) for c in relocate_cores]
+
+    # Phase 2: WIDTH_SHARDED, TILE_LAYOUT, BFP4 per-core tensor with distinct
+    # nonzero data per column-shard (column block c filled with value c+1).
+    data = torch.zeros(H, W, dtype=torch.float32)
+    for c in range(num_cores):
+        data[:, c * shard_w : (c + 1) * shard_w] = float(c + 1)
+
+    shard_spec = ttnn.ShardSpec(kv_grid, [H, shard_w], ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
+    mem_config.experimental_set_per_core_allocation(True)
+
+    tensor = ttnn.from_torch(
+        data, dtype=ttnn.bfloat4_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem_config
+    )
+
+    addrs = {(c.x, c.y): tensor.experimental_per_core_buffer_address(c) for c in kv_cores}
+    base = addrs[(1, 8)]
+    relocated = [(c.x, c.y) for c in kv_cores if addrs[(c.x, c.y)] != base]
+    print(f"\n[REPRO-KVA] distinct_addrs={len(set(addrs.values()))} relocated={relocated} base_addr={base}")
+
+    result = ttnn.to_torch(ttnn.from_device(tensor)).float()
+    # per column-shard: mean abs (BFP4 is lossy, but zero stays ~zero)
+    zero_shards = []
+    for c in range(num_cores):
+        block = result[:, c * shard_w : (c + 1) * shard_w]
+        if float(block.abs().mean().item()) < 1e-3:
+            zero_shards.append((c, (kv_cores[c].x, kv_cores[c].y)))
+    print(f"[REPRO-KVA] zero_shards={len(zero_shards)}/{num_cores}: {zero_shards}")
+    assert not zero_shards, (
+        f"{len(zero_shards)}/{num_cores} WIDTH-sharded BFP4 per-core column-shards read back ZERO "
+        f"(BFP4/TILE/WIDTH per-core creation round-trip is broken): {zero_shards}"
+    )
+
+
+# Inline data-movement kernel: copy `num_bytes` from a per-core SOURCE L1 address
+# (passed as a runtime arg, exactly how blaze wires weights via
+# experimental_per_core_buffer_address(core)) into a lockstep DESTINATION L1 address
+# on the same core. A plain local L1->L1 word copy — no CB / NOC / TensorAccessor needed.
+_PER_CORE_READBACK_KERNEL = r"""
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t src_addr  = get_arg_val<uint32_t>(0);  // per-core source base (kernel's view)
+    const uint32_t dst_addr  = get_arg_val<uint32_t>(1);  // lockstep destination base
+    const uint32_t num_bytes = get_arg_val<uint32_t>(2);
+
+    volatile tt_l1_ptr uint32_t* src = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_addr);
+    volatile tt_l1_ptr uint32_t* dst = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_addr);
+    const uint32_t num_words = num_bytes >> 2;
+    for (uint32_t i = 0; i < num_words; ++i) {
+        dst[i] = src[i];
+    }
+}
+"""
+
+
+@requires_hybrid_allocator
+def test_per_core_kernel_readback_honors_per_core_address(device):
+    """REGRESSION test for the per-core data-movement address bug.
+
+    Unlike the host round-trip tests above, this introduces the asymmetry the bug
+    needs: a kernel reads each core's shard at the per-core address
+    (``experimental_per_core_buffer_address(core)``, wired as a runtime arg exactly how
+    blaze's matmul reads weights), while ``from_torch`` writes via the host
+    data-movement path.
+
+    The defect: host data movement wrote every core's shard at the uniform scalar
+    ``buffer.address()`` (== cores[0]'s address) plus the core's logical page offset,
+    instead of at each core's independent per-core address. Host round-trips
+    (``to_torch``) can't see this because they use the same scalar on both sides. A
+    kernel reading at the per-core address CAN: a core whose per-core address sits
+    *below* the scalar by more than the write's page span reads whatever is there
+    (zeros), not the written data — exactly what made 16/18 kv_a cores read zero
+    (-> kv-cache inf) in the full dense run.
+
+    To reproduce robustly in isolation we recreate that key geometry directly: a
+    per-core triangle pre-alloc with a step (``PREALLOC_STEP``) far LARGER than the
+    shard/page size pushes each core's per-core address far below cores[0]'s (the
+    scalar), while the buggy host write only advances by the small page size. So the
+    written bytes and the kernel's read address diverge on (almost) every core.
+
+    With the fix (host data movement honors ``get_per_core_address``), the kernel reads
+    real data on every core. With the fix reverted, the diverged cores read zeros and
+    this test FAILS.
+    """
+    grid = device.compute_with_storage_grid_size()
+    cores = [ttnn.CoreCoord(x, y) for y in range(grid.y) for x in range(grid.x)]
+    num_cores = len(cores)
+
+    SHARD_BYTES = 1024  # small page; word-aligned
+    PREALLOC_STEP = 4096  # > SHARD_BYTES: spreads per-core addresses apart faster than
+    #                       the host write advances (and stays within an L1 bank: the
+    #                       largest core's pre-alloc is num_cores * PREALLOC_STEP)
+
+    # Phase 1: triangle pre-alloc with a LARGE step. cores[0] consumes the least (=>
+    # highest address => the scalar buffer.address()); each later core sits a full
+    # PREALLOC_STEP lower. The buggy host write advances only by SHARD_BYTES per core,
+    # so it never reaches the far-lower per-core addresses.
+    triangle_tensors = {}
+    for i, core in enumerate(cores):
+        triangle_tensors[i] = _create_single_core_tensor(device, core, (i + 1) * PREALLOC_STEP)
+
+    # Phase 2: the SOURCE per-core sharded tensor with DISTINCT NONZERO data per core.
+    core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))])
+    shard_spec = ttnn.ShardSpec(core_grid, [1, SHARD_BYTES], ttnn.ShardOrientation.ROW_MAJOR)
+    src_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    src_mem.experimental_set_per_core_allocation(True)
+
+    data = torch.zeros(num_cores, SHARD_BYTES, dtype=torch.uint8)
+    for i in range(num_cores):
+        data[i, :] = (i % 255) + 1
+    src = ttnn.from_torch(data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=src_mem)
+
+    # Precondition: per-core addresses must be non-uniform, else scalar == per-core and
+    # the bug is structurally invisible.
+    src_addrs = [src.experimental_per_core_buffer_address(c) for c in cores]
+    assert len(set(src_addrs)) > 1, f"expected non-uniform per-core addresses; got {len(set(src_addrs))} distinct"
+
+    # DESTINATION: a lockstep (uniform-address) uint8 tensor the kernel copies into,
+    # read back reliably via to_torch.
+    dst_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    dst = ttnn.from_torch(
+        torch.zeros(num_cores, SHARD_BYTES, dtype=torch.uint8),
+        dtype=ttnn.uint8,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=dst_mem,
+    )
+    dst_base = dst.buffer_address()  # lockstep: uniform across cores
+
+    # Wire the kernel: per core, source = the per-core address (the kernel's true view),
+    # destination = the lockstep base.
+    rt_args = ttnn.RuntimeArgs()
+    for c in cores:
+        rt_args[c.x][c.y] = [src.experimental_per_core_buffer_address(c), dst_base, SHARD_BYTES]
+
+    kernel = ttnn.KernelDescriptor(
+        kernel_source=_PER_CORE_READBACK_KERNEL,
+        source_type=ttnn.KernelDescriptor.SourceType.SOURCE_CODE,
+        core_ranges=core_grid,
+        compile_time_args=[],
+        runtime_args=rt_args,
+        config=ttnn.ReaderConfigDescriptor(),
+    )
+    program = ttnn.ProgramDescriptor(kernels=[kernel], semaphores=[], cbs=[])
+
+    ttnn.generic_op([src, dst], program)
+
+    result = ttnn.to_torch(ttnn.from_device(dst))
+    mismatched = [i for i in range(num_cores) if not torch.equal(result[i], data[i])]
+    zero_rows = [i for i in range(num_cores) if int(result[i].max().item()) == 0]
+    print(
+        f"\n[KERNEL-READBACK] distinct_src_addrs={len(set(src_addrs))} "
+        f"mismatched={len(mismatched)}/{num_cores} zero={len(zero_rows)}/{num_cores}"
+    )
+    assert not mismatched, (
+        f"{len(mismatched)}/{num_cores} cores' kernel-read shards differ from the written data "
+        f"({len(zero_rows)} read ALL-ZERO) — host data movement wrote at the uniform scalar "
+        f"buffer.address() instead of the per-core address the kernel reads "
+        f"(reproduces dense kv_a inf). rows={mismatched[:32]}"
+    )
+
+
+@requires_hybrid_allocator
 def test_triangle_allocation_then_uniform_sharded(device):
     """Triangle per-core allocation on ALL compute cores, then a per-core sharded tensor.
 

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation.py
@@ -11,6 +11,7 @@ which triggers the per-bank allocator (AllocatorID bank_id+1) instead of lockste
 The local conftest.py sets TT_METAL_ALLOCATOR_MODE_HYBRID=1 and creates the device.
 """
 
+import pytest
 import torch
 import ttnn
 from conftest import requires_hybrid_allocator
@@ -416,6 +417,10 @@ def test_all_cores_lockstep_then_per_core_then_reverse(device):
         assert per_core_tensors[i].is_allocated()
 
 
+# Fixed kv_grid rows 8-9, columns 0-8: this reproduces a specific dense-attention core layout,
+# so it cannot be sized from the device grid like the other tests here. Skip where those cores
+# do not exist (e.g. Wormhole's 8x8 worker grid) rather than building an invalid shard grid.
+@pytest.mark.requires_grid_size((9, 10))
 @requires_hybrid_allocator
 def test_per_core_width_sharded_tiled_bfp4_round_trip(device):
     """FORMAT coverage: per-core allocation coexists with WIDTH_SHARDED + TILE_LAYOUT +
@@ -442,11 +447,15 @@ def test_per_core_width_sharded_tiled_bfp4_round_trip(device):
     relocate_cores = [ttnn.CoreCoord(0, 8), ttnn.CoreCoord(0, 9)]
     prealloc = [_create_single_core_tensor(device, c, 2048) for c in relocate_cores]
 
-    # Phase 2: WIDTH_SHARDED, TILE_LAYOUT, BFP4 per-core tensor with distinct
-    # nonzero data per column-shard (column block c filled with value c+1).
+    # Phase 2: WIDTH_SHARDED, TILE_LAYOUT, BFP4 per-core tensor with distinct nonzero data per
+    # column-shard (column block c filled with 2**c). Powers of two because BFP4 keeps only a
+    # few mantissa bits: consecutive integers quantize into each other (17 and 18 both read back
+    # 16), so no tolerance could both absorb that and still catch a shard read from the wrong
+    # address. Each block is uniform, so its shared exponent reproduces a power of two exactly,
+    # and neighbouring shards differ by 2x — far outside any rounding.
     data = torch.zeros(H, W, dtype=torch.float32)
     for c in range(num_cores):
-        data[:, c * shard_w : (c + 1) * shard_w] = float(c + 1)
+        data[:, c * shard_w : (c + 1) * shard_w] = float(2**c)
 
     shard_spec = ttnn.ShardSpec(kv_grid, [H, shard_w], ttnn.ShardOrientation.ROW_MAJOR)
     mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
@@ -462,16 +471,20 @@ def test_per_core_width_sharded_tiled_bfp4_round_trip(device):
     print(f"\n[REPRO-KVA] distinct_addrs={len(set(addrs.values()))} relocated={relocated} base_addr={base}")
 
     result = ttnn.to_torch(ttnn.from_device(tensor)).float()
-    # per column-shard: mean abs (BFP4 is lossy, but zero stays ~zero)
-    zero_shards = []
+    # Check the VALUE, not just non-zeroness: a shard read back from the wrong address is
+    # usually still nonzero, holding a neighbour's constant, which a zero-only check passes.
+    bad_shards = []
     for c in range(num_cores):
         block = result[:, c * shard_w : (c + 1) * shard_w]
-        if float(block.abs().mean().item()) < 1e-3:
-            zero_shards.append((c, (kv_cores[c].x, kv_cores[c].y)))
-    print(f"[REPRO-KVA] zero_shards={len(zero_shards)}/{num_cores}: {zero_shards}")
-    assert not zero_shards, (
-        f"{len(zero_shards)}/{num_cores} WIDTH-sharded BFP4 per-core column-shards read back ZERO "
-        f"(BFP4/TILE/WIDTH per-core creation round-trip is broken): {zero_shards}"
+        expected = float(2**c)
+        max_err = float((block - expected).abs().max().item())
+        if max_err > 1e-3 * expected:
+            bad_shards.append((c, (kv_cores[c].x, kv_cores[c].y), expected, float(block.mean().item())))
+    print(f"[REPRO-KVA] bad_shards={len(bad_shards)}/{num_cores}: {bad_shards}")
+    assert not bad_shards, (
+        f"{len(bad_shards)}/{num_cores} WIDTH-sharded BFP4 per-core column-shards read back the "
+        f"wrong values (BFP4/TILE/WIDTH per-core creation round-trip is broken); "
+        f"(shard, core, expected, actual_mean): {bad_shards}"
     )
 
 

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_multi_device.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_multi_device.py
@@ -535,6 +535,71 @@ def test_single_device_loopback(mesh_device):
 
 
 @requires_hybrid_allocator
+def test_kva_width_sharded_bfp4_replicate_data_round_trip(mesh_device):
+    """FORMAT + MESH coverage: per-core allocation coexists with WIDTH_SHARDED,
+    TILE_LAYOUT, BFLOAT4_B, (7168,576) over the 18-core grid (0,8)-(8,9) under
+    ReplicateTensorToMesh, with co-resident per-core tensors on (0,8)/(0,9).
+
+    Writes DISTINCT NONZERO data per column-shard and reads it back PER DEVICE via
+    to_torch(from_device(device_tensor)).
+
+    NOTE: this is a host round-trip, which is SYMMETRIC (write and read use the same
+    buffer address), so it does NOT catch the per-core data-movement address bug — it
+    passes even when that bug is present (the isolated co-resident topology differs from
+    the real dense run). The authoritative guard is
+    ``test_per_core_kernel_readback_honors_per_core_address`` in the single-device file
+    (kernel reads at the per-core address). This test only verifies that the replicated
+    BFP4/TILE/WIDTH-sharded per-core creation path round-trips per device.
+    """
+    H, W = 7168, 576
+    kv_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(8, 9))])
+    kv_cores = list(ttnn.corerange_to_cores(kv_grid, row_wise=True))
+    num_cores = len(kv_cores)
+    assert num_cores == 18
+    shard_w = W // num_cores  # 32
+
+    # Co-resident per-core tensors on (0,8)/(0,9) -> those cores relocate up.
+    _co = [
+        _create_per_core_single(mesh_device, ttnn.CoreCoord(0, 8), 2048),
+        _create_per_core_single(mesh_device, ttnn.CoreCoord(0, 9), 2048),
+    ]
+
+    data = torch.zeros(H, W, dtype=torch.float32)
+    for c in range(num_cores):
+        data[:, c * shard_w : (c + 1) * shard_w] = float(c + 1)
+
+    shard_spec = ttnn.ShardSpec(kv_grid, [H, shard_w], ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
+    mem_config.experimental_set_per_core_allocation(True)
+    tensor = ttnn.from_torch(
+        data,
+        dtype=ttnn.bfloat4_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    # per-device per-core addresses + data round-trip
+    for dev_idx, dt in enumerate(ttnn.get_device_tensors(tensor)):
+        addrs = [dt.experimental_per_core_buffer_address(c) for c in kv_cores]
+        result = ttnn.to_torch(ttnn.from_device(dt)).float()
+        zero_shards = []
+        for c in range(num_cores):
+            block = result[:, c * shard_w : (c + 1) * shard_w]
+            if float(block.abs().mean().item()) < 1e-3:
+                zero_shards.append((c, (kv_cores[c].x, kv_cores[c].y)))
+        logger.info(
+            f"[KVA-MESH] dev{dev_idx} distinct_addrs={len(set(addrs))} "
+            f"zero_shards={len(zero_shards)}/{num_cores} {zero_shards}"
+        )
+        assert not zero_shards, (
+            f"dev{dev_idx}: {len(zero_shards)}/{num_cores} replicated BFP4 per-core column-shards "
+            f"read ZERO (per-core creation round-trip broken on this device): {zero_shards}"
+        )
+
+
+@requires_hybrid_allocator
 def test_divergent_per_device_then_lockstep(mesh_device):
     """Allocate different-sized per-core tensors on each device independently,
     causing divergent allocator states. Then lockstep must get the same address

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_multi_device.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_multi_device.py
@@ -10,12 +10,12 @@ Tests the two-level allocator architecture:
 - Per-core and lockstep allocations never overlap on any device
 """
 
+import pytest
 import torch
 from loguru import logger
 
 import ttnn
 from conftest import requires_hybrid_allocator
-
 
 # --- Helpers ---
 
@@ -534,6 +534,9 @@ def test_single_device_loopback(mesh_device):
         )
 
 
+# Fixed kv_grid rows 8-9, columns 0-8 (see the single-device counterpart): skip where those
+# cores do not exist rather than building an invalid shard grid.
+@pytest.mark.requires_grid_size((9, 10))
 @requires_hybrid_allocator
 def test_kva_width_sharded_bfp4_replicate_data_round_trip(mesh_device):
     """FORMAT + MESH coverage: per-core allocation coexists with WIDTH_SHARDED,
@@ -565,8 +568,11 @@ def test_kva_width_sharded_bfp4_replicate_data_round_trip(mesh_device):
     ]
 
     data = torch.zeros(H, W, dtype=torch.float32)
+    # 2**c rather than consecutive integers: BFP4 quantizes neighbouring integers into each
+    # other, so only well-separated values can distinguish a shard read from the wrong address.
+    # See the single-device counterpart.
     for c in range(num_cores):
-        data[:, c * shard_w : (c + 1) * shard_w] = float(c + 1)
+        data[:, c * shard_w : (c + 1) * shard_w] = float(2**c)
 
     shard_spec = ttnn.ShardSpec(kv_grid, [H, shard_w], ttnn.ShardOrientation.ROW_MAJOR)
     mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
@@ -584,18 +590,23 @@ def test_kva_width_sharded_bfp4_replicate_data_round_trip(mesh_device):
     for dev_idx, dt in enumerate(ttnn.get_device_tensors(tensor)):
         addrs = [_per_core_addr(dt, c) for c in kv_cores]
         result = ttnn.to_torch(ttnn.from_device(dt)).float()
-        zero_shards = []
+        # Check the value, not just non-zeroness: a shard read from the wrong address usually
+        # still holds a neighbour's (nonzero) constant. See the single-device counterpart.
+        bad_shards = []
         for c in range(num_cores):
             block = result[:, c * shard_w : (c + 1) * shard_w]
-            if float(block.abs().mean().item()) < 1e-3:
-                zero_shards.append((c, (kv_cores[c].x, kv_cores[c].y)))
+            expected = float(2**c)
+            max_err = float((block - expected).abs().max().item())
+            if max_err > 1e-3 * expected:
+                bad_shards.append((c, (kv_cores[c].x, kv_cores[c].y), expected, float(block.mean().item())))
         logger.info(
             f"[KVA-MESH] dev{dev_idx} distinct_addrs={len(set(addrs))} "
-            f"zero_shards={len(zero_shards)}/{num_cores} {zero_shards}"
+            f"bad_shards={len(bad_shards)}/{num_cores} {bad_shards}"
         )
-        assert not zero_shards, (
-            f"dev{dev_idx}: {len(zero_shards)}/{num_cores} replicated BFP4 per-core column-shards "
-            f"read ZERO (per-core creation round-trip broken on this device): {zero_shards}"
+        assert not bad_shards, (
+            f"dev{dev_idx}: {len(bad_shards)}/{num_cores} replicated BFP4 per-core column-shards "
+            f"read back the wrong values (per-core creation round-trip broken on this device); "
+            f"(shard, core, expected, actual_mean): {bad_shards}"
         )
 
 

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_multi_device.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_multi_device.py
@@ -582,7 +582,7 @@ def test_kva_width_sharded_bfp4_replicate_data_round_trip(mesh_device):
 
     # per-device per-core addresses + data round-trip
     for dev_idx, dt in enumerate(ttnn.get_device_tensors(tensor)):
-        addrs = [dt.experimental_per_core_buffer_address(c) for c in kv_cores]
+        addrs = [_per_core_addr(dt, c) for c in kv_cores]
         result = ttnn.to_torch(ttnn.from_device(dt)).float()
         zero_shards = []
         for c in range(num_cores):

--- a/tt_metal/api/tt-metalium/experimental/per_core_allocation/buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/per_core_allocation/buffer.hpp
@@ -18,6 +18,14 @@ DeviceAddr get_per_core_address(const Buffer& buffer, CoreCoord core);
 const std::unordered_map<CoreCoord, DeviceAddr>& get_per_core_addresses(const Buffer& buffer);
 void copy_per_core_addresses(Buffer& dst, const Buffer& src);
 
+// Base address of ``buffer``'s shard on ``core``, for either allocation mode.
+//
+// Per-core-allocated buffers give each core an INDEPENDENT shard address, while
+// Buffer::address() returns only cores[0]'s. Host data movement must target the same address
+// the kernel reads, otherwise a relocated core reads/writes at the wrong offset. Falls back to
+// Buffer::address() for ordinary lockstep buffers, so callers need no mode check.
+DeviceAddr get_shard_base_address(const Buffer& buffer, CoreCoord core);
+
 // BufferShardingArgs free functions.
 
 BufferShardingArgs& set_per_core_allocation(BufferShardingArgs& args, bool enable);

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -35,10 +35,23 @@
 #include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 #include <tt_stl/overloaded.hpp>
 #include "tt_metal/api/tt-metalium/experimental/pinned_memory.hpp"
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
 
 namespace tt::tt_metal::buffer_dispatch {
+
+// Per-core-allocated L1 buffers give each core an INDEPENDENT shard address;
+// Buffer::address() is only cores[0]'s address. Host data movement must target
+// the same per-core address the kernel reads via
+// experimental_per_core_buffer_address(core), otherwise relocated cores get
+// their data written/read at the wrong offset.
+inline DeviceAddr per_core_shard_base_address(const Buffer& buffer, const CoreCoord& core) {
+    if (experimental::per_core_allocation::is_per_core_allocation(buffer)) {
+        return experimental::per_core_allocation::get_per_core_address(buffer, core);
+    }
+    return buffer.address();
+}
 
 // ====== Utility Functions for Writes ======
 
@@ -344,8 +357,8 @@ public:
     void reset_params_for_core(const CoreCoord& core, const BufferCorePageMapping& core_page_mapping) {
         this->core = core;
         this->core_page_mapping_it = core_page_mapping.begin();
-        this->address =
-            this->buffer->address() + core_page_mapping.device_start_page * this->buffer->aligned_page_size();
+        this->address = per_core_shard_base_address(*this->buffer, core) +
+                        core_page_mapping.device_start_page * this->buffer->aligned_page_size();
         if (this->buffer->is_dram()) {
             this->address += this->buffer->device()->allocator()->get_bank_offset(
                 BufferType::DRAM, this->buffer->device()->dram_channel_from_logical_core(core));
@@ -705,7 +718,8 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
     const uint32_t noc_xy_addr = buffer.device()->get_noc_unicast_encoding(k_dispatch_downstream_noc, virtual_core);
 
     // Calculate base destination address for this core
-    uint32_t dst_base_address = buffer.address() + (core_page_mapping.device_start_page * buffer.aligned_page_size());
+    uint32_t dst_base_address =
+        per_core_shard_base_address(buffer, core) + (core_page_mapping.device_start_page * buffer.aligned_page_size());
     if (buffer.is_dram()) {
         dst_base_address += buffer.device()->allocator()->get_bank_offset(
             BufferType::DRAM, buffer.device()->dram_channel_from_logical_core(core));
@@ -1242,8 +1256,8 @@ bool write_to_device_buffer(
                         for (const BufferCorePageMapping& core_page_mapping :
                              buffer_page_mapping->core_page_mappings[core_id]) {
                             // Check destination L1 address alignment
-                            uint32_t dst_address =
-                                buffer.address() + (core_page_mapping.device_start_page * buffer.aligned_page_size());
+                            uint32_t dst_address = per_core_shard_base_address(buffer, cores[core_id]) +
+                                                   (core_page_mapping.device_start_page * buffer.aligned_page_size());
                             if (buffer.is_dram()) {
                                 dst_address += buffer.device()->allocator()->get_bank_offset(
                                     BufferType::DRAM, buffer.device()->dram_channel_from_logical_core(cores[core_id]));
@@ -1543,7 +1557,7 @@ void copy_sharded_buffer_from_core_to_completion_queue(
     ttsl::Span<const SubDeviceId> sub_device_ids,
     const CoreCoord core,
     CoreType dispatch_core_type) {
-    auto address = buffer.address();
+    auto address = per_core_shard_base_address(buffer, core);
 
     if (buffer.is_dram()) {
         address += buffer.device()->allocator()->get_bank_offset(

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -41,17 +41,7 @@
 
 namespace tt::tt_metal::buffer_dispatch {
 
-// Per-core-allocated L1 buffers give each core an INDEPENDENT shard address;
-// Buffer::address() is only cores[0]'s address. Host data movement must target
-// the same per-core address the kernel reads via
-// experimental_per_core_buffer_address(core), otherwise relocated cores get
-// their data written/read at the wrong offset.
-inline DeviceAddr per_core_shard_base_address(const Buffer& buffer, const CoreCoord& core) {
-    if (experimental::per_core_allocation::is_per_core_allocation(buffer)) {
-        return experimental::per_core_allocation::get_per_core_address(buffer, core);
-    }
-    return buffer.address();
-}
+using experimental::per_core_allocation::get_shard_base_address;
 
 // ====== Utility Functions for Writes ======
 
@@ -357,7 +347,7 @@ public:
     void reset_params_for_core(const CoreCoord& core, const BufferCorePageMapping& core_page_mapping) {
         this->core = core;
         this->core_page_mapping_it = core_page_mapping.begin();
-        this->address = per_core_shard_base_address(*this->buffer, core) +
+        this->address = get_shard_base_address(*this->buffer, core) +
                         core_page_mapping.device_start_page * this->buffer->aligned_page_size();
         if (this->buffer->is_dram()) {
             this->address += this->buffer->device()->allocator()->get_bank_offset(
@@ -719,7 +709,7 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
 
     // Calculate base destination address for this core
     uint32_t dst_base_address =
-        per_core_shard_base_address(buffer, core) + (core_page_mapping.device_start_page * buffer.aligned_page_size());
+        get_shard_base_address(buffer, core) + (core_page_mapping.device_start_page * buffer.aligned_page_size());
     if (buffer.is_dram()) {
         dst_base_address += buffer.device()->allocator()->get_bank_offset(
             BufferType::DRAM, buffer.device()->dram_channel_from_logical_core(core));
@@ -1256,7 +1246,7 @@ bool write_to_device_buffer(
                         for (const BufferCorePageMapping& core_page_mapping :
                              buffer_page_mapping->core_page_mappings[core_id]) {
                             // Check destination L1 address alignment
-                            uint32_t dst_address = per_core_shard_base_address(buffer, cores[core_id]) +
+                            uint32_t dst_address = get_shard_base_address(buffer, cores[core_id]) +
                                                    (core_page_mapping.device_start_page * buffer.aligned_page_size());
                             if (buffer.is_dram()) {
                                 dst_address += buffer.device()->allocator()->get_bank_offset(
@@ -1557,7 +1547,7 @@ void copy_sharded_buffer_from_core_to_completion_queue(
     ttsl::Span<const SubDeviceId> sub_device_ids,
     const CoreCoord core,
     CoreType dispatch_core_type) {
-    auto address = per_core_shard_base_address(buffer, core);
+    auto address = get_shard_base_address(buffer, core);
 
     if (buffer.is_dram()) {
         address += buffer.device()->allocator()->get_bank_offset(

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -67,6 +67,7 @@
 #include <experimental/fabric/control_plane.hpp>
 #include "impl/buffers/circular_buffer.hpp"
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include <internal/service/service_core_manager.hpp>
 
 #ifdef TT_METAL_USE_EMULE
@@ -553,6 +554,17 @@ void print_page(
     std::cout << std::dec << std::endl;
 }
 
+// Per-core-allocated L1 buffers give each core an INDEPENDENT shard address;
+// buffer.address() is only cores[0]'s address. Slow-dispatch host data movement
+// must target the same per-core address the kernel reads via
+// experimental_per_core_buffer_address(core).
+inline DeviceAddr per_core_or_uniform_base(const Buffer& buffer, const CoreCoord& logical_core) {
+    if (experimental::per_core_allocation::is_per_core_allocation(buffer)) {
+        return experimental::per_core_allocation::get_per_core_address(buffer, logical_core);
+    }
+    return buffer.address();
+}
+
 void WriteToDeviceSharded(
     Buffer& buffer, ttsl::Span<const uint8_t> host_buffer, const CoreRangeSet* logical_core_filter) {
     TT_FATAL(
@@ -592,8 +604,8 @@ void WriteToDeviceSharded(
             }
             std::span<const std::uint8_t> page(host_buffer.data() + data_index + offset, size_in_bytes);
             if (buffer.is_l1()) {
-                auto absolute_address =
-                    buffer.address() + bank_offset + (write_device_page * buffer.aligned_page_size()) + offset;
+                auto absolute_address = per_core_or_uniform_base(buffer, core) + bank_offset +
+                                        (write_device_page * buffer.aligned_page_size()) + offset;
                 auto core_coordinates =
                     device->worker_core_from_logical_core(buffer.allocator()->get_logical_core_from_bank_id(bank_id));
                 MetalContext::instance().get_cluster().write_core(
@@ -781,10 +793,11 @@ void read_pages_to_host_helper(
     size_t aligned_page_size = tt::align(page_size, cluster.get_alignment_requirements(device->id(), page_size));
 
     if (dev_buffer.is_l1()) {
-        auto core_coordinates =
-            device->worker_core_from_logical_core(dev_buffer.allocator()->get_logical_core_from_bank_id(bank_id));
+        auto logical_core = dev_buffer.allocator()->get_logical_core_from_bank_id(bank_id);
+        auto core_coordinates = device->worker_core_from_logical_core(logical_core);
         auto bank_offset = device->allocator()->get_bank_offset(dev_buffer.buffer_type(), bank_id);
-        auto absolute_address = dev_buffer.address() + bank_offset + (core_page_id * dev_buffer.aligned_page_size());
+        auto absolute_address = per_core_or_uniform_base(dev_buffer, logical_core) + bank_offset +
+                                (core_page_id * dev_buffer.aligned_page_size());
         if (aligned_page_size > page_size) {
             std::vector<uint8_t> page(aligned_page_size);
             MetalContext::instance().get_cluster().read_core(

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -554,16 +554,7 @@ void print_page(
     std::cout << std::dec << std::endl;
 }
 
-// Per-core-allocated L1 buffers give each core an INDEPENDENT shard address;
-// buffer.address() is only cores[0]'s address. Slow-dispatch host data movement
-// must target the same per-core address the kernel reads via
-// experimental_per_core_buffer_address(core).
-inline DeviceAddr per_core_or_uniform_base(const Buffer& buffer, const CoreCoord& logical_core) {
-    if (experimental::per_core_allocation::is_per_core_allocation(buffer)) {
-        return experimental::per_core_allocation::get_per_core_address(buffer, logical_core);
-    }
-    return buffer.address();
-}
+using experimental::per_core_allocation::get_shard_base_address;
 
 void WriteToDeviceSharded(
     Buffer& buffer, ttsl::Span<const uint8_t> host_buffer, const CoreRangeSet* logical_core_filter) {
@@ -604,7 +595,7 @@ void WriteToDeviceSharded(
             }
             std::span<const std::uint8_t> page(host_buffer.data() + data_index + offset, size_in_bytes);
             if (buffer.is_l1()) {
-                auto absolute_address = per_core_or_uniform_base(buffer, core) + bank_offset +
+                auto absolute_address = get_shard_base_address(buffer, core) + bank_offset +
                                         (write_device_page * buffer.aligned_page_size()) + offset;
                 auto core_coordinates =
                     device->worker_core_from_logical_core(buffer.allocator()->get_logical_core_from_bank_id(bank_id));
@@ -796,7 +787,7 @@ void read_pages_to_host_helper(
         auto logical_core = dev_buffer.allocator()->get_logical_core_from_bank_id(bank_id);
         auto core_coordinates = device->worker_core_from_logical_core(logical_core);
         auto bank_offset = device->allocator()->get_bank_offset(dev_buffer.buffer_type(), bank_id);
-        auto absolute_address = per_core_or_uniform_base(dev_buffer, logical_core) + bank_offset +
+        auto absolute_address = get_shard_base_address(dev_buffer, logical_core) + bank_offset +
                                 (core_page_id * dev_buffer.aligned_page_size());
         if (aligned_page_size > page_size) {
             std::vector<uint8_t> page(aligned_page_size);

--- a/tt_metal/impl/per_core_allocation/buffer.cpp
+++ b/tt_metal/impl/per_core_allocation/buffer.cpp
@@ -21,6 +21,13 @@ const std::unordered_map<CoreCoord, DeviceAddr>& get_per_core_addresses(const Bu
     return buffer.per_core_addresses_;
 }
 
+DeviceAddr get_shard_base_address(const Buffer& buffer, CoreCoord core) {
+    if (is_per_core_allocation(buffer)) {
+        return get_per_core_address(buffer, core);
+    }
+    return buffer.address();
+}
+
 void copy_per_core_addresses(Buffer& dst, const Buffer& src) {
     TT_FATAL(
         dst.per_core_allocation_ && src.per_core_allocation_,


### PR DESCRIPTION
Per-core-allocated L1 buffers give every core an **independent** shard address, but
`Buffer::address()` returns only `cores[0]`'s. Kernels already did the right thing and read
each core's shard via `get_per_core_address()`. Host data movement did not — it computed
`buffer.address() + page_offset` for every core.

Host and device therefore disagreed about where a core's data lives. Whenever a core's real
per-core address sat below `cores[0]`'s by more than the write's page span, the host wrote the
bytes somewhere the kernel never looked, and the kernel read whatever was already in L1 —
typically zeros. In a dense attention run this showed up as 16 of 18 `kv_a` cores reading zero
and poisoning the KV cache with infinities.

Host round-trips cannot detect this, which is why it went unnoticed: `from_torch`/`to_torch`
use the same incorrect scalar on both sides, so the error cancels. Catching it requires an
asymmetric test where a kernel reads at the per-core address while the host writes through the
data-movement path.

The fix resolves the per-core address on both host paths:

| path | file | helper |
|---|---|---|
| fast dispatch | `tt_metal/impl/buffers/dispatch.cpp` | `per_core_shard_base_address()`, 3 call sites |
| slow dispatch | `tt_metal/impl/host_api/tt_metal.cpp` | `per_core_or_uniform_base()`, write + read |

Both helpers are gated on `is_per_core_allocation(buffer)` and fall through to
`buffer.address()` otherwise, so **lockstep buffers are byte-for-byte unaffected**.

Three tests are added: a kernel-readback regression guard, a BFP4/TILE/WIDTH-sharded per-core
creation round-trip, and a multi-device replicated variant.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kwerblinskiTT/per-core-host-dma-addressing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kwerblinskiTT/per-core-host-dma-addressing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kwerblinskiTT/per-core-host-dma-addressing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kwerblinskiTT/per-core-host-dma-addressing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kwerblinskiTT/per-core-host-dma-addressing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kwerblinskiTT/per-core-host-dma-addressing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kwerblinskiTT/per-core-host-dma-addressing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kwerblinskiTT/per-core-host-dma-addressing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kwerblinskiTT/per-core-host-dma-addressing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kwerblinskiTT/per-core-host-dma-addressing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kwerblinskiTT/per-core-host-dma-addressing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kwerblinskiTT/per-core-host-dma-addressing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kwerblinskiTT/per-core-host-dma-addressing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kwerblinskiTT/per-core-host-dma-addressing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kwerblinskiTT/per-core-host-dma-addressing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kwerblinskiTT/per-core-host-dma-addressing)