### PR TITLE
[sweeps] n150 lead-model lane discards every vector it is given (runs 0, reports green)

### DIFF
--- a/tests/sweep_framework/framework/matrix_runner_config.py
+++ b/tests/sweep_framework/framework/matrix_runner_config.py
@@ -475,7 +475,23 @@ TEST_GROUP_HARDWARE_CAPABILITY_RULES = {
     "blackhole-p300a-sweeps": ({"board_type": "blackhole", "device_series": "p300a", "card_count": 2},),
     "wormhole-t3k-sweeps": ({"device_series": "n300", "card_count": 4},),
     "wormhole-galaxy-sweeps": ({"device_series": "tt_galaxy_wh"},),
-    "lead-models-single-chip": ({"max_card_count": 1, "excluded_device_series": ("tt_galaxy_wh",)},),
+    # Gates on the TRACING BOX only (board family), not on how many cards it had.
+    #
+    # It used to be ({"max_card_count": 1, "excluded_device_series": ("tt_galaxy_wh",)},), which
+    # made this lane reject every vector routed to it and run ZERO vectors on every run. Lead
+    # models are traced on a galaxy, so even a single-chip op carries device_series
+    # 'tt_galaxy_wh' and card_count 32 -- both halves of that rule rejected it, while
+    # LEAD_MODELS_MESH_TEST_GROUPS["1x1"] kept routing 1x1 here. Routing and capability
+    # contradicted each other, and 36 vectors (28 col + 8 row, 19 modules) were discarded at
+    # load with "machine mismatch" every run. The lane still went green, because zero vectors
+    # means zero failures.
+    #
+    # What actually decides whether a traced config runs on an n150 is the MESH it needs, not
+    # the machine it was traced on: a 1x1 mesh needs one Wormhole chip, and the per-chip core
+    # grid is the same on a galaxy card. Mesh is already enforced twice over -- only "1x1"
+    # routes to this lane, and the batch exports MESH_DEVICE_SHAPE=1x1, which vector_source
+    # checks separately -- so this rule only has to answer "is the traced board a Wormhole?".
+    "lead-models-single-chip": ({"board_type": "wormhole"},),
     "lead-models-galaxy": (
         {"device_series": "tt_galaxy_wh"},
         {"min_card_count": 2},


### PR DESCRIPTION
> **Draft:** the rule change is validated against the real code paths (below), but the 36 vectors
> have not yet been run on a single-chip box. Marking ready once that run is green.

## Problem

The single-chip lead-model lane has been running **zero vectors on every run**, and reporting
green while doing it — zero vectors means zero failures, so nothing ever pointed at it.

Two rules in `matrix_runner_config.py` contradict each other:

```python
LEAD_MODELS_MESH_TEST_GROUPS["1x1"] = "lead-models-single-chip"        # routing: send 1x1 here
"lead-models-single-chip": ({"max_card_count": 1,                      # capability: reject it
                            "excluded_device_series": ("tt_galaxy_wh",)},)
```

Lead models are traced on a Galaxy, so **even a single-chip op** carries
`device_series: 'tt_galaxy_wh'` and `card_count: 32` in its `traced_machine_info`. Routing sends
the `1x1` device key to this lane, and the lane's own capability rule then rejects exactly what
routing sent it — on *both* halves (excluded series, and `32 > max_card_count 1`).

In lead-models run [30806918846](https://github.com/tenstorrent/tt-metal/actions/runs/30806918846)
that was **36 vectors across 19 modules**, discarded at load:

```
2353 vectors -> 18 batches
mesh1x1_col_1d    1x1  col  1d    28 vectors   17 modules
mesh1x1_row_1d    1x1  row  1d     8 vectors    2 modules
```
```
Filtered out 2 vectors (mesh mismatch: 0, machine mismatch: 2), loaded 0 vectors
No vectors found for module model_traced.add_model_traced, suite model_traced
```

Both jobs finished `success` having executed nothing.

Note `mesh mismatch: 0` — device-key batching (#51817) routed these correctly. It is the
hardware-capability rule that drops them. (The nearby
`get_machine_info() returned suspicious board_type='None'` warning is unrelated — that guard
returns before this check and disables a different machine-info path.)

## Fix

```diff
-"lead-models-single-chip": ({"max_card_count": 1, "excluded_device_series": ("tt_galaxy_wh",)},),
+"lead-models-single-chip": ({"board_type": "wormhole"},),
```

What decides whether a traced config runs on an n150 is the **mesh it needs**, not the machine it
happened to be traced on: a 1x1 mesh needs one Wormhole chip, and the per-chip core grid is the
same on a Galaxy card. Mesh is already enforced twice over — only `"1x1"` routes to this lane, and
the batch exports `MESH_DEVICE_SHAPE=1x1`, which `vector_source` checks separately — so this rule
only has to answer *"is the traced board a Wormhole?"*.

## Validation

Driving the real functions, not by inspection.

**1. `hardware_group_matches_any_rule`, with the `traced_machine_info` tuples that actually appear
in exported vectors:**

| traced hardware | lane | before | after |
|---|---|---|---|
| `('wormhole','tt_galaxy_wh',32)` 1x1 — *the 36 dead vectors* | single-chip | reject | **admit** |
| `('wormhole','n150',1)` | single-chip | admit | admit |
| `('wormhole','n300',1)` | single-chip | reject | **admit** |
| `('blackhole','p100a',1)` | single-chip | reject | reject |
| `('wormhole','tt_galaxy_wh',32)` 4x8 | galaxy | admit | admit |

Every other lane unchanged: `wormhole-n150-sweeps`, `wormhole-n300-sweeps`,
`blackhole-p150b-sweeps`, `blackhole-p300a-sweeps`, `wormhole-t3k-sweeps`,
`wormhole-galaxy-sweeps`, `lead-models-galaxy`.

**2. `vector_source.load_vectors` end to end**, on a fixture carrying the real galaxy-traced 1x1
`traced_machine_info`, with `TEST_GROUP_NAME` and `MESH_DEVICE_SHAPE` set the way CI sets them —
both rules exercised in one process:

```
--- OLD rule (main today) ---
  Filtered out 1 vectors (mesh mismatch: 0, machine mismatch: 1), loaded 0 vectors
  loaded 0
--- NEW rule (this PR) ---
  loaded 1
```

And the mesh filter still does its job — same lane, `MESH_DEVICE_SHAPE=4x8`:

```
Filtered out 1 vectors (mesh mismatch: 1, machine mismatch: 0), loaded 0 vectors
```

The rejection moved from `machine mismatch` to `mesh mismatch`, which is the intended division of
labour.

## Follow-up worth considering separately

A lane that loads zero vectors should not report success. That silent-zero is why this survived
this long, and it is the same failure mode as the manifest-drop fixed in #51817. Out of scope
here, but I can add a "batch selected N vectors, loaded 0" hard failure in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/sweeps-n150-lead-lane-runs-zero-vectors)