### PR TITLE
[Bug Fix] Updating experimental::quasar DM CreateKernel to skip DM0 & DM1

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -1013,9 +1013,9 @@ inline tt_metal::KernelHandle create_sd_cq_kernel(
                 .is_legacy_kernel = true});
     }
     if (device->arch() == tt::ARCH::QUASAR) {
-        // Quasar interim Tensix path (TT_METAL_TENSIX_DISPATCH_CORES=1): the experimental API
-        // auto-assigns DMs by creation order (prefetch first -> DM0, dispatch -> DM1), matching the
-        // legacy behavior. dm_processor is not used here.
+        // Quasar interim Tensix path (TT_METAL_TENSIX_DISPATCH_CORES=1): CreateKernel skips
+        // reserved DM0/DM1 and auto-assigns free user DMs (prefetch first -> DM2, …).
+        // dm_processor is not used here.
         return tt::tt_metal::experimental::quasar::CreateKernel(
             program,
             kernel_path,

--- a/tt_metal/impl/host_api/temp_quasar_api.cpp
+++ b/tt_metal/impl/host_api/temp_quasar_api.cpp
@@ -71,6 +71,15 @@ std::set<ProcessorClassType> GetProcessorsPerClusterQuasar(
         enchantum::values<ProcessorClassType>.begin(), enchantum::values<ProcessorClassType>.end());
     std::vector<std::set<DataMovementProcessor>> dm_processors_in_use_per_kernel_group;
 
+    // Tensix WORKER: DM0/DM1 are reserved for runtime use (ISR / remapper) and must not host
+    // user kernels. Dispatch-engine cores keep the full DM0..DM7 set.
+    if constexpr (std::is_same_v<ProcessorClassType, DataMovementProcessor>) {
+        if (programmable_core_type == HalProgrammableCoreType::TENSIX) {
+            processors.erase(DataMovementProcessor::RISCV_0);
+            processors.erase(DataMovementProcessor::RISCV_1);
+        }
+    }
+
     const uint32_t programmable_core_type_index =
         MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type);
     std::unordered_set<const KernelGroup*> kernel_groups;
@@ -151,9 +160,10 @@ KernelHandle CreateQuasarDataMovementKernel(
     const CoreRangeSet& core_ranges,
     const QuasarDataMovementConfig& config) {
     TT_FATAL(
-        1 <= config.num_threads_per_cluster && config.num_threads_per_cluster <= QUASAR_NUM_DM_CORES_PER_CLUSTER,
-        "Requested number of data movement cores per cluster must be between 1 and {} (inclusive)",
-        QUASAR_NUM_DM_CORES_PER_CLUSTER);
+        1 <= config.num_threads_per_cluster && config.num_threads_per_cluster <= QUASAR_NUM_USER_DM_CORES_PER_CLUSTER,
+        "Requested number of data movement cores per cluster must be between 1 and {} (inclusive); "
+        "DM0/DM1 are reserved on Tensix",
+        QUASAR_NUM_USER_DM_CORES_PER_CLUSTER);
     const std::set<DataMovementProcessor> dm_processors = GetProcessorsPerClusterQuasar<DataMovementProcessor>(
         program, core_ranges, config.num_threads_per_cluster, HalProgrammableCoreType::TENSIX);
     std::shared_ptr<Kernel> kernel =

--- a/tt_metal/impl/host_api/temp_quasar_api.hpp
+++ b/tt_metal/impl/host_api/temp_quasar_api.hpp
@@ -31,11 +31,16 @@ class Program;
 
 namespace experimental::quasar {
 static constexpr uint32_t QUASAR_NUM_DM_CORES_PER_CLUSTER = 8;
+// Tensix WORKER clusters reserve DM0 (ISR) and DM1 (remapper) for runtime use; CreateKernel
+// assigns user kernels to DM2..DM7 only. Dispatch-engine cores do not apply this reservation.
+static constexpr uint32_t QUASAR_NUM_RESERVED_DM_CORES_PER_CLUSTER = 2;
+static constexpr uint32_t QUASAR_NUM_USER_DM_CORES_PER_CLUSTER =
+    QUASAR_NUM_DM_CORES_PER_CLUSTER - QUASAR_NUM_RESERVED_DM_CORES_PER_CLUSTER;
 static constexpr uint32_t QUASAR_NUM_TENSIX_ENGINES_PER_CLUSTER = 4;
 
 struct QuasarDataMovementConfig {
-    // Number of data movement cores per cluster to use
-    uint32_t num_threads_per_cluster = QUASAR_NUM_DM_CORES_PER_CLUSTER;
+    // Number of data movement cores per cluster to use (max is QUASAR_NUM_USER_DM_CORES_PER_CLUSTER)
+    uint32_t num_threads_per_cluster = QUASAR_NUM_USER_DM_CORES_PER_CLUSTER;
 
     std::vector<uint32_t> compile_args;
 
@@ -132,6 +137,7 @@ KernelHandle CreateKernel(
  * @brief Reserve free data-movement processors on the given programmable core type.
  *
  * Same allocation policy as Quasar Tensix CreateKernel: pick the lowest-numbered free DMs.
+ * On TENSIX, DM0/DM1 are reserved and skipped; on DISPATCH the full DM0..DM7 set is available.
  */
 std::set<DataMovementProcessor> GetAvailableDataMovementProcessors(
     Program& program,


### PR DESCRIPTION
### PR Category

Bug Fix: #52093 

### Summary
Kernels should be skipping DM0 & DM1 on Quasar, as these are reserved. A recent change stopping the FW from running kernels on DM0 & DM1 exposed several tests and at least one code path that are relying on `experimental::quasar::CreateKernel` instead of using proper Host 2.0 APIs. Long term we should stop using this internal API, but in the meantime I am updating `experimental::quasar::CreateKernel` to disallow usage of DM0 & DM1.

Quasar DPRINT DM tests & FD tests run on WORKER cores hang without this change, pass with this change.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/issue_52093)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/issue_52093)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/issue_52093)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/issue_52093)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kstevens/issue_52093)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kstevens/issue_52093)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/issue_52093)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/issue_52093)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/issue_52093)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/issue_52093)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/issue_52093)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/issue_52093)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/issue_52093)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/issue_52093)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/issue_52093)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/issue_52093)