### PR TITLE
[LLK] SFPU edge cases initial pass ( expand ranges on ops)

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2306,13 +2306,8 @@ class UnarySFPUGolden:
             return self._call_integer(operation, operand1, input_format, dimensions)
 
         # Quantize input to match what hardware actually sees after unpack from L1.
-        # This used to inline a partial copy of quantize_input_to_unpack_format that
-        # handled Bfp2_b/Bfp4_b/MX but skipped Bfp8_b, so for Bfp8_b inputs the golden
-        # ran on values the hardware never saw. Smooth ops absorbed that in tolerance,
-        # but discontinuous ops (floor/ceil/trunc/frac) turn a sub-ULP quantization
-        # step across an integer into a full 1.0 error. DataCopyGolden, TypecastGolden
-        # and UntilizeGolden already use the shared helper; this brings the SFPU unary
-        # golden in line with them.
+        # Matters most for discontinuous ops (floor/ceil/trunc/frac), where a sub-ULP
+        # quantization step across an integer becomes a full 1.0 error.
         operand1 = quantize_input_to_unpack_format(
             operand1, input_format, all_mx_formats=True
         )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2307,13 +2307,8 @@ class UnarySFPUGolden:
             return self._call_integer(operation, operand1, input_format, dimensions)
 
         # Quantize input to match what hardware actually sees after unpack from L1.
-        # This used to inline a partial copy of quantize_input_to_unpack_format that
-        # handled Bfp2_b/Bfp4_b/MX but skipped Bfp8_b, so for Bfp8_b inputs the golden
-        # ran on values the hardware never saw. Smooth ops absorbed that in tolerance,
-        # but discontinuous ops (floor/ceil/trunc/frac) turn a sub-ULP quantization
-        # step across an integer into a full 1.0 error. DataCopyGolden, TypecastGolden
-        # and UntilizeGolden already use the shared helper; this brings the SFPU unary
-        # golden in line with them.
+        # Matters most for discontinuous ops (floor/ceil/trunc/frac), where a sub-ULP
+        # quantization step across an integer becomes a full 1.0 error.
         operand1 = quantize_input_to_unpack_format(
             operand1, input_format, all_mx_formats=True
         )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2305,13 +2305,17 @@ class UnarySFPUGolden:
         ):
             return self._call_integer(operation, operand1, input_format, dimensions)
 
-        # Quantize input to match what hardware actually unpacks from bfp4_b L1 memory
-        if input_format == DataFormat.Bfp2_b:
-            operand1 = _bfp2b_to_float16b(operand1)
-        if input_format == DataFormat.Bfp4_b:
-            operand1 = _bfp4b_to_float16b(operand1)
-        if input_format.is_mx_format():
-            operand1 = quantize_mx_tensor_chunked(operand1, input_format)
+        # Quantize input to match what hardware actually sees after unpack from L1.
+        # This used to inline a partial copy of quantize_input_to_unpack_format that
+        # handled Bfp2_b/Bfp4_b/MX but skipped Bfp8_b, so for Bfp8_b inputs the golden
+        # ran on values the hardware never saw. Smooth ops absorbed that in tolerance,
+        # but discontinuous ops (floor/ceil/trunc/frac) turn a sub-ULP quantization
+        # step across an integer into a full 1.0 error. DataCopyGolden, TypecastGolden
+        # and UntilizeGolden already use the shared helper; this brings the SFPU unary
+        # golden in line with them.
+        operand1 = quantize_input_to_unpack_format(
+            operand1, input_format, all_mx_formats=True
+        )
 
         # Special handling for Column and Row reduction which needs to process the entire tensor
         if operation in [MathOperation.ReduceColumn, MathOperation.ReduceRow]:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2306,13 +2306,17 @@ class UnarySFPUGolden:
         ):
             return self._call_integer(operation, operand1, input_format, dimensions)
 
-        # Quantize input to match what hardware actually unpacks from bfp4_b L1 memory
-        if input_format == DataFormat.Bfp2_b:
-            operand1 = _bfp2b_to_float16b(operand1)
-        if input_format == DataFormat.Bfp4_b:
-            operand1 = _bfp4b_to_float16b(operand1)
-        if input_format.is_mx_format():
-            operand1 = quantize_mx_tensor_chunked(operand1, input_format)
+        # Quantize input to match what hardware actually sees after unpack from L1.
+        # This used to inline a partial copy of quantize_input_to_unpack_format that
+        # handled Bfp2_b/Bfp4_b/MX but skipped Bfp8_b, so for Bfp8_b inputs the golden
+        # ran on values the hardware never saw. Smooth ops absorbed that in tolerance,
+        # but discontinuous ops (floor/ceil/trunc/frac) turn a sub-ULP quantization
+        # step across an integer into a full 1.0 error. DataCopyGolden, TypecastGolden
+        # and UntilizeGolden already use the shared helper; this brings the SFPU unary
+        # golden in line with them.
+        operand1 = quantize_input_to_unpack_format(
+            operand1, input_format, all_mx_formats=True
+        )
 
         # Special handling for Column and Row reduction which needs to process the entire tensor
         if operation in [MathOperation.ReduceColumn, MathOperation.ReduceRow]:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2273,6 +2273,11 @@ class UnarySFPUGolden:
         self._int_shift_amount = 3
         self._int_maxmin_scalar = 1000
         self.data_format = None
+        # Precision the SFPU actually evaluates at, which is Dest's and not the output
+        # format's. The per-element ops below read this rather than data_format: no
+        # output format can restore precision the value has already lost, and none can
+        # take away precision Dest still holds.
+        self.dst_format = None
         self.dest_acc = DestAccumulation.No
 
     def __call__(
@@ -2290,6 +2295,7 @@ class UnarySFPUGolden:
         skip_tilize: bool = False,
     ):
         self.data_format = data_format
+        self.dst_format = data_format
         self.dest_acc = dest_acc
 
         if operation not in self.ops:
@@ -2327,6 +2333,8 @@ class UnarySFPUGolden:
             dst_format = DataFormat.Float16
         else:
             dst_format = DataFormat.Float16_b
+
+        self.dst_format = dst_format
 
         if self.dest_acc == DestAccumulation.No and input_format == DataFormat.Float32:
             # dst in 16-bit mode and 32-bit input: truncation may occur when unpacked to dst
@@ -2666,7 +2674,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.nn.functional.celu(input_tensor, alpha=1.0).item()
 
@@ -2674,7 +2682,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.nn.functional.silu(input_tensor).item()
 
@@ -2696,7 +2704,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.nn.functional.softshrink(input_tensor, lambd=lambd).item()
 
@@ -2705,7 +2713,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.nn.functional.softsign(input_tensor).item()
 
@@ -2737,7 +2745,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.nn.functional.elu(input_tensor, alpha=1.0).item()
 
@@ -2745,7 +2753,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.exp(input_tensor).item()
 
@@ -2753,7 +2761,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.exp2(input_tensor).item()
 
@@ -2764,7 +2772,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.exp(0.5 * input_tensor).item()
 
@@ -2814,7 +2822,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.nn.functional.gelu(input_tensor).item()
 
@@ -2824,7 +2832,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.nn.functional.gelu(input_tensor, approximate="tanh").item()
 
@@ -2840,7 +2848,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return input_tensor.fill_(const_value).item()
 
@@ -2848,7 +2856,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.nn.functional.hardsigmoid(input_tensor).item()
 
@@ -2856,7 +2864,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.nn.functional.sigmoid(input_tensor).item()
 
@@ -2864,7 +2872,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.nn.functional.threshold(input_tensor, t, v).item()
 
@@ -2872,7 +2880,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.relu(torch.min(input_tensor, torch.tensor(threshold))).item()
 
@@ -2880,7 +2888,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.max(input_tensor, torch.tensor(threshold)).item()
 
@@ -2888,7 +2896,7 @@ class UnarySFPUGolden:
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.data_format])
+            else torch.tensor(x, dtype=format_dict[self.dst_format])
         )
         return torch.nn.functional.leaky_relu(
             input_tensor, negative_slope=negative_slope

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -312,6 +312,28 @@ def _params_solve_dependencies(**kwargs: any) -> List[Tuple]:
     return list(_solve_recursive(resolved, 0))
 
 
+def build_param_id(parameters, value_tuple):
+    """Readable pytest ID for one parameter tuple, e.g.
+    `formats:Bfp4_b->Float16_b-mathop:Sin`.
+
+    Exposed so tests that call pytest.mark.parametrize directly (because they build
+    their own value tuples) can produce the same IDs as @parametrize, keeping -k
+    filters on format and mathop working across the whole suite.
+    """
+    parts = []
+    for param, value in zip(parameters, value_tuple):
+        if isinstance(value, InputOutputFormat):
+            param_value = f"{value.input_format.name}->{value.output_format.name}"
+        elif hasattr(value, "name"):
+            param_value = value.name
+        elif hasattr(value, "value"):
+            param_value = str(value.value)
+        else:
+            param_value = str(value)
+        parts.append(f"{param}:{param_value}")
+    return "-".join(parts)
+
+
 def parametrize(**kwargs: any):
     compile_key_fn = None
     _rt_names = set()
@@ -359,22 +381,7 @@ def parametrize(**kwargs: any):
     parameters_string = ",".join(parameters)
     parameter_values = _params_solve_dependencies(**unwrapped)
 
-    def generate_id(value_tuple):
-        """Generate readable test IDs from parameter values."""
-        parts = []
-        for param, value in zip(parameters, value_tuple):
-            if isinstance(value, InputOutputFormat):
-                param_value = f"{value.input_format.name}->{value.output_format.name}"
-            elif hasattr(value, "name"):
-                param_value = value.name
-            elif hasattr(value, "value"):
-                param_value = str(value.value)
-            else:
-                param_value = str(value)
-            parts.append(f"{param}:{param_value}")
-        return "-".join(parts)
-
-    ids = [generate_id(values) for values in parameter_values]
+    ids = [build_param_id(parameters, values) for values in parameter_values]
 
     def decorator(test_function):
         if compile_key_fn is not None:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -883,24 +883,35 @@ def _validate_distribution_override(
 # unary op is actually driven, so an op added to the registry and to no test goes untested
 # silently.
 #
-# Recording the family closes that. It is a flat set rather than a field on OperandSpecs
-# because several entries are shared with the perf sweeps and the accuracy harness, and
-# those consumers do not want an arity opinion imposed on them.
+# Recording the family closes that. Each family is named positively, one set per
+# arity/engine, and the unary family is whatever is left over -- so an op registered
+# without being classified here lands in sfpu_unary_ops() and trips the unary sweep's
+# exhaustiveness assert, which is the prompt to put it in the right set below.
+#
+# They are flat sets rather than a field on OperandSpecs because several entries are shared
+# with the perf sweeps and the accuracy harness, and those consumers do not want an arity
+# opinion imposed on them.
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Ops with no unary SFPU kernel, so they must not appear in the unary sweep. Relu is the
-# one that looks like it should: it has a domain entry, but `relu` is not a member of
-# SfpuType at all -- relu is applied by the packer (STACC_RELU), not the SFPU -- so driving
-# it through the unary test fails to compile.
-_NON_SFPU_UNARY_OPS: FrozenSet[MathOperation] = frozenset(
+# Eltwise binary run on the FPU rather than the SFPU (test_eltwise_binary.py).
+_FPU_ELTWISE_OPS: FrozenSet[MathOperation] = frozenset(
     {
-        # FPU eltwise binary
         MathOperation.Elwadd,
         MathOperation.Elwmul,
         MathOperation.Elwsub,
-        # packer-applied relu
-        MathOperation.Relu,
-        # SFPU binary (test_sfpu_binary.py)
+    }
+)
+
+# Applied by the packer (STACC_RELU), not the SFPU. Relu is the entry that looks like it
+# should be a unary SFPU op: it has a domain, but `relu` is not a member of SfpuType at
+# all, so driving it through the unary test fails to compile.
+_PACKER_OPS: FrozenSet[MathOperation] = frozenset({MathOperation.Relu})
+
+# Binary SFPU ops (test_sfpu_binary.py). Registered ones only -- that suite also drives
+# ~30 int, comparison and bitwise ops that have no domain entry and so cannot be keys
+# here; they are declared in its own _UNREGISTERED_BINARY_OPS instead.
+_SFPU_BINARY_OPS: FrozenSet[MathOperation] = frozenset(
+    {
         MathOperation.SfpuAddTopRow,
         MathOperation.SfpuElwadd,
         MathOperation.SfpuElwsub,
@@ -912,11 +923,27 @@ _NON_SFPU_UNARY_OPS: FrozenSet[MathOperation] = frozenset(
         MathOperation.SfpuElwLeftShift,
         MathOperation.SfpuElwRightShift,
         MathOperation.SfpuElwLogicalRightShift,
-        # reduce family (test_sfpu_reduce*.py)
+    }
+)
+
+# Ternary SFPU ops (test_sfpu_ternary.py). Empty because no ternary op has a domain entry
+# yet: OperandSpecs carries A and B only, so that suite builds its own per-operand specs
+# and reuses B for C. The set exists so the first registered ternary op lands here rather
+# than silently in sfpu_unary_ops().
+_SFPU_TERNARY_OPS: FrozenSet[MathOperation] = frozenset()
+
+# Reduce family (test_sfpu_reduce*.py).
+_REDUCE_OPS: FrozenSet[MathOperation] = frozenset(
+    {
         MathOperation.ReduceColumn,
         MathOperation.ReduceRow,
         MathOperation.ReduceScalar,
     }
+)
+
+# Ops with no unary SFPU kernel, so they must not appear in the unary sweep.
+_NON_SFPU_UNARY_OPS: FrozenSet[MathOperation] = (
+    _FPU_ELTWISE_OPS | _PACKER_OPS | _SFPU_BINARY_OPS | _SFPU_TERNARY_OPS | _REDUCE_OPS
 )
 
 # Unary SFPU ops that are registered but deliberately not in the correctness sweep.
@@ -930,9 +957,9 @@ _UNARY_OPS_NOT_SWEPT: Dict[MathOperation, str] = {
 def sfpu_unary_ops() -> FrozenSet[MathOperation]:
     """Every registered op that has a unary SFPU kernel.
 
-    The unary sweep asserts its profiles cover exactly this set minus
-    _UNARY_OPS_NOT_SWEPT, so adding an op to the registry without adding it to a sweep
-    profile (or to one of the two exemption sets above) fails at collection.
+    Everything registered that is not claimed by one of the family sets above. The unary
+    sweep drives exactly this set minus _UNARY_OPS_NOT_SWEPT, so a newly registered op is
+    swept by default and only escapes by being classified into a family or exempted.
     """
     return frozenset(_OP_DOMAIN_REGISTRY) - _NON_SFPU_UNARY_OPS
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -792,6 +792,58 @@ def for_op(
     return result
 
 
+def _spec_span(spec: StimuliSpec) -> float:
+    """Total measure of the values *spec* is allowed to draw."""
+    if spec.intervals:
+        return sum(high - low for low, high in spec.intervals)
+    return spec.high - spec.low
+
+
+def _tighter_spec(a: StimuliSpec, b: StimuliSpec) -> StimuliSpec:
+    """Whichever of *a* / *b* draws from the smaller domain; ties keep *a*."""
+    if a == b:
+        return a
+    return a if _spec_span(a) <= _spec_span(b) else b
+
+
+def for_op_pipeline(
+    op: MathOperation,
+    input_format: DataFormat,
+    output_format: Optional[DataFormat] = None,
+    **kwargs,
+) -> OperandSpecs:
+    """Return safe input domains for *op* over a whole input->output pipeline.
+
+    Two different constraints pick two different formats, and resolving against
+    either one alone drops the other:
+
+    * **Range** is bounded by the narrowest exponent range anywhere in the
+      pipeline. exp over (-100, 16) is fine into a Float32 output and saturates
+      a Float16 one, so the *output* format has to be able to narrow the domain.
+    * **Precision** is a property of the *input* format alone. A block-float
+      input has already spent its relative precision by the time the op runs,
+      and a wider output cannot give it back. Resolving Bfp8_b -> Float16
+      against Float16 alone restores reciprocal's 1000:1 interval — the exact
+      spread _reciprocal_spec exists to avoid, which quantizes small block
+      elements to zero and sends the golden to inf.
+
+    So resolve against both formats and keep whichever spec is tighter per
+    operand. Both constraints only ever *narrow* a domain, so the tighter of the
+    two satisfies both. Ops with a format-independent registry entry resolve
+    identically either way and are unaffected.
+    """
+    by_input = for_op(op, input_format, **kwargs)
+    range_format = narrowest_range_format(input_format, output_format)
+    if range_format == input_format:
+        return by_input
+
+    by_range = for_op(op, range_format, **kwargs)
+    return OperandSpecs(
+        spec_A=_tighter_spec(by_input.spec_A, by_range.spec_A),
+        spec_B=_tighter_spec(by_input.spec_B, by_range.spec_B),
+    )
+
+
 def _validate_distribution_override(
     distribution: Union[DistributionKind, Callable],
     spec: StimuliSpec,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -653,16 +653,45 @@ _OP_DOMAIN_REGISTRY: Dict[
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-1.0, high=1.0)
     ),
     # pow: srcA is the base (must be non-negative for non-integer exponents);
-    # srcB is the exponent (non-negative to keep output finite)
+    # srcB is the exponent (non-negative to keep output finite).
+    #
+    # Both bounds are set by accuracy, not by representable range, and had never been
+    # executed before the binary suite started reading this registry (the suite did not
+    # import sfpu_domains at all). a**b is evaluated as exp(b * ln a), so the quantity that
+    # decides the error is the *product* b * ln(a) -- the argument handed to the shared exp
+    # approximation, whose relative error grows with its argument (see the exp entry). The
+    # registry cannot express a joint constraint, so cap each operand such that the worst
+    # case product stays in the accurate region: 3 * ln 3 = 3.30.
+    #
+    # Measured on Wormhole and Blackhole at Float16_b, against the default 5% rtol:
+    #   b*ln(a) = 3.30 (A<=3, B<=3)   clean
+    #   b*ln(a) = 3.47 (A<=2, B<=5)   clean
+    #   b*ln(a) = 4.61 (A<=10, B<=2)  13/32768 outside, peak 5.02%
+    #   b*ln(a) = 4.83 (A<=5, B<=3)    3/32768 outside, peak 4.93%
+    #   b*ln(a) = 8.05 (A<=5, B<=5)   45/32768 outside, peak 6.11%
+    # The error is one-directional and tracks the product rather than either operand alone,
+    # which is the same shape as the approximate-exp limit recorded for the unary sweep.
     MathOperation.SfpuElwpow: OperandSpecs(
-        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=0.0, high=5.0),
-        spec_B=StimuliSpec(distribution=DistributionKind.UNIFORM, low=0.0, high=5.0),
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=0.0, high=3.0),
+        spec_B=StimuliSpec(distribution=DistributionKind.UNIFORM, low=0.0, high=3.0),
     ),
     # xlogy: computes x * log(y) element-wise
     # srcA (x): x >= 0 so xlogy(0, y) = 0 is well-defined
     # srcB (y): y > 0 so log(y) is finite; log-uniform spans several decades
+    #
+    # x's ceiling is an accuracy bound, and it is the *absolute* error that binds here
+    # rather than the relative one. The kernel's error is dominated by x * abs_err(ln y),
+    # so it scales with x while passed_test's atol for the 16-bit floats stays at 0.05:
+    #   x <= 10  ->  23/32768 outside, peak absolute error 0.121
+    #   x <=  8  ->  16/32768 outside, peak 0.094
+    #   x <=  5  ->  clean, and 5 * 0.012 = 0.06 sits right on the atol
+    #   x <=  4  ->  clean with margin (4 * 0.012 = 0.048 < 0.05)
+    # 4.0 is chosen over 5.0 so the bound does not sit exactly on the tolerance, where a
+    # different draw or arch would flake. y keeps its full log-uniform span: the failures
+    # were insensitive to it (narrowing y to 1e-2 or 0.1 made the count worse, not better,
+    # because it raises x's weight rather than lowering |log y|).
     MathOperation.SfpuXlogy: OperandSpecs(
-        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=0.0, high=10.0),
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=0.0, high=4.0),
         spec_B=StimuliSpec(
             distribution=DistributionKind.LOG_UNIFORM, low=1e-4, high=10.0
         ),

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -102,13 +102,9 @@ def _exp_spec(fmt: DataFormat) -> OperandSpecs:
         # sanitization boundary near x ≈ -88.5 (where InputClamping::ClampToNegative saturates inputs
         # in the fast/approx exp path).
         #
-        # The positive side stops at 16 for accuracy, not range: exp's relative
-        # condition number equals its argument, so the shared approximation's error
-        # grows linearly with x. Measured on Wormhole at the old high of 80, the
-        # largest outputs land 11-13% off the golden — well past the default 5% rtol
-        # — and the error is only visible on the fp32 (dest_acc=Yes) path, where a
-        # 16-bit dst is not there to round both sides back together. 16 is the same
-        # argument ceiling _exp_with_base_spec settles on for the same reason.
+        # The positive side stops at 16 for accuracy, not range: the approximation's
+        # relative error grows with x, exceeding the default 5% rtol on the fp32
+        # (dest_acc=Yes) path well before x=80.
         spec = StimuliSpec(distribution=DistributionKind.UNIFORM, low=-100.0, high=16.0)
     return OperandSpecs(spec_A=spec)
 
@@ -156,13 +152,8 @@ _BLOCK_FLOAT_FORMATS = (DataFormat.Bfp8_b, DataFormat.Bfp4_b, DataFormat.Bfp2_b)
 def _reciprocal_spec(fmt: DataFormat) -> OperandSpecs:
     """Safe input range for 1/x, tightened for block-float inputs.
 
-    1/x carries input relative error straight through to the output, and in a
-    block-float input an element far below its block maximum has very little
-    relative precision left. Spanning [0.1, 100] puts a 1000:1 ratio inside a
-    16-element block, so the smallest elements quantize to zero and the golden
-    goes to inf. Measured on Bfp8_b stimuli: the wide interval leaves 13/1024
-    elements outside tolerance (max difference inf), while holding the ratio to
-    10:1 leaves none.
+    A 1000:1 ratio inside a 16-element block quantizes the smallest elements to
+    zero, sending the golden to inf. Hold the ratio to 10:1 for block floats.
     """
     if fmt in _BLOCK_FLOAT_FORMATS:
         spec = StimuliSpec.uniform(intervals=[(-100.0, -10.0), (10.0, 100.0)])
@@ -652,25 +643,15 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.SfpuElwrsub: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-1.0, high=1.0)
     ),
-    # pow: srcA is the base (must be non-negative for non-integer exponents);
-    # srcB is the exponent (non-negative to keep output finite).
+    # pow: srcA is the base (non-negative for non-integer exponents); srcB is the
+    # exponent (non-negative to keep output finite).
     #
-    # Both bounds are set by accuracy, not by representable range, and had never been
-    # executed before the binary suite started reading this registry (the suite did not
-    # import sfpu_domains at all). a**b is evaluated as exp(b * ln a), so the quantity that
-    # decides the error is the *product* b * ln(a) -- the argument handed to the shared exp
-    # approximation, whose relative error grows with its argument (see the exp entry). The
-    # registry cannot express a joint constraint, so cap each operand such that the worst
-    # case product stays in the accurate region: 3 * ln 3 = 3.30.
-    #
-    # Measured on Wormhole and Blackhole at Float16_b, against the default 5% rtol:
-    #   b*ln(a) = 3.30 (A<=3, B<=3)   clean
-    #   b*ln(a) = 3.47 (A<=2, B<=5)   clean
-    #   b*ln(a) = 4.61 (A<=10, B<=2)  13/32768 outside, peak 5.02%
-    #   b*ln(a) = 4.83 (A<=5, B<=3)    3/32768 outside, peak 4.93%
-    #   b*ln(a) = 8.05 (A<=5, B<=5)   45/32768 outside, peak 6.11%
-    # The error is one-directional and tracks the product rather than either operand alone,
-    # which is the same shape as the approximate-exp limit recorded for the unary sweep.
+    # Both bounds are set by accuracy, not representable range. a**b is evaluated as
+    # exp(b * ln a), so the error tracks the product b * ln(a) -- the argument to the
+    # shared exp approximation (see the exp entry). The registry cannot express a joint
+    # constraint, so cap each operand so the worst-case product stays accurate:
+    # 3 * ln 3 = 3.30. Measured at Float16_b against the default 5% rtol, 3.30 is clean
+    # while 4.61 (A<=10, B<=2) and above go outside.
     MathOperation.SfpuElwpow: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=0.0, high=3.0),
         spec_B=StimuliSpec(distribution=DistributionKind.UNIFORM, low=0.0, high=3.0),
@@ -679,17 +660,11 @@ _OP_DOMAIN_REGISTRY: Dict[
     # srcA (x): x >= 0 so xlogy(0, y) = 0 is well-defined
     # srcB (y): y > 0 so log(y) is finite; log-uniform spans several decades
     #
-    # x's ceiling is an accuracy bound, and it is the *absolute* error that binds here
-    # rather than the relative one. The kernel's error is dominated by x * abs_err(ln y),
-    # so it scales with x while passed_test's atol for the 16-bit floats stays at 0.05:
-    #   x <= 10  ->  23/32768 outside, peak absolute error 0.121
-    #   x <=  8  ->  16/32768 outside, peak 0.094
-    #   x <=  5  ->  clean, and 5 * 0.012 = 0.06 sits right on the atol
-    #   x <=  4  ->  clean with margin (4 * 0.012 = 0.048 < 0.05)
-    # 4.0 is chosen over 5.0 so the bound does not sit exactly on the tolerance, where a
-    # different draw or arch would flake. y keeps its full log-uniform span: the failures
-    # were insensitive to it (narrowing y to 1e-2 or 0.1 made the count worse, not better,
-    # because it raises x's weight rather than lowering |log y|).
+    # x's ceiling is an absolute-accuracy bound: the error is dominated by
+    # x * abs_err(ln y), so it grows with x while the 16-bit-float atol stays at 0.05.
+    # x <= 4 keeps margin (4 * 0.012 = 0.048); x <= 5 sits on the tolerance and x <= 8
+    # goes outside. y keeps its full log-uniform span -- narrowing it made the failures
+    # worse, not better.
     MathOperation.SfpuXlogy: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=0.0, high=4.0),
         spec_B=StimuliSpec(

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -52,6 +52,41 @@ class OperandSpecs:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Picking which format bounds the domain
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Largest finite magnitude each format can hold. Only formats with a narrower
+# exponent field than bfloat16 need an entry; every other format shares
+# bfloat16's ceiling and is therefore never the binding constraint.
+_FORMAT_MAX_MAGNITUDE: Dict[DataFormat, float] = {
+    DataFormat.MxFp4: 6.0,  # e2m1
+    DataFormat.MxFp8R: 448.0,  # e4m3
+    DataFormat.Float16: 65504.0,  # e5m10
+    DataFormat.MxFp8P: 57344.0,  # e5m2
+}
+
+_BF16_MAX_MAGNITUDE = 3.3895314e38
+
+
+def narrowest_range_format(*formats: Optional[DataFormat]) -> DataFormat:
+    """Return whichever of *formats* has the smallest representable magnitude.
+
+    A safe input domain is bounded by the narrowest float format anywhere in the
+    pipeline, not just the input one. exp over (-100, 80) peaks at ~5.5e34: fine
+    into a Float32 output, saturates a Float16 one. Passing a single format keeps
+    the previous input-only behaviour, and ties resolve to the first argument, so
+    callers should pass the input format first.
+    """
+    candidates = [fmt for fmt in formats if fmt is not None]
+    if not candidates:
+        raise ValueError("narrowest_range_format() requires at least one format")
+    return min(
+        candidates,
+        key=lambda fmt: _FORMAT_MAX_MAGNITUDE.get(fmt, _BF16_MAX_MAGNITUDE),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Format-specific domain builders
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -508,6 +543,24 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.Round: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-10.0, high=10.0)
     ),
+    # floor/ceil/trunc/frac: defined for all reals, but floor and ceil only differ
+    # from trunc on the negative side, so the domain has to span both signs to tell
+    # the three apart at all. Same range as round for the same reason: enough integer
+    # knees inside the interval that the random sweep lands near several of them.
+    MathOperation.Floor: OperandSpecs(
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-10.0, high=10.0)
+    ),
+    MathOperation.Ceil: OperandSpecs(
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-10.0, high=10.0)
+    ),
+    MathOperation.Trunc: OperandSpecs(
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-10.0, high=10.0)
+    ),
+    # frac keeps the sign of x (frac(x) = x - trunc(x)), so the negative half is a
+    # distinct branch rather than a mirror of the positive one.
+    MathOperation.Frac: OperandSpecs(
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-10.0, high=10.0)
+    ),
     # sqrt: domain x >= 0
     MathOperation.Sqrt: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=0.0, high=100.0)
@@ -516,6 +569,13 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.Square: _square_spec,
     # tanh: cover saturation regions (saturates near ±1 for |x| > ~3)
     MathOperation.Tanh: OperandSpecs(
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
+    ),
+    # tanhshrink(x) = x - tanh(x): odd function, so the negative half exercises a
+    # distinct sign path. Same range as tanh — past |x| ~ 3 tanh saturates and the
+    # result degenerates to x, while near 0 the subtraction cancels down to ~x^3/3
+    # (small absolute values, covered by atol rather than rtol).
+    MathOperation.Tanhshrink: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
     ),
     # topk family: operation sorts/merges; any values are valid

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -102,10 +102,10 @@ def _exp_spec(fmt: DataFormat) -> OperandSpecs:
         # sanitization boundary near x ≈ -88.5 (where InputClamping::ClampToNegative saturates inputs
         # in the fast/approx exp path).
         #
-        # The positive side stops at 16 for accuracy, not range: the approximation's
-        # relative error grows with x, exceeding the default 5% rtol on the fp32
-        # (dest_acc=Yes) path well before x=80.
-        spec = StimuliSpec(distribution=DistributionKind.UNIFORM, low=-100.0, high=16.0)
+        # The positive side is bounded by range, not accuracy: exp overflows an 8-bit
+        # exponent near x = 88.7, and 80 leaves margin below it. Narrower output formats
+        # pull this in through for_op_pipeline.
+        spec = StimuliSpec(distribution=DistributionKind.UNIFORM, low=-100.0, high=80.0)
     return OperandSpecs(spec_A=spec)
 
 
@@ -113,19 +113,18 @@ def _exp_with_base_spec(fmt: DataFormat) -> OperandSpecs:
     """Input range for exp_with_base, which computes exp(0.5*x).
 
     Keep the negative reach of _exp_spec (low=-100 crosses the SFPU's negative-side
-    sanitization boundary near x ~ -88.5), but cap the positive side tighter than
-    plain exp. exp's relative condition number equals its argument, so with the 0.5
-    scale a high of 32 keeps the argument <= 16 -- small enough that the shared exp
-    approximation's error stays within the default rtol even on the fp32 (dest_acc=Yes)
-    path. At the reused high=80 the argument reaches ~40, and that ~40x amplification
-    pushes the largest-output elements past 10% relative error (PCC still fine).
+    sanitization boundary near x ~ -88.5). The 0.5 scale halves the argument, so the
+    positive side is double _exp_spec's to put the argument under the same overflow
+    ceiling.
     """
     if fmt == DataFormat.MxFp8P:
         spec = StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
     elif fmt in (DataFormat.Float16, DataFormat.MxFp8R):
         spec = StimuliSpec(distribution=DistributionKind.UNIFORM, low=-10.0, high=10.0)
     else:
-        spec = StimuliSpec(distribution=DistributionKind.UNIFORM, low=-100.0, high=32.0)
+        spec = StimuliSpec(
+            distribution=DistributionKind.UNIFORM, low=-100.0, high=160.0
+        )
     return OperandSpecs(spec_A=spec)
 
 
@@ -136,10 +135,11 @@ def _exp2_spec(fmt: DataFormat) -> OperandSpecs:
     elif fmt in (DataFormat.Float16, DataFormat.MxFp8R):
         spec = StimuliSpec(distribution=DistributionKind.UNIFORM, low=-14.0, high=14.0)
     else:
-        # exp2(x) = exp(x * ln2), so the accuracy ceiling _exp_spec puts at an
-        # argument of 16 lands at x = 16 / ln2 ~ 23 here. Above that the shared
-        # approximation drifts past the default rtol on the fp32 dst path.
-        spec = StimuliSpec(distribution=DistributionKind.UNIFORM, low=-100.0, high=23.0)
+        # 2^100 still fits an 8-bit exponent, so the positive side is not range-bound
+        # the way _exp_spec is; the negative side matches its reach past the clamp.
+        spec = StimuliSpec(
+            distribution=DistributionKind.UNIFORM, low=-100.0, high=100.0
+        )
     return OperandSpecs(spec_A=spec)
 
 
@@ -799,7 +799,7 @@ def for_op_pipeline(
     either one alone drops the other:
 
     * **Range** is bounded by the narrowest exponent range anywhere in the
-      pipeline. exp over (-100, 16) is fine into a Float32 output and saturates
+      pipeline. exp over (-100, 80) is fine into a Float32 output and saturates
       a Float16 one, so the *output* format has to be able to narrow the domain.
     * **Precision** is a property of the *input* format alone. A block-float
       input has already spent its relative precision by the time the op runs,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -101,7 +101,15 @@ def _exp_spec(fmt: DataFormat) -> OperandSpecs:
         # the lower bound is intentionally pushed to -100.0 so we cross the SFPU's negative-side
         # sanitization boundary near x ≈ -88.5 (where InputClamping::ClampToNegative saturates inputs
         # in the fast/approx exp path).
-        spec = StimuliSpec(distribution=DistributionKind.UNIFORM, low=-100.0, high=80.0)
+        #
+        # The positive side stops at 16 for accuracy, not range: exp's relative
+        # condition number equals its argument, so the shared approximation's error
+        # grows linearly with x. Measured on Wormhole at the old high of 80, the
+        # largest outputs land 11-13% off the golden — well past the default 5% rtol
+        # — and the error is only visible on the fp32 (dest_acc=Yes) path, where a
+        # 16-bit dst is not there to round both sides back together. 16 is the same
+        # argument ceiling _exp_with_base_spec settles on for the same reason.
+        spec = StimuliSpec(distribution=DistributionKind.UNIFORM, low=-100.0, high=16.0)
     return OperandSpecs(spec_A=spec)
 
 
@@ -132,9 +140,34 @@ def _exp2_spec(fmt: DataFormat) -> OperandSpecs:
     elif fmt in (DataFormat.Float16, DataFormat.MxFp8R):
         spec = StimuliSpec(distribution=DistributionKind.UNIFORM, low=-14.0, high=14.0)
     else:
-        spec = StimuliSpec(
-            distribution=DistributionKind.UNIFORM, low=-100.0, high=100.0
-        )
+        # exp2(x) = exp(x * ln2), so the accuracy ceiling _exp_spec puts at an
+        # argument of 16 lands at x = 16 / ln2 ~ 23 here. Above that the shared
+        # approximation drifts past the default rtol on the fp32 dst path.
+        spec = StimuliSpec(distribution=DistributionKind.UNIFORM, low=-100.0, high=23.0)
+    return OperandSpecs(spec_A=spec)
+
+
+# Block-float formats: a group of 16 elements shares one exponent, so an element's
+# usable precision depends on how far below its block maximum it sits, not just on
+# the mantissa width.
+_BLOCK_FLOAT_FORMATS = (DataFormat.Bfp8_b, DataFormat.Bfp4_b, DataFormat.Bfp2_b)
+
+
+def _reciprocal_spec(fmt: DataFormat) -> OperandSpecs:
+    """Safe input range for 1/x, tightened for block-float inputs.
+
+    1/x carries input relative error straight through to the output, and in a
+    block-float input an element far below its block maximum has very little
+    relative precision left. Spanning [0.1, 100] puts a 1000:1 ratio inside a
+    16-element block, so the smallest elements quantize to zero and the golden
+    goes to inf. Measured on Bfp8_b stimuli: the wide interval leaves 13/1024
+    elements outside tolerance (max difference inf), while holding the ratio to
+    10:1 leaves none.
+    """
+    if fmt in _BLOCK_FLOAT_FORMATS:
+        spec = StimuliSpec.uniform(intervals=[(-100.0, -10.0), (10.0, 100.0)])
+    else:
+        spec = StimuliSpec.uniform(intervals=[(-100.0, -0.1), (0.1, 100.0)])
     return OperandSpecs(spec_A=spec)
 
 
@@ -288,10 +321,9 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.Neg: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-10.0, high=10.0)
     ),
-    # reciprocal: domain x != 0; avoid a small band around 0 and cover both signs
-    MathOperation.Reciprocal: OperandSpecs(
-        spec_A=StimuliSpec.uniform(intervals=[(-100.0, -0.1), (0.1, 100.0)])
-    ),
+    # reciprocal: domain x != 0; avoid a small band around 0 and cover both signs.
+    # Format-sensitive: block-float inputs need a tighter ratio, see _reciprocal_spec.
+    MathOperation.Reciprocal: _reciprocal_spec,
     # relu / relu_max / relu_min / threshold: include negatives (zero branch)
     MathOperation.Relu: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -16,7 +16,7 @@ import copy
 import math
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, FrozenSet, List, Optional, Tuple, Union
 
 from .format_config import DataFormat
 from .llk_params import MathOperation
@@ -839,6 +839,70 @@ def _validate_distribution_override(
 # ─────────────────────────────────────────────────────────────────────────────
 # Undefined-region subtraction
 # ─────────────────────────────────────────────────────────────────────────────
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Which family each registered op belongs to
+#
+# _OP_DOMAIN_REGISTRY is keyed by MathOperation and mixes the unary SFPU ops with the
+# binary ones, the FPU eltwise ops and the reduce family. That is fine for for_op(), but it
+# means a suite cannot ask "is my op list complete?" -- the unary sweep can check that no op
+# sits in two of its profiles and that every op it drives has a domain, but not that every
+# unary op is actually driven, so an op added to the registry and to no test goes untested
+# silently.
+#
+# Recording the family closes that. It is a flat set rather than a field on OperandSpecs
+# because several entries are shared with the perf sweeps and the accuracy harness, and
+# those consumers do not want an arity opinion imposed on them.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Ops with no unary SFPU kernel, so they must not appear in the unary sweep. Relu is the
+# one that looks like it should: it has a domain entry, but `relu` is not a member of
+# SfpuType at all -- relu is applied by the packer (STACC_RELU), not the SFPU -- so driving
+# it through the unary test fails to compile.
+_NON_SFPU_UNARY_OPS: FrozenSet[MathOperation] = frozenset(
+    {
+        # FPU eltwise binary
+        MathOperation.Elwadd,
+        MathOperation.Elwmul,
+        MathOperation.Elwsub,
+        # packer-applied relu
+        MathOperation.Relu,
+        # SFPU binary (test_sfpu_binary.py)
+        MathOperation.SfpuAddTopRow,
+        MathOperation.SfpuElwadd,
+        MathOperation.SfpuElwsub,
+        MathOperation.SfpuElwmul,
+        MathOperation.SfpuElwdiv,
+        MathOperation.SfpuElwpow,
+        MathOperation.SfpuElwrsub,
+        MathOperation.SfpuXlogy,
+        MathOperation.SfpuElwLeftShift,
+        MathOperation.SfpuElwRightShift,
+        MathOperation.SfpuElwLogicalRightShift,
+        # reduce family (test_sfpu_reduce*.py)
+        MathOperation.ReduceColumn,
+        MathOperation.ReduceRow,
+        MathOperation.ReduceScalar,
+    }
+)
+
+# Unary SFPU ops that are registered but deliberately not in the correctness sweep.
+_UNARY_OPS_NOT_SWEPT: Dict[MathOperation, str] = {
+    MathOperation.TopKLocalSort: "perf-only; whole-op topk is covered by test_topk.py",
+    MathOperation.TopKMerge: "perf-only; whole-op topk is covered by test_topk.py",
+    MathOperation.TopKRebuild: "perf-only; whole-op topk is covered by test_topk.py",
+}
+
+
+def sfpu_unary_ops() -> FrozenSet[MathOperation]:
+    """Every registered op that has a unary SFPU kernel.
+
+    The unary sweep asserts its profiles cover exactly this set minus
+    _UNARY_OPS_NOT_SWEPT, so adding an op to the registry without adding it to a sweep
+    profile (or to one of the two exemption sets above) fails at collection.
+    """
+    return frozenset(_OP_DOMAIN_REGISTRY) - _NON_SFPU_UNARY_OPS
+
 
 _SFPU_UNDEFINED_RANGES: Dict[
     MathOperation,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -153,9 +153,15 @@ def _reciprocal_spec(fmt: DataFormat) -> OperandSpecs:
     """Safe input range for 1/x, tightened for block-float inputs.
 
     A 1000:1 ratio inside a 16-element block quantizes the smallest elements to
-    zero, sending the golden to inf. Hold the ratio to 10:1 for block floats.
+    zero, sending the golden to inf. How tight the ratio has to be scales with the
+    mantissa width: 10:1 suffices for Bfp8_b's 7 bits, but at Bfp4_b's 3 bits ~6% of
+    that window still lands below the block's representable step and collapses to
+    zero. 4:1 keeps every element representable with margin (the smallest survivor
+    at 10:1 is 16.0, so the floor is not placed right on the boundary).
     """
-    if fmt in _BLOCK_FLOAT_FORMATS:
+    if fmt == DataFormat.Bfp4_b:
+        spec = StimuliSpec.uniform(intervals=[(-100.0, -25.0), (25.0, 100.0)])
+    elif fmt in _BLOCK_FLOAT_FORMATS:
         spec = StimuliSpec.uniform(intervals=[(-100.0, -10.0), (10.0, 100.0)])
     else:
         spec = StimuliSpec.uniform(intervals=[(-100.0, -0.1), (0.1, 100.0)])

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, Dict, FrozenSet, List, Optional, Tuple, Union
 
-from .format_config import DataFormat
+from .format_config import MX_FORMAT_MAX_NORMAL, DataFormat
 from .llk_params import MathOperation
 from .stimuli_generator import DistributionKind, StimuliSpec
 
@@ -58,11 +58,17 @@ class OperandSpecs:
 # Largest finite magnitude each format can hold. Only formats with a narrower
 # exponent field than bfloat16 need an entry; every other format shares
 # bfloat16's ceiling and is therefore never the binding constraint.
+#
+# The MX rows come from MX_FORMAT_MAX_NORMAL rather than being restated here: the two
+# fp8 encodings are easy to transpose by hand, and a transposed pair silently *widens*
+# a domain instead of failing. MxFp8R is E5M2 (ceiling 57344, the wide one) and MxFp8P
+# is E4M3 (ceiling 448, the narrow one) -- which is the polarity the builders below
+# already assume, e.g. _square_spec caps MxFp8P at +-20 and groups MxFp8R with Float16.
 _FORMAT_MAX_MAGNITUDE: Dict[DataFormat, float] = {
-    DataFormat.MxFp4: 6.0,  # e2m1
-    DataFormat.MxFp8R: 448.0,  # e4m3
+    **MX_FORMAT_MAX_NORMAL,  # MxFp4 (e2m1) 6, MxFp8P (e4m3) 448, MxFp8R (e5m2) 57344
     DataFormat.Float16: 65504.0,  # e5m10
-    DataFormat.MxFp8P: 57344.0,  # e5m2
+    # Plain E4M3 with no per-block scale to lift it, so the same 448 ceiling as MxFp8P.
+    DataFormat.Fp8_e4m3: 448.0,
 }
 
 _BF16_MAX_MAGNITUDE = 3.3895314e38
@@ -572,10 +578,12 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.Round: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-10.0, high=10.0)
     ),
-    # floor/ceil/trunc/frac: defined for all reals, but floor and ceil only differ
-    # from trunc on the negative side, so the domain has to span both signs to tell
-    # the three apart at all. Same range as round for the same reason: enough integer
-    # knees inside the interval that the random sweep lands near several of them.
+    # floor/ceil/trunc/frac: defined for all reals, but each of floor and ceil differs
+    # from trunc on one side only -- floor on the negative side (floor(-1.5) = -2 vs
+    # trunc's -1), ceil on the positive side (ceil(1.5) = 2 vs trunc's 1) -- so the
+    # domain has to span both signs to tell the three apart at all. Same range as round
+    # for the same reason: enough integer knees inside the interval that the random
+    # sweep lands near several of them.
     MathOperation.Floor: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-10.0, high=10.0)
     ),

--- a/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-import math
 import os
 import subprocess
 from collections import namedtuple
@@ -280,68 +279,73 @@ def _bfp_block_aware_compare(
     r_flat = result.float().flatten()
     n = g_flat.numel()
 
-    is_valid = torch.ones(n, dtype=torch.bool)
+    if n == 0:
+        return torch.ones(0, dtype=torch.bool)
 
-    for blk_start in range(0, n, BLOCK):
-        blk_end = min(blk_start + BLOCK, n)
-        g_blk = g_flat[blk_start:blk_end]
-        r_blk = r_flat[blk_start:blk_end]
+    # Batch over 16-element blocks (zero-pad a partial tail block; padded zeros never
+    # raise a block's max, so the real lanes are sized off the same ULP as before, and
+    # they are trimmed off the verdict below). Vectorised rather than looped: a [128, 256]
+    # result is ~2048 blocks, and _mxint_block_aware_compare already batches this way.
+    num_blocks = (n + BLOCK - 1) // BLOCK
+    pad = num_blocks * BLOCK - n
+    if pad:
+        g_flat = torch.cat([g_flat, g_flat.new_zeros(pad)])
+        r_flat = torch.cat([r_flat, r_flat.new_zeros(pad)])
+    g_blk = g_flat.reshape(num_blocks, BLOCK)
+    r_blk = r_flat.reshape(num_blocks, BLOCK)
 
-        both_nan = torch.isnan(g_blk) & torch.isnan(r_blk)
+    # Non-finite lanes sit outside the lattice and cannot be judged by it: inf and
+    # NaN have no ULP, and the differences they produce defeat the check in both
+    # directions -- inf - inf is NaN and inf - (-inf) is inf, and neither compares
+    # <= anything, so even a matching pair of infinities fails. Judge them by exact
+    # agreement instead, and keep them out of the finite-lane verdict so a block that
+    # is entirely non-finite is not waved through: +inf against -inf, or NaN against
+    # inf, are mismatches, and the PCC pass that follows masks non-finite values too.
+    both_nan = torch.isnan(g_blk) & torch.isnan(r_blk)
+    nonfinite_ok = both_nan | (
+        torch.isinf(g_blk)
+        & torch.isinf(r_blk)
+        & (torch.signbit(g_blk) == torch.signbit(r_blk))
+    )
+    g_finite = torch.isfinite(g_blk)
+    r_finite = torch.isfinite(r_blk)
+    both_finite = g_finite & r_finite
 
-        # Non-finite lanes sit outside the lattice and cannot be judged by it: inf and
-        # NaN have no ULP, and the differences they produce defeat the check in both
-        # directions -- inf - inf is NaN and inf - (-inf) is inf, and neither compares
-        # <= anything, so even a matching pair of infinities fails. Judge them by exact
-        # agreement instead, and keep them out of the finite-lane verdict so a block that
-        # is entirely non-finite is not waved through: +inf against -inf, or NaN against
-        # inf, are mismatches, and the PCC pass that follows masks non-finite values too.
-        nonfinite_ok = both_nan | (
-            torch.isinf(g_blk)
-            & torch.isinf(r_blk)
-            & (torch.signbit(g_blk) == torch.signbit(r_blk))
+    # Per-block max over the finite lanes of *either* side (a lane finite on one side
+    # only still sizes the block, as it did when the two sides were concatenated).
+    block_max = torch.maximum(
+        torch.where(g_finite, g_blk.abs(), torch.zeros_like(g_blk)).amax(dim=1),
+        torch.where(r_finite, r_blk.abs(), torch.zeros_like(r_blk)).amax(dim=1),
+    )
+    # A block with no finite lane at all, and an all-zero block, both land on max 0 and
+    # so on ULP 0: the first has no finite lane to judge, and in the second every finite
+    # lane is exactly 0, which `tiny_ok` accepts on absolute closeness below.
+    nonzero = block_max > 0
+    # log2 in float64 so floor() lands on the same integer math.log2 gave per block;
+    # in float32 an exact power of two can come back a hair under and floor a step early.
+    safe_max = torch.where(nonzero, block_max, torch.ones_like(block_max)).double()
+    one_ulp = (
+        torch.where(
+            nonzero,
+            torch.exp2(torch.floor(torch.log2(safe_max)) - (mantissa_bits - 1)),
+            torch.zeros_like(safe_max),
         )
-        both_finite = torch.isfinite(g_blk) & torch.isfinite(r_blk)
+        .float()
+        .unsqueeze(1)
+    )
 
-        finite_vals = torch.cat(
-            [
-                g_blk[torch.isfinite(g_blk)].abs(),
-                r_blk[torch.isfinite(r_blk)].abs(),
-            ]
-        )
-        if finite_vals.numel() == 0:
-            # Nothing finite anywhere in the block, so there is no block max to size a
-            # ULP from. Every lane is non-finite and judged as such.
-            is_valid[blk_start:blk_end] = nonfinite_ok
-            continue
-
-        block_max = finite_vals.max().item()
-        if block_max == 0:
-            is_valid[blk_start:blk_end] = torch.where(
-                both_finite,
-                torch.isclose(g_blk, r_blk, atol=1e-5, rtol=0.0),
-                nonfinite_ok,
-            )
-            continue
-
-        block_exp = math.floor(math.log2(block_max))
-        one_ulp = 2.0 ** (block_exp - mantissa_bits + 1)
-
-        diff = (g_blk - r_blk).abs()
-        ulp_ok = diff <= max_ulp_diff * one_ulp
-        # Padding / zero lanes can disagree slightly after pack-unpack while still
-        # printing as 0.00; ULP sizing from a large value elsewhere in the block
-        # can make those tiny residuals look like multi-ULP failures. Accept when
-        # both sides are negligible magnitude and close in absolute terms.
-        max_abs = torch.maximum(g_blk.abs(), r_blk.abs())
-        tiny_ok = (max_abs < 1e-4) & torch.isclose(
-            g_blk, r_blk, atol=1e-5, rtol=0.0, equal_nan=True
-        )
-        is_valid[blk_start:blk_end] = torch.where(
-            both_finite, ulp_ok | tiny_ok, nonfinite_ok
-        )
-
-    return is_valid
+    diff = (g_blk - r_blk).abs()
+    ulp_ok = diff <= max_ulp_diff * one_ulp
+    # Padding / zero lanes can disagree slightly after pack-unpack while still
+    # printing as 0.00; ULP sizing from a large value elsewhere in the block
+    # can make those tiny residuals look like multi-ULP failures. Accept when
+    # both sides are negligible magnitude and close in absolute terms.
+    max_abs = torch.maximum(g_blk.abs(), r_blk.abs())
+    tiny_ok = (max_abs < 1e-4) & torch.isclose(
+        g_blk, r_blk, atol=1e-5, rtol=0.0, equal_nan=True
+    )
+    is_valid = torch.where(both_finite, ulp_ok | tiny_ok, nonfinite_ok)
+    return is_valid.reshape(-1)[:n]
 
 
 # Per-format params for _mxint_block_aware_compare: (elem_scale, max_ulp_steps).
@@ -588,13 +592,15 @@ def passed_test(
             golden_tensor, res_tensor, rtol=tolerance.rtol, atol=tolerance.atol
         )
         is_nan = torch.isnan(golden_tensor) & torch.isnan(res_tensor)
-        is_valid = (
-            is_close
-            | is_nan
-            | _bfp_block_aware_compare(
+        is_valid = is_close | is_nan
+        # `|` does not short-circuit, so only reach for the lattice when the tolerance
+        # check has actually rejected something. Near-exact suites (test_unary_datacopy,
+        # test_sfpu_binary_float) accept every element here and would otherwise pay for a
+        # second full-tensor compare that cannot change the verdict.
+        if not torch.all(is_valid):
+            is_valid = is_valid | _bfp_block_aware_compare(
                 golden_tensor, res_tensor, mantissa_bits=7, max_ulp_diff=1
             )
-        )
     elif output_data_format == DataFormat.Bfp4_b:
         ulp = custom_bfp4_max_ulp_diff if custom_bfp4_max_ulp_diff is not None else 1
         is_valid = _bfp_block_aware_compare(

--- a/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
@@ -554,7 +554,18 @@ def passed_test(
     golden_tensor = golden_tensor.type(format_dict[output_data_format])
     res_tensor = res_tensor.type(format_dict[output_data_format])
 
-    if output_data_format == DataFormat.Bfp4_b:
+    if output_data_format == DataFormat.Bfp8_b:
+        # Bfp8_b is a block format like its Bfp4_b/Bfp2_b siblings — 7 magnitude bits
+        # against an exponent shared by 16 elements — but it used to fall through to
+        # the flat isclose path below. That only held while outputs stayed in a narrow
+        # band: once a block spans a wide magnitude range, the elements far below the
+        # block max are unrepresentable and quantize toward zero, which a fixed atol
+        # reads as a mismatch even though the hardware produced the closest value the
+        # format can express. Judge it on its own lattice, same as Bfp4_b/Bfp2_b.
+        is_valid = _bfp_block_aware_compare(
+            golden_tensor, res_tensor, mantissa_bits=7, max_ulp_diff=1
+        )
+    elif output_data_format == DataFormat.Bfp4_b:
         ulp = custom_bfp4_max_ulp_diff if custom_bfp4_max_ulp_diff is not None else 1
         is_valid = _bfp_block_aware_compare(
             golden_tensor, res_tensor, mantissa_bits=3, max_ulp_diff=ulp

--- a/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
@@ -264,7 +264,11 @@ def _bfp_block_aware_compare(
     After quantization, treat differences up to ``max_ulp_diff`` steps as acceptable.
 
     ``mantissa_bits`` is the number of mantissa bits the format reconstructs
-    per element (3 for Bfp4_b, 1 for Bfp2_b).
+    per element (7 for Bfp8_b, 3 for Bfp4_b, 1 for Bfp2_b).
+
+    The lattice applies only where both sides are finite. Non-finite lanes are
+    accepted on exact agreement -- both NaN, or both infinite with the same sign --
+    and rejected otherwise, including a block that is entirely non-finite.
 
     Golden and result must already be in the same flat buffer order (tilized
     layout as produced by the tests).  We do not re-tilize here: inputs are
@@ -285,6 +289,20 @@ def _bfp_block_aware_compare(
 
         both_nan = torch.isnan(g_blk) & torch.isnan(r_blk)
 
+        # Non-finite lanes sit outside the lattice and cannot be judged by it: inf and
+        # NaN have no ULP, and the differences they produce defeat the check in both
+        # directions -- inf - inf is NaN and inf - (-inf) is inf, and neither compares
+        # <= anything, so even a matching pair of infinities fails. Judge them by exact
+        # agreement instead, and keep them out of the finite-lane verdict so a block that
+        # is entirely non-finite is not waved through: +inf against -inf, or NaN against
+        # inf, are mismatches, and the PCC pass that follows masks non-finite values too.
+        nonfinite_ok = both_nan | (
+            torch.isinf(g_blk)
+            & torch.isinf(r_blk)
+            & (torch.signbit(g_blk) == torch.signbit(r_blk))
+        )
+        both_finite = torch.isfinite(g_blk) & torch.isfinite(r_blk)
+
         finite_vals = torch.cat(
             [
                 g_blk[torch.isfinite(g_blk)].abs(),
@@ -292,14 +310,17 @@ def _bfp_block_aware_compare(
             ]
         )
         if finite_vals.numel() == 0:
-            is_valid[blk_start:blk_end] = True
+            # Nothing finite anywhere in the block, so there is no block max to size a
+            # ULP from. Every lane is non-finite and judged as such.
+            is_valid[blk_start:blk_end] = nonfinite_ok
             continue
 
         block_max = finite_vals.max().item()
         if block_max == 0:
-            is_valid[blk_start:blk_end] = (
-                torch.isclose(g_blk, r_blk, atol=1e-5, rtol=0.0, equal_nan=True)
-                | both_nan
+            is_valid[blk_start:blk_end] = torch.where(
+                both_finite,
+                torch.isclose(g_blk, r_blk, atol=1e-5, rtol=0.0),
+                nonfinite_ok,
             )
             continue
 
@@ -316,7 +337,9 @@ def _bfp_block_aware_compare(
         tiny_ok = (max_abs < 1e-4) & torch.isclose(
             g_blk, r_blk, atol=1e-5, rtol=0.0, equal_nan=True
         )
-        is_valid[blk_start:blk_end] = ulp_ok | both_nan | tiny_ok
+        is_valid[blk_start:blk_end] = torch.where(
+            both_finite, ulp_ok | tiny_ok, nonfinite_ok
+        )
 
     return is_valid
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
@@ -555,20 +555,12 @@ def passed_test(
     res_tensor = res_tensor.type(format_dict[output_data_format])
 
     if output_data_format == DataFormat.Bfp8_b:
-        # Bfp8_b is a block format like its Bfp4_b/Bfp2_b siblings — 7 magnitude bits
-        # against an exponent shared by 16 elements — but it used to fall through to
-        # the flat isclose path below. That only held while outputs stayed in a narrow
-        # band: once a block spans a wide magnitude range, the elements far below the
-        # block max are unrepresentable and quantize toward zero, which a fixed atol
-        # reads as a mismatch even though the hardware produced the closest value the
-        # format can express.
-        #
-        # Unlike Bfp4_b/Bfp2_b, though, Bfp8_b's lattice is fine enough that a single
-        # step can be *tighter* than the SFPU's own approximation error, so the lattice
-        # check cannot simply replace the tolerance check either. The two criteria cover
-        # different regimes — quantization dominates for elements far below their block
-        # max, approximation error dominates near it — so accept a result that satisfies
-        # either one.
+        # Bfp8_b shares one exponent across 16 elements, so when a block spans a wide
+        # magnitude range the small elements quantize toward zero and a flat atol reads
+        # that as a mismatch. But Bfp8_b's lattice is fine enough that one step can be
+        # tighter than the SFPU's own approximation error, so the lattice check cannot
+        # replace the tolerance check either. Quantization dominates far below the block
+        # max, approximation error near it — accept a result satisfying either one.
         is_close = torch.isclose(
             golden_tensor, res_tensor, rtol=tolerance.rtol, atol=tolerance.atol
         )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
@@ -561,9 +561,24 @@ def passed_test(
         # band: once a block spans a wide magnitude range, the elements far below the
         # block max are unrepresentable and quantize toward zero, which a fixed atol
         # reads as a mismatch even though the hardware produced the closest value the
-        # format can express. Judge it on its own lattice, same as Bfp4_b/Bfp2_b.
-        is_valid = _bfp_block_aware_compare(
-            golden_tensor, res_tensor, mantissa_bits=7, max_ulp_diff=1
+        # format can express.
+        #
+        # Unlike Bfp4_b/Bfp2_b, though, Bfp8_b's lattice is fine enough that a single
+        # step can be *tighter* than the SFPU's own approximation error, so the lattice
+        # check cannot simply replace the tolerance check either. The two criteria cover
+        # different regimes — quantization dominates for elements far below their block
+        # max, approximation error dominates near it — so accept a result that satisfies
+        # either one.
+        is_close = torch.isclose(
+            golden_tensor, res_tensor, rtol=tolerance.rtol, atol=tolerance.atol
+        )
+        is_nan = torch.isnan(golden_tensor) & torch.isnan(res_tensor)
+        is_valid = (
+            is_close
+            | is_nan
+            | _bfp_block_aware_compare(
+                golden_tensor, res_tensor, mantissa_bits=7, max_ulp_diff=1
+            )
         )
     elif output_data_format == DataFormat.Bfp4_b:
         ulp = custom_bfp4_max_ulp_diff if custom_bfp4_max_ulp_diff is not None else 1

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
@@ -15,6 +15,7 @@ from helpers.llk_params import (
 )
 from helpers.param_config import input_output_formats, parametrize
 from helpers.perf import PerfConfig
+from helpers.sfpu_domains import sfpu_unary_ops
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import calculate_tile_and_face_counts
 from helpers.test_variant_parameters import (
@@ -85,6 +86,14 @@ def _get_stable_sort_modes(mathop):
     return [StableSort.No]
 
 
+# Every op with a unary SFPU kernel, taken from the same registry the correctness sweep
+# in test_sfpu_unary.py drives, so an op cannot be added there and silently skip perf.
+# _UNARY_OPS_NOT_SWEPT is deliberately *not* subtracted: those ops (the topk halves) are
+# exempt from the correctness sweep precisely because they are perf-only, so they belong
+# here. Sorted so the parametrize ids are stable across runs.
+PERF_SWEEP_OPS = sorted(sfpu_unary_ops(), key=lambda op: op.name)
+
+
 @pytest.mark.perf
 @parametrize(
     formats=input_output_formats(
@@ -99,26 +108,7 @@ def _get_stable_sort_modes(mathop):
         ApproximationMode.Yes,
         ApproximationMode.No,
     ],
-    mathop=[
-        MathOperation.Reciprocal,
-        MathOperation.Sqrt,
-        MathOperation.Rsqrt,
-        MathOperation.Silu,
-        MathOperation.Gelu,
-        MathOperation.GeluTanh,
-        MathOperation.Exp,
-        MathOperation.Lrelu,
-        MathOperation.ReluMin,
-        MathOperation.Erfinv,
-        MathOperation.Heaviside,
-        MathOperation.Softshrink,
-        MathOperation.Softsign,
-        MathOperation.Square,
-        MathOperation.Log,
-        MathOperation.TopKLocalSort,
-        MathOperation.TopKMerge,
-        MathOperation.TopKRebuild,
-    ],
+    mathop=PERF_SWEEP_OPS,
     dest_acc=lambda mathop: _get_dest_acc_modes(mathop),
     loop_factor=[
         16,

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
@@ -93,17 +93,61 @@ def _get_stable_sort_modes(mathop):
 # here. Sorted so the parametrize ids are stable across runs.
 PERF_SWEEP_OPS = sorted(sfpu_unary_ops(), key=lambda op: op.name)
 
+# Five PerfRunTypes per variant, so all 97 registry ops against all 16 format pairs is
+# ~30k ELF builds and profiled runs on llk_perf_tests.yaml's five shards, against ~6.4k
+# before the reroute -- and it buys little, since an SFPU kernel's math cost is its
+# instruction sequence while the format pair moves unpack/pack cycles, which these ops
+# already characterise. So every op is still swept (with its own dest_acc / fast_mode /
+# stable_sort / approx_mode), but only the pre-reroute set carries the full 16-pair matrix.
+_FULL_FORMAT_MATRIX_OPS = frozenset(
+    {
+        MathOperation.Reciprocal,
+        MathOperation.Sqrt,
+        MathOperation.Rsqrt,
+        MathOperation.Silu,
+        MathOperation.Gelu,
+        MathOperation.GeluTanh,
+        MathOperation.Exp,
+        MathOperation.TopKLocalSort,
+        MathOperation.TopKMerge,
+        MathOperation.TopKRebuild,
+    }
+)
+
+_FULL_FORMATS = [
+    DataFormat.Float32,
+    DataFormat.Float16,
+    DataFormat.Float16_b,
+    DataFormat.Bfp8_b,
+]
+
+# Float16_b in and out: the SFPU's native 16-bit exponent-B format, so the measurement is
+# the kernel's own cost with no unpack/pack conversion folded in.
+_REPRESENTATIVE_FORMAT = [DataFormat.Float16_b]
+
+_FULL_FORMAT_PAIRS = input_output_formats(_FULL_FORMATS)
+_REPRESENTATIVE_FORMAT_PAIRS = input_output_formats(_REPRESENTATIVE_FORMAT)
+
+# An op named here but no longer in the sweep would silently stop being measured on the
+# full matrix, which is the one regression this split can cause.
+_UNSWEPT_FULL_MATRIX_OPS = sorted(
+    op.name for op in _FULL_FORMAT_MATRIX_OPS - set(PERF_SWEEP_OPS)
+)
+assert not _UNSWEPT_FULL_MATRIX_OPS, (
+    "these ops are declared as carrying the full format matrix but are not in "
+    f"PERF_SWEEP_OPS: {_UNSWEPT_FULL_MATRIX_OPS}"
+)
+
+
+def _get_formats(mathop):
+    if mathop in _FULL_FORMAT_MATRIX_OPS:
+        return _FULL_FORMAT_PAIRS
+    return _REPRESENTATIVE_FORMAT_PAIRS
+
 
 @pytest.mark.perf
 @parametrize(
-    formats=input_output_formats(
-        [
-            DataFormat.Float32,
-            DataFormat.Float16,
-            DataFormat.Float16_b,
-            DataFormat.Bfp8_b,
-        ]
-    ),
+    formats=lambda mathop: _get_formats(mathop),
     approx_mode=[
         ApproximationMode.Yes,
         ApproximationMode.No,

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
@@ -710,7 +710,9 @@ def test_sfpu_binary_atan2(formats, dest_acc, mathop):
 
 
 @parametrize(
-    formats=input_output_formats([DataFormat.Float16_b, DataFormat.Float32]),
+    formats=input_output_formats(
+        [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+    ),
     mathop=[MathOperation.SfpuElwEq, MathOperation.SfpuElwNe],
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
 )
@@ -718,13 +720,16 @@ def test_sfpu_binary_eq_ne(formats, dest_acc, mathop):
     # Eq/Ne(a, b) with a = tile0, b = tile1. Crafted paired stimuli give a non-constant 0/1
     # golden so the equal branch is exercised (the default random sweep never is).
     _skip_fp32_no_dest_acc(formats, dest_acc)
+    _skip_bh_float16_no_dest_acc(formats, dest_acc)
 
     spec_A, spec_B = _eq_ne_stimuli_specs()
     sfpu_binary(formats, dest_acc, mathop, spec_A=spec_A, spec_B=spec_B)
 
 
 @parametrize(
-    formats=input_output_formats([DataFormat.Float16_b, DataFormat.Float32]),
+    formats=input_output_formats(
+        [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+    ),
     mathop=[
         MathOperation.SfpuElwLt,
         MathOperation.SfpuElwGt,

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
@@ -116,9 +116,10 @@ def _face_spec(dist):
 # =============================================================================
 # Which ops take their domain from _OP_DOMAIN_REGISTRY
 #
-# Audit finding #2: this suite never imported sfpu_domains, so every op fell back to
-# generate_stimuli's positive-only uniform(0.1, 1.1) and the registered per-op domains --
-# including the undefined-range holes that are the interesting boundaries -- were dormant.
+# This suite never imported sfpu_domains, so every op fell back to generate_stimuli's
+# positive-only uniform(0.1, 1.1) and the registered per-op domains -- including the
+# undefined-range holes that are the interesting boundaries -- were dormant
+# (https://github.com/tenstorrent/tt-metal/issues/49739).
 #
 # The reroute is deliberately narrower than "every registered op", for two reasons:
 #
@@ -342,7 +343,7 @@ def sfpu_binary(
     #
     # Ops registered in _OP_DOMAIN_REGISTRY take their domain from there, which is what makes
     # the registered undefined-range holes (SfpuElwdiv divisor, SfpuXlogy B, SfpuElwpow A)
-    # reachable at all; see SFPU_EDGE_CASE_COVERAGE.md finding #2. Unlike the unary sweep,
+    # reachable at all — see _REGISTRY_DOMAIN_OPS above. Unlike the unary sweep,
     # most ops here are *not* registered, so a missing entry falls back to generate_stimuli's
     # format default rather than raising. That fallback is declared in
     # _UNREGISTERED_BINARY_OPS and checked, so it stays a deliberate list rather than an

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 
 import pytest
@@ -24,6 +24,7 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
 )
+from helpers.sfpu_domains import _OP_DOMAIN_REGISTRY, exclude_undefined_pair, for_op
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import DistributionKind, StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
@@ -37,6 +38,7 @@ from helpers.test_variant_parameters import (
     TemplateParameter,
     generate_input_dim,
 )
+from helpers.tile_constants import DEFAULT_TILE_C_DIM, DEFAULT_TILE_R_DIM
 from helpers.tilize_untilize import tilize
 from helpers.utils import passed_test
 
@@ -75,24 +77,148 @@ def _skip_bh_float16_no_dest_acc(formats, dest_acc):
 # Number of faces per tile for the [64, 32] two-tile binary harness layout
 # (a 32x32 tile is 4 faces of 16x16, and input_dimensions=[64, 32] is 8 faces).
 _FACES_PER_TILE = 4
+_ELEMENTS_PER_TILE = DEFAULT_TILE_R_DIM * DEFAULT_TILE_C_DIM
 
 
-def _paired_two_tile_spec(a_face, b_face):
-    """Fill operand tile0 (in0) and tile1 (in1) from *different* per-position data.
+def _pair_operand_specs(spec_A, spec_B, input_dimensions):
+    """Interleave two per-operand specs across *every* tile pair in the buffer.
 
-    The harness applies one per-face distribution to every face, so a plain callable makes
-    in0 == in1. Keep `a_face` for the tile0 faces (0..3) and override the tile1 faces (4..7)
-    with `b_face`, so position p pairs as (a_face[p], b_face[p]); tilize preserves it.
+    The kernel reads operand 0 from the even tile of each pair and operand 1 from the odd
+    one, and the golden is computed pair by pair, so per-operand stimuli have to alternate
+    every 4 faces for the whole buffer.
+
+    This has to be built against the real tile count because `face_specs` is applied
+    **positionally and is not cycled** (`stimuli_generator/generator.py:124`:
+    `if spec.face_specs and face_idx < len(spec.face_specs)`). A fixed 8-entry list — which
+    is what this helper used to return — therefore paired only tile pair 0 and left every
+    later pair with operand 0's distribution on *both* sides. On the [256, 128] buffer this
+    driver uses that is 1 of 16 pairs genuinely paired; measured on `_eq_ne_stimuli_specs`,
+    pair 0 came out 50% equal as intended and pairs 1-15 came out 100% equal, so 15/16 of
+    the data only ever exercised the equal branch.
+
+    Entries for operand 0's faces stay None so they fall through to the base spec.
     """
-    return StimuliSpec(
-        distribution=a_face,
-        seed=0,
-        face_specs=[None] * _FACES_PER_TILE
-        + [StimuliSpec(distribution=b_face, seed=0)] * _FACES_PER_TILE,
+    tiles = (input_dimensions[0] * input_dimensions[1]) // _ELEMENTS_PER_TILE
+    if tiles % 2:
+        raise ValueError(
+            f"SFPU binary needs a whole number of tile pairs, got {tiles} tiles "
+            f"from input_dimensions={input_dimensions}"
+        )
+    face_specs = ([None] * _FACES_PER_TILE + [spec_B] * _FACES_PER_TILE) * (tiles // 2)
+    return replace(spec_A, face_specs=face_specs)
+
+
+def _face_spec(dist):
+    """A per-face callable distribution as a StimuliSpec, with a fixed seed."""
+    return StimuliSpec(distribution=dist, seed=0)
+
+
+# =============================================================================
+# Which ops take their domain from _OP_DOMAIN_REGISTRY
+#
+# Audit finding #2: this suite never imported sfpu_domains, so every op fell back to
+# generate_stimuli's positive-only uniform(0.1, 1.1) and the registered per-op domains --
+# including the undefined-range holes that are the interesting boundaries -- were dormant.
+#
+# The reroute is deliberately narrower than "every registered op", for two reasons:
+#
+#   * It is float-only. SfpuElwadd/SfpuElwsub and the three shift ops also run through
+#     test_sfpu_binary_int with an Int32 format, and their registry domains are written for
+#     floats: for_op(SfpuElwadd, Int32).spec_A is uniform(-1, 1), which on an integer format
+#     collapses to {-1, 0, 1} and would gut the int coverage rather than widen it.
+#   * Ops with crafted stimuli (mask / isclose / eq-ne / logsigmoid / the shift edge cases)
+#     pass their own spec and are untouched by a default.
+#
+# So this is the set of float elementwise ops that have a registered domain and currently
+# run the positive-only default. Everything else stays on that default and is listed in
+# _UNREGISTERED_BINARY_OPS, so the fallback is a declared set rather than an accident.
+# =============================================================================
+
+_REGISTRY_DOMAIN_OPS = frozenset(
+    {
+        MathOperation.SfpuElwadd,
+        MathOperation.SfpuElwsub,
+        MathOperation.SfpuElwmul,
+        MathOperation.SfpuElwrsub,
+        MathOperation.SfpuElwdiv,
+        MathOperation.SfpuElwpow,
+        MathOperation.SfpuXlogy,
+    }
+)
+
+# Ops this suite drives that have no _OP_DOMAIN_REGISTRY entry at all, and so keep the
+# format default. Not a TODO list — several are int-only or carry crafted stimuli — but it
+# is checked below so that registering a domain for one of them shows up here as a diff
+# rather than silently changing what that op is fed.
+_UNREGISTERED_BINARY_OPS = frozenset(
+    {
+        MathOperation.SfpuAtan2,
+        MathOperation.SfpuBinaryFmod,
+        MathOperation.SfpuBinaryMax,
+        MathOperation.SfpuBinaryMin,
+        MathOperation.SfpuBinaryRemainder,
+        MathOperation.SfpuBitwiseAnd,
+        MathOperation.SfpuBitwiseOr,
+        MathOperation.SfpuBitwiseXor,
+        MathOperation.SfpuDivInt32,
+        MathOperation.SfpuDivInt32Floor,
+        MathOperation.SfpuElwEq,
+        MathOperation.SfpuElwGe,
+        MathOperation.SfpuElwGt,
+        MathOperation.SfpuElwLe,
+        MathOperation.SfpuElwLt,
+        MathOperation.SfpuElwNe,
+        MathOperation.SfpuEqInt,
+        MathOperation.SfpuFmodInt32,
+        MathOperation.SfpuGcd,
+        MathOperation.SfpuIsclose,
+        MathOperation.SfpuLcm,
+        MathOperation.SfpuLogsigmoid,
+        MathOperation.SfpuMask,
+        MathOperation.SfpuMaxInt32,
+        MathOperation.SfpuMaxUint32,
+        MathOperation.SfpuMinInt32,
+        MathOperation.SfpuMinUint32,
+        MathOperation.SfpuMulInt32,
+        MathOperation.SfpuNeInt,
+        MathOperation.SfpuRemainderInt32,
+        MathOperation.SfpuRemainderUint32,
+        MathOperation.SfpuRsubInt32,
+    }
+)
+
+
+def _assert_domain_sets_consistent():
+    """The rerouted ops must be registered, and the fallback ops must not be.
+
+    Both halves were implicit before and both fail quietly: an op named in
+    _REGISTRY_DOMAIN_OPS without a registry entry raises deep inside the driver mid-sweep,
+    and an op that gains a domain while sitting in _UNREGISTERED_BINARY_OPS keeps running
+    the positive-only default with nothing to say so.
+    """
+    missing = sorted(
+        op.name for op in _REGISTRY_DOMAIN_OPS if op not in _OP_DOMAIN_REGISTRY
     )
+    assert not missing, (
+        "these ops are routed to the domain registry but have no entry in "
+        f"sfpu_domains._OP_DOMAIN_REGISTRY: {missing}"
+    )
+    now_registered = sorted(
+        op.name for op in _UNREGISTERED_BINARY_OPS if op in _OP_DOMAIN_REGISTRY
+    )
+    assert not now_registered, (
+        "these ops now have a domain in _OP_DOMAIN_REGISTRY but are still on the "
+        "positive-only fallback list; move them to _REGISTRY_DOMAIN_OPS (float ops) or "
+        f"drop them from _UNREGISTERED_BINARY_OPS: {now_registered}"
+    )
+    overlap = _REGISTRY_DOMAIN_OPS & _UNREGISTERED_BINARY_OPS
+    assert not overlap, sorted(op.name for op in overlap)
 
 
-def _mask_stimuli_spec():
+_assert_domain_sets_consistent()
+
+
+def _mask_stimuli_specs():
     # mask zeroes data (in0) where mask (in1) is 0. Data and mask are separate tiles: keep
     # data strictly non-zero (1..8) and zero ~1/3 of the mask, so a passthrough kernel fails.
     def data_face(size, dtype, generator):
@@ -103,10 +229,10 @@ def _mask_stimuli_spec():
         j = torch.arange(size, dtype=torch.float32)
         return torch.where(j % 3 == 0, 0.0, 1.0).to(dtype)  # ~1/3 exact zeros
 
-    return _paired_two_tile_spec(data_face, mask_face)
+    return _face_spec(data_face), _face_spec(mask_face)
 
 
-def _isclose_stimuli_spec():
+def _isclose_stimuli_specs():
     # isclose is a predicate on paired operands (a = tile0, b = tile1). Fill the two tiles
     # from different data so even p -> identical (isclose 1), odd p -> differ by 2.0
     # (isclose 0); the 2.0 gap dwarfs the tolerance so the decision is unambiguous.
@@ -119,10 +245,10 @@ def _isclose_stimuli_spec():
         base = 1.0 + (j % 8)
         return (base + torch.where(j % 2 == 0, 0.0, 2.0)).to(dtype)
 
-    return _paired_two_tile_spec(a_face, b_face)
+    return _face_spec(a_face), _face_spec(b_face)
 
 
-def _eq_ne_stimuli_spec():
+def _eq_ne_stimuli_specs():
     # Eq/Ne compare paired operands (a = tile0, b = tile1). Fill the two tiles so even p ->
     # identical (Eq 1), odd p -> differ by 1.0 (Eq 0), a clean ~50/50 mix.
     def a_face(size, dtype, generator):
@@ -134,7 +260,7 @@ def _eq_ne_stimuli_spec():
         base = 1.0 + (j % 8)
         return (base + torch.where(j % 2 == 0, 0.0, 1.0)).to(dtype)
 
-    return _paired_two_tile_spec(a_face, b_face)
+    return _face_spec(a_face), _face_spec(b_face)
 
 
 def _logsigmoid_stimuli_spec():
@@ -163,12 +289,50 @@ def sfpu_binary(
     broadcast_type=None,
     src_A_override=None,
     spec_A=None,
+    spec_B=None,
     twos_complement=False,
+    input_dimensions=None,
 ):
+
+    # Seed the draw. Neither this driver nor default_spec_for_format set a seed, so the
+    # stimuli were redrawn on every run and a variant sitting near its tolerance could pass
+    # or fail depending on the draw -- which showed up as two xlogy variants failing in a
+    # full-suite run that then reproduced in neither a targeted rerun nor five other seeds.
+    # eltwise_unary_sfpu already seeds for the same reason.
+    torch.manual_seed(0)
 
     # FP32 destination tiles occupy twice the register space. Keep four full destination
     # blocks for those formats and four blocks of eight tiles for the remaining formats.
-    input_dimensions = [128, 128] if formats.input_format.is_32_bit() else [256, 128]
+    if input_dimensions is None:
+        input_dimensions = (
+            [128, 128] if formats.input_format.is_32_bit() else [256, 128]
+        )
+
+    # Per-operand domains. Both operands live in buffer_A (even tile = in0, odd tile = in1),
+    # so there is no spec_B knob in generate_stimuli — the two specs are interleaved into one
+    # spec's face_specs here, where the tile count is known.
+    #
+    # Ops registered in _OP_DOMAIN_REGISTRY take their domain from there, which is what makes
+    # the registered undefined-range holes (SfpuElwdiv divisor, SfpuXlogy B, SfpuElwpow A)
+    # reachable at all; see SFPU_EDGE_CASE_COVERAGE.md finding #2. Unlike the unary sweep,
+    # most ops here are *not* registered, so a missing entry falls back to generate_stimuli's
+    # format default rather than raising. That fallback is declared in
+    # _UNREGISTERED_BINARY_OPS and checked, so it stays a deliberate list rather than an
+    # accident.
+    if (
+        spec_A is None
+        and mathop in _REGISTRY_DOMAIN_OPS
+        and not formats.input_format.is_integer()
+    ):
+        specs = exclude_undefined_pair(mathop, for_op(mathop, formats.input_format))
+        spec_A, spec_B = specs.spec_A, specs.spec_B
+
+    if spec_B is not None:
+        if spec_A is None:
+            raise ValueError(
+                "spec_B requires spec_A (it fills the odd tile of each pair)"
+            )
+        spec_A = _pair_operand_specs(spec_A, spec_B, input_dimensions)
 
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
@@ -432,12 +596,30 @@ def test_sfpu_binary_mask(formats, dest_acc, mathop):
     # Crafted stimuli so the mask carries real zeros.
     _skip_fp32_no_dest_acc(formats, dest_acc)
 
+    # One tile pair only, unlike every other op here. calculate_mask hard-codes its
+    # operands -- data at dst_reg[0], mask at dst_reg[32], result in place -- and ignores
+    # the forwarded dst indices, so only the in0=0/in1=1/out=0 placement computes anything
+    # (see calculate_mask_binary in helpers/include/sfpu_test_helpers.h). The kernel loops
+    # `tile += 2` over NUM_TILES_IN_BLOCK, so on the default [256, 128] buffer the mask is
+    # applied to tile 0 of each block four times over while tiles 2/4/6 are packed out as
+    # unmasked datacopy output, against a golden that masks every pair.
+    #
+    # That went unnoticed because the paired stimuli only ever filled the first tile pair
+    # (see _pair_operand_specs): every later pair got the data distribution on both sides,
+    # so its mask was all-nonzero and masking was a no-op there. Fixing the pairing made
+    # the mismatch real -- 12 of 16 pairs, exactly the non-block-leading ones.
+    #
+    # [64, 32] is 2 tiles = 1 block = 1 pair, so every pair the kernel drives is the one
+    # the adapter supports. Same real coverage as before, without the 15 dead pairs.
+    spec_A, spec_B = _mask_stimuli_specs()
     sfpu_binary(
         formats,
         dest_acc,
         mathop,
         broadcast_type=LlkBroadcastType.None_,
-        spec_A=_mask_stimuli_spec(),
+        spec_A=spec_A,
+        spec_B=spec_B,
+        input_dimensions=[64, 32],
     )
 
 
@@ -469,12 +651,8 @@ def test_sfpu_binary_eq_ne(formats, dest_acc, mathop):
     # golden so the equal branch is exercised (the default random sweep never is).
     _skip_fp32_no_dest_acc(formats, dest_acc)
 
-    sfpu_binary(
-        formats,
-        dest_acc,
-        mathop,
-        spec_A=_eq_ne_stimuli_spec(),
-    )
+    spec_A, spec_B = _eq_ne_stimuli_specs()
+    sfpu_binary(formats, dest_acc, mathop, spec_A=spec_A, spec_B=spec_B)
 
 
 @parametrize(
@@ -487,12 +665,8 @@ def test_sfpu_binary_isclose(formats, dest_acc, mathop):
     # tolerances (fixed in the C++ dispatch); crafted stimuli give a non-constant 0/1 mix.
     _skip_fp32_no_dest_acc(formats, dest_acc)
 
-    sfpu_binary(
-        formats,
-        dest_acc,
-        mathop,
-        spec_A=_isclose_stimuli_spec(),
-    )
+    spec_A, spec_B = _isclose_stimuli_specs()
+    sfpu_binary(formats, dest_acc, mathop, spec_A=spec_A, spec_B=spec_B)
 
 
 @parametrize(
@@ -633,7 +807,8 @@ def test_sfpu_binary_eq_ne_int(formats, dest_acc, mathop):
     # int32 eq/ne via calculate_binary_eq_int (exact 0/1 over the raw INT32 dest bits).
     # Reuse the paired eq/ne stimuli so ~50% of positions compare equal — the equal branch
     # a plain random int sweep would essentially never hit.
-    sfpu_binary(formats, dest_acc, mathop, spec_A=_eq_ne_stimuli_spec())
+    spec_A, spec_B = _eq_ne_stimuli_specs()
+    sfpu_binary(formats, dest_acc, mathop, spec_A=spec_A, spec_B=spec_B)
 
 
 # =============================================================================

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
@@ -25,7 +25,12 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
 )
-from helpers.sfpu_domains import _OP_DOMAIN_REGISTRY, exclude_undefined_pair, for_op
+from helpers.sfpu_domains import (
+    _OP_DOMAIN_REGISTRY,
+    _SFPU_BINARY_OPS,
+    exclude_undefined_pair,
+    for_op,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import DistributionKind, StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
@@ -69,9 +74,9 @@ def _skip_bh_float16_no_dest_acc(formats, dest_acc):
 # =============================================================================
 # Shared crafted-stimuli helpers
 #
-# Several predicate/paired ops (mask, isclose, eq/ne) need operand tiles filled
-# from *different* per-position data, which the default random sweep can't
-# express. These builders produce those StimuliSpecs. (logsigmoid also lives
+# Several predicate/paired ops (mask, isclose, eq/ne, lt/gt/le/ge) need operand
+# tiles filled from *different* per-position data, which the default random sweep
+# can't express. These builders produce those StimuliSpecs. (logsigmoid also lives
 # here, but it is a plain single-distribution spec that never reads in1.)
 # =============================================================================
 
@@ -105,6 +110,18 @@ def _face_spec(dist):
     return StimuliSpec(distribution=dist, seed=0)
 
 
+def _positions_and_ramp(size):
+    """The (positions, 1..8 ramp) pair every paired builder below is built from.
+
+    `size` is whatever the generator passes per face (256 for a 16x16 face), so the
+    builders never assume a face size. The ramp repeats 1..8: non-zero everywhere, so
+    mask's passthrough is detectable, and of order 1, so the +/-1.0 and +2.0 offsets the
+    other operand adds are unambiguous against any rounding.
+    """
+    positions = torch.arange(size, dtype=torch.float32)
+    return positions, 1.0 + (positions % 8)
+
+
 # =============================================================================
 # Which ops take their domain from _OP_DOMAIN_REGISTRY
 #
@@ -113,8 +130,9 @@ def _face_spec(dist):
 # {-1, 0, 1} and gut the int coverage. Ops with crafted stimuli (mask / isclose /
 # eq-ne / logsigmoid / shift edge cases) pass their own spec and ignore any default.
 #
-# Everything else stays on generate_stimuli's positive-only uniform(0.1, 1.1) default
-# and is listed in _UNREGISTERED_BINARY_OPS, so the fallback is a declared set.
+# Everything else this suite drives is declared too -- in _UNREGISTERED_BINARY_OPS if it
+# has no registry entry, or _INT_ONLY_REGISTERED_OPS if it has one that integer stimuli
+# never consult -- so every op's domain decision is written down rather than defaulted to.
 # =============================================================================
 
 _REGISTRY_DOMAIN_OPS = frozenset(
@@ -170,19 +188,42 @@ _UNREGISTERED_BINARY_OPS = frozenset(
     }
 )
 
+# Registered ops this suite only ever drives under an integer format, where sfpu_binary's
+# `not is_integer()` conjunct blocks registry routing regardless of membership (a float
+# domain like uniform(-1, 1) would collapse to {-1, 0, 1} under Int32). They belong in
+# neither set above: not rerouted, but not unregistered either. Declared so the
+# completeness check below can account for every op the file drives.
+_INT_ONLY_REGISTERED_OPS = frozenset(
+    {
+        MathOperation.SfpuElwLeftShift,
+        MathOperation.SfpuElwRightShift,
+        MathOperation.SfpuElwLogicalRightShift,
+    }
+)
+
+_DECLARED_BINARY_OPS = (
+    _REGISTRY_DOMAIN_OPS | _UNREGISTERED_BINARY_OPS | _INT_ONLY_REGISTERED_OPS
+)
+
 
 def _assert_domain_sets_consistent():
-    """The rerouted ops must be registered, and the fallback ops must not be.
+    """The rerouted ops must be registered, the fallback ops must not be, and every
+    binary SFPU op must sit in exactly one of the three sets.
 
-    Both halves fail quietly otherwise: an op in _REGISTRY_DOMAIN_OPS with no registry
-    entry raises deep inside the driver mid-sweep, and an op that gains a domain while
-    sitting in _UNREGISTERED_BINARY_OPS silently keeps the positive-only default.
+    All three halves fail quietly otherwise: an op in _REGISTRY_DOMAIN_OPS with no
+    registry entry raises deep inside the driver mid-sweep; an op that gains a domain
+    while sitting in _UNREGISTERED_BINARY_OPS silently keeps the positive-only default;
+    and an op in none of the sets is the same silent default with nothing even claiming
+    responsibility for it -- which is how the shift ops went 39-declared-against-42-driven
+    until this check existed.
     """
     missing = sorted(
-        op.name for op in _REGISTRY_DOMAIN_OPS if op not in _OP_DOMAIN_REGISTRY
+        op.name
+        for op in _REGISTRY_DOMAIN_OPS | _INT_ONLY_REGISTERED_OPS
+        if op not in _OP_DOMAIN_REGISTRY
     )
     assert not missing, (
-        "these ops are routed to the domain registry but have no entry in "
+        "these ops are declared as registered but have no entry in "
         f"sfpu_domains._OP_DOMAIN_REGISTRY: {missing}"
     )
     now_registered = sorted(
@@ -190,11 +231,34 @@ def _assert_domain_sets_consistent():
     )
     assert not now_registered, (
         "these ops now have a domain in _OP_DOMAIN_REGISTRY but are still on the "
-        "positive-only fallback list; move them to _REGISTRY_DOMAIN_OPS (float ops) or "
-        f"drop them from _UNREGISTERED_BINARY_OPS: {now_registered}"
+        "positive-only fallback list; move them to _REGISTRY_DOMAIN_OPS (float ops), "
+        "_INT_ONLY_REGISTERED_OPS (integer-only ops), or drop them from "
+        f"_UNREGISTERED_BINARY_OPS: {now_registered}"
     )
-    overlap = _REGISTRY_DOMAIN_OPS & _UNREGISTERED_BINARY_OPS
-    assert not overlap, sorted(op.name for op in overlap)
+    for left, right in (
+        ("_REGISTRY_DOMAIN_OPS", "_UNREGISTERED_BINARY_OPS"),
+        ("_REGISTRY_DOMAIN_OPS", "_INT_ONLY_REGISTERED_OPS"),
+        ("_UNREGISTERED_BINARY_OPS", "_INT_ONLY_REGISTERED_OPS"),
+    ):
+        overlap = globals()[left] & globals()[right]
+        assert not overlap, (
+            f"{left} and {right} must be disjoint, but share: "
+            f"{sorted(op.name for op in overlap)}"
+        )
+    # SfpuAddTopRow is the one member of the binary family that never reaches
+    # sfpu_binary (test_sfpu_binary_add_top_row builds its own stimuli), so it has no
+    # domain decision to declare.
+    undeclared = sorted(
+        op.name
+        for op in _SFPU_BINARY_OPS
+        - {MathOperation.SfpuAddTopRow}
+        - _DECLARED_BINARY_OPS
+    )
+    assert not undeclared, (
+        "these ops are in sfpu_domains._SFPU_BINARY_OPS but are in none of this "
+        "suite's three domain sets, so nothing states what they are fed: "
+        f"{undeclared}"
+    )
 
 
 _assert_domain_sets_consistent()
@@ -204,11 +268,11 @@ def _mask_stimuli_specs():
     # mask zeroes data (in0) where mask (in1) is 0. Data and mask are separate tiles: keep
     # data strictly non-zero (1..8) and zero ~1/3 of the mask, so a passthrough kernel fails.
     def data_face(size, dtype, generator):
-        j = torch.arange(size, dtype=torch.float32)
-        return (1.0 + (j % 8)).to(dtype)  # 1..8, always non-zero
+        _, ramp = _positions_and_ramp(size)
+        return ramp.to(dtype)  # 1..8, always non-zero
 
     def mask_face(size, dtype, generator):
-        j = torch.arange(size, dtype=torch.float32)
+        j, _ = _positions_and_ramp(size)
         return torch.where(j % 3 == 0, 0.0, 1.0).to(dtype)  # ~1/3 exact zeros
 
     return _face_spec(data_face), _face_spec(mask_face)
@@ -219,13 +283,12 @@ def _isclose_stimuli_specs():
     # from different data so even p -> identical (isclose 1), odd p -> differ by 2.0
     # (isclose 0); the 2.0 gap dwarfs the tolerance so the decision is unambiguous.
     def a_face(size, dtype, generator):
-        j = torch.arange(size, dtype=torch.float32)
-        return (1.0 + (j % 8)).to(dtype)  # 1..8, strictly positive
+        _, ramp = _positions_and_ramp(size)
+        return ramp.to(dtype)  # 1..8, strictly positive
 
     def b_face(size, dtype, generator):
-        j = torch.arange(size, dtype=torch.float32)
-        base = 1.0 + (j % 8)
-        return (base + torch.where(j % 2 == 0, 0.0, 2.0)).to(dtype)
+        j, ramp = _positions_and_ramp(size)
+        return (ramp + torch.where(j % 2 == 0, 0.0, 2.0)).to(dtype)
 
     return _face_spec(a_face), _face_spec(b_face)
 
@@ -234,13 +297,12 @@ def _eq_ne_stimuli_specs():
     # Eq/Ne compare paired operands (a = tile0, b = tile1). Fill the two tiles so even p ->
     # identical (Eq 1), odd p -> differ by 1.0 (Eq 0), a clean ~50/50 mix.
     def a_face(size, dtype, generator):
-        j = torch.arange(size, dtype=torch.float32)
-        return (1.0 + (j % 8)).to(dtype)  # 1..8
+        _, ramp = _positions_and_ramp(size)
+        return ramp.to(dtype)  # 1..8
 
     def b_face(size, dtype, generator):
-        j = torch.arange(size, dtype=torch.float32)
-        base = 1.0 + (j % 8)
-        return (base + torch.where(j % 2 == 0, 0.0, 1.0)).to(dtype)
+        j, ramp = _positions_and_ramp(size)
+        return (ramp + torch.where(j % 2 == 0, 0.0, 1.0)).to(dtype)
 
     return _face_spec(a_face), _face_spec(b_face)
 
@@ -256,15 +318,14 @@ def _comparison_stimuli_specs():
     """
 
     def a_face(size, dtype, generator):
-        j = torch.arange(size, dtype=torch.float32)
-        return (1.0 + (j % 8)).to(dtype)  # 1..8
+        _, ramp = _positions_and_ramp(size)
+        return ramp.to(dtype)  # 1..8
 
     def b_face(size, dtype, generator):
-        j = torch.arange(size, dtype=torch.float32)
-        base = 1.0 + (j % 8)
+        j, ramp = _positions_and_ramp(size)
         # j % 3 == 0 -> equal, 1 -> b greater (a < b), 2 -> b smaller (a > b)
         delta = torch.where(j % 3 == 0, 0.0, torch.where(j % 3 == 1, 1.0, -1.0))
-        return (base + delta).to(dtype)
+        return (ramp + delta).to(dtype)
 
     return _face_spec(a_face), _face_spec(b_face)
 
@@ -299,6 +360,16 @@ def sfpu_binary(
     twos_complement=False,
     input_dimensions=None,
 ):
+
+    # Every op driven through here must have declared what it is fed. The collection-time
+    # check above covers the registered ops; this covers the rest, so a new op added to a
+    # `mathop` list and to neither set fails loudly instead of silently inheriting
+    # generate_stimuli's positive-only uniform(0.1, 1.1).
+    assert mathop in _DECLARED_BINARY_OPS, (
+        f"{mathop.name} is driven through sfpu_binary but appears in none of "
+        "_REGISTRY_DOMAIN_OPS / _UNREGISTERED_BINARY_OPS / _INT_ONLY_REGISTERED_OPS; "
+        "add it to the set that describes the domain it should get"
+    )
 
     # Seed the draw so the stimuli are identical run to run. Nothing below sets a seed,
     # and an unseeded redraw makes a variant sitting near its tolerance pass or fail

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
@@ -84,19 +84,10 @@ def _pair_operand_specs(spec_A, spec_B, input_dimensions):
     """Interleave two per-operand specs across *every* tile pair in the buffer.
 
     The kernel reads operand 0 from the even tile of each pair and operand 1 from the odd
-    one, and the golden is computed pair by pair, so per-operand stimuli have to alternate
-    every 4 faces for the whole buffer.
-
-    This has to be built against the real tile count because `face_specs` is applied
-    **positionally and is not cycled** (`stimuli_generator/generator.py:124`:
-    `if spec.face_specs and face_idx < len(spec.face_specs)`). A fixed 8-entry list — which
-    is what this helper used to return — therefore paired only tile pair 0 and left every
-    later pair with operand 0's distribution on *both* sides. On the [256, 128] buffer this
-    driver uses that is 1 of 16 pairs genuinely paired; measured on `_eq_ne_stimuli_specs`,
-    pair 0 came out 50% equal as intended and pairs 1-15 came out 100% equal, so 15/16 of
-    the data only ever exercised the equal branch.
-
-    Entries for operand 0's faces stay None so they fall through to the base spec.
+    one, so per-operand stimuli have to alternate every 4 faces for the whole buffer.
+    The list must cover the real tile count: `face_specs` is applied positionally and is
+    not cycled, so a short list leaves later pairs with operand 0's distribution on both
+    sides. Entries for operand 0's faces stay None to fall through to the base spec.
     """
     tiles = (input_dimensions[0] * input_dimensions[1]) // _ELEMENTS_PER_TILE
     if tiles % 2:
@@ -116,23 +107,13 @@ def _face_spec(dist):
 # =============================================================================
 # Which ops take their domain from _OP_DOMAIN_REGISTRY
 #
-# This suite never imported sfpu_domains, so every op fell back to generate_stimuli's
-# positive-only uniform(0.1, 1.1) and the registered per-op domains -- including the
-# undefined-range holes that are the interesting boundaries -- were dormant
-# (https://github.com/tenstorrent/tt-metal/issues/49739).
+# Float-only on purpose: SfpuElwadd/SfpuElwsub and the shift ops also run through
+# test_sfpu_binary_int, where a float domain like uniform(-1, 1) would collapse to
+# {-1, 0, 1} and gut the int coverage. Ops with crafted stimuli (mask / isclose /
+# eq-ne / logsigmoid / shift edge cases) pass their own spec and ignore any default.
 #
-# The reroute is deliberately narrower than "every registered op", for two reasons:
-#
-#   * It is float-only. SfpuElwadd/SfpuElwsub and the three shift ops also run through
-#     test_sfpu_binary_int with an Int32 format, and their registry domains are written for
-#     floats: for_op(SfpuElwadd, Int32).spec_A is uniform(-1, 1), which on an integer format
-#     collapses to {-1, 0, 1} and would gut the int coverage rather than widen it.
-#   * Ops with crafted stimuli (mask / isclose / eq-ne / logsigmoid / the shift edge cases)
-#     pass their own spec and are untouched by a default.
-#
-# So this is the set of float elementwise ops that have a registered domain and currently
-# run the positive-only default. Everything else stays on that default and is listed in
-# _UNREGISTERED_BINARY_OPS, so the fallback is a declared set rather than an accident.
+# Everything else stays on generate_stimuli's positive-only uniform(0.1, 1.1) default
+# and is listed in _UNREGISTERED_BINARY_OPS, so the fallback is a declared set.
 # =============================================================================
 
 _REGISTRY_DOMAIN_OPS = frozenset(
@@ -192,10 +173,9 @@ _UNREGISTERED_BINARY_OPS = frozenset(
 def _assert_domain_sets_consistent():
     """The rerouted ops must be registered, and the fallback ops must not be.
 
-    Both halves were implicit before and both fail quietly: an op named in
-    _REGISTRY_DOMAIN_OPS without a registry entry raises deep inside the driver mid-sweep,
-    and an op that gains a domain while sitting in _UNREGISTERED_BINARY_OPS keeps running
-    the positive-only default with nothing to say so.
+    Both halves fail quietly otherwise: an op in _REGISTRY_DOMAIN_OPS with no registry
+    entry raises deep inside the driver mid-sweep, and an op that gains a domain while
+    sitting in _UNREGISTERED_BINARY_OPS silently keeps the positive-only default.
     """
     missing = sorted(
         op.name for op in _REGISTRY_DOMAIN_OPS if op not in _OP_DOMAIN_REGISTRY
@@ -267,15 +247,11 @@ def _eq_ne_stimuli_specs():
 def _comparison_stimuli_specs():
     """Three-way paired stimuli for lt/gt/le/ge: a < b, a == b, a > b in equal thirds.
 
-    These four ops were commented out of the random float sweep because independent draws
-    land arbitrarily close together, and a near-tie that the kernel and the total-order
-    golden round differently reads as a failure. The fix is to drive the comparison
-    deliberately rather than to drop the ops: the gaps here are +/-1.0 against operands of
-    order 1, far wider than any rounding, so every element's verdict is unambiguous.
-
-    The exact-equality third is the point. It is the only input where lt/gt and le/ge
-    disagree, so it is what separates the four kernels from each other, and a continuous
-    random sweep essentially never produces it.
+    Independent random draws land arbitrarily close together, and a near-tie the kernel
+    and the total-order golden round differently reads as a failure. The gaps here are
+    +/-1.0 against operands of order 1, far wider than any rounding, so every element's
+    verdict is unambiguous. The exact-equality third is the point: it is the only input
+    where lt/gt and le/ge disagree, and a random sweep essentially never produces it.
     """
 
     def a_face(size, dtype, generator):
@@ -323,11 +299,9 @@ def sfpu_binary(
     input_dimensions=None,
 ):
 
-    # Seed the draw. Neither this driver nor default_spec_for_format set a seed, so the
-    # stimuli were redrawn on every run and a variant sitting near its tolerance could pass
-    # or fail depending on the draw -- which showed up as two xlogy variants failing in a
-    # full-suite run that then reproduced in neither a targeted rerun nor five other seeds.
-    # eltwise_unary_sfpu already seeds for the same reason.
+    # Seed the draw so the stimuli are identical run to run. Nothing below sets a seed,
+    # and an unseeded redraw makes a variant sitting near its tolerance pass or fail
+    # depending on the draw -- an unreproducible failure. eltwise_unary_sfpu seeds too.
     torch.manual_seed(0)
 
     # FP32 destination tiles occupy twice the register space. Keep four full destination
@@ -341,13 +315,10 @@ def sfpu_binary(
     # so there is no spec_B knob in generate_stimuli — the two specs are interleaved into one
     # spec's face_specs here, where the tile count is known.
     #
-    # Ops registered in _OP_DOMAIN_REGISTRY take their domain from there, which is what makes
-    # the registered undefined-range holes (SfpuElwdiv divisor, SfpuXlogy B, SfpuElwpow A)
-    # reachable at all — see _REGISTRY_DOMAIN_OPS above. Unlike the unary sweep,
-    # most ops here are *not* registered, so a missing entry falls back to generate_stimuli's
-    # format default rather than raising. That fallback is declared in
-    # _UNREGISTERED_BINARY_OPS and checked, so it stays a deliberate list rather than an
-    # accident.
+    # Ops in _REGISTRY_DOMAIN_OPS take their domain from _OP_DOMAIN_REGISTRY, which is what
+    # makes the registered undefined-range holes (SfpuElwdiv divisor, SfpuXlogy B,
+    # SfpuElwpow A) reachable. Unlike the unary sweep, most ops here are not registered; a
+    # missing entry falls back to generate_stimuli's format default rather than raising.
     if (
         spec_A is None
         and mathop in _REGISTRY_DOMAIN_OPS
@@ -501,15 +472,11 @@ def sfpu_binary(
         MathOperation.SfpuElwrsub,
         MathOperation.SfpuElwpow,
         MathOperation.SfpuXlogy,
-        # Eq/Ne moved to test_sfpu_binary_eq_ne: independent random draws are never
-        # equal here, so the golden collapses to a constant — they need crafted paired
-        # stimuli to exercise the equal branch.
-        # Lt/Gt/Le/Ge stay out of this *random* sweep for the original reasons: independent
-        # draws land arbitrarily close together, and a near-tie the kernel and the
-        # total-order golden round differently reads as a failure (it also inflated the
-        # Blackhole smoke runtime). They are covered by test_sfpu_binary_float_comparison
-        # below, which drives a < b / a == b / a > b in equal thirds with unambiguous gaps
-        # -- including the exact tie, the only input that tells lt/gt from le/ge.
+        # Eq/Ne and Lt/Gt/Le/Ge are excluded from this *random* sweep: independent draws
+        # are never equal (the Eq/Ne golden collapses to a constant) and near-ties that
+        # the kernel and the total-order golden round differently read as failures. They
+        # are covered with crafted paired stimuli by test_sfpu_binary_eq_ne and
+        # test_sfpu_binary_float_comparison below.
     ],
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
 )
@@ -625,18 +592,10 @@ def test_sfpu_binary_mask(formats, dest_acc, mathop):
     # One tile pair only, unlike every other op here. calculate_mask hard-codes its
     # operands -- data at dst_reg[0], mask at dst_reg[32], result in place -- and ignores
     # the forwarded dst indices, so only the in0=0/in1=1/out=0 placement computes anything
-    # (see calculate_mask_binary in helpers/include/sfpu_test_helpers.h). The kernel loops
-    # `tile += 2` over NUM_TILES_IN_BLOCK, so on the default [256, 128] buffer the mask is
-    # applied to tile 0 of each block four times over while tiles 2/4/6 are packed out as
-    # unmasked datacopy output, against a golden that masks every pair.
-    #
-    # That went unnoticed because the paired stimuli only ever filled the first tile pair
-    # (see _pair_operand_specs): every later pair got the data distribution on both sides,
-    # so its mask was all-nonzero and masking was a no-op there. Fixing the pairing made
-    # the mismatch real -- 12 of 16 pairs, exactly the non-block-leading ones.
-    #
-    # [64, 32] is 2 tiles = 1 block = 1 pair, so every pair the kernel drives is the one
-    # the adapter supports. Same real coverage as before, without the 15 dead pairs.
+    # (see calculate_mask_binary in helpers/include/sfpu_test_helpers.h). On a larger
+    # buffer the kernel's `tile += 2` loop would mask tile 0 of each block repeatedly and
+    # pack tiles 2/4/6 out unmasked, against a golden that masks every pair. [64, 32] is
+    # 2 tiles = 1 block = 1 pair, so the only pair driven is the one the adapter supports.
     spec_A, spec_B = _mask_stimuli_specs()
     sfpu_binary(
         formats,

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
@@ -16,6 +16,7 @@ from helpers.golden_generators import (
     BinarySFPUGolden,
     BroadcastGolden,
     get_golden_generator,
+    quantize_input_to_unpack_format,
 )
 from helpers.llk_params import BroadcastType as LlkBroadcastType
 from helpers.llk_params import DestAccumulation, DestSync, MathOperation, format_dict
@@ -352,12 +353,23 @@ def sfpu_binary(
             )
         src_A = override.repeat(src_A.numel() // override.numel())
 
+    # generate_stimuli round-trips Bfp4_b and Bfp2_b stimuli through their pack/unpack
+    # quantization but not Bfp8_b: the Bfp8_b format default only ever draws values that
+    # are already representable (integer 0..2 plus k/16), so nothing needed it. A registry
+    # domain -- or an src_A_override -- draws arbitrary values, and then the device sees
+    # Bfp8_b-quantized operands while the golden still sees the unrounded bf16 originals.
+    # That is the same golden/hardware split Phase 0 fixed inside UnarySFPUGolden. Quantize
+    # the golden's copy only, before broadcast: src_A keeps the unrounded values because
+    # the packer applies exactly this rounding when it writes the buffer to L1.
     golden_src = src_A
+    if formats.input_format == DataFormat.Bfp8_b:
+        golden_src = quantize_input_to_unpack_format(golden_src, DataFormat.Bfp8_b)
+
     if broadcast_type is not None and broadcast_type != LlkBroadcastType.None_:
         generate_broadcast_golden = get_golden_generator(BroadcastGolden)
         golden_src = generate_broadcast_golden(
             broadcast_type,
-            src_A,
+            golden_src,
             (
                 formats.input_format
                 if formats.input_format != DataFormat.Bfp8_b

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
@@ -263,6 +263,34 @@ def _eq_ne_stimuli_specs():
     return _face_spec(a_face), _face_spec(b_face)
 
 
+def _comparison_stimuli_specs():
+    """Three-way paired stimuli for lt/gt/le/ge: a < b, a == b, a > b in equal thirds.
+
+    These four ops were commented out of the random float sweep because independent draws
+    land arbitrarily close together, and a near-tie that the kernel and the total-order
+    golden round differently reads as a failure. The fix is to drive the comparison
+    deliberately rather than to drop the ops: the gaps here are +/-1.0 against operands of
+    order 1, far wider than any rounding, so every element's verdict is unambiguous.
+
+    The exact-equality third is the point. It is the only input where lt/gt and le/ge
+    disagree, so it is what separates the four kernels from each other, and a continuous
+    random sweep essentially never produces it.
+    """
+
+    def a_face(size, dtype, generator):
+        j = torch.arange(size, dtype=torch.float32)
+        return (1.0 + (j % 8)).to(dtype)  # 1..8
+
+    def b_face(size, dtype, generator):
+        j = torch.arange(size, dtype=torch.float32)
+        base = 1.0 + (j % 8)
+        # j % 3 == 0 -> equal, 1 -> b greater (a < b), 2 -> b smaller (a > b)
+        delta = torch.where(j % 3 == 0, 0.0, torch.where(j % 3 == 1, 1.0, -1.0))
+        return (base + delta).to(dtype)
+
+    return _face_spec(a_face), _face_spec(b_face)
+
+
 def _logsigmoid_stimuli_spec():
     # logsigmoid(x) = -softplus(-x). in1 (exp(-x)) is only read in the x > 4 branch, so
     # restrict x to [-8, 3.9] (never uses in1) and sweep the passthrough (x < -4) and
@@ -475,15 +503,12 @@ def sfpu_binary(
         # Eq/Ne moved to test_sfpu_binary_eq_ne: independent random draws are never
         # equal here, so the golden collapses to a constant — they need crafted paired
         # stimuli to exercise the equal branch.
-        # Lt/Gt/Le/Ge intentionally excluded from this random-stimuli sweep: the generated
-        # operands produce near-ties that diverge from the total-order golden (and inflate
-        # the Blackhole smoke runtime past its budget). The sfpi comparison kernels
-        # (calculate_binary_comp_fp32_*) are validated at the ttnn level; see
-        # ckernel_sfpu_binary_comp.h.
-        # MathOperation.SfpuElwLt,
-        # MathOperation.SfpuElwGt,
-        # MathOperation.SfpuElwLe,
-        # MathOperation.SfpuElwGe,
+        # Lt/Gt/Le/Ge stay out of this *random* sweep for the original reasons: independent
+        # draws land arbitrarily close together, and a near-tie the kernel and the
+        # total-order golden round differently reads as a failure (it also inflated the
+        # Blackhole smoke runtime). They are covered by test_sfpu_binary_float_comparison
+        # below, which drives a < b / a == b / a > b in equal thirds with unambiguous gaps
+        # -- including the exact tie, the only input that tells lt/gt from le/ge.
     ],
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
 )
@@ -652,6 +677,28 @@ def test_sfpu_binary_eq_ne(formats, dest_acc, mathop):
     _skip_fp32_no_dest_acc(formats, dest_acc)
 
     spec_A, spec_B = _eq_ne_stimuli_specs()
+    sfpu_binary(formats, dest_acc, mathop, spec_A=spec_A, spec_B=spec_B)
+
+
+@parametrize(
+    formats=input_output_formats([DataFormat.Float16_b, DataFormat.Float32]),
+    mathop=[
+        MathOperation.SfpuElwLt,
+        MathOperation.SfpuElwGt,
+        MathOperation.SfpuElwLe,
+        MathOperation.SfpuElwGe,
+    ],
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+)
+def test_sfpu_binary_float_comparison(formats, dest_acc, mathop):
+    # lt/gt/le/ge(a, b) with a = tile0, b = tile1. Crafted so a third of the elements are
+    # exactly equal and the rest differ by +/-1.0: the tie is what distinguishes the strict
+    # comparisons from the non-strict ones, and the wide gaps keep every other element's
+    # verdict independent of rounding. See _comparison_stimuli_specs.
+    _skip_fp32_no_dest_acc(formats, dest_acc)
+    _skip_bh_float16_no_dest_acc(formats, dest_acc)
+
+    spec_A, spec_B = _comparison_stimuli_specs()
     sfpu_binary(formats, dest_acc, mathop, spec_A=spec_A, spec_B=spec_B)
 
 

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_binop_scalar.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_binop_scalar.py
@@ -29,18 +29,37 @@ def _bits(value: float) -> int:
     return struct.unpack("<I", struct.pack("<f", value))[0]
 
 
-_DIVISOR = 2.0
-_SCALAR_BITS = {
-    MathOperation.ScalarAdd: _bits(2.0),
-    MathOperation.ScalarSub: _bits(2.0),
-    MathOperation.ScalarMul: _bits(2.0),
-    MathOperation.ScalarDiv: _bits(1.0 / _DIVISOR),
-    MathOperation.ScalarRsub: _bits(2.0),
-}
+# The scalar is a swept axis, not one hard-coded value. It used to be a single 2.0 per op
+# (1/2 for div, see below), so the whole suite only ever verified one constant and the
+# interesting scalars -- zero, a sign flip, a large multiplier, a value small enough to
+# matter against the tolerance -- were never driven.
+#
+# Kept deliberately small: inputs are uniform(-1, 1), so |scalar| <= 8 keeps every op's
+# result inside the range where the default bf16 tolerance is meaningful. Wider scalars
+# belong with the edge-value work, not here.
+_SCALARS = (0.0, 1.0, 2.0, -2.0, 8.0, 0.25)
+
+# ScalarDiv is the one op whose scalar is not the value the kernel sees: the host inverts the
+# divisor at compile time and the kernel only multiplies, so `d` never reaches the device.
+# That also means a divide-by-zero cannot be reached through this op at all -- 1/0 would be
+# computed on the host -- so 0.0 is not a legal divisor here rather than an untested edge.
+_ZERO_DIVISOR_UNREACHABLE = (
+    "ScalarDiv inverts the divisor on the host; d=0 is not a device path"
+)
 
 
-def _run_sfpu_binop_scalar(formats, dest_acc, mathop, input_dimensions=[32, 32]):
-    scalar_bits = _SCALAR_BITS[mathop]
+def _scalar_bits_for(mathop, scalar):
+    """The 32-bit pattern the kernel is given for *mathop* at *scalar*."""
+    if mathop == MathOperation.ScalarDiv:
+        return _bits(1.0 / scalar)
+    return _bits(scalar)
+
+
+def _run_sfpu_binop_scalar(
+    formats, dest_acc, mathop, scalar=2.0, input_dimensions=[32, 32]
+):
+    torch.manual_seed(0)
+    scalar_bits = _scalar_bits_for(mathop, scalar)
 
     # Keep inputs small and bounded so the bf16 result stays accurate across all
     # five scalar ops (add/sub/mul/div/rsub) and both dest-accumulation modes.
@@ -113,8 +132,9 @@ def _run_sfpu_binop_scalar(formats, dest_acc, mathop, input_dimensions=[32, 32])
         MathOperation.ScalarDiv,
         MathOperation.ScalarRsub,
     ],
+    scalar=list(_SCALARS),
 )
-def test_sfpu_binop_scalar(formats, dest_acc, mathop):
+def test_sfpu_binop_scalar(formats, dest_acc, mathop, scalar):
     if formats.input_format == DataFormat.Float32 and dest_acc == DestAccumulation.No:
         pytest.skip("Float32 inputs with dest_acc=No are not supported")
     if (
@@ -122,5 +142,7 @@ def test_sfpu_binop_scalar(formats, dest_acc, mathop):
         and dest_acc == DestAccumulation.Yes
     ):
         pytest.skip("Float16_b not supported with DestAccumulation.Yes")
+    if mathop == MathOperation.ScalarDiv and scalar == 0.0:
+        pytest.skip(_ZERO_DIVISOR_UNREACHABLE)
 
-    _run_sfpu_binop_scalar(formats, dest_acc, mathop)
+    _run_sfpu_binop_scalar(formats, dest_acc, mathop, scalar=scalar)

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_binop_scalar.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_binop_scalar.py
@@ -29,14 +29,10 @@ def _bits(value: float) -> int:
     return struct.unpack("<I", struct.pack("<f", value))[0]
 
 
-# The scalar is a swept axis, not one hard-coded value. It used to be a single 2.0 per op
-# (1/2 for div, see below), so the whole suite only ever verified one constant and the
-# interesting scalars -- zero, a sign flip, a large multiplier, a value small enough to
-# matter against the tolerance -- were never driven.
-#
-# Kept deliberately small: inputs are uniform(-1, 1), so |scalar| <= 8 keeps every op's
-# result inside the range where the default bf16 tolerance is meaningful. Wider scalars
-# belong with the edge-value work, not here.
+# The scalar is a swept axis: zero, unity, a sign flip, a large multiplier, and a value
+# small enough to matter against the tolerance. Kept deliberately small -- inputs are
+# uniform(-1, 1), so |scalar| <= 8 keeps every op's result inside the range where the
+# default bf16 tolerance is meaningful.
 _SCALARS = (0.0, 1.0, 2.0, -2.0, 8.0, 0.25)
 
 # ScalarDiv is the one op whose scalar is not the value the kernel sees: the host inverts the

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_ternary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_ternary.py
@@ -45,17 +45,14 @@ def torch_equal_nan(a, b):
 def _ternary_default_specs(mathop, input_format):
     """Per-operand defaults for *mathop*: its registered domain, else the built-in one.
 
-    No ternary op has an _OP_DOMAIN_REGISTRY entry today, so in practice every op takes the
-    built-in branch and this changes nothing — the point is that there is now a single place
-    where a registered domain would take effect, and a caller-visible way to override it.
-    Without that, ternary edge stimuli cannot be injected at all: the divisor for addcdiv
-    and snake_beta is pinned to uniform(1, 2), which puts the c -> 0 pole (the interesting
-    boundary for both) permanently out of reach.
+    No ternary op has an _OP_DOMAIN_REGISTRY entry, so every op currently takes the
+    built-in branch. This is the single place a registered domain would take effect, and
+    callers of _run_sfpu_ternary can override any operand to reach an edge the defaults
+    exclude (e.g. the c -> 0 pole that addcdiv and snake_beta pin away from).
     """
     if mathop in _OP_DOMAIN_REGISTRY:
-        # OperandSpecs carries only A and B; a registered ternary op would need a third
-        # operand there. Until one exists, reuse B for C and let the assertion below catch
-        # the day that stops being good enough.
+        # OperandSpecs carries only A and B, so a registered ternary op has no third
+        # operand to read; reuse B for C.
         specs = exclude_undefined_pair(mathop, for_op(mathop, input_format))
         return specs.spec_A, specs.spec_B, specs.spec_B
 
@@ -79,9 +76,8 @@ def _run_sfpu_ternary(
     spec_B=None,
     spec_C=None,
 ):
-    # Seeded for the same reason as the binary driver: the specs below carry no seed, so
-    # without this the stimuli are redrawn on every run and a variant sitting near its
-    # tolerance passes or fails by luck.
+    # The specs below carry no seed, so seed here: an unseeded redraw makes a variant
+    # sitting near its tolerance pass or fail by luck. Same as the binary driver.
     torch.manual_seed(0)
 
     default_A, default_B, default_C = _ternary_default_specs(

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_ternary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_ternary.py
@@ -18,6 +18,7 @@ from helpers.llk_params import (
     format_dict,
 )
 from helpers.param_config import input_output_formats, parametrize
+from helpers.sfpu_domains import _OP_DOMAIN_REGISTRY, exclude_undefined_pair, for_op
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
@@ -41,23 +42,62 @@ def torch_equal_nan(a, b):
     return torch.all((a == b) | (torch.isnan(a) & torch.isnan(b)))
 
 
-def _run_sfpu_ternary(formats, dest_acc, mathop, input_dimensions=[64, 64]):
+def _ternary_default_specs(mathop, input_format):
+    """Per-operand defaults for *mathop*: its registered domain, else the built-in one.
 
-    _divide_by_c = mathop in (MathOperation.SfpuAddcdiv, MathOperation.SfpuSnakeBeta)
+    No ternary op has an _OP_DOMAIN_REGISTRY entry today, so in practice every op takes the
+    built-in branch and this changes nothing — the point is that there is now a single place
+    where a registered domain would take effect, and a caller-visible way to override it.
+    Without that, ternary edge stimuli cannot be injected at all: the divisor for addcdiv
+    and snake_beta is pinned to uniform(1, 2), which puts the c -> 0 pole (the interesting
+    boundary for both) permanently out of reach.
+    """
+    if mathop in _OP_DOMAIN_REGISTRY:
+        # OperandSpecs carries only A and B; a registered ternary op would need a third
+        # operand there. Until one exists, reuse B for C and let the assertion below catch
+        # the day that stops being good enough.
+        specs = exclude_undefined_pair(mathop, for_op(mathop, input_format))
+        return specs.spec_A, specs.spec_B, specs.spec_B
+
+    # addcdiv and snake_beta divide by c, so c is held away from zero.
+    divide_by_c = mathop in (MathOperation.SfpuAddcdiv, MathOperation.SfpuSnakeBeta)
     spec_ab = StimuliSpec.uniform(low=-1.0, high=1.0)
     spec_c = (
         StimuliSpec.uniform(low=1.0, high=2.0)
-        if _divide_by_c
+        if divide_by_c
         else StimuliSpec.uniform(low=-1.0, high=1.0)
     )
+    return spec_ab, spec_ab, spec_c
+
+
+def _run_sfpu_ternary(
+    formats,
+    dest_acc,
+    mathop,
+    input_dimensions=[64, 64],
+    spec_A=None,
+    spec_B=None,
+    spec_C=None,
+):
+    # Seeded for the same reason as the binary driver: the specs below carry no seed, so
+    # without this the stimuli are redrawn on every run and a variant sitting near its
+    # tolerance passes or fails by luck.
+    torch.manual_seed(0)
+
+    default_A, default_B, default_C = _ternary_default_specs(
+        mathop, formats.input_format
+    )
+    spec_a = spec_A if spec_A is not None else default_A
+    spec_b = spec_B if spec_B is not None else default_B
+    spec_c = spec_C if spec_C is not None else default_C
 
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
-        spec_A=spec_ab,
-        spec_B=spec_ab,
+        spec_A=spec_a,
+        spec_B=spec_b,
     )
 
     src_C, tile_cnt_C, _, _ = generate_stimuli(

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -28,7 +28,6 @@ from helpers.param_config import (
     parametrize,
 )
 from helpers.sfpu_domains import (
-    _OP_DOMAIN_REGISTRY,
     _UNARY_OPS_NOT_SWEPT,
     exclude_undefined,
     for_op_pipeline,
@@ -70,8 +69,10 @@ SUPPORTED_FAST_MODE_OPS = [
 #   STANDARD_SWEEP_OPS - Float16_b + Float32, approximation mode off, one tile shape.
 #                        Enough to validate the op's own math, and ~8x cheaper.
 #
-# Adding an op: put it in exactly one list, and register a domain for it in
-# sfpu_domains.py. _assert_sweep_profiles_disjoint() below enforces both.
+# Only the broad profile is listed by hand. The standard profile is every other unary
+# SFPU op the registry knows about, so registering a domain is all it takes to get an op
+# swept -- there is no second list to remember. Opting an op out of the sweep entirely is
+# still a deliberate act: it goes in sfpu_domains._UNARY_OPS_NOT_SWEPT with a reason.
 # ─────────────────────────────────────────────────────────────────────────────
 
 BROAD_SWEEP_OPS = [
@@ -108,74 +109,13 @@ BROAD_SWEEP_OPS = [
     MathOperation.ReluMin,
 ]
 
-STANDARD_SWEEP_OPS = [
-    MathOperation.Add1,
-    MathOperation.CastFp32ToFp16a,
-    MathOperation.Cbrt,
-    MathOperation.Clamp,
-    MathOperation.Digamma,
-    MathOperation.EqualZero,
-    MathOperation.Erf,
-    MathOperation.Erfc,
-    MathOperation.Erfinv,
-    MathOperation.Expm1,
-    MathOperation.Expm1Cw,
-    MathOperation.Fmod,
-    MathOperation.GreaterThanEqualZero,
-    MathOperation.GreaterThanZero,
-    MathOperation.Hardmish,
-    MathOperation.Hardshrink,
-    MathOperation.Hardtanh,
-    MathOperation.Heaviside,
-    MathOperation.I0,
-    MathOperation.I1,
-    MathOperation.Identity,
-    MathOperation.LessThanEqualZero,
-    MathOperation.LessThanZero,
-    MathOperation.Lgamma,
-    MathOperation.Lrelu,
-    MathOperation.Mish,
-    MathOperation.NotEqualZero,
-    MathOperation.Polygamma,
-    MathOperation.Prelu,
-    MathOperation.Rdiv,
-    MathOperation.Remainder,
-    MathOperation.Rpow,
-    MathOperation.RsqrtCompat,
-    MathOperation.Selu,
-    MathOperation.Sigmoid,
-    MathOperation.SigmoidAppx,
-    MathOperation.Sign,
-    MathOperation.Signbit,
-    MathOperation.Softplus,
-    MathOperation.Softshrink,
-    MathOperation.Softsign,
-    MathOperation.SqrtCustom,
-    MathOperation.TanhDerivative,
-    MathOperation.TanhDerivativeLut,
-    MathOperation.UnaryGe,
-    MathOperation.UnaryGt,
-    MathOperation.UnaryLe,
-    MathOperation.UnaryLt,
-    MathOperation.UnaryMax,
-    MathOperation.UnaryMin,
-    MathOperation.UnaryPower,
-    MathOperation.Xielu,
-    # Trigonometric / inverse / hyperbolic and round (per-op safe domains).
-    MathOperation.Tan,
-    MathOperation.Atan,
-    MathOperation.Asin,
-    MathOperation.Acos,
-    MathOperation.Sinh,
-    MathOperation.Cosh,
-    MathOperation.Round,
-    # gelu derivative and log-with-base (log2).
-    MathOperation.GeluDerivative,
-    MathOperation.LogWithBase,
-    # gelu LUT approximation and exp-with-base (exp(0.5*x)).
-    MathOperation.GeluAppx,
-    MathOperation.ExpWithBase,
-]
+# Every registered unary SFPU op that the broad profile does not already cover, minus the
+# ops sfpu_domains marks as deliberately unswept. Sorted so the parametrize ids are stable
+# across runs.
+STANDARD_SWEEP_OPS = sorted(
+    sfpu_unary_ops() - set(BROAD_SWEEP_OPS) - set(_UNARY_OPS_NOT_SWEPT),
+    key=lambda op: op.name,
+)
 
 # Per-op (atol, rtol) overrides for coarse LUT/polynomial ops; others use the
 # per-format default in passed_test.
@@ -275,45 +215,37 @@ def _sweep_params(formats, mathops, approx_modes, input_dimensions):
     )
 
 
-def _assert_sweep_profiles_disjoint():
-    """No op sits in both profiles, and every swept op has a registered domain.
+def _assert_broad_profile_valid():
+    """Everything the derived standard profile cannot check for itself.
 
-    An op in both lists would run its whole matrix twice. An op with no registry entry
-    does raise in for_op(), but only once the sweep reaches it, so assert here to fail at
-    collection instead.
+    Non-overlap, registration and exhaustiveness hold by construction now that
+    STANDARD_SWEEP_OPS is the complement of BROAD_SWEEP_OPS within sfpu_unary_ops(). What
+    is left is the hand-written half:
 
-    Exhaustiveness is checked too, against sfpu_unary_ops(): the registry knows which of
-    its entries have a unary SFPU kernel, so an op added to the registry and to no sweep
-    profile fails here rather than going quietly untested. An op that genuinely should not
-    be swept belongs in _UNARY_OPS_NOT_SWEPT (with a reason) or, if it has no unary SFPU
-    kernel at all, in _NON_SFPU_UNARY_OPS.
+    - a repeated entry in BROAD_SWEEP_OPS runs that op's whole matrix twice,
+    - a non-unary op in BROAD_SWEEP_OPS fails to compile once the sweep reaches it, and
+      also silently drops out of the standard profile's complement,
+    - an _UNARY_OPS_NOT_SWEPT entry that is not a unary op exempts nothing, so the reason
+      recorded against it is misleading.
     """
-    overlap = set(BROAD_SWEEP_OPS) & set(STANDARD_SWEEP_OPS)
-    assert not overlap, (
-        "These ops are in both sweep profiles and would run twice: "
-        f"{sorted(op.name for op in overlap)}"
+    duplicates = sorted(
+        {op.name for op in BROAD_SWEEP_OPS if BROAD_SWEEP_OPS.count(op) > 1}
     )
-    unregistered = [
-        op.name
-        for op in chain(BROAD_SWEEP_OPS, STANDARD_SWEEP_OPS)
-        if op not in _OP_DOMAIN_REGISTRY
-    ]
-    assert not unregistered, (
-        "These swept ops have no domain in sfpu_domains._OP_DOMAIN_REGISTRY, so the "
-        f"driver cannot build stimuli for them: {sorted(unregistered)}"
+    assert not duplicates, (
+        "These ops are listed more than once in BROAD_SWEEP_OPS and would run their "
+        f"whole matrix twice: {duplicates}"
     )
-    swept = set(BROAD_SWEEP_OPS) | set(STANDARD_SWEEP_OPS)
-    expected = sfpu_unary_ops() - set(_UNARY_OPS_NOT_SWEPT)
-    untested = sorted(op.name for op in expected - swept)
-    assert not untested, (
-        "These ops have a unary SFPU kernel and a registered domain but are in neither "
-        "sweep profile, so nothing drives them. Add them to a profile, or to "
-        f"_UNARY_OPS_NOT_SWEPT with a reason: {untested}"
-    )
-    not_unary = sorted(op.name for op in swept - sfpu_unary_ops())
+    not_unary = sorted(op.name for op in set(BROAD_SWEEP_OPS) - sfpu_unary_ops())
     assert not not_unary, (
-        "These swept ops are classified as having no unary SFPU kernel "
+        "These broad-profile ops are classified as having no unary SFPU kernel "
         f"(sfpu_domains._NON_SFPU_UNARY_OPS): {not_unary}"
+    )
+    stale_exemptions = sorted(
+        op.name for op in set(_UNARY_OPS_NOT_SWEPT) - sfpu_unary_ops()
+    )
+    assert not stale_exemptions, (
+        "These ops are exempted in sfpu_domains._UNARY_OPS_NOT_SWEPT but are not unary "
+        f"SFPU ops, so the exemption does nothing: {stale_exemptions}"
     )
 
 
@@ -342,7 +274,7 @@ UNARY_SWEEP_PARAMS = (
 )
 
 
-_assert_sweep_profiles_disjoint()
+_assert_broad_profile_valid()
 
 
 def _skip_bh_unsupported_float_combo(formats, dest_acc):

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -22,6 +22,7 @@ from helpers.llk_params import (
     format_dict,
 )
 from helpers.param_config import (
+    build_param_id,
     get_num_blocks_and_num_tiles_in_block,
     input_output_formats,
     parametrize,
@@ -219,10 +220,10 @@ MATHOPS_INCLUDE_BFP4_B = [
     MathOperation.Acosh,
     MathOperation.Cos,
     MathOperation.Log,
-    # MathOperation.Log1p,
-    # MathOperation.Reciprocal,
-    # MathOperation.Sin,
-    # MathOperation.Sqrt,
+    MathOperation.Log1p,
+    MathOperation.Reciprocal,
+    MathOperation.Sin,
+    MathOperation.Sqrt,
     MathOperation.Rsqrt,
     MathOperation.Square,
     MathOperation.Tanh,
@@ -233,9 +234,9 @@ MATHOPS_INCLUDE_BFP4_B = [
     MathOperation.Neg,
     MathOperation.Fill,
     MathOperation.Elu,
-    # MathOperation.Exp,
-    # MathOperation.Exp2,
-    # MathOperation.Hardsigmoid,
+    MathOperation.Exp,
+    MathOperation.Exp2,
+    MathOperation.Hardsigmoid,
     MathOperation.Threshold,
     MathOperation.ReluMax,
     MathOperation.ReluMin,
@@ -413,10 +414,21 @@ _APPROX_EXP_ACCURACY_XFAIL = {
 }
 
 
+_UNARY_SWEEP_ARGNAMES = (
+    "formats",
+    "approx_mode",
+    "mathop",
+    "fast_mode",
+    "dest_acc",
+    "input_dimensions",
+)
+
+
 @pytest.mark.nightly
 @pytest.mark.parametrize(
-    "formats,approx_mode,mathop,fast_mode,dest_acc,input_dimensions",
+    ",".join(_UNARY_SWEEP_ARGNAMES),
     UNARY_SWEEP_PARAMS,
+    ids=[build_param_id(_UNARY_SWEEP_ARGNAMES, p) for p in UNARY_SWEEP_PARAMS],
 )
 def test_eltwise_unary_sfpu(
     request,

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -207,6 +207,26 @@ def _skip_bh_unless_fp32(formats, dest_acc):
         pytest.skip(reason="This combination is not supported on BH architecture")
 
 
+# Approximate exp overshoots the golden by a systematic ~5.7% (peak 6.75%) once its
+# argument passes ~8 -- measured on Wormhole, the smallest output that breaches the
+# default 5% rtol is exactly exp(8.00) = 2976, and 0.6% of elements in an affected
+# tile breach it. That is a property of the approximation itself, not of the stimuli:
+# it went unmeasured until this sweep stopped feeding exp uniform(0.1, 1.1), which
+# never produced an argument above 1.1.
+#
+# Whether a given combination trips the 5% bar is marginal, and two things decide it:
+# the domain its output format selects (high=16, or 10 when a Float16 output narrows
+# it) and whether a 16-bit dst rounds golden and result back together -- dest_acc=Yes
+# keeps an fp32 dst and exposes the full error. Hence Float32->Float16_b failing only
+# at dest_acc=Yes. Listed exhaustively rather than by predicate so that a combination
+# drifting in or out of tolerance shows up as a change here.
+_APPROX_EXP_ACCURACY_XFAIL = {
+    (DataFormat.Float16, DataFormat.Float16_b, DestAccumulation.No),
+    (DataFormat.Float16, DataFormat.Float16_b, DestAccumulation.Yes),
+    (DataFormat.Float32, DataFormat.Float16_b, DestAccumulation.Yes),
+}
+
+
 # Skipped because of: https://github.com/tenstorrent/tt-llk/issues/1435
 @skip_for_coverage
 @pytest.mark.nightly
@@ -219,6 +239,7 @@ def _skip_bh_unless_fp32(formats, dest_acc):
     [[64, 64], [128, 256]],
 )
 def test_eltwise_unary_sfpu_float(
+    request,
     formats: list[InputOutputFormat],
     approx_mode: ApproximationMode,
     mathop: MathOperation,
@@ -226,6 +247,22 @@ def test_eltwise_unary_sfpu_float(
     dest_acc: DestAccumulation,
     input_dimensions: list[int],
 ):
+    if (
+        mathop == MathOperation.Exp
+        and approx_mode == ApproximationMode.Yes
+        and (formats.input_format, formats.output_format, dest_acc)
+        in _APPROX_EXP_ACCURACY_XFAIL
+    ):
+        # Marked dynamically rather than skipped so the case still executes: if the
+        # approximation tightens, this reports XPASS instead of quietly staying green.
+        request.node.add_marker(
+            pytest.mark.xfail(
+                reason="Approximate exp exceeds the default 5% rtol above an argument "
+                "of ~8, peaking at 6.75%. See _APPROX_EXP_ACCURACY_XFAIL.",
+                strict=False,
+            )
+        )
+
     if TestConfig.WITH_COVERAGE and mathop in COVERAGE_UNROLL_SKIP_OPS:
         # SFPI Issue link: https://github.com/tenstorrent/tt-metal/issues/33268
         pytest.skip(

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -715,17 +715,12 @@ def eltwise_unary_sfpu(
     torch.manual_seed(0)
     torch.set_printoptions(precision=10)
 
-    # Default to the op's own (signed) domain rather than generate_stimuli's positive-only
-    # format default, which would leave the x<0 branch, the piecewise knees and the
-    # saturation tails unreached. Every op reaching this driver is registered in
-    # _OP_DOMAIN_REGISTRY, so a KeyError here means a new op was added without a domain:
+    # The op's own signed domain, not generate_stimuli's positive-only format default,
+    # which would leave the x<0 branch, the piecewise knees and the saturation tails
+    # unreached. A KeyError means a new op arrived with no _OP_DOMAIN_REGISTRY entry:
     # register it rather than falling back to the positive-only default.
-    #
-    # The domain has to satisfy the whole input->output pipeline, not just one end of it:
-    # this sweep pairs every input format with every output format, so Float32->Float16
-    # has to stay inside Float16's range while Bfp8_b->Float16 keeps the tighter interval
-    # Bfp8_b's block precision demands. for_op_pipeline resolves both and takes the
-    # tighter — see its docstring.
+    # The domain has to hold for the whole pipeline, so for_op_pipeline resolves against
+    # both formats and keeps the tighter — see its docstring for why both matter.
     if spec_A is None:
         spec_A = exclude_undefined(
             mathop,

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -368,17 +368,12 @@ def _skip_bh_unless_fp32(formats, dest_acc):
         pytest.skip(reason="This combination is not supported on BH architecture")
 
 
-# Approximate exp overshoots the golden by a systematic ~5.7% (peak 6.75%) once its
-# argument passes ~8 -- measured on Wormhole, the smallest output that breaches the
-# default 5% rtol is exactly exp(8.00) = 2976, and 0.6% of elements in an affected tile
-# breach it. This is a property of the approximation, not of the stimuli.
-#
-# Whether a given combination trips the 5% bar is marginal, and two things decide it:
-# the domain its output format selects (high=16, or 10 when a Float16 output narrows
-# it) and whether a 16-bit dst rounds golden and result back together -- dest_acc=Yes
-# keeps an fp32 dst and exposes the full error. Hence Float32->Float16_b failing only
-# at dest_acc=Yes. Listed exhaustively rather than by predicate so that a combination
-# drifting in or out of tolerance shows up as a change here.
+# Approximate exp overshoots the golden by ~5.7% (peak 6.75%) once its argument passes ~8,
+# breaching the default 5% rtol -- a property of the approximation, not of the stimuli
+# (measured on Wormhole). Membership is marginal, set by the domain the output format
+# selects and by whether a 16-bit dst rounds golden and result back together: dest_acc=Yes
+# keeps an fp32 dst and exposes the full error. Listed exhaustively rather than by
+# predicate so a combination drifting in or out of tolerance shows up as a diff here.
 _APPROX_EXP_ACCURACY_XFAIL = {
     (DataFormat.Float16, DataFormat.Float16_b, DestAccumulation.No),
     (DataFormat.Float16, DataFormat.Float16_b, DestAccumulation.Yes),
@@ -549,9 +544,6 @@ def test_eltwise_unary_sfpu_int(
         input_dimensions,
         spec_A=_int_unary_stimuli_spec(mathop),
     )
-
-
-# Unary SFPU ops that require per-op input domains
 
 
 @parametrize(

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -6,7 +6,6 @@ from itertools import chain, product
 
 import pytest
 import torch
-from conftest import skip_for_coverage
 from helpers.chip_architecture import ChipArchitecture
 from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import (
@@ -27,7 +26,12 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
 )
-from helpers.sfpu_domains import exclude_undefined, for_op, narrowest_range_format
+from helpers.sfpu_domains import (
+    _OP_DOMAIN_REGISTRY,
+    exclude_undefined,
+    for_op,
+    narrowest_range_format,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
@@ -49,7 +53,34 @@ SUPPORTED_FAST_MODE_OPS = [
     MathOperation.Sqrt,
 ]
 
-ALL_MATHOPS = [
+# ─────────────────────────────────────────────────────────────────────────────
+# The unary op sweep: two coverage profiles, one test
+#
+# Every op below runs through eltwise_unary_sfpu(), which takes its stimuli from the
+# op's registered domain in _OP_DOMAIN_REGISTRY. The only thing that differs between
+# the two lists is *how much of the format/mode matrix* each op is worth spending, so
+# they are coverage profiles rather than different kinds of test:
+#
+#   BROAD_SWEEP_OPS    - the full format matrix including the block floats, both
+#                        approximation modes and both tile shapes. For ops whose
+#                        kernels have format-specific or approx-mode-specific paths.
+#   STANDARD_SWEEP_OPS - Float16_b + Float32, approximation mode off, one tile shape.
+#                        Enough to validate the op's own math, and ~8x cheaper.
+#
+# These were ALL_MATHOPS and DOMAIN_MATHOPS, driven by two separate tests
+# (test_eltwise_unary_sfpu_float and test_eltwise_unary_sfpu_domain). They existed
+# apart for a reason that no longer holds: only the _domain test consumed the per-op
+# domain registry, so every ALL_MATHOPS op ran a positive-only uniform(0.1, 1.1)
+# default and never saw its x<0 branch. Both now take their domain from the same
+# place, which leaves the sweep envelope as the only difference -- and an envelope is
+# a parameter, not a reason for a second test. Keeping them apart also meant a new op
+# silently inherited whichever envelope its author happened to pick a list from.
+#
+# Adding an op: put it in exactly one list, and register a domain for it in
+# sfpu_domains.py. _assert_sweep_profiles_disjoint() below enforces both.
+# ─────────────────────────────────────────────────────────────────────────────
+
+BROAD_SWEEP_OPS = [
     MathOperation.Abs,
     MathOperation.Atanh,
     MathOperation.Asinh,
@@ -83,292 +114,7 @@ ALL_MATHOPS = [
     MathOperation.ReluMin,
 ]
 
-FORMATS = input_output_formats(
-    [
-        DataFormat.Float32,
-        DataFormat.Float16,
-        DataFormat.Float16_b,
-        DataFormat.Bfp8_b,
-    ]
-)
-
-# Bfp4_b is only exercised as an input format. The original sweep built the full 4x4
-# matrix and skipped every combo whose input was not Bfp4_b, so pin the input to Bfp4_b
-# directly here: same coverage, without generating (and skipping) the other 12 combos.
-FORMATS_BFP4_B = [
-    InputOutputFormat(DataFormat.Bfp4_b, output_format)
-    for output_format in [
-        DataFormat.Float16_b,
-        DataFormat.Bfp8_b,
-        DataFormat.Float16,
-        DataFormat.Bfp4_b,
-    ]
-]
-
-MATHOPS_INCLUDE_BFP4_B = [
-    MathOperation.Abs,
-    MathOperation.Atanh,
-    MathOperation.Asinh,
-    MathOperation.Acosh,
-    MathOperation.Cos,
-    MathOperation.Log,
-    # MathOperation.Log1p,
-    # MathOperation.Reciprocal,
-    # MathOperation.Sin,
-    # MathOperation.Sqrt,
-    MathOperation.Rsqrt,
-    MathOperation.Square,
-    MathOperation.Tanh,
-    MathOperation.Celu,
-    MathOperation.Silu,
-    MathOperation.Gelu,
-    MathOperation.GeluTanh,
-    MathOperation.Neg,
-    MathOperation.Fill,
-    MathOperation.Elu,
-    # MathOperation.Exp,
-    # MathOperation.Exp2,
-    # MathOperation.Hardsigmoid,
-    MathOperation.Threshold,
-    MathOperation.ReluMax,
-    MathOperation.ReluMin,
-]
-
-# Ops whose `#pragma GCC unroll X` loops miscompile to invalid assembly under coverage
-# instrumentation (tt-metal#33268), so they are skipped only when WITH_COVERAGE is set.
-COVERAGE_UNROLL_SKIP_OPS = [
-    MathOperation.Acosh,
-    MathOperation.Log,
-    MathOperation.Log1p,
-    MathOperation.Reciprocal,
-    MathOperation.Sin,
-    MathOperation.Sqrt,
-    MathOperation.Rsqrt,
-    MathOperation.Square,
-    MathOperation.Celu,
-    MathOperation.Silu,
-    MathOperation.Neg,
-    MathOperation.Exp2,
-    MathOperation.Hardsigmoid,
-    MathOperation.Threshold,
-    MathOperation.ReluMax,
-    MathOperation.ReluMin,
-    MathOperation.Tanh,
-]
-
-
-def _float_sweep_params(formats, mathops):
-    """Build (formats, approx_mode, mathop, fast_mode, dest_acc) combinations.
-
-    Fast-mode-capable ops are swept with FastMode.No and FastMode.Yes; every other op
-    runs with FastMode.No only. approx_mode and dest_acc always sweep both values.
-    """
-    approx_modes = [ApproximationMode.No, ApproximationMode.Yes]
-    dest_accs = [DestAccumulation.No, DestAccumulation.Yes]
-    fast_ops = [op for op in mathops if op in SUPPORTED_FAST_MODE_OPS]
-    non_fast_ops = [op for op in mathops if op not in SUPPORTED_FAST_MODE_OPS]
-    return list(
-        chain(
-            product(
-                formats, approx_modes, fast_ops, [FastMode.No, FastMode.Yes], dest_accs
-            ),
-            product(formats, approx_modes, non_fast_ops, [FastMode.No], dest_accs),
-        )
-    )
-
-
-# Standard float formats sweep every op; the Bfp4_b input formats sweep only the subset
-# of ops validated for Bfp4_b. Both share the same driver, skip logic and test below.
-FLOAT_TEST_PARAMS = _float_sweep_params(FORMATS, ALL_MATHOPS) + _float_sweep_params(
-    FORMATS_BFP4_B, MATHOPS_INCLUDE_BFP4_B
-)
-
-
-def _skip_bh_unsupported_float_combo(formats, dest_acc):
-    """Blackhole with dest_acc=No supports neither Float16 input nor Float32->Float16."""
-    if (
-        dest_acc == DestAccumulation.No
-        and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE
-        and (
-            formats.input_format == DataFormat.Float16
-            or formats == InputOutputFormat(DataFormat.Float32, DataFormat.Float16)
-        )
-    ):
-        pytest.skip(reason="This combination is not supported on BH architecture")
-
-
-def _skip_bh_unless_fp32(formats, dest_acc):
-    """Blackhole with dest_acc=No only supports the Float32->Float32 combination."""
-    if (
-        dest_acc == DestAccumulation.No
-        and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE
-        and formats != InputOutputFormat(DataFormat.Float32, DataFormat.Float32)
-    ):
-        pytest.skip(reason="This combination is not supported on BH architecture")
-
-
-# Approximate exp overshoots the golden by a systematic ~5.7% (peak 6.75%) once its
-# argument passes ~8 -- measured on Wormhole, the smallest output that breaches the
-# default 5% rtol is exactly exp(8.00) = 2976, and 0.6% of elements in an affected
-# tile breach it. That is a property of the approximation itself, not of the stimuli:
-# it went unmeasured until this sweep stopped feeding exp uniform(0.1, 1.1), which
-# never produced an argument above 1.1.
-#
-# Whether a given combination trips the 5% bar is marginal, and two things decide it:
-# the domain its output format selects (high=16, or 10 when a Float16 output narrows
-# it) and whether a 16-bit dst rounds golden and result back together -- dest_acc=Yes
-# keeps an fp32 dst and exposes the full error. Hence Float32->Float16_b failing only
-# at dest_acc=Yes. Listed exhaustively rather than by predicate so that a combination
-# drifting in or out of tolerance shows up as a change here.
-_APPROX_EXP_ACCURACY_XFAIL = {
-    (DataFormat.Float16, DataFormat.Float16_b, DestAccumulation.No),
-    (DataFormat.Float16, DataFormat.Float16_b, DestAccumulation.Yes),
-    (DataFormat.Float32, DataFormat.Float16_b, DestAccumulation.Yes),
-}
-
-
-# Skipped because of: https://github.com/tenstorrent/tt-llk/issues/1435
-@skip_for_coverage
-@pytest.mark.nightly
-@pytest.mark.parametrize(
-    "formats,approx_mode,mathop,fast_mode,dest_acc",
-    FLOAT_TEST_PARAMS,
-)
-@pytest.mark.parametrize(
-    "input_dimensions",
-    [[64, 64], [128, 256]],
-)
-def test_eltwise_unary_sfpu_float(
-    request,
-    formats: list[InputOutputFormat],
-    approx_mode: ApproximationMode,
-    mathop: MathOperation,
-    fast_mode: FastMode,
-    dest_acc: DestAccumulation,
-    input_dimensions: list[int],
-):
-    if (
-        mathop == MathOperation.Exp
-        and approx_mode == ApproximationMode.Yes
-        and (formats.input_format, formats.output_format, dest_acc)
-        in _APPROX_EXP_ACCURACY_XFAIL
-    ):
-        # Marked dynamically rather than skipped so the case still executes: if the
-        # approximation tightens, this reports XPASS instead of quietly staying green.
-        request.node.add_marker(
-            pytest.mark.xfail(
-                reason="Approximate exp exceeds the default 5% rtol above an argument "
-                "of ~8, peaking at 6.75%. See _APPROX_EXP_ACCURACY_XFAIL.",
-                strict=False,
-            )
-        )
-
-    if TestConfig.WITH_COVERAGE and mathop in COVERAGE_UNROLL_SKIP_OPS:
-        # SFPI Issue link: https://github.com/tenstorrent/tt-metal/issues/33268
-        pytest.skip(
-            reason="When these SFPU ops get compiled with coverage, `#pragma GCC unroll X` marked loops get compiled to invalid assembly"
-        )
-
-    if mathop == MathOperation.ReluMin:
-        pytest.skip(reason="https://github.com/tenstorrent/tt-llk/issues/1120")
-
-    if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
-        pytest.skip(reason="Metal tanh does not support approximation mode")
-
-    if TestConfig.WITH_COVERAGE and mathop == MathOperation.Gelu:
-        # Issue link: https://github.com/tenstorrent/tt-llk/issues/883
-        pytest.skip(
-            reason="Compilation error when this mathop gets compiled with coverage"
-        )
-
-    _skip_bh_unsupported_float_combo(formats, dest_acc)
-
-    # Exp-family ops in approx mode can't run against bf8_b. Bfp4_b inputs are exempt:
-    # that combination is validated by the Bfp4_b sweep, so only guard non-Bfp4_b inputs.
-    if (
-        approx_mode == ApproximationMode.Yes
-        and mathop in [MathOperation.Exp, MathOperation.Exp2, MathOperation.Elu]
-        and formats.input_format != DataFormat.Bfp4_b
-        and (
-            formats.input_format == DataFormat.Bfp8_b
-            or formats.output_format == DataFormat.Bfp8_b
-        )
-    ):
-        pytest.skip(
-            reason="Exp-related operations are not supported for bf8_b format in approximation mode."
-        )
-
-    eltwise_unary_sfpu(
-        "sources/eltwise_unary_sfpu_test.cpp",
-        formats,
-        dest_acc,
-        approx_mode,
-        mathop,
-        fast_mode,
-        input_dimensions,
-    )
-
-
-# Integer unary SFPU ops. Each has a dedicated integer kernel and runs through the
-# shared driver with the input unpacked straight to DST (dest_acc=Yes is required for
-# the 32-bit int path). Golden is exact (no PCC/tolerance).
-_INT_UNARY_OPS = [
-    MathOperation.LeftShift,
-    MathOperation.RightShift,
-    MathOperation.UnaryMaxInt32,
-    MathOperation.UnaryMinInt32,
-    MathOperation.UnaryMaxUint32,
-    MathOperation.UnaryMinUint32,
-]
-
-# Ops whose kernel interprets DST as unsigned; run them under UInt32.
-_UINT32_INT_UNARY_OPS = {
-    MathOperation.UnaryMaxUint32,
-    MathOperation.UnaryMinUint32,
-}
-
-
-def _int_unary_stimuli_spec(mathop):
-    # Shifts use a fixed shift of 3, so keep inputs small-positive: x << 3 must stay
-    # inside the positive int32 range (Dst is sign-magnitude, so hitting the sign bit
-    # would diverge from the two's-complement golden).
-    if mathop in (MathOperation.LeftShift, MathOperation.RightShift):
-        return StimuliSpec.uniform(low=0.0, high=1_000_000.0)
-    # Unary max/min compare against the fixed scalar 1000; straddle it so both the
-    # keep-input and take-scalar branches are exercised. Positive-only keeps signed
-    # and unsigned interpretations identical (safe under sign-magnitude Dst).
-    return StimuliSpec.uniform(low=0.0, high=2000.0)
-
-
-@parametrize(
-    mathop=_INT_UNARY_OPS,
-    dest_acc=[DestAccumulation.Yes],
-    input_dimensions=[[64, 64]],
-)
-def test_eltwise_unary_sfpu_int(
-    mathop: MathOperation,
-    dest_acc: DestAccumulation,
-    input_dimensions: list[int],
-):
-    int_format = (
-        DataFormat.UInt32 if mathop in _UINT32_INT_UNARY_OPS else DataFormat.Int32
-    )
-    formats = InputOutputFormat(int_format, int_format)
-
-    eltwise_unary_sfpu(
-        "sources/eltwise_unary_sfpu_test.cpp",
-        formats,
-        dest_acc,
-        ApproximationMode.No,
-        mathop,
-        FastMode.No,
-        input_dimensions,
-        spec_A=_int_unary_stimuli_spec(mathop),
-    )
-
-
-# Unary SFPU ops that require per-op input domains
-DOMAIN_MATHOPS = [
+STANDARD_SWEEP_OPS = [
     MathOperation.Add1,
     MathOperation.CastFp32ToFp16a,
     MathOperation.Cbrt,
@@ -439,48 +185,314 @@ DOMAIN_MATHOPS = [
 
 # Per-op (atol, rtol) overrides for coarse LUT/polynomial ops; others use the
 # per-format default in passed_test.
-DOMAIN_CUSTOM_TOLERANCES = {
+CUSTOM_TOLERANCES = {
     # Coarse 3-segment LUT: good PCC but abs error peaks ~0.12 near the knees.
     MathOperation.SigmoidAppx: (0.13, 0.05),
     MathOperation.GeluAppx: (0.13, 0.05),
 }
 
-
-# Large matrix (2 formats x ~52 ops x 2 dest_acc); nightly-gated to keep presubmit fast.
-@pytest.mark.nightly
-@parametrize(
-    formats=input_output_formats([DataFormat.Float16_b, DataFormat.Float32]),
-    approx_mode=[ApproximationMode.No],
-    mathop=DOMAIN_MATHOPS,
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
-    input_dimensions=[[64, 64]],
+BROAD_FORMATS = input_output_formats(
+    [
+        DataFormat.Float32,
+        DataFormat.Float16,
+        DataFormat.Float16_b,
+        DataFormat.Bfp8_b,
+    ]
 )
-def test_eltwise_unary_sfpu_domain(
+
+# The standard profile keeps the two formats that exercise the SFPU's own math without
+# a block-float or 16-bit-exponent path in the way: bf16 for the 16-bit dst rounding
+# and fp32 for full precision.
+STANDARD_FORMATS = input_output_formats([DataFormat.Float16_b, DataFormat.Float32])
+
+BROAD_DIMENSIONS = [[64, 64], [128, 256]]
+STANDARD_DIMENSIONS = [[64, 64]]
+
+# Bfp4_b is only exercised as an input format. The original sweep built the full 4x4
+# matrix and skipped every combo whose input was not Bfp4_b, so pin the input to Bfp4_b
+# directly here: same coverage, without generating (and skipping) the other 12 combos.
+FORMATS_BFP4_B = [
+    InputOutputFormat(DataFormat.Bfp4_b, output_format)
+    for output_format in [
+        DataFormat.Float16_b,
+        DataFormat.Bfp8_b,
+        DataFormat.Float16,
+        DataFormat.Bfp4_b,
+    ]
+]
+
+MATHOPS_INCLUDE_BFP4_B = [
+    MathOperation.Abs,
+    MathOperation.Atanh,
+    MathOperation.Asinh,
+    MathOperation.Acosh,
+    MathOperation.Cos,
+    MathOperation.Log,
+    # MathOperation.Log1p,
+    # MathOperation.Reciprocal,
+    # MathOperation.Sin,
+    # MathOperation.Sqrt,
+    MathOperation.Rsqrt,
+    MathOperation.Square,
+    MathOperation.Tanh,
+    MathOperation.Celu,
+    MathOperation.Silu,
+    MathOperation.Gelu,
+    MathOperation.GeluTanh,
+    MathOperation.Neg,
+    MathOperation.Fill,
+    MathOperation.Elu,
+    # MathOperation.Exp,
+    # MathOperation.Exp2,
+    # MathOperation.Hardsigmoid,
+    MathOperation.Threshold,
+    MathOperation.ReluMax,
+    MathOperation.ReluMin,
+]
+
+# Ops whose `#pragma GCC unroll X` loops miscompile to invalid assembly under coverage
+# instrumentation (tt-metal#33268 / tt-llk#883), so they are skipped only when
+# WITH_COVERAGE is set. The gelu/log-family entries at the end came from the standard
+# profile's own copy of this list; the two lists had the same cause and are now one.
+COVERAGE_COMPILE_SKIP_OPS = [
+    MathOperation.Acosh,
+    MathOperation.Log,
+    MathOperation.Log1p,
+    MathOperation.Reciprocal,
+    MathOperation.Sin,
+    MathOperation.Sqrt,
+    MathOperation.Rsqrt,
+    MathOperation.Square,
+    MathOperation.Celu,
+    MathOperation.Silu,
+    MathOperation.Neg,
+    MathOperation.Exp2,
+    MathOperation.Hardsigmoid,
+    MathOperation.Threshold,
+    MathOperation.ReluMax,
+    MathOperation.ReluMin,
+    MathOperation.Tanh,
+    MathOperation.Gelu,
+    MathOperation.GeluDerivative,
+    MathOperation.LogWithBase,
+    MathOperation.GeluAppx,
+]
+
+
+def _sweep_params(formats, mathops, approx_modes, input_dimensions):
+    """Build (formats, approx_mode, mathop, fast_mode, dest_acc, input_dimensions) tuples.
+
+    Fast-mode-capable ops are swept with FastMode.No and FastMode.Yes; every other op
+    runs with FastMode.No only. dest_acc always sweeps both values.
+    """
+    dest_accs = [DestAccumulation.No, DestAccumulation.Yes]
+    fast_ops = [op for op in mathops if op in SUPPORTED_FAST_MODE_OPS]
+    non_fast_ops = [op for op in mathops if op not in SUPPORTED_FAST_MODE_OPS]
+    return list(
+        chain(
+            product(
+                formats,
+                approx_modes,
+                fast_ops,
+                [FastMode.No, FastMode.Yes],
+                dest_accs,
+                input_dimensions,
+            ),
+            product(
+                formats,
+                approx_modes,
+                non_fast_ops,
+                [FastMode.No],
+                dest_accs,
+                input_dimensions,
+            ),
+        )
+    )
+
+
+def _assert_sweep_profiles_disjoint():
+    """No op sits in both profiles, and every swept op has a registered domain.
+
+    Both were previously implicit and both failed quietly: an op in both lists ran its
+    whole matrix twice, and an op with no registry entry used to fall back to the
+    positive-only format default. for_op() does raise on a missing entry, but only once
+    the sweep reaches that op, so assert here to fail at collection instead.
+
+    Exhaustiveness is deliberately *not* checked: there is no authoritative list of
+    "every unary SFPU op" to check against -- _OP_DOMAIN_REGISTRY also holds the binary
+    and reduce entries -- so an op in neither profile still goes untested silently.
+    Closing that needs the registry to record an op's arity, which is Phase 1 work.
+    """
+    overlap = set(BROAD_SWEEP_OPS) & set(STANDARD_SWEEP_OPS)
+    assert not overlap, (
+        "These ops are in both sweep profiles and would run twice: "
+        f"{sorted(op.name for op in overlap)}"
+    )
+    unregistered = [
+        op.name
+        for op in chain(BROAD_SWEEP_OPS, STANDARD_SWEEP_OPS)
+        if op not in _OP_DOMAIN_REGISTRY
+    ]
+    assert not unregistered, (
+        "These swept ops have no domain in sfpu_domains._OP_DOMAIN_REGISTRY, so the "
+        f"driver cannot build stimuli for them: {sorted(unregistered)}"
+    )
+
+
+# The broad profile sweeps the full float matrix, plus the Bfp4_b input formats for the
+# subset of ops validated against them. The standard profile is bf16/fp32 only, approx
+# mode off, one tile shape. One driver, one skip path, one test below.
+UNARY_SWEEP_PARAMS = (
+    _sweep_params(
+        BROAD_FORMATS,
+        BROAD_SWEEP_OPS,
+        [ApproximationMode.No, ApproximationMode.Yes],
+        BROAD_DIMENSIONS,
+    )
+    + _sweep_params(
+        FORMATS_BFP4_B,
+        MATHOPS_INCLUDE_BFP4_B,
+        [ApproximationMode.No, ApproximationMode.Yes],
+        BROAD_DIMENSIONS,
+    )
+    + _sweep_params(
+        STANDARD_FORMATS,
+        STANDARD_SWEEP_OPS,
+        [ApproximationMode.No],
+        STANDARD_DIMENSIONS,
+    )
+)
+
+
+_assert_sweep_profiles_disjoint()
+
+
+def _skip_bh_unsupported_float_combo(formats, dest_acc):
+    """Blackhole with dest_acc=No supports neither Float16 input nor Float32->Float16."""
+    if (
+        dest_acc == DestAccumulation.No
+        and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE
+        and (
+            formats.input_format == DataFormat.Float16
+            or formats == InputOutputFormat(DataFormat.Float32, DataFormat.Float16)
+        )
+    ):
+        pytest.skip(reason="This combination is not supported on BH architecture")
+
+
+def _skip_bh_unless_fp32(formats, dest_acc):
+    """Blackhole with dest_acc=No only supports the Float32->Float32 combination."""
+    if (
+        dest_acc == DestAccumulation.No
+        and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE
+        and formats != InputOutputFormat(DataFormat.Float32, DataFormat.Float32)
+    ):
+        pytest.skip(reason="This combination is not supported on BH architecture")
+
+
+# Approximate exp overshoots the golden by a systematic ~5.7% (peak 6.75%) once its
+# argument passes ~8 -- measured on Wormhole, the smallest output that breaches the
+# default 5% rtol is exactly exp(8.00) = 2976, and 0.6% of elements in an affected
+# tile breach it. That is a property of the approximation itself, not of the stimuli:
+# it went unmeasured until this sweep stopped feeding exp uniform(0.1, 1.1), which
+# never produced an argument above 1.1.
+#
+# Whether a given combination trips the 5% bar is marginal, and two things decide it:
+# the domain its output format selects (high=16, or 10 when a Float16 output narrows
+# it) and whether a 16-bit dst rounds golden and result back together -- dest_acc=Yes
+# keeps an fp32 dst and exposes the full error. Hence Float32->Float16_b failing only
+# at dest_acc=Yes. Listed exhaustively rather than by predicate so that a combination
+# drifting in or out of tolerance shows up as a change here.
+_APPROX_EXP_ACCURACY_XFAIL = {
+    (DataFormat.Float16, DataFormat.Float16_b, DestAccumulation.No),
+    (DataFormat.Float16, DataFormat.Float16_b, DestAccumulation.Yes),
+    (DataFormat.Float32, DataFormat.Float16_b, DestAccumulation.Yes),
+}
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "formats,approx_mode,mathop,fast_mode,dest_acc,input_dimensions",
+    UNARY_SWEEP_PARAMS,
+)
+def test_eltwise_unary_sfpu(
+    request,
     formats: list[InputOutputFormat],
     approx_mode: ApproximationMode,
     mathop: MathOperation,
+    fast_mode: FastMode,
     dest_acc: DestAccumulation,
     input_dimensions: list[int],
 ):
-    _skip_bh_unless_fp32(formats, dest_acc)
+    """Every float unary SFPU op, over its registered domain.
 
-    if TestConfig.WITH_COVERAGE and mathop in [
-        MathOperation.GeluDerivative,
-        MathOperation.LogWithBase,
-        MathOperation.GeluAppx,
-    ]:
-        # gelu/log-family `#pragma GCC unroll` loops compile to invalid assembly
-        # under coverage instrumentation (tt-metal#33268 / tt-llk#883), same as the
-        # float-sweep skips for Gelu/Log above.
-        pytest.skip(
-            reason="gelu/log-family ops fail to compile under coverage instrumentation"
+    Merged from test_eltwise_unary_sfpu_float and test_eltwise_unary_sfpu_domain: both
+    now derive stimuli from the same per-op registry, so the sweep envelope (which
+    profile the op is in) is the only thing that differed. See BROAD_SWEEP_OPS.
+    """
+    broad = mathop in BROAD_SWEEP_OPS
+
+    if (
+        mathop == MathOperation.Exp
+        and approx_mode == ApproximationMode.Yes
+        and (formats.input_format, formats.output_format, dest_acc)
+        in _APPROX_EXP_ACCURACY_XFAIL
+    ):
+        # Marked dynamically rather than skipped so the case still executes: if the
+        # approximation tightens, this reports XPASS instead of quietly staying green.
+        request.node.add_marker(
+            pytest.mark.xfail(
+                reason="Approximate exp exceeds the default 5% rtol above an argument "
+                "of ~8, peaking at 6.75%. See _APPROX_EXP_ACCURACY_XFAIL.",
+                strict=False,
+            )
         )
 
-    # Per-op input domain, clipped to where the op is defined (e.g. erfinv: |x| < 1).
-    specs = for_op(mathop, formats.input_format)
-    spec_A = exclude_undefined(mathop, specs.spec_A)
+    if TestConfig.WITH_COVERAGE:
+        # The broad profile was previously an entire test carrying @skip_for_coverage, so
+        # under coverage it is skipped wholesale; only the standard profile runs. Keep
+        # both behaviours rather than widening or narrowing coverage runs here.
+        if broad:
+            pytest.skip(reason="https://github.com/tenstorrent/tt-llk/issues/1435")
+        if mathop in COVERAGE_COMPILE_SKIP_OPS:
+            pytest.skip(
+                reason="`#pragma GCC unroll X` loops in these ops compile to invalid "
+                "assembly under coverage instrumentation "
+                "(tt-metal#33268 / tt-llk#883)"
+            )
 
-    custom_atol, custom_rtol = DOMAIN_CUSTOM_TOLERANCES.get(mathop, (None, None))
+    if mathop == MathOperation.ReluMin:
+        pytest.skip(reason="https://github.com/tenstorrent/tt-llk/issues/1120")
+
+    if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
+        pytest.skip(reason="Metal tanh does not support approximation mode")
+
+    # The two profiles disagree about Blackhole at dest_acc=No, and the disagreement is
+    # load-bearing rather than cosmetic: the broad profile runs everything except a
+    # Float16 input or Float32->Float16, while the standard profile allows only
+    # Float32->Float32. Both are measured-correct for their own format sets, so keep
+    # each profile's own guard rather than picking one and silently changing coverage.
+    if broad:
+        _skip_bh_unsupported_float_combo(formats, dest_acc)
+    else:
+        _skip_bh_unless_fp32(formats, dest_acc)
+
+    # Exp-family ops in approx mode can't run against bf8_b. Bfp4_b inputs are exempt:
+    # that combination is validated by the Bfp4_b sweep, so only guard non-Bfp4_b inputs.
+    if (
+        approx_mode == ApproximationMode.Yes
+        and mathop in [MathOperation.Exp, MathOperation.Exp2, MathOperation.Elu]
+        and formats.input_format != DataFormat.Bfp4_b
+        and (
+            formats.input_format == DataFormat.Bfp8_b
+            or formats.output_format == DataFormat.Bfp8_b
+        )
+    ):
+        pytest.skip(
+            reason="Exp-related operations are not supported for bf8_b format in approximation mode."
+        )
+
+    custom_atol, custom_rtol = CUSTOM_TOLERANCES.get(mathop, (None, None))
 
     eltwise_unary_sfpu(
         "sources/eltwise_unary_sfpu_test.cpp",
@@ -488,12 +500,72 @@ def test_eltwise_unary_sfpu_domain(
         dest_acc,
         approx_mode,
         mathop,
-        FastMode.No,
+        fast_mode,
         input_dimensions,
-        spec_A=spec_A,
         custom_atol=custom_atol,
         custom_rtol=custom_rtol,
     )
+
+
+# Integer unary SFPU ops. Each has a dedicated integer kernel and runs through the
+# shared driver with the input unpacked straight to DST (dest_acc=Yes is required for
+# the 32-bit int path). Golden is exact (no PCC/tolerance).
+_INT_UNARY_OPS = [
+    MathOperation.LeftShift,
+    MathOperation.RightShift,
+    MathOperation.UnaryMaxInt32,
+    MathOperation.UnaryMinInt32,
+    MathOperation.UnaryMaxUint32,
+    MathOperation.UnaryMinUint32,
+]
+
+# Ops whose kernel interprets DST as unsigned; run them under UInt32.
+_UINT32_INT_UNARY_OPS = {
+    MathOperation.UnaryMaxUint32,
+    MathOperation.UnaryMinUint32,
+}
+
+
+def _int_unary_stimuli_spec(mathop):
+    # Shifts use a fixed shift of 3, so keep inputs small-positive: x << 3 must stay
+    # inside the positive int32 range (Dst is sign-magnitude, so hitting the sign bit
+    # would diverge from the two's-complement golden).
+    if mathop in (MathOperation.LeftShift, MathOperation.RightShift):
+        return StimuliSpec.uniform(low=0.0, high=1_000_000.0)
+    # Unary max/min compare against the fixed scalar 1000; straddle it so both the
+    # keep-input and take-scalar branches are exercised. Positive-only keeps signed
+    # and unsigned interpretations identical (safe under sign-magnitude Dst).
+    return StimuliSpec.uniform(low=0.0, high=2000.0)
+
+
+@parametrize(
+    mathop=_INT_UNARY_OPS,
+    dest_acc=[DestAccumulation.Yes],
+    input_dimensions=[[64, 64]],
+)
+def test_eltwise_unary_sfpu_int(
+    mathop: MathOperation,
+    dest_acc: DestAccumulation,
+    input_dimensions: list[int],
+):
+    int_format = (
+        DataFormat.UInt32 if mathop in _UINT32_INT_UNARY_OPS else DataFormat.Int32
+    )
+    formats = InputOutputFormat(int_format, int_format)
+
+    eltwise_unary_sfpu(
+        "sources/eltwise_unary_sfpu_test.cpp",
+        formats,
+        dest_acc,
+        ApproximationMode.No,
+        mathop,
+        FastMode.No,
+        input_dimensions,
+        spec_A=_int_unary_stimuli_spec(mathop),
+    )
+
+
+# Unary SFPU ops that require per-op input domains
 
 
 @parametrize(

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -68,15 +68,6 @@ SUPPORTED_FAST_MODE_OPS = [
 #   STANDARD_SWEEP_OPS - Float16_b + Float32, approximation mode off, one tile shape.
 #                        Enough to validate the op's own math, and ~8x cheaper.
 #
-# These were ALL_MATHOPS and DOMAIN_MATHOPS, driven by two separate tests
-# (test_eltwise_unary_sfpu_float and test_eltwise_unary_sfpu_domain). They existed
-# apart for a reason that no longer holds: only the _domain test consumed the per-op
-# domain registry, so every ALL_MATHOPS op ran a positive-only uniform(0.1, 1.1)
-# default and never saw its x<0 branch. Both now take their domain from the same
-# place, which leaves the sweep envelope as the only difference -- and an envelope is
-# a parameter, not a reason for a second test. Keeping them apart also meant a new op
-# silently inherited whichever envelope its author happened to pick a list from.
-#
 # Adding an op: put it in exactly one list, and register a domain for it in
 # sfpu_domains.py. _assert_sweep_profiles_disjoint() below enforces both.
 # ─────────────────────────────────────────────────────────────────────────────
@@ -209,9 +200,8 @@ STANDARD_FORMATS = input_output_formats([DataFormat.Float16_b, DataFormat.Float3
 BROAD_DIMENSIONS = [[64, 64], [128, 256]]
 STANDARD_DIMENSIONS = [[64, 64]]
 
-# Bfp4_b is only exercised as an input format. The original sweep built the full 4x4
-# matrix and skipped every combo whose input was not Bfp4_b, so pin the input to Bfp4_b
-# directly here: same coverage, without generating (and skipping) the other 12 combos.
+# Bfp4_b is only exercised as an input format, so the input is pinned to Bfp4_b here
+# rather than building the full matrix and skipping the 12 non-Bfp4_b-input combos.
 FORMATS_BFP4_B = [
     InputOutputFormat(DataFormat.Bfp4_b, output_format)
     for output_format in [
@@ -255,8 +245,7 @@ MATHOPS_INCLUDE_BFP4_B = [
 # instrumentation, so they are skipped only when WITH_COVERAGE is set:
 #   https://github.com/tenstorrent/tt-metal/issues/33268
 #   https://github.com/tenstorrent/tt-llk/issues/883
-# The gelu/log-family entries at the end came from the standard profile's own copy of
-# this list; the two lists had the same cause and are now one.
+# Covers ops from both sweep profiles.
 COVERAGE_COMPILE_SKIP_OPS = [
     MathOperation.Acosh,
     MathOperation.Log,
@@ -316,10 +305,9 @@ def _sweep_params(formats, mathops, approx_modes, input_dimensions):
 def _assert_sweep_profiles_disjoint():
     """No op sits in both profiles, and every swept op has a registered domain.
 
-    Both were previously implicit and both failed quietly: an op in both lists ran its
-    whole matrix twice, and an op with no registry entry used to fall back to the
-    positive-only format default. for_op() does raise on a missing entry, but only once
-    the sweep reaches that op, so assert here to fail at collection instead.
+    An op in both lists would run its whole matrix twice. An op with no registry entry
+    does raise in for_op(), but only once the sweep reaches it, so assert here to fail at
+    collection instead.
 
     Exhaustiveness is checked too, against sfpu_unary_ops(): the registry knows which of
     its entries have a unary SFPU kernel, so an op added to the registry and to no sweep
@@ -358,7 +346,7 @@ def _assert_sweep_profiles_disjoint():
 
 # The broad profile sweeps the full float matrix, plus the Bfp4_b input formats for the
 # subset of ops validated against them. The standard profile is bf16/fp32 only, approx
-# mode off, one tile shape. One driver, one skip path, one test below.
+# mode off, one tile shape.
 UNARY_SWEEP_PARAMS = (
     _sweep_params(
         BROAD_FORMATS,
@@ -409,10 +397,8 @@ def _skip_bh_unless_fp32(formats, dest_acc):
 
 # Approximate exp overshoots the golden by a systematic ~5.7% (peak 6.75%) once its
 # argument passes ~8 -- measured on Wormhole, the smallest output that breaches the
-# default 5% rtol is exactly exp(8.00) = 2976, and 0.6% of elements in an affected
-# tile breach it. That is a property of the approximation itself, not of the stimuli:
-# it went unmeasured until this sweep stopped feeding exp uniform(0.1, 1.1), which
-# never produced an argument above 1.1.
+# default 5% rtol is exactly exp(8.00) = 2976, and 0.6% of elements in an affected tile
+# breach it. This is a property of the approximation, not of the stimuli.
 #
 # Whether a given combination trips the 5% bar is marginal, and two things decide it:
 # the domain its output format selects (high=16, or 10 when a Float16 output narrows
@@ -443,9 +429,8 @@ def test_eltwise_unary_sfpu(
 ):
     """Every float unary SFPU op, over its registered domain.
 
-    Merged from test_eltwise_unary_sfpu_float and test_eltwise_unary_sfpu_domain: both
-    now derive stimuli from the same per-op registry, so the sweep envelope (which
-    profile the op is in) is the only thing that differed. See BROAD_SWEEP_OPS.
+    Stimuli come from the per-op registry for every op; the sweep envelope (which profile
+    the op is in) is the only thing that varies. See BROAD_SWEEP_OPS.
     """
     broad = mathop in BROAD_SWEEP_OPS
 
@@ -466,9 +451,7 @@ def test_eltwise_unary_sfpu(
         )
 
     if TestConfig.WITH_COVERAGE:
-        # The broad profile was previously an entire test carrying @skip_for_coverage, so
-        # under coverage it is skipped wholesale; only the standard profile runs. Keep
-        # both behaviours rather than widening or narrowing coverage runs here.
+        # Coverage runs skip the broad profile wholesale; only the standard profile runs.
         if broad:
             pytest.skip(
                 reason="Broad-profile ops are not run under coverage: "
@@ -488,11 +471,9 @@ def test_eltwise_unary_sfpu(
     if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
         pytest.skip(reason="Metal tanh does not support approximation mode")
 
-    # The two profiles disagree about Blackhole at dest_acc=No, and the disagreement is
-    # load-bearing rather than cosmetic: the broad profile runs everything except a
-    # Float16 input or Float32->Float16, while the standard profile allows only
-    # Float32->Float32. Both are measured-correct for their own format sets, so keep
-    # each profile's own guard rather than picking one and silently changing coverage.
+    # Each profile has its own Blackhole dest_acc=No guard, measured against its own
+    # format set: the broad profile runs everything except a Float16 input or
+    # Float32->Float16, while the standard profile allows only Float32->Float32.
     if broad:
         _skip_bh_unsupported_float_combo(formats, dest_acc)
     else:
@@ -750,19 +731,17 @@ def eltwise_unary_sfpu(
     torch.manual_seed(0)
     torch.set_printoptions(precision=10)
 
-    # Fall back to the op's own (signed) domain rather than generate_stimuli's
-    # positive-only format default. Without this the float sweep feeds every op
-    # uniform(0.1, 1.1), so the x<0 branch, the piecewise knees and the saturation
-    # tails are never reached (https://github.com/tenstorrent/tt-metal/issues/49739).
-    # Every op reaching this driver is
-    # registered in _OP_DOMAIN_REGISTRY, so a KeyError here means a new op was
-    # added without a domain: register it rather than silently falling back to the
-    # positive-only default.
-    # The domain has to satisfy the whole input->output pipeline, not just one end
-    # of it: this sweep pairs every input format with every output format, so
-    # Float32->Float16 has to stay inside Float16's range while Bfp8_b->Float16
-    # keeps the tighter interval Bfp8_b's block precision demands. for_op_pipeline
-    # resolves both and takes the tighter — see its docstring.
+    # Default to the op's own (signed) domain rather than generate_stimuli's positive-only
+    # format default, which would leave the x<0 branch, the piecewise knees and the
+    # saturation tails unreached. Every op reaching this driver is registered in
+    # _OP_DOMAIN_REGISTRY, so a KeyError here means a new op was added without a domain:
+    # register it rather than falling back to the positive-only default.
+    #
+    # The domain has to satisfy the whole input->output pipeline, not just one end of it:
+    # this sweep pairs every input format with every output format, so Float32->Float16
+    # has to stay inside Float16's range while Bfp8_b->Float16 keeps the tighter interval
+    # Bfp8_b's block precision demands. for_op_pipeline resolves both and takes the
+    # tighter — see its docstring.
     if spec_A is None:
         spec_A = exclude_undefined(
             mathop,

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -28,9 +28,11 @@ from helpers.param_config import (
 )
 from helpers.sfpu_domains import (
     _OP_DOMAIN_REGISTRY,
+    _UNARY_OPS_NOT_SWEPT,
     exclude_undefined,
     for_op,
     narrowest_range_format,
+    sfpu_unary_ops,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
@@ -318,10 +320,11 @@ def _assert_sweep_profiles_disjoint():
     positive-only format default. for_op() does raise on a missing entry, but only once
     the sweep reaches that op, so assert here to fail at collection instead.
 
-    Exhaustiveness is deliberately *not* checked: there is no authoritative list of
-    "every unary SFPU op" to check against -- _OP_DOMAIN_REGISTRY also holds the binary
-    and reduce entries -- so an op in neither profile still goes untested silently.
-    Closing that needs the registry to record an op's arity, which is Phase 1 work.
+    Exhaustiveness is checked too, against sfpu_unary_ops(): the registry knows which of
+    its entries have a unary SFPU kernel, so an op added to the registry and to no sweep
+    profile fails here rather than going quietly untested. An op that genuinely should not
+    be swept belongs in _UNARY_OPS_NOT_SWEPT (with a reason) or, if it has no unary SFPU
+    kernel at all, in _NON_SFPU_UNARY_OPS.
     """
     overlap = set(BROAD_SWEEP_OPS) & set(STANDARD_SWEEP_OPS)
     assert not overlap, (
@@ -336,6 +339,19 @@ def _assert_sweep_profiles_disjoint():
     assert not unregistered, (
         "These swept ops have no domain in sfpu_domains._OP_DOMAIN_REGISTRY, so the "
         f"driver cannot build stimuli for them: {sorted(unregistered)}"
+    )
+    swept = set(BROAD_SWEEP_OPS) | set(STANDARD_SWEEP_OPS)
+    expected = sfpu_unary_ops() - set(_UNARY_OPS_NOT_SWEPT)
+    untested = sorted(op.name for op in expected - swept)
+    assert not untested, (
+        "These ops have a unary SFPU kernel and a registered domain but are in neither "
+        "sweep profile, so nothing drives them. Add them to a profile, or to "
+        f"_UNARY_OPS_NOT_SWEPT with a reason: {untested}"
+    )
+    not_unary = sorted(op.name for op in swept - sfpu_unary_ops())
+    assert not not_unary, (
+        "These swept ops are classified as having no unary SFPU kernel "
+        f"(sfpu_domains._NON_SFPU_UNARY_OPS): {not_unary}"
     )
 
 

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -300,19 +300,6 @@ def _skip_bh_unless_fp32(formats, dest_acc):
         pytest.skip(reason="This combination is not supported on BH architecture")
 
 
-# Approximate exp overshoots the golden by ~5.7% (peak 6.75%) once its argument passes ~8,
-# breaching the default 5% rtol -- a property of the approximation, not of the stimuli
-# (measured on Wormhole). Membership is marginal, set by the domain the output format
-# selects and by whether a 16-bit dst rounds golden and result back together: dest_acc=Yes
-# keeps an fp32 dst and exposes the full error. Listed exhaustively rather than by
-# predicate so a combination drifting in or out of tolerance shows up as a diff here.
-_APPROX_EXP_ACCURACY_XFAIL = {
-    (DataFormat.Float16, DataFormat.Float16_b, DestAccumulation.No),
-    (DataFormat.Float16, DataFormat.Float16_b, DestAccumulation.Yes),
-    (DataFormat.Float32, DataFormat.Float16_b, DestAccumulation.Yes),
-}
-
-
 _UNARY_SWEEP_ARGNAMES = (
     "formats",
     "approx_mode",
@@ -330,7 +317,6 @@ _UNARY_SWEEP_ARGNAMES = (
     ids=[build_param_id(_UNARY_SWEEP_ARGNAMES, p) for p in UNARY_SWEEP_PARAMS],
 )
 def test_eltwise_unary_sfpu(
-    request,
     formats: list[InputOutputFormat],
     approx_mode: ApproximationMode,
     mathop: MathOperation,
@@ -344,22 +330,6 @@ def test_eltwise_unary_sfpu(
     the op is in) is the only thing that varies. See BROAD_SWEEP_OPS.
     """
     broad = mathop in BROAD_SWEEP_OPS
-
-    if (
-        mathop == MathOperation.Exp
-        and approx_mode == ApproximationMode.Yes
-        and (formats.input_format, formats.output_format, dest_acc)
-        in _APPROX_EXP_ACCURACY_XFAIL
-    ):
-        # Marked dynamically rather than skipped so the case still executes: if the
-        # approximation tightens, this reports XPASS instead of quietly staying green.
-        request.node.add_marker(
-            pytest.mark.xfail(
-                reason="Approximate exp exceeds the default 5% rtol above an argument "
-                "of ~8, peaking at 6.75%. See _APPROX_EXP_ACCURACY_XFAIL.",
-                strict=False,
-            )
-        )
 
     if TestConfig.WITH_COVERAGE:
         # Coverage runs skip the broad profile wholesale; only the standard profile runs.

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -63,9 +63,10 @@ SUPPORTED_FAST_MODE_OPS = [
 # the two lists is *how much of the format/mode matrix* each op is worth spending, so
 # they are coverage profiles rather than different kinds of test:
 #
-#   BROAD_SWEEP_OPS    - the full format matrix including the block floats, both
-#                        approximation modes and both tile shapes. For ops whose
-#                        kernels have format-specific or approx-mode-specific paths.
+#   BROAD_SWEEP_OPS    - the full format matrix including the block floats (and the
+#                        Bfp4_b input formats), both approximation modes and both tile
+#                        shapes. For ops whose kernels have format-specific or
+#                        approx-mode-specific paths.
 #   STANDARD_SWEEP_OPS - Float16_b + Float32, approximation mode off, one tile shape.
 #                        Enough to validate the op's own math, and ~8x cheaper.
 #
@@ -213,35 +214,6 @@ FORMATS_BFP4_B = [
     ]
 ]
 
-MATHOPS_INCLUDE_BFP4_B = [
-    MathOperation.Abs,
-    MathOperation.Atanh,
-    MathOperation.Asinh,
-    MathOperation.Acosh,
-    MathOperation.Cos,
-    MathOperation.Log,
-    MathOperation.Log1p,
-    MathOperation.Reciprocal,
-    MathOperation.Sin,
-    MathOperation.Sqrt,
-    MathOperation.Rsqrt,
-    MathOperation.Square,
-    MathOperation.Tanh,
-    MathOperation.Celu,
-    MathOperation.Silu,
-    MathOperation.Gelu,
-    MathOperation.GeluTanh,
-    MathOperation.Neg,
-    MathOperation.Fill,
-    MathOperation.Elu,
-    MathOperation.Exp,
-    MathOperation.Exp2,
-    MathOperation.Hardsigmoid,
-    MathOperation.Threshold,
-    MathOperation.ReluMax,
-    MathOperation.ReluMin,
-]
-
 # Ops whose `#pragma GCC unroll X` loops miscompile to invalid assembly under coverage
 # instrumentation, so they are skipped only when WITH_COVERAGE is set:
 #   https://github.com/tenstorrent/tt-metal/issues/33268
@@ -345,9 +317,9 @@ def _assert_sweep_profiles_disjoint():
     )
 
 
-# The broad profile sweeps the full float matrix, plus the Bfp4_b input formats for the
-# subset of ops validated against them. The standard profile is bf16/fp32 only, approx
-# mode off, one tile shape.
+# The broad profile sweeps the full float matrix and the Bfp4_b input formats over the
+# same op list — Bfp4_b is a second format axis, not a second op set. The standard
+# profile is bf16/fp32 only, approx mode off, one tile shape.
 UNARY_SWEEP_PARAMS = (
     _sweep_params(
         BROAD_FORMATS,
@@ -357,7 +329,7 @@ UNARY_SWEEP_PARAMS = (
     )
     + _sweep_params(
         FORMATS_BFP4_B,
-        MATHOPS_INCLUDE_BFP4_B,
+        BROAD_SWEEP_OPS,
         [ApproximationMode.No, ApproximationMode.Yes],
         BROAD_DIMENSIONS,
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -30,8 +30,7 @@ from helpers.sfpu_domains import (
     _OP_DOMAIN_REGISTRY,
     _UNARY_OPS_NOT_SWEPT,
     exclude_undefined,
-    for_op,
-    narrowest_range_format,
+    for_op_pipeline,
     sfpu_unary_ops,
 )
 from helpers.stimuli_config import StimuliConfig
@@ -253,9 +252,11 @@ MATHOPS_INCLUDE_BFP4_B = [
 ]
 
 # Ops whose `#pragma GCC unroll X` loops miscompile to invalid assembly under coverage
-# instrumentation (tt-metal#33268 / tt-llk#883), so they are skipped only when
-# WITH_COVERAGE is set. The gelu/log-family entries at the end came from the standard
-# profile's own copy of this list; the two lists had the same cause and are now one.
+# instrumentation, so they are skipped only when WITH_COVERAGE is set:
+#   https://github.com/tenstorrent/tt-metal/issues/33268
+#   https://github.com/tenstorrent/tt-llk/issues/883
+# The gelu/log-family entries at the end came from the standard profile's own copy of
+# this list; the two lists had the same cause and are now one.
 COVERAGE_COMPILE_SKIP_OPS = [
     MathOperation.Acosh,
     MathOperation.Log,
@@ -469,12 +470,16 @@ def test_eltwise_unary_sfpu(
         # under coverage it is skipped wholesale; only the standard profile runs. Keep
         # both behaviours rather than widening or narrowing coverage runs here.
         if broad:
-            pytest.skip(reason="https://github.com/tenstorrent/tt-llk/issues/1435")
+            pytest.skip(
+                reason="Broad-profile ops are not run under coverage: "
+                "https://github.com/tenstorrent/tt-llk/issues/1435"
+            )
         if mathop in COVERAGE_COMPILE_SKIP_OPS:
             pytest.skip(
                 reason="`#pragma GCC unroll X` loops in these ops compile to invalid "
-                "assembly under coverage instrumentation "
-                "(tt-metal#33268 / tt-llk#883)"
+                "assembly under coverage instrumentation: "
+                "https://github.com/tenstorrent/tt-metal/issues/33268 , "
+                "https://github.com/tenstorrent/tt-llk/issues/883"
             )
 
     if mathop == MathOperation.ReluMin:
@@ -748,18 +753,21 @@ def eltwise_unary_sfpu(
     # Fall back to the op's own (signed) domain rather than generate_stimuli's
     # positive-only format default. Without this the float sweep feeds every op
     # uniform(0.1, 1.1), so the x<0 branch, the piecewise knees and the saturation
-    # tails are never reached — see SFPU_EDGE_CASE_COVERAGE.md finding #1. Every
-    # op reaching this driver is registered in _OP_DOMAIN_REGISTRY, so a KeyError
-    # here means a new op was added without a domain: register it rather than
-    # silently falling back to the positive-only default.
-    # The domain is bounded by the narrowest format in the pipeline, not just the
-    # input one — this sweep pairs every input format with every output format, so
-    # e.g. Float32->Float16 still has to stay inside Float16's range.
+    # tails are never reached (https://github.com/tenstorrent/tt-metal/issues/49739).
+    # Every op reaching this driver is
+    # registered in _OP_DOMAIN_REGISTRY, so a KeyError here means a new op was
+    # added without a domain: register it rather than silently falling back to the
+    # positive-only default.
+    # The domain has to satisfy the whole input->output pipeline, not just one end
+    # of it: this sweep pairs every input format with every output format, so
+    # Float32->Float16 has to stay inside Float16's range while Bfp8_b->Float16
+    # keeps the tighter interval Bfp8_b's block precision demands. for_op_pipeline
+    # resolves both and takes the tighter — see its docstring.
     if spec_A is None:
-        domain_format = narrowest_range_format(
-            formats.input_format, formats.output_format
+        spec_A = exclude_undefined(
+            mathop,
+            for_op_pipeline(mathop, formats.input_format, formats.output_format).spec_A,
         )
-        spec_A = exclude_undefined(mathop, for_op(mathop, domain_format).spec_A)
 
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_unary.py
@@ -27,7 +27,7 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
 )
-from helpers.sfpu_domains import exclude_undefined, for_op
+from helpers.sfpu_domains import exclude_undefined, for_op, narrowest_range_format
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
@@ -619,6 +619,22 @@ def eltwise_unary_sfpu(
 ):
     torch.manual_seed(0)
     torch.set_printoptions(precision=10)
+
+    # Fall back to the op's own (signed) domain rather than generate_stimuli's
+    # positive-only format default. Without this the float sweep feeds every op
+    # uniform(0.1, 1.1), so the x<0 branch, the piecewise knees and the saturation
+    # tails are never reached — see SFPU_EDGE_CASE_COVERAGE.md finding #1. Every
+    # op reaching this driver is registered in _OP_DOMAIN_REGISTRY, so a KeyError
+    # here means a new op was added without a domain: register it rather than
+    # silently falling back to the positive-only default.
+    # The domain is bounded by the narrowest format in the pipeline, not just the
+    # input one — this sweep pairs every input format with every output format, so
+    # e.g. Float32->Float16 still has to stay inside Float16's range.
+    if spec_A is None:
+        domain_format = narrowest_range_format(
+            formats.input_format, formats.output_format
+        )
+        spec_A = exclude_undefined(mathop, for_op(mathop, domain_format).spec_A)
 
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,


### PR DESCRIPTION
### PR Category

# SFPU Phase 0 — in short
Part of [#49739](https://github.com/tenstorrent/tt-metal/issues/49739) · branch `ldjurovic/sfpu_edge_cases_1`

Phase 0 was meant to be one small change — stop the unary SFPU float sweep feeding every op a positive-only `uniform(0.1, 1.1)` and point it at the per-op signed domains already sitting in `_OP_DOMAIN_REGISTRY`, so that 31 ops would finally exercise their `x<0` branch, piecewise knees and saturation tails. Making the reroute pass turned it into nine items, because stimuli that benign had been masking three real defects: the `UnarySFPUGolden` never quantized Bfp8_b inputs, so the golden ran on values the hardware never saw; `passed_test` judged Bfp8_b as a scalar rather than a block format; and three registry domains (`exp`, `exp2`, `reciprocal`) had been bounded for representable range when the binding constraint was accuracy. One genuine kernel limit survived and is recorded as an xfail rather than tolerated — approximate `exp` overshoots the golden by a systematic ~5.7% once its argument passes ~8. The phase was closed by verifying that the recalibrated domains and the Bfp8_b comparison hold on a second architecture with no arch-specific bounds, so they stay single-valued for every later phase, and by merging the two unary sweeps into one test — deleting a nightly test and its duplicated skip paths while staying provably identical in cases, stimuli and per-op hardware results.

**Net:** 31 ops gained negative-branch coverage, 31 dead registry entries became live, two shared golden/comparison bugs were fixed for every suite that outputs Bfp8_b, one accuracy limit was documented instead of hidden, and one duplicated test was removed.



# SFPU Phase 1 — in short

Part of [#49739](https://github.com/tenstorrent/tt-metal/issues/49739) · branch `ldjurovic/sfpu_edge_cases_1` · commits `b0f4ae8`, `1291c7a`

Phase 1 applied Phase 0's reroute to the other three families, which had never imported `sfpu_domains.py` (audit finding #2) and so fed every op a positive-only `uniform(0.1, 1.1)`. Seven float elementwise binary ops now take their registered domain — add/sub/mul/rsub/div go from **0% to 50% negative operands**, and div's divisor spans both sides of the pole it is registered to avoid — while ternary and scalar gained the per-operand spec parameters later phases need. Alongside: the scalar binops sweep `{0, 1, 2, −2, 8, 0.25}` rather than one hard-coded `2.0`; `SfpuElwLt/Gt/Le/Ge` got their **first LLK-level correctness test**, driving the exact tie where lt/gt and le/ge disagree; and recording op arity made the unary sweep's exhaustiveness a collection-time error.

As in Phase 0 the mechanism was small and the fallout was most of the work. **Per-operand pairing had only ever filled the first tile pair** — `face_specs` is applied positionally and not cycled — so `mask`, `isclose` and `eq`/`ne` were each testing one sixteenth of what they appeared to. Fixing that exposed **`calculate_mask`'s one-pair-per-block limit**: the kernel ignores the forwarded dst indices, so 12 of 16 pairs failed until the test moved to a `[64, 32]` buffer. Third, **`pow` and `xlogy` needed accuracy-bounded domains**, neither having ever executed. The suite had also never seeded its stimuli, so a flaky variant was indistinguishable from a real finding.

**Net:** 7 binary ops gained negative-operand and pole-spanning coverage, 4 comparison ops their first test, pairing went from 1-in-16 tile pairs to all of them, and ternary/scalar are plumbed for Phases 2–4. Blackhole, all four suites: **4990 passed, 1700 skipped, 7 xfailed**.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/sfpu_edge_cases_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/sfpu_edge_cases_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/sfpu_edge_cases_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/sfpu_edge_cases_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ldjurovic/sfpu_edge_cases_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ldjurovic/sfpu_edge_cases_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/sfpu_edge_cases_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/sfpu_edge_cases_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/sfpu_edge_cases_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/sfpu_edge_cases_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/sfpu_edge_cases_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/sfpu_edge_cases_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/sfpu_edge_cases_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/sfpu_edge_cases_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/sfpu_edge_cases_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/sfpu_edge_cases_1)