### PR TITLE
[Bug fix] fix(eltwise): overflow-safe logaddexp/logaddexp2 via native SFPU kernel

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -113,6 +113,28 @@ inline void calculate_sfpu_binary(const uint dst_index_in0, const uint dst_index
                 result = sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] * in0;
             }
             v_endif;
+        } else if constexpr (BINOP == BinaryOp::LOGADDEXP) {
+            // logaddexp(a,b) = max(a,b) + log(1 + exp(-|a-b|)); exp never overflows
+            sfpi::vFloat diff = in0 - in1;
+            sfpi::vFloat abs_diff = sfpi::abs(diff);
+            sfpi::vFloat m = in0;
+            v_if (in1 > in0) { m = in1; }
+            v_endif;
+            sfpi::vFloat exp_neg = _calculate_exponential_body_<is_fp32_dest_acc_en>(-abs_diff);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = 1.0f + exp_neg;
+            _calculate_log_body_<false>(0, dst_index_out);
+            result = m + sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi];
+        } else if constexpr (BINOP == BinaryOp::LOGADDEXP2) {
+            // logaddexp2(a,b) = max(a,b) + log2(1 + 2^{-|a-b|})
+            sfpi::vFloat diff = in0 - in1;
+            sfpi::vFloat abs_diff = sfpi::abs(diff);
+            sfpi::vFloat m = in0;
+            v_if (in1 > in0) { m = in1; }
+            v_endif;
+            sfpi::vFloat exp2_neg = _calculate_exponential_body_<is_fp32_dest_acc_en>(-abs_diff * 0.6931472f);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = 1.0f + exp2_neg;
+            _calculate_log_body_<false>(0, dst_index_out);
+            result = m + sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] * 1.4426950f;
         }
 
         sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
@@ -193,6 +215,8 @@ inline void sfpu_binary_init() {
         // Initialisation for use of sfpu_reciprocal_iter<2> in DIV or POW.
         sfpu_reciprocal_init<false>();
     } else if constexpr (BINOP == BinaryOp::XLOGY) {
+        _init_log_<APPROXIMATION_MODE>();
+    } else if constexpr (BINOP == BinaryOp::LOGADDEXP || BINOP == BinaryOp::LOGADDEXP2) {
         _init_log_<APPROXIMATION_MODE>();
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -120,7 +120,7 @@ inline void calculate_sfpu_binary(const uint dst_index_in0, const uint dst_index
             sfpi::vFloat m = in0;
             v_if (in1 > in0) { m = in1; }
             v_endif;
-            sfpi::vFloat exp_neg = _calculate_exponential_body_<is_fp32_dest_acc_en>(-abs_diff);
+            sfpi::vFloat exp_neg = _sfpu_exp_fp32_accurate_(-abs_diff);
             sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = 1.0f + exp_neg;
             _calculate_log_body_<false>(0, dst_index_out);
             result = m + sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi];
@@ -131,7 +131,7 @@ inline void calculate_sfpu_binary(const uint dst_index_in0, const uint dst_index
             sfpi::vFloat m = in0;
             v_if (in1 > in0) { m = in1; }
             v_endif;
-            sfpi::vFloat exp2_neg = _calculate_exponential_body_<is_fp32_dest_acc_en>(-abs_diff * 0.6931472f);
+            sfpi::vFloat exp2_neg = _sfpu_exp_fp32_accurate_(-abs_diff * 0.6931472f);
             sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = 1.0f + exp2_neg;
             _calculate_log_body_<false>(0, dst_index_out);
             result = m + sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] * 1.4426950f;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -121,7 +121,7 @@ inline void calculate_sfpu_binary(
             sfpi::vFloat m = in0;
             v_if (in1 > in0) { m = in1; }
             v_endif;
-            sfpi::vFloat exp_neg = _calculate_exponential_body_<is_fp32_dest_acc_en>(-abs_diff);
+            sfpi::vFloat exp_neg = _sfpu_exp_fp32_accurate_(-abs_diff);
             sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = 1.0f + exp_neg;
             _calculate_log_body_<false>(0, dst_index_out);
             result = m + sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi];
@@ -132,7 +132,7 @@ inline void calculate_sfpu_binary(
             sfpi::vFloat m = in0;
             v_if (in1 > in0) { m = in1; }
             v_endif;
-            sfpi::vFloat exp2_neg = _calculate_exponential_body_<is_fp32_dest_acc_en>(-abs_diff * 0.6931472f);
+            sfpi::vFloat exp2_neg = _sfpu_exp_fp32_accurate_(-abs_diff * 0.6931472f);
             sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = 1.0f + exp2_neg;
             _calculate_log_body_<false>(0, dst_index_out);
             result = m + sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] * 1.4426950f;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -114,6 +114,28 @@ inline void calculate_sfpu_binary(
                 result = sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] * in0;
             }
             v_endif;
+        } else if constexpr (BINOP == BinaryOp::LOGADDEXP) {
+            // logaddexp(a,b) = max(a,b) + log(1 + exp(-|a-b|)); exp never overflows
+            sfpi::vFloat diff = in0 - in1;
+            sfpi::vFloat abs_diff = sfpi::abs(diff);
+            sfpi::vFloat m = in0;
+            v_if (in1 > in0) { m = in1; }
+            v_endif;
+            sfpi::vFloat exp_neg = _calculate_exponential_body_<is_fp32_dest_acc_en>(-abs_diff);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = 1.0f + exp_neg;
+            _calculate_log_body_<false>(0, dst_index_out);
+            result = m + sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi];
+        } else if constexpr (BINOP == BinaryOp::LOGADDEXP2) {
+            // logaddexp2(a,b) = max(a,b) + log2(1 + 2^{-|a-b|})
+            sfpi::vFloat diff = in0 - in1;
+            sfpi::vFloat abs_diff = sfpi::abs(diff);
+            sfpi::vFloat m = in0;
+            v_if (in1 > in0) { m = in1; }
+            v_endif;
+            sfpi::vFloat exp2_neg = _calculate_exponential_body_<is_fp32_dest_acc_en>(-abs_diff * 0.6931472f);
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = 1.0f + exp2_neg;
+            _calculate_log_body_<false>(0, dst_index_out);
+            result = m + sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] * 1.4426950f;
         }
 
         sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
@@ -195,6 +217,8 @@ inline void sfpu_binary_init() {
         // Initialisation for use of sfpu_reciprocal_iter<2> in DIV or POW.
         sfpu_reciprocal_init<false>();
     } else if constexpr (BINOP == BinaryOp::XLOGY) {
+        _init_log_<APPROXIMATION_MODE>();
+    } else if constexpr (BINOP == BinaryOp::LOGADDEXP || BINOP == BinaryOp::LOGADDEXP2) {
         _init_log_<APPROXIMATION_MODE>();
     }
 }

--- a/tt_metal/hw/inc/api/compute/logaddexp.h
+++ b/tt_metal/hw/inc/api/compute/logaddexp.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include "api/compute/common_globals.h"
+#ifdef TRISC_MATH
+#include "ckernel_sfpu_binary.h"
+#include "llk_math_eltwise_binary_sfpu_macros.h"
+#endif
+namespace ckernel {
+ALWI void logaddexp_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_sfpu_binary,
+        (APPROX, BinaryOp::LOGADDEXP, 8 /* ITERATIONS */),
+        idst0, idst1, odst, VectorMode::RC)));
+}
+ALWI void logaddexp_binary_tile_init() {
+    MATH((SFPU_BINARY_INIT_FN(unused, sfpu::sfpu_binary_init, (APPROX, BinaryOp::LOGADDEXP))));
+}
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/logaddexp2.h
+++ b/tt_metal/hw/inc/api/compute/logaddexp2.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include "api/compute/common_globals.h"
+#ifdef TRISC_MATH
+#include "ckernel_sfpu_binary.h"
+#include "llk_math_eltwise_binary_sfpu_macros.h"
+#endif
+namespace ckernel {
+ALWI void logaddexp2_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_sfpu_binary,
+        (APPROX, BinaryOp::LOGADDEXP2, 8 /* ITERATIONS */),
+        idst0, idst1, odst, VectorMode::RC)));
+}
+ALWI void logaddexp2_binary_tile_init() {
+    MATH((SFPU_BINARY_INIT_FN(unused, sfpu::sfpu_binary_init, (APPROX, BinaryOp::LOGADDEXP2))));
+}
+}  // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -326,8 +326,6 @@ enum class BinaryOp : std::uint8_t
     MAX             = 17,
     MIN             = 18,
     FMOD            = 19,
-    LOGADDEXP       = 20,
-    LOGADDEXP2      = 21,
     REMAINDER       = 20,
     BITWISE_AND     = 21,
     BITWISE_OR      = 22,
@@ -353,6 +351,8 @@ enum class BinaryOp : std::uint8_t
     REMAINDER_INT32  = 40,
     REMAINDER_UINT32 = 41,
     FMOD_INT32       = 42,
+    LOGADDEXP        = 43,
+    LOGADDEXP2       = 44,
 };
 
 enum class PackMode : std::uint8_t

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -326,6 +326,8 @@ enum class BinaryOp : std::uint8_t
     MAX             = 17,
     MIN             = 18,
     FMOD            = 19,
+    LOGADDEXP       = 20,
+    LOGADDEXP2      = 21,
     REMAINDER       = 20,
     BITWISE_AND     = 21,
     BITWISE_OR      = 22,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -308,6 +308,8 @@ enum class BinaryOp : std::uint8_t
     MAX             = 17,
     MIN             = 18,
     FMOD            = 19,
+    LOGADDEXP       = 20,
+    LOGADDEXP2      = 21,
     REMAINDER       = 20,
     BITWISE_AND     = 21,
     BITWISE_OR      = 22,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -308,8 +308,6 @@ enum class BinaryOp : std::uint8_t
     MAX             = 17,
     MIN             = 18,
     FMOD            = 19,
-    LOGADDEXP       = 20,
-    LOGADDEXP2      = 21,
     REMAINDER       = 20,
     BITWISE_AND     = 21,
     BITWISE_OR      = 22,
@@ -335,6 +333,8 @@ enum class BinaryOp : std::uint8_t
     REMAINDER_INT32  = 40,
     REMAINDER_UINT32 = 41,
     FMOD_INT32       = 42,
+    LOGADDEXP        = 43,
+    LOGADDEXP2       = 44,
 };
 
 enum class PackMode : std::uint8_t

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -399,20 +399,12 @@ std::map<std::string, std::string> get_defines_fp32(
             op_name = "lcm_tile";
             break;
         case BinaryOpType::LOGADDEXP:
-            // PRE_IN0_0 ===> Applies prescaling for first input
-            // PRE_IN1_0 ====> Applies prescaling for second input
-            new_defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN0_0"));
-            new_defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN1_0"));
-            new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
-            op_name = "add_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::LOG, std::nullopt, "0", idst1));
+            new_defines.insert({"BINOP_INIT", fmt::format("logaddexp_binary_tile_init();")});
+            op_name = "logaddexp_binary_tile";
             break;
         case BinaryOpType::LOGADDEXP2:
-            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN0_0"));
-            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
-            new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
-            op_name = "add_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::LOG2, std::nullopt, "0", idst1));
+            new_defines.insert({"BINOP_INIT", fmt::format("logaddexp2_binary_tile_init();")});
+            op_name = "logaddexp2_binary_tile";
             break;
         case BinaryOpType::LDEXP:
             new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -247,19 +247,13 @@ OpConfig::OpConfig(
             process_rhs = unary::UnaryOpType::EXP2;
             binary_op = EnumT::MUL;
             break;
-        // log( exp(a) + exp(b) )
+        // max(a,b) + log(1 + exp(-|a-b|)) -- overflow-safe
         case BinaryOpType::LOGADDEXP:
-            process_lhs = unary::UnaryOpType::EXP;
-            process_rhs = unary::UnaryOpType::EXP;
-            binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::LOG;
+            binary_op = SfpuBinaryOp::LOGADDEXP;
             break;
-        // log2( 2**a + 2**b )
+        // max(a,b) + log2(1 + 2^{-|a-b|}) -- overflow-safe
         case BinaryOpType::LOGADDEXP2:
-            process_lhs = unary::UnaryOpType::EXP2;
-            process_rhs = unary::UnaryOpType::EXP2;
-            binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::LOG2;
+            binary_op = SfpuBinaryOp::LOGADDEXP2;
             break;
         case BinaryOpType::BITWISE_AND:
             if (is_sfpu_op()) {
@@ -551,6 +545,8 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             return {"where_tile_init();", fmt::format("where_tile<DataFormat::{}>", data_format)};
         }
         case ISCLOSE: return {"isclose_binary_tile_init();", "isclose_binary_tile<(bool)ISCLOSE_EQUAL_NAN>"};
+        case LOGADDEXP: return {"logaddexp_binary_tile_init();", "logaddexp_binary_tile"};
+        case LOGADDEXP2: return {"logaddexp2_binary_tile_init();", "logaddexp2_binary_tile"};
         default: TT_THROW("Unsupported sfpu binary op {}", sfpu_binary_op);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -88,6 +88,8 @@ struct OpConfig {
         EQ,
         NE,
         ISCLOSE,
+    LOGADDEXP,
+    LOGADDEXP2,
     };
 
     template <class EnumT>


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`ttnn.logaddexp` and `ttnn.logaddexp2` silently return `inf` for large inputs
because the naive decomposition `log(exp(a) + exp(b))` saturates at |a| or |b| > ~88.7
(the FP32 overflow threshold of `exp`).

This PR fixes both ops using the numerically stable identity:
  logaddexp(a,b)  = max(a,b) + log(1 + exp(-|a-b|))
  logaddexp2(a,b) = max(a,b) + log2(1 + 2^{-|a-b|})

Because exp(-|a-b|) has argument ≤ 0, its result is in (0,1] and can never
overflow regardless of the magnitude of a or b. The log argument is in (1,2],
so log is also well-behaved.

Implementation:
- Adds BinaryOp::LOGADDEXP/LOGADDEXP2 to ckernel_defs.h (wormhole_b0 + blackhole)
- Implements the stable kernel cases in ckernel_sfpu_binary.h (both architectures)
- Adds logaddexp.h / logaddexp2.h compute API headers (mirrors xlogy.h pattern)
- Wires SfpuBinaryOp::LOGADDEXP/LOGADDEXP2 through binary_ng_utils and binary_op_utils
- Removes the broken unary-compose EXP+ADD+LOG pipeline from both code paths

Fixes #52037

### Notes for reviewers
- The two kernel cases in ckernel_sfpu_binary.h are the core change — the rest is wiring.
- sfpi::abs() is used for |a-b|; v_if (in1 > in0) for the max.
- _calculate_exponential_body_ and _calculate_log_body_ are reused from the existing XLOGY case.
- log2(x) = log(x) * 1.4426950f since _calculate_log2_body_ does not exist.
- The legacy FPU path in get_defines() retains the old decomposition; only the SFPU and binary_ng paths are fixed here.
- Hardware validation requires Wormhole n300s; CI results will confirm correctness.
