### PR TITLE
Default CB tracking for tt-smi to off

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -602,11 +602,12 @@ bool Device::initialize(
         return true;
     }
 
-    // Create shared memory stats provider (disabled by default, re-enable with TT_METAL_SHM_TRACKING_DISABLED=0).
+    // Create shared memory stats provider (enabled by default, disable with TT_METAL_SHM_TRACKING_DISABLED=1).
     // Snapshot the SHM rtoptions once here -- they are process-wide debug toggles, so capturing
     // them at construction time avoids the SHM helpers having to look up a MetalContext on every
     // allocation (and avoids any "find any context" walk that mock+silicon coexistence forced).
     const bool shm_tracking_disabled = context_->rtoptions().get_shm_tracking_disabled();
+    const bool shm_cb_tracking_enabled = context_->rtoptions().get_shm_cb_tracking_enabled();
     const bool shm_verbose = context_->rtoptions().get_shm_verbose();
     if (!shm_tracking_disabled) {
         // Use UMD's chip_unique_ids for globally unique chip identification.
@@ -649,8 +650,8 @@ bool Device::initialize(
             asic_id = this->id_;
         }
 
-        shm_stats_provider_ =
-            std::make_unique<SharedMemoryStatsProvider>(asic_id, this->id_, shm_tracking_disabled, shm_verbose);
+        shm_stats_provider_ = std::make_unique<SharedMemoryStatsProvider>(
+            asic_id, this->id_, shm_tracking_disabled, shm_cb_tracking_enabled, shm_verbose);
         log_debug(tt::LogMetal, "Shared memory tracking enabled for device {}, asic_id=0x{:x}", this->id_, asic_id);
 
         // Register ShmTrackingProcessor globally once (when first device with SHM is created).

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -602,7 +602,7 @@ bool Device::initialize(
         return true;
     }
 
-    // Create shared memory stats provider (enabled by default, disable with TT_METAL_SHM_TRACKING_DISABLED=1).
+    // Create shared memory stats provider (disabled by default, re-enable with TT_METAL_SHM_TRACKING_DISABLED=0).
     // Snapshot the SHM rtoptions once here -- they are process-wide debug toggles, so capturing
     // them at construction time avoids the SHM helpers having to look up a MetalContext on every
     // allocation (and avoids any "find any context" walk that mock+silicon coexistence forced).

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.cpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.cpp
@@ -35,7 +35,7 @@ SharedMemoryStatsProvider::SharedMemoryStatsProvider(
     device_id_(device_id),
     shm_fd_(-1),
     region_(nullptr),
-    // Per-PID tracking is enabled by default and disabled by TT_METAL_SHM_TRACKING_DISABLED=1.
+    // Per-PID tracking is disabled by default and re-enabled by TT_METAL_SHM_TRACKING_DISABLED=0.
     // The flag is captured once at construction (passed in by Device::initialize from its
     // MetalContext's rtoptions) -- it's a process-wide debug toggle, no need to look it up
     // again per allocation.

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.cpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.cpp
@@ -30,16 +30,17 @@ class Allocator;
 // Implementation of SharedMemoryStatsProvider
 
 SharedMemoryStatsProvider::SharedMemoryStatsProvider(
-    uint64_t asic_id, int device_id, bool tracking_disabled, bool verbose) :
+    uint64_t asic_id, int device_id, bool tracking_disabled, bool cb_tracking_enabled, bool verbose) :
     asic_id_(asic_id),
     device_id_(device_id),
     shm_fd_(-1),
     region_(nullptr),
-    // Per-PID tracking is disabled by default and re-enabled by TT_METAL_SHM_TRACKING_DISABLED=0.
+    // Per-PID tracking is enabled by default and disabled by TT_METAL_SHM_TRACKING_DISABLED=1.
     // The flag is captured once at construction (passed in by Device::initialize from its
     // MetalContext's rtoptions) -- it's a process-wide debug toggle, no need to look it up
     // again per allocation.
     per_pid_tracking_enabled_(!tracking_disabled),
+    cb_tracking_enabled_(cb_tracking_enabled),
     verbose_enabled_(verbose),
     is_creator_(false) {
     // Format: /tt_device_<chip_unique_id>_memory

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
@@ -189,8 +189,6 @@ public:
     void set_per_pid_tracking(bool enabled) { per_pid_tracking_enabled_ = enabled; }
     bool is_per_pid_tracking_enabled() const { return per_pid_tracking_enabled_; }
 
-    bool is_cb_tracking_enabled() const { return cb_tracking_enabled_; }
-
 private:
     uint64_t asic_id_;               // UMD chip_unique_id (for SHM naming)
     int device_id_;                  // Logical Metal device ID (for internal tracking)

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
@@ -104,8 +104,12 @@ public:
     // tracking_disabled: process-wide TT_METAL_SHM_TRACKING_DISABLED flag, captured at
     //                    construction time from the owning Device's MetalContext rtoptions
     //                    so the SHM provider does not need to walk MetalContext slots later
+    // cb_tracking_enabled: process-wide TT_METAL_SHM_CB_TRACKING_ENABLED flag, captured the same way.
+    //                    Gates the expensive per-program CB aggregation (update_from_allocator);
+    //                    off by default so only the CB column is dropped, not the whole feature.
     // verbose: process-wide TT_METAL_SHM_VERBOSE flag, captured the same way
-    SharedMemoryStatsProvider(uint64_t asic_id, int device_id, bool tracking_disabled, bool verbose);
+    SharedMemoryStatsProvider(
+        uint64_t asic_id, int device_id, bool tracking_disabled, bool cb_tracking_enabled, bool verbose);
 
     // Destructor unmaps shared memory and closes file descriptor
     // NOTE: SHM file persists (like UMD locks) - not deleted on process exit
@@ -181,9 +185,12 @@ public:
     // Get composite asic_id
     uint64_t asic_id() const { return asic_id_; }
 
-    // Enable/disable per-PID tracking (default: disabled, re-enable with TT_METAL_SHM_TRACKING_DISABLED=0)
+    // Enable/disable per-PID tracking (default: enabled, disable with TT_METAL_SHM_TRACKING_DISABLED=1)
     void set_per_pid_tracking(bool enabled) { per_pid_tracking_enabled_ = enabled; }
     bool is_per_pid_tracking_enabled() const { return per_pid_tracking_enabled_; }
+
+    // Whether the expensive per-program CB aggregation runs (TT_METAL_SHM_CB_TRACKING_ENABLED).
+    bool is_cb_tracking_enabled() const { return cb_tracking_enabled_; }
 
 private:
     uint64_t asic_id_;               // UMD chip_unique_id (for SHM naming)
@@ -191,6 +198,7 @@ private:
     int shm_fd_;                     // Shared memory file descriptor
     DeviceMemoryRegion* region_;     // Mapped shared memory region
     bool per_pid_tracking_enabled_;  // Enable detailed per-PID tracking
+    bool cb_tracking_enabled_;       // Cached TT_METAL_SHM_CB_TRACKING_ENABLED flag (process-wide)
     bool verbose_enabled_;           // Cached TT_METAL_SHM_VERBOSE flag (process-wide)
     bool is_creator_;                // True if this process created the shared memory
 

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
@@ -181,7 +181,7 @@ public:
     // Get composite asic_id
     uint64_t asic_id() const { return asic_id_; }
 
-    // Enable/disable per-PID tracking (default: enabled, disable with TT_METAL_SHM_TRACKING_DISABLED=1)
+    // Enable/disable per-PID tracking (default: disabled, re-enable with TT_METAL_SHM_TRACKING_DISABLED=0)
     void set_per_pid_tracking(bool enabled) { per_pid_tracking_enabled_ = enabled; }
     bool is_per_pid_tracking_enabled() const { return per_pid_tracking_enabled_; }
 

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
@@ -105,8 +105,8 @@ public:
     //                    construction time from the owning Device's MetalContext rtoptions
     //                    so the SHM provider does not need to walk MetalContext slots later
     // cb_tracking_enabled: process-wide TT_METAL_SHM_CB_TRACKING_ENABLED flag, captured the same way.
-    //                    Gates the expensive per-program CB aggregation (update_from_allocator);
-    //                    off by default so only the CB column is dropped, not the whole feature.
+    //                    Gates per-program CB aggregation (update_from_allocator);
+    //                    off by default so only the CB column is dropped.
     // verbose: process-wide TT_METAL_SHM_VERBOSE flag, captured the same way
     SharedMemoryStatsProvider(
         uint64_t asic_id, int device_id, bool tracking_disabled, bool cb_tracking_enabled, bool verbose);
@@ -189,7 +189,6 @@ public:
     void set_per_pid_tracking(bool enabled) { per_pid_tracking_enabled_ = enabled; }
     bool is_per_pid_tracking_enabled() const { return per_pid_tracking_enabled_; }
 
-    // Whether the expensive per-program CB aggregation runs (TT_METAL_SHM_CB_TRACKING_ENABLED).
     bool is_cb_tracking_enabled() const { return cb_tracking_enabled_; }
 
 private:

--- a/tt_metal/impl/memory_tracking/update_allocator_stats.cpp
+++ b/tt_metal/impl/memory_tracking/update_allocator_stats.cpp
@@ -15,6 +15,14 @@ namespace tt::tt_metal {
 // Query ONLY locally-allocated CBs (device->get_total_cb_allocated() only counts local CBs)
 // Globally-allocated CBs create L1 Buffers and are already tracked in L1 column
 void SharedMemoryStatsProvider::update_from_allocator(const Device* device, pid_t pid) {
+    // reviewer: narrow to CB-only. Per-program CB aggregation (device->get_total_cb_allocated())
+    // rescans all active programs and is the only expensive part of SHM tracking, so it is gated
+    // OFF by default (TT_METAL_SHM_CB_TRACKING_ENABLED). The cheap DRAM/L1/L1_SMALL/TRACE columns
+    // are updated on the record_allocation() fast path and are unaffected -- only the CB column
+    // reads 0 when this is disabled.
+    if (!cb_tracking_enabled_) {
+        return;
+    }
     if (!region_ || !device) {
         return;
     }

--- a/tt_metal/impl/memory_tracking/update_allocator_stats.cpp
+++ b/tt_metal/impl/memory_tracking/update_allocator_stats.cpp
@@ -15,11 +15,6 @@ namespace tt::tt_metal {
 // Query ONLY locally-allocated CBs (device->get_total_cb_allocated() only counts local CBs)
 // Globally-allocated CBs create L1 Buffers and are already tracked in L1 column
 void SharedMemoryStatsProvider::update_from_allocator(const Device* device, pid_t pid) {
-    // reviewer: narrow to CB-only. Per-program CB aggregation (device->get_total_cb_allocated())
-    // rescans all active programs and is the only expensive part of SHM tracking, so it is gated
-    // OFF by default (TT_METAL_SHM_CB_TRACKING_ENABLED). The cheap DRAM/L1/L1_SMALL/TRACE columns
-    // are updated on the record_allocation() fast path and are unaffected -- only the CB column
-    // reads 0 when this is disabled.
     if (!cb_tracking_enabled_) {
         return;
     }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -1675,8 +1675,8 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
 
         // TT_METAL_SHM_TRACKING_DISABLED
         // Disable shared memory tracking for tt-smi.
-        // Default: 0 (SHM tracking enabled)
-        // Usage: export TT_METAL_SHM_TRACKING_DISABLED=1
+        // Default: 1 (SHM tracking disabled)
+        // Usage: export TT_METAL_SHM_TRACKING_DISABLED=0  (to re-enable tracking)
         case EnvVarID::TT_METAL_SHM_TRACKING_DISABLED: this->shm_tracking_disabled = is_env_enabled(value); break;
 
         // TT_METAL_SHM_VERBOSE

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -1676,15 +1676,13 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         case EnvVarID::TT_METAL_ALLOCATOR_MODE_HYBRID: this->allocator_mode_hybrid = is_env_enabled(value); break;
 
         // TT_METAL_SHM_TRACKING_DISABLED
-        // Disable shared memory tracking for tt-smi (whole feature).
+        // Disable shared memory tracking for tt-smi.
         // Default: 0 (SHM tracking enabled)
         // Usage: export TT_METAL_SHM_TRACKING_DISABLED=1
         case EnvVarID::TT_METAL_SHM_TRACKING_DISABLED: this->shm_tracking_disabled = is_env_enabled(value); break;
 
         // TT_METAL_SHM_CB_TRACKING_ENABLED
-        // Enable per-program CB (circular buffer) aggregation, the only expensive part of SHM
-        // tracking (it rescans all active programs on every program dispatch). Off by default so
-        // DRAM/L1/L1_SMALL/TRACE tracking stays live while only the CB column reads 0.
+        // Enable per-program CB (circular buffer) aggregation tracking.
         // Default: 0 (CB aggregation disabled)
         // Usage: export TT_METAL_SHM_CB_TRACKING_ENABLED=1
         case EnvVarID::TT_METAL_SHM_CB_TRACKING_ENABLED: this->shm_cb_tracking_enabled = is_env_enabled(value); break;

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -92,33 +92,34 @@ enum class EnvVarID {
     // ========================================
     // HARDWARE CONFIGURATION
     // ========================================
-    TT_METAL_ENABLE_HW_CACHE_INVALIDATION,     // Enable HW cache invalidation
-    TT_METAL_DISABLE_RELAXED_MEM_ORDERING,     // Disable relaxed memory ordering
-    TT_METAL_ENABLE_GATHERING,                 // Enable instruction gathering
-    TT_METAL_FABRIC_BW_TELEMETRY,              // Enable fabric bandwidth telemetry
-    TT_METAL_FABRIC_TELEMETRY,                 // Enable fabric telemetry
-    TT_FABRIC_PROFILE_RX_CH_FWD,               // Enable fabric RX channel forwarding profiling
-    TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE,  // Enable channel trimming resource usage capture
-    TT_METAL_FABRIC_TRIMMING_PROFILE,          // Path to channel trimming profile YAML for import
-    TT_METAL_FABRIC_TRIMMING_OVERRIDE,         // Path to channel trimming global override YAML
-    TT_METAL_ENABLE_FABRIC_VC2,                // Enable fabric VC2 (neighbour exchange)
-    TT_METAL_ENABLE_FABRIC_MESH_PASS_THROUGH,  // Enable experimental VC1 inter-mesh pass-through
-    TT_METAL_FORCE_REINIT,                     // Force context reinitialization
-    TT_METAL_DISABLE_FABRIC_TWO_ERISC,         // Disable fabric 2-ERISC mode
-    TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,     // Log kernel compilation commands
-    TT_METAL_SLOW_DISPATCH_MODE,               // Use slow dispatch mode
-    TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN,      // Skip Ethernet cores during retrain
-    TT_METAL_VALIDATE_PROGRAM_BINARIES,        // Validate kernel binary integrity
-    TT_METAL_DISABLE_DMA_OPS,                  // Disable DMA operations
-    RELIABILITY_MODE,                          // Fabric reliability mode (strict/relaxed)
-    TT_METAL_DISABLE_MULTI_AERISC,             // Disable multi-erisc mode (inverted logic, enabled by default)
-    TT_METAL_USE_MGD_2_0,                      // Use mesh graph descriptor 2.0
-    TT_METAL_FORCE_JIT_COMPILE,                // Force JIT compilation
-    TT_METAL_DISABLE_SFPLOADMACRO,             // Disable use of SFPLOADMACRO instructions
-    TT_METAL_DRAM_BACKED_CQ,                   // Store command queues in device DRAM
-    TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES,   // Simulator tensor preload bypasses FD CQ copies
+    TT_METAL_ENABLE_HW_CACHE_INVALIDATION,              // Enable HW cache invalidation
+    TT_METAL_DISABLE_RELAXED_MEM_ORDERING,              // Disable relaxed memory ordering
+    TT_METAL_ENABLE_GATHERING,                          // Enable instruction gathering
+    TT_METAL_FABRIC_BW_TELEMETRY,                       // Enable fabric bandwidth telemetry
+    TT_METAL_FABRIC_TELEMETRY,                          // Enable fabric telemetry
+    TT_FABRIC_PROFILE_RX_CH_FWD,                        // Enable fabric RX channel forwarding profiling
+    TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE,           // Enable channel trimming resource usage capture
+    TT_METAL_FABRIC_TRIMMING_PROFILE,                   // Path to channel trimming profile YAML for import
+    TT_METAL_FABRIC_TRIMMING_OVERRIDE,                  // Path to channel trimming global override YAML
+    TT_METAL_ENABLE_FABRIC_VC2,                         // Enable fabric VC2 (neighbour exchange)
+    TT_METAL_ENABLE_FABRIC_MESH_PASS_THROUGH,           // Enable experimental VC1 inter-mesh pass-through
+    TT_METAL_FORCE_REINIT,                              // Force context reinitialization
+    TT_METAL_DISABLE_FABRIC_TWO_ERISC,                  // Disable fabric 2-ERISC mode
+    TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,              // Log kernel compilation commands
+    TT_METAL_SLOW_DISPATCH_MODE,                        // Use slow dispatch mode
+    TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN,               // Skip Ethernet cores during retrain
+    TT_METAL_VALIDATE_PROGRAM_BINARIES,                 // Validate kernel binary integrity
+    TT_METAL_DISABLE_DMA_OPS,                           // Disable DMA operations
+    RELIABILITY_MODE,                                   // Fabric reliability mode (strict/relaxed)
+    TT_METAL_DISABLE_MULTI_AERISC,                      // Disable multi-erisc mode (inverted logic, enabled by default)
+    TT_METAL_USE_MGD_2_0,                               // Use mesh graph descriptor 2.0
+    TT_METAL_FORCE_JIT_COMPILE,                         // Force JIT compilation
+    TT_METAL_DISABLE_SFPLOADMACRO,                      // Disable use of SFPLOADMACRO instructions
+    TT_METAL_DRAM_BACKED_CQ,                            // Store command queues in device DRAM
+    TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES,            // Simulator tensor preload bypasses FD CQ copies
     TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES,  // Override Blackhole DRAM programmable cores
-    TT_METAL_MEASURE_DFB_INIT_TIME,                     // Temporary DFB init rdcycle instrumentation (deprecate once device profiler covers this).
+    TT_METAL_MEASURE_DFB_INIT_TIME,  // Temporary DFB init rdcycle instrumentation (deprecate once device profiler
+                                     // covers this).
 
     // ========================================
     // PROFILING & PERFORMANCE
@@ -251,8 +252,9 @@ enum class EnvVarID {
     // ========================================
     // SHM TRACKING
     // ========================================
-    TT_METAL_SHM_TRACKING_DISABLED,  // Disable shared memory tracking for tt-smi
-    TT_METAL_SHM_VERBOSE,            // Enable verbose logging for SHM tracking
+    TT_METAL_SHM_TRACKING_DISABLED,    // Disable shared memory tracking for tt-smi
+    TT_METAL_SHM_CB_TRACKING_ENABLED,  // Enable per-program CB aggregation (the expensive part; off by default)
+    TT_METAL_SHM_VERBOSE,              // Enable verbose logging for SHM tracking
 };
 
 // Environment variable name for TT-Metal root directory
@@ -1674,10 +1676,18 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         case EnvVarID::TT_METAL_ALLOCATOR_MODE_HYBRID: this->allocator_mode_hybrid = is_env_enabled(value); break;
 
         // TT_METAL_SHM_TRACKING_DISABLED
-        // Disable shared memory tracking for tt-smi.
-        // Default: 1 (SHM tracking disabled)
-        // Usage: export TT_METAL_SHM_TRACKING_DISABLED=0  (to re-enable tracking)
+        // Disable shared memory tracking for tt-smi (whole feature).
+        // Default: 0 (SHM tracking enabled)
+        // Usage: export TT_METAL_SHM_TRACKING_DISABLED=1
         case EnvVarID::TT_METAL_SHM_TRACKING_DISABLED: this->shm_tracking_disabled = is_env_enabled(value); break;
+
+        // TT_METAL_SHM_CB_TRACKING_ENABLED
+        // Enable per-program CB (circular buffer) aggregation, the only expensive part of SHM
+        // tracking (it rescans all active programs on every program dispatch). Off by default so
+        // DRAM/L1/L1_SMALL/TRACE tracking stays live while only the CB column reads 0.
+        // Default: 0 (CB aggregation disabled)
+        // Usage: export TT_METAL_SHM_CB_TRACKING_ENABLED=1
+        case EnvVarID::TT_METAL_SHM_CB_TRACKING_ENABLED: this->shm_cb_tracking_enabled = is_env_enabled(value); break;
 
         // TT_METAL_SHM_VERBOSE
         // Enable verbose logging for SHM tracking.

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -398,12 +398,9 @@ class RunTimeOptions {
     // Enable hybrid lockstep + per-core L1 allocator mode
     bool allocator_mode_hybrid = false;
 
-    // Disable shared memory tracking for tt-smi (whole feature). Enabled by default; disable with
-    // TT_METAL_SHM_TRACKING_DISABLED=1.
+    // Disable shared memory tracking for tt-smi
     bool shm_tracking_disabled = false;
-    // Per-program CB (circular buffer) aggregation rescans all active programs and is the only
-    // expensive part of SHM tracking, so it is OFF by default. Enable with
-    // TT_METAL_SHM_CB_TRACKING_ENABLED=1. Note: opposite polarity to shm_tracking_disabled above.
+    // Enable per-program CB (circular buffer) tracking for tt-smi
     bool shm_cb_tracking_enabled = false;
     bool shm_verbose = false;
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -398,9 +398,13 @@ class RunTimeOptions {
     // Enable hybrid lockstep + per-core L1 allocator mode
     bool allocator_mode_hybrid = false;
 
-    // Disable shared memory tracking for tt-smi. Disabled by default; re-enable with
-    // TT_METAL_SHM_TRACKING_DISABLED=0.
-    bool shm_tracking_disabled = true;
+    // Disable shared memory tracking for tt-smi (whole feature). Enabled by default; disable with
+    // TT_METAL_SHM_TRACKING_DISABLED=1.
+    bool shm_tracking_disabled = false;
+    // Per-program CB (circular buffer) aggregation rescans all active programs and is the only
+    // expensive part of SHM tracking, so it is OFF by default. Enable with
+    // TT_METAL_SHM_CB_TRACKING_ENABLED=1. Note: opposite polarity to shm_tracking_disabled above.
+    bool shm_cb_tracking_enabled = false;
     bool shm_verbose = false;
 
     SanitizerSettings sanitizer_settings;
@@ -496,6 +500,7 @@ public:
     bool get_allocator_mode_hybrid() const { return allocator_mode_hybrid; }
 
     bool get_shm_tracking_disabled() const { return shm_tracking_disabled; }
+    bool get_shm_cb_tracking_enabled() const { return shm_cb_tracking_enabled; }
     bool get_shm_verbose() const { return shm_verbose; }
 
     // Info from inspector environment variables, setters included so that user

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -398,8 +398,9 @@ class RunTimeOptions {
     // Enable hybrid lockstep + per-core L1 allocator mode
     bool allocator_mode_hybrid = false;
 
-    // Disable shared memory tracking for tt-smi
-    bool shm_tracking_disabled = false;
+    // Disable shared memory tracking for tt-smi. Disabled by default; re-enable with
+    // TT_METAL_SHM_TRACKING_DISABLED=0.
+    bool shm_tracking_disabled = true;
     bool shm_verbose = false;
 
     SanitizerSettings sanitizer_settings;


### PR DESCRIPTION
### Summary

For models with a large number of kernels running on large mesh devices memory tracking can become very expensive. This temporarily disables CB memory tracking until it can be optimized (work-in-progress, issue [52010](https://github.com/tenstorrent/tt-metal/issues/52010)).

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sosborne/disable-memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sosborne/disable-memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sosborne/disable-memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sosborne/disable-memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sosborne/disable-memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sosborne/disable-memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sosborne/disable-memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sosborne/disable-memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sosborne/disable-memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sosborne/disable-memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sosborne/disable-memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sosborne/disable-memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sosborne/disable-memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sosborne/disable-memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sosborne/disable-memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sosborne/disable-memory-tracking)