### PR TITLE
[Bug fix] fix(eltwise): rpow_bw differentiates x**e instead of e**x

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_rpow.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_rpow.py
@@ -96,3 +96,53 @@ def test_bw_rpow_base_two_agrees_with_exp2_bw(input_shapes, device):
     assert torch.allclose(rpow_out, exp2_out, rtol=0.05, atol=1e-6), (
         "rpow_bw(x, 2.0) and exp2_bw(x) differ, but exp2(x) and rpow(x, 2.0) are the same function"
     )
+@pytest.mark.parametrize("exponent", (-2.0, -0.5, -10.0))
+@pytest.mark.parametrize("input_value", (-3.0, 0.0, 1.5, 7.0))
+def test_bw_rpow_negative_base_is_nan_everywhere(exponent, input_value, device):
+    # A negative base is only defined on integer inputs, so exponent ** input has no
+    # derivative with respect to input and the op promises NaN for every element.
+    # torch agrees: torch.pow(-2.0, x).backward() is NaN for every x.
+    #
+    # This is checked element by element on purpose. compare_pcc cannot see it: get_pcc
+    # zeroes NaN and Inf on both sides before correlating, so an all-NaN tensor and an
+    # all-zero one correlate perfectly.
+    shape = torch.Size([1, 1, 32, 32])
+    torch_input = torch.full(shape, input_value, dtype=torch.float32)
+    torch_grad = torch.ones(shape, dtype=torch.float32)
+
+    input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    grad_tensor = ttnn.from_torch(torch_grad, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    tt_out = ttnn.to_torch(ttnn.rpow_bw(grad_tensor, input_tensor, exponent)[0]).float()
+
+    assert torch.isnan(tt_out).all(), (
+        f"rpow_bw with negative base {exponent} at input {input_value} returned "
+        f"{tt_out.flatten()[0].item()}, but a negative base has no real derivative"
+    )
+
+
+@pytest.mark.parametrize("input_value", (-4.0, -0.25, 0.5, 6.0))
+def test_bw_rpow_zero_base_splits_at_zero(input_value, device):
+    # 0 ** input is 0 above zero and +inf below it, so the derivative the op promises is
+    # 0 above zero and -inf below it. Both halves are exact values, not approximations,
+    # and -inf is precisely what compare_pcc would normalize away.
+    shape = torch.Size([1, 1, 32, 32])
+    torch_input = torch.full(shape, input_value, dtype=torch.float32)
+    torch_grad = torch.ones(shape, dtype=torch.float32)
+
+    input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    grad_tensor = ttnn.from_torch(torch_grad, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    tt_out = ttnn.to_torch(ttnn.rpow_bw(grad_tensor, input_tensor, 0.0)[0]).float()
+
+    if input_value < 0.0:
+        expected = float("-inf")
+        assert torch.isinf(tt_out).all() and (tt_out < 0).all(), (
+            f"rpow_bw with base 0 at input {input_value} returned "
+            f"{tt_out.flatten()[0].item()}, expected {expected}"
+        )
+    else:
+        assert torch.equal(tt_out, torch.zeros_like(tt_out)), (
+            f"rpow_bw with base 0 at input {input_value} returned "
+            f"{tt_out.flatten()[0].item()}, expected 0"
+        )

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_rpow.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_rpow.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import torch
 import pytest
 import ttnn
@@ -22,15 +24,22 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
 @pytest.mark.parametrize(
     "exponent",
     (
-        1.5,
-        5.7,
         0.0,
+        0.5,
+        1.5,
+        2.0,
+        3.0,
+        5.7,
         15.2,
     ),
 )
 def test_bw_rpow(input_shapes, exponent, device):
+    # rpow(input, exponent) is exponent ** input, so the input range has to keep
+    # exponent ** input representable. The previous range of (-201, 199) saturated to
+    # inf or 0 for every exponent above ~1.6, which made the comparison meaningless.
+    # With (-20, 20) the largest value here is 15.2 ** 20 = 4.2e23, well inside bfloat16.
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -201, 199, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
 
     tt_output_tensor_on_device = ttnn.rpow_bw(grad_tensor, input_tensor, exponent)
 
@@ -38,3 +47,52 @@ def test_bw_rpow(input_shapes, exponent, device):
     golden_tensor = golden_function(grad_data, in_data, exponent)
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass
+
+
+@pytest.mark.parametrize("exponent", (2.0, 3.0, 10.0))
+@pytest.mark.parametrize("input_value", (-5.0, -0.5, -20.0))
+def test_bw_rpow_negative_input_has_a_finite_gradient(exponent, input_value, device):
+    # rpow(-5, 2) is 2 ** -5 = 0.03125, an ordinary number, so its derivative is ordinary
+    # too: ln(2) * 2 ** -5 = 0.02166. Negative inputs used to be overwritten with NaN.
+    #
+    # compare_pcc cannot catch this on its own: get_pcc zeroes NaN and Inf on both sides
+    # before correlating, so this test compares the values directly.
+    shape = torch.Size([1, 1, 32, 32])
+    torch_input = torch.full(shape, input_value, dtype=torch.float32)
+    torch_grad = torch.ones(shape, dtype=torch.float32)
+
+    input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    grad_tensor = ttnn.from_torch(torch_grad, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    tt_out = ttnn.to_torch(ttnn.rpow_bw(grad_tensor, input_tensor, exponent)[0]).float()
+
+    assert torch.isfinite(tt_out).all(), (
+        f"rpow_bw({exponent}) returned a non-finite gradient at input {input_value}, "
+        f"where the forward value {exponent} ** {input_value} is finite"
+    )
+
+    expected = math.log(exponent) * exponent**input_value
+    assert torch.allclose(tt_out, torch.full_like(tt_out, expected), rtol=0.05, atol=0.0), (
+        f"rpow_bw({exponent}) at input {input_value}: got {tt_out.flatten()[0].item()}, expected {expected}"
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+    ),
+)
+def test_bw_rpow_base_two_agrees_with_exp2_bw(input_shapes, device):
+    # ttnn.exp2(x) and ttnn.rpow(x, 2.0) compute the same function, so their backward
+    # passes have to agree. exp2_bw already implements grad * ln(2) * 2 ** x.
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
+
+    rpow_out = ttnn.to_torch(ttnn.rpow_bw(grad_tensor, input_tensor, 2.0)[0]).float()
+    exp2_out = ttnn.to_torch(ttnn.exp2_bw(grad_tensor, input_tensor)[0]).float()
+
+    assert torch.allclose(rpow_out, exp2_out, rtol=0.05, atol=1e-6), (
+        "rpow_bw(x, 2.0) and exp2_bw(x) differ, but exp2(x) and rpow(x, 2.0) are the same function"
+    )

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cmath>
 #include <numbers>
 #include <utility>
 #include "ttnn/operations/eltwise/unary_backward/unary_backward.hpp"
@@ -793,19 +794,34 @@ std::vector<Tensor> celu_bw(
     return grad_tensor;
 }
 
+// rpow: y = exponent ** input, i.e. the float parameter is the base, not the exponent
+// of input. See _golden_function_rpow in ttnn/ttnn/operations/unary.py and the kernel
+// comment in ckernel_sfpu_rpow.h.
+// bw (rpow) = grad * ln(exponent) * exponent ** input
+// This mirrors exp2_bw below, which is the same derivative with the base fixed at 2.
 std::vector<Tensor> rpow_bw(
     const Tensor& grad, const Tensor& input, float exponent, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    float t_nan = std::nanf("");
-    Tensor grad_result = ttnn::zeros_like(input, input.dtype(), input.layout(), std::nullopt, output_mem_config);
-    if (exponent != 0.0) {
-        grad_result = ttnn::multiply(
-            grad,
-            ttnn::multiply(pow(input, exponent - 1, output_mem_config), exponent, std::nullopt, output_mem_config),
-            std::nullopt,
-            output_mem_config);
-        grad_result = ttnn::where(ltz(input, output_mem_config), t_nan, grad_result, output_mem_config);
+    if (exponent < 0.0f) {
+        // A negative base is only defined on integer inputs, so exponent ** input has no
+        // derivative with respect to input: torch.pow(-2.0, x).backward() is NaN for every x.
+        Tensor grad_result =
+            ttnn::full_like(input, std::nanf(""), input.dtype(), input.layout(), std::nullopt, output_mem_config);
+        grad_tensor.emplace_back(grad_result);
+        return grad_tensor;
     }
+    if (exponent == 0.0f) {
+        // 0 ** input is 0 above zero and +inf below it, so the derivative is 0 above zero
+        // and -inf below it.
+        Tensor deriv = ttnn::where(
+            ttnn::ltz(input, output_mem_config), -std::numeric_limits<float>::infinity(), 0.0f, output_mem_config);
+        Tensor grad_result = ttnn::multiply(grad, deriv, std::nullopt, output_mem_config);
+        grad_tensor.emplace_back(grad_result);
+        return grad_tensor;
+    }
+    Tensor rpow_result = ttnn::rpow(input, exponent, output_mem_config);
+    rpow_result = ttnn::multiply(rpow_result, std::log(exponent), std::nullopt, output_mem_config);
+    Tensor grad_result = ttnn::multiply(grad, rpow_result, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_result);
     return grad_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cmath>
 #include <numbers>
 #include <utility>
 #include "ttnn/operations/eltwise/unary_backward/unary_backward.hpp"
@@ -804,19 +805,34 @@ std::vector<Tensor> celu_bw(
     return grad_tensor;
 }
 
+// rpow: y = exponent ** input, i.e. the float parameter is the base, not the exponent
+// of input. See _golden_function_rpow in ttnn/ttnn/operations/unary.py and the kernel
+// comment in ckernel_sfpu_rpow.h.
+// bw (rpow) = grad * ln(exponent) * exponent ** input
+// This mirrors exp2_bw below, which is the same derivative with the base fixed at 2.
 std::vector<Tensor> rpow_bw(
     const Tensor& grad, const Tensor& input, float exponent, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    float t_nan = std::nanf("");
-    Tensor grad_result = ttnn::zeros_like(input, input.dtype(), input.layout(), std::nullopt, output_mem_config);
-    if (exponent != 0.0) {
-        grad_result = ttnn::multiply(
-            grad,
-            ttnn::multiply(pow(input, exponent - 1, output_mem_config), exponent, std::nullopt, output_mem_config),
-            std::nullopt,
-            output_mem_config);
-        grad_result = ttnn::where(ltz(input, output_mem_config), t_nan, grad_result, output_mem_config);
+    if (exponent < 0.0f) {
+        // A negative base is only defined on integer inputs, so exponent ** input has no
+        // derivative with respect to input: torch.pow(-2.0, x).backward() is NaN for every x.
+        Tensor grad_result =
+            ttnn::full_like(input, std::nanf(""), input.dtype(), input.layout(), std::nullopt, output_mem_config);
+        grad_tensor.emplace_back(grad_result);
+        return grad_tensor;
     }
+    if (exponent == 0.0f) {
+        // 0 ** input is 0 above zero and +inf below it, so the derivative is 0 above zero
+        // and -inf below it.
+        Tensor deriv = ttnn::where(
+            ttnn::ltz(input, output_mem_config), -std::numeric_limits<float>::infinity(), 0.0f, output_mem_config);
+        Tensor grad_result = ttnn::multiply(grad, deriv, std::nullopt, output_mem_config);
+        grad_tensor.emplace_back(grad_result);
+        return grad_tensor;
+    }
+    Tensor rpow_result = ttnn::rpow(input, exponent, output_mem_config);
+    rpow_result = ttnn::multiply(rpow_result, std::log(exponent), std::nullopt, output_mem_config);
+    Tensor grad_result = ttnn::multiply(grad, rpow_result, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_result);
     return grad_tensor;
 }

--- a/ttnn/ttnn/operations/unary_backward.py
+++ b/ttnn/ttnn/operations/unary_backward.py
@@ -194,12 +194,20 @@ ttnn.attach_golden_function(
     ),
 )
 
-ttnn.attach_golden_function(
-    ttnn.rpow_bw,
-    golden_function=lambda grad, input, alpha, *args, **kwargs: _golden_function_unary_backward_with_float(
-        "pow", grad, input, alpha, *args, **kwargs
-    ),
-)
+def _golden_function_rpow_bw(grad_tensor, input_tensor, exponent, *args, **kwargs):
+    import torch
+
+    # ttnn.rpow(input, exponent) computes exponent ** input -- the float parameter is the
+    # base. See _golden_function_rpow in ttnn/ttnn/operations/unary.py, which returns
+    # torch.pow(dim, input_tensor_a). The gradient with respect to input is therefore
+    # ln(exponent) * exponent ** input.
+    pyt_y = torch.pow(exponent, input_tensor)
+    input_tensor.retain_grad()
+    pyt_y.backward(gradient=grad_tensor)
+    return [input_tensor.grad]
+
+
+ttnn.attach_golden_function(ttnn.rpow_bw, golden_function=_golden_function_rpow_bw)
 
 ttnn.attach_golden_function(
     ttnn.logiteps_bw,

--- a/ttnn/ttnn/operations/unary_backward.py
+++ b/ttnn/ttnn/operations/unary_backward.py
@@ -245,12 +245,20 @@ ttnn.attach_golden_function(
     ),
 )
 
-ttnn.attach_golden_function(
-    ttnn.rpow_bw,
-    golden_function=lambda grad, input, alpha, *args, **kwargs: _golden_function_unary_backward_with_float(
-        "pow", grad, input, alpha, *args, **kwargs
-    ),
-)
+def _golden_function_rpow_bw(grad_tensor, input_tensor, exponent, *args, **kwargs):
+    import torch
+
+    # ttnn.rpow(input, exponent) computes exponent ** input -- the float parameter is the
+    # base. See _golden_function_rpow in ttnn/ttnn/operations/unary.py, which returns
+    # torch.pow(dim, input_tensor_a). The gradient with respect to input is therefore
+    # ln(exponent) * exponent ** input.
+    pyt_y = torch.pow(exponent, input_tensor)
+    input_tensor.retain_grad()
+    pyt_y.backward(gradient=grad_tensor)
+    return [input_tensor.grad]
+
+
+ttnn.attach_golden_function(ttnn.rpow_bw, golden_function=_golden_function_rpow_bw)
 
 ttnn.attach_golden_function(
     ttnn.logiteps_bw,


### PR DESCRIPTION
### Prior work

`rpow` itself was reworked recently and carefully. **#28235** (*"Migrate rpow as LLK op"*, closing
#24199) reimplemented the forward as an LLK op and tabulated sixteen edge cases against the golden,
flagging the ones that still differ. Two rows of that table are worth repeating here, because they
settle the semantics from Tenstorrent's own measurements:

```
ttnn.rpow(-inf, 5)  ->  0        golden 0
ttnn.rpow(inf, 5)   ->  inf      golden inf
```

`rpow(-inf, 5) = 0` is `5**(-inf)`. Under the other reading it would be `(-inf)**5 = -inf`.

**That change touched twelve files, none of them `unary_backward.cpp`.** The backward was not part
of it, and still differentiates the other function. The backward has not been modified since it was
added in #6011 (March 2024) — an 82-line PR whose description is three CI links, with no review
comments and an empty parent issue, so the derivative was never stated anywhere to be checked
against.

### What is wrong

`ttnn.rpow(input, exponent)` computes `exponent ** input` — the float parameter is the **base**. But `rpow_bw` returns `grad * exponent * input ** (exponent - 1)`, which is the derivative of `input ** exponent`. It differentiates a different function from the one the forward computes, and then overwrites every negative input with NaN.

```
ttnn.rpow_bw(grad=1.0, input=10.0, exponent=2.0)  ->  20.0
correct: ln(2) * 2**10                            =   709.7827

ttnn.rpow_bw(grad=1.0, input=-5.0, exponent=2.0)  ->  NaN
correct: ln(2) * 2**-5                            =   0.021660849
```

The NaN case needs no measurement to see. `unary_backward.cpp:807` ends with

```cpp
grad_result = ttnn::where(ltz(input, output_mem_config), t_nan, grad_result, output_mem_config);
```

which is unconditional for any non-zero `exponent`. But `rpow(-5, 2)` is `2 ** -5 = 0.03125`, a perfectly ordinary number — there is nothing to sanitise. Half the domain returns NaN where the true gradient is finite.

### Current state measured on ttsim

ttsim, Wormhole, bf16, through `ttnn`, with `TT_METAL_DISABLE_SFPLOADMACRO=1`.

**First, that the float parameter is the base:**

```
rpow(10, 2) = 1024      2**10 = 1024      10**2 = 100
rpow(3, 2)  = 8         2**3  = 8         3**2  = 9
rpow(4, 3)  = 81        3**4  = 81        4**3  = 64
```

**Then the gradient. The measured output is not merely close to `e * x**(e-1)` — it is that value
exactly**, for every case:

| grad | x | e | `rpow_bw` returns | correct `ln(e) * e**x` | `e * x**(e-1)` |
|---|---|---|---|---|---|
| 1 | 10 | 2 | **20** | 709.783 | **20** |
| 1 | 3 | 2 | **6** | 5.54518 | **6** |
| 1 | 4 | 3 | **48** | 88.9876 | **48** |

The op differentiates `x**e` while the forward computes `e**x`.

> The negative half cannot be shown on ttsim: the simulator does not propagate NaN — a plain
> `ttnn.multiply(nan, 2)` returns `inf` there — so `rpow_bw(1, -5, 2)` reads back as `inf` rather
> than `NaN`. **The NaN claim rests on line 807 of the source, quoted above, not on this run.**

### That `rpow(x, e)` means `e ** x` is stated three times in this repository

1. The kernel comment, `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rpow.h:12`:
   ```cpp
   // ttnn.rpow(exponent, scalar_base) = pow(scalar_base, exponent)
   ```
   with the body computing `_sfpu_binary_power_(base_val_v, dst_reg[0])`.
2. The forward golden, `ttnn/ttnn/operations/unary.py:794-800`, returns `torch.pow(dim, input_tensor_a)`.
3. `ldexp_bw` at `binary_backward.cpp:347` computes `grad * ttnn::rpow(other, 2.0f)` and then multiplies by `std::numbers::ln2_v<float>` — that is `ln(2) * 2**x`, the correct derivative of `rpow`.

### The same file already contains the correct implementation

`exp2_bw` is `rpow_bw` with the base fixed at 2. `ttnn.exp2(x)` and `ttnn.rpow(x, 2.0)` are the same function, and 500 lines below the code under discussion, `unary_backward.cpp:1311-1321` does:

```cpp
// #  bw (exp2) = grad * exp2(input) * M_LN2
Tensor exp_result = ttnn::exp2(input, output_mem_config);
exp_result = ttnn::multiply(exp_result, std::numbers::ln2_v<float>, std::nullopt, output_mem_config);
Tensor result = ttnn::multiply(grad, exp_result, std::nullopt, output_mem_config);
```

So the repository differentiates `rpow` correctly in one place and incorrectly in the other. This PR makes `rpow_bw` do what `exp2_bw` does, with `std::log(exponent)` in place of `ln2`.

### Scale

Sweeping the input over all 34,299 distinct bfloat16 values for which `2**x` is finite and normal, with `exponent = 2.0` and `grad = 1.0`, 34,287 disagree with `ln(2) * 2**x`. That is **99.97%**. Of those, 17,148 (50.00%) are NaN while the true gradient is finite; the remaining 17,139 are finite but off by more than 1%. The 12 that agree are curve crossings.

I do not have a board. Those numbers come from reimplementing the composite in float32 and comparing against `torch`; the NaN half is provable from the source alone, as shown above. The change itself uses only constructs already present in `unary_backward.cpp` — `ttnn::rpow` (as in `binary_backward.cpp:347`), `ttnn::multiply(tensor, float, ...)` (as in `exp2_bw`), `ttnn::full_like` (as in `div_no_nan_bw:1301`) and `ttnn::where(tensor, float, float, ...)` (as at lines 405, 406 and 852).

### Why no test caught it

The golden registered for `rpow_bw` is the same wrong function. `ttnn/ttnn/operations/unary_backward.py:197-202` attaches `_golden_function_unary_backward_with_float("pow", ...)`, i.e. `torch.pow(input, alpha).backward()`, so the nightly test compares the kernel against its own error and cannot fail.

Three further layers sit on top of that:

- `test_backward_rpow.py` only parametrises non-integer exponents (`1.5`, `5.7`, `15.2`, `0.0`). For those, `torch.pow(negative, 1.5)` is also NaN, so kernel and golden agree on the 17,096 negative inputs by accident.
- Its input range is `(-201, 199)`. Under the correct semantics `15.2 ** 199` saturates, so most of the tensor is `inf` or `0` on both sides.
- `get_pcc` (`ttnn/tt_lib/_internal/comparison_funcs.py`) sets every NaN and Inf to 0 in both tensors before correlating, so a NaN-vs-finite divergence is invisible to `compare_pcc` by construction.

The sweep at `tests/sweep_framework/sweeps/eltwise/unary_backward/rpow_bw/rpow_bw.py` is filed under the suite named `"xfail"`.

### What this PR changes

- `unary_backward.cpp` — `rpow_bw` computes `grad * ln(exponent) * exponent ** input`, and the unconditional NaN for negative inputs is removed. A negative **base** now returns NaN (`torch.pow(-2.0, x).backward()` is NaN for every `x`, integer or not), and base `0` returns `0` above zero and `-inf` below, matching `torch`.
- `unary_backward.py` — the golden mirrors the forward: `torch.pow(exponent, input).backward()`. Without this, the corrected kernel would fail CI against the old golden.
- `test_backward_rpow.py` — integer exponents added; the input range narrowed to `(-20, 20)` so `exponent ** input` stays representable; a direct-value test for negative inputs that does not go through `compare_pcc`; and a test asserting `rpow_bw(x, 2.0)` agrees with `exp2_bw(x)`.

### Deliberately not changed

`get_pcc` zeroing NaN and Inf makes the whole `*_bw` family blind to this class of divergence, not just `rpow_bw`. That felt like a separate change, so this PR works around it in the new test rather than touching the comparator.

### Scope

Files touched:

- `ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp` — `rpow_bw` only.
- `ttnn/ttnn/operations/unary_backward.py` — the golden registered for `rpow_bw`.
- `tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_rpow.py`.

**Not touched:** the forward `rpow` and its kernels (`ckernel_sfpu_rpow.h` on either
architecture) — the forward is correct and this PR does not go near it. Also unchanged: function
signatures, Python bindings, the dispatch path, and every other op in `unary_backward.cpp`.

The golden change is not cosmetic and is called out on purpose: the registered golden differentiates
the same wrong function, so **correcting the kernel alone would turn CI red**. Both have to move
together, and that is the reason this PR touches a `.py` file at all.

### Test plan

- [x] Reimplemented both the current and the patched expression in float32 and compared against
      float64 over the reported range
- [x] Negative control: in-range values are **bit-identical** before and after
- [ ] **Not run on hardware — I do not have a Tenstorrent device.** The numbers above come from a
      float32 emulation of the same arithmetic, not from silicon.

### References

`#48204` (*[Bug fix] clamp_bw / clip_bw: fix inverted ge/le in tensor*, merged 2026-06-26) fixed a
comparison defect in a backward op in this same file, with the same shape of change: a corrected
expression plus a regression case, no signature or dispatch changes.

---

<sub>Written with AI assistance. I reviewed the change, ran the verification above myself, and I am
responsible for the submission.</sub>
