### PR TITLE
[Feature] Reduce dispatch engine prefetch ringbuffer size for two command queues

### DIFF
--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -162,7 +162,10 @@ public:
 private:
     void init_worker_defaults(
         uint32_t num_hw_cqs, bool is_galaxy_cluster, bool are_cqs_dram_backed, uint32_t l1_alignment);
+    void init_dispatch_defaults(uint32_t num_hw_cqs, bool are_cqs_dram_backed, uint32_t l1_alignment);
     void init_eth_defaults(uint32_t num_hw_cqs, uint32_t l1_alignment);
+    uint32_t get_prefetch_q_entries(
+        CoreType core_type, uint32_t num_hw_cqs, bool is_galaxy_cluster, bool are_cqs_dram_backed);
 };
 
 // Convenience type alias for arrays of `DISPATCH_MESSAGE_ENTRIES` size.

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -47,12 +47,9 @@ DispatchSettings::DispatchSettings(
     this->prefetch_q_entry_size_bytes_ = prefetch_q_entry_size_bytes;
     switch (core_type) {
         case CoreType::WORKER:
-        // Quasar dispatch-engine cores run the cq kernels like worker DMs; their DISPATCH HAL memmap
-        // mirrors the Tensix (worker) L1 layout, so reuse the worker dispatch defaults. core_type_ is
-        // set to DISPATCH below, overriding the WORKER value the builder sets internally.
-        case CoreType::DISPATCH:
             init_worker_defaults(num_hw_cqs, is_galaxy_cluster, are_cqs_dram_backed, l1_alignment);
             break;
+        case CoreType::DISPATCH: init_dispatch_defaults(num_hw_cqs, are_cqs_dram_backed, l1_alignment); break;
         case CoreType::ETH: init_eth_defaults(num_hw_cqs, l1_alignment); break;
         default: TT_THROW("init_defaults not implemented for core type {}", enchantum::to_string(core_type));
     }
@@ -62,18 +59,10 @@ DispatchSettings::DispatchSettings(
 
 void DispatchSettings::init_worker_defaults(
     uint32_t num_hw_cqs, bool is_galaxy_cluster, bool are_cqs_dram_backed, uint32_t l1_alignment) {
-    uint32_t prefetch_q_entries;
-    if (are_cqs_dram_backed) {
-        prefetch_q_entries = 64 / num_hw_cqs;
-    } else if (is_galaxy_cluster) {
-        prefetch_q_entries = 1532 / num_hw_cqs;
-    } else {
-        prefetch_q_entries = 1534;
-    }
-
     this->num_hw_cqs(num_hw_cqs)
         .core_type(CoreType::WORKER)
-        .prefetch_q_entries(prefetch_q_entries)
+        .prefetch_q_entries(
+            get_prefetch_q_entries(CoreType::WORKER, num_hw_cqs, is_galaxy_cluster, are_cqs_dram_backed))
         .prefetch_max_cmd_size(128_KB)
         .prefetch_cmddat_q_size(256_KB)
         .prefetch_scratch_db_size(128_KB)
@@ -88,10 +77,34 @@ void DispatchSettings::init_worker_defaults(
         .build();
 }
 
+void DispatchSettings::init_dispatch_defaults(uint32_t num_hw_cqs, bool are_cqs_dram_backed, uint32_t l1_alignment) {
+    this->num_hw_cqs(num_hw_cqs)
+        .core_type(CoreType::DISPATCH)
+        .prefetch_q_entries(
+            get_prefetch_q_entries(CoreType::DISPATCH, num_hw_cqs, /*is_galaxy_cluster=*/false, are_cqs_dram_backed))
+        .prefetch_max_cmd_size(128_KB)
+        .prefetch_cmddat_q_size(256_KB)
+        .prefetch_scratch_db_size(128_KB)
+        // Quasar currently only has a single dispatch engine, so if there is more than one CQ, they will be placed in
+        // the same dispatch engine. The ringbuffer size of each CQ is lowered to 864 KB so that both CQs can fit in the
+        // same dispatch engine. Once support for multiple dispatch engines is added, this will need to be updated as
+        // each CQ will be placed in a separate dispatch engine.
+        .prefetch_ringbuffer_size(num_hw_cqs > 1 ? 864_KB : 1024_KB)
+        .prefetch_d_buffer_size(256_KB)
+
+        .dispatch_size(512_KB)
+        .dispatch_s_buffer_size(32_KB)
+
+        .with_alignment(l1_alignment)
+
+        .build();
+}
+
 void DispatchSettings::init_eth_defaults(uint32_t num_hw_cqs, uint32_t l1_alignment) {
     this->num_hw_cqs(num_hw_cqs)
         .core_type(CoreType::ETH)
-        .prefetch_q_entries(128)
+        .prefetch_q_entries(get_prefetch_q_entries(
+            CoreType::ETH, num_hw_cqs, /*is_galaxy_cluster=*/false, /*are_cqs_dram_backed=*/false))
         .prefetch_max_cmd_size(32_KB)
         .prefetch_cmddat_q_size(64_KB)
         .prefetch_scratch_db_size(19_KB)
@@ -104,6 +117,21 @@ void DispatchSettings::init_eth_defaults(uint32_t num_hw_cqs, uint32_t l1_alignm
         .with_alignment(l1_alignment)
 
         .build();
+}
+
+uint32_t DispatchSettings::get_prefetch_q_entries(
+    CoreType core_type, uint32_t num_hw_cqs, bool is_galaxy_cluster, bool are_cqs_dram_backed) {
+    uint32_t prefetch_q_entries = 0;
+    if (core_type == CoreType::ETH) {
+        prefetch_q_entries = 128;
+    } else if (are_cqs_dram_backed) {
+        prefetch_q_entries = 64 / num_hw_cqs;
+    } else if (is_galaxy_cluster) {
+        prefetch_q_entries = 1532 / num_hw_cqs;
+    } else {
+        prefetch_q_entries = 1534;
+    }
+    return prefetch_q_entries;
 }
 
 std::vector<std::string> DispatchSettings::get_errors() const {


### PR DESCRIPTION
### PR Category
Feature

### Summary
On Quasar, 2 CQs can now share a single dispatch engine with the prefetch ringbuffer size reduced from 1024 KB to 864 KB so that both CQs can fit in memory. The 1 CQ case keeps 1024 KB and behaves exactly as before.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_2cq_de)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_2cq_de)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_2cq_de)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_2cq_de)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_2cq_de)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sagarwal/qsr_2cq_de)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_2cq_de)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_2cq_de)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_2cq_de)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_2cq_de)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_2cq_de)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_2cq_de)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_2cq_de)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_2cq_de)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_2cq_de)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_2cq_de)