### PR TITLE
[Bug fix] ttnn.i0: improve accuracy for large |x| by use of a domain split

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_i0.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_i0.py
@@ -8,19 +8,63 @@ import torch
 
 import ttnn
 
-
-@pytest.mark.parametrize(
-    "shapes",
-    [
-        [1, 1, 32, 32],
-        [4, 2, 96, 192],
-        [4, 7, 21, 133],
-        [4, 6, 105, 245],
-        [64, 64],
-        [3, 128, 512],
-    ],
+from tests.ttnn.utils_for_testing import (
+    assert_allclose,
+    assert_equal,
+    assert_with_ulp,
+    flush_subnormal_values_to_zero,
+    generate_all_bfloat16_bitpatterns,
 )
-def test_i0_range(device, shapes):
+
+# Largest |x| the kernel evaluates; beyond it, i0 returns +inf. The bound is the
+# point where FP32 exp() saturates -- see ckernel_sfpu_i0.h for the full rationale.
+I0_MAX_INPUT = 88.5
+
+# Worst-case ULP error measured on silicon (Blackhole p150b) over the kernel's full
+# input domain, including the exhaustive bfloat16 sweep below: 6.0 ULP for float32 and
+# 1.0 ULP for bfloat16. The budgets carry ~2x headroom over those measurements.
+#
+# Units are the true spacing of the output dtype (what comp_ulp/assert_with_ulp use),
+# not a relative-mantissa proxy -- the two differ by up to 2x within a binade and
+# diverge at power-of-2 boundaries, so a budget calibrated against one is not valid
+# for the other.
+_MAX_ULP = {
+    ttnn.float32: 12,
+    ttnn.bfloat16: 2,
+}
+
+
+def _quantise(x, dtype):
+    """Round a float32 reference input to the dtype the device will see.
+
+    Without this the golden is charged for input-quantisation error rather than
+    kernel error. It matters unusually much for i0: dI0/dx = I1(x) ~ I0(x), so a
+    relative input error eps becomes roughly |x| * eps relative output error -- at
+    x = 88.5, one bfloat16 ULP of input (0.4%) is ~35% of output on its own.
+    """
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    return x.to(torch_dtype).to(torch.float32)
+
+
+def _run_i0(device, x_torch, dtype, layout=ttnn.TILE_LAYOUT, preserve_nan_values=False):
+    input_tensor = ttnn.from_torch(
+        x_torch,
+        layout=layout,
+        dtype=dtype,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        preserve_nan_values=preserve_nan_values,
+    )
+    output_tensor = ttnn.i0(input_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    assert output_tensor.layout == layout, f"output layout {output_tensor.layout} should match input layout {layout}"
+    return ttnn.to_torch(output_tensor)
+
+
+# Eltwise ops share their shape/tiling infrastructure, so a shape bug is not
+# op-specific: one tile-aligned shape plus one that needs padding is enough.
+@pytest.mark.parametrize("shapes", [[1, 1, 32, 32], [4, 7, 21, 133]])
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+def test_i0_range(device, shapes, layout):
     torch.manual_seed(0)
 
     high = 10
@@ -28,128 +72,96 @@ def test_i0_range(device, shapes):
     torch_input_tensor_a = torch.rand(shapes, dtype=torch.float32) * (high - low) + low
     torch_output_tensor = torch.special.i0(torch_input_tensor_a)
 
-    input_tensor_a = ttnn.from_torch(
-        torch_input_tensor_a,
-        layout=ttnn.TILE_LAYOUT,
-        dtype=ttnn.float32,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = _run_i0(device, torch_input_tensor_a, ttnn.float32, layout=layout)
 
-    pcc = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
-    assert pcc >= 0.9999
+    # I0 spans 1 -> 2815 over this range. PCC is unusable here: it is invariant to
+    # scale and offset (PCC(y, a*y + b) = 1), and its sum is dominated by the largest
+    # values, so an error near x = 0 would be invisible next to i0(10) ~ 2.8e3.
+    assert_allclose(torch_output_tensor, output_tensor, rtol=1e-5, atol=1e-6)
+    assert_with_ulp(torch_output_tensor, output_tensor, _MAX_ULP[ttnn.float32])
 
 
-@pytest.mark.parametrize(
-    "shapes",
-    [
-        [4, 2, 96, 192],
-        [1, 1, 64, 64],
-    ],
-)
-def test_i0_zero(device, shapes):
-    torch.manual_seed(0)
-
-    # i0(0) = 1 (unlike i1, i0 has no zeros; I0(x) >= 1 everywhere).
+@pytest.mark.parametrize("shapes", [[1, 1, 32, 32], [4, 7, 21, 133]])
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+def test_i0_zero(device, shapes, dtype):
+    # I0(0) = 1 exactly and is representable in every dtype. (Unlike i1, i0 has no
+    # zeros: I0(x) >= 1 everywhere.)
+    #
+    # This cannot be an equality check against the torch golden: torch.special.i0
+    # evaluates in float32 and returns 0x3f7fffff at x = 0, exactly 1 ULP below 1.0
+    # (its float64 path returns exactly 1.0). The device returns exactly 1.0, so the
+    # kernel is the more accurate of the two here. Assert both bounds -- within 1 ULP
+    # of the golden, and exact against the mathematical value.
     torch_input_tensor_a = torch.zeros(shapes, dtype=torch.float32)
     torch_output_tensor = torch.special.i0(torch_input_tensor_a)
 
-    input_tensor_a = ttnn.from_torch(
-        torch_input_tensor_a,
-        layout=ttnn.TILE_LAYOUT,
-        dtype=ttnn.bfloat16,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = _run_i0(device, torch_input_tensor_a, dtype)
 
-    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.9999
+    assert_with_ulp(torch_output_tensor.to(output_tensor.dtype), output_tensor, 1)
+    assert_equal(torch.ones(shapes, dtype=output_tensor.dtype), output_tensor)
 
 
-# Tolerances mirror test_unary_i1.py exactly — i0 is held to the same bar as its
-# sibling. Units are native to the device dtype (FP32 ULP for fp32, BF16 ULP for
-# bf16); BF16's 7-bit mantissa gives 1 BF16 ULP ~= 0.78% relative.
-# I0(x) >= 1 everywhere, so atol never masks a near-zero output the way it can
-# for i1 (i1(x) ~= x/2 near 0) — relative error is a fair metric throughout.
-_TOLS = {
-    ttnn.float32: dict(rtol=1e-4, atol=1e-6, max_ulp=20, ulp_mantissa_bits=23),
-    ttnn.bfloat16: dict(rtol=1e-2, atol=1e-3, max_ulp=1, ulp_mantissa_bits=7),
-}
-
-
-def _ulp_error(got_f32, ref_f32, mantissa_bits):
-    """Per-element ULP distance, expressed in `2^-mantissa_bits` units of |ref|."""
-    ulp_size = ref_f32.abs() * (2.0**-mantissa_bits) + 1e-38
-    return (got_f32 - ref_f32).abs() / ulp_size
-
-
-def _assert_close(name, got, ref, dtype):
-    tols = _TOLS[dtype]
-    got_f32 = got.float()
-    ref_f32 = ref.float()
-    rtol, atol = tols["rtol"], tols["atol"]
-
-    # 1) allclose check
-    if not torch.allclose(got_f32, ref_f32, rtol=rtol, atol=atol):
-        diff = (got_f32 - ref_f32).abs()
-        rel = diff / (ref_f32.abs() + atol)
-        idx = rel.argmax()
-        raise AssertionError(
-            f"{name}: not allclose (rtol={rtol}, atol={atol}); "
-            f"worst rel_err={rel.flatten()[idx].item():.2e} "
-            f"ref={ref_f32.flatten()[idx].item():.4e} got={got_f32.flatten()[idx].item():.4e}"
-        )
-
-    # 2) ULP check (in dtype-native ULP units)
-    valid = ~(ref_f32.isnan() | ref_f32.isinf() | got_f32.isnan() | got_f32.isinf())
-    ulps = _ulp_error(got_f32, ref_f32, tols["ulp_mantissa_bits"])[valid]
-    max_ulp = ulps.max().item() if ulps.numel() else 0.0
-    assert max_ulp <= tols["max_ulp"], (
-        f"{name}: MaxULP={max_ulp:.2f} exceeds limit {tols['max_ulp']} "
-        f"(units: 2^-{tols['ulp_mantissa_bits']} of |ref|)"
-    )
-
-
-# Covers |x| beyond the Maclaurin series' useful range and the +/-88.5 input clamp.
-# Range [-50, 50] keeps reference values within FP32 (i0(50) ~= 2.93e20).
-@pytest.mark.parametrize(
-    "shapes",
-    [
-        [1, 1, 32, 32],
-        [4, 2, 96, 192],
-    ],
-)
-@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
-def test_i0_ood(device, shapes, dtype):
+# Covers |x| beyond the Maclaurin series' useful range, where the old single-polynomial
+# implementation degraded badly (21% rel err at x = 20, 89% at x = 30). Range [-50, 50]
+# keeps the reference within FP32 (i0(50) ~ 2.93e20).
+#
+# float32 only. Every bfloat16 value this could draw is already in the exhaustive sweep
+# below, so a random bfloat16 draw here would add nothing; float32 has 2^32 values and
+# cannot be enumerated, so sampling still earns its place.
+@pytest.mark.parametrize("shapes", [[1, 1, 32, 32], [4, 7, 21, 133]])
+def test_i0_ood(device, shapes):
     torch.manual_seed(0)
 
     high = 50.0
     low = -50.0
     torch_input_tensor_a = torch.rand(shapes, dtype=torch.float32) * (high - low) + low
-    # Quantise the reference input to the device dtype so we measure kernel
-    # error, not input-quantisation noise.
-    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
-    ref_input = torch_input_tensor_a.to(torch_dtype).to(torch.float32)
-    torch_output_tensor = torch.special.i0(ref_input)
+    torch_output_tensor = torch.special.i0(torch_input_tensor_a)
 
-    input_tensor_a = ttnn.from_torch(
-        torch_input_tensor_a,
-        layout=ttnn.TILE_LAYOUT,
-        dtype=dtype,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    output_tensor = _run_i0(device, torch_input_tensor_a, ttnn.float32)
+
+    assert_with_ulp(torch_output_tensor, output_tensor, _MAX_ULP[ttnn.float32])
+
+
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+def test_i0_all_bfloat16_bitpatterns(device, dtype):
+    """Exhaustive sweep over all 65,536 bfloat16 values.
+
+    A random draw cannot substitute for this: floats are distributed logarithmically
+    but torch.rand is uniform in linear space, so a draw over [-50, 50] lands almost
+    nothing in |x| < 1 even though half of all bfloat16 values live there.
+    """
+    all_bf16_values = generate_all_bfloat16_bitpatterns(torch.float32)
+
+    # Hardware flushes subnormal inputs to zero; do the same to the golden's input so
+    # the two agree on what was actually evaluated.
+    x_torch = flush_subnormal_values_to_zero(all_bf16_values)
+
+    # Non-finite *inputs* are excluded and covered by test_i0_overflow instead: torch
+    # returns NaN for i0(+/-inf) (its exp(inf)/sqrt(inf) goes to inf/inf), whereas the
+    # kernel returns +inf, which is the mathematically correct value. Comparing against
+    # the golden out there would encode a torch artifact as the expected result.
+    finite_in = torch.isfinite(x_torch)
+    x_torch = torch.where(finite_in, x_torch, torch.zeros_like(x_torch))
+
+    output_tensor = _run_i0(device, x_torch, dtype)
+
+    # The golden overflows to +inf at 88.7228 (FP32 exp() saturation); the kernel does
+    # so just above its 88.5 clamp. No bfloat16 value falls inside that 0.22-wide
+    # window -- the neighbouring representable values are 88.5 and 89.0 -- so the two
+    # agree on every input in this sweep. allow_nonfinite still requires the resulting
+    # infinities to match position and sign.
+    torch_output_tensor = flush_subnormal_values_to_zero(torch.special.i0(x_torch))
+
+    assert_with_ulp(
+        torch_output_tensor.to(output_tensor.dtype),
+        output_tensor,
+        _MAX_ULP[dtype],
+        allow_nonfinite=True,
     )
-    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    output_tensor = ttnn.to_torch(output_tensor)
-
-    _assert_close("test_i0_ood", output_tensor, torch_output_tensor, dtype)
 
 
-# i0 is even: i0(-x) == i0(x). Verifies symmetry is preserved across whatever
-# domain split the kernel uses, so a threshold bug cannot go unnoticed on one side.
+# i0 is even: i0(-x) == i0(x). Verifies symmetry is preserved across the kernel's
+# domain split, so a one-sided threshold bug cannot go unnoticed.
 @pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
 def test_i0_even_symmetry(device, dtype):
     mags = torch.tensor([0.5, 3.0, 7.0, 10.0, 13.0, 20.0, 30.0, 50.0], dtype=torch.float32)
@@ -158,46 +170,65 @@ def test_i0_even_symmetry(device, dtype):
     padded[0, 0, 0, : mags.numel()] = mags
     padded[0, 0, 1, : mags.numel()] = -mags
 
-    input_tensor_a = ttnn.from_torch(
-        padded,
-        layout=ttnn.TILE_LAYOUT,
-        dtype=dtype,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    output_tensor = ttnn.to_torch(output_tensor).float()
+    output_tensor = _run_i0(device, padded, dtype).float()
 
     pos = output_tensor[0, 0, 0, : mags.numel()]
     neg = output_tensor[0, 0, 1, : mags.numel()]
     assert torch.equal(pos, neg), f"i0 not even: i0(+x)={pos.tolist()} vs i0(-x)={neg.tolist()}"
 
 
-# Boundary inputs straddling the +/-88.5 clamp, where exp() saturates in FP32.
 @pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
-def test_i0_clamp_boundary(device, dtype):
-    boundaries = torch.tensor(
-        [-100.0, -88.5, -88.0, -30.0, -13.0, -10.0, -7.0, 7.0, 10.0, 13.0, 30.0, 88.0, 88.5, 100.0],
-        dtype=torch.float32,
-    )
-    # i0 is unbounded; out-of-clamp inputs (|x| > 88.5) return i0(+/-88.5).
-    expected_input = torch.clamp(boundaries, min=-88.5, max=88.5)
-    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
-    expected_input = expected_input.to(torch_dtype).to(torch.float32)
-    torch_output_tensor = torch.special.i0(expected_input)
+def test_i0_overflow(device, dtype):
+    """|x| past the representable range returns +inf, not a clamped finite value.
 
-    # Pad to a tile-aligned shape so we can run on device.
+    I0 grows without bound, so there is no correct finite answer out here. Clamping
+    the input instead produced a silent wrong result: i0(1e4) returned i0(88.5) =
+    1.16e+37, which is finite, plausible-looking, and off by 5 orders of magnitude.
+    """
+    finite = [0.0, 1.0, 6.0, 60.0, 88.0, I0_MAX_INPUT]
+    # torch.special.i0 returns NaN for +/-inf rather than +inf, because its
+    # exp(inf)/sqrt(inf) evaluates to inf/inf. The kernel returns +inf, which is the
+    # mathematically correct limit, so +/-inf is asserted directly rather than against
+    # the golden.
+    overflow = [89.0, 100.0, 1.0e4, float("inf")]
+    # i0 is even, so both signs must behave identically.
+    values = finite + [-v for v in finite] + overflow + [-v for v in overflow]
+
     padded = torch.zeros((1, 1, 32, 32), dtype=torch.float32)
-    padded[0, 0, 0, : boundaries.numel()] = boundaries
+    padded[0, 0, 0, : len(values)] = torch.tensor(values, dtype=torch.float32)
 
-    input_tensor_a = ttnn.from_torch(
-        padded,
-        layout=ttnn.TILE_LAYOUT,
-        dtype=dtype,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    output_tensor = ttnn.to_torch(output_tensor)[0, 0, 0, : boundaries.numel()]
+    # Keep the device dtype: converting to float32 first would make assert_with_ulp
+    # measure a bfloat16 result against float32 spacing, inflating the error by ~2^16.
+    output_tensor = _run_i0(device, padded, dtype)[0, 0, 0, : len(values)]
 
-    _assert_close("test_i0_clamp_boundary", output_tensor, torch_output_tensor, dtype)
+    n_finite = 2 * len(finite)
+    got_finite, got_overflow = output_tensor[:n_finite], output_tensor[n_finite:]
+
+    expected_finite = torch.special.i0(_quantise(torch.tensor(finite + [-v for v in finite]), dtype))
+    assert torch.isfinite(got_finite).all(), f"|x| <= {I0_MAX_INPUT} must stay finite, got {got_finite.tolist()}"
+    assert_with_ulp(expected_finite.to(got_finite.dtype), got_finite, _MAX_ULP[dtype])
+
+    got_overflow = got_overflow.float()
+    assert torch.isinf(got_overflow).all(), f"|x| > {I0_MAX_INPUT} must be inf, got {got_overflow.tolist()}"
+    assert (got_overflow > 0).all(), f"overflow must be +inf on both sides (i0 is even), got {got_overflow.tolist()}"
+
+
+def test_i0_nan(device):
+    """NaN propagates instead of being swallowed by the overflow branch.
+
+    The SFPU compare is not IEEE-ordered -- NaN carries the maximal exponent and
+    passes ``> 88.5`` -- so the kernel detects it by bit pattern and restores it.
+    Before this change the input clamp mapped NaN to the finite 1.15e+37.
+
+    float32 only: on the bfloat16 path NaN still emerges as +inf. A DRAM round-trip
+    with no op returns NaN intact, so the payload is lost unpacking bfloat16 into DST,
+    upstream of the kernel. Asserting it here would pin a defect this change does not
+    own; +inf is still an improvement on the previous finite 1.15e+37.
+    """
+    padded = torch.zeros((1, 1, 32, 32), dtype=torch.float32)
+    padded[0, 0, 0, :2] = torch.tensor([float("nan"), -float("nan")], dtype=torch.float32)
+
+    output_tensor = _run_i0(device, padded, ttnn.float32, preserve_nan_values=True)
+
+    got = output_tensor.float()[0, 0, 0, :2]
+    assert torch.isnan(got).all(), f"i0(NaN) must be NaN, got {got.tolist()}"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_i0.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_i0.py
@@ -24,6 +24,16 @@ I0_MAX_INPUT = 88.5
 # input domain, including the exhaustive bfloat16 sweep below: 6.0 ULP for float32 and
 # 1.0 ULP for bfloat16. The budgets carry ~2x headroom over those measurements.
 #
+# Re-measured after the tenstorrent/tt-metal#52126 review trim (region-1 12->9 terms,
+# region-2 BF16-specific 5-term Q, unified overflow/NaN branch): 6.0 FP32 ULP again
+# (unchanged) and 0.91 BF16 ULP (a small improvement). Trimming both regions did not
+# measurably change accuracy -- consistent with the review's finding that region-1
+# accuracy is bounded by FP32 rounding of t = fl(x*x), not by the polynomial's degree.
+# Budgets left unchanged; they already carried headroom over the re-measured numbers.
+#
+# Confirmed on both architectures with the same seed: Blackhole p150b and Wormhole
+# n300 produced bit-identical results (same worst-case x, same output, same reference).
+#
 # Units are the true spacing of the output dtype (what comp_ulp/assert_with_ulp use),
 # not a relative-mantissa proxy -- the two differ by up to 2x within a binade and
 # diverge at power-of-2 boundaries, so a budget calibrated against one is not valid

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_i0.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_i0.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [1, 1, 32, 32],
+        [4, 2, 96, 192],
+        [4, 7, 21, 133],
+        [4, 6, 105, 245],
+        [64, 64],
+        [3, 128, 512],
+    ],
+)
+def test_i0_range(device, shapes):
+    torch.manual_seed(0)
+
+    high = 10
+    low = -10
+    torch_input_tensor_a = torch.rand(shapes, dtype=torch.float32) * (high - low) + low
+    torch_output_tensor = torch.special.i0(torch_input_tensor_a)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.float32,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    pcc = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert pcc >= 0.9999
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [4, 2, 96, 192],
+        [1, 1, 64, 64],
+    ],
+)
+def test_i0_zero(device, shapes):
+    torch.manual_seed(0)
+
+    # i0(0) = 1 (unlike i1, i0 has no zeros; I0(x) >= 1 everywhere).
+    torch_input_tensor_a = torch.zeros(shapes, dtype=torch.float32)
+    torch_output_tensor = torch.special.i0(torch_input_tensor_a)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.9999
+
+
+# Tolerances mirror test_unary_i1.py exactly — i0 is held to the same bar as its
+# sibling. Units are native to the device dtype (FP32 ULP for fp32, BF16 ULP for
+# bf16); BF16's 7-bit mantissa gives 1 BF16 ULP ~= 0.78% relative.
+# I0(x) >= 1 everywhere, so atol never masks a near-zero output the way it can
+# for i1 (i1(x) ~= x/2 near 0) — relative error is a fair metric throughout.
+_TOLS = {
+    ttnn.float32: dict(rtol=1e-4, atol=1e-6, max_ulp=20, ulp_mantissa_bits=23),
+    ttnn.bfloat16: dict(rtol=1e-2, atol=1e-3, max_ulp=1, ulp_mantissa_bits=7),
+}
+
+
+def _ulp_error(got_f32, ref_f32, mantissa_bits):
+    """Per-element ULP distance, expressed in `2^-mantissa_bits` units of |ref|."""
+    ulp_size = ref_f32.abs() * (2.0**-mantissa_bits) + 1e-38
+    return (got_f32 - ref_f32).abs() / ulp_size
+
+
+def _assert_close(name, got, ref, dtype):
+    tols = _TOLS[dtype]
+    got_f32 = got.float()
+    ref_f32 = ref.float()
+    rtol, atol = tols["rtol"], tols["atol"]
+
+    # 1) allclose check
+    if not torch.allclose(got_f32, ref_f32, rtol=rtol, atol=atol):
+        diff = (got_f32 - ref_f32).abs()
+        rel = diff / (ref_f32.abs() + atol)
+        idx = rel.argmax()
+        raise AssertionError(
+            f"{name}: not allclose (rtol={rtol}, atol={atol}); "
+            f"worst rel_err={rel.flatten()[idx].item():.2e} "
+            f"ref={ref_f32.flatten()[idx].item():.4e} got={got_f32.flatten()[idx].item():.4e}"
+        )
+
+    # 2) ULP check (in dtype-native ULP units)
+    valid = ~(ref_f32.isnan() | ref_f32.isinf() | got_f32.isnan() | got_f32.isinf())
+    ulps = _ulp_error(got_f32, ref_f32, tols["ulp_mantissa_bits"])[valid]
+    max_ulp = ulps.max().item() if ulps.numel() else 0.0
+    assert max_ulp <= tols["max_ulp"], (
+        f"{name}: MaxULP={max_ulp:.2f} exceeds limit {tols['max_ulp']} "
+        f"(units: 2^-{tols['ulp_mantissa_bits']} of |ref|)"
+    )
+
+
+# Covers |x| beyond the Maclaurin series' useful range and the +/-88.5 input clamp.
+# Range [-50, 50] keeps reference values within FP32 (i0(50) ~= 2.93e20).
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [1, 1, 32, 32],
+        [4, 2, 96, 192],
+    ],
+)
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+def test_i0_ood(device, shapes, dtype):
+    torch.manual_seed(0)
+
+    high = 50.0
+    low = -50.0
+    torch_input_tensor_a = torch.rand(shapes, dtype=torch.float32) * (high - low) + low
+    # Quantise the reference input to the device dtype so we measure kernel
+    # error, not input-quantisation noise.
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    ref_input = torch_input_tensor_a.to(torch_dtype).to(torch.float32)
+    torch_output_tensor = torch.special.i0(ref_input)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=dtype,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    _assert_close("test_i0_ood", output_tensor, torch_output_tensor, dtype)
+
+
+# i0 is even: i0(-x) == i0(x). Verifies symmetry is preserved across whatever
+# domain split the kernel uses, so a threshold bug cannot go unnoticed on one side.
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+def test_i0_even_symmetry(device, dtype):
+    mags = torch.tensor([0.5, 3.0, 7.0, 10.0, 13.0, 20.0, 30.0, 50.0], dtype=torch.float32)
+
+    padded = torch.zeros((1, 1, 32, 32), dtype=torch.float32)
+    padded[0, 0, 0, : mags.numel()] = mags
+    padded[0, 0, 1, : mags.numel()] = -mags
+
+    input_tensor_a = ttnn.from_torch(
+        padded,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=dtype,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_torch(output_tensor).float()
+
+    pos = output_tensor[0, 0, 0, : mags.numel()]
+    neg = output_tensor[0, 0, 1, : mags.numel()]
+    assert torch.equal(pos, neg), f"i0 not even: i0(+x)={pos.tolist()} vs i0(-x)={neg.tolist()}"
+
+
+# Boundary inputs straddling the +/-88.5 clamp, where exp() saturates in FP32.
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+def test_i0_clamp_boundary(device, dtype):
+    boundaries = torch.tensor(
+        [-100.0, -88.5, -88.0, -30.0, -13.0, -10.0, -7.0, 7.0, 10.0, 13.0, 30.0, 88.0, 88.5, 100.0],
+        dtype=torch.float32,
+    )
+    # i0 is unbounded; out-of-clamp inputs (|x| > 88.5) return i0(+/-88.5).
+    expected_input = torch.clamp(boundaries, min=-88.5, max=88.5)
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    expected_input = expected_input.to(torch_dtype).to(torch.float32)
+    torch_output_tensor = torch.special.i0(expected_input)
+
+    # Pad to a tile-aligned shape so we can run on device.
+    padded = torch.zeros((1, 1, 32, 32), dtype=torch.float32)
+    padded[0, 0, 0, : boundaries.numel()] = boundaries
+
+    input_tensor_a = ttnn.from_torch(
+        padded,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=dtype,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_torch(output_tensor)[0, 0, 0, : boundaries.numel()]
+
+    _assert_close("test_i0_clamp_boundary", output_tensor, torch_output_tensor, dtype)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_i0.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_i0.py
@@ -20,19 +20,10 @@ from tests.ttnn.utils_for_testing import (
 # point where FP32 exp() saturates -- see ckernel_sfpu_i0.h for the full rationale.
 I0_MAX_INPUT = 88.5
 
-# Worst-case ULP error measured on silicon (Blackhole p150b) over the kernel's full
-# input domain, including the exhaustive bfloat16 sweep below: 6.0 ULP for float32 and
-# 1.0 ULP for bfloat16. The budgets carry ~2x headroom over those measurements.
-#
-# Re-measured after the tenstorrent/tt-metal#52126 review trim (region-1 12->9 terms,
-# region-2 BF16-specific 5-term Q, unified overflow/NaN branch): 6.0 FP32 ULP again
-# (unchanged) and 0.91 BF16 ULP (a small improvement). Trimming both regions did not
-# measurably change accuracy -- consistent with the review's finding that region-1
-# accuracy is bounded by FP32 rounding of t = fl(x*x), not by the polynomial's degree.
-# Budgets left unchanged; they already carried headroom over the re-measured numbers.
-#
-# Confirmed on both architectures with the same seed: Blackhole p150b and Wormhole
-# n300 produced bit-identical results (same worst-case x, same output, same reference).
+# Worst-case ULP error measured on silicon over the kernel's full input domain,
+# including the exhaustive bfloat16 sweep below: 6.0 ULP for float32 and 0.91 ULP
+# for bfloat16, confirmed bit-identical on Blackhole p150b and Wormhole n300 with
+# the same seed. Budgets below carry ~2x headroom over those measurements.
 #
 # Units are the true spacing of the output dtype (what comp_ulp/assert_with_ulp use),
 # not a relative-mantissa proxy -- the two differ by up to 2x within a binade and
@@ -42,6 +33,15 @@ _MAX_ULP = {
     ttnn.float32: 12,
     ttnn.bfloat16: 2,
 }
+
+# test_unary_category1_bfloat16.py::test_bessel_ops gates ttnn.i0 separately, at
+# assert_with_ulp(..., 1) over an exhaustive bfloat16 sweep of [-10, 10] -- a
+# stricter, pre-existing 1-ULP budget this file does not share. Measured on
+# Blackhole p150b at this head: Max ULP Delta = 1.0, i.e. it still passes but with
+# no headroom left. The two budgets disagree because they build the golden
+# differently -- that test calls torch.i0 directly on a bfloat16-dtype tensor,
+# while _quantise below rounds to bfloat16 then calls torch.special.i0 in float32
+# -- not because the device output differs between the two runs.
 
 
 def _quantise(x, dtype):
@@ -224,16 +224,11 @@ def test_i0_overflow(device, dtype):
 
 
 def test_i0_nan(device):
-    """NaN propagates instead of being swallowed by the overflow branch.
+    """Test ensures i0 on NaN inputs (including -NaN) gives NaN outputs.
 
-    The SFPU compare is not IEEE-ordered -- NaN carries the maximal exponent and
-    passes ``> 88.5`` -- so the kernel detects it by bit pattern and restores it.
-    Before this change the input clamp mapped NaN to the finite 1.15e+37.
-
-    float32 only: on the bfloat16 path NaN still emerges as +inf. A DRAM round-trip
-    with no op returns NaN intact, so the payload is lost unpacking bfloat16 into DST,
-    upstream of the kernel. Asserting it here would pin a defect this change does not
-    own; +inf is still an improvement on the previous finite 1.15e+37.
+    float32 only: on the bfloat16 path, NaN becomes +inf before the kernel ever
+    sees it (lost unpacking bfloat16 into DST) -- a separate, pre-existing gap
+    this test does not cover.
     """
     padded = torch.zeros((1, 1, 32, 32), dtype=torch.float32)
     padded[0, 0, 0, :2] = torch.tensor([float("nan"), -float("nan")], dtype=torch.float32)
@@ -242,3 +237,38 @@ def test_i0_nan(device):
 
     got = output_tensor.float()[0, 0, 0, :2]
     assert torch.isnan(got).all(), f"i0(NaN) must be NaN, got {got.tolist()}"
+
+
+def test_i0_mixed_dtype_output(device):
+    """A bfloat16 input with a preallocated float32 output_tensor keeps float32 precision.
+
+    ttnn.i0(bf16_tensor, output_tensor=<float32 tensor>) is a supported mixed-dtype
+    call (unary.cpp's is_supported_mixed_float_dtype). It runs DEST in 32-bit mode
+    because the *output* is float32, independent of the bfloat16 input -- so the
+    kernel must store at float32 precision here rather than truncating to bfloat16
+    just because the input dtype happens to be bfloat16.
+    """
+    torch.manual_seed(0)
+    shape = [1, 1, 32, 32]
+    torch_input = torch.rand(shape, dtype=torch.float32) * 20 - 10
+    torch_output = torch.special.i0(_quantise(torch_input, ttnn.bfloat16))
+
+    input_tensor = ttnn.from_torch(
+        torch_input,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.from_torch(
+        torch.zeros(shape, dtype=torch.float32),
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.float32,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ttnn.i0(input_tensor, output_tensor=output_tensor)
+    result = ttnn.to_torch(output_tensor)
+
+    assert result.dtype == torch.float32
+    assert_with_ulp(torch_output, result, _MAX_ULP[ttnn.float32])

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -6,52 +6,136 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu_exp.h"
 #include "cmath_common.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 
-using namespace sfpi;
+namespace ckernel::sfpu {
 
-namespace ckernel {
-namespace sfpu {
+// ======================================================================
+// i0(x) — modified Bessel function of the first kind, order 0.
+//
+// Two-region implementation, exploiting that i0 is even: i0(-x) = i0(x).
+//   |x| <= 6:  Maclaurin series, I0(x) = sum_k (x^2/4)^k / (k!)^2,
+//              truncated at k=11 (12 terms). Max rel err 1.4e-08.
+//   |x| >  6:  asymptotic expansion (Abramowitz & Stegun 9.7.1)
+//                i0(x) = exp(|x|) / sqrt(|x|) * Q(1/|x|)
+//              degree-5 fit (6 coeffs), 1/sqrt(2*pi) folded into Q's
+//              leading term. Max rel err 4.7e-08 over [6, 88.5].
+//
+// Worst case over [0, 88.5] is 4.7e-08 relative (~0.4 FP32 ULP), at the
+// handover. The threshold was chosen by sweeping it: the polynomial's
+// truncation grows and the asymptotic fit's residual shrinks with |x|,
+// and 6 is where the two curves cross. Above ~13 the polynomial alone
+// (the previous implementation) is unusable: 21% rel err at x=20, 89%
+// at x=30, because the series' largest term sits near k ~ x/2 and the
+// omitted tail — eventually the omitted peak itself — dominates.
+//
+// Code shape (chosen to relieve SFPI LRA budget), mirroring i1:
+//   1. Compute polynomial result unconditionally and store to DST.
+//      Polynomial-path intermediates die at the store, freeing LRegs.
+//   2. v_if (|x|>6): overwrite DST with asymptotic result.
+//
+// Inputs are clamped to [-88.5, 88.5] to avoid exp() overflow; I0 stays
+// finite to ~88.5 in FP32 (I0(88.5) ~ 1.2e+37).
+//
+// APPROXIMATION_MODE is accepted for call-site compatibility; both paths
+// are already the accurate ones and it does not select a cheaper route.
+// ======================================================================
 
-#define POLYVAL10(coef10, coef9, coef8, coef7, coef6, coef5, coef4, coef3, coef2, coef1, coef0, t4)               \
-    ((coef0 +                                                                                                     \
-      (coef1 +                                                                                                    \
-       (coef2 +                                                                                                   \
-        (coef3 +                                                                                                  \
-         (coef4 + (coef5 + (coef6 + (coef7 + (coef8 + (coef9 + coef10 * t4) * t4) * t4) * t4) * t4) * t4) * t4) * \
-            t4) *                                                                                                 \
-           t4) *                                                                                                  \
-          t4) *                                                                                                   \
-     t4)
+// Asymptotic path is outlined to keep register pressure within SFPI's
+// LRA budget. Returns exp(|x|) * 1/sqrt(|x|) * Q(1/|x|).
+// Note: this function must stay minimalist — SFPU LRA is limited.
+// Every operation here competes with the main loop.
+inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
+    // exp(|x|) — unsafe variants in both paths: |x| in [6, 88.5] precludes
+    // overflow/underflow, so the safe wrappers' clamping/guards are dead
+    // and skipped.
+#ifdef INP_FLOAT32
+    const sfpi::vFloat exp_abs = _sfpu_exp_fp32_accurate_unsafe_(abs_x);
+#else
+    const sfpi::vFloat exp_abs = _sfpu_exp_21f_bf16_unsafe_<true>(abs_x);
+#endif
+
+    // 1/sqrt(|x|) via Quake-style magic constant + two Newton refinements.
+    // Computed first so that 1/|x| can be derived as rsqrt_y^2 without a
+    // separate sfpu_reciprocal call.
+    const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
+    sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
+    sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
+    c0 = 1.0f + (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = c0 * sfpi::addexp(rsqrt_y, -1) + rsqrt_y;
+
+    // 1/|x| = (1/sqrt(|x|))^2 — reuses the refined rsqrt instead of a fresh reciprocal.
+    const sfpi::vFloat inv_abs_x = rsqrt_y * rsqrt_y;
+
+    // Q(y) on y in [1/88.5, 1/6]; leading term is 1/sqrt(2*pi) = 0.39894228.
+    // This outlined function does not stress the main loop's LRA, so full precision is safe.
+    const sfpi::vFloat correction = PolynomialEvaluator::eval(
+        inv_abs_x,
+        3.9894214272e-01f,
+        4.9887448549e-02f,
+        2.7172168717e-02f,
+        4.6332854778e-02f,
+        -1.0997270793e-01f,
+        6.5736579895e-01f);
+
+    // i0 is even — no sign restoration needed (cf. i1's copysgn).
+    return exp_abs * rsqrt_y * correction;
+}
+
 inline void i0_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_i0() {
-#pragma GCC unroll 0
+    constexpr float I0_MAX_INPUT = 88.5f;
+    constexpr float I0_THRESHOLD = 6.0f;
 
+#pragma GCC unroll 1
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat result = 0.0f;
-        vFloat input = dst_reg[0];
-        vFloat x = input * input;
+        sfpi::vFloat x = sfpi::dst_reg[0];
 
-        result = 1.0f + POLYVAL10(
-                            1.50E-22f,
-                            7.24E-20f,
-                            2.90E-17f,
-                            9.39E-15f,
-                            2.40E-12f,
-                            4.71E-10f,
-                            6.78E-08f,
-                            0.000006781684028f,
-                            0.0004340277778f,
-                            0.015625f,
-                            0.25f,
-                            x);
+        // Clamp to [-88.5, 88.5] — exp() saturates near +/-88.7 in FP32.
+        x = sfpi::symmetric_clamp(x, I0_MAX_INPUT);
 
-        dst_reg[0] = result;
-        dst_reg++;
+        const sfpi::vFloat abs_x = sfpi::abs(x);
+
+        sfpi::vFloat val;
+        // ─── Polynomial path (always; valid for |x| <= 6) ────────────────
+        // Computed unconditionally and stored — its LRegs are then free
+        // for the asymptotic block to use.
+        //
+        // Coefficients are (1/4)^k/(k!)^2 for k = 1..11, rounded to FP32.
+        // The previous implementation carried these to only three
+        // significant figures, which cost ~52 FP32 ULP at |x| = 5 on its
+        // own — independent of, and masked by, the truncation problem.
+        {
+            const sfpi::vFloat t = x * x;
+            val = 1.0f + t * PolynomialEvaluator::eval(
+                                 t,
+                                 2.5000000000e-01f,
+                                 1.5625000000e-02f,
+                                 4.3402778101e-04f,
+                                 6.7816840783e-06f,
+                                 6.7816841920e-08f,
+                                 4.7095027877e-10f,
+                                 2.4028075536e-12f,
+                                 9.3859670063e-15f,
+                                 2.8969033031e-17f,
+                                 7.2422583611e-20f,
+                                 1.4963343367e-22f);
+        }
+
+        // ─── Asymptotic overwrite for OOD lanes (|x| > 6) ────────────────
+        v_if(abs_x > I0_THRESHOLD) { val = calculate_i0_asymptotic_(abs_x); }
+        v_endif;
+#ifndef INP_FLOAT32
+        val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);
+#endif
+        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -36,8 +36,19 @@ namespace ckernel::sfpu {
 //      Polynomial-path intermediates die at the store, freeing LRegs.
 //   2. v_if (|x|>6): overwrite DST with asymptotic result.
 //
-// Inputs are clamped to [-88.5, 88.5] to avoid exp() overflow; I0 stays
-// finite to ~88.5 in FP32 (I0(88.5) ~ 1.2e+37).
+// Overflow: I0 grows without bound, so |x| past the representable range
+// returns +inf rather than a clamped finite value. The computation is
+// still clamped to 88.5 (FP32 exp() saturates at 88.7228), and lanes above
+// that bound are then overwritten with +inf. i0(+/-inf) = +inf follows from
+// the same test.
+//
+// This matches ttnn's declared golden, torch.i0, which overflows to inf at
+// the same 88.7228 for the same reason (cf. the note on torch.sinh in
+// test_unary_fp32.py). The two differ only for FP32 inputs in the 0.22-wide
+// window (88.5, 88.7228), where torch still returns a finite value below
+// 1.45e+37; no bfloat16 value lands strictly inside it. The true I0 stays
+// representable to x = 91.9008 (I0 = 3.4028e+38), but no exp()-first
+// formulation can reach it without the intermediate overflowing.
 //
 // APPROXIMATION_MODE is accepted for call-site compatibility; both paths
 // are already the accurate ones and it does not select a cheaper route.
@@ -94,12 +105,15 @@ inline void calculate_i0() {
 
 #pragma GCC unroll 1
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat x = sfpi::dst_reg[0];
+        // i0 is even, so the sign is never needed: take |x| up front and clamp with a
+        // plain min. Strictly cheaper than symmetric_clamp() followed by abs(), which
+        // computes a copysgn() only for the abs() to discard it — and it leaves the
+        // unclamped magnitude live for the overflow test below at no extra LReg cost.
+        const sfpi::vFloat x = sfpi::dst_reg[0];
+        const sfpi::vFloat abs_x_in = sfpi::abs(x);
 
-        // Clamp to [-88.5, 88.5] — exp() saturates near +/-88.7 in FP32.
-        x = sfpi::symmetric_clamp(x, I0_MAX_INPUT);
-
-        const sfpi::vFloat abs_x = sfpi::abs(x);
+        // Clamp to 88.5 — exp() saturates near 88.7 in FP32.
+        const sfpi::vFloat abs_x = sfpi::min(abs_x_in, I0_MAX_INPUT);
 
         sfpi::vFloat val;
         // ─── Polynomial path (always; valid for |x| <= 6) ────────────────
@@ -111,7 +125,7 @@ inline void calculate_i0() {
         // significant figures, which cost ~52 FP32 ULP at |x| = 5 on its
         // own — independent of, and masked by, the truncation problem.
         {
-            const sfpi::vFloat t = x * x;
+            const sfpi::vFloat t = abs_x * abs_x;
             val = 1.0f + t * PolynomialEvaluator::eval(
                                  t,
                                  2.5000000000e-01f,
@@ -129,6 +143,28 @@ inline void calculate_i0() {
 
         // ─── Asymptotic overwrite for OOD lanes (|x| > 6) ────────────────
         v_if(abs_x > I0_THRESHOLD) { val = calculate_i0_asymptotic_(abs_x); }
+        v_endif;
+
+        // ─── Overflow: |x| past the representable range → +inf ───────────
+        // Tested on the *unclamped* magnitude. Without this, i0(1e4) would
+        // return i0(88.5) = 1.16e+37 — a silent wrong finite answer.
+        // i0(+/-inf) = +inf falls out of the same test.
+        v_if(abs_x_in > I0_MAX_INPUT) { val = std::numeric_limits<float>::infinity(); }
+        v_endif;
+
+        // ─── NaN in → NaN out ────────────────────────────────────────────
+        // The SFPU compare is not IEEE-ordered: NaN carries the maximal
+        // exponent and passes the > test above, so it would be converted to
+        // +inf. Detect it by bit pattern instead — exponent all ones with a
+        // non-zero mantissa — and restore it.
+        //
+        // Measured on Blackhole p150b: this restores NaN on the FP32 path.
+        // On the BF16 path NaN still emerges as +inf — a DRAM round-trip with
+        // no op returns NaN intact, so the payload is lost unpacking BF16 into
+        // DST, upstream of this branch. Both remain an improvement on the
+        // previous behaviour, where the input clamp mapped NaN to a finite
+        // 1.15e+37.
+        v_if(sfpi::exexp(abs_x_in) == 128 && sfpi::exman(abs_x_in) != 0) { val = abs_x_in; }
         v_endif;
 #ifndef INP_FLOAT32
         val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -17,38 +17,72 @@ namespace ckernel::sfpu {
 //
 // Two-region implementation, exploiting that i0 is even: i0(-x) = i0(x).
 //   |x| <= 6:  Maclaurin series, I0(x) = sum_k (x^2/4)^k / (k!)^2,
-//              truncated at k=11 (12 terms). Max rel err 1.4e-08.
+//              degree-8 minimax fit in t=x^2 (9 terms incl. the leading
+//              1.0), Remez-derived. Max rel err ~3.1e-07 in idealized
+//              arithmetic, dominated in practice by rounding t = fl(x*x)
+//              itself rather than by the polynomial fit — see the note
+//              below.
 //   |x| >  6:  asymptotic expansion (Abramowitz & Stegun 9.7.1)
 //                i0(x) = exp(|x|) / sqrt(|x|) * Q(1/|x|)
-//              degree-5 fit (6 coeffs), 1/sqrt(2*pi) folded into Q's
-//              leading term. Max rel err 4.7e-08 over [6, 88.5].
+//              FP32: degree-5 fit (6 coeffs). BF16: degree-4 fit (5
+//              coeffs) — one term shorter, since BF16 output precision
+//              cannot see the extra term (0/498 exhaustive BF16 values
+//              in [6, 88.5] differ from the correctly-rounded result).
+//              1/sqrt(2*pi) folded into Q's leading term in both.
 //
-// Worst case over [0, 88.5] is 4.7e-08 relative (~0.4 FP32 ULP), at the
-// handover. The threshold was chosen by sweeping it: the polynomial's
-// truncation grows and the asymptotic fit's residual shrinks with |x|,
-// and 6 is where the two curves cross. Above ~13 the polynomial alone
-// (the previous implementation) is unusable: 21% rel err at x=20, 89%
-// at x=30, because the series' largest term sits near k ~ x/2 and the
-// omitted tail — eventually the omitted peak itself — dominates.
+// Measured worst case over the full domain (200k-sample random sweep over
+// [-88.5, 88.5], both dtypes, same seed on both arches): 6.0 FP32 ULP (at
+// x = -5.93, inside region 1) and 0.91 BF16 ULP. Blackhole p150b and
+// Wormhole n300 silicon produced bit-identical results -- same worst-case
+// x, same output, same reference, to the last digit -- so the WH/BH source
+// identity this file maintains is measured equivalence, not an inference
+// from it. Identical to the pre-trim kernel's FP32 figure and marginally
+// better on BF16 -- trimming both regions did not measurably change
+// accuracy, confirming the analysis below. See tests/.../test_unary_i0.py's
+// _MAX_ULP for the test budget (12 / 2), which already carried headroom
+// over these numbers.
+//
+// Both regions were originally 3 terms longer (12-term Maclaurin, one
+// shared 6-term Q for both dtypes). The trim follows a silicon+analysis
+// review (tenstorrent/tt-metal#52126, comment 5265986150): compiling
+// standalone against the pinned sfpi build and counting the disassembly,
+// plus bit-exact FP32/BF16 Horner simulation against mpmath, showed the
+// extra terms cost real instructions (dominated by SFPLOADI coefficient
+// materialization) without measurable accuracy — because accuracy near
+// the region-1 boundary is bounded by FP32 rounding of t = fl(x*x), not
+// by truncation, and the region-2 rsqrt Newton step alone already costs
+// ~1.7 FP32 ULP, both floors well above what the trimmed terms bought.
+// This kernel's own independent Remez fit and FP32/BF16 simulation (see
+// tt-bounty/tt-metal/04/review-52126 for the scripts) reproduced those findings.
 //
 // Code shape (chosen to relieve SFPI LRA budget), mirroring i1:
 //   1. Compute polynomial result unconditionally and store to DST.
 //      Polynomial-path intermediates die at the store, freeing LRegs.
 //   2. v_if (|x|>6): overwrite DST with asymptotic result.
 //
-// Overflow: I0 grows without bound, so |x| past the representable range
-// returns +inf rather than a clamped finite value. The computation is
-// still clamped to 88.5 (FP32 exp() saturates at 88.7228), and lanes above
-// that bound are then overwritten with +inf. i0(+/-inf) = +inf follows from
-// the same test.
+// No input clamp: unlike the previous version, abs_x here is never
+// clamped to 88.5 before use. Every lane a clamp would change is a lane
+// with |x| > 88.5, and every one of those is unconditionally overwritten
+// below by the overflow branch — so a clamp only ever protects a value
+// that is then discarded. The unclamped polynomial/asymptotic paths can
+// produce garbage (even overflow to inf, or NaN for NaN input) on those
+// lanes; since SFPU lanes are independent and the garbage never reaches
+// the store, this is safe and costs nothing.
 //
-// This matches ttnn's declared golden, torch.i0, which overflows to inf at
-// the same 88.7228 for the same reason (cf. the note on torch.sinh in
-// test_unary_fp32.py). The two differ only for FP32 inputs in the 0.22-wide
-// window (88.5, 88.7228), where torch still returns a finite value below
-// 1.45e+37; no bfloat16 value lands strictly inside it. The true I0 stays
-// representable to x = 91.9008 (I0 = 3.4028e+38), but no exp()-first
-// formulation can reach it without the intermediate overflowing.
+// Overflow, +/-inf and NaN all resolve in one branch: multiplying by
+// infinity rather than assigning it handles all three cases from a
+// single predicate. Finite |x| > 88.5 gives +inf (FP32 exp() saturates
+// at 88.7228, matching torch's identical limitation — cf. the note on
+// torch.sinh in test_unary_fp32.py); +/-inf gives +inf; NaN stays NaN,
+// relying on SFPMUL propagating a NaN operand the same way
+// _sfpu_exp_fp32_accurate_ relies on 0*inf = NaN for the same purpose.
+// The true I0 stays representable to x = 91.9008 (I0 = 3.4028e+38), but
+// no exp()-first formulation can reach it without the intermediate
+// overflowing.
+//
+// On the BF16 path NaN still emerges as +inf regardless of this branch:
+// a DRAM round-trip with no op returns NaN intact, so the payload is
+// lost unpacking BF16 into DST, upstream of this kernel entirely.
 //
 // APPROXIMATION_MODE is accepted for call-site compatibility; both paths
 // are already the accurate ones and it does not select a cheaper route.
@@ -59,9 +93,10 @@ namespace ckernel::sfpu {
 // Note: this function must stay minimalist — SFPU LRA is limited.
 // Every operation here competes with the main loop.
 inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
-    // exp(|x|) — unsafe variants in both paths: |x| in [6, 88.5] precludes
-    // overflow/underflow, so the safe wrappers' clamping/guards are dead
-    // and skipped.
+    // exp(|x|) — unsafe variants in both paths. For the |x| in [6, 88.5] that
+    // reaches the store, overflow/underflow is impossible and the safe
+    // wrappers' clamping/guards would be dead code. Above 88.5 these wrap and
+    // return garbage; the caller overwrites those lanes unconditionally.
 #ifdef INP_FLOAT32
     const sfpi::vFloat exp_abs = _sfpu_exp_fp32_accurate_unsafe_(abs_x);
 #else
@@ -71,6 +106,14 @@ inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
     // 1/sqrt(|x|) via Quake-style magic constant + two Newton refinements.
     // Computed first so that 1/|x| can be derived as rsqrt_y^2 without a
     // separate sfpu_reciprocal call.
+    //
+    // Kept unconditional (not dtype-split): the Newton step is load-bearing
+    // for FP32 (dropping it costs ~343 FP32 ULP against a budget in the
+    // teens) and only marginal for BF16 (~0.2% of outputs move by 1 ULP,
+    // comfortably inside the existing 2-ULP BF16 test budget either way).
+    // Splitting it to save 4 instructions on the BF16 path was left alone: it
+    // would add a third dtype branch inside the kernel's most precision-
+    // sensitive block for the smallest of the four savings on the table.
     const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
     sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
     sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
@@ -82,7 +125,17 @@ inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
     const sfpi::vFloat inv_abs_x = rsqrt_y * rsqrt_y;
 
     // Q(y) on y in [1/88.5, 1/6]; leading term is 1/sqrt(2*pi) = 0.39894228.
-    // This outlined function does not stress the main loop's LRA, so full precision is safe.
+    // This outlined function does not stress the main loop's LRA, so full
+    // precision is safe.
+    //
+    // FP32: degree-5 (6 coeffs). BF16: degree-4 (5 coeffs) — one term
+    // shorter, verified against an exhaustive sweep of all BF16-representable
+    // values in [6, 88.5] (0/498 differ from the correctly-rounded result).
+    // Coefficients must stay FP32 in both cases: rounding the BF16 Q's
+    // leading term to BF16 (which would let sfpi use SFPADDI's 16-bit
+    // immediate instead of an SFPLOADI pair) costs 1.27e-03 relative on that
+    // term alone — four orders of magnitude above the accuracy budget.
+#ifdef INP_FLOAT32
     const sfpi::vFloat correction = PolynomialEvaluator::eval(
         inv_abs_x,
         3.9894214272e-01f,
@@ -91,6 +144,10 @@ inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
         4.6332854778e-02f,
         -1.0997270793e-01f,
         6.5736579895e-01f);
+#else
+    const sfpi::vFloat correction = PolynomialEvaluator::eval(
+        inv_abs_x, 3.9894300699e-01f, 4.9790032208e-02f, 3.0512193218e-02f, -9.7926484887e-04f, 1.8299004436e-01f);
+#endif
 
     // i0 is even — no sign restoration needed (cf. i1's copysgn).
     return exp_abs * rsqrt_y * correction;
@@ -103,68 +160,54 @@ inline void calculate_i0() {
     constexpr float I0_MAX_INPUT = 88.5f;
     constexpr float I0_THRESHOLD = 6.0f;
 
+    // Decorative but intentional: unroll 0, unroll 1, and no pragma at all
+    // produce byte-identical codegen here (-funroll-loops included), since
+    // sfpi lowers this loop's body through the 32-entry Tensix replay buffer
+    // regardless — dynamic work per datum stays flat all the way to unroll
+    // 8, while code size grows ~5.7x. Kept as documentation of that, not as
+    // a knob that does anything.
 #pragma GCC unroll 1
     for (int d = 0; d < ITERATIONS; d++) {
-        // i0 is even, so the sign is never needed: take |x| up front and clamp with a
-        // plain min. Strictly cheaper than symmetric_clamp() followed by abs(), which
-        // computes a copysgn() only for the abs() to discard it — and it leaves the
-        // unclamped magnitude live for the overflow test below at no extra LReg cost.
+        // i0 is even, so the sign is never needed: take |x| up front with a
+        // plain abs. No clamp — see the file-level comment for why an
+        // unclamped magnitude here is safe.
         const sfpi::vFloat x = sfpi::dst_reg[0];
-        const sfpi::vFloat abs_x_in = sfpi::abs(x);
-
-        // Clamp to 88.5 — exp() saturates near 88.7 in FP32.
-        const sfpi::vFloat abs_x = sfpi::min(abs_x_in, I0_MAX_INPUT);
+        const sfpi::vFloat abs_x = sfpi::abs(x);
 
         sfpi::vFloat val;
         // ─── Polynomial path (always; valid for |x| <= 6) ────────────────
-        // Computed unconditionally and stored — its LRegs are then free
-        // for the asymptotic block to use.
+        // Computed unconditionally so its LRegs are free for the asymptotic
+        // block to reuse.
         //
-        // Coefficients are (1/4)^k/(k!)^2 for k = 1..11, rounded to FP32.
-        // The previous implementation carried these to only three
-        // significant figures, which cost ~52 FP32 ULP at |x| = 5 on its
-        // own — independent of, and masked by, the truncation problem.
+        // Degree-8 minimax fit in t (Remez, weighted for relative I0 error),
+        // not truncated Maclaurin — a naive truncation at this degree is
+        // measurably worse. k = 1 and k = 2 are pinned to their exact
+        // Maclaurin values (1/4 and 1/64): both are BF16-representable, so
+        // sfpi folds them into SFPADDI's immediate instead of materialising
+        // them with an SFPLOADI pair.
         {
             const sfpi::vFloat t = abs_x * abs_x;
             val = 1.0f + t * PolynomialEvaluator::eval(
                                  t,
                                  2.5000000000e-01f,
                                  1.5625000000e-02f,
-                                 4.3402778101e-04f,
-                                 6.7816840783e-06f,
-                                 6.7816841920e-08f,
-                                 4.7095027877e-10f,
-                                 2.4028075536e-12f,
-                                 9.3859670063e-15f,
-                                 2.8969033031e-17f,
-                                 7.2422583611e-20f,
-                                 1.4963343367e-22f);
+                                 4.3402606389e-04f,
+                                 6.7823571044e-06f,
+                                 6.7718225694e-08f,
+                                 4.7797393821e-10f,
+                                 2.1436320601e-12f,
+                                 1.4051053479e-14f);
         }
 
         // ─── Asymptotic overwrite for OOD lanes (|x| > 6) ────────────────
         v_if(abs_x > I0_THRESHOLD) { val = calculate_i0_asymptotic_(abs_x); }
         v_endif;
 
-        // ─── Overflow: |x| past the representable range → +inf ───────────
-        // Tested on the *unclamped* magnitude. Without this, i0(1e4) would
-        // return i0(88.5) = 1.16e+37 — a silent wrong finite answer.
-        // i0(+/-inf) = +inf falls out of the same test.
-        v_if(abs_x_in > I0_MAX_INPUT) { val = std::numeric_limits<float>::infinity(); }
-        v_endif;
-
-        // ─── NaN in → NaN out ────────────────────────────────────────────
-        // The SFPU compare is not IEEE-ordered: NaN carries the maximal
-        // exponent and passes the > test above, so it would be converted to
-        // +inf. Detect it by bit pattern instead — exponent all ones with a
-        // non-zero mantissa — and restore it.
-        //
-        // Measured on Blackhole p150b: this restores NaN on the FP32 path.
-        // On the BF16 path NaN still emerges as +inf — a DRAM round-trip with
-        // no op returns NaN intact, so the payload is lost unpacking BF16 into
-        // DST, upstream of this branch. Both remain an improvement on the
-        // previous behaviour, where the input clamp mapped NaN to a finite
-        // 1.15e+37.
-        v_if(sfpi::exexp(abs_x_in) == 128 && sfpi::exman(abs_x_in) != 0) { val = abs_x_in; }
+        // ─── Overflow, +/-inf and NaN → +inf (NaN stays NaN) ─────────────
+        // See the file-level comment for the SFPMUL/NaN-propagation
+        // assumption this relies on, and why it replaces two branches
+        // (overflow-assign + bit-pattern NaN-restore) with one.
+        v_if(abs_x > I0_MAX_INPUT) { val = abs_x * std::numeric_limits<float>::infinity(); }
         v_endif;
 #ifndef INP_FLOAT32
         val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -45,16 +45,10 @@ namespace ckernel::sfpu {
 // exceed what a longer fit would buy, which is why each region uses only
 // as many terms as its own arithmetic can resolve.
 //
-// Code shape (chosen to relieve SFPI LRA budget), mirroring i1:
-//   1. Compute the region-1 result into a local `val`, inside a nested
-//      scope; the scope's closing brace retires `t`'s LReg immediately,
-//      freeing it for the asymptotic block below. No intermediate DST
-//      store/reload is involved -- unlike the store-then-reload idiom
-//      ckernel_sfpu_erfinv.h / ckernel_sfpu_gelu.h use for the same
-//      purpose.
-//   2. v_if (|x|>6): overwrite `val` (not DST) with the asymptotic result.
-//   3. One store: `dst_reg[0] = val`, after the overflow/NaN branch and
-//      the optional BF16 downconvert below.
+// Code shape (chosen to relieve SFPI LRA budget), mirroring i1: region-1's
+// result lives in a local `val` inside a nested scope, so its LRegs are
+// freed by the scope exit -- not a DST store/reload -- before the
+// asymptotic block needs them.
 //
 // No input clamp: abs_x is never clamped to 88.5 before use. Every lane
 // a clamp would change is a lane
@@ -66,18 +60,12 @@ namespace ckernel::sfpu {
 // the store, this is safe and costs nothing.
 //
 // Overflow and +/-inf both resolve to +inf here: multiplying by infinity
-// rather than assigning it lets one predicate cover both. This branch
-// fires for any finite |x| > 88.5 -- stricter than exp() itself needs.
-// FP32 exp() doesn't saturate until 88.7228 (cf. the note on torch.sinh
-// in test_unary_fp32.py), so for x in (88.5, 88.7228] the true value is
-// still finite and representable (I0(88.6) ~= 1.28e37) and
-// torch.special.i0 returns it, but this kernel returns +inf anyway: 88.5
-// is where Q's own Remez fit ends, not where exp() saturates. The gap is
-// invisible in BF16 (test_i0_all_bfloat16_bitpatterns in test_unary_i0.py:
-// no representable BF16 value lands inside that 0.22-wide window) and
-// only costs FP32 accuracy, on a band already deep in i0's exponential
-// blow-up. +/-inf gives +inf regardless. NaN survives regardless of
-// which branch it takes:
+// rather than assigning it lets one predicate cover both. The 88.5 cutoff
+// is Q's fitted boundary, not exp()'s true saturation point (88.7228) --
+// a narrow finite, torch-matching band above 88.5 also lands on +inf here,
+// accepted rather than re-fit since it's invisible in BF16 and already
+// deep in i0's exponential blow-up. NaN survives regardless of which
+// branch it takes:
 // lanes the compare excludes propagate NaN through ordinary arithmetic in
 // region 1, lanes it includes propagate NaN through this SFPMUL the same
 // way _sfpu_exp_fp32_accurate_ relies on 0*inf = NaN -- so correctness

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -46,9 +46,15 @@ namespace ckernel::sfpu {
 // as many terms as its own arithmetic can resolve.
 //
 // Code shape (chosen to relieve SFPI LRA budget), mirroring i1:
-//   1. Compute polynomial result unconditionally and store to DST.
-//      Polynomial-path intermediates die at the store, freeing LRegs.
-//   2. v_if (|x|>6): overwrite DST with asymptotic result.
+//   1. Compute the region-1 result into a local `val`, inside a nested
+//      scope; the scope's closing brace retires `t`'s LReg immediately,
+//      freeing it for the asymptotic block below. No intermediate DST
+//      store/reload is involved -- unlike the store-then-reload idiom
+//      ckernel_sfpu_erfinv.h / ckernel_sfpu_gelu.h use for the same
+//      purpose.
+//   2. v_if (|x|>6): overwrite `val` (not DST) with the asymptotic result.
+//   3. One store: `dst_reg[0] = val`, after the overflow/NaN branch and
+//      the optional BF16 downconvert below.
 //
 // No input clamp: abs_x is never clamped to 88.5 before use. Every lane
 // a clamp would change is a lane
@@ -60,10 +66,18 @@ namespace ckernel::sfpu {
 // the store, this is safe and costs nothing.
 //
 // Overflow and +/-inf both resolve to +inf here: multiplying by infinity
-// rather than assigning it lets one predicate cover both. Finite
-// |x| > 88.5 gives +inf (FP32 exp() saturates at 88.7228, matching torch's
-// identical limitation — cf. the note on torch.sinh in test_unary_fp32.py);
-// +/-inf gives +inf. NaN survives regardless of which branch it takes:
+// rather than assigning it lets one predicate cover both. This branch
+// fires for any finite |x| > 88.5 -- stricter than exp() itself needs.
+// FP32 exp() doesn't saturate until 88.7228 (cf. the note on torch.sinh
+// in test_unary_fp32.py), so for x in (88.5, 88.7228] the true value is
+// still finite and representable (I0(88.6) ~= 1.28e37) and
+// torch.special.i0 returns it, but this kernel returns +inf anyway: 88.5
+// is where Q's own Remez fit ends, not where exp() saturates. The gap is
+// invisible in BF16 (test_i0_all_bfloat16_bitpatterns in test_unary_i0.py:
+// no representable BF16 value lands inside that 0.22-wide window) and
+// only costs FP32 accuracy, on a band already deep in i0's exponential
+// blow-up. +/-inf gives +inf regardless. NaN survives regardless of
+// which branch it takes:
 // lanes the compare excludes propagate NaN through ordinary arithmetic in
 // region 1, lanes it includes propagate NaN through this SFPMUL the same
 // way _sfpu_exp_fp32_accurate_ relies on 0*inf = NaN -- so correctness
@@ -92,7 +106,7 @@ inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
 #ifdef INP_FLOAT32
     const sfpi::vFloat exp_abs = _sfpu_exp_fp32_accurate_unsafe_(abs_x);
 #else
-    const sfpi::vFloat exp_abs = _sfpu_exp_21f_bf16_unsafe_<true>(abs_x);
+    const sfpi::vFloat exp_abs = _sfpu_exp_21f_bf16_unsafe_<true /* is_fp32_dest_acc_en */>(abs_x);
 #endif
 
     // 1/sqrt(|x|) via Quake-style magic constant + two Newton refinements.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -36,32 +36,22 @@ namespace ckernel::sfpu {
 // Wormhole n300 silicon produced bit-identical results -- same worst-case
 // x, same output, same reference, to the last digit -- so the WH/BH source
 // identity this file maintains is measured equivalence, not an inference
-// from it. Identical to the pre-trim kernel's FP32 figure and marginally
-// better on BF16 -- trimming both regions did not measurably change
-// accuracy, confirming the analysis below. See tests/.../test_unary_i0.py's
-// _MAX_ULP for the test budget (12 / 2), which already carried headroom
-// over these numbers.
+// from it. See tests/.../test_unary_i0.py's _MAX_ULP for the test budget
+// (12 / 2), which carries headroom over these numbers.
 //
-// Both regions were originally 3 terms longer (12-term Maclaurin, one
-// shared 6-term Q for both dtypes). The trim follows a silicon+analysis
-// review (tenstorrent/tt-metal#52126, comment 5265986150): compiling
-// standalone against the pinned sfpi build and counting the disassembly,
-// plus bit-exact FP32/BF16 Horner simulation against mpmath, showed the
-// extra terms cost real instructions (dominated by SFPLOADI coefficient
-// materialization) without measurable accuracy — because accuracy near
-// the region-1 boundary is bounded by FP32 rounding of t = fl(x*x), not
-// by truncation, and the region-2 rsqrt Newton step alone already costs
-// ~1.7 FP32 ULP, both floors well above what the trimmed terms bought.
-// This kernel's own independent Remez fit and FP32/BF16 simulation (see
-// tt-bounty/tt-metal/04/review-52126 for the scripts) reproduced those findings.
+// Region-1 accuracy near the |x| = 6 boundary is bounded by FP32 rounding
+// of t = fl(x*x) rather than by the polynomial's degree, and the region-2
+// rsqrt Newton step alone costs ~1.7 FP32 ULP -- both floors already
+// exceed what a longer fit would buy, which is why each region uses only
+// as many terms as its own arithmetic can resolve.
 //
 // Code shape (chosen to relieve SFPI LRA budget), mirroring i1:
 //   1. Compute polynomial result unconditionally and store to DST.
 //      Polynomial-path intermediates die at the store, freeing LRegs.
 //   2. v_if (|x|>6): overwrite DST with asymptotic result.
 //
-// No input clamp: unlike the previous version, abs_x here is never
-// clamped to 88.5 before use. Every lane a clamp would change is a lane
+// No input clamp: abs_x is never clamped to 88.5 before use. Every lane
+// a clamp would change is a lane
 // with |x| > 88.5, and every one of those is unconditionally overwritten
 // below by the overflow branch — so a clamp only ever protects a value
 // that is then discarded. The unclamped polynomial/asymptotic paths can
@@ -69,13 +59,15 @@ namespace ckernel::sfpu {
 // lanes; since SFPU lanes are independent and the garbage never reaches
 // the store, this is safe and costs nothing.
 //
-// Overflow, +/-inf and NaN all resolve in one branch: multiplying by
-// infinity rather than assigning it handles all three cases from a
-// single predicate. Finite |x| > 88.5 gives +inf (FP32 exp() saturates
-// at 88.7228, matching torch's identical limitation — cf. the note on
-// torch.sinh in test_unary_fp32.py); +/-inf gives +inf; NaN stays NaN,
-// relying on SFPMUL propagating a NaN operand the same way
-// _sfpu_exp_fp32_accurate_ relies on 0*inf = NaN for the same purpose.
+// Overflow and +/-inf both resolve to +inf here: multiplying by infinity
+// rather than assigning it lets one predicate cover both. Finite
+// |x| > 88.5 gives +inf (FP32 exp() saturates at 88.7228, matching torch's
+// identical limitation — cf. the note on torch.sinh in test_unary_fp32.py);
+// +/-inf gives +inf. NaN survives regardless of which branch it takes:
+// lanes the compare excludes propagate NaN through ordinary arithmetic in
+// region 1, lanes it includes propagate NaN through this SFPMUL the same
+// way _sfpu_exp_fp32_accurate_ relies on 0*inf = NaN -- so correctness
+// does not depend on how SFPSETCC orders NaN against the threshold.
 // The true I0 stays representable to x = 91.9008 (I0 = 3.4028e+38), but
 // no exp()-first formulation can reach it without the intermediate
 // overflowing.
@@ -107,17 +99,14 @@ inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
     // Computed first so that 1/|x| can be derived as rsqrt_y^2 without a
     // separate sfpu_reciprocal call.
     //
-    // Kept unconditional (not dtype-split): the Newton step is load-bearing
-    // for FP32 (dropping it costs ~343 FP32 ULP against a budget in the
-    // teens) and only marginal for BF16 (~0.2% of outputs move by 1 ULP,
-    // comfortably inside the existing 2-ULP BF16 test budget either way).
-    // Splitting it to save 4 instructions on the BF16 path was left alone: it
-    // would add a third dtype branch inside the kernel's most precision-
-    // sensitive block for the smallest of the four savings on the table.
+    // Kept unconditional (not dtype-split): dropping the Newton step costs
+    // ~343 FP32 ULP against a budget in the teens, but only moves ~0.2% of
+    // BF16 outputs by 1 ULP -- not worth a third dtype branch in the
+    // kernel's most precision-sensitive block to save 4 BF16 instructions.
     const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
     sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
     sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
-    rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
+    rsqrt_y = rsqrt_y * (2.2825186f + c0 * (2.2533049f + c0));
     c0 = 1.0f + (-rsqrt_y) * (abs_x * rsqrt_y);
     rsqrt_y = c0 * sfpi::addexp(rsqrt_y, -1) + rsqrt_y;
 
@@ -155,17 +144,16 @@ inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
 
 inline void i0_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_i0() {
     constexpr float I0_MAX_INPUT = 88.5f;
     constexpr float I0_THRESHOLD = 6.0f;
 
     // Decorative but intentional: unroll 0, unroll 1, and no pragma at all
-    // produce byte-identical codegen here (-funroll-loops included), since
-    // sfpi lowers this loop's body through the 32-entry Tensix replay buffer
-    // regardless — dynamic work per datum stays flat all the way to unroll
-    // 8, while code size grows ~5.7x. Kept as documentation of that, not as
-    // a knob that does anything.
+    // produce byte-identical codegen here (-funroll-loops included) --
+    // dynamic work per datum stays flat all the way to unroll 8, while code
+    // size grows ~5.7x. Kept as documentation of that, not as a knob that
+    // does anything.
 #pragma GCC unroll 1
     for (int d = 0; d < ITERATIONS; d++) {
         // i0 is even, so the sign is never needed: take |x| up front with a
@@ -209,9 +197,16 @@ inline void calculate_i0() {
         // (overflow-assign + bit-pattern NaN-restore) with one.
         v_if(abs_x > I0_MAX_INPUT) { val = abs_x * std::numeric_limits<float>::infinity(); }
         v_endif;
-#ifndef INP_FLOAT32
-        val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);
-#endif
+
+        // Gated on the true DEST width, not INP_FLOAT32: a bf16-in/float32-out
+        // call (ttnn.i0(bf16_tensor, output_tensor=<float32 tensor>), a
+        // supported mixed-dtype combination) runs DEST in 32-bit mode with
+        // INP_FLOAT32 undefined, so this convert must key off
+        // is_fp32_dest_acc_en to avoid rounding a genuine FP32 output down
+        // to BF16 precision.
+        if constexpr (!is_fp32_dest_acc_en) {
+            val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);
+        }
         sfpi::dst_reg[0] = val;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -6,52 +6,136 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu_exp.h"
 #include "cmath_common.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 
-using namespace sfpi;
+namespace ckernel::sfpu {
 
-namespace ckernel {
-namespace sfpu {
+// ======================================================================
+// i0(x) — modified Bessel function of the first kind, order 0.
+//
+// Two-region implementation, exploiting that i0 is even: i0(-x) = i0(x).
+//   |x| <= 6:  Maclaurin series, I0(x) = sum_k (x^2/4)^k / (k!)^2,
+//              truncated at k=11 (12 terms). Max rel err 1.4e-08.
+//   |x| >  6:  asymptotic expansion (Abramowitz & Stegun 9.7.1)
+//                i0(x) = exp(|x|) / sqrt(|x|) * Q(1/|x|)
+//              degree-5 fit (6 coeffs), 1/sqrt(2*pi) folded into Q's
+//              leading term. Max rel err 4.7e-08 over [6, 88.5].
+//
+// Worst case over [0, 88.5] is 4.7e-08 relative (~0.4 FP32 ULP), at the
+// handover. The threshold was chosen by sweeping it: the polynomial's
+// truncation grows and the asymptotic fit's residual shrinks with |x|,
+// and 6 is where the two curves cross. Above ~13 the polynomial alone
+// (the previous implementation) is unusable: 21% rel err at x=20, 89%
+// at x=30, because the series' largest term sits near k ~ x/2 and the
+// omitted tail — eventually the omitted peak itself — dominates.
+//
+// Code shape (chosen to relieve SFPI LRA budget), mirroring i1:
+//   1. Compute polynomial result unconditionally and store to DST.
+//      Polynomial-path intermediates die at the store, freeing LRegs.
+//   2. v_if (|x|>6): overwrite DST with asymptotic result.
+//
+// Inputs are clamped to [-88.5, 88.5] to avoid exp() overflow; I0 stays
+// finite to ~88.5 in FP32 (I0(88.5) ~ 1.2e+37).
+//
+// APPROXIMATION_MODE is accepted for call-site compatibility; both paths
+// are already the accurate ones and it does not select a cheaper route.
+// ======================================================================
 
-#define POLYVAL10(coef10, coef9, coef8, coef7, coef6, coef5, coef4, coef3, coef2, coef1, coef0, t4)               \
-    ((coef0 +                                                                                                     \
-      (coef1 +                                                                                                    \
-       (coef2 +                                                                                                   \
-        (coef3 +                                                                                                  \
-         (coef4 + (coef5 + (coef6 + (coef7 + (coef8 + (coef9 + coef10 * t4) * t4) * t4) * t4) * t4) * t4) * t4) * \
-            t4) *                                                                                                 \
-           t4) *                                                                                                  \
-          t4) *                                                                                                   \
-     t4)
+// Asymptotic path is outlined to keep register pressure within SFPI's
+// LRA budget. Returns exp(|x|) * 1/sqrt(|x|) * Q(1/|x|).
+// Note: this function must stay minimalist — SFPU LRA is limited.
+// Every operation here competes with the main loop.
+inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
+    // exp(|x|) — unsafe variants in both paths: |x| in [6, 88.5] precludes
+    // overflow/underflow, so the safe wrappers' clamping/guards are dead
+    // and skipped.
+#ifdef INP_FLOAT32
+    const sfpi::vFloat exp_abs = _sfpu_exp_fp32_accurate_unsafe_(abs_x);
+#else
+    const sfpi::vFloat exp_abs = _sfpu_exp_21f_bf16_unsafe_<true>(abs_x);
+#endif
+
+    // 1/sqrt(|x|) via Quake-style magic constant + two Newton refinements.
+    // Computed first so that 1/|x| can be derived as rsqrt_y^2 without a
+    // separate sfpu_reciprocal call.
+    const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
+    sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
+    sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
+    c0 = 1.0f + (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = c0 * sfpi::addexp(rsqrt_y, -1) + rsqrt_y;
+
+    // 1/|x| = (1/sqrt(|x|))^2 — reuses the refined rsqrt instead of a fresh reciprocal.
+    const sfpi::vFloat inv_abs_x = rsqrt_y * rsqrt_y;
+
+    // Q(y) on y in [1/88.5, 1/6]; leading term is 1/sqrt(2*pi) = 0.39894228.
+    // This outlined function does not stress the main loop's LRA, so full precision is safe.
+    const sfpi::vFloat correction = PolynomialEvaluator::eval(
+        inv_abs_x,
+        3.9894214272e-01f,
+        4.9887448549e-02f,
+        2.7172168717e-02f,
+        4.6332854778e-02f,
+        -1.0997270793e-01f,
+        6.5736579895e-01f);
+
+    // i0 is even — no sign restoration needed (cf. i1's copysgn).
+    return exp_abs * rsqrt_y * correction;
+}
+
 inline void i0_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_i0() {
-#pragma GCC unroll 0
+    constexpr float I0_MAX_INPUT = 88.5f;
+    constexpr float I0_THRESHOLD = 6.0f;
 
+#pragma GCC unroll 1
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat result = 0.0f;
-        vFloat input = dst_reg[0];
-        vFloat x = input * input;
+        sfpi::vFloat x = sfpi::dst_reg[0];
 
-        result = 1.0f + POLYVAL10(
-                            1.50E-22f,
-                            7.24E-20f,
-                            2.90E-17f,
-                            9.39E-15f,
-                            2.40E-12f,
-                            4.71E-10f,
-                            6.78E-08f,
-                            0.000006781684028f,
-                            0.0004340277778f,
-                            0.015625f,
-                            0.25f,
-                            x);
+        // Clamp to [-88.5, 88.5] — exp() saturates near +/-88.7 in FP32.
+        x = sfpi::symmetric_clamp(x, I0_MAX_INPUT);
 
-        dst_reg[0] = result;
-        dst_reg++;
+        const sfpi::vFloat abs_x = sfpi::abs(x);
+
+        sfpi::vFloat val;
+        // ─── Polynomial path (always; valid for |x| <= 6) ────────────────
+        // Computed unconditionally and stored — its LRegs are then free
+        // for the asymptotic block to use.
+        //
+        // Coefficients are (1/4)^k/(k!)^2 for k = 1..11, rounded to FP32.
+        // The previous implementation carried these to only three
+        // significant figures, which cost ~52 FP32 ULP at |x| = 5 on its
+        // own — independent of, and masked by, the truncation problem.
+        {
+            const sfpi::vFloat t = x * x;
+            val = 1.0f + t * PolynomialEvaluator::eval(
+                                 t,
+                                 2.5000000000e-01f,
+                                 1.5625000000e-02f,
+                                 4.3402778101e-04f,
+                                 6.7816840783e-06f,
+                                 6.7816841920e-08f,
+                                 4.7095027877e-10f,
+                                 2.4028075536e-12f,
+                                 9.3859670063e-15f,
+                                 2.8969033031e-17f,
+                                 7.2422583611e-20f,
+                                 1.4963343367e-22f);
+        }
+
+        // ─── Asymptotic overwrite for OOD lanes (|x| > 6) ────────────────
+        v_if(abs_x > I0_THRESHOLD) { val = calculate_i0_asymptotic_(abs_x); }
+        v_endif;
+#ifndef INP_FLOAT32
+        val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);
+#endif
+        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -36,8 +36,19 @@ namespace ckernel::sfpu {
 //      Polynomial-path intermediates die at the store, freeing LRegs.
 //   2. v_if (|x|>6): overwrite DST with asymptotic result.
 //
-// Inputs are clamped to [-88.5, 88.5] to avoid exp() overflow; I0 stays
-// finite to ~88.5 in FP32 (I0(88.5) ~ 1.2e+37).
+// Overflow: I0 grows without bound, so |x| past the representable range
+// returns +inf rather than a clamped finite value. The computation is
+// still clamped to 88.5 (FP32 exp() saturates at 88.7228), and lanes above
+// that bound are then overwritten with +inf. i0(+/-inf) = +inf follows from
+// the same test.
+//
+// This matches ttnn's declared golden, torch.i0, which overflows to inf at
+// the same 88.7228 for the same reason (cf. the note on torch.sinh in
+// test_unary_fp32.py). The two differ only for FP32 inputs in the 0.22-wide
+// window (88.5, 88.7228), where torch still returns a finite value below
+// 1.45e+37; no bfloat16 value lands strictly inside it. The true I0 stays
+// representable to x = 91.9008 (I0 = 3.4028e+38), but no exp()-first
+// formulation can reach it without the intermediate overflowing.
 //
 // APPROXIMATION_MODE is accepted for call-site compatibility; both paths
 // are already the accurate ones and it does not select a cheaper route.
@@ -94,12 +105,15 @@ inline void calculate_i0() {
 
 #pragma GCC unroll 1
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat x = sfpi::dst_reg[0];
+        // i0 is even, so the sign is never needed: take |x| up front and clamp with a
+        // plain min. Strictly cheaper than symmetric_clamp() followed by abs(), which
+        // computes a copysgn() only for the abs() to discard it — and it leaves the
+        // unclamped magnitude live for the overflow test below at no extra LReg cost.
+        const sfpi::vFloat x = sfpi::dst_reg[0];
+        const sfpi::vFloat abs_x_in = sfpi::abs(x);
 
-        // Clamp to [-88.5, 88.5] — exp() saturates near +/-88.7 in FP32.
-        x = sfpi::symmetric_clamp(x, I0_MAX_INPUT);
-
-        const sfpi::vFloat abs_x = sfpi::abs(x);
+        // Clamp to 88.5 — exp() saturates near 88.7 in FP32.
+        const sfpi::vFloat abs_x = sfpi::min(abs_x_in, I0_MAX_INPUT);
 
         sfpi::vFloat val;
         // ─── Polynomial path (always; valid for |x| <= 6) ────────────────
@@ -111,7 +125,7 @@ inline void calculate_i0() {
         // significant figures, which cost ~52 FP32 ULP at |x| = 5 on its
         // own — independent of, and masked by, the truncation problem.
         {
-            const sfpi::vFloat t = x * x;
+            const sfpi::vFloat t = abs_x * abs_x;
             val = 1.0f + t * PolynomialEvaluator::eval(
                                  t,
                                  2.5000000000e-01f,
@@ -129,6 +143,28 @@ inline void calculate_i0() {
 
         // ─── Asymptotic overwrite for OOD lanes (|x| > 6) ────────────────
         v_if(abs_x > I0_THRESHOLD) { val = calculate_i0_asymptotic_(abs_x); }
+        v_endif;
+
+        // ─── Overflow: |x| past the representable range → +inf ───────────
+        // Tested on the *unclamped* magnitude. Without this, i0(1e4) would
+        // return i0(88.5) = 1.16e+37 — a silent wrong finite answer.
+        // i0(+/-inf) = +inf falls out of the same test.
+        v_if(abs_x_in > I0_MAX_INPUT) { val = std::numeric_limits<float>::infinity(); }
+        v_endif;
+
+        // ─── NaN in → NaN out ────────────────────────────────────────────
+        // The SFPU compare is not IEEE-ordered: NaN carries the maximal
+        // exponent and passes the > test above, so it would be converted to
+        // +inf. Detect it by bit pattern instead — exponent all ones with a
+        // non-zero mantissa — and restore it.
+        //
+        // Measured on Blackhole p150b: this restores NaN on the FP32 path.
+        // On the BF16 path NaN still emerges as +inf — a DRAM round-trip with
+        // no op returns NaN intact, so the payload is lost unpacking BF16 into
+        // DST, upstream of this branch. Both remain an improvement on the
+        // previous behaviour, where the input clamp mapped NaN to a finite
+        // 1.15e+37.
+        v_if(sfpi::exexp(abs_x_in) == 128 && sfpi::exman(abs_x_in) != 0) { val = abs_x_in; }
         v_endif;
 #ifndef INP_FLOAT32
         val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -17,38 +17,72 @@ namespace ckernel::sfpu {
 //
 // Two-region implementation, exploiting that i0 is even: i0(-x) = i0(x).
 //   |x| <= 6:  Maclaurin series, I0(x) = sum_k (x^2/4)^k / (k!)^2,
-//              truncated at k=11 (12 terms). Max rel err 1.4e-08.
+//              degree-8 minimax fit in t=x^2 (9 terms incl. the leading
+//              1.0), Remez-derived. Max rel err ~3.1e-07 in idealized
+//              arithmetic, dominated in practice by rounding t = fl(x*x)
+//              itself rather than by the polynomial fit — see the note
+//              below.
 //   |x| >  6:  asymptotic expansion (Abramowitz & Stegun 9.7.1)
 //                i0(x) = exp(|x|) / sqrt(|x|) * Q(1/|x|)
-//              degree-5 fit (6 coeffs), 1/sqrt(2*pi) folded into Q's
-//              leading term. Max rel err 4.7e-08 over [6, 88.5].
+//              FP32: degree-5 fit (6 coeffs). BF16: degree-4 fit (5
+//              coeffs) — one term shorter, since BF16 output precision
+//              cannot see the extra term (0/498 exhaustive BF16 values
+//              in [6, 88.5] differ from the correctly-rounded result).
+//              1/sqrt(2*pi) folded into Q's leading term in both.
 //
-// Worst case over [0, 88.5] is 4.7e-08 relative (~0.4 FP32 ULP), at the
-// handover. The threshold was chosen by sweeping it: the polynomial's
-// truncation grows and the asymptotic fit's residual shrinks with |x|,
-// and 6 is where the two curves cross. Above ~13 the polynomial alone
-// (the previous implementation) is unusable: 21% rel err at x=20, 89%
-// at x=30, because the series' largest term sits near k ~ x/2 and the
-// omitted tail — eventually the omitted peak itself — dominates.
+// Measured worst case over the full domain (200k-sample random sweep over
+// [-88.5, 88.5], both dtypes, same seed on both arches): 6.0 FP32 ULP (at
+// x = -5.93, inside region 1) and 0.91 BF16 ULP. Blackhole p150b and
+// Wormhole n300 silicon produced bit-identical results -- same worst-case
+// x, same output, same reference, to the last digit -- so the WH/BH source
+// identity this file maintains is measured equivalence, not an inference
+// from it. Identical to the pre-trim kernel's FP32 figure and marginally
+// better on BF16 -- trimming both regions did not measurably change
+// accuracy, confirming the analysis below. See tests/.../test_unary_i0.py's
+// _MAX_ULP for the test budget (12 / 2), which already carried headroom
+// over these numbers.
+//
+// Both regions were originally 3 terms longer (12-term Maclaurin, one
+// shared 6-term Q for both dtypes). The trim follows a silicon+analysis
+// review (tenstorrent/tt-metal#52126, comment 5265986150): compiling
+// standalone against the pinned sfpi build and counting the disassembly,
+// plus bit-exact FP32/BF16 Horner simulation against mpmath, showed the
+// extra terms cost real instructions (dominated by SFPLOADI coefficient
+// materialization) without measurable accuracy — because accuracy near
+// the region-1 boundary is bounded by FP32 rounding of t = fl(x*x), not
+// by truncation, and the region-2 rsqrt Newton step alone already costs
+// ~1.7 FP32 ULP, both floors well above what the trimmed terms bought.
+// This kernel's own independent Remez fit and FP32/BF16 simulation (see
+// tt-bounty/tt-metal/04/review-52126 for the scripts) reproduced those findings.
 //
 // Code shape (chosen to relieve SFPI LRA budget), mirroring i1:
 //   1. Compute polynomial result unconditionally and store to DST.
 //      Polynomial-path intermediates die at the store, freeing LRegs.
 //   2. v_if (|x|>6): overwrite DST with asymptotic result.
 //
-// Overflow: I0 grows without bound, so |x| past the representable range
-// returns +inf rather than a clamped finite value. The computation is
-// still clamped to 88.5 (FP32 exp() saturates at 88.7228), and lanes above
-// that bound are then overwritten with +inf. i0(+/-inf) = +inf follows from
-// the same test.
+// No input clamp: unlike the previous version, abs_x here is never
+// clamped to 88.5 before use. Every lane a clamp would change is a lane
+// with |x| > 88.5, and every one of those is unconditionally overwritten
+// below by the overflow branch — so a clamp only ever protects a value
+// that is then discarded. The unclamped polynomial/asymptotic paths can
+// produce garbage (even overflow to inf, or NaN for NaN input) on those
+// lanes; since SFPU lanes are independent and the garbage never reaches
+// the store, this is safe and costs nothing.
 //
-// This matches ttnn's declared golden, torch.i0, which overflows to inf at
-// the same 88.7228 for the same reason (cf. the note on torch.sinh in
-// test_unary_fp32.py). The two differ only for FP32 inputs in the 0.22-wide
-// window (88.5, 88.7228), where torch still returns a finite value below
-// 1.45e+37; no bfloat16 value lands strictly inside it. The true I0 stays
-// representable to x = 91.9008 (I0 = 3.4028e+38), but no exp()-first
-// formulation can reach it without the intermediate overflowing.
+// Overflow, +/-inf and NaN all resolve in one branch: multiplying by
+// infinity rather than assigning it handles all three cases from a
+// single predicate. Finite |x| > 88.5 gives +inf (FP32 exp() saturates
+// at 88.7228, matching torch's identical limitation — cf. the note on
+// torch.sinh in test_unary_fp32.py); +/-inf gives +inf; NaN stays NaN,
+// relying on SFPMUL propagating a NaN operand the same way
+// _sfpu_exp_fp32_accurate_ relies on 0*inf = NaN for the same purpose.
+// The true I0 stays representable to x = 91.9008 (I0 = 3.4028e+38), but
+// no exp()-first formulation can reach it without the intermediate
+// overflowing.
+//
+// On the BF16 path NaN still emerges as +inf regardless of this branch:
+// a DRAM round-trip with no op returns NaN intact, so the payload is
+// lost unpacking BF16 into DST, upstream of this kernel entirely.
 //
 // APPROXIMATION_MODE is accepted for call-site compatibility; both paths
 // are already the accurate ones and it does not select a cheaper route.
@@ -59,9 +93,10 @@ namespace ckernel::sfpu {
 // Note: this function must stay minimalist — SFPU LRA is limited.
 // Every operation here competes with the main loop.
 inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
-    // exp(|x|) — unsafe variants in both paths: |x| in [6, 88.5] precludes
-    // overflow/underflow, so the safe wrappers' clamping/guards are dead
-    // and skipped.
+    // exp(|x|) — unsafe variants in both paths. For the |x| in [6, 88.5] that
+    // reaches the store, overflow/underflow is impossible and the safe
+    // wrappers' clamping/guards would be dead code. Above 88.5 these wrap and
+    // return garbage; the caller overwrites those lanes unconditionally.
 #ifdef INP_FLOAT32
     const sfpi::vFloat exp_abs = _sfpu_exp_fp32_accurate_unsafe_(abs_x);
 #else
@@ -71,6 +106,14 @@ inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
     // 1/sqrt(|x|) via Quake-style magic constant + two Newton refinements.
     // Computed first so that 1/|x| can be derived as rsqrt_y^2 without a
     // separate sfpu_reciprocal call.
+    //
+    // Kept unconditional (not dtype-split): the Newton step is load-bearing
+    // for FP32 (dropping it costs ~343 FP32 ULP against a budget in the
+    // teens) and only marginal for BF16 (~0.2% of outputs move by 1 ULP,
+    // comfortably inside the existing 2-ULP BF16 test budget either way).
+    // Splitting it to save 4 instructions on the BF16 path was left alone: it
+    // would add a third dtype branch inside the kernel's most precision-
+    // sensitive block for the smallest of the four savings on the table.
     const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
     sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
     sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
@@ -82,7 +125,17 @@ inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
     const sfpi::vFloat inv_abs_x = rsqrt_y * rsqrt_y;
 
     // Q(y) on y in [1/88.5, 1/6]; leading term is 1/sqrt(2*pi) = 0.39894228.
-    // This outlined function does not stress the main loop's LRA, so full precision is safe.
+    // This outlined function does not stress the main loop's LRA, so full
+    // precision is safe.
+    //
+    // FP32: degree-5 (6 coeffs). BF16: degree-4 (5 coeffs) — one term
+    // shorter, verified against an exhaustive sweep of all BF16-representable
+    // values in [6, 88.5] (0/498 differ from the correctly-rounded result).
+    // Coefficients must stay FP32 in both cases: rounding the BF16 Q's
+    // leading term to BF16 (which would let sfpi use SFPADDI's 16-bit
+    // immediate instead of an SFPLOADI pair) costs 1.27e-03 relative on that
+    // term alone — four orders of magnitude above the accuracy budget.
+#ifdef INP_FLOAT32
     const sfpi::vFloat correction = PolynomialEvaluator::eval(
         inv_abs_x,
         3.9894214272e-01f,
@@ -91,6 +144,10 @@ inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
         4.6332854778e-02f,
         -1.0997270793e-01f,
         6.5736579895e-01f);
+#else
+    const sfpi::vFloat correction = PolynomialEvaluator::eval(
+        inv_abs_x, 3.9894300699e-01f, 4.9790032208e-02f, 3.0512193218e-02f, -9.7926484887e-04f, 1.8299004436e-01f);
+#endif
 
     // i0 is even — no sign restoration needed (cf. i1's copysgn).
     return exp_abs * rsqrt_y * correction;
@@ -103,68 +160,54 @@ inline void calculate_i0() {
     constexpr float I0_MAX_INPUT = 88.5f;
     constexpr float I0_THRESHOLD = 6.0f;
 
+    // Decorative but intentional: unroll 0, unroll 1, and no pragma at all
+    // produce byte-identical codegen here (-funroll-loops included), since
+    // sfpi lowers this loop's body through the 32-entry Tensix replay buffer
+    // regardless — dynamic work per datum stays flat all the way to unroll
+    // 8, while code size grows ~5.7x. Kept as documentation of that, not as
+    // a knob that does anything.
 #pragma GCC unroll 1
     for (int d = 0; d < ITERATIONS; d++) {
-        // i0 is even, so the sign is never needed: take |x| up front and clamp with a
-        // plain min. Strictly cheaper than symmetric_clamp() followed by abs(), which
-        // computes a copysgn() only for the abs() to discard it — and it leaves the
-        // unclamped magnitude live for the overflow test below at no extra LReg cost.
+        // i0 is even, so the sign is never needed: take |x| up front with a
+        // plain abs. No clamp — see the file-level comment for why an
+        // unclamped magnitude here is safe.
         const sfpi::vFloat x = sfpi::dst_reg[0];
-        const sfpi::vFloat abs_x_in = sfpi::abs(x);
-
-        // Clamp to 88.5 — exp() saturates near 88.7 in FP32.
-        const sfpi::vFloat abs_x = sfpi::min(abs_x_in, I0_MAX_INPUT);
+        const sfpi::vFloat abs_x = sfpi::abs(x);
 
         sfpi::vFloat val;
         // ─── Polynomial path (always; valid for |x| <= 6) ────────────────
-        // Computed unconditionally and stored — its LRegs are then free
-        // for the asymptotic block to use.
+        // Computed unconditionally so its LRegs are free for the asymptotic
+        // block to reuse.
         //
-        // Coefficients are (1/4)^k/(k!)^2 for k = 1..11, rounded to FP32.
-        // The previous implementation carried these to only three
-        // significant figures, which cost ~52 FP32 ULP at |x| = 5 on its
-        // own — independent of, and masked by, the truncation problem.
+        // Degree-8 minimax fit in t (Remez, weighted for relative I0 error),
+        // not truncated Maclaurin — a naive truncation at this degree is
+        // measurably worse. k = 1 and k = 2 are pinned to their exact
+        // Maclaurin values (1/4 and 1/64): both are BF16-representable, so
+        // sfpi folds them into SFPADDI's immediate instead of materialising
+        // them with an SFPLOADI pair.
         {
             const sfpi::vFloat t = abs_x * abs_x;
             val = 1.0f + t * PolynomialEvaluator::eval(
                                  t,
                                  2.5000000000e-01f,
                                  1.5625000000e-02f,
-                                 4.3402778101e-04f,
-                                 6.7816840783e-06f,
-                                 6.7816841920e-08f,
-                                 4.7095027877e-10f,
-                                 2.4028075536e-12f,
-                                 9.3859670063e-15f,
-                                 2.8969033031e-17f,
-                                 7.2422583611e-20f,
-                                 1.4963343367e-22f);
+                                 4.3402606389e-04f,
+                                 6.7823571044e-06f,
+                                 6.7718225694e-08f,
+                                 4.7797393821e-10f,
+                                 2.1436320601e-12f,
+                                 1.4051053479e-14f);
         }
 
         // ─── Asymptotic overwrite for OOD lanes (|x| > 6) ────────────────
         v_if(abs_x > I0_THRESHOLD) { val = calculate_i0_asymptotic_(abs_x); }
         v_endif;
 
-        // ─── Overflow: |x| past the representable range → +inf ───────────
-        // Tested on the *unclamped* magnitude. Without this, i0(1e4) would
-        // return i0(88.5) = 1.16e+37 — a silent wrong finite answer.
-        // i0(+/-inf) = +inf falls out of the same test.
-        v_if(abs_x_in > I0_MAX_INPUT) { val = std::numeric_limits<float>::infinity(); }
-        v_endif;
-
-        // ─── NaN in → NaN out ────────────────────────────────────────────
-        // The SFPU compare is not IEEE-ordered: NaN carries the maximal
-        // exponent and passes the > test above, so it would be converted to
-        // +inf. Detect it by bit pattern instead — exponent all ones with a
-        // non-zero mantissa — and restore it.
-        //
-        // Measured on Blackhole p150b: this restores NaN on the FP32 path.
-        // On the BF16 path NaN still emerges as +inf — a DRAM round-trip with
-        // no op returns NaN intact, so the payload is lost unpacking BF16 into
-        // DST, upstream of this branch. Both remain an improvement on the
-        // previous behaviour, where the input clamp mapped NaN to a finite
-        // 1.15e+37.
-        v_if(sfpi::exexp(abs_x_in) == 128 && sfpi::exman(abs_x_in) != 0) { val = abs_x_in; }
+        // ─── Overflow, +/-inf and NaN → +inf (NaN stays NaN) ─────────────
+        // See the file-level comment for the SFPMUL/NaN-propagation
+        // assumption this relies on, and why it replaces two branches
+        // (overflow-assign + bit-pattern NaN-restore) with one.
+        v_if(abs_x > I0_MAX_INPUT) { val = abs_x * std::numeric_limits<float>::infinity(); }
         v_endif;
 #ifndef INP_FLOAT32
         val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -45,16 +45,10 @@ namespace ckernel::sfpu {
 // exceed what a longer fit would buy, which is why each region uses only
 // as many terms as its own arithmetic can resolve.
 //
-// Code shape (chosen to relieve SFPI LRA budget), mirroring i1:
-//   1. Compute the region-1 result into a local `val`, inside a nested
-//      scope; the scope's closing brace retires `t`'s LReg immediately,
-//      freeing it for the asymptotic block below. No intermediate DST
-//      store/reload is involved -- unlike the store-then-reload idiom
-//      ckernel_sfpu_erfinv.h / ckernel_sfpu_gelu.h use for the same
-//      purpose.
-//   2. v_if (|x|>6): overwrite `val` (not DST) with the asymptotic result.
-//   3. One store: `dst_reg[0] = val`, after the overflow/NaN branch and
-//      the optional BF16 downconvert below.
+// Code shape (chosen to relieve SFPI LRA budget), mirroring i1: region-1's
+// result lives in a local `val` inside a nested scope, so its LRegs are
+// freed by the scope exit -- not a DST store/reload -- before the
+// asymptotic block needs them.
 //
 // No input clamp: abs_x is never clamped to 88.5 before use. Every lane
 // a clamp would change is a lane
@@ -66,18 +60,12 @@ namespace ckernel::sfpu {
 // the store, this is safe and costs nothing.
 //
 // Overflow and +/-inf both resolve to +inf here: multiplying by infinity
-// rather than assigning it lets one predicate cover both. This branch
-// fires for any finite |x| > 88.5 -- stricter than exp() itself needs.
-// FP32 exp() doesn't saturate until 88.7228 (cf. the note on torch.sinh
-// in test_unary_fp32.py), so for x in (88.5, 88.7228] the true value is
-// still finite and representable (I0(88.6) ~= 1.28e37) and
-// torch.special.i0 returns it, but this kernel returns +inf anyway: 88.5
-// is where Q's own Remez fit ends, not where exp() saturates. The gap is
-// invisible in BF16 (test_i0_all_bfloat16_bitpatterns in test_unary_i0.py:
-// no representable BF16 value lands inside that 0.22-wide window) and
-// only costs FP32 accuracy, on a band already deep in i0's exponential
-// blow-up. +/-inf gives +inf regardless. NaN survives regardless of
-// which branch it takes:
+// rather than assigning it lets one predicate cover both. The 88.5 cutoff
+// is Q's fitted boundary, not exp()'s true saturation point (88.7228) --
+// a narrow finite, torch-matching band above 88.5 also lands on +inf here,
+// accepted rather than re-fit since it's invisible in BF16 and already
+// deep in i0's exponential blow-up. NaN survives regardless of which
+// branch it takes:
 // lanes the compare excludes propagate NaN through ordinary arithmetic in
 // region 1, lanes it includes propagate NaN through this SFPMUL the same
 // way _sfpu_exp_fp32_accurate_ relies on 0*inf = NaN -- so correctness

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -46,9 +46,15 @@ namespace ckernel::sfpu {
 // as many terms as its own arithmetic can resolve.
 //
 // Code shape (chosen to relieve SFPI LRA budget), mirroring i1:
-//   1. Compute polynomial result unconditionally and store to DST.
-//      Polynomial-path intermediates die at the store, freeing LRegs.
-//   2. v_if (|x|>6): overwrite DST with asymptotic result.
+//   1. Compute the region-1 result into a local `val`, inside a nested
+//      scope; the scope's closing brace retires `t`'s LReg immediately,
+//      freeing it for the asymptotic block below. No intermediate DST
+//      store/reload is involved -- unlike the store-then-reload idiom
+//      ckernel_sfpu_erfinv.h / ckernel_sfpu_gelu.h use for the same
+//      purpose.
+//   2. v_if (|x|>6): overwrite `val` (not DST) with the asymptotic result.
+//   3. One store: `dst_reg[0] = val`, after the overflow/NaN branch and
+//      the optional BF16 downconvert below.
 //
 // No input clamp: abs_x is never clamped to 88.5 before use. Every lane
 // a clamp would change is a lane
@@ -60,10 +66,18 @@ namespace ckernel::sfpu {
 // the store, this is safe and costs nothing.
 //
 // Overflow and +/-inf both resolve to +inf here: multiplying by infinity
-// rather than assigning it lets one predicate cover both. Finite
-// |x| > 88.5 gives +inf (FP32 exp() saturates at 88.7228, matching torch's
-// identical limitation — cf. the note on torch.sinh in test_unary_fp32.py);
-// +/-inf gives +inf. NaN survives regardless of which branch it takes:
+// rather than assigning it lets one predicate cover both. This branch
+// fires for any finite |x| > 88.5 -- stricter than exp() itself needs.
+// FP32 exp() doesn't saturate until 88.7228 (cf. the note on torch.sinh
+// in test_unary_fp32.py), so for x in (88.5, 88.7228] the true value is
+// still finite and representable (I0(88.6) ~= 1.28e37) and
+// torch.special.i0 returns it, but this kernel returns +inf anyway: 88.5
+// is where Q's own Remez fit ends, not where exp() saturates. The gap is
+// invisible in BF16 (test_i0_all_bfloat16_bitpatterns in test_unary_i0.py:
+// no representable BF16 value lands inside that 0.22-wide window) and
+// only costs FP32 accuracy, on a band already deep in i0's exponential
+// blow-up. +/-inf gives +inf regardless. NaN survives regardless of
+// which branch it takes:
 // lanes the compare excludes propagate NaN through ordinary arithmetic in
 // region 1, lanes it includes propagate NaN through this SFPMUL the same
 // way _sfpu_exp_fp32_accurate_ relies on 0*inf = NaN -- so correctness
@@ -92,7 +106,7 @@ inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
 #ifdef INP_FLOAT32
     const sfpi::vFloat exp_abs = _sfpu_exp_fp32_accurate_unsafe_(abs_x);
 #else
-    const sfpi::vFloat exp_abs = _sfpu_exp_21f_bf16_unsafe_<true>(abs_x);
+    const sfpi::vFloat exp_abs = _sfpu_exp_21f_bf16_unsafe_<true /* is_fp32_dest_acc_en */>(abs_x);
 #endif
 
     // 1/sqrt(|x|) via Quake-style magic constant + two Newton refinements.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -36,32 +36,22 @@ namespace ckernel::sfpu {
 // Wormhole n300 silicon produced bit-identical results -- same worst-case
 // x, same output, same reference, to the last digit -- so the WH/BH source
 // identity this file maintains is measured equivalence, not an inference
-// from it. Identical to the pre-trim kernel's FP32 figure and marginally
-// better on BF16 -- trimming both regions did not measurably change
-// accuracy, confirming the analysis below. See tests/.../test_unary_i0.py's
-// _MAX_ULP for the test budget (12 / 2), which already carried headroom
-// over these numbers.
+// from it. See tests/.../test_unary_i0.py's _MAX_ULP for the test budget
+// (12 / 2), which carries headroom over these numbers.
 //
-// Both regions were originally 3 terms longer (12-term Maclaurin, one
-// shared 6-term Q for both dtypes). The trim follows a silicon+analysis
-// review (tenstorrent/tt-metal#52126, comment 5265986150): compiling
-// standalone against the pinned sfpi build and counting the disassembly,
-// plus bit-exact FP32/BF16 Horner simulation against mpmath, showed the
-// extra terms cost real instructions (dominated by SFPLOADI coefficient
-// materialization) without measurable accuracy — because accuracy near
-// the region-1 boundary is bounded by FP32 rounding of t = fl(x*x), not
-// by truncation, and the region-2 rsqrt Newton step alone already costs
-// ~1.7 FP32 ULP, both floors well above what the trimmed terms bought.
-// This kernel's own independent Remez fit and FP32/BF16 simulation (see
-// tt-bounty/tt-metal/04/review-52126 for the scripts) reproduced those findings.
+// Region-1 accuracy near the |x| = 6 boundary is bounded by FP32 rounding
+// of t = fl(x*x) rather than by the polynomial's degree, and the region-2
+// rsqrt Newton step alone costs ~1.7 FP32 ULP -- both floors already
+// exceed what a longer fit would buy, which is why each region uses only
+// as many terms as its own arithmetic can resolve.
 //
 // Code shape (chosen to relieve SFPI LRA budget), mirroring i1:
 //   1. Compute polynomial result unconditionally and store to DST.
 //      Polynomial-path intermediates die at the store, freeing LRegs.
 //   2. v_if (|x|>6): overwrite DST with asymptotic result.
 //
-// No input clamp: unlike the previous version, abs_x here is never
-// clamped to 88.5 before use. Every lane a clamp would change is a lane
+// No input clamp: abs_x is never clamped to 88.5 before use. Every lane
+// a clamp would change is a lane
 // with |x| > 88.5, and every one of those is unconditionally overwritten
 // below by the overflow branch — so a clamp only ever protects a value
 // that is then discarded. The unclamped polynomial/asymptotic paths can
@@ -69,13 +59,15 @@ namespace ckernel::sfpu {
 // lanes; since SFPU lanes are independent and the garbage never reaches
 // the store, this is safe and costs nothing.
 //
-// Overflow, +/-inf and NaN all resolve in one branch: multiplying by
-// infinity rather than assigning it handles all three cases from a
-// single predicate. Finite |x| > 88.5 gives +inf (FP32 exp() saturates
-// at 88.7228, matching torch's identical limitation — cf. the note on
-// torch.sinh in test_unary_fp32.py); +/-inf gives +inf; NaN stays NaN,
-// relying on SFPMUL propagating a NaN operand the same way
-// _sfpu_exp_fp32_accurate_ relies on 0*inf = NaN for the same purpose.
+// Overflow and +/-inf both resolve to +inf here: multiplying by infinity
+// rather than assigning it lets one predicate cover both. Finite
+// |x| > 88.5 gives +inf (FP32 exp() saturates at 88.7228, matching torch's
+// identical limitation — cf. the note on torch.sinh in test_unary_fp32.py);
+// +/-inf gives +inf. NaN survives regardless of which branch it takes:
+// lanes the compare excludes propagate NaN through ordinary arithmetic in
+// region 1, lanes it includes propagate NaN through this SFPMUL the same
+// way _sfpu_exp_fp32_accurate_ relies on 0*inf = NaN -- so correctness
+// does not depend on how SFPSETCC orders NaN against the threshold.
 // The true I0 stays representable to x = 91.9008 (I0 = 3.4028e+38), but
 // no exp()-first formulation can reach it without the intermediate
 // overflowing.
@@ -107,17 +99,14 @@ inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
     // Computed first so that 1/|x| can be derived as rsqrt_y^2 without a
     // separate sfpu_reciprocal call.
     //
-    // Kept unconditional (not dtype-split): the Newton step is load-bearing
-    // for FP32 (dropping it costs ~343 FP32 ULP against a budget in the
-    // teens) and only marginal for BF16 (~0.2% of outputs move by 1 ULP,
-    // comfortably inside the existing 2-ULP BF16 test budget either way).
-    // Splitting it to save 4 instructions on the BF16 path was left alone: it
-    // would add a third dtype branch inside the kernel's most precision-
-    // sensitive block for the smallest of the four savings on the table.
+    // Kept unconditional (not dtype-split): dropping the Newton step costs
+    // ~343 FP32 ULP against a budget in the teens, but only moves ~0.2% of
+    // BF16 outputs by 1 ULP -- not worth a third dtype branch in the
+    // kernel's most precision-sensitive block to save 4 BF16 instructions.
     const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
     sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
     sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
-    rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
+    rsqrt_y = rsqrt_y * (2.2825186f + c0 * (2.2533049f + c0));
     c0 = 1.0f + (-rsqrt_y) * (abs_x * rsqrt_y);
     rsqrt_y = c0 * sfpi::addexp(rsqrt_y, -1) + rsqrt_y;
 
@@ -155,17 +144,16 @@ inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
 
 inline void i0_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_i0() {
     constexpr float I0_MAX_INPUT = 88.5f;
     constexpr float I0_THRESHOLD = 6.0f;
 
     // Decorative but intentional: unroll 0, unroll 1, and no pragma at all
-    // produce byte-identical codegen here (-funroll-loops included), since
-    // sfpi lowers this loop's body through the 32-entry Tensix replay buffer
-    // regardless — dynamic work per datum stays flat all the way to unroll
-    // 8, while code size grows ~5.7x. Kept as documentation of that, not as
-    // a knob that does anything.
+    // produce byte-identical codegen here (-funroll-loops included) --
+    // dynamic work per datum stays flat all the way to unroll 8, while code
+    // size grows ~5.7x. Kept as documentation of that, not as a knob that
+    // does anything.
 #pragma GCC unroll 1
     for (int d = 0; d < ITERATIONS; d++) {
         // i0 is even, so the sign is never needed: take |x| up front with a
@@ -209,9 +197,16 @@ inline void calculate_i0() {
         // (overflow-assign + bit-pattern NaN-restore) with one.
         v_if(abs_x > I0_MAX_INPUT) { val = abs_x * std::numeric_limits<float>::infinity(); }
         v_endif;
-#ifndef INP_FLOAT32
-        val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);
-#endif
+
+        // Gated on the true DEST width, not INP_FLOAT32: a bf16-in/float32-out
+        // call (ttnn.i0(bf16_tensor, output_tensor=<float32 tensor>), a
+        // supported mixed-dtype combination) runs DEST in 32-bit mode with
+        // INP_FLOAT32 undefined, so this convert must key off
+        // is_fp32_dest_acc_en to avoid rounding a genuine FP32 output down
+        // to BF16 precision.
+        if constexpr (!is_fp32_dest_acc_en) {
+            val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);
+        }
         sfpi::dst_reg[0] = val;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/i0.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/i0.h
@@ -24,8 +24,10 @@ namespace ckernel {
  * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void i0_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_i0, (APPROX), idst, VectorMode::RC));
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE, is_fp32_dest_acc_en, calculate_i0, (APPROX, is_fp32_dest_acc_en), idst, VectorMode::RC));
 }
 
 /**

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -1215,7 +1215,7 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::i0)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_i0, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_i0, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::rdiv)
     {

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2974,7 +2974,8 @@ class UnarySFPUGolden:
         return self._torch_unary(x, torch.nn.functional.selu)
 
     def _i0(self, x):
-        # modified Bessel I0; kernel uses a poly approx valid on |x| <= 3.75.
+        # modified Bessel I0; two-region kernel: Maclaurin poly for |x| <= 6,
+        # asymptotic expansion beyond that up to the 88.5 overflow clamp.
         #
         # torch.special.i0 returns NaN at +/-inf. That is a torch limitation, not the
         # mathematics: I0 is even and increases without bound, so I0(+/-inf) = +inf -- which is

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2974,8 +2974,7 @@ class UnarySFPUGolden:
         return self._torch_unary(x, torch.nn.functional.selu)
 
     def _i0(self, x):
-        # modified Bessel I0; two-region kernel: Maclaurin poly for |x| <= 6,
-        # asymptotic expansion beyond that up to the 88.5 overflow clamp.
+        # modified Bessel I0; two-region kernel: Maclaurin |x| <= 6, asymptotic beyond.
         #
         # torch.special.i0 returns NaN at +/-inf. That is a torch limitation, not the
         # mathematics: I0 is even and increases without bound, so I0(+/-inf) = +inf -- which is

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -515,9 +515,12 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.Selu: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
     ),
-    # i0: modified Bessel I0; kernel poly approx is only valid on |x| <= 3.75
+    # i0: modified Bessel I0; two-region kernel -- Maclaurin poly for |x| <= 6,
+    # asymptotic expansion beyond that up to the 88.5 overflow clamp. Span past
+    # both boundaries so a single draw exercises the poly path, the asymptotic
+    # path, and the +inf overflow branch.
     MathOperation.I0: OperandSpecs(
-        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-3.75, high=3.75)
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-95.0, high=95.0)
     ),
     # i1: modified Bessel I1; poly path valid on |x| <= ~3.75 (asymptotic beyond)
     MathOperation.I1: OperandSpecs(

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -515,10 +515,8 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.Selu: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
     ),
-    # i0: modified Bessel I0; two-region kernel -- Maclaurin poly for |x| <= 6,
-    # asymptotic expansion beyond that up to the 88.5 overflow clamp. Span past
-    # both boundaries so a single draw exercises the poly path, the asymptotic
-    # path, and the +inf overflow branch.
+    # i0: two-region kernel (Maclaurin |x| <= 6, asymptotic + overflow clamp
+    # beyond); span past both so region 2 and overflow get exercised too.
     MathOperation.I0: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-95.0, high=95.0)
     ),

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
@@ -1553,14 +1553,15 @@ void py_module(nb::module_& mod) {
     bind_unary_operation_subcoregrids<"i0">(
         mod,
         &ttnn::i0,
-        R"doc(\mathrm{{output\_tensor}}_i = \verb|i0|(\mathrm{{input\_tensor}}_i))doc",
-        "",
-        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+        R"doc(\mathrm{{output\_tensor}}_i = I_0(\mathrm{{input\_tensor}}_i))doc",
+        "[Validated range: -88.5 to 88.5; inputs outside this range are clamped]",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc",
+        R"doc(Computes the modified Bessel function of the first kind of order 0.)doc");
     bind_unary_operation_subcoregrids<"i1">(
         mod,
         &ttnn::i1,
         R"doc(\mathrm{{output\_tensor}}_i = I_1(\mathrm{{input\_tensor}}_i))doc",
-        "[Validated range: -10 to 10]",
+        "[Validated range: -88.5 to 88.5; inputs outside this range are clamped]",
         R"doc(BFLOAT16, BFLOAT8_B)doc",
         R"doc(Computes the modified Bessel function of the first kind of order 1.)doc");
     bind_unary_operation_subcoregrids<"isfinite">(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
@@ -1554,7 +1554,7 @@ void py_module(nb::module_& mod) {
         mod,
         &ttnn::i0,
         R"doc(\mathrm{{output\_tensor}}_i = I_0(\mathrm{{input\_tensor}}_i))doc",
-        "[Validated range: -88.5 to 88.5; inputs outside this range are clamped]",
+        "[Validated range: -88.5 to 88.5; inputs outside this range return +inf]",
         R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc",
         R"doc(Computes the modified Bessel function of the first kind of order 0.)doc");
     bind_unary_operation_subcoregrids<"i1">(


### PR DESCRIPTION
### PR Category
Bug fix.

### Summary
Closes #50465

`ttnn.i0` computed the modified Bessel function I₀ with a single 12-term Maclaurin
series and no domain split. The series' largest term sits near k ≈ x/2, so 12 terms
hold only while x/2 stays comfortably under 11 — about x = 13. Past that the omitted
tail takes over, and past x ≈ 22 the omitted *peak* takes over. There is no branch, no
asymptotic, no clamp. It just returns a smaller number than it should, silently, well
inside the range where I₀ is perfectly representable.

This ports the two-region structure `ttnn.i1` has carried since #43246. I₀ is even, so
it is the simpler of the two — no odd symmetry, no `copysgn` on the result:

- `|x| <= 6` — the Maclaurin series, as before;
- `|x| > 6` — asymptotic `exp(|x|)/sqrt(2*pi*|x|) * Q(1/|x|)` (A&S 9.7.1), degree-5 fit
  with `1/sqrt(2*pi)` folded into Q's leading term;
- clamp at ±88.5, where `exp()` saturates in FP32.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217888402689314