### PR TITLE
Combine tests fixes and pruning

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -222,6 +222,22 @@ def pytest_collection_modifyitems(config, items):
         ttnn.FabricConfig.FABRIC_1D_RING,
     }
 
+    QB = [
+        ttnn.cluster.ClusterType.P150_X4,  # BH QuietBox — 4x P150
+        ttnn.cluster.ClusterType.T3K,
+    ]  # WH QuietBox — 4x n300 (8 chips)  [ambiguous]
+
+    LB = [
+        ttnn.cluster.ClusterType.P150_X8,  # BH LoudBox — 8x P150
+        ttnn.cluster.ClusterType.T3K,
+    ]  # WH LoudBox / T3000               [ambiguous]
+
+    GLX = [
+        ttnn.cluster.ClusterType.GALAXY,  # WH Galaxy   (board_type UBB)
+        ttnn.cluster.ClusterType.BLACKHOLE_GALAXY,  # BH Galaxy   (board_type UBB_BLACKHOLE)
+        ttnn.cluster.ClusterType.TG,
+    ]
+
     def _is_ring_or_torus(item):
         params = getattr(getattr(item, "callspec", None), "params", {})
         dp = params.get("device_params")
@@ -234,12 +250,15 @@ def pytest_collection_modifyitems(config, items):
     # hold CHIP_IN_USE, deadlocking the child (get_num_devices() below is likewise gated by a marker).
     # On detection failure default to skipping (a missed skip on a galaxy hangs, worse than over-skip on LB).
     skip_rings = False
+    machine_type = None
     if on_ci and any(_is_ring_or_torus(item) for item in items):
         try:
-            skip_rings = ttnn.cluster.get_cluster_type() in (
-                ttnn.cluster.ClusterType.GALAXY,
-                ttnn.cluster.ClusterType.TG,
-                ttnn.cluster.ClusterType.BLACKHOLE_GALAXY,
+            cluster_type = ttnn.cluster.get_cluster_type()
+            skip_rings = cluster_type in GLX
+            machine_type = (
+                "GLX"
+                if cluster_type in GLX
+                else ("LB" if machine_type in LB else ("QB" if machine_type in QB else None))
             )
         except Exception:
             skip_rings = True
@@ -271,6 +290,17 @@ def pytest_collection_modifyitems(config, items):
 
         if mesh_shape is None or topology is None:
             continue
+
+        # Unsupported fabric rings on QB/LB meshes
+        if machine_type == "LB" or machine_type == "QB":
+            if min(mesh_shape[0], mesh_shape[1]) > 1 and _is_ring_or_torus(item):
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason="ring/torus config on a CI LB or QB runner:"
+                        "Such machines lack cables for anything but 8x1 / 4x1 rings"
+                    )
+                )
+                continue
 
         devices_needed = mesh_shape[0] * mesh_shape[1]
         is_ring = topology == "ring"

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -222,26 +222,104 @@ def pytest_collection_modifyitems(config, items):
         ttnn.FabricConfig.FABRIC_1D_RING,
     }
 
-    QB = [
-        ttnn.cluster.ClusterType.P150_X4,  # BH QuietBox — 4x P150
-        ttnn.cluster.ClusterType.T3K,
-    ]  # WH QuietBox — 4x n300 (8 chips)  [ambiguous]
+    CT = ttnn.cluster.ClusterType
+    FC = ttnn.FabricConfig
+    DEFAULT_ALLOWED_FABRICS = frozenset({FC.FABRIC_1D, FC.FABRIC_2D})
+    CI_ALLOWED_FABRICS = {
+        CT.P150: {(1, 1): [FC.FABRIC_1D, FC.FABRIC_2D]},  # single chip
+        CT.P300: {(2, 1): [FC.FABRIC_1D, FC.FABRIC_2D], (1, 2): [FC.FABRIC_1D, FC.FABRIC_2D]},  # 2 chips
+        CT.P300_X2: {  # 4 chips (bh_quietbox_2), no ring cables in any configuration
+            (4, 1): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (2, 2): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (1, 4): [FC.FABRIC_1D, FC.FABRIC_2D],
+        },
+        CT.P150_X8: {
+            (8, 1): [FC.FABRIC_1D, FC.FABRIC_1D_RING, FC.FABRIC_2D, FC.FABRIC_2D_TORUS_Y],
+            (4, 2): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (2, 4): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (1, 8): [FC.FABRIC_1D, FC.FABRIC_1D_RING, FC.FABRIC_2D, FC.FABRIC_2D_TORUS_X],
+        },
+        CT.T3K: {
+            (8, 1): [FC.FABRIC_1D, FC.FABRIC_1D_RING, FC.FABRIC_2D, FC.FABRIC_2D_TORUS_Y],
+            (4, 2): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (2, 4): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (1, 8): [FC.FABRIC_1D, FC.FABRIC_1D_RING, FC.FABRIC_2D, FC.FABRIC_2D_TORUS_X],
+        },
+        CT.BLACKHOLE_GALAXY: {
+            (32, 1): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (16, 2): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (8, 4): [
+                FC.FABRIC_1D,
+                FC.FABRIC_1D_RING,
+                FC.FABRIC_2D,
+                FC.FABRIC_2D_TORUS_X,
+                FC.FABRIC_2D_TORUS_Y,
+                FC.FABRIC_2D_TORUS_XY,
+            ],
+            (4, 8): [
+                FC.FABRIC_1D,
+                FC.FABRIC_1D_RING,
+                FC.FABRIC_2D,
+                FC.FABRIC_2D_TORUS_X,
+                FC.FABRIC_2D_TORUS_Y,
+                FC.FABRIC_2D_TORUS_XY,
+            ],
+            (2, 16): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (1, 32): [FC.FABRIC_1D, FC.FABRIC_2D],
+        },
+        CT.GALAXY: {
+            (32, 1): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (16, 2): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (8, 4): [
+                FC.FABRIC_1D,
+                FC.FABRIC_1D_RING,
+                FC.FABRIC_2D,
+                FC.FABRIC_2D_TORUS_X,
+                FC.FABRIC_2D_TORUS_Y,
+                FC.FABRIC_2D_TORUS_XY,
+            ],
+            (4, 8): [
+                FC.FABRIC_1D,
+                FC.FABRIC_1D_RING,
+                FC.FABRIC_2D,
+                FC.FABRIC_2D_TORUS_X,
+                FC.FABRIC_2D_TORUS_Y,
+                FC.FABRIC_2D_TORUS_XY,
+            ],
+            (2, 16): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (1, 32): [FC.FABRIC_1D, FC.FABRIC_2D],
+        },
+        CT.TG: {
+            (32, 1): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (16, 2): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (8, 4): [
+                FC.FABRIC_1D,
+                FC.FABRIC_1D_RING,
+                FC.FABRIC_2D,
+                FC.FABRIC_2D_TORUS_X,
+                FC.FABRIC_2D_TORUS_Y,
+                FC.FABRIC_2D_TORUS_XY,
+            ],
+            (4, 8): [
+                FC.FABRIC_1D,
+                FC.FABRIC_1D_RING,
+                FC.FABRIC_2D,
+                FC.FABRIC_2D_TORUS_X,
+                FC.FABRIC_2D_TORUS_Y,
+                FC.FABRIC_2D_TORUS_XY,
+            ],
+            (2, 16): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (1, 32): [FC.FABRIC_1D, FC.FABRIC_2D],
+        },
+    }
 
-    LB = [
-        ttnn.cluster.ClusterType.P150_X8,  # BH LoudBox — 8x P150
-        ttnn.cluster.ClusterType.T3K,
-    ]  # WH LoudBox / T3000               [ambiguous]
-
-    GLX = [
-        ttnn.cluster.ClusterType.GALAXY,  # WH Galaxy   (board_type UBB)
-        ttnn.cluster.ClusterType.BLACKHOLE_GALAXY,  # BH Galaxy   (board_type UBB_BLACKHOLE)
-        ttnn.cluster.ClusterType.TG,
-    ]
-
-    def _is_ring_or_torus(item):
+    def _get_requested_fabric_cfg(item):  # returns fabric cfg that a particular test case requested for the test
         params = getattr(getattr(item, "callspec", None), "params", {})
         dp = params.get("device_params")
-        return isinstance(dp, dict) and dp.get("fabric_config") in ring_or_torus_fabrics
+        if isinstance(dp, dict):
+            return dp.get("fabric_config")
+        else:
+            return None
 
     # Only skip ring/torus on a galaxy; LoudBox rings are native. Galaxy detection via
     # get_cluster_type() OPENS the chip cluster as a side effect, so only call it when this session
@@ -250,24 +328,20 @@ def pytest_collection_modifyitems(config, items):
     # hold CHIP_IN_USE, deadlocking the child (get_num_devices() below is likewise gated by a marker).
     # On detection failure default to skipping (a missed skip on a galaxy hangs, worse than over-skip on LB).
     skip_rings = False
-    machine_type = None
-    if on_ci and any(_is_ring_or_torus(item) for item in items):
+    cluster_type = None
+    if on_ci and any((_get_requested_fabric_cfg(item) in ring_or_torus_fabrics) for item in items):
         try:
             cluster_type = ttnn.cluster.get_cluster_type()
-            skip_rings = cluster_type in GLX
-            machine_type = (
-                "GLX"
-                if cluster_type in GLX
-                else ("LB" if machine_type in LB else ("QB" if machine_type in QB else None))
-            )
+            skip_rings = cluster_type in [CT.GALAXY, CT.BLACKHOLE_GALAXY, CT.TG]
         except Exception:
             skip_rings = True
 
     for item in items:
         # Galaxy ring/subtorus guard — runs before the marker check so it catches configs whether or
         # not they carry a requires_mesh_topology mark.
+        requested_fabric_cfg = _get_requested_fabric_cfg(item)
         if skip_rings:
-            if _is_ring_or_torus(item):
+            if requested_fabric_cfg in ring_or_torus_fabrics:
                 item.add_marker(
                     pytest.mark.skip(
                         reason="ring/subtorus config on a CI galaxy runner: an 8-/4-ring on one galaxy "
@@ -292,15 +366,19 @@ def pytest_collection_modifyitems(config, items):
             continue
 
         # Unsupported fabric rings on QB/LB meshes
-        if machine_type == "LB" or machine_type == "QB":
-            if min(mesh_shape[0], mesh_shape[1]) > 1 and _is_ring_or_torus(item):
-                item.add_marker(
-                    pytest.mark.skip(
-                        reason="ring/torus config on a CI LB or QB runner:"
-                        "Such machines lack cables for anything but 8x1 / 4x1 rings"
-                    )
+        allowed_fabric_cfgs = DEFAULT_ALLOWED_FABRICS
+        if cluster_type in CI_ALLOWED_FABRICS.keys():
+            allowed_fabric_dct = CI_ALLOWED_FABRICS[cluster_type]
+            if mesh_shape in allowed_fabric_dct.keys():
+                allowed_fabric_cfgs = allowed_fabric_dct[mesh_shape]
+
+        if requested_fabric_cfg not in allowed_fabric_cfgs:
+            item.add_marker(
+                pytest.mark.skip(
+                    reason="requested combination of fabric config and mesh, unfeasible on the given hardware"
                 )
-                continue
+            )
+            continue
 
         devices_needed = mesh_shape[0] * mesh_shape[1]
         is_ring = topology == "ring"

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -29,7 +29,7 @@ from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Confi
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
-from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import DSP_CMB_FABRIC_CFGS, fabric_to_device_params
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import fabric_to_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
@@ -343,16 +343,23 @@ def run_combine(
 @dataclass
 class _Test_Mesh:
     full_model_mesh: tuple[int, int]  # Intended for full production-scale testing
-    proxy_test_meshes: list[tuple[int, int]]  # Intended for [0..N] proxy tests, typically on smaller HW
-
-    def target_reference_pairs(self):
-        pairs = [(self.full_model_mesh, self.full_model_mesh)]
-        for prxy in self.proxy_test_meshes:
-            pairs.append((prxy, self.full_model_mesh))
-        return pairs
+    target_meshes: list[
+        dict[tuple[int, int], ttnn.FabricConfig]
+    ]  # Intended for [0..N] proxy tests, typically on smaller HW
 
 
-SINGLE_GLX_AND_PROXY_MESHES = _Test_Mesh((8, 4), [(8, 1), (4, 2), (4, 1)])
+SINGLE_GLX_AND_PROXY_MESHES = _Test_Mesh(
+    (8, 4),
+    {
+        # Ideally all would run torus XY, but some HW configurations like LB/QB cannot support
+        # rings in all configurations. Pick fabric option as representative as possible.
+        (8, 4): ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+        (8, 1): ttnn.FabricConfig.FABRIC_2D_TORUS_XY,  # TODO [dlukic]: check if this has to fallback to torus_y
+        (4, 2): ttnn.FabricConfig.FABRIC_2D,
+        (4, 1): ttnn.FabricConfig.FABRIC_2D_TORUS_XY,  # TODO [dlukic]: check if this has to fallback to torus_y
+        (2, 2): ttnn.FabricConfig.FABRIC_2D,
+    },
+)
 
 
 # Per-model combine shapes as (id_prefix, config, extended_model). Each model contributes a pcc
@@ -436,80 +443,47 @@ def _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg):
         return ttnn.Topology.Ring
 
 
-def _ring_over_one_or_two_chips(fabric_cfg, mesh) -> bool:
-    if (
-        fabric_cfg
-        in [
-            ttnn.FabricConfig.FABRIC_1D_RING,
-            ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-            ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-        ]
-        and mesh[0] <= 2
-    ):
-        return True
-
-    if (
-        fabric_cfg
-        in [
-            ttnn.FabricConfig.FABRIC_2D_TORUS_X,
-            ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-        ]
-        and mesh[1] <= 2
-    ):
-        return True
-
-    return False
-
-
 def _cross_product_conflated_cmb_test_dimensions():
     params = []
-    for fabric_cfg, fabric_cfg_id in DSP_CMB_FABRIC_CFGS:
-        device_params = fabric_to_device_params(fabric_cfg)
-        fabric_topo = _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg)
-        for model_name, model_config, is_extended_model, test_meshes in COMBINE_MODELS:
-            for target_mesh, reference_mesh in test_meshes.target_reference_pairs():
-                # Skip fabric configurations which don't make sense on some grids.
-                # In particular, what makes no sense here is ring over anything with 1 or 2 chips.
-                # (Although in general, ring-2 can theoretically make sense in general.)
-                #
-                if _ring_over_one_or_two_chips(fabric_cfg, target_mesh):
-                    continue
-
-                topo_marker = _topo_marker(target_mesh, fabric_cfg)
-                mesh_requirements_marker = pytest.mark.requires_mesh_topology(
-                    mesh_shape=target_mesh, topology=topo_marker
+    for model_name, model_config, is_extended_model, test_meshes in COMBINE_MODELS:
+        for target_mesh, fabric_cfg in test_meshes.target_meshes.items():
+            device_params = fabric_to_device_params(fabric_cfg)
+            fabric_topo = _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg)
+            topo_marker = _topo_marker(target_mesh, fabric_cfg)
+            mesh_requirements_marker = pytest.mark.requires_mesh_topology(mesh_shape=target_mesh, topology=topo_marker)
+            marks = (
+                (pytest.mark.extended_model, mesh_requirements_marker)
+                if is_extended_model
+                else (mesh_requirements_marker)
+            )
+            test_scenarios = [
+                ("pcc", 128, 4, True),
+                ("perf_no_pcc", 640, 8, False),
+            ]
+            for test_scenario_id, seq_len_per_chip, dispatch_buffer_capacity_factor, run_pcc in test_scenarios:
+                model_config = _model_scaledown_for_combine(
+                    model_config, test_meshes.full_model_mesh, target_mesh, run_pcc
                 )
-                marks = (
-                    (pytest.mark.extended_model, mesh_requirements_marker)
-                    if is_extended_model
-                    else (mesh_requirements_marker)
-                )
-                test_scenarios = [
-                    ("pcc", 128, 4, True),
-                    ("perf_no_pcc", 640, 8, False),
-                ]
-                for test_scenario_id, seq_len_per_chip, dispatch_buffer_capacity_factor, run_pcc in test_scenarios:
-                    model_config = _model_scaledown_for_combine(model_config, reference_mesh, target_mesh, run_pcc)
 
-                    num_experts = model_config.NUM_ROUTED_EXPERTS
-                    topk = model_config.NUM_EXPERTS_PER_TOKEN
-                    shape = target_mesh
+                num_experts = model_config.NUM_ROUTED_EXPERTS
+                topk = model_config.NUM_EXPERTS_PER_TOKEN
+                shape = target_mesh
 
-                    params.append(
-                        pytest.param(
-                            shape,
-                            device_params,
-                            fabric_topo,
-                            seq_len_per_chip,
-                            model_config.EMB_SIZE,
-                            num_experts,
-                            topk,
-                            dispatch_buffer_capacity_factor,
-                            run_pcc,
-                            marks=marks,
-                            id=f"{model_name}-{_mesh_id(target_mesh, fabric_cfg)}-{test_scenario_id}-{fabric_cfg_id}",
-                        )
+                params.append(
+                    pytest.param(
+                        shape,
+                        device_params,
+                        fabric_topo,
+                        seq_len_per_chip,
+                        model_config.EMB_SIZE,
+                        num_experts,
+                        topk,
+                        dispatch_buffer_capacity_factor,
+                        run_pcc,
+                        marks=marks,
+                        id=f"{model_name}-{_mesh_id(target_mesh, fabric_cfg)}-{test_scenario_id}",
                     )
+                )
 
     return params
 

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -117,11 +117,11 @@ def run_combine(
     production_num_devices = production_mesh[0] * production_mesh[1]
     production_num_dispatch_groups = production_mesh[1]
 
-    # scale down top-K in the test by the factor between production and test number of dispatch groups, to get more representative test on smaller meshes.
-    num_experts_per_tok = num_experts_per_tok * num_dispatch_groups // production_num_dispatch_groups
-
-    # scale down total number of experts by the factor between production and test number of chips, to get more representative test on smaller meshes.
-    num_routed_experts = num_routed_experts * num_devices // production_num_devices
+    # Scale the model onto the test mesh: hold production experts-per-chip constant (keeps
+    # num_routed_experts a multiple of num_devices, as ExpertMapping's layout requires), and
+    # scale top-K by the dispatch-group ratio. Both floor at 1 on small meshes.
+    num_routed_experts = max(1, num_routed_experts // production_num_devices) * num_devices
+    num_experts_per_tok = max(1, num_experts_per_tok * num_dispatch_groups // production_num_dispatch_groups)
 
     logger.debug(f"Testing with {mesh_device.shape=}, {num_devices=} {dispatch_group_size=} {num_dispatch_groups=}")
     ttnn.visualize_mesh_device(mesh_device)
@@ -376,8 +376,6 @@ def combine_shape_params():
                 "pcc",
                 128,
                 config.NUM_ROUTED_EXPERTS // 8,  # reduced seq/experts for faster correctness check.
-                # further reducing num_experts would yield 0 experts on 8x4 mesh, thus effectively
-                # skipping the test on the intended production mesh.
                 config.NUM_EXPERTS_PER_TOKEN // 2,
                 4,
                 True,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -12,7 +12,6 @@ Uses torch-generated dispatch inputs to isolate the combine operation.
 
 import copy
 from dataclasses import dataclass
-from typing import list, tuple
 
 import pytest
 import torch
@@ -30,7 +29,7 @@ from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Confi
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
-from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import DSP_CMB_FABRIC_CFGS
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import DSP_CMB_FABRIC_CFGS, fabric_to_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
@@ -346,10 +345,10 @@ class _Test_Mesh:
     full_model_mesh: tuple[int, int]  # Intended for full production-scale testing
     proxy_test_meshes: list[tuple[int, int]]  # Intended for [0..N] proxy tests, typically on smaller HW
 
-    def target_reference_pairs():
-        pairs = [(full_model_mesh, full_model_mesh)]
-        for prxy in proxy_test_meshes:
-            pairs.append((prxy, full_model_mesh))
+    def target_reference_pairs(self):
+        pairs = [(self.full_model_mesh, self.full_model_mesh)]
+        for prxy in self.proxy_test_meshes:
+            pairs.append((prxy, self.full_model_mesh))
         return pairs
 
 
@@ -440,7 +439,7 @@ def _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg):
 def _cross_product_conflated_cmb_test_dimensions():
     params = []
     for fabric_cfg, fabric_cfg_id in DSP_CMB_FABRIC_CFGS:
-        device_params = _fabric_to_device_params(fabric_cfg)
+        device_params = fabric_to_device_params(fabric_cfg)
         fabric_topo = _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg)
         for model_name, model_config, is_extended_model, test_meshes in COMBINE_MODELS:
             for target_mesh, reference_mesh in test_meshes.target_reference_pairs():
@@ -476,7 +475,7 @@ def _cross_product_conflated_cmb_test_dimensions():
                             dispatch_buffer_capacity_factor,
                             run_pcc,
                             marks=marks,
-                            id=f"{model_name}-{_mesh_id(target_mesh)}-{test_scenario_id}-{fabric_cfg_id}",
+                            id=f"{model_name}-{_mesh_id(target_mesh, fabric_cfg)}-{test_scenario_id}-{fabric_cfg_id}",
                         )
                     )
 

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -375,12 +375,13 @@ def combine_shape_params():
             (
                 "pcc",
                 128,
-                config.NUM_ROUTED_EXPERTS // 8,
+                config.NUM_ROUTED_EXPERTS // 8,  # reduced seq/experts for faster correctness check.
+                # further reducing num_experts would yield 0 experts on 8x4 mesh, thus effectively
+                # skipping the test on the intended production mesh.
                 config.NUM_EXPERTS_PER_TOKEN // 2,
                 4,
                 True,
-            ),  # reduced seq/experts for faster correctness check.
-            # further reducing num_experts would yield 0 experts on 8x4 mesh, thus effectively skipping the test on the intended production mesh.
+            ),
             (
                 "perf_no_pcc",
                 640,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -66,8 +66,8 @@ def run_combine(
     is_ci_v2_env,
 ):
     """Run the TTNN combine op in isolation against the torch reference. Shared body for the
-    per-model test entrypoints below — they differ only on the model hyperparams (e.g. num_experts, embedded_dim, ...)
-    and scenario hyperparams (e.g. ISL, proxy test on scaled down HW, ...)."""
+    per-model test entrypoints below — they differ only on the model hyperparams (e.g. num_routed_experts,
+    emb_dim, num_experts_per_tok,...) and scenario hyperparams (e.g. ISL, proxy test on scaled down HW, ...)."""
 
     num_devices = mesh_device.get_num_devices()
     if num_devices >= 8 and not run_pcc_check and use_predictable_data:
@@ -387,8 +387,8 @@ def combine_shape_params():
                 config.NUM_ROUTED_EXPERTS,
                 config.NUM_EXPERTS_PER_TOKEN,
                 8,
-                True,
-            ),  # TODO: revert pcc check back to false before checkin
+                False,
+            ),
         ]
         for shape_id, seq, num_experts, topk, capacity, run_pcc in shapes:
             params.append(
@@ -423,7 +423,6 @@ def combine_shape_params():
     ids=["tile", "row_major"],
 )
 @pytest.mark.parametrize("use_fp8_output", [False, True], ids=["bf16_out", "fp8_out"])
-@pytest.mark.parametrize("cmb_version", [1, 2], ids=["cmb_v1", "cmb_v2"])
 def test_ttnn_combine(
     mesh_device,
     seq_len_per_chip,
@@ -438,7 +437,6 @@ def test_ttnn_combine(
     run_pcc_check,
     dispatched_buffer_layout,
     use_fp8_output,
-    cmb_version,
     is_ci_env,
     is_ci_v2_env,
 ):
@@ -456,7 +454,6 @@ def test_ttnn_combine(
         run_pcc_check,
         dispatched_buffer_layout,
         use_fp8_output,
-        cmb_version,
         is_ci_env,
         is_ci_v2_env,
     )

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -54,6 +54,7 @@ def run_combine(
     emb_dim,
     num_routed_experts,
     num_experts_per_tok,
+    production_mesh,
     dispatch_buffer_capacity_factor,
     num_links,
     topology,
@@ -65,8 +66,9 @@ def run_combine(
     is_ci_v2_env,
 ):
     """Run the TTNN combine op in isolation against the torch reference. Shared body for the
-    per-model test entrypoints below — they differ only on the (emb_dim, num_routed_experts,
-    num_experts_per_tok) shape axis."""
+    per-model test entrypoints below — they differ only on the model hyperparams (e.g. num_experts, embedded_dim, ...)
+    and scenario hyperparams (e.g. ISL, proxy test on scaled down HW, ...)."""
+
     num_devices = mesh_device.get_num_devices()
     if num_devices >= 8 and not run_pcc_check and use_predictable_data:
         pytest.skip("8-chip perf only runs with random data")
@@ -112,6 +114,14 @@ def run_combine(
     sp_axis = mesh_config.sp_axis
     dispatch_group_size = mesh_config.dispatch_group_size
     num_dispatch_groups = mesh_config.num_dispatch_groups
+    production_num_devices = production_mesh[0] * production_mesh[1]
+    production_num_dispatch_groups = production_mesh[1]
+
+    # scale down top-K in the test by the factor between production and test number of dispatch groups, to get more representative test on smaller meshes.
+    num_experts_per_tok = num_experts_per_tok * num_dispatch_groups // production_num_dispatch_groups
+
+    # scale down total number of experts by the factor between production and test number of chips, to get more representative test on smaller meshes.
+    num_routed_experts = num_routed_experts * num_devices // production_num_devices
 
     logger.debug(f"Testing with {mesh_device.shape=}, {num_devices=} {dispatch_group_size=} {num_dispatch_groups=}")
     ttnn.visualize_mesh_device(mesh_device)
@@ -337,19 +347,21 @@ def run_combine(
     logger.debug("✅ TTNN combine operation matches torch reference!")
 
 
-# Per-model combine shapes as (id_prefix, config, extended_model). Each model contributes a pcc
-# param (seq 128, // 16 experts, top-4) and a perf param (seq 640, // 4 experts, top-2). DeepSeek
-# V3 is the baseline and runs by default; every other model is gated behind
+# Per-model combine shapes as (id_prefix, config, extended_model). Each model contributes
+#   test case 1: (seq 128, // 8 experts, // 2 top-K) for quick accuracy check
+#   test case 2: (seq 640, all experts, full top-K) for perf on realistic workload for ISL=5k.
+# DeepSeek V3 is the baseline and runs by default; every other model is gated behind
 # @pytest.mark.extended_model. dispatch_buffer_capacity_factor is ceil(N/2) of the most
 # conservative integer N such that dgs*seq*N >= worst-case dispatch buffer.
+
 COMBINE_MODELS = [
-    ("dsv3", DeepSeekV3Config, False),
-    ("glm_51", GLM51Config, True),
-    ("kimi_k26", KimiK26Config, True),
-    ("minimax_m27", MiniMaxM27Config, True),
-    ("dsv4_pro", DeepSeekV4ProConfig, True),
-    ("dsv4_flash", DeepSeekV4FlashConfig, True),
-    ("gptoss_120b", GptOss120BConfig, True),
+    ("dsv3", DeepSeekV3Config, (8, 4), False),
+    ("glm_51", GLM51Config, (8, 4), True),
+    ("kimi_k26", KimiK26Config, (8, 4), True),
+    ("minimax_m27", MiniMaxM27Config, (8, 4), True),
+    ("dsv4_pro", DeepSeekV4ProConfig, (8, 4), True),
+    ("dsv4_flash", DeepSeekV4FlashConfig, (8, 4), True),
+    ("gptoss_120b", GptOss120BConfig, (8, 4), True),
 ]
 
 
@@ -357,11 +369,26 @@ def combine_shape_params():
     """Build the per-model (shape, run_pcc_check) parametrization. Non-baseline models carry the
     extended_model marker on their params so they stay gated exactly as the separate tests were."""
     params = []
-    for name, config, extended in COMBINE_MODELS:
+    for name, config, production_mesh, extended in COMBINE_MODELS:
         marks = (pytest.mark.extended_model,) if extended else ()
         shapes = [
-            ("pcc", 128, config.NUM_ROUTED_EXPERTS // 16, 4, 4, True),
-            ("perf_no_pcc", 640, config.NUM_ROUTED_EXPERTS // 4, 2, 8, False),
+            (
+                "pcc",
+                128,
+                config.NUM_ROUTED_EXPERTS // 8,
+                config.NUM_EXPERTS_PER_TOKEN // 2,
+                4,
+                True,
+            ),  # reduced seq/experts for faster correctness check.
+            # further reducing num_experts would yield 0 experts on 8x4 mesh, thus effectively skipping the test on the intended production mesh.
+            (
+                "perf_no_pcc",
+                640,
+                config.NUM_ROUTED_EXPERTS,
+                config.NUM_EXPERTS_PER_TOKEN,
+                8,
+                True,
+            ),  # TODO: revert pcc check back to false before checkin
         ]
         for shape_id, seq, num_experts, topk, capacity, run_pcc in shapes:
             params.append(
@@ -372,6 +399,7 @@ def combine_shape_params():
                     topk,
                     capacity,
                     run_pcc,
+                    production_mesh,
                     marks=marks,
                     id=f"{name}-{shape_id}",
                 )
@@ -380,7 +408,7 @@ def combine_shape_params():
 
 
 @pytest.mark.parametrize(
-    "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, dispatch_buffer_capacity_factor, run_pcc_check",
+    "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, dispatch_buffer_capacity_factor, run_pcc_check, production_mesh",
     combine_shape_params(),
 )
 @pytest.mark.parametrize(
@@ -395,12 +423,14 @@ def combine_shape_params():
     ids=["tile", "row_major"],
 )
 @pytest.mark.parametrize("use_fp8_output", [False, True], ids=["bf16_out", "fp8_out"])
+@pytest.mark.parametrize("cmb_version", [1, 2], ids=["cmb_v1", "cmb_v2"])
 def test_ttnn_combine(
     mesh_device,
     seq_len_per_chip,
     emb_dim,
     num_routed_experts,
     num_experts_per_tok,
+    production_mesh,
     dispatch_buffer_capacity_factor,
     num_links,
     topology,
@@ -408,6 +438,7 @@ def test_ttnn_combine(
     run_pcc_check,
     dispatched_buffer_layout,
     use_fp8_output,
+    cmb_version,
     is_ci_env,
     is_ci_v2_env,
 ):
@@ -417,6 +448,7 @@ def test_ttnn_combine(
         emb_dim,
         num_routed_experts,
         num_experts_per_tok,
+        production_mesh,
         dispatch_buffer_capacity_factor,
         num_links,
         topology,
@@ -424,6 +456,7 @@ def test_ttnn_combine(
         run_pcc_check,
         dispatched_buffer_layout,
         use_fp8_output,
+        cmb_version,
         is_ci_env,
         is_ci_v2_env,
     )

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -353,7 +353,7 @@ SINGLE_GLX_AND_PROXY_MESHES = _Test_Mesh(
         # Ideally all would run torus XY, but some HW configurations like LB/QB cannot support
         # rings in all configurations. Pick fabric option as representative as possible.
         (8, 4): ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-        (8, 1): ttnn.FabricConfig.FABRIC_2D,  # unexpetedly FABRIC_2D_TORUS_Y hangs on LB
+        (8, 1): ttnn.FabricConfig.FABRIC_1D_RING,  # unexpectedly FABRIC_2D variants hang
         (4, 2): ttnn.FabricConfig.FABRIC_2D,
         (4, 1): ttnn.FabricConfig.FABRIC_1D_RING,  # unexpectedly FABRIC_2D variants hang
         (2, 2): ttnn.FabricConfig.FABRIC_2D,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -353,9 +353,9 @@ SINGLE_GLX_AND_PROXY_MESHES = _Test_Mesh(
         # Ideally all would run torus XY, but some HW configurations like LB/QB cannot support
         # rings in all configurations. Pick fabric option as representative as possible.
         (8, 4): ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-        (8, 1): ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
+        (8, 1): ttnn.FabricConfig.FABRIC_2D,  # unexpetedly FABRIC_2D_TORUS_Y hangs on LB
         (4, 2): ttnn.FabricConfig.FABRIC_2D,
-        (4, 1): ttnn.FabricConfig.FABRIC_2D,
+        (4, 1): ttnn.FabricConfig.FABRIC_1D_RING,  # unexpectedly FABRIC_2D variants hang
         (2, 2): ttnn.FabricConfig.FABRIC_2D,
     },
 )

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -10,7 +10,6 @@ PyTorch reference implementation when combining expert outputs back to token pos
 Uses torch-generated dispatch inputs to isolate the combine operation.
 """
 
-import copy
 from dataclasses import dataclass
 
 import pytest
@@ -392,25 +391,23 @@ COMBINE_MODELS = [
 # How exactly to scale it down is op-specific (more precisely - even op-implementation specific)
 # Thus it makes sense for this to be combine-specific function
 def _model_scaledown_for_combine(model, ref_mesh, target_mesh, pcc_only):
-    model_cpy = copy.copy(model)
-
     # number of experts has to be reduced to preserve the experts per chip
     ref_num_chips = ref_mesh[0] * ref_mesh[1]
     target_num_chips = target_mesh[0] * target_mesh[1]
     if ref_num_chips != target_num_chips:
         # oreder of the operation keeps the number of routed experts divisible by the number of chips
-        model_cpy.NUM_ROUTED_EXPERTS = (model_cpy.NUM_ROUTED_EXPERTS // ref_num_chips) * target_num_chips
+        model.NUM_ROUTED_EXPERTS = (model.NUM_ROUTED_EXPERTS // ref_num_chips) * target_num_chips
 
     # number of experts selected to proces every token (top-K) has to be scaled to preserve average expert activation per dispatch group
     if ref_mesh[1] != target_mesh[1]:
-        model_cpy.NUM_EXPERTS_PER_TOKEN = (model_cpy.NUM_EXPERTS_PER_TOKEN // ref_mesh[1]) * target_mesh[1]
+        model.NUM_EXPERTS_PER_TOKEN = (model.NUM_EXPERTS_PER_TOKEN // ref_mesh[1]) * target_mesh[1]
 
     # further reduce these two hyperparams in case of pcc check test to get faster, although not perf-representative test
     if pcc_only:
-        model_cpy.NUM_ROUTED_EXPERTS = max(target_num_chips, model_cpy.NUM_ROUTED_EXPERTS // 16)
-        model_cpy.NUM_EXPERTS_PER_TOKEN = max(2, model_cpy.NUM_EXPERTS_PER_TOKEN // 4)
+        model.NUM_ROUTED_EXPERTS = max(target_num_chips, model.NUM_ROUTED_EXPERTS // 16)
+        model.NUM_EXPERTS_PER_TOKEN = max(2, model.NUM_EXPERTS_PER_TOKEN // 4)
 
-    return model_cpy
+    return model
 
 
 def _topo_marker(mesh, fabric_cfg):
@@ -445,7 +442,7 @@ def _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg):
 
 def _cross_product_conflated_cmb_test_dimensions():
     params = []
-    for model_name, model_config, is_extended_model, test_meshes in COMBINE_MODELS:
+    for model_name, model_config_class, is_extended_model, test_meshes in COMBINE_MODELS:
         for target_mesh, fabric_cfg in test_meshes.target_meshes.items():
             device_params = fabric_to_device_params(fabric_cfg)
             fabric_topo = _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg)
@@ -462,7 +459,7 @@ def _cross_product_conflated_cmb_test_dimensions():
             ]
             for test_scenario_id, seq_len_per_chip, dispatch_buffer_capacity_factor, run_pcc in test_scenarios:
                 model_config = _model_scaledown_for_combine(
-                    model_config, test_meshes.full_model_mesh, target_mesh, run_pcc
+                    model_config_class(), test_meshes.full_model_mesh, target_mesh, run_pcc
                 )
 
                 num_experts = model_config.NUM_ROUTED_EXPERTS

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -436,6 +436,31 @@ def _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg):
         return ttnn.Topology.Ring
 
 
+def _ring_over_one_or_two_chips(fabric_cfg, mesh) -> bool:
+    if (
+        fabric_cfg
+        in [
+            ttnn.FabricConfig.FABRIC_1D_RING,
+            ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
+            ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+        ]
+        and mesh[0] <= 2
+    ):
+        return True
+
+    if (
+        fabric_cfg
+        in [
+            ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+            ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+        ]
+        and mesh[1] <= 2
+    ):
+        return True
+
+    return False
+
+
 def _cross_product_conflated_cmb_test_dimensions():
     params = []
     for fabric_cfg, fabric_cfg_id in DSP_CMB_FABRIC_CFGS:
@@ -443,6 +468,13 @@ def _cross_product_conflated_cmb_test_dimensions():
         fabric_topo = _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg)
         for model_name, model_config, is_extended_model, test_meshes in COMBINE_MODELS:
             for target_mesh, reference_mesh in test_meshes.target_reference_pairs():
+                # Skip fabric configurations which don't make sense on some grids.
+                # In particular, what makes no sense here is ring over anything with 1 or 2 chips.
+                # (Although in general, ring-2 can theoretically make sense in general.)
+                #
+                if _ring_over_one_or_two_chips(fabric_cfg, target_mesh):
+                    continue
+
                 topo_marker = _topo_marker(target_mesh, fabric_cfg)
                 mesh_requirements_marker = pytest.mark.requires_mesh_topology(
                     mesh_shape=target_mesh, topology=topo_marker

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -10,6 +10,10 @@ PyTorch reference implementation when combining expert outputs back to token pos
 Uses torch-generated dispatch inputs to isolate the combine operation.
 """
 
+import copy
+from dataclasses import dataclass
+from typing import list, tuple
+
 import pytest
 import torch
 from loguru import logger
@@ -26,7 +30,7 @@ from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Confi
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
-from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import ALL_MESH_CONFIGS
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import DSP_CMB_FABRIC_CFGS
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
@@ -337,57 +341,181 @@ def run_combine(
     logger.debug("✅ TTNN combine operation matches torch reference!")
 
 
+@dataclass
+class _Test_Mesh:
+    full_model_mesh: tuple[int, int]  # Intended for full production-scale testing
+    proxy_test_meshes: list[tuple[int, int]]  # Intended for [0..N] proxy tests, typically on smaller HW
+
+    def target_reference_pairs():
+        pairs = [(full_model_mesh, full_model_mesh)]
+        for prxy in proxy_test_meshes:
+            pairs.append((prxy, full_model_mesh))
+        return pairs
+
+
+SINGLE_GLX_AND_PROXY_MESHES = _Test_Mesh((8, 4), [(8, 1), (4, 2), (4, 1)])
+
+
 # Per-model combine shapes as (id_prefix, config, extended_model). Each model contributes a pcc
 # param (seq 128, // 16 experts, top-4) and a perf param (seq 640, // 4 experts, top-2). DeepSeek
 # V3 is the baseline and runs by default; every other model is gated behind
 # @pytest.mark.extended_model. dispatch_buffer_capacity_factor is ceil(N/2) of the most
 # conservative integer N such that dgs*seq*N >= worst-case dispatch buffer.
 COMBINE_MODELS = [
-    ("dsv3", DeepSeekV3Config, False),
-    ("glm_51", GLM51Config, True),
-    ("kimi_k26", KimiK26Config, True),
-    ("minimax_m27", MiniMaxM27Config, True),
-    ("dsv4_pro", DeepSeekV4ProConfig, True),
-    ("dsv4_flash", DeepSeekV4FlashConfig, True),
-    ("gptoss_120b", GptOss120BConfig, True),
+    ("dsv3", DeepSeekV3Config, False, SINGLE_GLX_AND_PROXY_MESHES),
+    (
+        "glm_51",
+        GLM51Config,
+        True,
+        SINGLE_GLX_AND_PROXY_MESHES,
+    ),  # TODO [dlukic]: Instead of extended_flag+same mesh list,
+    (
+        "kimi_k26",
+        KimiK26Config,
+        True,
+        SINGLE_GLX_AND_PROXY_MESHES,
+    ),  # can we just drop the flag and use different mesh lists?
+    ("minimax_m27", MiniMaxM27Config, True, SINGLE_GLX_AND_PROXY_MESHES),
+    ("dsv4_pro", DeepSeekV4ProConfig, True, SINGLE_GLX_AND_PROXY_MESHES),
+    ("dsv4_flash", DeepSeekV4FlashConfig, True, SINGLE_GLX_AND_PROXY_MESHES),
+    ("gptoss_120b", GptOss120BConfig, True, SINGLE_GLX_AND_PROXY_MESHES),
 ]
 
 
-def combine_shape_params():
-    """Build the per-model (shape, run_pcc_check) parametrization. Non-baseline models carry the
-    extended_model marker on their params so they stay gated exactly as the separate tests were."""
+# Scales down model hyper-params for a given hardware to obtain good/meaningful proxy test
+# How exactly to scale it down is op-specific (more precisely - even op-implementation specific)
+# Thus it makes sense for this to be combine-specific function
+def _model_scaledown_for_combine(model, ref_mesh, target_mesh, pcc_only):
+    model_cpy = copy.copy(model)
+
+    # number of experts has to be reduced to preserve the experts per chip
+    ref_num_chips = ref_mesh[0] * ref_mesh[1]
+    target_num_chips = target_mesh[0] * target_mesh[1]
+    if ref_num_chips != target_num_chips:
+        # oreder of the operation keeps the number of routed experts divisible by the number of chips
+        model_cpy.NUM_ROUTED_EXPERTS = (model_cpy.NUM_ROUTED_EXPERTS // ref_num_chips) * target_num_chips
+
+    # number of experts selected to proces every token (top-K) has to be scaled to preserve average expert activation per dispatch group
+    if ref_mesh[1] != target_mesh[1]:
+        model_cpy.NUM_EXPERTS_PER_TOKEN = (model_cpy.NUM_EXPERTS_PER_TOKEN // ref_mesh[1]) * target_mesh[1]
+
+    # further reduce these two hyperparams in case of pcc check test to get faster, although not perf-representative test
+    if pcc_only:
+        model_cpy.NUM_ROUTED_EXPERTS = max(target_num_chips, model_cpy.NUM_ROUTED_EXPERTS // 16)
+        model_cpy.NUM_EXPERTS_PER_TOKEN = max(2, model_cpy.NUM_EXPERTS_PER_TOKEN // 4)
+
+    return model_cpy
+
+
+def _topo_marker(mesh, fabric_cfg):
+    if mesh[1] == 1 and fabric_cfg == ttnn.FabricConfig.FABRIC_1D:
+        return "linear"
+    if mesh[1] == 1 and fabric_cfg == ttnn.FabricConfig.FABRIC_1D_RING:
+        return "ring"
+    return f"mesh-{mesh[0]}x{mesh[1]}"
+
+
+def _mesh_id(mesh, fabric_cfg):
+    if mesh[1] == 1 and fabric_cfg == ttnn.FabricConfig.FABRIC_1D:
+        return f"linear-{mesh[0]}"
+    if mesh[1] == 1 and fabric_cfg == ttnn.FabricConfig.FABRIC_1D_RING:
+        return f"ring-{mesh[0]}"
+    return f"mesh-{mesh[0]}x{mesh[1]}"
+
+
+def _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg):
+    # This mapping is specific to an op because fabric topology is the CCL algorithm's data-flow shape (Linear / Ring / Mesh / Torus)
+    # ttnn.FabricConfig is the device-level fabric wiring (FABRIC_1D / FABRIC_1D_RING / FABRIC_2D / FABRIC_2D_TORUS_Y) —
+    # set via the `mesh_device` fixture's device_params.
+    # ttnn.Topology on the other hand is what data-movement pattern the algorithm will use in op kernel runtime.
+    # It depends on the fabric config because config might prevent some topology (e.g. FABRIC_1D does not support Ring topology), but topology
+    # doesn't have to use all of the supported movements. For example it is perfectly valid to ask for Topology.Linear (and not Topology.Mesh)
+    # on FABRIC_2D. Thus it is natural for every CCL op to derive which topology to use from the given fabric config.
+    if fabric_cfg in (ttnn.FabricConfig.FABRIC_1D, ttnn.FabricConfig.FABRIC_2D, ttnn.FabricConfig.FABRIC_2D_TORUS_X):
+        return ttnn.Topology.Linear
+    else:
+        return ttnn.Topology.Ring
+
+
+def _cross_product_conflated_cmb_test_dimensions():
     params = []
-    for name, config, extended in COMBINE_MODELS:
-        marks = (pytest.mark.extended_model,) if extended else ()
-        shapes = [
-            ("pcc", 128, config.NUM_ROUTED_EXPERTS // 16, 4, 4, True),
-            ("perf_no_pcc", 640, config.NUM_ROUTED_EXPERTS // 4, 2, 8, False),
-        ]
-        for shape_id, seq, num_experts, topk, capacity, run_pcc in shapes:
-            params.append(
-                pytest.param(
-                    seq,
-                    config.EMB_SIZE,
-                    num_experts,
-                    topk,
-                    capacity,
-                    run_pcc,
-                    marks=marks,
-                    id=f"{name}-{shape_id}",
+    for fabric_cfg, fabric_cfg_id in DSP_CMB_FABRIC_CFGS:
+        device_params = _fabric_to_device_params(fabric_cfg)
+        fabric_topo = _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg)
+        for model_name, model_config, is_extended_model, test_meshes in COMBINE_MODELS:
+            for target_mesh, reference_mesh in test_meshes.target_reference_pairs():
+                topo_marker = _topo_marker(target_mesh, fabric_cfg)
+                mesh_requirements_marker = pytest.mark.requires_mesh_topology(
+                    mesh_shape=target_mesh, topology=topo_marker
                 )
-            )
+                marks = (
+                    (pytest.mark.extended_model, mesh_requirements_marker)
+                    if is_extended_model
+                    else (mesh_requirements_marker)
+                )
+                test_scenarios = [
+                    ("pcc", 128, 4, True),
+                    ("perf_no_pcc", 640, 8, False),
+                ]
+                for test_scenario_id, seq_len_per_chip, dispatch_buffer_capacity_factor, run_pcc in test_scenarios:
+                    model_config = _model_scaledown_for_combine(model_config, reference_mesh, target_mesh, run_pcc)
+
+                    num_experts = model_config.NUM_ROUTED_EXPERTS
+                    topk = model_config.NUM_EXPERTS_PER_TOKEN
+                    shape = target_mesh
+
+                    params.append(
+                        pytest.param(
+                            shape,
+                            device_params,
+                            fabric_topo,
+                            seq_len_per_chip,
+                            model_config.EMB_SIZE,
+                            num_experts,
+                            topk,
+                            dispatch_buffer_capacity_factor,
+                            run_pcc,
+                            marks=marks,
+                            id=f"{model_name}-{_mesh_id(target_mesh)}-{test_scenario_id}-{fabric_cfg_id}",
+                        )
+                    )
+
     return params
 
 
+# Test parametrization axes are semantically
+# 1. Chip count and layout
+#   1.1. mesh column size, which is consequently the size of a dispatch group
+#   1.2. mesh row size, which is consequently the number of dispatch groups
+# 2. Fabric-related
+#   2.1. Fabric dimensionality (1d / 2d / maybe more in the future)
+#   2.2. Ring/Linear across column
+#   2.3. Ring/Linear across row
+#   2.4. number of links in a single chip-to-chip connection
+# 3. Model-related (embed-dim, topK, num-experts, ...)
+# 4. Input related (ISL, tile/RM, datum format, ...)
+# 5. Scenario/type of test
+#   5.1. accuracy or perf test
+#   5.2. production test / proxy test on smaller hardware (like single DG simulation) / op generality test
+#   5.3. random or predictable (fixed) data
+#
+# Each level-2 item in this list is a valid parametrization axis (semantically).
+# However there are two reasons some of them are conflated into single parametrization axis.
+# 1. pytest requires some marks to be populated. And it allows marks to be calculated only based on a single axis values.
+#    Some of our marks are besed on multiple semantic axes (e.g. topology marker is calculated based on 1.1, 1.2, 2.1, 2.2 and 2.3)
+#    Industry standard work-around is conflating these axes into a single @pytest.mark.parametrize axis + a function which generates
+#    its values as a cross product of the semantical axis which are conflated. Then calculate marks based on the value of the resulting
+#    conflated axis, which from the perspective of the pytest is a single parametrization axis.
+# 2. Even on a semantical level, we don't want full cross product of some axes. E.g. production test makes sense only on 8x4 mesh.
+#    Or fp8 test doesn't run PCC. Or fabric 1d doesn't support both x and y rings. Such combination are either prevented during necesarry
+#    test-code cross product calculation, or are skipped in the body of the test, depending on where it was less cumbersome to implement it.
+#
 @pytest.mark.parametrize(
-    "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, dispatch_buffer_capacity_factor, run_pcc_check",
-    combine_shape_params(),
-)
-@pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
-    ALL_MESH_CONFIGS,
+    "mesh_device, device_params, topology, seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, dispatch_buffer_capacity_factor, run_pcc_check",
+    _cross_product_conflated_cmb_test_dimensions(),
     indirect=["mesh_device", "device_params"],
 )
+@pytest.mark.parametrize("num_links", [1, 2], ids=["1link", "2link"])
 @pytest.mark.parametrize("use_predictable_data", [True, False], ids=["predictable", "random"])
 @pytest.mark.parametrize(
     "dispatched_buffer_layout",

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -368,18 +368,8 @@ SINGLE_GLX_AND_PROXY_MESHES = _Test_Mesh(
 # conservative integer N such that dgs*seq*N >= worst-case dispatch buffer.
 COMBINE_MODELS = [
     ("dsv3", DeepSeekV3Config, False, SINGLE_GLX_AND_PROXY_MESHES),
-    (
-        "glm_51",
-        GLM51Config,
-        True,
-        SINGLE_GLX_AND_PROXY_MESHES,
-    ),  # TODO [dlukic]: Instead of extended_flag+same mesh list,
-    (
-        "kimi_k26",
-        KimiK26Config,
-        True,
-        SINGLE_GLX_AND_PROXY_MESHES,
-    ),  # can we just drop the flag and use different mesh lists?
+    ("glm_51", GLM51Config, True, SINGLE_GLX_AND_PROXY_MESHES),
+    ("kimi_k26", KimiK26Config, True, SINGLE_GLX_AND_PROXY_MESHES),
     ("minimax_m27", MiniMaxM27Config, True, SINGLE_GLX_AND_PROXY_MESHES),
     ("dsv4_pro", DeepSeekV4ProConfig, True, SINGLE_GLX_AND_PROXY_MESHES),
     ("dsv4_flash", DeepSeekV4FlashConfig, True, SINGLE_GLX_AND_PROXY_MESHES),
@@ -489,11 +479,8 @@ def _cross_product_conflated_cmb_test_dimensions():
 # 1. Chip count and layout
 #   1.1. mesh column size, which is consequently the size of a dispatch group
 #   1.2. mesh row size, which is consequently the number of dispatch groups
-# 2. Fabric-related
-#   2.1. Fabric dimensionality (1d / 2d / maybe more in the future)
-#   2.2. Ring/Linear across column
-#   2.3. Ring/Linear across row
-#   2.4. number of links in a single chip-to-chip connection
+# 2. Number of fabric links in a single chip-to-chip connection. (Other fabric props are either cherry-picked
+#    for the test case, such as fabric config or packet size, or are derivable from them, like fabric topology)
 # 3. Model-related (embed-dim, topK, num-experts, ...)
 # 4. Input related (ISL, tile/RM, datum format, ...)
 # 5. Scenario/type of test

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -353,9 +353,9 @@ SINGLE_GLX_AND_PROXY_MESHES = _Test_Mesh(
         # Ideally all would run torus XY, but some HW configurations like LB/QB cannot support
         # rings in all configurations. Pick fabric option as representative as possible.
         (8, 4): ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-        (8, 1): ttnn.FabricConfig.FABRIC_2D_TORUS_XY,  # TODO [dlukic]: check if this has to fallback to torus_y
+        (8, 1): ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
         (4, 2): ttnn.FabricConfig.FABRIC_2D,
-        (4, 1): ttnn.FabricConfig.FABRIC_2D_TORUS_XY,  # TODO [dlukic]: check if this has to fallback to torus_y
+        (4, 1): ttnn.FabricConfig.FABRIC_2D,
         (2, 2): ttnn.FabricConfig.FABRIC_2D,
     },
 )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
@@ -214,35 +214,6 @@ ALL_MESH_CONFIGS = [
     ),
 ]
 
-# Cross product: {f_1d, f2d} x {linear_x, ring_x} x {linear_y, ring_y}, expressed via ttnn.FabricConfig.
-# This drives the creation of device_params and thus has to stay conflated as a single parametrization axis rather than separate axes.
-# ttnn.Topology can actually be algorithmically derived from the FabricConfig and the fact that we never need 2d data movement
-# (thus no mesh or torus values), but is kept hand-written to avoid additional function for this short list.
-# ttnn.FabricReliabilityMode is similarly derivable but is always None for 1d and relaxed for 2d.
-# [Add issue Id] It should be bumped to strict once we have machines with 2link-2d_torus superpowers, marked in CI.
-DSP_CMB_FABRIC_CFGS = [
-    (ttnn.FabricConfig.FABRIC_1D, "f1d-Xlin-Ylin"),  # 1D - DG-linear - cross_DG-linear, kept for op generality testintg
-    (
-        ttnn.FabricConfig.FABRIC_1D_RING,
-        "f1d-Xlin-Yring",
-    ),  # 1D - DG-ring.  - cross_DG-linear, kept for op generality testintg
-    #                                                          # 1D - DG-linear - cross_DG-ring,   not needed enough to justify test setup complexity
-    #                                                          # 1D - DG-ring.  - cross_DG-ring,   not supported by 1D fabric
-    (ttnn.FabricConfig.FABRIC_2D, "f2d-Xlin-Ylin"),  # 2D - DG-linear - cross_DG-linear, kept for op generality testintg
-    (
-        ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-        "f2d-Xlin-Yring",
-    ),  # 2D - DG-ring.  - cross_DG-linear, kept for op generality testintg
-    (
-        ttnn.FabricConfig.FABRIC_2D_TORUS_X,
-        "f2d-Xring-Ylin",
-    ),  # 2D - DG-linear - cross_DG-ring,   kept for op generality testintg
-    (
-        ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-        "f2d-Xring-Yring",
-    ),  # 2D - DG-ring.  - cross_DG-ring,   ** production scenario testing **
-]
-
 
 def _fabric_cfg_to_init_reliability_mode(fabric_cfg):
     # For fabric 1d the param is omitted. For fabric 2d ideally it would be strict for reliable perf measurements

--- a/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
@@ -213,3 +213,53 @@ ALL_MESH_CONFIGS = [
         reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
     ),
 ]
+
+# Cross product: {f_1d, f2d} x {linear_x, ring_x} x {linear_y, ring_y}, expressed via ttnn.FabricConfig.
+# This drives the creation of device_params and thus has to stay conflated as a single parametrization axis rather than separate axes.
+# ttnn.Topology can actually be algorithmically derived from the FabricConfig and the fact that we never need 2d data movement
+# (thus no mesh or torus values), but is kept hand-written to avoid additional function for this short list.
+# ttnn.FabricReliabilityMode is similarly derivable but is always None for 1d and relaxed for 2d.
+# [Add issue Id] It should be bumped to strict once we have machines with 2link-2d_torus superpowers, marked in CI.
+DSP_CMB_FABRIC_CFGS = [
+    (ttnn.FabricConfig.FABRIC_1D, "f1d-Xlin-Ylin"),  # 1D - DG-linear - cross_DG-linear, kept for op generality testintg
+    (
+        ttnn.FabricConfig.FABRIC_1D_RING,
+        "f1d-Xlin-Yring",
+    ),  # 1D - DG-ring.  - cross_DG-linear, kept for op generality testintg
+    #                                                          # 1D - DG-linear - cross_DG-ring,   not needed enough to justify test setup complexity
+    #                                                          # 1D - DG-ring.  - cross_DG-ring,   not supported by 1D fabric
+    (ttnn.FabricConfig.FABRIC_2D, "f2d-Xlin-Ylin"),  # 2D - DG-linear - cross_DG-linear, kept for op generality testintg
+    (
+        ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
+        "f2d-Xlin-Yring",
+    ),  # 2D - DG-ring.  - cross_DG-linear, kept for op generality testintg
+    (
+        ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+        "f2d-Xring-Ylin",
+    ),  # 2D - DG-linear - cross_DG-ring,   kept for op generality testintg
+    (
+        ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+        "f2d-Xring-Yring",
+    ),  # 2D - DG-ring.  - cross_DG-ring,   ** production scenario testing **
+]
+
+
+def fabric_cfg_to_init_reliability_mode(fabric_cfg):
+    # For fabric 1d the param is omitted. For fabric 2d ideally it would be strict for reliable perf measurements
+    # Until CI HW supports it, use relaxed
+    if fabric_cfg in (ttnn.FabricConfig.FABRIC_1D, ttnn.FabricConfig.FABRIC_1D_RING):
+        return None
+    else:
+        return ttnn.FabricReliabilityMode.RELAXED_INIT
+
+
+def fabric_to_device_params(fabric_cfg):
+    device_params = {
+        "fabric_config": fabric_cfg,
+        "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+    }
+    reliability_mode = _fabric_cfg_to_init_reliability_mode(fabric_cfg)
+    if reliability_mode is not None:
+        device_params["reliability_mode"] = reliability_mode
+
+    return device_params

--- a/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
@@ -43,9 +43,10 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_route
 def _mesh_param(shape, fabric, payload, nlinks, topo, topo_marker, test_id, reliability_mode=None):
     """Build a single pytest.param for the mesh_device parametrize axis.
 
-    `topo_marker` is the CI hardware-class string consumed by the `requires_mesh_topology`
-    pytest mark, NOT the test's mesh shape. For example, a (2,2) test uses `topo_marker=
-    "mesh-4x2"` because (2,2) and (4,2) both run on the LoudBox "mesh-4x2"-class machine.
+    `topo_marker` is the hardware-class string passed to the `requires_mesh_topology` mark.
+    The conftest hook only tests it against the literal "ring" (to apply the Wormhole
+    ring-needs-8-chips rule); every other value is descriptive, so it mirrors the mesh shape
+    (a (2,2) entry uses "mesh-2x2"), matching the other deepseek test modules.
     """
     device_params = {
         "fabric_config": fabric,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
@@ -87,13 +87,13 @@ ALL_MESH_CONFIGS = [
     ),
     # 2D mesh topologies
     _mesh_param(
-        (2, 2), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "mesh-4x2", "mesh-2x2"
+        (2, 2), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "mesh-2x2", "mesh-2x2"
     ),
     _mesh_param(
         (4, 2), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "mesh-4x2", "mesh-4x2"
     ),
     _mesh_param(
-        (2, 4), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "mesh-4x2", "mesh-2x4"
+        (2, 4), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "mesh-2x4", "mesh-2x4"
     ),
     # 8-chip linear
     _mesh_param(
@@ -210,6 +210,16 @@ ALL_MESH_CONFIGS = [
         ttnn.Topology.Ring,
         "mesh-8x4",
         "fabric2d-torus-xy-8x4-1link",
+        reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
+    ),
+    _mesh_param(
+        (8, 4),
+        ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+        get_max_payload_size(),
+        2,
+        ttnn.Topology.Ring,
+        "mesh-8x4",
+        "fabric2d-torus-xy-8x4-2link",
         reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
     ),
 ]

--- a/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
@@ -244,7 +244,7 @@ DSP_CMB_FABRIC_CFGS = [
 ]
 
 
-def fabric_cfg_to_init_reliability_mode(fabric_cfg):
+def _fabric_cfg_to_init_reliability_mode(fabric_cfg):
     # For fabric 1d the param is omitted. For fabric 2d ideally it would be strict for reliable perf measurements
     # Until CI HW supports it, use relaxed
     if fabric_cfg in (ttnn.FabricConfig.FABRIC_1D, ttnn.FabricConfig.FABRIC_1D_RING):


### PR DESCRIPTION
### PR Category - Test Only
### Summary
Fixes 2 bugs in current combine test cases
* On 8x4 mesh topK=2 cases tokens to get selected for movement to only up to 2 destination chips across all DGs, thus reducing the volume of traffic. This makes traffic volume of ISL=5k to be roughly as for the case of ISL=1.25k, thus giving misleading perf numbers (in perf tests).
* On 8x4 mesh + pcc test flavor, number of experts per chip is (e.g. for deepseek) (256 // 16) // (8*4) = 0 experts per chip, which skips the test.

Also, as part of the wider CI refactor effort, this removes some test cases
* Those on 1 or 2 chips
* Multiple fabric configs on the same mesh are collapsed into one test case - the one with fabric being as close to FABRIC_2D_TORUS_XY as supported on the given HW/mesh. Ideally all would be some FABRIC_2D flavor, but 8x1 and 4x1 hang with fabric 2d so they are left as FABRIC_1D_RING for now. Separate issues are opened to track these bugs.

New safeguard in conftest.py is added to prevent test cases which use unavailable fabric wiring on CI machines, because these will likely just hang which slows down tests and keeps HW unutilized.

Num links is promoted to its own separate parametrization axis.

More explicit model downscaling is created for adjusting hyperparams for proxy tests.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
https://github.com/tenstorrent/tt-metal/actions/runs/31570497655
https://github.com/tenstorrent/tt-metal/actions/runs/31570526793

Manual and AI diffing with main don't suggest these changes make things worse.