### PR TITLE
[Bug Fix] tril/triu: masked-out inf/NaN becomes NaN instead of 0 (#52038)

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_tril_triu_inf.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_tril_triu_inf.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Regression test for https://github.com/tenstorrent/tt-metal/issues/52038
+# tril/triu were composed as multiply(input, mask): in IEEE-754, 0 * inf = NaN,
+# so a masked-out infinity/NaN came out as NaN instead of 0 (fp32 path).
+import torch
+import ttnn
+import pytest
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+pytestmark = pytest.mark.use_module_device
+
+@pytest.mark.parametrize("fn", [ttnn.tril, ttnn.triu])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_tril_triu_inf_masked_is_zero(device, fn, dtype):
+    torch.manual_seed(0)
+    shape = torch.Size([1, 1, 32, 32])
+    # -inf in the masked region: 0 * -inf = NaN under the old multiply-based impl
+    a = torch.full(shape, float("-inf"))
+    golden = fn(a).to(dtype)  # cast to the device dtype so torch.equal compares like-for-like
+    ta = ttnn.from_torch(a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    out = ttnn.to_torch(fn(ta))
+    # Masked region must be exactly 0 (never NaN), selected region keeps -inf
+    assert torch.equal(out, golden), "tril/triu with inf must match torch exactly"
+    assert not torch.isnan(out).any(), "masked-out inf became NaN - fix regression"
+    assert (out == float("-inf")).any(), "selected region lost the -inf"
+
+@pytest.mark.parametrize("fn", [ttnn.tril, ttnn.triu])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_tril_triu_normal_unchanged(device, fn, dtype):
+    torch.manual_seed(1)
+    shape = torch.Size([1, 1, 32, 32])
+    a = torch.rand(shape, dtype=torch.float32) * 2.0 - 1.0
+    golden = fn(a)
+    ta = ttnn.from_torch(a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    out = ttnn.to_torch(fn(ta))
+    assert_with_pcc(golden, out, 0.999)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -314,7 +314,10 @@ Tensor tril(const Tensor& input_a, std::int32_t diag, const std::optional<Memory
         Layout::TILE,
         input_a.device(),
         output_mem_config.value_or(input_a.memory_config()));
-    return ttnn::multiply(input_a, index_l, std::nullopt, output_mem_config);
+    // IEEE-754: `0 * inf = NaN`, so multiplying by the 0/1 mask corrupts masked-out
+    // infinities/NaNs. `where` selects the value (1/0 mask acts as predicate) instead,
+    // giving a true zero in the masked region (issue #52038).
+    return ttnn::where(index_l, input_a, 0.0f, output_mem_config.value_or(input_a.memory_config()));
 }
 
 // triu : select upper triangular region of input matrix
@@ -327,7 +330,8 @@ Tensor triu(const Tensor& input_a, std::int32_t diag, const std::optional<Memory
         Layout::TILE,
         input_a.device(),
         output_mem_config.value_or(input_a.memory_config()));
-    return ttnn::multiply(input_a, index_u, std::nullopt, output_mem_config);
+    // Same as tril: select instead of multiply so masked-out inf/NaN becomes 0, not NaN.
+    return ttnn::where(index_u, input_a, 0.0f, output_mem_config.value_or(input_a.memory_config()));
 }
 
 // polygamma ψ^(n)(x): implemented via a fused SFPU kernel using a finite-sum + tail approximation.


### PR DESCRIPTION
### Summary
Fixes #52038

`ttnn.tril` / `ttnn.triu` are composed as `multiply(input, mask)` where the mask
is a 0/1 index tensor. In IEEE-754, `0 * +/-inf = NaN` and `0 * NaN = NaN`, so any
infinity or NaN in the masked-out region came out as **NaN** instead of **0**
(fp32 path — bf16 happened to survive because of the narrower exponent).

Reproduced on ttsim: a 32x32 fp32 tensor of `-inf` turned 496/496 masked cells
into NaN under `tril`.

### Root cause
`ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp` — `tril`
(L308-318) and `triu` (L321-331) return `ttnn::multiply(input_a, index_l/u)`.

### Fix
Select instead of multiply — the 1/0 mask works as a `where` predicate, and the
masked region gets a true zero:

```cpp
return ttnn::where(index_l, input_a, 0.0f, output_mem_config.value_or(input_a.memory_config()));
```

Same change for `triu`. Behavior for normal inputs is unchanged (1xvalue in the
selected region, 0 outside).

### Validation
- New regression test `tests/ttnn/unit_tests/operations/eltwise/test_tril_triu_inf.py`:
  - full-`-inf` input: output must equal torch golden exactly, contain no NaN,
    and keep `-inf` in the selected region
  - normal-range input unchanged vs torch
  - both ops (`tril`, `triu`) x both dtypes (`bfloat16`, `float32`)
