### PR TITLE
[Cleanup] Collapse per-core-type command queue dispatch layouts into a single layout

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -243,8 +243,7 @@ void MetalContext::initialize(
         dispatch_core_type =
             resolve_dispatch_core_type(MetalEnvAccessor(*env_).impl(), device_id, dispatch_core_config_);
     }
-    const CommandQueueDispatchLayout& cq_dispatch_layout =
-        dispatch_query_manager_->cq_dispatch_layout(dispatch_core_type);
+    const CommandQueueDispatchLayout& cq_dispatch_layout = dispatch_query_manager_->cq_dispatch_layout();
     dispatch_mem_map_ = std::make_unique<DispatchMemMap>(
         dispatch_core_type, num_hw_cqs, hal(), is_galaxy_cluster, cq_dispatch_layout, rtoptions());
     // Initialize debug servers. Attaching individual devices done below

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -10,7 +10,6 @@
 #include <unordered_set>
 #include <utility>
 
-#include <enchantum/enchantum.hpp>
 #include <tt_stl/assert.hpp>
 #include "context/metal_env_accessor.hpp"
 #include "core_descriptor.hpp"
@@ -83,9 +82,8 @@ std::vector<tt::tt_metal::CoreCoord> populate_all_logical_dispatch_cores(
     return get_consistent_logical_cores(env, num_hw_cqs, dispatch_core_config);
 }
 
-tt::tt_metal::CommandQueueDispatchLayout generate_cq_dispatch_layout(
-    tt::ARCH arch, tt::CoreType core_type, tt::CoreType dispatch_core_type, uint8_t num_hw_cqs) {
-    if (core_type != dispatch_core_type || arch != tt::ARCH::QUASAR) {
+tt::tt_metal::CommandQueueDispatchLayout generate_cq_dispatch_layout(tt::ARCH arch, uint8_t num_hw_cqs) {
+    if (arch != tt::ARCH::QUASAR) {
         return {.fd_kernels_on_same_core = false, .num_cqs_per_core = 1};
     }
     return {.fd_kernels_on_same_core = true, .num_cqs_per_core = num_hw_cqs};
@@ -128,12 +126,7 @@ void DispatchQueryManager::reset(DispatchCoreConfig& dispatch_core_config, uint8
     }
 
     go_signal_noc_ = (dispatch_s_enabled_ and arch != tt::ARCH::QUASAR) ? NOC::NOC_1 : NOC::NOC_0;
-    worker_cq_dispatch_layout_ =
-        generate_cq_dispatch_layout(arch, CoreType::WORKER, resolved_dispatch_core_type_, num_hw_cqs);
-    eth_cq_dispatch_layout_ =
-        generate_cq_dispatch_layout(arch, CoreType::ETH, resolved_dispatch_core_type_, num_hw_cqs);
-    dispatch_cq_dispatch_layout_ =
-        generate_cq_dispatch_layout(arch, CoreType::DISPATCH, resolved_dispatch_core_type_, num_hw_cqs);
+    cq_dispatch_layout_ = generate_cq_dispatch_layout(arch, num_hw_cqs);
     // Reset the dispatch cores reported by the manager. Will be re-populated when the associated query is made
     dispatch_cores_ = {};
     // Populate dispatch
@@ -159,11 +152,10 @@ tt_cxy_pair DispatchQueryManager::get_dispatch_core(uint8_t cq_id) const {
             // with ethernet dispatch.
             dispatch_cores_.push_back(dispatch_core(env_, core_manager_, cq));
         }
-        const CommandQueueDispatchLayout& layout = cq_dispatch_layout(resolved_dispatch_core_type_);
-        if (layout.fd_kernels_on_same_core) {
+        if (cq_dispatch_layout_.fd_kernels_on_same_core) {
             // The shared, non-offset L1 regions and the per-CQ zoning in DispatchMemMap are only valid if these CQs
             // really do land on one physical core.
-            for (uint8_t cq = 1; cq < layout.num_cqs_per_core; cq++) {
+            for (uint8_t cq = 1; cq < cq_dispatch_layout_.num_cqs_per_core; cq++) {
                 TT_FATAL(
                     dispatch_cores_[cq] == dispatch_cores_[0],
                     "CQs sharing a dispatch core diverged: CQ 0 resolved to chip {} ({}, {}), CQ {} resolved to "
@@ -181,16 +173,7 @@ tt_cxy_pair DispatchQueryManager::get_dispatch_core(uint8_t cq_id) const {
     return dispatch_cores_[cq_id];
 }
 
-const CommandQueueDispatchLayout& DispatchQueryManager::cq_dispatch_layout(CoreType core_type) const {
-    switch (core_type) {
-        case CoreType::WORKER: return worker_cq_dispatch_layout_;
-        case CoreType::ETH: return eth_cq_dispatch_layout_;
-        case CoreType::DISPATCH: return dispatch_cq_dispatch_layout_;
-        default:
-            TT_THROW(
-                "Unsupported core type for cq_dispatch_layout: {}", enchantum::to_string(core_type));
-    }
-}
+const CommandQueueDispatchLayout& DispatchQueryManager::cq_dispatch_layout() const { return cq_dispatch_layout_; }
 
 DispatchQueryManager::DispatchQueryManager(
     MetalEnv& env, dispatch_core_manager& core_manager, DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) :

--- a/tt_metal/impl/dispatch/dispatch_query_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.hpp
@@ -46,8 +46,8 @@ public:
     const std::vector<CoreCoord>& get_logical_dispatch_cores_on_user_chips() const;
     tt_cxy_pair get_dispatch_core(uint8_t cq_id) const;
 
-    // How command queues share a dispatch core of core_type (WORKER, ETH, or DISPATCH)
-    const CommandQueueDispatchLayout& cq_dispatch_layout(CoreType core_type) const;
+    // How command queues share the dispatch core
+    const CommandQueueDispatchLayout& cq_dispatch_layout() const;
 
 private:
     void reset(DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs);
@@ -57,9 +57,7 @@ private:
     bool dispatch_s_enabled_ = false;
     bool distributed_dispatcher_ = false;
     NOC go_signal_noc_ = NOC::NOC_0;
-    CommandQueueDispatchLayout worker_cq_dispatch_layout_;
-    CommandQueueDispatchLayout eth_cq_dispatch_layout_;
-    CommandQueueDispatchLayout dispatch_cq_dispatch_layout_;
+    CommandQueueDispatchLayout cq_dispatch_layout_;
     CoreType resolved_dispatch_core_type_ = CoreType::WORKER;
     uint8_t num_hw_cqs_ = 0;
     DispatchCoreConfig dispatch_core_config_;  // The config this object was initialized with, need to store it so we

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -56,9 +56,8 @@ void issue_record_event_commands(
 
     const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
     const uint32_t num_worker_counters = sub_device_ids.size();
-    const CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     const uint32_t num_cqs_per_dispatch_core =
-        MetalContext::instance().get_dispatch_query_manager().cq_dispatch_layout(dispatch_core_type).num_cqs_per_core;
+        MetalContext::instance().get_dispatch_query_manager().cq_dispatch_layout().num_cqs_per_core;
     const uint32_t num_dispatch_cores = num_command_queues / num_cqs_per_dispatch_core;
     const uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
 
@@ -123,6 +122,7 @@ void issue_record_event_commands(
     std::vector<CQDispatchWritePackedUnicastSubCmd> unicast_sub_cmds(num_command_queues);
     std::vector<std::pair<const void*, uint32_t>> event_payloads(num_command_queues);
 
+    const CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     for (auto cq = 0; cq < num_command_queues; cq++) {
         tt_cxy_pair dispatch_location = MetalContext::instance().get_dispatch_query_manager().get_dispatch_core(cq);
         CoreCoord dispatch_virtual_core = device->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
`DispatchQueryManager` stored three `CommandQueueDispatchLayout` copies (worker, ethernet,
dispatch) behind `cq_dispatch_layout(CoreType)`, but it was always queried with the same
core type the manager itself resolves, never with the other core types.

Now a single `cq_dispatch_layout_` is derived from architecture and hardware command queue
count, read through a no-argument accessor.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/cq_layout_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/cq_layout_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/cq_layout_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/cq_layout_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sagarwal/cq_layout_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sagarwal/cq_layout_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/cq_layout_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/cq_layout_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/cq_layout_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/cq_layout_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/cq_layout_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/cq_layout_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/cq_layout_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/cq_layout_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/cq_layout_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/cq_layout_cleanup)