### PR TITLE
[Bug Fix] xlogy: fix dead NaN guard so xlogy(x, NaN) returns NaN (#52036)

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_xlogy_nan.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_xlogy_nan.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Regression test for https://github.com/tenstorrent/tt-metal/issues/52036
+# The SFPU xlogy guard used `in1 == nan`, which is never true in IEEE-754,
+# so xlogy(x, NaN) fell through to the log path and returned ~89 instead of NaN.
+import torch
+import ttnn
+import pytest
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+pytestmark = pytest.mark.use_module_device
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_xlogy_positive_nan(device, dtype):
+    # Positive NaN payload (sign bit clear) — the case the old guard missed.
+    torch.manual_seed(0)
+    shape = torch.Size([1, 1, 32, 32])
+    a = torch.rand(shape, dtype=torch.float32) * 2.0 + 0.5
+    b = torch.full(shape, float("nan"))
+    golden = torch.xlogy(a, b)
+    ta = ttnn.from_torch(a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tb = ttnn.from_torch(b, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    out = ttnn.to_torch(ttnn.xlogy(ta, tb))
+    # NaN masks must match exactly (NaN == NaN is False, so compare isnan).
+    assert torch.equal(torch.isnan(out), torch.isnan(golden))
+    assert torch.isnan(out).all(), "xlogy(x, +NaN) should be NaN everywhere"
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_xlogy_negative_y_is_nan(device, dtype):
+    torch.manual_seed(1)
+    shape = torch.Size([1, 1, 32, 32])
+    a = torch.rand(shape, dtype=torch.float32) * 2.0 + 0.5
+    b = torch.full(shape, -1.0)
+    golden = torch.xlogy(a, b)
+    ta = ttnn.from_torch(a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tb = ttnn.from_torch(b, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    out = ttnn.to_torch(ttnn.xlogy(ta, tb))
+    assert torch.equal(torch.isnan(out), torch.isnan(golden))
+    assert torch.isnan(out).all(), "xlogy(x, y<0) should be NaN everywhere"
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_xlogy_inf_unchanged(device, dtype):
+    # Regression guard: the fix keeps ±inf on the log path (inf has mantissa 0,
+    # so a naive `exexp == 128`-only check must NOT return NaN for it).
+    torch.manual_seed(3)
+    shape = torch.Size([1, 1, 32, 32])
+    a = torch.rand(shape, dtype=torch.float32) + 0.5  # all positive
+    b = torch.full(shape, float("inf"))
+    golden = torch.xlogy(a, b)
+    ta = ttnn.from_torch(a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tb = ttnn.from_torch(b, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    out = ttnn.to_torch(ttnn.xlogy(ta, tb))
+    assert torch.isinf(out).all(), "xlogy(x, +inf) should be +inf, not NaN"
+    assert torch.equal(torch.isinf(out), torch.isinf(golden))
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_xlogy_normal_range_unchanged(device, dtype):
+    torch.manual_seed(2)
+    shape = torch.Size([1, 1, 32, 32])
+    a = torch.rand(shape, dtype=torch.float32) * 2.0 + 0.5
+    b = torch.rand(shape, dtype=torch.float32) * 5.0 + 1.0
+    golden = torch.xlogy(a, b)
+    ta = ttnn.from_torch(a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tb = ttnn.from_torch(b, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    out = ttnn.to_torch(ttnn.xlogy(ta, tb))
+    assert_with_pcc(golden, out, 0.99)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -106,7 +106,11 @@ inline void calculate_sfpu_binary(const uint dst_index_in0, const uint dst_index
         } else if constexpr (BINOP == BinaryOp::POW) {
             result = calculate_sfpu_binary_power(in0, in1);
         } else if constexpr (BINOP == BinaryOp::XLOGY) {
-            v_if((in1 < 0.0f) || (in1 == nan)) { result = nan; }
+            // IEEE-754: `in1 == nan` is always false (NaN != NaN), so the old guard never
+            // caught positive NaNs and xlogy(x, NaN) returned ~log(NaN) instead of NaN.
+            // A NaN has exponent 0xFF (unbiased 128) and a non-zero mantissa; ±inf has
+            // mantissa 0, so it keeps flowing to the log path (pattern: digamma).
+            v_if((in1 < 0.0f) || (sfpi::exexp(in1) == 128 && sfpi::exman(in1) != 0)) { result = nan; }
             v_else {
                 sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = in1;
                 _calculate_log_body_<false>(0, dst_index_out);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -107,7 +107,11 @@ inline void calculate_sfpu_binary(
         } else if constexpr (BINOP == BinaryOp::POW) {
             result = calculate_sfpu_binary_power(in0, in1);
         } else if constexpr (BINOP == BinaryOp::XLOGY) {
-            v_if((in1 < 0.0f) || (in1 == nan)) { result = nan; }
+            // IEEE-754: `in1 == nan` is always false (NaN != NaN), so the old guard never
+            // caught positive NaNs and xlogy(x, NaN) returned ~log(NaN) instead of NaN.
+            // A NaN has exponent 0xFF (unbiased 128) and a non-zero mantissa; ±inf has
+            // mantissa 0, so it keeps flowing to the log path (pattern: digamma).
+            v_if((in1 < 0.0f) || (sfpi::exexp(in1) == 128 && sfpi::exman(in1) != 0)) { result = nan; }
             v_else {
                 sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = in1;
                 _calculate_log_body_<false>(0, dst_index_out);


### PR DESCRIPTION
### Summary
Fixes #52036

`ttnn.xlogy(x, y)` with a **positive NaN** `y` returned `~89.0` instead of `NaN`.
The SFPU guard in `ckernel_sfpu_binary.h` was:

```cpp
v_if((in1 < 0.0f) || (in1 == nan)) { result = nan; }
```

The `(in1 == nan)` term is dead code: in IEEE-754, `x == NaN` is always false.
So only *negative* NaNs were caught (accidentally, via the sign-bit compare in
`in1 < 0`), and positive NaNs fell through to the log path.

### Root cause
`ckernel_sfpu_binary.h` L109 (Blackhole) / L110 (Wormhole) — XLOGY branch of
`calculate_sfpu_binary`. The value returned varied with the NaN payload because
`setexp` keeps the mantissa (e.g. `0x7FA00000` -> 88.908, `0x7FFFFFFF` -> 89.366).

### Fix
Detect NaN the IEEE way, reusing the primitives the codebase already uses
(`digamma` uses `exexp(x) == 128 && exman(x) == 0` to identify infinity):

```cpp
v_if((in1 < 0.0f) || (sfpi::exexp(in1) == 128 && sfpi::exman(in1) != 0)) { result = nan; }
```

A NaN has exponent `0xFF` (unbiased 128) and a non-zero mantissa; +/-inf has
mantissa 0, so infinities continue to flow to the log path unchanged.

Applied to both architectures (Blackhole + Wormhole B0), the only two call
sites of the XLOGY guard.

### Validation
- New regression test `tests/ttnn/unit_tests/operations/eltwise/test_xlogy_nan.py`:
  - `xlogy(x, +NaN)` -> NaN everywhere (the broken case)
  - `xlogy(x, y<0)` -> NaN everywhere (unchanged)
  - `xlogy(x, +inf)` -> +inf, **not** NaN (guards against a naive `exexp==128`-only fix)
  - normal range -> matches torch golden
  - both `bfloat16` and `float32`
