### PR TITLE
Remove dead enough_space_width heuristic from tilize and untilize

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
@@ -62,6 +62,59 @@ def test_untilize_with_unpadding_fp32(device, dtype, shape_output_end, input_buf
     assert torch.equal(result, torch_result), f"untilize_with_unpadding lost {dtype} precision"
 
 
+def test_untilize_with_unpadding_reuses_cache_when_only_width_l1_heuristic_changes(device, isolate_program_cache):
+    """
+    Regression test for issue #46533 first-shot fix.
+
+    This shape keeps the height-side CB estimate tiny (1 tile row) while making the
+    width-side estimate large enough to react to unrelated resident L1 buffers.
+    enough_space_width is not consumed by factory selection or descriptor creation,
+    so changing only that heuristic must not fork the program cache.
+    """
+    torch.manual_seed(0)
+
+    input_shape = [1, 10240, 32]
+    output_end = [0, 10239, 31]
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    assert device.num_program_cache_entries() == 0, "Program cache should be empty before the test"
+
+    with device.cache_entries_counter.measure():
+        output_tensor = ttnn.untilize_with_unpadding(
+            input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+
+    assert_equal(ttnn.to_torch(output_tensor), torch_input)
+    assert device.cache_entries_counter.total == 1
+
+    ttnn.synchronize_device(device)
+
+    hog_shape = [1, 1, 32, 16384]
+    hog_tensors = [
+        ttnn.allocate_tensor_on_device(
+            ttnn.Shape(hog_shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device, ttnn.L1_MEMORY_CONFIG
+        )
+        for _ in range(3)
+    ]
+    assert len(hog_tensors) == 3
+
+    with device.cache_entries_counter.measure():
+        output_tensor = ttnn.untilize_with_unpadding(
+            input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+
+    assert_equal(ttnn.to_torch(output_tensor), torch_input)
+    assert device.cache_entries_counter.total == 1
+
+
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize(
     "shape, output_end, shard_shape, num_cores",

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
@@ -62,59 +62,6 @@ def test_untilize_with_unpadding_fp32(device, dtype, shape_output_end, input_buf
     assert torch.equal(result, torch_result), f"untilize_with_unpadding lost {dtype} precision"
 
 
-def test_untilize_with_unpadding_reuses_cache_when_only_width_l1_heuristic_changes(device, isolate_program_cache):
-    """
-    Regression test for issue #46533 first-shot fix.
-
-    This shape keeps the height-side CB estimate tiny (1 tile row) while making the
-    width-side estimate large enough to react to unrelated resident L1 buffers.
-    enough_space_width is not consumed by factory selection or descriptor creation,
-    so changing only that heuristic must not fork the program cache.
-    """
-    torch.manual_seed(0)
-
-    input_shape = [1, 10240, 32]
-    output_end = [0, 10239, 31]
-    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
-
-    input_tensor = ttnn.from_torch(
-        torch_input,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-    assert device.num_program_cache_entries() == 0, "Program cache should be empty before the test"
-
-    with device.cache_entries_counter.measure():
-        output_tensor = ttnn.untilize_with_unpadding(
-            input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
-        )
-
-    assert_equal(ttnn.to_torch(output_tensor), torch_input)
-    assert device.cache_entries_counter.total == 1
-
-    ttnn.synchronize_device(device)
-
-    hog_shape = [1, 1, 32, 16384]
-    hog_tensors = [
-        ttnn.allocate_tensor_on_device(
-            ttnn.Shape(hog_shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device, ttnn.L1_MEMORY_CONFIG
-        )
-        for _ in range(3)
-    ]
-    assert len(hog_tensors) == 3
-
-    with device.cache_entries_counter.measure():
-        output_tensor = ttnn.untilize_with_unpadding(
-            input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
-        )
-
-    assert_equal(ttnn.to_torch(output_tensor), torch_input)
-    assert device.cache_entries_counter.total == 1
-
-
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize(
     "shape, output_end, shard_shape, num_cores",

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -309,7 +309,7 @@ TilizeDeviceOperation::program_factory_t TilizeDeviceOperation::select_program_f
         }
         return ttnn::prim::TilizeMultiCoreDefaultProgramFactory{};
     }
-    if (!operation_attributes.enough_space_width) {
+    if (!operation_attributes.enough_space_height) {
         return ttnn::prim::TilizeMultiCoreBlockProgramFactory{};
     }
     auto sub_core_grids = operation_attributes.sub_core_grids;
@@ -374,7 +374,7 @@ ttnn::Tensor tilize(
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<DataType>& output_dtype,
     bool use_multicore,
-    bool enough_space_width,
+    bool enough_space_height,
     bool use_low_perf,
     const Tile& tile,
     const std::optional<CoreRangeSet>& sub_core_grids) {
@@ -383,7 +383,7 @@ ttnn::Tensor tilize(
             .output_mem_config = output_mem_config.value_or(input_tensor.memory_config()),
             .output_dtype = output_dtype.value_or(input_tensor.dtype()),
             .use_multicore = use_multicore,
-            .enough_space_width = enough_space_width,
+            .enough_space_height = enough_space_height,
             .use_low_perf = use_low_perf,
             .tile = tile,
             .sub_core_grids = sub_core_grids,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -309,7 +309,7 @@ TilizeDeviceOperation::program_factory_t TilizeDeviceOperation::select_program_f
         }
         return ttnn::prim::TilizeMultiCoreDefaultProgramFactory{};
     }
-    if (!operation_attributes.enough_space_height) {
+    if (!operation_attributes.enough_space_width) {
         return ttnn::prim::TilizeMultiCoreBlockProgramFactory{};
     }
     auto sub_core_grids = operation_attributes.sub_core_grids;
@@ -375,7 +375,6 @@ ttnn::Tensor tilize(
     const std::optional<DataType>& output_dtype,
     bool use_multicore,
     bool enough_space_width,
-    bool enough_space_height,
     bool use_low_perf,
     const Tile& tile,
     const std::optional<CoreRangeSet>& sub_core_grids) {
@@ -385,7 +384,6 @@ ttnn::Tensor tilize(
             .output_dtype = output_dtype.value_or(input_tensor.dtype()),
             .use_multicore = use_multicore,
             .enough_space_width = enough_space_width,
-            .enough_space_height = enough_space_height,
             .use_low_perf = use_low_perf,
             .tile = tile,
             .sub_core_grids = sub_core_grids,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.hpp
@@ -56,7 +56,7 @@ ttnn::Tensor tilize(
     const std::optional<tt::tt_metal::MemoryConfig>& output_mem_config,
     const std::optional<tt::tt_metal::DataType>& output_dtype,
     bool use_multicore,
-    bool enough_space_width,
+    bool enough_space_height,
     bool use_low_perf,
     const tt::tt_metal::Tile& tile,
     const std::optional<CoreRangeSet>& sub_core_grids);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.hpp
@@ -57,7 +57,6 @@ ttnn::Tensor tilize(
     const std::optional<tt::tt_metal::DataType>& output_dtype,
     bool use_multicore,
     bool enough_space_width,
-    bool enough_space_height,
     bool use_low_perf,
     const tt::tt_metal::Tile& tile,
     const std::optional<CoreRangeSet>& sub_core_grids);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation_types.hpp
@@ -14,8 +14,8 @@ struct TilizeParams {
     tt::tt_metal::MemoryConfig output_mem_config;
     tt::tt_metal::DataType output_dtype;
     bool use_multicore = false;
+    // Host L1 heuristic: default multicore path CBs fit one full tile-row (tensor width in tiles).
     bool enough_space_width = false;
-    bool enough_space_height = false;
     const bool use_low_perf = false;
     tt::tt_metal::Tile tile;
     const std::optional<CoreRangeSet> sub_core_grids = std::nullopt;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation_types.hpp
@@ -14,8 +14,7 @@ struct TilizeParams {
     tt::tt_metal::MemoryConfig output_mem_config;
     tt::tt_metal::DataType output_dtype;
     bool use_multicore = false;
-    // Host L1 heuristic: default multicore path CBs fit one full tile-row (tensor width in tiles).
-    bool enough_space_width = false;
+    bool enough_space_height = false;
     const bool use_low_perf = false;
     tt::tt_metal::Tile tile;
     const std::optional<CoreRangeSet> sub_core_grids = std::nullopt;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
@@ -66,8 +66,7 @@ ttnn::Tensor tilize(
     const uint32_t staging_bytes_per_tile = input_single_tile_size / input_tile_height;
     const uint32_t fixed_staging_bytes = 2 * dram_alignment;
 
-    // True when L1 can hold default-path CBs sized for one full tile-row (num_tiles_per_row tiles).
-    bool enough_space_width = ttnn::operations::data_movement::is_enough_space(
+    bool enough_space_height = ttnn::operations::data_movement::is_enough_space(
         input_tensor,
         input_single_tile_size,
         output_single_tile_size,
@@ -83,7 +82,7 @@ ttnn::Tensor tilize(
         // and exceed L1. Reroute via interleaved DRAM so the prim selects
         // TilizeMultiCoreBlockProgramFactory, whose CBs are bounded by
         // max_l1 / (input_tile_size + output_tile_size) by construction.
-        if (input_tensor.memory_config().is_sharded() && !enough_space_width) {
+        if (input_tensor.memory_config().is_sharded() && !enough_space_height) {
             log_debug(tt::LogOp, "ttnn::tilize: rerouting wide sharded input via DRAM interleaved (#45331)");
             const auto target_memory_config = memory_config.value_or(input_tensor.memory_config());
             auto interleaved_input = ttnn::to_memory_config(input_tensor, ttnn::DRAM_MEMORY_CONFIG);
@@ -92,7 +91,7 @@ ttnn::Tensor tilize(
                 ttnn::DRAM_MEMORY_CONFIG,
                 output_dtype,
                 use_multicore,
-                /*enough_space_width=*/false,
+                /*enough_space_height=*/false,
                 use_low_perf,
                 tile,
                 sub_core_grids);
@@ -103,7 +102,7 @@ ttnn::Tensor tilize(
             memory_config,
             output_dtype,
             use_multicore,
-            enough_space_width,
+            enough_space_height,
             use_low_perf,
             tile,
             sub_core_grids);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
@@ -60,21 +60,14 @@ ttnn::Tensor tilize(
     uint32_t input_tile_height = tile.get_height();
 
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / input_tile_width;
-    uint32_t num_tiles_per_col = input_tensor.padded_shape()[-2] / input_tile_height;
 
     // Fold in the block factory's c_1 staging CB so routing does not pick "fits" when only c_0+c_16 fit.
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
     const uint32_t staging_bytes_per_tile = input_single_tile_size / input_tile_height;
     const uint32_t fixed_staging_bytes = 2 * dram_alignment;
 
+    // True when L1 can hold default-path CBs sized for one full tile-row (num_tiles_per_row tiles).
     bool enough_space_width = ttnn::operations::data_movement::is_enough_space(
-        input_tensor,
-        input_single_tile_size,
-        output_single_tile_size,
-        num_tiles_per_col,
-        staging_bytes_per_tile,
-        fixed_staging_bytes);
-    bool enough_space_height = ttnn::operations::data_movement::is_enough_space(
         input_tensor,
         input_single_tile_size,
         output_single_tile_size,
@@ -90,7 +83,7 @@ ttnn::Tensor tilize(
         // and exceed L1. Reroute via interleaved DRAM so the prim selects
         // TilizeMultiCoreBlockProgramFactory, whose CBs are bounded by
         // max_l1 / (input_tile_size + output_tile_size) by construction.
-        if (input_tensor.memory_config().is_sharded() && !enough_space_height) {
+        if (input_tensor.memory_config().is_sharded() && !enough_space_width) {
             log_debug(tt::LogOp, "ttnn::tilize: rerouting wide sharded input via DRAM interleaved (#45331)");
             const auto target_memory_config = memory_config.value_or(input_tensor.memory_config());
             auto interleaved_input = ttnn::to_memory_config(input_tensor, ttnn::DRAM_MEMORY_CONFIG);
@@ -99,8 +92,7 @@ ttnn::Tensor tilize(
                 ttnn::DRAM_MEMORY_CONFIG,
                 output_dtype,
                 use_multicore,
-                enough_space_width,
-                /*enough_space_height=*/false,
+                /*enough_space_width=*/false,
                 use_low_perf,
                 tile,
                 sub_core_grids);
@@ -112,7 +104,6 @@ ttnn::Tensor tilize(
             output_dtype,
             use_multicore,
             enough_space_width,
-            enough_space_height,
             use_low_perf,
             tile,
             sub_core_grids);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
@@ -300,7 +300,7 @@ UntilizeDeviceOperation::program_factory_t UntilizeDeviceOperation::select_progr
         // Note that this implementation does not support sharding, which is enforced in validate().
         return UntilizeMultiCoreSubCoreGridsProgramFactory{};
     }
-    if (!operation_attributes.enough_space_height && !input_is_sharded && !output_is_sharded) {
+    if (!operation_attributes.enough_space_width && !input_is_sharded && !output_is_sharded) {
         // Optimized special case implementation, only supported when neither input or output is sharded
         return UntilizeMultiCoreBlockProgramFactory{};
     }
@@ -403,7 +403,6 @@ Tensor untilize(
     bool fp32_dest_acc_en,
     std::optional<CoreRangeSet> sub_core_grids,
     bool enough_space_width,
-    bool enough_space_height,
     uint32_t pf_type) {
     return ttnn::device_operation::launch<UntilizeDeviceOperation>(
         UntilizeOperationAttributes{
@@ -412,7 +411,6 @@ Tensor untilize(
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .sub_core_grids = std::move(sub_core_grids),
             .enough_space_width = enough_space_width,
-            .enough_space_height = enough_space_height,
             .pf_type = pf_type},
         UntilizeTensorArgs{.input = input});
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
@@ -300,7 +300,7 @@ UntilizeDeviceOperation::program_factory_t UntilizeDeviceOperation::select_progr
         // Note that this implementation does not support sharding, which is enforced in validate().
         return UntilizeMultiCoreSubCoreGridsProgramFactory{};
     }
-    if (!operation_attributes.enough_space_width && !input_is_sharded && !output_is_sharded) {
+    if (!operation_attributes.enough_space_height && !input_is_sharded && !output_is_sharded) {
         // Optimized special case implementation, only supported when neither input or output is sharded
         return UntilizeMultiCoreBlockProgramFactory{};
     }
@@ -402,7 +402,7 @@ Tensor untilize(
     bool use_multicore,
     bool fp32_dest_acc_en,
     std::optional<CoreRangeSet> sub_core_grids,
-    bool enough_space_width,
+    bool enough_space_height,
     uint32_t pf_type) {
     return ttnn::device_operation::launch<UntilizeDeviceOperation>(
         UntilizeOperationAttributes{
@@ -410,7 +410,7 @@ Tensor untilize(
             .use_multicore = use_multicore,
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .sub_core_grids = std::move(sub_core_grids),
-            .enough_space_width = enough_space_width,
+            .enough_space_height = enough_space_height,
             .pf_type = pf_type},
         UntilizeTensorArgs{.input = input});
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp
@@ -63,7 +63,7 @@ struct UntilizeDeviceOperation {
         bool use_multicore,
         bool fp32_dest_acc_en,
         std::optional<CoreRangeSet> sub_core_grids,
-        bool enough_space_width,
+        bool enough_space_height,
         uint32_t pf_type);
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
@@ -76,7 +76,7 @@ Tensor untilize(
     bool use_multicore,
     bool fp32_dest_acc_en,
     std::optional<CoreRangeSet> sub_core_grids,
-    bool enough_space_width,
+    bool enough_space_height,
     uint32_t pf_type);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp
@@ -64,7 +64,6 @@ struct UntilizeDeviceOperation {
         bool fp32_dest_acc_en,
         std::optional<CoreRangeSet> sub_core_grids,
         bool enough_space_width,
-        bool enough_space_height,
         uint32_t pf_type);
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
@@ -78,7 +77,6 @@ Tensor untilize(
     bool fp32_dest_acc_en,
     std::optional<CoreRangeSet> sub_core_grids,
     bool enough_space_width,
-    bool enough_space_height,
     uint32_t pf_type);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp
@@ -26,8 +26,7 @@ struct UntilizeOperationAttributes {
     bool use_multicore{};
     bool fp32_dest_acc_en{};
     std::optional<CoreRangeSet> sub_core_grids;
-    // Host L1 heuristic: default multicore path CBs fit one full tile-row (tensor width in tiles).
-    bool enough_space_width{};
+    bool enough_space_height{};
     uint32_t pf_type{};
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp
@@ -26,8 +26,8 @@ struct UntilizeOperationAttributes {
     bool use_multicore{};
     bool fp32_dest_acc_en{};
     std::optional<CoreRangeSet> sub_core_grids;
+    // Host L1 heuristic: default multicore path CBs fit one full tile-row (tensor width in tiles).
     bool enough_space_width{};
-    bool enough_space_height{};
     uint32_t pf_type{};
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
@@ -63,11 +63,9 @@ ttnn::Tensor untilize(
     uint32_t output_single_tile_size = input_single_tile_size;
 
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / tt::constants::TILE_WIDTH;
-    uint32_t num_tiles_per_col = input_tensor.padded_shape()[-2] / tt::constants::TILE_HEIGHT;
 
+    // True when L1 can hold default-path CBs sized for one full tile-row (num_tiles_per_row tiles).
     bool enough_space_width = operations::data_movement::is_enough_space(
-        input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_col);
-    bool enough_space_height = operations::data_movement::is_enough_space(
         input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
 
     auto base_untilize = [=](const ttnn::Tensor& input_tensor) {
@@ -81,7 +79,6 @@ ttnn::Tensor untilize(
             fp32_dest_acc_en,
             sub_core_grids,
             enough_space_width,
-            enough_space_height,
             pf_type);
     };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
@@ -64,8 +64,7 @@ ttnn::Tensor untilize(
 
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / tt::constants::TILE_WIDTH;
 
-    // True when L1 can hold default-path CBs sized for one full tile-row (num_tiles_per_row tiles).
-    bool enough_space_width = operations::data_movement::is_enough_space(
+    bool enough_space_height = operations::data_movement::is_enough_space(
         input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
 
     auto base_untilize = [=](const ttnn::Tensor& input_tensor) {
@@ -78,7 +77,7 @@ ttnn::Tensor untilize(
             use_multicore,
             fp32_dest_acc_en,
             sub_core_grids,
-            enough_space_width,
+            enough_space_height,
             pf_type);
     };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
@@ -193,7 +193,7 @@ TilizeDeviceOperation::program_factory_t TilizeDeviceOperation::select_program_f
         }
         return ttnn::prim::qsr::TilizeMultiCoreDefaultProgramFactory{};
     }
-    if (!operation_attributes.enough_space_width) {
+    if (!operation_attributes.enough_space_height) {
         return ttnn::prim::qsr::TilizeMultiCoreBlockProgramFactory{};
     }
     auto sub_core_grids = operation_attributes.sub_core_grids;
@@ -238,7 +238,7 @@ ttnn::Tensor tilize(
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<DataType>& output_dtype,
     bool use_multicore,
-    bool enough_space_width,
+    bool enough_space_height,
     bool use_low_perf,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return ttnn::device_operation::launch<TilizeDeviceOperation>(
@@ -246,7 +246,7 @@ ttnn::Tensor tilize(
             .output_mem_config = output_mem_config.value_or(input_tensor.memory_config()),
             .output_dtype = output_dtype.value_or(input_tensor.dtype()),
             .use_multicore = use_multicore,
-            .enough_space_width = enough_space_width,
+            .enough_space_height = enough_space_height,
             .use_low_perf = use_low_perf,
             .sub_core_grids = sub_core_grids,
         },

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
@@ -193,7 +193,7 @@ TilizeDeviceOperation::program_factory_t TilizeDeviceOperation::select_program_f
         }
         return ttnn::prim::qsr::TilizeMultiCoreDefaultProgramFactory{};
     }
-    if (!operation_attributes.enough_space_height) {
+    if (!operation_attributes.enough_space_width) {
         return ttnn::prim::qsr::TilizeMultiCoreBlockProgramFactory{};
     }
     auto sub_core_grids = operation_attributes.sub_core_grids;
@@ -239,7 +239,6 @@ ttnn::Tensor tilize(
     const std::optional<DataType>& output_dtype,
     bool use_multicore,
     bool enough_space_width,
-    bool enough_space_height,
     bool use_low_perf,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return ttnn::device_operation::launch<TilizeDeviceOperation>(
@@ -248,7 +247,6 @@ ttnn::Tensor tilize(
             .output_dtype = output_dtype.value_or(input_tensor.dtype()),
             .use_multicore = use_multicore,
             .enough_space_width = enough_space_width,
-            .enough_space_height = enough_space_height,
             .use_low_perf = use_low_perf,
             .sub_core_grids = sub_core_grids,
         },

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.hpp
@@ -43,7 +43,7 @@ ttnn::Tensor tilize(
     const std::optional<tt::tt_metal::MemoryConfig>& output_mem_config,
     const std::optional<tt::tt_metal::DataType>& output_dtype,
     bool use_multicore,
-    bool enough_space_width,
+    bool enough_space_height,
     bool use_low_perf,
     const std::optional<CoreRangeSet>& sub_core_grids);
 }  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.hpp
@@ -44,7 +44,6 @@ ttnn::Tensor tilize(
     const std::optional<tt::tt_metal::DataType>& output_dtype,
     bool use_multicore,
     bool enough_space_width,
-    bool enough_space_height,
     bool use_low_perf,
     const std::optional<CoreRangeSet>& sub_core_grids);
 }  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation_types.hpp
@@ -13,8 +13,8 @@ struct TilizeParams {
     tt::tt_metal::MemoryConfig output_mem_config;
     tt::tt_metal::DataType output_dtype;
     bool use_multicore = false;
+    // Host L1 heuristic: default multicore path CBs fit one full tile-row (tensor width in tiles).
     bool enough_space_width = false;
-    bool enough_space_height = false;
     const bool use_low_perf = false;
     const std::optional<CoreRangeSet> sub_core_grids = std::nullopt;
 };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation_types.hpp
@@ -13,8 +13,7 @@ struct TilizeParams {
     tt::tt_metal::MemoryConfig output_mem_config;
     tt::tt_metal::DataType output_dtype;
     bool use_multicore = false;
-    // Host L1 heuristic: default multicore path CBs fit one full tile-row (tensor width in tiles).
-    bool enough_space_width = false;
+    bool enough_space_height = false;
     const bool use_low_perf = false;
     const std::optional<CoreRangeSet> sub_core_grids = std::nullopt;
 };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.cpp
@@ -63,11 +63,9 @@ ttnn::Tensor tilize(
     uint32_t input_tile_height = input_tensor.tensor_spec().tile().get_height();
 
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / input_tile_width;
-    uint32_t num_tiles_per_col = input_tensor.padded_shape()[-1] / input_tile_height;
 
+    // True when L1 can hold default-path CBs sized for one full tile-row (num_tiles_per_row tiles).
     bool enough_space_width = ttnn::operations::data_movement::is_enough_space(
-        input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_col);
-    bool enough_space_height = ttnn::operations::data_movement::is_enough_space(
         input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
 
     auto base_tilize = [=](const ttnn::Tensor& input_tensor) {
@@ -75,7 +73,7 @@ ttnn::Tensor tilize(
         // to the default tilize factory, whose CBs are sized to a full tile-row (ntiles_per_block) and
         // exceed L1. Reroute via interleaved DRAM so the prim selects the block factory (CBs bounded by
         // max_l1 / (in_tile + out_tile)). Uses the quasar to_memory_config (same namespace).
-        if (input_tensor.memory_config().is_sharded() && !enough_space_height) {
+        if (input_tensor.memory_config().is_sharded() && !enough_space_width) {
             const auto target_memory_config = memory_config.value_or(input_tensor.memory_config());
             auto interleaved_input = to_memory_config(input_tensor, ttnn::DRAM_MEMORY_CONFIG);
             auto interleaved_tile = ttnn::prim::qsr::tilize(
@@ -83,8 +81,7 @@ ttnn::Tensor tilize(
                 ttnn::DRAM_MEMORY_CONFIG,
                 output_dtype,
                 use_multicore,
-                enough_space_width,
-                /*enough_space_height=*/false,
+                /*enough_space_width=*/false,
                 use_low_perf,
                 sub_core_grids);
             return to_memory_config(interleaved_tile, target_memory_config);
@@ -95,7 +92,6 @@ ttnn::Tensor tilize(
             output_dtype,
             use_multicore,
             enough_space_width,
-            enough_space_height,
             use_low_perf,
             sub_core_grids);
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.cpp
@@ -60,12 +60,10 @@ ttnn::Tensor tilize(
                                  : input_single_tile_size;
 
     uint32_t input_tile_width = input_tensor.tensor_spec().tile().get_width();
-    uint32_t input_tile_height = input_tensor.tensor_spec().tile().get_height();
 
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / input_tile_width;
 
-    // True when L1 can hold default-path CBs sized for one full tile-row (num_tiles_per_row tiles).
-    bool enough_space_width = ttnn::operations::data_movement::is_enough_space(
+    bool enough_space_height = ttnn::operations::data_movement::is_enough_space(
         input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
 
     auto base_tilize = [=](const ttnn::Tensor& input_tensor) {
@@ -73,7 +71,7 @@ ttnn::Tensor tilize(
         // to the default tilize factory, whose CBs are sized to a full tile-row (ntiles_per_block) and
         // exceed L1. Reroute via interleaved DRAM so the prim selects the block factory (CBs bounded by
         // max_l1 / (in_tile + out_tile)). Uses the quasar to_memory_config (same namespace).
-        if (input_tensor.memory_config().is_sharded() && !enough_space_width) {
+        if (input_tensor.memory_config().is_sharded() && !enough_space_height) {
             const auto target_memory_config = memory_config.value_or(input_tensor.memory_config());
             auto interleaved_input = to_memory_config(input_tensor, ttnn::DRAM_MEMORY_CONFIG);
             auto interleaved_tile = ttnn::prim::qsr::tilize(
@@ -81,7 +79,7 @@ ttnn::Tensor tilize(
                 ttnn::DRAM_MEMORY_CONFIG,
                 output_dtype,
                 use_multicore,
-                /*enough_space_width=*/false,
+                /*enough_space_height=*/false,
                 use_low_perf,
                 sub_core_grids);
             return to_memory_config(interleaved_tile, target_memory_config);
@@ -91,7 +89,7 @@ ttnn::Tensor tilize(
             memory_config,
             output_dtype,
             use_multicore,
-            enough_space_width,
+            enough_space_height,
             use_low_perf,
             sub_core_grids);
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.cpp
@@ -300,7 +300,7 @@ UntilizeDeviceOperation::program_factory_t UntilizeDeviceOperation::select_progr
         // Note that this implementation does not support sharding, which is enforced in validate().
         return UntilizeMultiCoreSubCoreGridsProgramFactory{};
     }
-    if (!operation_attributes.enough_space_height && !input_is_sharded && !output_is_sharded) {
+    if (!operation_attributes.enough_space_width && !input_is_sharded && !output_is_sharded) {
         // Optimized special case implementation, only supported when neither input or output is sharded
         return UntilizeMultiCoreBlockProgramFactory{};
     }
@@ -403,7 +403,6 @@ Tensor untilize(
     bool fp32_dest_acc_en,
     std::optional<CoreRangeSet> sub_core_grids,
     bool enough_space_width,
-    bool enough_space_height,
     uint32_t pf_type) {
     return ttnn::device_operation::launch<UntilizeDeviceOperation>(
         UntilizeOperationAttributes{
@@ -412,7 +411,6 @@ Tensor untilize(
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .sub_core_grids = std::move(sub_core_grids),
             .enough_space_width = enough_space_width,
-            .enough_space_height = enough_space_height,
             .pf_type = pf_type},
         UntilizeTensorArgs{.input = input});
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.cpp
@@ -300,7 +300,7 @@ UntilizeDeviceOperation::program_factory_t UntilizeDeviceOperation::select_progr
         // Note that this implementation does not support sharding, which is enforced in validate().
         return UntilizeMultiCoreSubCoreGridsProgramFactory{};
     }
-    if (!operation_attributes.enough_space_width && !input_is_sharded && !output_is_sharded) {
+    if (!operation_attributes.enough_space_height && !input_is_sharded && !output_is_sharded) {
         // Optimized special case implementation, only supported when neither input or output is sharded
         return UntilizeMultiCoreBlockProgramFactory{};
     }
@@ -402,7 +402,7 @@ Tensor untilize(
     bool use_multicore,
     bool fp32_dest_acc_en,
     std::optional<CoreRangeSet> sub_core_grids,
-    bool enough_space_width,
+    bool enough_space_height,
     uint32_t pf_type) {
     return ttnn::device_operation::launch<UntilizeDeviceOperation>(
         UntilizeOperationAttributes{
@@ -410,7 +410,7 @@ Tensor untilize(
             .use_multicore = use_multicore,
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .sub_core_grids = std::move(sub_core_grids),
-            .enough_space_width = enough_space_width,
+            .enough_space_height = enough_space_height,
             .pf_type = pf_type},
         UntilizeTensorArgs{.input = input});
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.hpp
@@ -63,7 +63,7 @@ struct UntilizeDeviceOperation {
         bool use_multicore,
         bool fp32_dest_acc_en,
         std::optional<CoreRangeSet> sub_core_grids,
-        bool enough_space_width,
+        bool enough_space_height,
         uint32_t pf_type);
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
@@ -76,7 +76,7 @@ Tensor untilize(
     bool use_multicore,
     bool fp32_dest_acc_en,
     std::optional<CoreRangeSet> sub_core_grids,
-    bool enough_space_width,
+    bool enough_space_height,
     uint32_t pf_type);
 
 }  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.hpp
@@ -64,7 +64,6 @@ struct UntilizeDeviceOperation {
         bool fp32_dest_acc_en,
         std::optional<CoreRangeSet> sub_core_grids,
         bool enough_space_width,
-        bool enough_space_height,
         uint32_t pf_type);
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
@@ -78,7 +77,6 @@ Tensor untilize(
     bool fp32_dest_acc_en,
     std::optional<CoreRangeSet> sub_core_grids,
     bool enough_space_width,
-    bool enough_space_height,
     uint32_t pf_type);
 
 }  // namespace ttnn::prim::qsr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation_types.hpp
@@ -26,8 +26,7 @@ struct UntilizeOperationAttributes {
     bool use_multicore{};
     bool fp32_dest_acc_en{};
     std::optional<CoreRangeSet> sub_core_grids;
-    // Host L1 heuristic: default multicore path CBs fit one full tile-row (tensor width in tiles).
-    bool enough_space_width{};
+    bool enough_space_height{};
     uint32_t pf_type{};
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation_types.hpp
@@ -26,8 +26,8 @@ struct UntilizeOperationAttributes {
     bool use_multicore{};
     bool fp32_dest_acc_en{};
     std::optional<CoreRangeSet> sub_core_grids;
+    // Host L1 heuristic: default multicore path CBs fit one full tile-row (tensor width in tiles).
     bool enough_space_width{};
-    bool enough_space_height{};
     uint32_t pf_type{};
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/untilize.cpp
@@ -72,11 +72,9 @@ ttnn::Tensor untilize(
     uint32_t output_single_tile_size = input_single_tile_size;
 
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / tt::constants::TILE_WIDTH;
-    uint32_t num_tiles_per_col = input_tensor.padded_shape()[-2] / tt::constants::TILE_HEIGHT;
 
+    // True when L1 can hold default-path CBs sized for one full tile-row (num_tiles_per_row tiles).
     bool enough_space_width = operations::data_movement::is_enough_space(
-        input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_col);
-    bool enough_space_height = operations::data_movement::is_enough_space(
         input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
 
     auto base_untilize = [=](const ttnn::Tensor& input_tensor) {
@@ -90,7 +88,6 @@ ttnn::Tensor untilize(
             fp32_dest_acc_en,
             sub_core_grids,
             enough_space_width,
-            enough_space_height,
             pf_type);
     };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/untilize.cpp
@@ -73,8 +73,7 @@ ttnn::Tensor untilize(
 
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / tt::constants::TILE_WIDTH;
 
-    // True when L1 can hold default-path CBs sized for one full tile-row (num_tiles_per_row tiles).
-    bool enough_space_width = operations::data_movement::is_enough_space(
+    bool enough_space_height = operations::data_movement::is_enough_space(
         input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
 
     auto base_untilize = [=](const ttnn::Tensor& input_tensor) {
@@ -87,7 +86,7 @@ ttnn::Tensor untilize(
             use_multicore,
             fp32_dest_acc_en,
             sub_core_grids,
-            enough_space_width,
+            enough_space_height,
             pf_type);
     };
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Relates to #46533. Extends the fix from #46562 to `tilize` and `untilize`.

`tilize` and `untilize` compute `enough_space_width` from currently-free L1 and
fold it into the device op attributes, but `select_program_factory` only ever
branches on `enough_space_height`. `enough_space_width` has never been read for
factory selection since it was introduced in #17790.

Because it lives in the operation attributes, it still contributes to the
program-cache key. The same tensor spec can therefore fork the cache when
unrelated resident L1 allocations flip a heuristic that does not change the
selected program factory.

This removes `enough_space_width` from the host-side attribute surface of
`tilize` and `untilize`, plus their `experimental::quasar` mirrors. The diff is
deletions only.

### Notes for reviewers
I deliberately left `enough_space_height` untouched, matching the reasoning in
#46562.

It is easy to read these two flags as mis-named, since `enough_space_height` is
computed from `num_tiles_per_row`. They are not. The name refers to the
parallelization axis of the candidate program factory, and the tile count passed
in is the orthogonal extent each core must buffer:

- `untilize_multi_core` calls `split_blocks_for_tilize(grid_size, num_tiles_per_col)`,
  splitting tile-rows across cores, so it is height-parallel. Each core's CB holds
  one full row, `num_tiles_per_row` tiles. `enough_space_height = is_enough_space(..., num_tiles_per_row)`
  is therefore correct.
- A width-parallel factory would split columns across cores, each buffering a full
  column of `num_tiles_per_col` tiles, which is what `enough_space_width` was
  computed from. That factory was never implemented.

So the flag being removed is the one whose consumer never landed, not the one
whose name looks wrong.

Incidental: the quasar `tilize` copy of the dead heuristic computed
`num_tiles_per_col` from `padded_shape()[-1]` rather than `[-2]`, further evidence
it was never exercised. That line is removed here.

`tilize_with_val_padding` still carries the same dead flag. Happy to fold it into
this PR or file a follow-up, reviewer's preference.

### Test plan
- [ ] Untilize / tilize unit tests on device
- [ ] Confirm low-L1 shapes still route to the block factory via `enough_space_height`
- [ ] `pytest tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py` (unchanged by this PR, should stay green)

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cleanup/enough-space-width-tile-row-heuristic)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cleanup/enough-space-width-tile-row-heuristic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cleanup/enough-space-width-tile-row-heuristic)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cleanup/enough-space-width-tile-row-heuristic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=cleanup/enough-space-width-tile-row-heuristic)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:cleanup/enough-space-width-tile-row-heuristic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cleanup/enough-space-width-tile-row-heuristic)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cleanup/enough-space-width-tile-row-heuristic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cleanup/enough-space-width-tile-row-heuristic)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cleanup/enough-space-width-tile-row-heuristic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cleanup/enough-space-width-tile-row-heuristic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cleanup/enough-space-width-tile-row-heuristic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cleanup/enough-space-width-tile-row-heuristic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cleanup/enough-space-width-tile-row-heuristic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cleanup/enough-space-width-tile-row-heuristic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cleanup/enough-space-width-tile-row-heuristic)