### PR TITLE
[Test Only] Add Quasar fast dispatch stress tests

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -1072,6 +1072,15 @@ inline bool is_quasar_cq_dram_backed() {
     return !rtoptions.is_dram_backed_cq_specified() || rtoptions.get_dram_backed_cq();
 }
 
+struct CompletionQueuePtrToggle {
+    uint32_t ptr_16B = 0;
+    uint32_t toggle = 0;
+};
+
+inline CompletionQueuePtrToggle split_ptr_toggle(uint32_t ptr_and_toggle) {
+    return {ptr_and_toggle & 0x7fffffffu, ptr_and_toggle >> 31};
+}
+
 // Wrapper template that marks any base fixture as the Quasar-simulator-only variant; the constructor
 // sets quasar_simulator_variant_ before gtest's SetUp() reads it.
 template <class FDFixture>
@@ -1115,13 +1124,7 @@ protected:
     // Test Config defaults
     DispatchTestConfig cfg_;
 
-    void SetUp() override {
-        if (!validate_dispatch_mode()) {
-            GTEST_SKIP();
-        }
-        tt_metal::GenericMeshDeviceFixture::SetUp();
-
-        // Setup Config
+    virtual DispatchPayloadGenerator::Config payload_generator_config() const {
         DispatchPayloadGenerator::Config pgcfg;
         pgcfg.use_coherent_data = cfg_.use_coherent_data;
         pgcfg.perf_test = cfg_.perf_test;
@@ -1131,8 +1134,17 @@ protected:
         // Handle Seeding
         std::random_device rd;
         pgcfg.seed = rd();
+        return pgcfg;
+    }
+
+    void SetUp() override {
+        if (!validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
+        tt_metal::GenericMeshDeviceFixture::SetUp();
 
         // Initialize Generator
+        const DispatchPayloadGenerator::Config pgcfg = payload_generator_config();
         payload_generator_ = std::make_unique<DispatchPayloadGenerator>(pgcfg);
         log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
 
@@ -1213,12 +1225,12 @@ protected:
         const auto start = std::chrono::steady_clock::now();
         uint32_t avail = 0;
         while (avail < total_expected_cq_payload) {
-            const uint32_t completion_queue_write_ptr_and_toggle =
-                mgr_->completion_queue_wait_front(fdcq_->id(), exit_condition);
-            const uint32_t completion_q_write_ptr = (completion_queue_write_ptr_and_toggle & 0x7fffffff) << 4;
-            const uint32_t completion_q_write_toggle = completion_queue_write_ptr_and_toggle >> (31);
+            const auto [completion_q_write_ptr_16B, completion_q_write_toggle] =
+                split_ptr_toggle(mgr_->completion_queue_wait_front(fdcq_->id(), exit_condition));
+            const uint32_t completion_q_write_ptr = completion_q_write_ptr_16B << 4;
             const uint32_t completion_q_read_ptr = mgr_->get_completion_queue_read_ptr(fdcq_->id());
             const uint32_t completion_q_read_toggle = mgr_->get_completion_queue_read_toggle(fdcq_->id());
+            const uint32_t completion_q_base = mgr_->get_issue_queue_limit(fdcq_->id());
             const uint32_t limit = mgr_->get_completion_queue_limit(fdcq_->id());  // offset of end, in bytes
 
             if (completion_q_write_toggle == completion_q_read_toggle) {
@@ -1226,7 +1238,7 @@ protected:
                             ? completion_q_write_ptr - completion_q_read_ptr
                             : 0u;
             } else {
-                avail = (limit - completion_q_read_ptr) + completion_q_write_ptr;
+                avail = (limit - completion_q_read_ptr) + (completion_q_write_ptr - completion_q_base);
             }
 
             if (timeout_ms > 0 && !Common::is_quasar_sim()) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -66,8 +66,7 @@ constexpr uint32_t QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES = 96 * 1024;
 struct LinearWriteParams {
     uint32_t transfer_size_bytes{};  // Total transfer size in bytes for the test iteration
     uint32_t num_iterations{};       // Number of iterations for the test
-    uint32_t dram_data_size_words{};
-    bool is_mcast{};  // Whether to use multicast or unicast
+    bool is_mcast{};                 // Whether to use multicast or unicast
 };
 
 // How the paged write test reads PagedWriteParams::page_size. Random draws a size per run with
@@ -78,10 +77,9 @@ enum class PageSizeMode : uint8_t { Random, Exact };
 // Params that control the data volume, iteration count, and DRAM/L1
 // for the paged write test
 struct PagedWriteParams {
-    uint32_t page_size{};       // Page size in bytes
-    uint32_t num_pages{};       // Number of pages
-    uint32_t num_iterations{};  // Number of iterations for the test
-    uint32_t dram_data_size_words{};
+    uint32_t page_size{};                                // Page size in bytes
+    uint32_t num_pages{};                                // Number of pages
+    uint32_t num_iterations{};                           // Number of iterations for the test
     bool is_dram{};                                      // Whether to use DRAM or L1
     PageSizeMode page_size_mode = PageSizeMode::Random;  // Whether page_size is a ceiling or the size to emit
 };
@@ -91,7 +89,9 @@ struct PagedWriteParams {
 struct PackedWriteParams {
     uint32_t transfer_size_bytes{};  // Total transfer size in bytes for the test iteration
     uint32_t num_iterations{};       // Number of iterations for the test
-    uint32_t dram_data_size_words{};
+    // Zero retains the randomized transaction count. Stress cases can request a dense
+    // packed-large command while the generator still observes the fetch-size limit.
+    uint32_t target_sub_cmds{};
 };
 
 namespace DeviceDataUpdater {
@@ -214,7 +214,6 @@ class DispatchLinearWriteTestFixture : public BaseDispatchTestFixture,
                                        public ::testing::WithParamInterface<LinearWriteParams> {
     uint32_t transfer_size_bytes_{};
     uint32_t num_iterations_{};
-    uint32_t dram_data_size_words_{};
     bool is_mcast_{};
 
 protected:
@@ -225,7 +224,6 @@ protected:
     void init_params(const LinearWriteParams& p) {
         transfer_size_bytes_ = p.transfer_size_bytes;
         num_iterations_ = p.num_iterations;
-        dram_data_size_words_ = p.dram_data_size_words;
         is_mcast_ = p.is_mcast;
     }
 
@@ -235,116 +233,88 @@ public:
         init_params(GetParam());
     }
 
-    // Splits the requested transfer into randomly sized chunks that
-    // respect max-fetch limits, generates payloads, and updates expected
-    // results before emitting HostMemDeviceCommands
-    std::vector<HostMemDeviceCommand> generate_linear_write_commands(
+protected:
+    uint32_t linear_write_noc_encoding(const CoreRange& worker_range) const {
+        const CoreCoord first_virt =
+            device_->virtual_core_from_logical_core(worker_range.start_coord, CoreType::WORKER);
+        if (!is_mcast_) {
+            return device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt);
+        }
+        const CoreCoord last_virt = device_->virtual_core_from_logical_core(worker_range.end_coord, CoreType::WORKER);
+        return device_->get_noc_multicast_encoding(k_dispatch_downstream_noc, CoreRange(first_virt, last_virt));
+    }
+
+    // Append random-sized linear write commands consuming budget_bytes, updating device_data.
+    void append_random_linear_writes(
+        std::vector<HostMemDeviceCommand>& commands,
         const CoreRange& worker_range,
         uint32_t noc_xy,
         uint32_t max_payload_per_cmd_bytes,
-        Common::DeviceData& device_data  // Pass by ref to update the expectation model
-    ) {
-        // This vector stores commands related information for each iteration
-        std::vector<HostMemDeviceCommand> commands_per_iteration;
-
-        uint32_t remaining_bytes = get_transfer_size_bytes();
+        uint32_t budget_bytes,
+        Common::DeviceData& device_data) {
         const CoreCoord first_worker = worker_range.start_coord;
-
-        // Relevel once for multicast before generating commands
-        if (is_mcast_) {
-            device_data.relevel(tt::CoreType::WORKER);
-        }
-
-        // Chunking logic:
-        // The prefetcher has a buffer limit (max_fetch_bytes_) which restricts the size of each command
-        // Thus, each chunk's payload is clamped to max_payload_per_cmd_bytes (= max_fetch_bytes_ - overhead)
-        // This loop generates random-sized linear write commands until all transfer bytes are consumed
-        while (remaining_bytes > 0) {
-            // Generate random transfer size
+        for (uint32_t remaining_bytes = budget_bytes; remaining_bytes > 0;) {
             uint32_t xfer_size_bytes =
                 payload_generator_->get_random_size(MAX_XFER_SIZE_16B, bytes_per_16B_unit, remaining_bytes);
-
-            // Clamp to max_payload_per_cmd_bytes constraints
-            // This ensures the command fits within the prefetcher's buffer limit
             xfer_size_bytes = std::min(xfer_size_bytes, max_payload_per_cmd_bytes);
-
-            // Capture address before updating device_data
-            uint32_t addr = device_data.get_result_data_addr(first_worker, 0);
-
-            // Generate payload
+            const uint32_t addr = device_data.get_result_data_addr(first_worker, 0);
             std::vector<uint32_t> payload = payload_generator_->generate_payload(xfer_size_bytes);
-
-            // Update Common::DeviceData for linear write
             Common::DeviceDataUpdater::update_linear_write(payload, device_data, worker_range, is_mcast_);
-
-            // Create the HostMemDeviceCommand
-            HostMemDeviceCommand cmd =
-                Common::CommandBuilder::build_linear_write_command<flush_prefetch_, inline_data_>(
-                    payload, worker_range, is_mcast_, noc_xy, addr, xfer_size_bytes);
-
-            commands_per_iteration.push_back(std::move(cmd));
+            commands.push_back(Common::CommandBuilder::build_linear_write_command<flush_prefetch_, inline_data_>(
+                payload, worker_range, is_mcast_, noc_xy, addr, xfer_size_bytes));
             remaining_bytes -= xfer_size_bytes;
         }
-
-        log_info(
-            tt::LogTest,
-            "Generated {} linear write commands totaling {} bytes",
-            commands_per_iteration.size(),
-            transfer_size_bytes_ - remaining_bytes);
-
-        return commands_per_iteration;
     }
 
+    // Stress variants prepend dispatch-CB-boundary-crossing commands ahead of the random stream and
+    // return the transfer bytes the crossing command consumed. Default: no prefix.
+    virtual uint32_t prepend_linear_boundary_crossing(
+        std::vector<HostMemDeviceCommand>&, const CoreRange&, uint32_t, uint32_t, Common::DeviceData&) {
+        return 0;
+    }
+
+public:
     uint32_t get_transfer_size_bytes() const { return transfer_size_bytes_; }
     uint32_t get_num_iterations() const { return num_iterations_; }
-    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
     bool get_is_mcast() const { return is_mcast_; }
 
     void run_linear_write_test() {
-        const uint32_t num_iterations = get_num_iterations();
-        const uint32_t dram_data_size_words = get_dram_data_size_words();
         const uint32_t total_target_bytes = get_transfer_size_bytes();
-        const bool is_mcast = get_is_mcast();
-
         ASSERT_EQ(total_target_bytes % 16, 0) << "Require 16B alignment for write payload";
 
         log_info(
             tt::LogTest,
             "Target total: {} bytes, Iterations: {}, Multicast: {}",
             total_target_bytes,
-            num_iterations,
-            is_mcast);
+            get_num_iterations(),
+            is_mcast_);
 
         const CoreCoord first_worker = worker_start();
-        const CoreRange worker_range = this->worker_range(first_worker, is_mcast);
-        const CoreCoord last_worker = worker_range.end_coord;
+        const CoreRange worker_range = this->worker_range(first_worker, is_mcast_);
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
         const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
 
+        // L1-only inline writes; skip DRAM prepopulation.
         Common::DeviceData device_data(
-            device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+            device_, worker_range, l1_base, dram_base, nullptr, false, /*dram_data_size_words=*/0, cfg_);
 
         DeviceCommandCalculator cmd_calc;
         cmd_calc.add_dispatch_write_linear<flush_prefetch_, inline_data_>(0);
-        const uint32_t overhead_bytes = cmd_calc.write_offset_bytes();
-        const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - overhead_bytes;
+        const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - cmd_calc.write_offset_bytes();
+        const uint32_t noc_xy = linear_write_noc_encoding(worker_range);
 
-        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
-        uint32_t noc_xy;
-        if (is_mcast) {
-            const CoreCoord last_virt_worker = device_->virtual_core_from_logical_core(last_worker, CoreType::WORKER);
-            noc_xy = device_->get_noc_multicast_encoding(
-                k_dispatch_downstream_noc, CoreRange(first_virt_worker, last_virt_worker));
-        } else {
-            noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+        if (is_mcast_) {
+            device_data.relevel(tt::CoreType::WORKER);
         }
-        // PHASE 1: Generate random-sized linear write commands metadata
-        auto commands_per_iteration =
-            generate_linear_write_commands(worker_range, noc_xy, max_payload_per_cmd_bytes, device_data);
 
-        // PHASE 2, 3, 4: Execute and Validate
-        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+        std::vector<HostMemDeviceCommand> commands;
+        const uint32_t prefix_bytes =
+            prepend_linear_boundary_crossing(commands, worker_range, noc_xy, max_payload_per_cmd_bytes, device_data);
+        append_random_linear_writes(
+            commands, worker_range, noc_xy, max_payload_per_cmd_bytes, total_target_bytes - prefix_bytes, device_data);
+
+        execute_generated_commands(commands, device_data, worker_range.size(), get_num_iterations());
     }
 };
 
@@ -354,7 +324,6 @@ class DispatchPagedWriteTestFixture : public BaseDispatchTestFixture,
     uint32_t page_size_{};
     uint32_t num_pages_{};
     uint32_t num_iterations_{};
-    uint32_t dram_data_size_words_{};
     bool is_dram_{};
     PageSizeMode page_size_mode_ = PageSizeMode::Random;
 
@@ -377,10 +346,21 @@ protected:
         page_size_ = p.page_size;
         num_pages_ = p.num_pages;
         num_iterations_ = p.num_iterations;
-        dram_data_size_words_ = p.dram_data_size_words;
         is_dram_ = p.is_dram;
         page_size_mode_ = p.page_size_mode;
     }
+
+    // Base FD test fuzzes the page size up to the requested value unless the case asks for it exactly;
+    // stress variants fix it.
+    virtual uint32_t paged_write_page_size_bytes(uint32_t requested_page_size) {
+        return get_page_size_mode() == PageSizeMode::Exact
+                   ? requested_page_size
+                   : payload_generator_->get_random_size(
+                         MAX_XFER_SIZE_16B - 1, bytes_per_16B_unit, requested_page_size);
+    }
+
+    // Stress variants prepend dispatch-CB-boundary-crossing commands (transient, not modeled). Default: none.
+    virtual void prepend_paged_boundary_crossing(std::vector<HostMemDeviceCommand>&, uint32_t) {}
 
 public:
     void SetUp() override {
@@ -481,14 +461,9 @@ public:
     PageSizeMode get_page_size_mode() const { return page_size_mode_; }
     uint32_t get_num_pages() const { return num_pages_; }
     uint32_t get_num_iterations() const { return num_iterations_; }
-    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
     bool get_is_dram() const { return is_dram_; }
 
     void run_paged_write_test() {
-        const uint32_t num_iterations = get_num_iterations();
-        const uint32_t dram_data_size_words = get_dram_data_size_words();
-        const uint32_t num_pages_per_cmd = get_num_pages();
-        const uint32_t page_size_bytes_param = get_page_size();
         const bool is_dram = get_is_dram();
 
         const CoreCoord first_worker = worker_start();
@@ -497,39 +472,37 @@ public:
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
         const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
 
+        // Inline paged payloads; skip DRAM prepopulation (destinations start at the DRAM/L1 result base).
         Common::DeviceData device_data(
-            device_, worker_range, l1_base, dram_base, nullptr, true, dram_data_size_words, cfg_);
+            device_, worker_range, l1_base, dram_base, nullptr, true, /*dram_data_size_words=*/0, cfg_);
 
         const auto buf_type = is_dram ? BufferType::DRAM : BufferType::L1;
         const uint32_t page_size_alignment_bytes = device_->allocator_impl()->get_alignment(buf_type);
         const uint32_t num_banks = device_->allocator_impl()->get_num_banks(buf_type);
         const tt::CoreType core_type = is_dram ? tt::CoreType::DRAM : tt::CoreType::WORKER;
-
-        const uint32_t max_allowed = MAX_XFER_SIZE_16B - 1;
-        const uint32_t page_size_bytes =
-            get_page_size_mode() == PageSizeMode::Exact
-                ? page_size_bytes_param
-                : payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, page_size_bytes_param);
+        const uint32_t page_size_bytes = paged_write_page_size_bytes(get_page_size());
 
         DeviceCommandCalculator cmd_calc;
         cmd_calc.add_dispatch_write_paged<inline_data_>(page_size_bytes, 0);
-        const uint32_t overhead_bytes = cmd_calc.write_offset_bytes();
-        const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - overhead_bytes;
+        const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - cmd_calc.write_offset_bytes();
 
         log_info(
             tt::LogTest,
-            "Paged Write test to {} - page_size: {} bytes, num_pages_per_cmd: {}, iterations: {}",
+            "Paged Write test to {} - page_size: {} bytes, num_pages: {}, iterations: {}",
             is_dram ? "DRAM" : "L1",
             page_size_bytes,
-            num_pages_per_cmd,
-            num_iterations);
+            get_num_pages(),
+            get_num_iterations());
 
-        // PHASE 1: Generate paged write command metadata
-        auto commands_per_iteration = generate_paged_write_commands(
+        std::vector<HostMemDeviceCommand> commands;
+        prepend_paged_boundary_crossing(commands, device_data.get_base_result_addr(core_type));
+        auto paged_commands = generate_paged_write_commands(
             page_size_bytes, page_size_alignment_bytes, num_banks, max_payload_per_cmd_bytes, core_type, device_data);
+        for (auto& cmd : paged_commands) {
+            commands.push_back(std::move(cmd));
+        }
 
-        // PHASE 2, 3, 4: Execute and Validate
-        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+        execute_generated_commands(commands, device_data, worker_range.size(), get_num_iterations());
     }
 };
 
@@ -537,7 +510,7 @@ class DispatchPackedWriteTestFixture : public BaseDispatchTestFixture,
                                        public ::testing::WithParamInterface<PackedWriteParams> {
     uint32_t transfer_size_bytes_{};
     uint32_t num_iterations_{};
-    uint32_t dram_data_size_words_{};
+    uint32_t target_sub_cmds_{};
 
     // Clamp xfer_size to fit within max_fetch_bytes_
     uint32_t clamp_to_max_fetch(
@@ -562,7 +535,7 @@ protected:
             transfer_size_bytes_ = std::min(transfer_size_bytes_, QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES);
         }
         num_iterations_ = p.num_iterations;
-        dram_data_size_words_ = p.dram_data_size_words;
+        target_sub_cmds_ = p.target_sub_cmds;
     }
 
 public:
@@ -662,11 +635,10 @@ public:
 
     uint32_t get_transfer_size_bytes() const { return transfer_size_bytes_; }
     uint32_t get_num_iterations() const { return num_iterations_; }
-    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
+    uint32_t get_target_sub_cmds() const { return target_sub_cmds_; }
 
     void run_packed_write_test() {
         const uint32_t num_iterations = get_num_iterations();
-        const uint32_t dram_data_size_words = get_dram_data_size_words();
         const uint32_t total_target_bytes = get_transfer_size_bytes();
 
         log_info(tt::LogTest, "Target total: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
@@ -677,8 +649,9 @@ public:
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
         const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
 
+        // L1-only packed writes; skip DRAM prepopulation.
         Common::DeviceData device_data(
-            device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+            device_, worker_range, l1_base, dram_base, nullptr, false, /*dram_data_size_words=*/0, cfg_);
 
         const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
         const uint32_t packed_write_max_unicast_sub_cmds =
@@ -734,6 +707,10 @@ class DispatchPackedWriteLargeTestFixture : public DispatchPackedWriteTestFixtur
             // We're first converting the max payload allowed by the packed large format into alignment units
             // get_random_size will clamp the size to remaining_bytes
             uint32_t max_allowed = dispatch_buffer_page_size_ * max_pages_per_transaction / l1_alignment;
+            if (get_target_sub_cmds() != 0) {
+                max_allowed = std::min(
+                    max_allowed, std::max(1U, max_fetch_bytes_ / (2U * get_target_sub_cmds() * bytes_per_16B_unit)));
+            }
             uint32_t xfer_size_bytes =
                 payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, remaining_bytes);
 
@@ -803,9 +780,10 @@ protected:
 
         // This loop generates random-sized packed-large commands until remaining_bytes is exhausted
         while (remaining_bytes > 0) {
-            // Random number of transactions per command (1-16)
             const int max_transactions =
-                payload_generator_->get_rand<int>(1, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS);
+                get_target_sub_cmds() == 0
+                    ? payload_generator_->get_rand<int>(1, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS)
+                    : static_cast<int>(get_target_sub_cmds());
 
             // These are temporary containers for building one multi-transaction command
             std::vector<CQDispatchWritePackedLargeSubCmd> sub_cmds;
@@ -860,7 +838,6 @@ protected:
 public:
     void run_packed_large_write_test() {
         const uint32_t num_iterations = get_num_iterations();
-        const uint32_t dram_data_size_words = get_dram_data_size_words();
         const uint32_t total_target_bytes = get_transfer_size_bytes();
 
         log_info(tt::LogTest, "Max transfer: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
@@ -871,8 +848,9 @@ public:
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
         const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
 
+        // L1-only packed-large writes; skip DRAM prepopulation.
         Common::DeviceData device_data(
-            device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+            device_, worker_range, l1_base, dram_base, nullptr, false, /*dram_data_size_words=*/0, cfg_);
 
         const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
 
@@ -902,6 +880,10 @@ class DispatchPackedWriteLargeUnicastTestFixture : public DispatchPackedWriteTes
 
         for (int i = 0; i < max_transactions && remaining_bytes > 0; i++) {
             uint32_t max_allowed = dispatch_buffer_page_size_ * max_pages_per_transaction / l1_alignment;
+            if (get_target_sub_cmds() != 0) {
+                max_allowed = std::min(
+                    max_allowed, std::max(1U, max_fetch_bytes_ / (2U * get_target_sub_cmds() * bytes_per_16B_unit)));
+            }
             uint32_t xfer_size_bytes =
                 payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, remaining_bytes);
 
@@ -961,9 +943,10 @@ protected:
 
         // This loop generates random-sized packed-large unicast commands until remaining_bytes is exhausted
         while (remaining_bytes > 0) {
-            // Random number of transactions per command (1-16)
             const int max_transactions =
-                payload_generator_->get_rand<int>(1, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
+                get_target_sub_cmds() == 0
+                    ? payload_generator_->get_rand<int>(1, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS)
+                    : static_cast<int>(get_target_sub_cmds());
 
             std::vector<CQDispatchWritePackedLargeUnicastSubCmd> sub_cmds;
             std::vector<std::vector<uint32_t>> payloads;
@@ -1029,7 +1012,6 @@ protected:
 public:
     void run_packed_large_unicast_write_test() {
         const uint32_t num_iterations = get_num_iterations();
-        const uint32_t dram_data_size_words = get_dram_data_size_words();
         const uint32_t total_target_bytes = get_transfer_size_bytes();
 
         log_info(tt::LogTest, "Max transfer: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
@@ -1040,8 +1022,9 @@ public:
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
         const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
 
+        // L1-only packed-large unicast writes; skip DRAM prepopulation.
         Common::DeviceData device_data(
-            device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+            device_, worker_range, l1_base, dram_base, nullptr, false, /*dram_data_size_words=*/0, cfg_);
 
         const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
 
@@ -1271,6 +1254,109 @@ class DispatchPackedWriteLargeQuasarSimulatorTestFixture
 class DispatchPackedWriteLargeUnicastQuasarSimulatorTestFixture
     : public Common::QuasarSimulatorVariant<DispatchPackedWriteLargeUnicastTestFixture> {};
 
+class DispatchPagedWriteQuasarSimulatorStressTestFixture
+    : public Common::QuasarSimulatorVariant<DispatchPagedWriteTestFixture> {
+protected:
+    uint32_t paged_write_page_size_bytes(uint32_t requested_page_size) override { return requested_page_size; }
+
+    void prepend_paged_boundary_crossing(std::vector<HostMemDeviceCommand>& commands, uint32_t base_addr) override {
+        const bool is_dram = get_is_dram();
+        const auto& mem_map = MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const uint32_t dispatch_cb_pages = mem_map.dispatch_buffer_pages();
+        constexpr uint32_t dispatch_cb_page_size = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
+        const uint32_t dispatch_cb_size = dispatch_cb_pages * dispatch_cb_page_size;
+        const uint32_t dispatch_cb_prefix_bytes = (dispatch_cb_pages - 1) * dispatch_cb_page_size;
+
+        // Fill every dispatch CB page except the last with small paged writes. They target page zero, which the real
+        // stress stream overwrites before validation.
+        constexpr uint32_t filler_page_size = 16;
+        const std::vector<uint32_t> filler_payload(filler_page_size / sizeof(uint32_t), 0xA5A5A5A5);
+        for (uint32_t page = 1; page < dispatch_cb_pages; ++page) {
+            HostMemDeviceCommand prefix_cmd = Common::CommandBuilder::build_paged_write_command<inline_data_>(
+                filler_payload, base_addr, filler_page_size, /*pages_in_chunk=*/1, /*start_page_cmd=*/0, is_dram);
+            const auto* prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(prefix_cmd.data());
+            TT_FATAL(
+                tt::align(prefetch_cmd->relay_inline.length, dispatch_cb_page_size) == dispatch_cb_page_size,
+                "Dispatch CB filler must consume one page (relay payload {} B, page {} B)",
+                prefetch_cmd->relay_inline.length,
+                dispatch_cb_page_size);
+            commands.push_back(std::move(prefix_cmd));
+        }
+
+        // A paged write larger than a dispatch CB page: with the prefix above it starts in the final page and must
+        // use the end-of-ring remainder.
+        const uint32_t crossing_page_size = dispatch_cb_page_size;
+        const std::vector<uint32_t> crossing_payload(crossing_page_size / sizeof(uint32_t), 0x5A5A5A5A);
+        HostMemDeviceCommand crossing_cmd = Common::CommandBuilder::build_paged_write_command<inline_data_>(
+            crossing_payload, base_addr, crossing_page_size, /*pages_in_chunk=*/1, /*start_page_cmd=*/0, is_dram);
+        const auto* crossing_prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(crossing_cmd.data());
+        const uint32_t crossing_dispatch_payload_bytes = crossing_prefetch_cmd->relay_inline.length;
+        TT_FATAL(
+            dispatch_cb_prefix_bytes + crossing_dispatch_payload_bytes > dispatch_cb_size,
+            "Dispatch CB crossing command does not cross the buffer end ({} + {} <= {})",
+            dispatch_cb_prefix_bytes,
+            crossing_dispatch_payload_bytes,
+            dispatch_cb_size);
+        commands.push_back(std::move(crossing_cmd));
+    }
+};
+class DispatchPackedWriteLargeQuasarSimulatorStressTestFixture
+    : public Common::QuasarSimulatorVariant<DispatchPackedWriteLargeTestFixture> {};
+class DispatchPackedWriteLargeUnicastQuasarSimulatorStressTestFixture
+    : public Common::QuasarSimulatorVariant<DispatchPackedWriteLargeUnicastTestFixture> {};
+class DispatchLinearWriteQuasarSimulatorStressTestFixture
+    : public Common::QuasarSimulatorVariant<DispatchLinearWriteTestFixture> {
+protected:
+    uint32_t prepend_linear_boundary_crossing(
+        std::vector<HostMemDeviceCommand>& commands,
+        const CoreRange& worker_range,
+        uint32_t noc_xy,
+        uint32_t max_payload_per_cmd_bytes,
+        Common::DeviceData& device_data) override {
+        const bool is_mcast = get_is_mcast();
+        const auto& mem_map = MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const uint32_t dispatch_cb_pages = mem_map.dispatch_buffer_pages();
+        constexpr uint32_t dispatch_cb_page_size = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
+        const uint32_t dispatch_cb_size = dispatch_cb_pages * dispatch_cb_page_size;
+        const uint32_t dispatch_cb_prefix_bytes = (dispatch_cb_pages - 1) * dispatch_cb_page_size;
+        const uint32_t addr = device_data.get_result_data_addr(worker_range.start_coord, 0);
+
+        // Fill every page except the last with exact-page commands. The synthetic commands
+        // target the normal stream's initial destination but are not added to DeviceData.
+        constexpr uint32_t filler_payload_size = 16;
+        const std::vector<uint32_t> filler_payload(filler_payload_size / sizeof(uint32_t), 0xA5A5A5A5);
+        for (uint32_t page = 1; page < dispatch_cb_pages; ++page) {
+            HostMemDeviceCommand filler_cmd =
+                Common::CommandBuilder::build_linear_write_command<flush_prefetch_, inline_data_>(
+                    filler_payload, worker_range, is_mcast, noc_xy, addr, filler_payload_size);
+            const auto* prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(filler_cmd.data());
+            TT_FATAL(
+                tt::align(prefetch_cmd->relay_inline.length, dispatch_cb_page_size) == dispatch_cb_page_size,
+                "Dispatch CB filler must consume one page (relay payload {} B, page {} B)",
+                prefetch_cmd->relay_inline.length,
+                dispatch_cb_page_size);
+            commands.push_back(std::move(filler_cmd));
+        }
+
+        const uint32_t crossing_payload_size = std::min(get_transfer_size_bytes(), max_payload_per_cmd_bytes);
+        std::vector<uint32_t> crossing_payload = payload_generator_->generate_payload(crossing_payload_size);
+        HostMemDeviceCommand crossing_cmd =
+            Common::CommandBuilder::build_linear_write_command<flush_prefetch_, inline_data_>(
+                crossing_payload, worker_range, is_mcast, noc_xy, addr, crossing_payload_size);
+        const auto* crossing_prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(crossing_cmd.data());
+        TT_FATAL(
+            dispatch_cb_prefix_bytes + crossing_prefetch_cmd->relay_inline.length > dispatch_cb_size,
+            "Dispatch CB crossing command does not cross the buffer end ({} + {} <= {})",
+            dispatch_cb_prefix_bytes,
+            crossing_prefetch_cmd->relay_inline.length,
+            dispatch_cb_size);
+        Common::DeviceDataUpdater::update_linear_write(crossing_payload, device_data, worker_range, is_mcast);
+        commands.push_back(std::move(crossing_cmd));
+
+        return crossing_payload_size;
+    }
+};
+
 // Linear Write Unicast/Multicast
 TEST_P(DispatchLinearWriteTestFixture, LinearWrite) {
     log_info(tt::LogTest, "DispatchLinearWriteTestFixture - LinearWrite (Fast Dispatch) - Test Start");
@@ -1375,22 +1461,51 @@ TEST_P(DispatchPackedWriteLargeUnicastQuasarSimulatorTestFixture, WriteLargePack
     run_packed_large_unicast_write_test();
 }
 
+TEST_P(DispatchPagedWriteQuasarSimulatorStressTestFixture, PagedWrite) {
+    log_info(
+        tt::LogTest,
+        "DispatchPagedWriteQuasarSimulatorStressTestFixture - PagedWrite (Quasar simulator FD) - Test Start");
+    run_paged_write_test();
+}
+
+TEST_P(DispatchLinearWriteQuasarSimulatorStressTestFixture, LinearWrite) {
+    log_info(
+        tt::LogTest,
+        "DispatchLinearWriteQuasarSimulatorStressTestFixture - LinearWrite (Quasar simulator FD) - Test Start");
+    run_linear_write_test();
+}
+
+TEST_P(DispatchPackedWriteLargeQuasarSimulatorStressTestFixture, WriteLargePackedMulticast) {
+    log_info(
+        tt::LogTest,
+        "DispatchPackedWriteLargeQuasarSimulatorStressTestFixture - WriteLargePackedMulticast (Quasar simulator FD) - "
+        "Test Start");
+    run_packed_large_write_test();
+}
+
+TEST_P(DispatchPackedWriteLargeUnicastQuasarSimulatorStressTestFixture, WriteLargePackedUnicast) {
+    log_info(
+        tt::LogTest,
+        "DispatchPackedWriteLargeUnicastQuasarSimulatorStressTestFixture - WriteLargePackedUnicast (Quasar simulator "
+        "FD) - Test Start");
+    run_packed_large_unicast_write_test();
+}
+
 INSTANTIATE_TEST_SUITE_P(
     DispatcherTests,
     DispatchLinearWriteTestFixture,
     ::testing::Values(
         // Testcase: 49152 bytes (Unicast)
-        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, false},
         // Testcase: 196608 bytes (Unicast)
-        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, false},
         // Testcase: 49152 bytes (Multicast)
-        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, true},
         // Testcase: 196608 bytes (Multicast)
-        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
+        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, true}),
     [](const testing::TestParamInfo<LinearWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
-               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_" +
-               (info.param.is_mcast ? "mcast" : "unicast");
+               "iter_" + (info.param.is_mcast ? "mcast" : "unicast");
     });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1398,23 +1513,22 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPagedWriteTestFixture,
     ::testing::Values(
         // Testcase: 512 pages x 16 bytes (DRAM)
-        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, true},
         // Testcase: 512 pages x 16 bytes (L1)
-        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, false},
         // Testcase: 128 pages x 2048 bytes (DRAM)
-        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, true},
         // Testcase: 128 pages x 2048 bytes (L1)
-        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, false},
         // Testcase: 10 pages x 4128 bytes (not 4K-aligned) (DRAM). Exact: a smaller drawn size would be 4K-aligned or
         // no longer straddle a dispatch buffer page, either of which drops the property being covered.
-        PagedWriteParams{
-            4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true, PageSizeMode::Exact},
+        PagedWriteParams{4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, true, PageSizeMode::Exact},
         // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (DRAM)
-        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, true},
         // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (L1)
-        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, false},
         // Testcase: 100 pages x 8192 bytes (high BW) (DRAM)
-        PagedWriteParams{8192, 100, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{8192, 100, DEFAULT_ITERATIONS_PAGED_WRITE, true},
         // Testcase: 40 pages x 4112 bytes (DRAM). A page occupies a whole allocation-aligned slot in its bank, so the
         // in-bank stride between rows of pages is the page size rounded up to that alignment. 4112 is not a multiple
         // of either DRAM alignment -- 32 B on Wormhole, 64 B on Blackhole -- so the stride differs from the page size
@@ -1422,13 +1536,11 @@ INSTANTIATE_TEST_SUITE_P(
         // available, which reaches the row advance on the split-page path as well as the whole-page one. 40 pages
         // wraps the bank cycle at least three times on either arch. Exact, since every one of those properties is a
         // property of 4112 specifically.
-        PagedWriteParams{
-            4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true, PageSizeMode::Exact},
+        PagedWriteParams{4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, true, PageSizeMode::Exact},
         // Testcase: 40 pages x 4112 bytes (L1). The control for the case above: L1 is 16 B aligned, so the same page
         // size strides by itself and only the DRAM case can tell the two strides apart. Exact for the same reason, and
         // so the two cases are guaranteed to run the same page size.
-        PagedWriteParams{
-            4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false, PageSizeMode::Exact}),
+        PagedWriteParams{4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, false, PageSizeMode::Exact}),
     [](const testing::TestParamInfo<PagedWriteParams>& info) {
         std::stringstream ss;
         ss << "page_size" << info.param.page_size << "_np" << info.param.num_pages << "_iter"
@@ -1441,12 +1553,12 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteTestFixture,
     ::testing::Values(
         // Testcase: 786432 bytes (Unicast)
-        PackedWriteParams{786432, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS},
+        PackedWriteParams{786432, DEFAULT_ITERATIONS_PACKED_WRITE},
         // Testcase: 819200 bytes (Unicast)
-        PackedWriteParams{819200, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS}),
+        PackedWriteParams{819200, DEFAULT_ITERATIONS_PACKED_WRITE}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
-               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+               "iter";
     });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1454,12 +1566,12 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteLargeTestFixture,
     ::testing::Values(
         // Testcase: 40960 bytes
-        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE},
         // Testcase: 409600 bytes
-        PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS}),
+        PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
-               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+               "iter";
     });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1467,12 +1579,12 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteLargeUnicastTestFixture,
     ::testing::Values(
         // Testcase: 40960 bytes
-        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE},
         // Testcase: 409600 bytes
-        PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS}),
+        PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
-               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+               "iter";
     });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1480,17 +1592,16 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchLinearWriteQuasarSimulatorTestFixture,
     ::testing::Values(
         // Testcase: 49152 bytes (Unicast)
-        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, false},
         // Testcase: 196608 bytes (Unicast)
-        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, false},
         // Testcase: 49152 bytes (Multicast)
-        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, true},
         // Testcase: 196608 bytes (Multicast)
-        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
+        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, true}),
     [](const testing::TestParamInfo<LinearWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
-               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_" +
-               (info.param.is_mcast ? "mcast" : "unicast");
+               "iter_" + (info.param.is_mcast ? "mcast" : "unicast");
     });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1498,22 +1609,21 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPagedWriteQuasarSimulatorTestFixture,
     ::testing::Values(
         // Testcase: 512 pages x 16 bytes (DRAM)
-        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, true},
         // Testcase: 512 pages x 16 bytes (L1)
-        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, false},
         // Testcase: 128 pages x 2048 bytes (DRAM)
-        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, true},
         // Testcase: 128 pages x 2048 bytes (L1)
-        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, false},
         // Testcase: 10 pages x 4128 bytes (not 4K-aligned) (DRAM)
-        PagedWriteParams{
-            4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true, PageSizeMode::Exact},
+        PagedWriteParams{4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, true, PageSizeMode::Exact},
         // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (DRAM)
-        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, true},
         // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (L1)
-        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, false},
         // Testcase: 45 pages x 8192 bytes (high BW) (DRAM)
-        PagedWriteParams{8192, 45, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
+        PagedWriteParams{8192, 45, DEFAULT_ITERATIONS_PAGED_WRITE, true}),
     [](const testing::TestParamInfo<PagedWriteParams>& info) {
         std::stringstream ss;
         ss << "page_size" << info.param.page_size << "_np" << info.param.num_pages << "_iter"
@@ -1526,13 +1636,12 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteQuasarSimulatorTestFixture,
     ::testing::Values(
         // Testcase: 40960 bytes (Unicast)
-        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS},
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE},
         // Testcase: 98304 bytes (= QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES = 96 KB) (Unicast)
-        PackedWriteParams{
-            QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS}),
+        PackedWriteParams{QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES, DEFAULT_ITERATIONS_PACKED_WRITE}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
-               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+               "iter";
     });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1540,15 +1649,12 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteLargeQuasarSimulatorTestFixture,
     ::testing::Values(
         // Testcase: 40960 bytes (fits within 96 KB budget)
-        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE},
         // Testcase: 98304 bytes (= QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES = 96 KB)
-        PackedWriteParams{
-            QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES,
-            DEFAULT_ITERATIONS_PACKED_WRITE_LARGE,
-            Common::DRAM_DATA_SIZE_WORDS}),
+        PackedWriteParams{QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
-               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+               "iter";
     });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1556,15 +1662,57 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteLargeUnicastQuasarSimulatorTestFixture,
     ::testing::Values(
         // Testcase: 40960 bytes (fits within 96 KB budget)
-        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE},
         // Testcase: 98304 bytes (= QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES = 96 KB)
-        PackedWriteParams{
-            QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES,
-            DEFAULT_ITERATIONS_PACKED_WRITE_LARGE,
-            Common::DRAM_DATA_SIZE_WORDS}),
+        PackedWriteParams{QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
-               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+               "iter";
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorDispatcherStressTests,
+    DispatchPagedWriteQuasarSimulatorStressTestFixture,
+    ::testing::Values(
+        PagedWriteParams{1024, 256, 1, true},
+        PagedWriteParams{1024, 256, 1, false},
+        PagedWriteParams{16384, 36, 3, true},
+        PagedWriteParams{16384, 36, 3, false}),
+    [](const testing::TestParamInfo<PagedWriteParams>& info) {
+        std::stringstream ss;
+        ss << "page_size" << info.param.page_size << "_np" << info.param.num_pages << "_iter"
+           << info.param.num_iterations << "_" << (info.param.is_dram ? "DRAM" : "L1");
+        return ss.str();
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorDispatcherStressTests,
+    DispatchLinearWriteQuasarSimulatorStressTestFixture,
+    ::testing::Values(
+        LinearWriteParams{613376, 1, /*is_mcast=*/false}, LinearWriteParams{1226752, 5, /*is_mcast=*/false}),
+    [](const testing::TestParamInfo<LinearWriteParams>& info) {
+        return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
+               "iter_" + (info.param.is_mcast ? "mcast" : "unicast");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorDispatcherStressTests,
+    DispatchPackedWriteLargeQuasarSimulatorStressTestFixture,
+    ::testing::Values(PackedWriteParams{
+        QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES, 3, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS}),
+    [](const testing::TestParamInfo<PackedWriteParams>& info) {
+        return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
+               "iter_" + std::to_string(info.param.target_sub_cmds) + "subcmds";
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorDispatcherStressTests,
+    DispatchPackedWriteLargeUnicastQuasarSimulatorStressTestFixture,
+    ::testing::Values(PackedWriteParams{
+        QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES, 3, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS}),
+    [](const testing::TestParamInfo<PackedWriteParams>& info) {
+        return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
+               "iter_" + std::to_string(info.param.target_sub_cmds) + "subcmds";
     });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1572,17 +1720,16 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchLinearWriteSDTestFixture,
     ::testing::Values(
         // Testcase: 49152 bytes (Unicast)
-        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, false},
         // Testcase: 196608 bytes (Unicast)
-        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, false},
         // Testcase: 49152 bytes (Multicast)
-        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, true},
         // Testcase: 196608 bytes (Multicast)
-        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
+        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, true}),
     [](const testing::TestParamInfo<LinearWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
-               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_" +
-               (info.param.is_mcast ? "mcast" : "unicast");
+               "iter_" + (info.param.is_mcast ? "mcast" : "unicast");
     });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1591,16 +1738,14 @@ INSTANTIATE_TEST_SUITE_P(
     // L1 paged writes (is_dram=false) are excluded from SD mode: process_write_paged<false> requires
     // L1 bank coordinate setup via CRTA that the SD spoof-prefetch fixture does not provide.
     ::testing::Values(
-        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
-        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
-        PagedWriteParams{
-            4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true, PageSizeMode::Exact},
-        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
-        PagedWriteParams{8192, 100, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, true},
+        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, true},
+        PagedWriteParams{4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, true, PageSizeMode::Exact},
+        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, true},
+        PagedWriteParams{8192, 100, DEFAULT_ITERATIONS_PAGED_WRITE, true},
         // Page size that is not a multiple of either DRAM alignment, so the in-bank row stride differs from it; see
         // the FD instantiation above.
-        PagedWriteParams{
-            4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true, PageSizeMode::Exact}),
+        PagedWriteParams{4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, true, PageSizeMode::Exact}),
     [](const testing::TestParamInfo<PagedWriteParams>& info) {
         return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
                std::to_string(info.param.num_iterations) + "iter_" + (info.param.is_dram ? "dram" : "l1");
@@ -1611,11 +1756,11 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteSDTestFixture,
     // SD sizes < FD: spoof prefetcher serves commands from worker L1, not a host huge page.
     ::testing::Values(
-        PackedWriteParams{131072, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS},
-        PackedWriteParams{262144, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS}),
+        PackedWriteParams{131072, DEFAULT_ITERATIONS_PACKED_WRITE},
+        PackedWriteParams{262144, DEFAULT_ITERATIONS_PACKED_WRITE}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
-               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+               "iter";
     });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1623,11 +1768,11 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteLargeSDTestFixture,
     // SD sizes < FD: bounded by spoof L1 (see DispatchPackedWriteSDTestFixture).
     ::testing::Values(
-        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
-        PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS}),
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE},
+        PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
-               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+               "iter";
     });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1635,11 +1780,11 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteLargeUnicastSDTestFixture,
     // SD sizes < FD: bounded by spoof L1 (see DispatchPackedWriteSDTestFixture).
     ::testing::Values(
-        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
-        PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS}),
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE},
+        PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
-               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+               "iter";
     });
 
 }  // namespace tt::tt_metal::tt_dispatch_tests::dispatcher_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1689,7 +1689,7 @@ INSTANTIATE_TEST_SUITE_P(
     QuasarSimulatorDispatcherStressTests,
     DispatchLinearWriteQuasarSimulatorStressTestFixture,
     ::testing::Values(
-        LinearWriteParams{613376, 1, /*is_mcast=*/false}, LinearWriteParams{1226752, 5, /*is_mcast=*/false}),
+        LinearWriteParams{614400, 3, /*is_mcast=*/false}, LinearWriteParams{1228800, 5, /*is_mcast=*/false}),
     [](const testing::TestParamInfo<LinearWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
                "iter_" + (info.param.is_mcast ? "mcast" : "unicast");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1261,7 +1261,7 @@ protected:
 
     void prepend_paged_boundary_crossing(std::vector<HostMemDeviceCommand>& commands, uint32_t base_addr) override {
         const bool is_dram = get_is_dram();
-        const auto& mem_map = MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const auto& mem_map = MetalContext::instance().dispatch_mem_map();
         const uint32_t dispatch_cb_pages = mem_map.dispatch_buffer_pages();
         constexpr uint32_t dispatch_cb_page_size = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
         const uint32_t dispatch_cb_size = dispatch_cb_pages * dispatch_cb_page_size;
@@ -1314,7 +1314,7 @@ protected:
         uint32_t max_payload_per_cmd_bytes,
         Common::DeviceData& device_data) override {
         const bool is_mcast = get_is_mcast();
-        const auto& mem_map = MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const auto& mem_map = MetalContext::instance().dispatch_mem_map();
         const uint32_t dispatch_cb_pages = mem_map.dispatch_buffer_pages();
         constexpr uint32_t dispatch_cb_page_size = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
         const uint32_t dispatch_cb_size = dispatch_cb_pages * dispatch_cb_page_size;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -3074,39 +3074,33 @@ class PrefetcherLinearPackedReadQuasarSimulatorTestFixture
     : public Common::QuasarSimulatorVariant<PrefetcherLinearPackedReadTestFixture> {};
 class PrefetcherHostQuasarSimulatorTestFixture : public Common::QuasarSimulatorVariant<PrefetcherHostTestFixture> {
 public:
-    // On the Quasar simulator the completion queue is DRAM-backed by default (no host hugepages). Validate
-    // against a host-side staging buffer that refresh_completion_data() fills from DRAM before validate().
-    // An explicit TT_METAL_DRAM_BACKED_CQ=0 opts out of DRAM-backed CQs; in that case defer to the base
-    // (hugepage-backed) completion-buffer behavior so the test matches the runtime CQ configuration.
+    // Validation always runs against a host-side staging buffer that refresh_completion_data() normalizes from
+    // the live completion region, so a write pointer that wraps the ring still reads back as one contiguous
+    // span. The region itself is DRAM on the Quasar simulator by default, or the mapped host channel under an
+    // explicit TT_METAL_DRAM_BACKED_CQ=0; both are staged the same way.
     void* get_completion_queue_buffer() override {
-        if (!mgr_->is_dram_backed()) {
-            return PrefetcherHostTestFixture::get_completion_queue_buffer();
-        }
         quasar_completion_buf_.resize(this->get_completion_queue_buffer_size());
         return quasar_completion_buf_.data();
     }
 
-    // On WH/BH the dirty pattern is written into the PCIe-mapped completion buffer, i.e. the real completion memory the
-    // dispatcher writes into. On the Quasar simulator that memory is DRAM, so dirty there too.
+    // Two regions need the dirty pattern: the staging buffer, so padding past the dispatcher-written span
+    // survives validation, and the completion region the dispatcher actually writes into.
     void dirty_host_completion_buffer(void* completion_queue_buffer, uint32_t size_bytes) override {
         PrefetcherHostTestFixture::dirty_host_completion_buffer(completion_queue_buffer, size_bytes);
-        if (!mgr_->is_dram_backed()) {
-            return;
+        if (mgr_->is_dram_backed()) {
+            std::vector<uint32_t> dirty(size_bytes / sizeof(uint32_t), HOST_DATA_DIRTY_PATTERN);
+            tt::tt_metal::MetalContext::instance().get_cluster().write_dram_vec(
+                dirty.data(), size_bytes, this->device_->id(), completion_dram_channel(), completion_dram_addr());
+        } else {
+            PrefetcherHostTestFixture::dirty_host_completion_buffer(completion_region_host_ptr(), size_bytes);
         }
-        std::vector<uint32_t> dirty(size_bytes / sizeof(uint32_t), HOST_DATA_DIRTY_PATTERN);
-        tt::tt_metal::MetalContext::instance().get_cluster().write_dram_vec(
-            dirty.data(), size_bytes, this->device_->id(), completion_dram_channel(), completion_dram_addr());
     }
 
-    // Read the dispatcher-written prefix of the DRAM completion queue into the staging buffer so
+    // Copy the dispatcher-written span of the completion region into the staging buffer so
     // device_data.validate() sees real data. When the device write pointer wraps, normalize the
-    // tail + head ring segments into one contiguous staging span. Skipped when DRAM-backed CQs
-    // are explicitly disabled (TT_METAL_DRAM_BACKED_CQ=0); the base (hugepage-backed) completion
-    // buffer is directly readable, so no DRAM readback is needed.
+    // tail + head ring segments into one contiguous staging span. Padding past the written span keeps
+    // its dirty fill.
     void refresh_completion_data() override {
-        if (!mgr_->is_dram_backed()) {
-            return;
-        }
         const uint8_t cq_id = fdcq_->id();
         std::atomic<bool> exit_condition{false};
         const auto [write_ptr_16B, write_toggle] =
@@ -3129,27 +3123,37 @@ public:
         }
         TT_FATAL(
             bytes_written <= quasar_completion_buf_.size(),
-            "Quasar completion readback {} B exceeds staging buffer {} B",
+            "Completion readback {} B exceeds staging buffer {} B",
             bytes_written,
             quasar_completion_buf_.size());
 
         const uint32_t read_offset = read_ptr_bytes - completion_base;
         const uint32_t tail_bytes = std::min(bytes_written, completion_limit - read_ptr_bytes);
-        tt::tt_metal::detail::ReadFromDeviceDRAMChannel(
-            this->device_,
-            completion_dram_channel(),
-            completion_dram_addr() + read_offset,
-            std::span<uint8_t>(quasar_completion_buf_.data(), tail_bytes));
+        read_completion_region(read_offset, std::span<uint8_t>(quasar_completion_buf_.data(), tail_bytes));
         if (tail_bytes < bytes_written) {
-            tt::tt_metal::detail::ReadFromDeviceDRAMChannel(
-                this->device_,
-                completion_dram_channel(),
-                completion_dram_addr(),
-                std::span<uint8_t>(quasar_completion_buf_.data() + tail_bytes, bytes_written - tail_bytes));
+            read_completion_region(
+                0, std::span<uint8_t>(quasar_completion_buf_.data() + tail_bytes, bytes_written - tail_bytes));
         }
     }
 
 private:
+    // Copy dst.size() bytes out of the completion region, starting region_offset bytes past its base.
+    void read_completion_region(uint32_t region_offset, std::span<uint8_t> dst) {
+        if (mgr_->is_dram_backed()) {
+            tt::tt_metal::detail::ReadFromDeviceDRAMChannel(
+                this->device_, completion_dram_channel(), completion_dram_addr() + region_offset, dst);
+            return;
+        }
+        std::memcpy(dst.data(), completion_region_host_ptr() + region_offset, dst.size());
+    }
+
+    // Host address of the completion region base. Only call this when the CQ is host-backed: the
+    // DRAM-backed form of get_completion_queue_ptr mirrors the whole region through DRAM on every call,
+    // which this fixture avoids by reading back only the written span.
+    uint8_t* completion_region_host_ptr() const {
+        return static_cast<uint8_t*>(mgr_->get_completion_queue_ptr(fdcq_->id()));
+    }
+
     // DRAM address of the completion region base, matching SystemMemoryManager::get_completion_queue_ptr.
     uint32_t completion_dram_addr() const {
         const uint8_t cq_id = fdcq_->id();
@@ -3176,7 +3180,7 @@ protected:
         const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/false);
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
         const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-        const uint32_t scratch_half = MetalContext::instance().dispatch_mem_map(CoreType::WORKER).scratch_db_size() / 2;
+        const uint32_t scratch_half = MetalContext::instance().dispatch_mem_map().scratch_db_size() / 2;
         const uint32_t scratch_half_dram_aligned = tt::align(scratch_half, dram_alignment);
         const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
         const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
@@ -3224,7 +3228,7 @@ protected:
             bytes_per_pass += cmd.size_bytes();
         }
 
-        const uint32_t cmddat_q_size = MetalContext::instance().dispatch_mem_map(CoreType::WORKER).cmddat_q_size();
+        const uint32_t cmddat_q_size = MetalContext::instance().dispatch_mem_map().cmddat_q_size();
 
         // num_iterations is the target number of cmddat_q wraps. Each command header is fetched into the
         // prefetcher's cmddat_q ring, so streaming more than N * cmddat_q_size command bytes forces the
@@ -3308,7 +3312,7 @@ protected:
             device_, worker_range, l1_base, dram_base_, nullptr, false, /*dram_data_size_words=*/0, cfg_);
         const uint32_t source_addr = device_data.get_result_data_addr(first_worker, 0);
 
-        const auto& mem_map = MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const auto& mem_map = MetalContext::instance().dispatch_mem_map();
         const uint32_t dispatch_cb_pages = mem_map.dispatch_buffer_pages();
         constexpr uint32_t dispatch_cb_page_size = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
         const uint32_t dispatch_cb_size = dispatch_cb_pages * dispatch_cb_page_size;
@@ -3408,8 +3412,7 @@ protected:
         // has wrapped to the base and the host producer is at the limit. The extra command makes the host
         // producer reset to the base before reserving the next entry.
         // The reserve/write loop in execute_generated_commands blocks for PrefetchQ space as needed.
-        const uint32_t prefetch_q_entries =
-            MetalContext::instance().dispatch_mem_map(CoreType::WORKER).prefetch_q_entries();
+        const uint32_t prefetch_q_entries = MetalContext::instance().dispatch_mem_map().prefetch_q_entries();
         const uint32_t num_traversals = get_num_iterations();
         execute_generated_commands(
             commands, device_data, worker_range.size(), (num_traversals * prefetch_q_entries) + 1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1950,45 +1950,6 @@ public:
         // PHASE 2, 3, 4: Execute and Validate
         execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
     }
-
-    void run_ringbuffer_boundary_reset_stress_test() {
-        constexpr uint32_t ringbuffer_page_size_log2 = 10;
-        constexpr uint32_t ringbuffer_page_size = 1 << ringbuffer_page_size_log2;
-
-        const auto& mem_map = MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
-        const uint32_t ringbuffer_size = mem_map.ringbuffer_size();
-
-        const CoreCoord first_worker = this->worker_start();
-        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/false);
-        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-        const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-        TT_FATAL(
-            ringbuffer_page_size % dram_alignment == 0,
-            "Ringbuffer staging page {} B must align to DRAM alignment {} B",
-            ringbuffer_page_size,
-            dram_alignment);
-
-        Common::DeviceData device_data(
-            device_, worker_range, l1_base, dram_base_, nullptr, false, get_dram_data_size_words(), cfg_);
-        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
-        const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
-        std::vector<HostMemDeviceCommand> commands;
-
-        const auto add_staged_relay = [&](const std::vector<uint32_t>& lengths) {
-            const uint32_t total_length = std::accumulate(lengths.begin(), lengths.end(), 0u);
-            const uint32_t dst_addr = device_data.get_result_data_addr(first_worker, 0);
-            auto sub_cmds = build_sub_cmds(lengths, static_cast<uint32_t>(lengths.size()));
-            commands.push_back(CommandBuilder::build_prefetch_ringbuffer_relay<false, false>(
-                sub_cmds, lengths, device_data, *this, noc_xy, dst_addr, total_length, ringbuffer_page_size_log2));
-        };
-
-        // The first command reaches the staging-buffer end exactly. The following command's reset flag
-        // restarts the write pointer, while the non-zero reader offset continues to exercise offset arithmetic.
-        add_staged_relay({ringbuffer_size});
-        add_staged_relay({ringbuffer_page_size});
-
-        execute_generated_commands(commands, device_data, worker_range.size(), get_num_iterations());
-    }
 };
 
 namespace CommandBuilder {
@@ -3206,8 +3167,6 @@ private:
 class PrefetcherRingbufferReadQuasarSimulatorTestFixture
     : public Common::QuasarSimulatorVariant<PrefetcherRingbufferReadTestFixture> {};
 
-class PrefetcherRingbufferBoundaryResetQuasarSimulatorStressTestFixture
-    : public PrefetcherRingbufferReadQuasarSimulatorTestFixture {};
 class RandomQuasarSimulatorTestFixture : public Common::QuasarSimulatorVariant<RandomTestFixture> {};
 class PrefetcherScratchThresholdQuasarSimulatorStressTestFixture
     : public Common::QuasarSimulatorVariant<BasePrefetcherTestFixture> {
@@ -3491,14 +3450,15 @@ protected:
         const uint32_t post_wrap_submit_bytes =
             tt::align(make_command(post_wrap_payload, l1_base).size_bytes() + barrier_bytes, issue_alignment);
 
-        // Submissions below pass wait_for_completion=false so nothing but the commands themselves is reserved from the
-        // issue queue - a per-submission distributed::Finish would reserve its event-record sequence here too and wrap
-        // the ring before the crossing command could. Everything is drained and validated once after the last
-        // iteration instead, which also means each wrap happens while the device is still consuming.
+        // The deterministic prefix is submitted with wait_for_completion=false so nothing but the commands
+        // themselves is reserved from the issue queue - a per-submission distributed::Finish would reserve its
+        // event-record sequence here too and could wrap the ring while filling the prefix, before the dedicated
+        // crossing command. The crossing command below passes wait_for_completion=true so the device is drained
+        // after every wrap.
         //
-        // The shadow model stays empty until that final drain, which keeps the validate() inside
-        // execute_generated_commands a no-op and holds get_result_data_addr() at the base address, so every submission
-        // writes the same L1 bytes.
+        // The shadow model is never updated inside the loop, so the validate() inside execute_generated_commands is
+        // a no-op on every submission and get_result_data_addr() stays at the base address - every submission writes
+        // the same L1 bytes. The only meaningful validation is the single check after the loop.
         // This test only writes to worker L1, so skip the DRAM prepopulation by passing 0 for dram_data_size_words.
         Common::DeviceData device_data(
             device_, worker_range, l1_base, dram_base_, nullptr, false, /*dram_data_size_words=*/0, cfg_);
@@ -3536,7 +3496,7 @@ protected:
                 prefix_iterations,
                 /*wait_for_completion=*/false);
 
-            // const uint32_t pre_wrap_write_ptr = mgr_->get_issue_queue_write_ptr(cq_id);
+            const uint32_t pre_wrap_write_ptr = mgr_->get_issue_queue_write_ptr(cq_id);
             const bool pre_wrap_toggle = mgr_->get_cq_interfaces()[cq_id].issue_fifo_wr_toggle;
             TT_FATAL(pre_wrap_toggle == toggle_before, "Issue queue wrapped while filling the deterministic prefix");
 
@@ -3546,16 +3506,14 @@ protected:
                 worker_range.size(),
                 1,
                 /*wait_for_completion=*/true);
-            // distributed::Finish(mesh_device_->mesh_command_queue());
 
-            // const uint32_t post_wrap_write_ptr = mgr_->get_issue_queue_write_ptr(cq_id);
-            // const bool post_wrap_toggle = mgr_->get_cq_interfaces()[cq_id].issue_fifo_wr_toggle;
-            // EXPECT_NE(post_wrap_toggle, pre_wrap_toggle);
-            // EXPECT_LT(post_wrap_write_ptr, pre_wrap_write_ptr);
+            const uint32_t post_wrap_write_ptr = mgr_->get_issue_queue_write_ptr(cq_id);
+            const bool post_wrap_toggle = mgr_->get_cq_interfaces()[cq_id].issue_fifo_wr_toggle;
+            EXPECT_NE(post_wrap_toggle, pre_wrap_toggle);
+            EXPECT_LT(post_wrap_write_ptr, pre_wrap_write_ptr);
         }
 
         // Every command targets the same L1 address, so the surviving state is the last crossing write.
-        // distributed::Finish(mesh_device_->mesh_command_queue());
         Common::DeviceDataUpdater::update_linear_write(
             post_wrap_payload, device_data, worker_range, /*is_mcast=*/false);
         EXPECT_TRUE(device_data.validate(device_));
@@ -4193,14 +4151,6 @@ TEST_P(PrefetcherHostQuasarSimulatorStressTestFixture, HostCompletionStress) {
     run_host_test();
 }
 
-TEST_P(PrefetcherRingbufferBoundaryResetQuasarSimulatorStressTestFixture, RingbufferBoundaryResetStress) {
-    log_info(
-        tt::LogTest,
-        "PrefetcherRingbufferBoundaryResetQuasarSimulatorStressTestFixture - RingbufferBoundaryResetStress "
-        "(Quasar simulator FD) - Test Start");
-    run_ringbuffer_boundary_reset_stress_test();
-}
-
 TEST_P(RandomQuasarSimulatorStressTestFixture, RandomStress) {
     log_info(tt::LogTest, "RandomQuasarSimulatorStressTestFixture - RandomStress (Quasar simulator FD) - Test Start");
     run_random_test();
@@ -4570,22 +4520,25 @@ INSTANTIATE_TEST_SUITE_P(
     QuasarSimulatorPrefetcherStressTests,
     PrefetcherCmddatQWrapQuasarSimulatorStressTestFixture,
     ::testing::Values(PagedReadParams{.num_iterations = 3}),
-    [](const testing::TestParamInfo<PagedReadParams>& /*info*/) { return "runtime_capacity"; });
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.num_iterations) + "iter";
+    });
 
 INSTANTIATE_TEST_SUITE_P(
     QuasarSimulatorPrefetcherStressTests,
     PrefetcherExecBufMidFetchQuasarSimulatorStressTestFixture,
-    ::testing::Values(PagedReadParams{.page_size = 128, .num_pages = 1, .num_iterations = 1, .use_exec_buf = true}),
+    ::testing::Values(PagedReadParams{.page_size = 128, .num_pages = 1, .num_iterations = 3, .use_exec_buf = true}),
     [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages";
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter";
     });
 
 INSTANTIATE_TEST_SUITE_P(
     QuasarSimulatorPrefetcherStressTests,
     PrefetcherExecBufStallQuasarSimulatorStressTestFixture,
-    ::testing::Values(PagedReadParams{.num_iterations = 4, .use_exec_buf = true}),
+    ::testing::Values(PagedReadParams{.num_iterations = 5, .use_exec_buf = true}),
     [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.num_iterations) + "_stall_transitions";
+        return std::to_string(info.param.num_iterations) + "iter";
     });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -4620,37 +4573,36 @@ INSTANTIATE_TEST_SUITE_P(
     PrefetcherHostQuasarSimulatorStressTestFixture,
     ::testing::Values(PagedReadParams{.num_iterations = 3}),
     [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.num_iterations) + "bulk_rounds";
-    });
-
-INSTANTIATE_TEST_SUITE_P(
-    QuasarSimulatorPrefetcherStressTests,
-    PrefetcherRingbufferBoundaryResetQuasarSimulatorStressTestFixture,
-    ::testing::Values(PagedReadParams{.num_iterations = 3}, PagedReadParams{.num_iterations = 3, .use_exec_buf = true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::string{"boundary_reset_nonzero_offset_"} +
-               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+        return std::to_string(info.param.num_iterations) + "iter";
     });
 
 INSTANTIATE_TEST_SUITE_P(
     QuasarSimulatorPrefetcherStressTests,
     PrefetcherPrefetchQWrapQuasarSimulatorStressTestFixture,
-    ::testing::Values(PagedReadParams{.num_iterations = 2}),
+    ::testing::Values(PagedReadParams{.num_iterations = 3}),
     [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.num_iterations) + "_full_queue_wraps";
+        return std::to_string(info.param.num_iterations) + "iter";
     });
 
 INSTANTIATE_TEST_SUITE_P(
     QuasarSimulatorPrefetcherStressTests,
     PrefetcherIssueQueueWrapQuasarSimulatorStressTestFixture,
-    ::testing::Values(PagedReadParams{.num_iterations = 2}),
-    [](const testing::TestParamInfo<PagedReadParams>& /*info*/) { return "runtime_boundary"; });
+    // Each iteration fills nearly the entire issue queue with 16 KB linear writes to force exactly one wrap at
+    // the issue queue limit, so a single iteration already exercises the wrap this test targets. We cap it at one
+    // iteration because that per-iteration volume is about as much as the Quasar simulator can handle before it
+    // segfaults. If/when the simulator can handle more, we can (and should) increase the iteration count.
+    ::testing::Values(PagedReadParams{.num_iterations = 1}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.num_iterations) + "iter";
+    });
 
 INSTANTIATE_TEST_SUITE_P(
     QuasarSimulatorPrefetcherStressTests,
     PrefetcherCompletionQueueWrapQuasarSimulatorStressTestFixture,
     ::testing::Values(PagedReadParams{.num_iterations = 3}),
-    [](const testing::TestParamInfo<PagedReadParams>& /*info*/) { return "runtime_boundary"; });
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.num_iterations) + "iter";
+    });
 
 INSTANTIATE_TEST_SUITE_P(
     QuasarSimulatorPrefetcherStressTests,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -76,11 +76,11 @@ constexpr uint32_t DEFAULT_SCRATCH_DB_SIZE = 16 * 1024;
 // Params that control the data volume, iteration count
 // for the packed / large packed write test
 struct PagedReadParams {
-    uint32_t page_size{};       // Page size in bytes
-    uint32_t num_pages{};       // Number of pages
-    uint32_t num_iterations{};  // Number of iterations for the test
-    uint32_t dram_data_size_words{};
-    bool use_exec_buf{};  // Whether to use exec buff
+    uint32_t page_size = DRAM_PAGE_SIZE_DEFAULT;                   // Page size in bytes
+    uint32_t num_pages = DRAM_PAGES_TO_READ_DEFAULT;               // Number of pages
+    uint32_t num_iterations = DEFAULT_ITERATIONS;                  // Number of iterations for the test
+    uint32_t dram_data_size_words = Common::DRAM_DATA_SIZE_WORDS;  // Initial DRAM data per bank, in words
+    bool use_exec_buf = false;                                     // Whether to use exec buff
 };
 
 namespace DeviceDataUpdater {
@@ -568,7 +568,6 @@ protected:
     void run_paged_read_write_test() {
         // Test parameters
         const uint32_t num_iterations = get_num_iterations();
-        const uint32_t dram_data_size_words = get_dram_data_size_words();
         const uint32_t page_size_bytes = get_page_size();
         const uint32_t num_pages = get_num_pages();
 
@@ -578,8 +577,9 @@ protected:
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
+        // Source data is written by the paged-write phase; skip DRAM prepopulation.
         Common::DeviceData device_data(
-            device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+            device_, worker_range, l1_base, dram_base_, nullptr, false, /*dram_data_size_words=*/0, cfg_);
 
         // PHASE 1: Generate paged end to end read + write command metadata
         auto commands_per_iteration =
@@ -599,15 +599,15 @@ protected:
         // Test parameters
         constexpr uint32_t xfer_size_bytes = 16;  // Very small write size
         const uint32_t num_iterations = get_num_iterations();
-        const uint32_t dram_data_size_words = get_dram_data_size_words();
 
         const CoreCoord first_worker = this->worker_start();
         const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
+        // L1-only inline write; skip DRAM prepopulation.
         Common::DeviceData device_data(
-            device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+            device_, worker_range, l1_base, dram_base_, nullptr, false, /*dram_data_size_words=*/0, cfg_);
 
         const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
         const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
@@ -918,8 +918,9 @@ public:
             for (uint32_t page = 0; page < pages_in_chunk; ++page) {
                 const uint32_t page_id = absolute_start_page + page;
                 const uint32_t bank_id = page_id % num_banks_;
-                // Add dram_data_size_words since we're reading after the pre-populated DRAM data
-                uint32_t bank_offset = dram_data_size_words_ + page_size_words * (page_id / num_banks_);
+                // Reads follow the paged-write destinations, which start at the DRAM result base
+                // (no prepopulated prefix for this end-to-end path).
+                uint32_t bank_offset = page_size_words * (page_id / num_banks_);
 
                 const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
                 const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
@@ -1258,58 +1259,60 @@ protected:
     }
 
 public:
-    // In this test, the prefetcher reads from L1 and relays it to dispatcher. Dispatcher then
-    // writes the data to the host completion queue.
-    // Note: Since we're writing into completion queue, we skip distributed::Finish
+    // Prefetcher reads from L1 and relays to the dispatcher, which writes into the host
+    // completion queue.
     void run_host_test() {
+        const uint32_t num_iterations = get_num_iterations();
+
         // Scale down data size on the Quasar simulator to avoid exceeding the 64 MB DRAM window.
         const uint32_t max_data_size = Common::is_quasar_sim() ? QUASAR_SIMULATION_DEVICE_DATA_SIZE : DEVICE_DATA_SIZE;
         const uint32_t max_data_size_words = max_data_size / sizeof(uint32_t);
-        const uint32_t dram_data_size_words = this->get_dram_data_size_words();
-        const uint32_t num_iterations = this->get_num_iterations();
 
         std::vector<uint32_t> data(max_data_size_words);
-        for (uint32_t i = 0; i < max_data_size_words; i++) {
+        for (uint32_t i = 0; i < max_data_size_words; ++i) {
             data[i] = i;
         }
 
-        // Setup target worker cores
         const CoreCoord first_worker = this->worker_start();
         const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
-
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
         const CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
-        // Write data into L1 for prefetcher to read it later
         MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, data, l1_base);
         MetalContext::instance().get_cluster().l1_barrier(device_->id());
 
-        // Get completion queue buffer pointer (FD: FDMeshCommandQueue, SD: hugepage region)
         void* completion_queue_buffer = get_completion_queue_buffer();
         const uint32_t completion_queue_size = get_completion_queue_buffer_size();
-        // Pre-fill with dirty pattern:
-        // The dispatcher writes commands and data but doesn't overwrite padding regions
-        // Pre-filling ensures padding areas retain the sentinel value for validation
+        // Pre-fill with dirty pattern so padding regions retain the sentinel for validation.
         dirty_host_completion_buffer(completion_queue_buffer, completion_queue_size);
 
+        // L1 -> host completion queue; skip DRAM prepopulation.
         Common::DeviceData device_data(
-            device_, worker_range, l1_base, dram_base_, completion_queue_buffer, false, dram_data_size_words, cfg_);
+            device_,
+            worker_range,
+            l1_base,
+            dram_base_,
+            completion_queue_buffer,
+            false,
+            /*dram_data_size_words=*/0,
+            cfg_);
 
-        // PHASE 1: Generate host write command metadata
-        auto commands_per_iteration = generate_host_write_commands(data, first_worker, l1_base, device_data);
+        std::vector<HostMemDeviceCommand> commands;
+        for (uint32_t iter = 0; iter < num_iterations; ++iter) {
+            auto round_commands = generate_host_write_commands(data, first_worker, l1_base, device_data);
+            commands.insert(
+                commands.end(),
+                std::make_move_iterator(round_commands.begin()),
+                std::make_move_iterator(round_commands.end()));
+        }
 
-        // PHASE 2, 3, 4: Execute and Validate
-        // Note: Skip distributed::Finish since we are manually writing into the completion queue
-        // which Finish doesn't expect
-        const bool wait_for_completion = false;
-        // For host writes, we need to wait for all writes to be written into the completion queue
-        const bool wait_for_host_writes = true;
+        // Each generated iteration already expands both the command stream and its shadow model.
         execute_generated_commands(
-            commands_per_iteration,
+            commands,
             device_data,
             worker_range.size(),
-            num_iterations,
-            wait_for_completion,
-            wait_for_host_writes);
+            /*num_iterations=*/1,
+            /*wait_for_completion=*/false,
+            /*wait_for_host_writes=*/true);
     }
 
     // Smoke test for writes to Host from dispatcher
@@ -1317,7 +1320,6 @@ public:
     // (we skip distributed::Finish)
     void run_host_smoke_test() {
         const uint32_t num_iterations = get_num_iterations();
-        const uint32_t dram_data_size_words = get_dram_data_size_words();
 
         // Setup target worker cores
         const CoreCoord first_worker = this->worker_start();
@@ -1333,8 +1335,16 @@ public:
         // Pre-filling ensures padding areas retain the sentinel value for validation
         dirty_host_completion_buffer(completion_queue_buffer, completion_queue_size);
 
+        // Host-write smoke; skip DRAM prepopulation.
         Common::DeviceData device_data(
-            device_, worker_range, l1_base, dram_base_, completion_queue_buffer, false, dram_data_size_words, cfg_);
+            device_,
+            worker_range,
+            l1_base,
+            dram_base_,
+            completion_queue_buffer,
+            false,
+            /*dram_data_size_words=*/0,
+            cfg_);
 
         // PHASE 1: Generate host smoke test command metadata
         std::vector<HostMemDeviceCommand> commands_per_iteration;
@@ -1483,8 +1493,8 @@ public:
     // This tests relay of packed paged data using prefetcher to dispacher
     // with multiple sub commands
     void run_packed_read_test() {
-        const uint32_t num_iterations = 1;
-        const uint32_t dram_data_size_words = Common::DRAM_DATA_SIZE_WORDS;
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
 
         // Setup target worker cores
         const CoreCoord first_worker = this->worker_start();
@@ -1752,7 +1762,7 @@ public:
     // with multiple sub commands, each with a linear address.
     // Source: Worker L1 (can overlap), Destination: DRAM bank 0
     void run_linear_packed_read_test() {
-        const uint32_t num_iterations = 1;
+        const uint32_t num_iterations = get_num_iterations();
 
         const CoreCoord first_worker = this->worker_start();
         const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
@@ -1939,6 +1949,45 @@ public:
 
         // PHASE 2, 3, 4: Execute and Validate
         execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    }
+
+    void run_ringbuffer_boundary_reset_stress_test() {
+        constexpr uint32_t ringbuffer_page_size_log2 = 10;
+        constexpr uint32_t ringbuffer_page_size = 1 << ringbuffer_page_size_log2;
+
+        const auto& mem_map = MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const uint32_t ringbuffer_size = mem_map.ringbuffer_size();
+
+        const CoreCoord first_worker = this->worker_start();
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/false);
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+        TT_FATAL(
+            ringbuffer_page_size % dram_alignment == 0,
+            "Ringbuffer staging page {} B must align to DRAM alignment {} B",
+            ringbuffer_page_size,
+            dram_alignment);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, get_dram_data_size_words(), cfg_);
+        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+        const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+        std::vector<HostMemDeviceCommand> commands;
+
+        const auto add_staged_relay = [&](const std::vector<uint32_t>& lengths) {
+            const uint32_t total_length = std::accumulate(lengths.begin(), lengths.end(), 0u);
+            const uint32_t dst_addr = device_data.get_result_data_addr(first_worker, 0);
+            auto sub_cmds = build_sub_cmds(lengths, static_cast<uint32_t>(lengths.size()));
+            commands.push_back(CommandBuilder::build_prefetch_ringbuffer_relay<false, false>(
+                sub_cmds, lengths, device_data, *this, noc_xy, dst_addr, total_length, ringbuffer_page_size_log2));
+        };
+
+        // The first command reaches the staging-buffer end exactly. The following command's reset flag
+        // restarts the write pointer, while the non-zero reader offset continues to exercise offset arithmetic.
+        add_staged_relay({ringbuffer_size});
+        add_staged_relay({ringbuffer_page_size});
+
+        execute_generated_commands(commands, device_data, worker_range.size(), get_num_iterations());
     }
 };
 
@@ -3089,18 +3138,31 @@ public:
     }
 
     // Read the dispatcher-written prefix of the DRAM completion queue into the staging buffer so
-    // device_data.validate() sees real data. Padding past the written span keeps its dirty fill.
-    // Skipped when DRAM-backed CQs are explicitly disabled (TT_METAL_DRAM_BACKED_CQ=0); the base
-    // (hugepage-backed) completion buffer is directly readable, so no DRAM readback is needed.
+    // device_data.validate() sees real data. When the device write pointer wraps, normalize the
+    // tail + head ring segments into one contiguous staging span. Skipped when DRAM-backed CQs
+    // are explicitly disabled (TT_METAL_DRAM_BACKED_CQ=0); the base (hugepage-backed) completion
+    // buffer is directly readable, so no DRAM readback is needed.
     void refresh_completion_data() override {
         if (!mgr_->is_dram_backed()) {
             return;
         }
         const uint8_t cq_id = fdcq_->id();
         std::atomic<bool> exit_condition{false};
-        const uint32_t write_ptr_bytes = (mgr_->completion_queue_wait_front(cq_id, exit_condition) & 0x7fffffff) << 4;
+        const auto [write_ptr_16B, write_toggle] =
+            Common::split_ptr_toggle(mgr_->completion_queue_wait_front(cq_id, exit_condition));
+        const uint32_t write_ptr_bytes = write_ptr_16B << 4;
         const uint32_t read_ptr_bytes = mgr_->get_completion_queue_read_ptr(cq_id);
-        const uint32_t bytes_written = (write_ptr_bytes > read_ptr_bytes) ? (write_ptr_bytes - read_ptr_bytes) : 0;
+        const uint32_t read_toggle = mgr_->get_completion_queue_read_toggle(cq_id);
+        const uint32_t completion_base = mgr_->get_issue_queue_limit(cq_id);
+        const uint32_t completion_limit = mgr_->get_completion_queue_limit(cq_id);
+        uint32_t bytes_written = 0;
+        if (write_toggle == read_toggle) {
+            if (write_ptr_bytes > read_ptr_bytes) {
+                bytes_written = write_ptr_bytes - read_ptr_bytes;
+            }
+        } else {
+            bytes_written = (completion_limit - read_ptr_bytes) + (write_ptr_bytes - completion_base);
+        }
         if (bytes_written == 0) {
             return;
         }
@@ -3109,11 +3171,21 @@ public:
             "Quasar completion readback {} B exceeds staging buffer {} B",
             bytes_written,
             quasar_completion_buf_.size());
+
+        const uint32_t read_offset = read_ptr_bytes - completion_base;
+        const uint32_t tail_bytes = std::min(bytes_written, completion_limit - read_ptr_bytes);
         tt::tt_metal::detail::ReadFromDeviceDRAMChannel(
             this->device_,
             completion_dram_channel(),
-            completion_dram_addr(),
-            std::span<uint8_t>(quasar_completion_buf_.data(), bytes_written));
+            completion_dram_addr() + read_offset,
+            std::span<uint8_t>(quasar_completion_buf_.data(), tail_bytes));
+        if (tail_bytes < bytes_written) {
+            tt::tt_metal::detail::ReadFromDeviceDRAMChannel(
+                this->device_,
+                completion_dram_channel(),
+                completion_dram_addr(),
+                std::span<uint8_t>(quasar_completion_buf_.data() + tail_bytes, bytes_written - tail_bytes));
+        }
     }
 
 private:
@@ -3133,7 +3205,505 @@ private:
 
 class PrefetcherRingbufferReadQuasarSimulatorTestFixture
     : public Common::QuasarSimulatorVariant<PrefetcherRingbufferReadTestFixture> {};
+
+class PrefetcherRingbufferBoundaryResetQuasarSimulatorStressTestFixture
+    : public PrefetcherRingbufferReadQuasarSimulatorTestFixture {};
 class RandomQuasarSimulatorTestFixture : public Common::QuasarSimulatorVariant<RandomTestFixture> {};
+class PrefetcherScratchThresholdQuasarSimulatorStressTestFixture
+    : public Common::QuasarSimulatorVariant<BasePrefetcherTestFixture> {
+protected:
+    void run_scratch_threshold_paged_read_stress_test() {
+        const CoreCoord first_worker = this->worker_start();
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/false);
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+        const uint32_t scratch_half = MetalContext::instance().dispatch_mem_map(CoreType::WORKER).scratch_db_size() / 2;
+        const uint32_t scratch_half_dram_aligned = tt::align(scratch_half, dram_alignment);
+        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+        const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+
+        // One page at each of below / at / above scratch_db_half.
+        const std::vector<uint32_t> page_sizes = {
+            scratch_half_dram_aligned - dram_alignment,
+            scratch_half_dram_aligned,
+            scratch_half_dram_aligned + dram_alignment};
+        for (const uint32_t page_size : page_sizes) {
+            Common::DeviceData device_data(
+                device_, worker_range, l1_base, dram_base_, nullptr, false, get_dram_data_size_words(), cfg_);
+            const uint32_t page_size_words = page_size / sizeof(uint32_t);
+            const uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
+            HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged<flush_prefetch_, inline_data_>(
+                noc_xy, l1_addr, /*start_page=*/0, dram_base_, page_size, /*pages_in_chunk=*/1);
+
+            const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(/*bank_id=*/0);
+            const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
+            DeviceDataUpdater::update_paged_dram_read(
+                worker_range, device_data, bank_core, /*bank_id=*/0, /*bank_offset=*/0, page_size_words);
+
+            execute_generated_commands({std::move(cmd)}, device_data, worker_range.size(), get_num_iterations());
+        }
+    }
+};
+class PrefetcherCmddatQWrapQuasarSimulatorStressTestFixture
+    : public Common::QuasarSimulatorVariant<BasePrefetcherTestFixture> {
+protected:
+    void run_cmddat_q_wrap_stress_test() {
+        TT_FATAL(!use_exec_buf_, "cmddat_q wrap stress test must read directly from the issue queue");
+
+        const CoreRange worker_range = this->worker_range(this->worker_start(), /*multi_core=*/false);
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, get_dram_data_size_words(), cfg_);
+        // One "pass" is the full paged-read stream. Every write targets the same L1 addresses, so replaying
+        // the pass is idempotent and the shadow model built here stays valid however many passes we run.
+        auto commands_per_pass =
+            generate_paged_read_commands(worker_range, dram_alignment, /*num_pages=*/1, device_data);
+
+        uint32_t bytes_per_pass = 0;
+        for (const auto& cmd : commands_per_pass) {
+            bytes_per_pass += cmd.size_bytes();
+        }
+
+        const uint32_t cmddat_q_size = MetalContext::instance().dispatch_mem_map(CoreType::WORKER).cmddat_q_size();
+
+        // num_iterations is the target number of cmddat_q wraps. Each command header is fetched into the
+        // prefetcher's cmddat_q ring, so streaming more than N * cmddat_q_size command bytes forces the
+        // producer to advance past its capacity at least N times. cmddat_q has no host-visible pointer or
+        // toggle to inspect, so this guarantees *at least* that many wraps rather than exactly N.
+        const uint32_t target_wraps = get_num_iterations();
+        const uint32_t passes_per_wrap = (cmddat_q_size + bytes_per_pass - 1) / bytes_per_pass;
+        const uint32_t total_passes = target_wraps * passes_per_wrap;
+
+        const uint32_t total_command_bytes = bytes_per_pass * total_passes;
+        TT_FATAL(
+            total_command_bytes > target_wraps * cmddat_q_size,
+            "cmddat_q wrap stream must exceed {}x queue capacity ({} B <= {} x {} B)",
+            target_wraps,
+            total_command_bytes,
+            target_wraps,
+            cmddat_q_size);
+        execute_generated_commands(commands_per_pass, device_data, worker_range.size(), total_passes);
+    }
+};
+class PrefetcherExecBufMidFetchQuasarSimulatorStressTestFixture
+    : public Common::QuasarSimulatorVariant<BasePrefetcherTestFixture> {
+protected:
+    void run_exec_buf_mid_fetch_stress_test() {
+        TT_FATAL(use_exec_buf_, "Exec buffer mid-fetch stress test requires use_exec_buf=true");
+
+        const CoreRange worker_range = this->worker_range(this->worker_start(), /*multi_core=*/false);
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, get_dram_data_size_words(), cfg_);
+        auto commands_per_iteration =
+            generate_paged_read_commands(worker_range, get_page_size(), get_num_pages(), device_data);
+
+        uint64_t serialized_bytes = 0;
+        for (const auto& cmd : commands_per_iteration) {
+            serialized_bytes += cmd.size_bytes();
+        }
+        serialized_bytes *= get_num_iterations();
+
+        DeviceCommandCalculator wait_calc;
+        wait_calc.add_dispatch_wait();
+        DeviceCommandCalculator exec_buf_end_calc;
+        exec_buf_end_calc.add_prefetch_exec_buf_end();
+        serialized_bytes += wait_calc.write_offset_bytes() + exec_buf_end_calc.write_offset_bytes();
+
+        // Match INITIAL_FETCH_SIZE in cq_prefetch.cpp so the stream forces a subsequent exec-buffer fetch.
+        constexpr uint32_t initial_exec_buf_fetch_bytes = 16 * 1024;
+        TT_FATAL(
+            serialized_bytes > initial_exec_buf_fetch_bytes,
+            "Exec buffer stream must exceed the {} B initial fetch (got {} B)",
+            initial_exec_buf_fetch_bytes,
+            serialized_bytes);
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), get_num_iterations());
+    }
+};
+class PrefetcherExecBufStallQuasarSimulatorStressTestFixture
+    : public Common::QuasarSimulatorVariant<BasePrefetcherTestFixture> {
+protected:
+    void run_exec_buf_stall_transition_stress_test() {
+        TT_FATAL(use_exec_buf_, "Exec buffer stall stress test requires use_exec_buf=true");
+        // Each iteration is one issue queue <-> exec buffer transition. The same count is also
+        // used inside run_dram_to_l1_paged_read_test() to size the command stream within each launch.
+        const uint32_t rounds = get_num_iterations();
+        for (uint32_t round = 0; round < rounds; ++round) {
+            run_dram_to_l1_paged_read_test();
+        }
+    }
+};
+class PrefetcherRelayLinearInlineNoflushQuasarSimulatorStressTestFixture
+    : public Common::QuasarSimulatorVariant<BasePrefetcherTestFixture> {
+protected:
+    void run_relay_linear_inline_noflush_boundary_stress_test() {
+        const CoreCoord first_worker = this->worker_start();
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/false);
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+        const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+
+        // L1-only inline / linear-read path; skip DRAM prepopulation.
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, /*dram_data_size_words=*/0, cfg_);
+        const uint32_t source_addr = device_data.get_result_data_addr(first_worker, 0);
+
+        const auto& mem_map = MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const uint32_t dispatch_cb_pages = mem_map.dispatch_buffer_pages();
+        constexpr uint32_t dispatch_cb_page_size = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
+        const uint32_t dispatch_cb_size = dispatch_cb_pages * dispatch_cb_page_size;
+        const uint32_t dispatch_cb_prefix_bytes = (dispatch_cb_pages - 1) * dispatch_cb_page_size;
+        TT_FATAL(dispatch_cb_pages >= 4, "RELAY_INLINE_NOFLUSH boundary stress needs at least four dispatch CB pages");
+
+        constexpr uint32_t filler_payload_size = 16;
+        const std::vector<uint32_t> filler_payload(filler_payload_size / sizeof(uint32_t), 0xA5A5A5A5);
+        std::vector<HostMemDeviceCommand> commands;
+        for (uint32_t page = 1; page < dispatch_cb_pages - 3; ++page) {
+            HostMemDeviceCommand filler_cmd = Common::CommandBuilder::build_linear_write_command<true, true>(
+                filler_payload, worker_range, /*is_mcast=*/false, noc_xy, source_addr, filler_payload_size);
+            const auto* prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(filler_cmd.data());
+            TT_FATAL(
+                tt::align(prefetch_cmd->relay_inline.length, dispatch_cb_page_size) == dispatch_cb_page_size,
+                "Dispatch CB filler must consume one page (relay payload {} B, page {} B)",
+                prefetch_cmd->relay_inline.length,
+                dispatch_cb_page_size);
+            commands.push_back(std::move(filler_cmd));
+        }
+
+        const uint32_t crossing_payload_size = dispatch_cb_page_size;
+        std::vector<uint32_t> crossing_payload = payload_generator_->generate_payload(crossing_payload_size);
+        HostMemDeviceCommand seed_cmd = Common::CommandBuilder::build_linear_write_command<true, true>(
+            crossing_payload, worker_range, /*is_mcast=*/false, noc_xy, source_addr, crossing_payload_size);
+        const auto* seed_prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(seed_cmd.data());
+        TT_FATAL(
+            tt::align(seed_prefetch_cmd->relay_inline.length, dispatch_cb_page_size) == 2 * dispatch_cb_page_size,
+            "Source-seed command must consume two dispatch CB pages (relay payload {} B, page {} B)",
+            seed_prefetch_cmd->relay_inline.length,
+            dispatch_cb_page_size);
+        Common::DeviceDataUpdater::update_linear_write(crossing_payload, device_data, worker_range, /*is_mcast=*/false);
+        commands.push_back(std::move(seed_cmd));
+
+        HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall();
+        const auto* stall_prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(stall_cmd.data());
+        TT_FATAL(
+            tt::align(stall_prefetch_cmd->relay_inline.length, dispatch_cb_page_size) == dispatch_cb_page_size,
+            "Prefetch-stall command must consume one dispatch CB page");
+        commands.push_back(std::move(stall_cmd));
+
+        const uint32_t dst_addr = device_data.get_result_data_addr(first_worker, 0);
+        HostMemDeviceCommand crossing_cmd = CommandBuilder::build_prefetch_relay_linear_read<false, false>(
+            noc_xy, dst_addr, source_addr, crossing_payload_size);
+        const auto* crossing_prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(crossing_cmd.data());
+        TT_FATAL(
+            crossing_prefetch_cmd->base.cmd_id == CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH,
+            "Boundary command must use RELAY_INLINE_NOFLUSH");
+        TT_FATAL(
+            dispatch_cb_prefix_bytes + crossing_prefetch_cmd->relay_inline.length + crossing_payload_size >
+                dispatch_cb_size,
+            "RELAY_INLINE_NOFLUSH relay does not cross the dispatch CB end ({} + {} + {} <= {})",
+            dispatch_cb_prefix_bytes,
+            crossing_prefetch_cmd->relay_inline.length,
+            crossing_payload_size,
+            dispatch_cb_size);
+        const uint32_t source_offset_words = (source_addr - l1_base) / sizeof(uint32_t);
+        DeviceDataUpdater::update_read(
+            first_worker,
+            device_data,
+            first_worker,
+            /*bank_id=*/0,
+            source_offset_words,
+            crossing_payload_size / sizeof(uint32_t),
+            tt::CoreType::WORKER);
+        device_data.pad(first_worker, /*bank=*/0, MetalContext::instance().hal().get_alignment(HalMemType::L1));
+        commands.push_back(std::move(crossing_cmd));
+
+        execute_generated_commands(commands, device_data, worker_range.size(), get_num_iterations());
+    }
+};
+class PrefetcherPrefetchQWrapQuasarSimulatorStressTestFixture
+    : public Common::QuasarSimulatorVariant<BasePrefetcherTestFixture> {
+protected:
+    void run_prefetch_q_wrap_stress_test() {
+        TT_FATAL(!use_exec_buf_, "prefetch queue wrap stress test must submit commands directly to the issue queue");
+
+        constexpr uint32_t transfer_size_bytes = 16;
+        const CoreCoord first_worker = this->worker_start();
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/false);
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        // This test only writes to worker L1, so skip the DRAM prepopulation by passing 0 for dram_data_size_words.
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, /*dram_data_size_words=*/0, cfg_);
+
+        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+        const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+        const uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
+        std::vector<uint32_t> payload = payload_generator_->generate_payload(transfer_size_bytes);
+        Common::DeviceDataUpdater::update_linear_write(payload, device_data, worker_range, /*is_mcast=*/false);
+
+        std::vector<HostMemDeviceCommand> commands;
+        commands.push_back(Common::CommandBuilder::build_linear_write_command<true, true>(
+            payload, worker_range, /*is_mcast=*/false, noc_xy, l1_addr, transfer_size_bytes));
+
+        // Each command consumes one PrefetchQ entry. After prefetch_q_entries commands, the device consumer
+        // has wrapped to the base and the host producer is at the limit. The extra command makes the host
+        // producer reset to the base before reserving the next entry.
+        // The reserve/write loop in execute_generated_commands blocks for PrefetchQ space as needed.
+        const uint32_t prefetch_q_entries =
+            MetalContext::instance().dispatch_mem_map(CoreType::WORKER).prefetch_q_entries();
+        const uint32_t num_traversals = get_num_iterations();
+        execute_generated_commands(
+            commands, device_data, worker_range.size(), (num_traversals * prefetch_q_entries) + 1);
+    }
+};
+class PrefetcherIssueQueueWrapQuasarSimulatorStressTestFixture
+    : public Common::QuasarSimulatorVariant<BasePrefetcherTestFixture> {
+protected:
+    void run_issue_queue_wrap_stress_test() {
+        TT_FATAL(!use_exec_buf_, "Issue queue wrap stress test must submit commands directly to the issue queue");
+
+        constexpr uint32_t transfer_size_bytes = 16384;
+        const uint8_t cq_id = fdcq_->id();
+        const CoreCoord first_worker = this->worker_start();
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/false);
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+        const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+
+        auto make_command = [&](const std::vector<uint32_t>& payload, uint32_t address) {
+            return Common::CommandBuilder::build_linear_write_command<true, true>(
+                payload, worker_range, /*is_mcast=*/false, noc_xy, address, transfer_size_bytes);
+        };
+
+        DeviceCommandCalculator barrier_calc;
+        barrier_calc.add_dispatch_wait();
+        const uint32_t barrier_bytes = barrier_calc.write_offset_bytes();
+        const uint32_t issue_alignment = mgr_->is_dram_backed()
+                                             ? MetalContext::instance().hal().get_alignment(HalMemType::DRAM)
+                                             : MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+        const uint32_t issue_limit = mgr_->get_issue_queue_limit(cq_id);
+
+        // Deterministic prefix / post-wrap payloads. Every write targets the same L1 address, so replaying
+        // them is idempotent and only the surviving last write has to be validated.
+        const std::vector<uint32_t> prefix_payload = payload_generator_->generate_payload(transfer_size_bytes);
+        const std::vector<uint32_t> post_wrap_payload = payload_generator_->generate_payload(transfer_size_bytes);
+        const uint32_t prefix_cmd_bytes = make_command(prefix_payload, l1_base).size_bytes();
+        const uint32_t post_wrap_submit_bytes =
+            tt::align(make_command(post_wrap_payload, l1_base).size_bytes() + barrier_bytes, issue_alignment);
+
+        // Submissions below pass wait_for_completion=false so nothing but the commands themselves is reserved from the
+        // issue queue - a per-submission distributed::Finish would reserve its event-record sequence here too and wrap
+        // the ring before the crossing command could. Everything is drained and validated once after the last
+        // iteration instead, which also means each wrap happens while the device is still consuming.
+        //
+        // The shadow model stays empty until that final drain, which keeps the validate() inside
+        // execute_generated_commands a no-op and holds get_result_data_addr() at the base address, so every submission
+        // writes the same L1 bytes.
+        // This test only writes to worker L1, so skip the DRAM prepopulation by passing 0 for dram_data_size_words.
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, /*dram_data_size_words=*/0, cfg_);
+        const uint32_t write_addr = device_data.get_result_data_addr(first_worker, 0);
+
+        // Each iteration fills the issue queue from the live write pointer up to just short of the runtime
+        // boundary, then submits one command that has to wrap - i.e. exactly one ring wrap per iteration.
+        const uint32_t num_iterations = get_num_iterations();
+        for (uint32_t iter = 0; iter < num_iterations; ++iter) {
+            const uint32_t write_ptr = mgr_->get_issue_queue_write_ptr(cq_id);
+            TT_FATAL(write_ptr < issue_limit, "Issue queue write pointer must be below its limit");
+            const uint32_t tail_bytes = issue_limit - write_ptr;
+
+            uint32_t prefix_iterations =
+                (tail_bytes > barrier_bytes) ? (tail_bytes - barrier_bytes) / prefix_cmd_bytes : 0;
+            uint32_t prefix_submit_bytes = 0;
+            while (prefix_iterations > 0) {
+                prefix_submit_bytes = tt::align(prefix_iterations * prefix_cmd_bytes + barrier_bytes, issue_alignment);
+                if (prefix_submit_bytes < tail_bytes && tail_bytes - prefix_submit_bytes < post_wrap_submit_bytes) {
+                    break;
+                }
+                --prefix_iterations;
+            }
+            TT_FATAL(
+                prefix_iterations > 0,
+                "Could not place an issue queue prefix before the runtime boundary (tail {} B, command {} B)",
+                tail_bytes,
+                prefix_cmd_bytes);
+
+            const bool toggle_before = mgr_->get_cq_interfaces()[cq_id].issue_fifo_wr_toggle;
+            execute_generated_commands(
+                {make_command(prefix_payload, write_addr)},
+                device_data,
+                worker_range.size(),
+                prefix_iterations,
+                /*wait_for_completion=*/false);
+
+            // const uint32_t pre_wrap_write_ptr = mgr_->get_issue_queue_write_ptr(cq_id);
+            const bool pre_wrap_toggle = mgr_->get_cq_interfaces()[cq_id].issue_fifo_wr_toggle;
+            TT_FATAL(pre_wrap_toggle == toggle_before, "Issue queue wrapped while filling the deterministic prefix");
+
+            execute_generated_commands(
+                {make_command(post_wrap_payload, write_addr)},
+                device_data,
+                worker_range.size(),
+                1,
+                /*wait_for_completion=*/true);
+            // distributed::Finish(mesh_device_->mesh_command_queue());
+
+            // const uint32_t post_wrap_write_ptr = mgr_->get_issue_queue_write_ptr(cq_id);
+            // const bool post_wrap_toggle = mgr_->get_cq_interfaces()[cq_id].issue_fifo_wr_toggle;
+            // EXPECT_NE(post_wrap_toggle, pre_wrap_toggle);
+            // EXPECT_LT(post_wrap_write_ptr, pre_wrap_write_ptr);
+        }
+
+        // Every command targets the same L1 address, so the surviving state is the last crossing write.
+        // distributed::Finish(mesh_device_->mesh_command_queue());
+        Common::DeviceDataUpdater::update_linear_write(
+            post_wrap_payload, device_data, worker_range, /*is_mcast=*/false);
+        EXPECT_TRUE(device_data.validate(device_));
+    }
+};
+class PrefetcherHostQuasarSimulatorStressTestFixture : public PrefetcherHostQuasarSimulatorTestFixture {};
+class PrefetcherCompletionQueueWrapQuasarSimulatorStressTestFixture : public PrefetcherHostQuasarSimulatorTestFixture {
+protected:
+    void run_completion_queue_wrap_stress_test() {
+        TT_FATAL(!use_exec_buf_, "Completion queue wrap stress test must submit commands directly to the issue queue");
+
+        const uint8_t cq_id = fdcq_->id();
+        const uint32_t completion_queue_size = get_completion_queue_buffer_size();
+        constexpr uint32_t completion_page_size = DispatchSettings::TRANSFER_PAGE_SIZE;
+        const uint32_t total_pages = completion_queue_size / completion_page_size;
+        const uint32_t completion_base = mgr_->get_issue_queue_limit(cq_id);
+        const uint32_t completion_limit = mgr_->get_completion_queue_limit(cq_id);
+        // The iteration bookkeeping assumes the completion ring starts drained at its base.
+        TT_FATAL(
+            mgr_->get_completion_queue_read_ptr(cq_id) == completion_base,
+            "Completion queue wrap stress test expects the ring to start empty at its base (read ptr {}, base {})",
+            mgr_->get_completion_queue_read_ptr(cq_id),
+            completion_base);
+
+        const CoreCoord first_worker = this->worker_start();
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
+        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+        const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+
+        constexpr uint32_t filler_size_bytes = 16;
+        const std::vector<uint32_t> filler_data(filler_size_bytes / sizeof(uint32_t), 0xA5A5A5A5);
+        constexpr uint32_t crossing_size_bytes = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
+        const std::vector<uint32_t> crossing_data(crossing_size_bytes / sizeof(uint32_t), 0x5A5A5A5A);
+
+        std::atomic<bool> exit_condition{false};
+
+        // completion_queue_pop_front() snaps the read pointer to the base whenever a pop reaches the
+        // region end, so a pop that crosses the boundary must be split into a to-the-end chunk and a
+        // from-the-base chunk to drain the ring exactly.
+        const auto drain_completion_pages = [&](uint32_t pages) {
+            while (pages > 0) {
+                const uint32_t read_ptr = mgr_->get_completion_queue_read_ptr(cq_id);
+                const uint32_t pages_to_limit = (completion_limit - read_ptr) / completion_page_size;
+                const uint32_t chunk = std::min(pages, pages_to_limit);
+                mgr_->completion_queue_pop_front(chunk, cq_id);
+                pages -= chunk;
+            }
+        };
+
+        // The completion write pointer starts at the base; each crossing leaves it a fixed number of
+        // pages past the base, which we track so every iteration refills up to the boundary and wraps once.
+        uint32_t write_offset_pages = 0;
+        const uint32_t num_iterations = get_num_iterations();
+        for (uint32_t iter = 0; iter < num_iterations; ++iter) {
+            // Phase 1: fill the ring up to exactly one page before the region end.
+            const uint32_t fill_pages = total_pages - write_offset_pages - 1;
+            TT_FATAL(fill_pages >= 1, "Completion queue fill left no room before the boundary");
+
+            MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, filler_data, l1_base);
+            MetalContext::instance().get_cluster().l1_barrier(device_->id());
+
+            void* completion_queue_buffer = get_completion_queue_buffer();
+            dirty_host_completion_buffer(completion_queue_buffer, completion_queue_size);
+            Common::DeviceData filler_expected(
+                device_,
+                worker_range,
+                l1_base,
+                dram_base_,
+                completion_queue_buffer,
+                false,
+                /*dram_data_size_words=*/0,
+                cfg_);
+            std::vector<HostMemDeviceCommand> fillers;
+            fillers.reserve(fill_pages);
+            for (uint32_t page = 0; page < fill_pages; ++page) {
+                fillers.push_back(
+                    CommandBuilder::build_prefetch_relay_linear_host<inline_data_>(noc_xy, l1_base, filler_size_bytes));
+                DeviceDataUpdater::update_host_data(filler_expected, filler_data, filler_size_bytes);
+                pad_host_data(filler_expected);
+            }
+            execute_generated_commands(
+                fillers,
+                filler_expected,
+                worker_range.size(),
+                /*num_iterations=*/1,
+                /*wait_for_completion=*/false,
+                /*wait_for_host_writes=*/true);
+            const uint32_t pre_wrap_ptr_and_toggle = mgr_->completion_queue_wait_front(cq_id, exit_condition);
+            drain_completion_pages(fill_pages);
+
+            // Phase 2: a single write whose padded footprint spans the region end, forcing the device
+            // write pointer to wrap and flip its toggle.
+            MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, crossing_data, l1_base);
+            MetalContext::instance().get_cluster().l1_barrier(device_->id());
+
+            completion_queue_buffer = get_completion_queue_buffer();
+            dirty_host_completion_buffer(completion_queue_buffer, completion_queue_size);
+            Common::DeviceData crossing_expected(
+                device_,
+                worker_range,
+                l1_base,
+                dram_base_,
+                completion_queue_buffer,
+                false,
+                /*dram_data_size_words=*/0,
+                cfg_);
+            std::vector<HostMemDeviceCommand> crossing_commands;
+            crossing_commands.push_back(
+                CommandBuilder::build_prefetch_relay_linear_host<inline_data_>(noc_xy, l1_base, crossing_size_bytes));
+            DeviceDataUpdater::update_host_data(crossing_expected, crossing_data, crossing_size_bytes);
+            pad_host_data(crossing_expected);
+            const uint32_t crossing_pages =
+                (static_cast<uint32_t>(crossing_expected.size()) * sizeof(uint32_t)) / completion_page_size;
+            TT_FATAL(
+                crossing_pages >= 2,
+                "Crossing write must span at least two pages to cross the ring boundary (got {} pages)",
+                crossing_pages);
+
+            execute_generated_commands(
+                crossing_commands,
+                crossing_expected,
+                worker_range.size(),
+                /*num_iterations=*/1,
+                /*wait_for_completion=*/false,
+                /*wait_for_host_writes=*/true);
+            const uint32_t post_wrap_ptr_and_toggle = mgr_->completion_queue_wait_front(cq_id, exit_condition);
+            const auto pre_wrap = Common::split_ptr_toggle(pre_wrap_ptr_and_toggle);
+            const auto post_wrap = Common::split_ptr_toggle(post_wrap_ptr_and_toggle);
+            EXPECT_NE(pre_wrap.toggle, post_wrap.toggle);
+            EXPECT_LT(post_wrap.ptr_16B, pre_wrap.ptr_16B);
+
+            // Drain the crossing so the next iteration starts from an empty ring, and record where the
+            // wrap left the device write pointer (crossing_pages - 1 pages past the base).
+            drain_completion_pages(crossing_pages);
+            write_offset_pages = crossing_pages - 1;
+        }
+    }
+};
+class RandomQuasarSimulatorStressTestFixture : public Common::QuasarSimulatorVariant<RandomTestFixture> {
+protected:
+    Common::DispatchPayloadGenerator::Config payload_generator_config() const override {
+        Common::DispatchPayloadGenerator::Config pgcfg = Common::BaseTestFixture::payload_generator_config();
+        pgcfg.seed = 0x51415352;  // Deterministic seed to reproduce Quasar stress failures
+        return pgcfg;
+    }
+};
 
 // In this we, we test the terminate command by adding a linear write unicast
 // with a small payload followed by commands to terminate prefetcher and dispatcher.
@@ -3334,7 +3904,6 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
     }
 
     const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
     const uint32_t page_size_bytes = get_page_size();
     const uint32_t requested_pages_per_cmd = get_num_pages();
     TT_FATAL(page_size_bytes % sizeof(uint32_t) == 0U, "page_size_bytes must be a multiple of 4");
@@ -3347,8 +3916,9 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
     const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
     const uint32_t page_alignment_bytes = device_->allocator_impl()->get_alignment(BufferType::DRAM);
 
+    // Inline host payloads write DRAM destinations; skip DRAM prepopulation.
     Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base, nullptr, /*is_banked=*/false, dram_data_size_words, cfg_);
+        device_, worker_range, l1_base, dram_base, nullptr, /*is_banked=*/false, /*dram_data_size_words=*/0, cfg_);
 
     // Find the maximum number of pages per command that fits within the configured max prefetch command size.
     uint32_t pages_per_cmd = 1U;
@@ -3549,6 +4119,90 @@ TEST_P(PrefetcherRingbufferReadQuasarSimulatorTestFixture, RingbufferReadTest) {
 
 TEST_P(RandomQuasarSimulatorTestFixture, RandomTest) {
     log_info(tt::LogTest, "RandomQuasarSimulatorTestFixture - RandomTest (Quasar simulator FD) - Test Start");
+    run_random_test();
+}
+
+TEST_P(PrefetcherScratchThresholdQuasarSimulatorStressTestFixture, ScratchThresholdPagedReadStress) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherScratchThresholdQuasarSimulatorStressTestFixture - ScratchThresholdPagedReadStress "
+        "(Quasar simulator FD) - Test Start");
+    run_scratch_threshold_paged_read_stress_test();
+}
+
+TEST_P(PrefetcherCmddatQWrapQuasarSimulatorStressTestFixture, CmddatQWrapStress) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherCmddatQWrapQuasarSimulatorStressTestFixture - CmddatQWrapStress "
+        "(Quasar simulator FD) - Test Start");
+    run_cmddat_q_wrap_stress_test();
+}
+
+TEST_P(PrefetcherExecBufMidFetchQuasarSimulatorStressTestFixture, ExecBufMidFetchStress) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherExecBufMidFetchQuasarSimulatorStressTestFixture - ExecBufMidFetchStress (Quasar simulator FD) - "
+        "Test Start");
+    run_exec_buf_mid_fetch_stress_test();
+}
+
+TEST_P(PrefetcherExecBufStallQuasarSimulatorStressTestFixture, ExecBufStallTransitionStress) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherExecBufStallQuasarSimulatorStressTestFixture - ExecBufStallTransitionStress "
+        "(Quasar simulator FD) - Test Start");
+    run_exec_buf_stall_transition_stress_test();
+}
+
+TEST_P(PrefetcherRelayLinearInlineNoflushQuasarSimulatorStressTestFixture, RelayLinearInlineNoflushBoundaryStress) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherRelayLinearInlineNoflushQuasarSimulatorStressTestFixture - "
+        "RelayLinearInlineNoflushBoundaryStress (Quasar simulator FD) - Test Start");
+    run_relay_linear_inline_noflush_boundary_stress_test();
+}
+
+TEST_P(PrefetcherPrefetchQWrapQuasarSimulatorStressTestFixture, PrefetchQWrapStress) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherPrefetchQWrapQuasarSimulatorStressTestFixture - PrefetchQWrapStress (Quasar simulator FD) - Test "
+        "Start");
+    run_prefetch_q_wrap_stress_test();
+}
+
+TEST_P(PrefetcherIssueQueueWrapQuasarSimulatorStressTestFixture, IssueQueueWrapStress) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherIssueQueueWrapQuasarSimulatorStressTestFixture - IssueQueueWrapStress (Quasar simulator FD) - Test "
+        "Start");
+    run_issue_queue_wrap_stress_test();
+}
+
+TEST_P(PrefetcherCompletionQueueWrapQuasarSimulatorStressTestFixture, CompletionQueueWrapStress) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherCompletionQueueWrapQuasarSimulatorStressTestFixture - CompletionQueueWrapStress (Quasar simulator "
+        "FD) - Test Start");
+    run_completion_queue_wrap_stress_test();
+}
+
+TEST_P(PrefetcherHostQuasarSimulatorStressTestFixture, HostCompletionStress) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherHostQuasarSimulatorStressTestFixture - HostCompletionStress (Quasar simulator FD) - Test Start");
+    run_host_test();
+}
+
+TEST_P(PrefetcherRingbufferBoundaryResetQuasarSimulatorStressTestFixture, RingbufferBoundaryResetStress) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherRingbufferBoundaryResetQuasarSimulatorStressTestFixture - RingbufferBoundaryResetStress "
+        "(Quasar simulator FD) - Test Start");
+    run_ringbuffer_boundary_reset_stress_test();
+}
+
+TEST_P(RandomQuasarSimulatorStressTestFixture, RandomStress) {
+    log_info(tt::LogTest, "RandomQuasarSimulatorStressTestFixture - RandomStress (Quasar simulator FD) - Test Start");
     run_random_test();
 }
 
@@ -3901,6 +4555,110 @@ INSTANTIATE_TEST_SUITE_P(
         return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
                std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
                "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    PrefetcherScratchThresholdQuasarSimulatorStressTestFixture,
+    ::testing::Values(PagedReadParams{.num_iterations = 3}, PagedReadParams{.num_iterations = 3, .use_exec_buf = true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return "below_at_above_scratch_half_" + std::to_string(info.param.num_iterations) + "iter_" +
+               (info.param.use_exec_buf ? std::string{"use_exec_buf_enabled"} : std::string{"use_exec_buf_disabled"});
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    PrefetcherCmddatQWrapQuasarSimulatorStressTestFixture,
+    ::testing::Values(PagedReadParams{.num_iterations = 3}),
+    [](const testing::TestParamInfo<PagedReadParams>& /*info*/) { return "runtime_capacity"; });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    PrefetcherExecBufMidFetchQuasarSimulatorStressTestFixture,
+    ::testing::Values(PagedReadParams{.page_size = 128, .num_pages = 1, .num_iterations = 1, .use_exec_buf = true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages";
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    PrefetcherExecBufStallQuasarSimulatorStressTestFixture,
+    ::testing::Values(PagedReadParams{.num_iterations = 4, .use_exec_buf = true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.num_iterations) + "_stall_transitions";
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    PrefetcherRelayLinearInlineNoflushQuasarSimulatorStressTestFixture,
+    ::testing::Values(PagedReadParams{.num_iterations = 3}, PagedReadParams{.num_iterations = 3, .use_exec_buf = true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.num_iterations) + "iter_" +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    PrefetcherPackedReadQuasarSimulatorTestFixture,
+    ::testing::Values(PagedReadParams{.num_iterations = 3}, PagedReadParams{.num_iterations = 3, .use_exec_buf = true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.num_iterations) + "iter_" +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    PrefetcherLinearPackedReadQuasarSimulatorTestFixture,
+    ::testing::Values(PagedReadParams{.num_iterations = 3}, PagedReadParams{.num_iterations = 3, .use_exec_buf = true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.num_iterations) + "iter_" +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    PrefetcherHostQuasarSimulatorStressTestFixture,
+    ::testing::Values(PagedReadParams{.num_iterations = 3}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.num_iterations) + "bulk_rounds";
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    PrefetcherRingbufferBoundaryResetQuasarSimulatorStressTestFixture,
+    ::testing::Values(PagedReadParams{.num_iterations = 3}, PagedReadParams{.num_iterations = 3, .use_exec_buf = true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::string{"boundary_reset_nonzero_offset_"} +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    PrefetcherPrefetchQWrapQuasarSimulatorStressTestFixture,
+    ::testing::Values(PagedReadParams{.num_iterations = 2}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.num_iterations) + "_full_queue_wraps";
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    PrefetcherIssueQueueWrapQuasarSimulatorStressTestFixture,
+    ::testing::Values(PagedReadParams{.num_iterations = 2}),
+    [](const testing::TestParamInfo<PagedReadParams>& /*info*/) { return "runtime_boundary"; });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    PrefetcherCompletionQueueWrapQuasarSimulatorStressTestFixture,
+    ::testing::Values(PagedReadParams{.num_iterations = 3}),
+    [](const testing::TestParamInfo<PagedReadParams>& /*info*/) { return "runtime_boundary"; });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherStressTests,
+    RandomQuasarSimulatorStressTestFixture,
+    ::testing::Values(PagedReadParams{.num_iterations = 8}, PagedReadParams{.num_iterations = 8, .use_exec_buf = true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.num_iterations) + "iter_fixed_seed_" +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
     });
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
### PR Category
Test Only

### Summary
This change adds stress tests for Quasar fast dispatch. At a high level, the stress tests cover:
- commands that wrap past the end of the dispatch buffer
- payloads at the edges of the prefetcher's scratch memory
- wrapping of the queues
- exec-buffer entry, exit, and mid-stream re-fetch
- fixed-seed random workload

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_stress_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_fd_stress_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_stress_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_fd_stress_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_stress_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sagarwal/qsr_fd_stress_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_fd_stress_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_fd_stress_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_stress_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_fd_stress_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_fd_stress_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_fd_stress_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_fd_stress_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_fd_stress_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_fd_stress_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_fd_stress_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_stress_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml?query=branch:sagarwal/qsr_fd_stress_test)