### PR TITLE
[Bug fix] tools/tracy: --process-logs-only resolving the .logs folder twice

### DIFF
--- a/tools/tracy/__main__.py
+++ b/tools/tracy/__main__.py
@@ -214,7 +214,7 @@ def main():
             sys.exit(1)
 
     if options.processLogsOnly:
-        generate_report(generate_logs_folder(outputFolder), binaryFolder, "", None, options.collect_noc_traces)
+        generate_report(outputFolder, binaryFolder, "", None, options.collect_noc_traces)
         sys.exit(0)
 
     if options.port:


### PR DESCRIPTION
generate_report() already resolves the logs folder from its outputFolder argument (tools/tracy/__init__.py:128), and the normal capture path at __main__.py:487 passes outputFolder unresolved. The --process-logs-only path instead passed generate_logs_folder(outputFolder), so the folder was resolved twice and the profiler looked for the capture under <out>/.logs/.logs.

The result was that --process-logs-only always failed: it waited 15 s for a capture file that could never appear, then exited 1, while the capture sat at <out>/.logs/ all along.

Reproduces with no hardware and no real capture, since the failure happens in the existence check before anything reads the file:

    mkdir -p /tmp/repro/.logs
    touch /tmp/repro/.logs/tracy_profile_log_host.tracy
    python3 -m tracy --process-logs-only -o /tmp/repro

With this change the same command finds the capture and proceeds to tracy-csvexport.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Relates to #52156 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

This PR changes a single line:

```diff
- generate_report(generate_logs_folder(outputFolder), binaryFolder, "", None, options.collect_noc_traces)
+ generate_report(outputFolder, binaryFolder, "", None, options.collect_noc_traces)
```

generate_report() is responsible for resolving the .logs directory internally, so callers should pass the original outputFolder.