### PR TITLE
[Bug fix] Avoid use of hard-coded bfloat16 intermediate CBs in Layernorm

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -1055,19 +1055,16 @@ def test_layernorm_pre_all_gather_welford_fp32_precision(device, inp_shape, offs
     )
 
 
-@pytest.mark.parametrize("fast_and_approximate_mode", [False, True], ids=["sfpu_accurate", "fpu_fast_approx"])
+@pytest.mark.parametrize("variant", ["layer_norm", "rms_norm", "rms_norm_2d"])
 @pytest.mark.parametrize("use_residual", [False, True])
-@pytest.mark.parametrize("inp_shape", [(1, 1, 32, 128)])
-def test_layernorm_pre_all_gather_non_welford_fp32_precision(
-    device, inp_shape, use_residual, fast_and_approximate_mode
-):
-    """Non-Welford Float32 pre_all_gather vs fp64 reference for both SFPU and FPU paths."""
+@pytest.mark.parametrize("fast_and_approximate_mode", [False, True], ids=["sfpu_accurate", "fpu_fast_approx"])
+def test_pre_all_gather_non_welford_fp32_precision(device, variant, use_residual, fast_and_approximate_mode):
+    """Float32 non-Welford pre_all_gather stats vs an fp64 reference."""
     torch.manual_seed(0)
-    torch_input = torch.randn(inp_shape, dtype=torch.float32)
-    torch_residual = torch.randn(inp_shape, dtype=torch.float32) if use_residual else None
-    combined = torch_input + torch_residual if use_residual else torch_input
-    ref_sumx2 = combined.to(torch.float64).pow(2).sum(dim=-1)
-    ref_sumx = combined.to(torch.float64).sum(dim=-1)
+    shape = (1, 1, 32, 128)
+    torch_input = torch.randn(shape, dtype=torch.float32)
+    torch_residual = torch.randn(shape, dtype=torch.float32) if use_residual else None
+    golden = torch_input + torch_residual if use_residual else torch_input
 
     kernel_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
@@ -1075,47 +1072,78 @@ def test_layernorm_pre_all_gather_non_welford_fp32_precision(
         fp32_dest_acc_en=True,
         packer_l1_acc=True,
     )
-    tt_inp = ttnn.from_torch(
+    tt_input = ttnn.from_torch(
         torch_input,
         dtype=ttnn.float32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    residual_kwargs = {}
+    tt_residual = None
     if use_residual:
-        residual_kwargs["residual_input_tensor"] = ttnn.from_torch(
+        tt_residual = ttnn.from_torch(
             torch_residual,
             dtype=ttnn.float32,
             device=device,
             layout=ttnn.TILE_LAYOUT,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
-    actual = ttnn.to_torch(
-        ttnn_layer_norm_pre_all_gather(
-            tt_inp,
+
+    if variant == "layer_norm":
+        tt_out = ttnn_layer_norm_pre_all_gather(
+            tt_input,
             dtype=ttnn.float32,
             compute_kernel_config=kernel_config,
             fast_and_approximate_mode=fast_and_approximate_mode,
-            **residual_kwargs,
+            residual_input_tensor=tt_residual,
         )
-    )
-    # Non-Welford layout: col 0 = sum(x^2), col 32 = sum(x).
-    tt_sumx2 = actual[..., 0].to(torch.float64).squeeze(-1)
-    tt_sumx = actual[..., 32].to(torch.float64).squeeze(-1)
-
-    # SFPU Accurate gets tight thresholds; FPU/TF32 is lossy so tolerances are looser.
-    if fast_and_approximate_mode:
-        rtol, atol, frob, pcc = 2e-3, 0.75, 2e-3, 0.99999
     else:
-        rtol, atol, frob, pcc = 1e-5, 1e-5, 1e-5, 0.99999
+        tt_out = ttnn_rms_norm_pre_all_gather(
+            tt_input,
+            dtype=ttnn.float32,
+            compute_kernel_config=kernel_config,
+            fast_and_approximate_mode=fast_and_approximate_mode,
+            residual_input_tensor=tt_residual,
+            use_2d_core_grid=(variant == "rms_norm_2d"),
+        )
+    actual = ttnn.to_torch(tt_out)
 
-    for ref, out in ((ref_sumx2, tt_sumx2), (ref_sumx, tt_sumx)):
-        assert_numeric_metrics(ref, out, rtol=rtol, atol=atol, frobenius_threshold=frob, pcc_threshold=pcc)
+    # Quasar always takes the FPU path, even when fast_and_approximate_mode=False.
+    if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR:
+        rtol, atol, frob = 2e-3, 0.75, 2e-3
+    else:
+        rtol, atol, frob = 1e-5, 1e-5, 1e-5
+
+    # col 0 = sum(x^2); layernorm also stores sum(x) at col 32.
+    ref_sumx2 = golden.to(torch.float64).pow(2).sum(dim=-1)
+    tt_sumx2 = actual[..., 0].to(torch.float64).squeeze(-1)
+    assert_numeric_metrics(
+        ref_sumx2,
+        tt_sumx2,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frob,
+        pcc_threshold=0.99999,
+    )
+    if variant == "layer_norm":
+        ref_sumx = golden.to(torch.float64).sum(dim=-1)
+        tt_sumx = actual[..., 32].to(torch.float64).squeeze(-1)
+        assert_numeric_metrics(
+            ref_sumx,
+            tt_sumx,
+            rtol=rtol,
+            atol=atol,
+            frobenius_threshold=frob,
+            pcc_threshold=0.99999,
+        )
 
 
-@pytest.mark.parametrize("inp_shape", [(1, 1, 32, 128)])
-def test_layernorm_pre_all_gather_non_welford_fp32_requires_fp32_dest_acc(device, inp_shape, expect_error):
+@pytest.mark.parametrize(
+    "op",
+    [ttnn.layer_norm_pre_all_gather, ttnn.rms_norm_pre_all_gather],
+    ids=["layer_norm", "rms_norm"],
+)
+def test_pre_all_gather_non_welford_fp32_requires_fp32_dest_acc(device, op, expect_error):
     """fp32 in without fp32_dest_acc_en would silently truncate in the unpacker, so it is a hard
     error rather than a quiet fallback."""
     kernel_config = ttnn.init_device_compute_kernel_config(
@@ -1125,11 +1153,11 @@ def test_layernorm_pre_all_gather_non_welford_fp32_requires_fp32_dest_acc(device
         packer_l1_acc=True,
     )
     tt_inp = ttnn.from_torch(
-        torch.randn(inp_shape, dtype=torch.float32),
+        torch.randn((1, 1, 32, 128), dtype=torch.float32),
         dtype=ttnn.float32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     with expect_error(RuntimeError, "requires fp32_dest_acc_en=true"):
-        ttnn_layer_norm_pre_all_gather(tt_inp, dtype=ttnn.float32, compute_kernel_config=kernel_config)
+        op(tt_inp, dtype=ttnn.float32, compute_kernel_config=kernel_config)

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -1053,3 +1053,83 @@ def test_layernorm_pre_all_gather_welford_fp32_precision(device, inp_shape, offs
         f"--- MEAN: {'PASSED' if mean_passed else 'FAILED'} ---\n{mean_msg}\n"
         f"--- VARIANCE: {'PASSED' if var_passed else 'FAILED'} ---\n{var_msg}"
     )
+
+
+@pytest.mark.parametrize("fast_and_approximate_mode", [False, True], ids=["sfpu_accurate", "fpu_fast_approx"])
+@pytest.mark.parametrize("use_residual", [False, True])
+@pytest.mark.parametrize("inp_shape", [(1, 1, 32, 128)])
+def test_layernorm_pre_all_gather_non_welford_fp32_precision(
+    device, inp_shape, use_residual, fast_and_approximate_mode
+):
+    """Non-Welford Float32 pre_all_gather vs fp64 reference for both SFPU and FPU paths."""
+    torch.manual_seed(0)
+    torch_input = torch.randn(inp_shape, dtype=torch.float32)
+    torch_residual = torch.randn(inp_shape, dtype=torch.float32) if use_residual else None
+    combined = torch_input + torch_residual if use_residual else torch_input
+    ref_sumx2 = combined.to(torch.float64).pow(2).sum(dim=-1)
+    ref_sumx = combined.to(torch.float64).sum(dim=-1)
+
+    kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+    tt_inp = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    residual_kwargs = {}
+    if use_residual:
+        residual_kwargs["residual_input_tensor"] = ttnn.from_torch(
+            torch_residual,
+            dtype=ttnn.float32,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+    actual = ttnn.to_torch(
+        ttnn_layer_norm_pre_all_gather(
+            tt_inp,
+            dtype=ttnn.float32,
+            compute_kernel_config=kernel_config,
+            fast_and_approximate_mode=fast_and_approximate_mode,
+            **residual_kwargs,
+        )
+    )
+    # Non-Welford layout: col 0 = sum(x^2), col 32 = sum(x).
+    tt_sumx2 = actual[..., 0].to(torch.float64).squeeze(-1)
+    tt_sumx = actual[..., 32].to(torch.float64).squeeze(-1)
+
+    # SFPU Accurate gets tight thresholds; FPU/TF32 is lossy so tolerances are looser.
+    if fast_and_approximate_mode:
+        rtol, atol, frob, pcc = 2e-3, 0.75, 2e-3, 0.99999
+    else:
+        rtol, atol, frob, pcc = 1e-5, 1e-5, 1e-5, 0.99999
+
+    for ref, out in ((ref_sumx2, tt_sumx2), (ref_sumx, tt_sumx)):
+        assert_numeric_metrics(ref, out, rtol=rtol, atol=atol, frobenius_threshold=frob, pcc_threshold=pcc)
+
+
+@pytest.mark.parametrize("inp_shape", [(1, 1, 32, 128)])
+def test_layernorm_pre_all_gather_non_welford_fp32_requires_fp32_dest_acc(device, inp_shape, expect_error):
+    """fp32 in without fp32_dest_acc_en would silently truncate in the unpacker, so it is a hard
+    error rather than a quiet fallback."""
+    kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+    tt_inp = ttnn.from_torch(
+        torch.randn(inp_shape, dtype=torch.float32),
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with expect_error(RuntimeError, "requires fp32_dest_acc_en=true"):
+        ttnn_layer_norm_pre_all_gather(tt_inp, dtype=ttnn.float32, compute_kernel_config=kernel_config)

--- a/ttnn/cpp/ttnn/operations/normalization/kernel_util/compute/pre_add.h
+++ b/ttnn/cpp/ttnn/operations/normalization/kernel_util/compute/pre_add.h
@@ -11,6 +11,8 @@
 #pragma once
 
 #include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/tile_move_copy.h"
 #include "api/dataflow/dataflow_buffer.h"
 
 namespace norm::kernel_util::compute::pre_add {
@@ -18,8 +20,12 @@ namespace norm::kernel_util::compute::pre_add {
 /**
  * Perform fused pre-add for one H row: dfb_inp = dfb_in0 + dfb_res for Wt tiles,
  * processed in blocks of blk tiles. Compile-time no-op when !fuse_pre_add.
+ *
+ * When unpack_fp32_active, adds on the SFPU: copy_tile brings both operands into DEST at full
+ * fp32, and add_binary_tile adds them there. FPU add_tiles reads its operands from SrcA/SrcB
+ * instead, and the unpacker rounds fp32 down to tf32 when it loads those registers.
  */
-template <bool fuse_pre_add>
+template <bool fuse_pre_add, bool unpack_fp32_active = false>
 ALWI void one_row(
     DataflowBuffer& dfb_in0, DataflowBuffer& dfb_res, DataflowBuffer& dfb_inp, uint32_t Wt, uint32_t blk) {
     if constexpr (!fuse_pre_add) {
@@ -27,19 +33,41 @@ ALWI void one_row(
     }
     reconfig_data_format(dfb_in0.get_id(), dfb_res.get_id());
     pack_reconfig_data_format(dfb_inp.get_id());
-    add_init(dfb_in0.get_id(), dfb_res.get_id());
+    if constexpr (unpack_fp32_active) {
+        copy_tile_to_dst_init_short(dfb_in0.get_id());
+        add_binary_tile_init();
+    } else {
+        add_init(dfb_in0.get_id(), dfb_res.get_id());
+    }
     for (uint32_t wt = 0; wt < Wt; wt += blk) {
         dfb_in0.wait_front(blk);
         dfb_res.wait_front(blk);
         dfb_inp.reserve_back(blk);
-        tile_regs_acquire();
-        tile_regs_wait();
-        for (uint32_t wtr = 0; wtr < blk; wtr++) {
-            add_tiles(dfb_in0.get_id(), dfb_res.get_id(), wtr, wtr, wtr);
-            pack_tile(wtr, dfb_inp.get_id());
+        if constexpr (unpack_fp32_active) {
+            for (uint32_t wtr = 0; wtr < blk; wtr++) {
+                tile_regs_acquire();
+                copy_tile(dfb_in0.get_id(), wtr, 0);
+                copy_tile_to_dst_init_short_with_dt(dfb_in0.get_id(), dfb_res.get_id());
+                copy_tile(dfb_res.get_id(), wtr, 1);
+                add_binary_tile(0, 1, 0);
+                tile_regs_commit();
+                tile_regs_wait();
+                pack_tile(0, dfb_inp.get_id());
+                tile_regs_release();
+                // Restore SrcA to dfb_in0's format for the next tile's first copy_tile; the
+                // residual CB may carry a different dtype than the input.
+                copy_tile_to_dst_init_short_with_dt(dfb_res.get_id(), dfb_in0.get_id());
+            }
+        } else {
+            tile_regs_acquire();
+            tile_regs_wait();
+            for (uint32_t wtr = 0; wtr < blk; wtr++) {
+                add_tiles(dfb_in0.get_id(), dfb_res.get_id(), wtr, wtr, wtr);
+                pack_tile(wtr, dfb_inp.get_id());
+            }
+            tile_regs_commit();
+            tile_regs_release();
         }
-        tile_regs_commit();
-        tile_regs_release();
         dfb_inp.push_back(blk);
         dfb_in0.pop_front(blk);
         dfb_res.pop_front(blk);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
@@ -15,6 +15,8 @@
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/layernorm.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/compute_kernel_api.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/operations/normalization/kernel_util/compute/pre_add.h"
 #include "experimental/kernel_args.h"
@@ -34,6 +36,10 @@ void kernel_main() {
     const auto NCHt = get_arg(args::NCHt);
     constexpr auto Wt = get_arg(args::Wt);
     constexpr auto blk = get_arg(args::blk);
+    constexpr bool unpack_fp32_active = get_arg(args::unpack_fp32_active) != 0;
+    // Accurate mode only supports SUM; with the reader's scaler of 1.0, SUM and AVG are equivalent.
+    constexpr auto reduce_type = unpack_fp32_active ? PoolType::SUM : PoolType::AVG;
+    constexpr auto reduce_fp32_mode = unpack_fp32_active ? ReduceFp32Mode::Accurate : ReduceFp32Mode::Fast;
 
     constexpr uint32_t onetile = 1;
 
@@ -54,7 +60,7 @@ void kernel_main() {
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         // Fuse pre-add: dfb_inp = dfb::in0 + dfb::res (absent entirely when there is no residual)
 #ifdef FUSE_PRE_ADD
-        pre_add::one_row<true>(dfb_in0, dfb_res, dfb_inp, Wt, blk);
+        pre_add::one_row<true, unpack_fp32_active>(dfb_in0, dfb_res, dfb_inp, Wt, blk);
 #endif
 
         /*
@@ -62,23 +68,38 @@ void kernel_main() {
          */
         reconfig_data_format(dfb_inp_id, dfb_inp_id);
         pack_reconfig_data_format(dfb::x2);
-        mul_init(dfb_inp_id, dfb_inp_id);
+        if constexpr (unpack_fp32_active) {
+            copy_tile_to_dst_init_short(dfb_inp_id);
+            square_tile_init();
+        } else {
+            mul_init(dfb_inp_id, dfb_inp_id);
+        }
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             dfb_inp.wait_front(wt + blk);  // cumulative wait
-
-            tile_regs_acquire();
-            for (uint32_t wtr = 0; wtr < blk; wtr++) {
-                mul_tiles(dfb_inp_id, dfb_inp_id, wt + wtr, wt + wtr, wtr);
-            }
-            tile_regs_commit();
-
             dfb_x2.reserve_back(blk);
 
-            tile_regs_wait();
-            for (uint32_t wtr = 0; wtr < blk; wtr++) {
-                pack_tile(wtr, dfb::x2, wt + wtr);
+            if constexpr (unpack_fp32_active) {
+                for (uint32_t wtr = 0; wtr < blk; wtr++) {
+                    tile_regs_acquire();
+                    copy_tile(dfb_inp_id, wt + wtr, 0);
+                    square_tile(0);
+                    tile_regs_commit();
+                    tile_regs_wait();
+                    pack_tile(0, dfb::x2, wt + wtr);
+                    tile_regs_release();
+                }
+            } else {
+                tile_regs_acquire();
+                for (uint32_t wtr = 0; wtr < blk; wtr++) {
+                    mul_tiles(dfb_inp_id, dfb_inp_id, wt + wtr, wt + wtr, wtr);
+                }
+                tile_regs_commit();
+                tile_regs_wait();
+                for (uint32_t wtr = 0; wtr < blk; wtr++) {
+                    pack_tile(wtr, dfb::x2, wt + wtr);
+                }
+                tile_regs_release();
             }
-            tile_regs_release();
 
             dfb_x2.push_back(blk);
         }
@@ -89,12 +110,14 @@ void kernel_main() {
         // BulkWaitBulkPop: All Wt tiles already in the buffer (see cumulative wait above)
         // Bulk mode for optimal performance
         compute_kernel_lib::reduce<
-            PoolType::AVG,
+            reduce_type,
             ReduceDim::REDUCE_ROW,
             dfb::x2,
             dfb::reduce,
             dfb::out,
-            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop,
+            compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT_AND_OUTPUT,
+            reduce_fp32_mode>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
 
         /*
          * sum(x)
@@ -102,12 +125,14 @@ void kernel_main() {
         // BulkWaitBulkPop: All Wt tiles already in the buffer (see cumulative wait above)
         // Bulk mode for optimal performance
         compute_kernel_lib::reduce<
-            PoolType::AVG,
+            reduce_type,
             ReduceDim::REDUCE_ROW,
             dfb_inp_id,
             dfb::reduce,
             dfb::out,
-            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop,
+            compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT_AND_OUTPUT,
+            reduce_fp32_mode>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
     }
     dfb_reduce.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_2d.cpp
@@ -13,6 +13,8 @@ For rmsnorm it computes E(x**2) and returns it as a one tile wide output
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/layernorm.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/compute_kernel_api.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/operations/normalization/kernel_util/compute/pre_add.h"
 #include "experimental/kernel_args.h"
@@ -33,6 +35,10 @@ void kernel_main() {
     constexpr auto Wt = get_arg(args::Wt);
     constexpr auto blk = get_arg(args::blk);
     constexpr auto num_cores_y = get_arg(args::num_cores_y);
+    constexpr bool unpack_fp32_active = get_arg(args::unpack_fp32_active) != 0;
+    // Accurate mode only supports SUM; with the reader's scaler of 1.0, SUM and AVG are equivalent.
+    constexpr auto reduce_type = unpack_fp32_active ? PoolType::SUM : PoolType::AVG;
+    constexpr auto reduce_fp32_mode = unpack_fp32_active ? ReduceFp32Mode::Accurate : ReduceFp32Mode::Fast;
 
     constexpr uint32_t onetile = 1;
 
@@ -56,7 +62,7 @@ void kernel_main() {
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         // Fuse pre-add: dfb_inp = dfb::in0 + dfb::res (absent entirely when there is no residual)
 #ifdef FUSE_PRE_ADD
-        pre_add::one_row<true>(dfb_in0, dfb_res, dfb_inp, Wt, blk);
+        pre_add::one_row<true, unpack_fp32_active>(dfb_in0, dfb_res, dfb_inp, Wt, blk);
 #endif
 
         /*
@@ -64,24 +70,39 @@ void kernel_main() {
          */
         reconfig_data_format(dfb_inp_id, dfb_inp_id);
         pack_reconfig_data_format(dfb::x2);
-        mul_init(dfb_inp_id, dfb_inp_id);
+        if constexpr (unpack_fp32_active) {
+            copy_tile_to_dst_init_short(dfb_inp_id);
+            square_tile_init();
+        } else {
+            mul_init(dfb_inp_id, dfb_inp_id);
+        }
 
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             dfb_inp.wait_front(wt + blk);  // cumulative wait
-
-            tile_regs_acquire();
-            for (uint32_t wtr = 0; wtr < blk; wtr++) {
-                mul_tiles(dfb_inp_id, dfb_inp_id, wt + wtr, wt + wtr, wtr);
-            }
-            tile_regs_commit();
-
             dfb_x2.reserve_back(blk);
 
-            tile_regs_wait();
-            for (uint32_t wtr = 0; wtr < blk; wtr++) {
-                pack_tile(wtr, dfb::x2, wt + wtr);
+            if constexpr (unpack_fp32_active) {
+                for (uint32_t wtr = 0; wtr < blk; wtr++) {
+                    tile_regs_acquire();
+                    copy_tile(dfb_inp_id, wt + wtr, 0);
+                    square_tile(0);
+                    tile_regs_commit();
+                    tile_regs_wait();
+                    pack_tile(0, dfb::x2, wt + wtr);
+                    tile_regs_release();
+                }
+            } else {
+                tile_regs_acquire();
+                for (uint32_t wtr = 0; wtr < blk; wtr++) {
+                    mul_tiles(dfb_inp_id, dfb_inp_id, wt + wtr, wt + wtr, wtr);
+                }
+                tile_regs_commit();
+                tile_regs_wait();
+                for (uint32_t wtr = 0; wtr < blk; wtr++) {
+                    pack_tile(wtr, dfb::x2, wt + wtr);
+                }
+                tile_regs_release();
             }
-            tile_regs_release();
 
             dfb_x2.push_back(blk);
         }
@@ -91,12 +112,14 @@ void kernel_main() {
          */
         // BulkWaitBulkPop: All Wt tiles already in the buffer (see cumulative wait above)
         compute_kernel_lib::reduce<
-            PoolType::AVG,
+            reduce_type,
             ReduceDim::REDUCE_ROW,
             dfb::x2,
             dfb::reduce,
             dfb::out,
-            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop,
+            compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT_AND_OUTPUT,
+            reduce_fp32_mode>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
         dfb_inp.pop_front(Wt);
         dfb_reduce.pop_front(1);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_2d.cpp
@@ -12,6 +12,7 @@ For rmsnorm it computes E(x**2) and returns it as a one tile wide output
 #include "api/compute/reduce.h"
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_binary_sfpu.h"
 #include "api/compute/layernorm.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/compute_kernel_api.h"
@@ -142,12 +143,26 @@ void kernel_main() {
         compute_kernel_hw_startup(dfb::x2_merge, dfb::zero, dfb::out_final);
         reconfig_data_format(dfb::x2_merge, dfb::zero);
         pack_reconfig_data_format(dfb::out_final);
-        add_init(dfb::x2_merge, dfb::zero, true);
+        // Add all the column's partials together. The accurate path sums them in Dest on the SFPU;
+        // add_tiles would pull each through SrcA/SrcB and round it to TF32.
+        if constexpr (unpack_fp32_active) {
+            copy_tile_to_dst_init_short(dfb::x2_merge);
+            add_binary_tile_init();
+        } else {
+            add_init(dfb::x2_merge, dfb::zero, true);
+        }
 
         tile_regs_acquire();
-        // Add all the column's partials together
-        for (uint32_t i = 0; i < num_cores_y; i++) {
-            add_tiles(dfb::x2_merge, dfb::zero, i, 0, dst0);
+        if constexpr (unpack_fp32_active) {
+            copy_tile(dfb::x2_merge, 0, dst0);
+            for (uint32_t i = 1; i < num_cores_y; i++) {
+                copy_tile(dfb::x2_merge, i, dst0 + 1);
+                add_binary_tile(dst0, dst0 + 1, dst0);
+            }
+        } else {
+            for (uint32_t i = 0; i < num_cores_y; i++) {
+                add_tiles(dfb::x2_merge, dfb::zero, i, 0, dst0);
+            }
         }
         tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_layernorm_preallgather_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_layernorm_preallgather_2d.cpp
@@ -28,8 +28,6 @@ void kernel_main() {
     const auto reduce_core_noc_y = get_arg(args::reduce_core_noc_y);
     const auto y = get_arg(args::y);
 
-    const uint32_t TILE_SIZE = 32 * 32;
-    const uint32_t BF16_TILE_BYTES = 2 * TILE_SIZE;
     const uint32_t onetile = 1;
 
     constexpr auto blk = get_arg(args::blk);
@@ -107,7 +105,8 @@ void kernel_main() {
     // wait on the partial output and then write it to the merge core over the NoC
     dfb_out_buf.wait_front(onetile);
 
-    uint32_t o_write_size = BF16_TILE_BYTES;
+    // Partial statistics use the intermediate format, which is Float32 with fp32_dest_acc_en.
+    uint32_t o_write_size = dfb_out_buf.get_tile_size();
     uint32_t worker_offset = o_write_size * y;
 
     UnicastEndpoint reduce_ep;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.cpp
@@ -45,6 +45,13 @@ void LayerNormPreAllGatherDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Operands to layernorm need to be on device!");
     TT_FATAL(input.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
 
+    // Op-level invariant, so it lives here rather than in each program factory.
+    TT_FATAL(
+        !(input.dtype() == DataType::FLOAT32 && !args.compute_kernel_config.fp32_dest_acc_en),
+        "{}_pre_all_gather with Float32 input requires fp32_dest_acc_en=true in the compute kernel "
+        "config; otherwise precision is silently lost in the unpacker format conversion.",
+        args.norm_type == LayerNormDistributedType::RMSNORM ? "rms_norm" : "layer_norm");
+
     // Additional validation for Welford - requires recip_tensor
     if (std::holds_alternative<LayerNormDefaultProgramConfig>(args.program_config)) {
         const auto& program_config = std::get<LayerNormDefaultProgramConfig>(args.program_config);
@@ -103,7 +110,8 @@ Tensor layer_norm_pre_all_gather(
     const std::optional<tt::tt_metal::DataType>& dtype,
     const DeviceComputeKernelConfig& compute_kernel_config,
     const LayerNormProgramConfig& program_config,
-    const std::optional<bool>& use_2d_core_grid) {
+    const std::optional<bool>& use_2d_core_grid,
+    bool fast_and_approximate_mode) {
     using OperationType = LayerNormPreAllGatherDeviceOperation;
 
     // Validate the residual before fill_implicit_tile_padding so a malformed residual surfaces
@@ -141,6 +149,7 @@ Tensor layer_norm_pre_all_gather(
             .compute_kernel_config = compute_kernel_config,
             .program_config = program_config,
             .use_2d_core_grid = use_2d_core_grid,
+            .fast_and_approximate_mode = fast_and_approximate_mode,
         },
         OperationType::tensor_args_t{
             .input = input_padded,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.hpp
@@ -70,6 +70,7 @@ Tensor layer_norm_pre_all_gather(
     const std::optional<tt::tt_metal::DataType>& dtype,
     const DeviceComputeKernelConfig& compute_kernel_config,
     const LayerNormProgramConfig& program_config,
-    const std::optional<bool>& use_2d_core_grid);
+    const std::optional<bool>& use_2d_core_grid,
+    bool fast_and_approximate_mode);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation_types.hpp
@@ -17,6 +17,9 @@ struct LayerNormPreAllGatherParams {
     DeviceComputeKernelConfig compute_kernel_config;
     LayerNormProgramConfig program_config;
     std::optional<bool> use_2d_core_grid;
+    // Float32 only: false (default) keeps the stats accurate on the SFPU, true takes the faster
+    // FPU path that rounds inputs to tf32.
+    bool fast_and_approximate_mode = false;
 };
 
 struct LayerNormPreAllGatherInputs {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -119,9 +119,14 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherProgramFactory::cr
 
     tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
-    tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;
-    tt::DataFormat scaler_cb_data_format =
-        in_data_format == tt::DataFormat::Float32 ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    const bool fp32_dest_acc_en = operation_attributes.compute_kernel_config.fp32_dest_acc_en;
+    tt::DataFormat cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    tt::DataFormat scaler_cb_data_format = cb_data_format;
+    // Float32 + fp32_dest_acc_en + !fast_and_approximate_mode -> SFPU Accurate; else FPU.
+    // Quasar has no SFPU Accurate reduce; fall back to FPU.
+    const bool unpack_fp32_active =
+        (in_data_format == tt::DataFormat::Float32 && fp32_dest_acc_en &&
+         !operation_attributes.fast_and_approximate_mode && device->arch() != tt::ARCH::QUASAR);
     tt::DataFormat inb_data_format = tt::DataFormat::Invalid;
     uint32_t inb_single_tile_size = 0;
     if (fuse_pre_add) {
@@ -271,7 +276,8 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherProgramFactory::cr
                 m2::DFBBinding{
                     .dfb_spec_name = PRE1D_OUT, .accessor_name = "out", .endpoint_type = m2::DFBEndpointType::PRODUCER},
             },
-        .compile_time_args = {{"Wt", Wt}, {"blk", block_size}},
+        .compile_time_args =
+            {{"Wt", Wt}, {"blk", block_size}, {"unpack_fp32_active", unpack_fp32_active ? 1u : 0u}},
         .runtime_arg_schema = {.runtime_arg_names = {"NCHt"}},
         .hw_config = compute_hw,
     };
@@ -289,12 +295,27 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherProgramFactory::cr
     // sums), and the FPU reads its operands out of SrcA/SrcB, so SrcA/B is the mode for all of them.
     // The intermediates are Float16_b whatever the Dest width, so only the inputs can qualify.
     if (compute_gen1.enable_32_bit_dest) {
+        auto unpack_operand = [&](const m2::DFBSpecName& dfb) {
+            if (unpack_fp32_active) {
+                unpack_via_dest(compute_gen1, dfb);
+            } else {
+                unpack_via_src(compute_gen1, dfb);
+            }
+        };
         if (in_data_format == tt::DataFormat::Float32) {
-            unpack_via_src(compute_gen1, PRE1D_INPUT);
-            unpack_via_src(compute_gen1, PRE1D_REDUCE);  // the scaler tile mirrors the input's dtype
+            unpack_operand(PRE1D_INPUT);
+        }
+        if (scaler_cb_data_format == tt::DataFormat::Float32) {
+            unpack_via_src(compute_gen1, PRE1D_REDUCE);
+        }
+        if (cb_data_format == tt::DataFormat::Float32) {
+            unpack_operand(PRE1D_X2);
+            if (fuse_pre_add) {
+                unpack_operand(PRE1D_FUSED);
+            }
         }
         if (fuse_pre_add && inb_data_format == tt::DataFormat::Float32) {
-            unpack_via_src(compute_gen1, PRE1D_RESIDUAL);
+            unpack_operand(PRE1D_RESIDUAL);
         }
     }
 
@@ -401,9 +422,14 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGather2DProgramFactory::
 
     tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
-    tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;
-    tt::DataFormat scaler_cb_data_format =
-        in_data_format == tt::DataFormat::Float32 ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    const bool fp32_dest_acc_en = operation_attributes.compute_kernel_config.fp32_dest_acc_en;
+    tt::DataFormat cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    tt::DataFormat scaler_cb_data_format = cb_data_format;
+    // Float32 + fp32_dest_acc_en + !fast_and_approximate_mode -> SFPU Accurate; else FPU.
+    // Quasar has no SFPU Accurate reduce; fall back to FPU.
+    const bool unpack_fp32_active =
+        (in_data_format == tt::DataFormat::Float32 && fp32_dest_acc_en &&
+         !operation_attributes.fast_and_approximate_mode && device->arch() != tt::ARCH::QUASAR);
     tt::DataFormat inb_data_format = tt::DataFormat::Invalid;
     uint32_t inb_single_tile_size = 0;
     if (fuse_pre_add) {
@@ -600,7 +626,11 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGather2DProgramFactory::
                         .endpoint_type = m2::DFBEndpointType::PRODUCER},
                 },
             .compile_time_args =
-                {{"NCHt", tiles_per_core_x}, {"Wt", tiles_per_core_y}, {"blk", block_size}, {"num_cores_y", cores_y}},
+                {{"NCHt", tiles_per_core_x},
+                 {"Wt", tiles_per_core_y},
+                 {"blk", block_size},
+                 {"num_cores_y", cores_y},
+                 {"unpack_fp32_active", unpack_fp32_active ? 1u : 0u}},
             .hw_config = ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config),
         };
         bind_self_loop(compute, PRE2D_X2, "x2");
@@ -624,12 +654,30 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGather2DProgramFactory::
         // SrcA/SrcB, so SrcA/B is the mode for all of them. The intermediates and the merge buffers are
         // Float16_b whatever the Dest width, so only the inputs can qualify.
         if (compute_gen1.enable_32_bit_dest) {
+            auto unpack_operand = [&](const m2::DFBSpecName& dfb) {
+                if (unpack_fp32_active) {
+                    unpack_via_dest(compute_gen1, dfb);
+                } else {
+                    unpack_via_src(compute_gen1, dfb);
+                }
+            };
             if (in_data_format == tt::DataFormat::Float32) {
-                unpack_via_src(compute_gen1, PRE2D_INPUT);
-                unpack_via_src(compute_gen1, PRE2D_REDUCE);  // the scaler tile mirrors the input's dtype
+                unpack_operand(PRE2D_INPUT);
+            }
+            if (scaler_cb_data_format == tt::DataFormat::Float32) {
+                unpack_via_src(compute_gen1, PRE2D_REDUCE);
+            }
+            if (cb_data_format == tt::DataFormat::Float32) {
+                unpack_operand(PRE2D_X2);
+                if (fuse_pre_add) {
+                    unpack_operand(PRE2D_FUSED);
+                }
+                // The cross-core merge sums partials with add_tiles, an FPU op.
+                unpack_via_src(compute_gen1, PRE2D_X2_MERGE);
+                unpack_via_src(compute_gen1, PRE2D_ZERO);
             }
             if (fuse_pre_add && inb_data_format == tt::DataFormat::Float32) {
-                unpack_via_src(compute_gen1, PRE2D_RESIDUAL);
+                unpack_operand(PRE2D_RESIDUAL);
             }
         }
         return compute;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -648,11 +648,8 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGather2DProgramFactory::
                 .endpoint_type = m2::DFBEndpointType::PRODUCER});
         }
         auto& compute_gen1 = gen1_compute_config(std::get<m2::ComputeHardwareConfig>(compute.hw_config));
-        // With the 32-bit Dest register enabled, every Float32 buffer the compute kernel consumes needs
-        // an explicit unpack mode. Here each one feeds an FPU op (mul_tiles for x**2, the row reduce for
-        // the sums, add_tiles for the cross-core merge), and the FPU reads its operands out of
-        // SrcA/SrcB, so SrcA/B is the mode for all of them. The intermediates and the merge buffers are
-        // Float16_b whatever the Dest width, so only the inputs can qualify.
+        // Float32 operands use UnpackToDest on the accurate SFPU path and SrcA/SrcB on the FPU path.
+        // The reduce scaler and the FPU merge's zero tile are always consumed through SrcA/SrcB.
         if (compute_gen1.enable_32_bit_dest) {
             auto unpack_operand = [&](const m2::DFBSpecName& dfb) {
                 if (unpack_fp32_active) {
@@ -672,8 +669,9 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGather2DProgramFactory::
                 if (fuse_pre_add) {
                     unpack_operand(PRE2D_FUSED);
                 }
-                // The cross-core merge sums partials with add_tiles, an FPU op.
-                unpack_via_src(compute_gen1, PRE2D_X2_MERGE);
+                // The merge sums the column's partials on the SFPU when accurate, add_tiles
+                // otherwise; dfb::zero is only the FPU path's operand.
+                unpack_operand(PRE2D_X2_MERGE);
                 unpack_via_src(compute_gen1, PRE2D_ZERO);
             }
             if (fuse_pre_add && inb_data_format == tt::DataFormat::Float32) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_nanobind.cpp
@@ -46,6 +46,7 @@ void bind_normalization_layernorm_pre_all_gather_operation(nb::module_& mod) {
                 program_config (ttnn.ProgramConfig, optional): the program configuration. Defaults to None.
                 memory_config (ttnn.MemoryConfig, optional): the memory configuration. Defaults to None.
                 recip_tensor (ttnn.Tensor, optional): the reciprocals tensor for Welford algorithm. Required when using Welford (use_welford=True in program_config). Create using :func:`ttnn.create_layer_norm_reciprocals`. Defaults to None.
+                fast_and_approximate_mode (bool, optional): FLOAT32 only. ``False`` (default) uses the accurate SFPU path (full float32 accumulation); ``True`` uses the faster FPU path (inputs truncated to TF32). The accurate path is unavailable on Quasar and falls back to the FPU there. Ignored by the Welford path. No effect for non-FLOAT32 inputs. Defaults to False.
 
               Returns:
                 ttnn.Tensor: the output tensor.
@@ -86,7 +87,8 @@ void bind_normalization_layernorm_pre_all_gather_operation(nb::module_& mod) {
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("program_config") = nb::none(),
         nb::arg("memory_config") = nb::none(),
-        nb::arg("recip_tensor") = nb::none());
+        nb::arg("recip_tensor") = nb::none(),
+        nb::arg("fast_and_approximate_mode") = false);
 }
 
 void bind_normalization_layernorm_post_all_gather_operation(nb::module_& mod) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
@@ -17,7 +17,8 @@ ttnn::Tensor layer_norm_pre_all_gather(
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const ttnn::prim::LayerNormProgramConfig>& program_config,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<const ttnn::Tensor>& recip_tensor) {
+    const std::optional<const ttnn::Tensor>& recip_tensor,
+    bool fast_and_approximate_mode) {
     auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch()
                                                                    : ttnn::GetDefaultDevice()->arch();
     auto kernel_config_val =
@@ -45,7 +46,8 @@ ttnn::Tensor layer_norm_pre_all_gather(
         dtype,
         kernel_config_val,
         program_config.value_or(ttnn::prim::LayerNormDefaultProgramConfig{}),
-        std::nullopt);  // use_2d_core_grid
+        std::nullopt,  // use_2d_core_grid
+        fast_and_approximate_mode);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp
@@ -19,6 +19,7 @@ ttnn::Tensor layer_norm_pre_all_gather(
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     const std::optional<const ttnn::prim::LayerNormProgramConfig>& program_config = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
-    const std::optional<const ttnn::Tensor>& recip_tensor = std::nullopt);
+    const std::optional<const ttnn::Tensor>& recip_tensor = std::nullopt,
+    bool fast_and_approximate_mode = false);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_pre_allgather.cpp
@@ -22,15 +22,6 @@
 
 namespace pre_add = norm::kernel_util::compute::pre_add;
 
-ALWI void ACQ() {
-    tile_regs_acquire();
-    tile_regs_wait();
-}
-ALWI void REL() {
-    tile_regs_commit();
-    tile_regs_release();
-}
-
 // The statistics pass reads either the raw input or the fused a + b result, depending on whether a
 // residual was supplied. Only the buffer selected here is bound on this build, so the alias is gated
 // at the preprocessor: naming an unbound handle would not compile even on a discarded branch.
@@ -97,12 +88,16 @@ void kernel_main() {
                     tile_regs_release();
                 }
             } else {
-                ACQ();
+                tile_regs_acquire();
                 for (uint32_t wtr = 0; wtr < blk; wtr++) {
                     mul_tiles(dfb_inp_id, dfb_inp_id, wt + wtr, wt + wtr, wtr);
+                }
+                tile_regs_commit();
+                tile_regs_wait();
+                for (uint32_t wtr = 0; wtr < blk; wtr++) {
                     pack_tile(wtr, dfb::x2, wt + wtr);
                 }
-                REL();
+                tile_regs_release();
             }
             dfb_x2.push_back(blk);
         }

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_pre_allgather.cpp
@@ -14,6 +14,8 @@
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/layernorm.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/compute_kernel_api.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "ttnn/operations/normalization/kernel_util/compute/pre_add.h"
 #include "experimental/kernel_args.h"
@@ -42,6 +44,10 @@ void kernel_main() {
     const auto NCHt = get_arg(args::NCHt);
     constexpr auto Wt = get_arg(args::Wt);
     constexpr auto blk = get_arg(args::blk);
+    constexpr bool unpack_fp32_active = get_arg(args::unpack_fp32_active) != 0;
+    // Accurate mode only supports SUM; with the reader's scaler of 1.0, SUM and AVG are equivalent.
+    constexpr auto reduce_type = unpack_fp32_active ? PoolType::SUM : PoolType::AVG;
+    constexpr auto reduce_fp32_mode = unpack_fp32_active ? ReduceFp32Mode::Accurate : ReduceFp32Mode::Fast;
 
     constexpr uint32_t onetile = 1;
 
@@ -62,7 +68,7 @@ void kernel_main() {
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         // Fuse pre-add: dfb_inp = dfb::in0 + dfb::res (absent entirely when there is no residual)
 #ifdef FUSE_PRE_ADD
-        pre_add::one_row<true>(dfb_in0, dfb_res, dfb_inp, Wt, blk);
+        pre_add::one_row<true, unpack_fp32_active>(dfb_in0, dfb_res, dfb_inp, Wt, blk);
 #endif
 
         /*
@@ -70,16 +76,34 @@ void kernel_main() {
          */
         reconfig_data_format(dfb_inp_id, dfb_inp_id);
         pack_reconfig_data_format(dfb::x2);
-        mul_init(dfb_inp_id, dfb_inp_id);
+        if constexpr (unpack_fp32_active) {
+            copy_tile_to_dst_init_short(dfb_inp_id);
+            square_tile_init();
+        } else {
+            mul_init(dfb_inp_id, dfb_inp_id);
+        }
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             dfb_inp.wait_front(wt + blk);  // cumulative wait
             dfb_x2.reserve_back(blk);
-            ACQ();
-            for (uint32_t wtr = 0; wtr < blk; wtr++) {
-                mul_tiles(dfb_inp_id, dfb_inp_id, wt + wtr, wt + wtr, wtr);
-                pack_tile(wtr, dfb::x2, wt + wtr);
+
+            if constexpr (unpack_fp32_active) {
+                for (uint32_t wtr = 0; wtr < blk; wtr++) {
+                    tile_regs_acquire();
+                    copy_tile(dfb_inp_id, wt + wtr, 0);
+                    square_tile(0);
+                    tile_regs_commit();
+                    tile_regs_wait();
+                    pack_tile(0, dfb::x2, wt + wtr);
+                    tile_regs_release();
+                }
+            } else {
+                ACQ();
+                for (uint32_t wtr = 0; wtr < blk; wtr++) {
+                    mul_tiles(dfb_inp_id, dfb_inp_id, wt + wtr, wt + wtr, wtr);
+                    pack_tile(wtr, dfb::x2, wt + wtr);
+                }
+                REL();
             }
-            REL();
             dfb_x2.push_back(blk);
         }
 
@@ -88,12 +112,14 @@ void kernel_main() {
          */
         // BulkWaitBulkPop: All Wt tiles already in the buffer (see cumulative wait above)
         compute_kernel_lib::reduce<
-            PoolType::AVG,
+            reduce_type,
             ReduceDim::REDUCE_ROW,
             dfb::x2,
             dfb::reduce,
             dfb::out,
-            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop,
+            compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT_AND_OUTPUT,
+            reduce_fp32_mode>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
         dfb_inp.pop_front(Wt);
     }
     dfb_reduce.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_nanobind.cpp
@@ -45,6 +45,7 @@ void bind_normalization_rmsnorm_pre_all_gather_operation(nb::module_& mod) {
                 program_config (ttnn.ProgramConfig, optional): the program configuration. Defaults to None.
                 memory_config (ttnn.MemoryConfig, optional): the memory configuration. Defaults to None.
                 use_2d_core_grid (bool, optional): the 2D core grid. Defaults to None.
+                fast_and_approximate_mode (bool, optional): FLOAT32 only. ``False`` (default) uses the accurate SFPU path (full float32 accumulation); ``True`` uses the faster FPU path (inputs truncated to TF32). The accurate path is unavailable on Quasar and falls back to the FPU there. No effect for non-FLOAT32 inputs. Defaults to False.
 
               Returns:
                 ttnn.Tensor: the output tensor.
@@ -83,7 +84,8 @@ void bind_normalization_rmsnorm_pre_all_gather_operation(nb::module_& mod) {
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("program_config") = nb::none(),
         nb::arg("memory_config") = nb::none(),
-        nb::arg("use_2d_core_grid") = nb::none());
+        nb::arg("use_2d_core_grid") = nb::none(),
+        nb::arg("fast_and_approximate_mode") = false);
 }
 
 void bind_normalization_rmsnorm_post_all_gather_operation(nb::module_& mod) {

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
@@ -17,7 +17,8 @@ ttnn::Tensor rms_norm_pre_all_gather(
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const ttnn::prim::LayerNormProgramConfig>& program_config,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<bool>& use_2d_core_grid) {
+    const std::optional<bool>& use_2d_core_grid,
+    bool fast_and_approximate_mode) {
     auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch()
                                                                    : ttnn::GetDefaultDevice()->arch();
     auto kernel_config_val =
@@ -44,7 +45,8 @@ ttnn::Tensor rms_norm_pre_all_gather(
         dtype,
         kernel_config_val,
         program_config.value_or(ttnn::prim::LayerNormDefaultProgramConfig{}),
-        use_2d_core_grid);
+        use_2d_core_grid,
+        fast_and_approximate_mode);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp
@@ -19,6 +19,7 @@ ttnn::Tensor rms_norm_pre_all_gather(
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     const std::optional<const ttnn::prim::LayerNormProgramConfig>& program_config = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
-    const std::optional<bool>& use_2d_core_grid = std::nullopt);
+    const std::optional<bool>& use_2d_core_grid = std::nullopt,
+    bool fast_and_approximate_mode = false);
 
 }  // namespace ttnn


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #43946.

Non-Welford `layer_norm_pre_all_gather` / `rms_norm_pre_all_gather` used hard-coded bf16 intermediate CBs (`x^2`, fused pre-add). With Float32 input and `fp32_dest_acc_en=true`, that still truncated values and left reduce on the FPU/tf32 path, so accuracy stayed poor even after only changing CB formats.

This PR:
1. Stores intermediate CBs (and the reduce scaler) in Float32 when `fp32_dest_acc_en` is set. Input/residual keep their own dtypes.
2. Adds an SFPU full-fp32 path for Float32 + `fp32_dest_acc_en` + `fast_and_approximate_mode=false`: `UnpackToDestFp32`, SFPU square/pre-add, and `ReduceFp32Mode::Accurate`. Otherwise keeps the existing FPU/tf32 path (Quasar always uses FPU).
3. Rejects Float32 input when `fp32_dest_acc_en` is false, instead of silently losing precision.
4. Adds `fast_and_approximate_mode` to both public APIs (default `false` = accurate).
5. Adds Float32 precision tests for layernorm (SFPU vs FPU, with/without residual) and a check for the `fp32_dest_acc_en` rejection.

### Notes for reviewers
- Main host changes: `layernorm_pre_all_gather_program_factory.cpp` (1D + 2D) — CB formats and `unpack_fp32_active`.
- Main device changes: layernorm/rmsnorm pre_allgather compute kernels and `pre_add.h` — SFPU vs FPU branches.
- Accurate reduce uses `PoolType::SUM` because SFPU Accurate only supports SUM. With the reader scaler of `1.0`, that matches the previous AVG+scaler behavior.
- `fast_and_approximate_mode` only matters for Float32 with `fp32_dest_acc_en=true`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-hardcoded-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-hardcoded-bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-hardcoded-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-hardcoded-bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/sudha-hardcoded-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/sudha-hardcoded-bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-hardcoded-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-hardcoded-bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-hardcoded-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-hardcoded-bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-hardcoded-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-hardcoded-bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-hardcoded-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-hardcoded-bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-hardcoded-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-hardcoded-bf16)