### PR TITLE
[Bug fix] tril/triu return NaN for non-finite inputs

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -444,3 +444,48 @@ def test_unary_composite_clamp_int_ttnn(input_shapes, min_val, max_val, device, 
         golden_tensor = golden_function(in_data1, min, max)
         comp_pass = compare_pcc([output_tensor], [golden_tensor])
         assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    ((torch.float32, ttnn.float32), (torch.bfloat16, ttnn.bfloat16)),
+    ids=("float32", "bfloat16"),
+)
+@pytest.mark.parametrize("ttnn_op", (ttnn.tril, ttnn.triu), ids=("tril", "triu"))
+def test_unary_composite_trilu_non_finite_ttnn(
+    input_shapes, torch_dtype, ttnn_dtype, ttnn_op, device
+):
+    # The masked-out triangle is defined as zero, and the registered goldens are
+    # torch.tril / torch.triu, which return zero there. Composing the mask as a
+    # multiply agrees with that only for finite operands: -inf * 0 is NaN.
+    #
+    # float32 is the failing path. bfloat16 already returns zero and is covered
+    # here so a later change cannot regress it quietly -- it is not padding: the
+    # two dtypes genuinely differ today, so a test that only ran bfloat16 would
+    # pass without the fix.
+    #
+    # The existing tril/triu coverage draws from [-100, 100], here and in
+    # tests/sweep_framework/sweeps/eltwise/unary/{tril,triu}, so non-finite
+    # inputs are not exercised anywhere.
+    in_data = torch.full(input_shapes, float("-inf"), dtype=torch_dtype)
+    input_tensor = ttnn.from_torch(
+        in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+    output_tensor = ttnn.to_torch(ttnn_op(input_tensor))
+    golden_tensor = ttnn.get_golden_function(ttnn_op)(in_data)
+
+    n_nan = int(torch.isnan(output_tensor).sum())
+    assert n_nan == 0, (
+        f"{ttnn_op.__name__}(-inf) [{torch_dtype}] returned {n_nan} NaN of "
+        f"{output_tensor.numel()}; the golden has "
+        f"{int(torch.isnan(golden_tensor).sum())}"
+    )
+    assert torch.equal(output_tensor, golden_tensor)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -314,7 +314,11 @@ Tensor tril(const Tensor& input_a, std::int32_t diag, const std::optional<Memory
         Layout::TILE,
         input_a.device(),
         output_mem_config.value_or(input_a.memory_config()));
-    return ttnn::multiply(input_a, index_l, std::nullopt, output_mem_config);
+    // where, not multiply. A masked-out element is defined as zero, but
+    // -inf * 0 and inf * 0 are NaN, so any non-finite input turns the masked
+    // triangle into NaN instead of zero. Multiplication is only equivalent to
+    // masking for finite operands; selection is what tril/triu actually mean.
+    return ttnn::where(index_l, input_a, 0.0f, output_mem_config);
 }
 
 // triu : select upper triangular region of input matrix
@@ -327,7 +331,11 @@ Tensor triu(const Tensor& input_a, std::int32_t diag, const std::optional<Memory
         Layout::TILE,
         input_a.device(),
         output_mem_config.value_or(input_a.memory_config()));
-    return ttnn::multiply(input_a, index_u, std::nullopt, output_mem_config);
+    // where, not multiply. A masked-out element is defined as zero, but
+    // -inf * 0 and inf * 0 are NaN, so any non-finite input turns the masked
+    // triangle into NaN instead of zero. Multiplication is only equivalent to
+    // masking for finite operands; selection is what tril/triu actually mean.
+    return ttnn::where(index_u, input_a, 0.0f, output_mem_config);
 }
 
 // polygamma ψ^(n)(x): implemented via a fused SFPU kernel using a finite-sum + tail approximation.


### PR DESCRIPTION
### Ticket

Fixes #52038.

### What's wrong

With a `float32` input, `ttnn.tril` and `ttnn.triu` return `NaN` in the masked-out triangle
whenever the input is not finite. The masked-out region is defined as zero, and the golden
functions registered for these ops are literally `torch.tril` and `torch.triu`, which return
zero there.

```
input = full([5, 5], -inf), triu(diagonal=1)

golden (torch.triu)              ttnn.triu today
  0  -inf -inf -inf -inf          nan  -inf -inf -inf -inf
  0    0  -inf -inf -inf          nan   nan -inf -inf -inf
  0    0    0  -inf -inf          nan   nan  nan -inf -inf
  0    0    0    0  -inf          nan   nan  nan  nan -inf
  0    0    0    0    0           nan   nan  nan  nan  nan
```

15 NaN where the golden has none.

### Cause

Both are composed as a multiply against a 0/1 index mask
(`unary_composite_op.cpp`):

```cpp
Tensor index_u = ttnn::index_triu<::bfloat16>(...);
return ttnn::multiply(input_a, index_u, std::nullopt, output_mem_config);
```

`index_trilu` fills that mask with a boolean cast — `int32_t value = (x >= (y + diag))` — so the
masked-out entries are exactly `0.0`. Multiplication is equivalent to masking only for finite
operands: `-inf * 0` and `inf * 0` are `NaN` under IEEE-754, and `nan * 0` stays `NaN`.

### Scope: float32 only, measured

`bfloat16` is unaffected. Measured on ttsim 1.9.7, `Arch.BLACKHOLE`, `ttnn.triu(diagonal=1)` on a
32×32 tile, counting the 528 masked-out cells:

| input | dtype | zero | NaN |
|---|---|---|---|
| `-inf` | **float32** | 0 | **528** |
| `-inf` | bfloat16 | 528 | 0 |
| `-1e30` | float32 | 528 | 0 |
| `-1.0` | float32 | 528 | 0 |

The finite controls rule out the masking itself: it is specifically a non-finite input on the
`float32` path.

Worth stating plainly because the obvious motivating example does **not** apply — the CLIP
tutorial in `ttnn/tutorials/basic_python/` builds exactly this kind of additive `-inf` mask, but
it does so in `bfloat16`, so it is not affected. The case that bites is the same construction in
`float32`, which is the default an eager PyTorch port lands on.

### Why no test catches it


Every existing path draws finite inputs:

| coverage | range |
|---|---|
| `test_composite.py::test_unary_composite_{tril,triu}_ttnn` | `data_gen_with_range(..., -100, 100, ...)` |
| `tests/sweep_framework/sweeps/eltwise/unary/{tril,triu}` | `torch_random(low=-100, high=100)` |

With finite operands `multiply` and masking agree exactly, so the composition is correct
everywhere it is currently exercised.

### Fix

Select instead of multiplying:

```cpp
return ttnn::where(index_u, input_a, 0.0f, output_mem_config);
```

`where` with a scalar false-value is already the idiom in this file — `clamp` uses the same
`where(predicate, tensor, scalar, memory_config)` shape a hundred lines up — and
`TensorScalarVariant` takes the `float` directly.

The dispatch matters here, so I checked it rather than assuming. `where(Tensor, Tensor, float)`
resolves to the TTS overload in `ternary.cpp`, which goes to
`where_operation_with_scalar<WHERE_TTS>` and the SFPU kernel. It does **not** reach
`ternary_utils::where_impl`, which is itself built out of
`multiply(gtz(p), a) + multiply(lez(p), b)` and would reproduce this exact defect.

I verified the primitive on ttsim 1.9.7 (blackhole) rather than trusting that reading — SFPU
`where` with `-inf` on the taken branch, over 2048 elements:

| dest | taken branch | untaken branch | NaN in untaken |
|---|---|---|---|
| bfloat16 | `-inf` | `0.0` | **0 / 2048** |
| float32 | `-inf` | `0.0` | **0 / 2048** |

It selects; it does not arithmetically combine.

### Verification

I do not have hardware and could not build ttnn here, so the change itself is not executed
end-to-end. What is measured:

- The composition's arithmetic, against the registered goldens: `multiply(full(-inf), mask)`
  gives 15 NaN on a 5×5 with `diagonal=1`; `torch.triu` gives 0; `where(mask, input, 0)` matches
  the golden exactly. With finite inputs all three agree, which is the control.
- The SFPU `where` behaviour with `-inf`, on ttsim, in the table above.

What is not: that the patched file compiles, and that the device reproduces the torch result for
the full op. The added test in `test_composite.py` covers both on your CI.

### Scope

`tril` and `triu` only. `index_trilu` and the mask semantics are untouched, and finite inputs
produce bit-identical output — the masked lanes were already exactly `0.0` and now come from the
selection rather than from a multiply.

---

<sub>Written with AI assistance. I reviewed the change, ran the measurements above myself, and I
am responsible for the submission.</sub>
