### PR TITLE
#52680: Fix noc_async_{read,write}_sharded per-chunk size underflow

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
@@ -9,7 +9,7 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc
 
 _TTNN_TO_TORCH_DTYPE = {
     ttnn.bfloat16: torch.bfloat16,
@@ -456,6 +456,40 @@ def test_repeat_rm_sharded_to_sharded(shape, input_factory, output_layout, devic
         input_mem_config=input_factory(device),
         output_mem_config=out_mc,
     )
+
+
+# Shard rows whose byte-size doesn't divide `get_aligned_page_size()` — repeat writes
+# with `offset=k*original_page_size_bytes` then hit `sharded_offset!=0` in the helper.
+@pytest.mark.parametrize(
+    "last_dim, num_repeats, num_cores",
+    [
+        pytest.param(56, 3, 2, id="ld56_r3_c2"),
+        pytest.param(24, 6, 2, id="ld24_r6_c2"),
+    ],
+)
+def test_repeat_rm_width_sharded_last_dim_non_page_aligned_offset(last_dim, num_repeats, num_cores, device):
+    compute_grid = device.compute_with_storage_grid_size()
+    if num_cores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has {compute_grid.x * compute_grid.y} cores, test needs {num_cores}")
+    height = 4
+    shape = (1, 1, height, last_dim)
+    if last_dim % num_cores != 0:
+        pytest.skip(f"width {last_dim} not divisible by shard core count {num_cores}")
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
+    in_spec = ttnn.ShardSpec(shard_grid, (height, last_dim // num_cores), ttnn.ShardOrientation.ROW_MAJOR)
+    in_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, in_spec)
+
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.repeat(
+        ttnn_in,
+        [1, 1, 1, num_repeats],
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1),
+    )
+    ref = x.repeat(1, 1, 1, num_repeats)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_equal(ref, got)
 
 
 # DRAM-sharded input -> L1 interleaved (to_memory_config fallback path).

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -341,8 +341,10 @@ FORCE_INLINE void noc_async_write_sharded(
         uint32_t sharded_dest_id = dest_id * pages_per_row + offset / page_size;
         uint32_t sharded_offset = offset % page_size;
         uint32_t num_pages = div_up(size + sharded_offset, page_size);
+        // Explicit counter; a derived `size - i*page_size` would underflow because iter 0 is a partial page.
+        uint32_t remaining = size;
         for (uint32_t i = 0; i < num_pages; i++) {
-            uint32_t write_size = std::min(size - i * page_size, page_size - sharded_offset);
+            uint32_t write_size = std::min(remaining, page_size - sharded_offset);
             noc.async_write(
                 CoreLocalMem<uint32_t>(l1_addr),
                 tensor,
@@ -352,6 +354,7 @@ FORCE_INLINE void noc_async_write_sharded(
             sharded_dest_id++;
             sharded_offset = 0;
             l1_addr += write_size;
+            remaining -= write_size;
         }
     }
 }
@@ -387,8 +390,10 @@ FORCE_INLINE void noc_async_read_sharded(
         uint32_t sharded_src_id = src_id * pages_per_row + offset / page_size;
         uint32_t sharded_offset = offset % page_size;
         uint32_t num_pages = div_up(size + sharded_offset, page_size);
+        // Explicit counter; a derived `size - i*page_size` would underflow because iter 0 is a partial page.
+        uint32_t remaining = size;
         for (uint32_t i = 0; i < num_pages; i++) {
-            uint32_t read_size = std::min(size - i * page_size, page_size - sharded_offset);
+            uint32_t read_size = std::min(remaining, page_size - sharded_offset);
             noc.async_read(
                 tensor,
                 CoreLocalMem<uint32_t>(l1_addr),
@@ -398,6 +403,7 @@ FORCE_INLINE void noc_async_read_sharded(
             sharded_src_id++;
             sharded_offset = 0;
             l1_addr += read_size;
+            remaining -= read_size;
         }
     }
 }


### PR DESCRIPTION
### Ticket
Closes #52680

_Sub-issue of parent #51213 (which tracks all 9 items in this series)._

### Problem
`tt::data_movement::common::noc_async_write_sharded` and `noc_async_read_sharded` split a `size`-byte transfer across up to `num_pages` shard pages when the requested region straddles a page boundary. The per-iteration remaining-bytes expression was:

```cpp
uint32_t write_size = std::min(size - i * page_size, page_size - sharded_offset);
```

This assumes every prior iteration consumed a full `page_size`, but iteration 0 only consumes `page_size - sharded_offset` bytes whenever the caller passes a non-page-aligned `offset` (`sharded_offset = offset % page_size != 0`). On any iteration where `i * page_size > size`, the unsigned subtraction underflows to a huge value, `std::min(...)` collapses to `page_size`, and the tail chunk NOC-transfers a whole page instead of the ~few bytes actually remaining. Writes clobber the next shard page in the destination; reads over-fetch past the CB slot.

Byte-for-byte identical to correct behaviour when `offset == 0` (the vast majority of callers), which is why the bug has stayed latent. Two in-tree callers hit the non-zero-offset path today: `repeat_last_dim_rm_sharded.cpp:43` (`offset = k * original_page_size_bytes`) and `slice_writer_unary_stick_layout_interleaved_start_id.cpp:56` (`offset = cur * chunk_size`). The same helper is included by kernels under `experimental/quasar`, which inherit the fix through the shared header.

Silent from `to_torch`'s perspective because the out-of-bounds writes fall past `output.physical_volume()`, so PCC and functional checks pass while neighbouring L1/DRAM allocations get clobbered.

### What this PR does
- **Replace the derived remaining-bytes expression with an explicit counter** — track `remaining` starting at `size` and decrement by each actual chunk transfer, so the last chunk NOC-transfers exactly the bytes still owed instead of a full page.
- **Apply the same one-line change to both helpers** in `ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp` (`noc_async_write_sharded` and `noc_async_read_sharded`). The `experimental/quasar` kernels pick up the fix through the shared header — no separate patch needed.
- **Add a nightly regression test** parametrised over two `(last_dim, num_repeats, num_cores)` tuples whose per-shard row bytes don't divide `get_aligned_page_size()`, so `repeat_last_dim_rm_sharded.cpp` calls `noc_async_write_sharded` with `offset = k * original_page_size_bytes` at values that produce a non-zero `sharded_offset` — the exact code path the fix targets. Uses byte-exact `assert_equal` against `torch.repeat` (not PCC) so any misplaced-byte corruption fails.

### Tests
All on Wormhole B0:

- `tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py::test_repeat_rm_width_sharded_last_dim_non_page_aligned_offset` **[ld56_r3_c2 / ld24_r6_c2]** — 2/2 PASSED (1.13 s total).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/noc_sharded_offset_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/noc_sharded_offset_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/noc_sharded_offset_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/noc_sharded_offset_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/noc_sharded_offset_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/noc_sharded_offset_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/noc_sharded_offset_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/noc_sharded_offset_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/noc_sharded_offset_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/noc_sharded_offset_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/noc_sharded_offset_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/noc_sharded_offset_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/noc_sharded_offset_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/noc_sharded_offset_fix)


