### PR TITLE
Reland "[Bug fix] Make sampling and top-k deterministic on sub-core grids." with int32 tie-break index reduce

### DIFF
--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -18,6 +18,18 @@ from models.common.sampling.vocab_padding import (
     get_vocab_shard_dims,
 )
 
+# Greedy tie-break boost (see TTSampling._adjust_values_for_tiebreak).
+# bfloat16 keeps an 8-bit mantissa, so the gap to the next representable value at magnitude |x| is
+# between |x| * 2^-8 and |x| * 2^-7. Scaling the tied maximum by 2^-6 is therefore at least 2 ULP at
+# every magnitude, whereas a fixed constant is not: 1.0 is below one ULP once |logit| >= 256 (bf16
+# spacing there is 2.0), so 256 + 1 rounds straight back to 256 and the tie survives. Multiplying by
+# a power of two is exact in bf16, so the boost is reproducible.
+TIEBREAK_DELTA_SCALE = 2**-6
+# Floor so the boost stays strictly positive when the tied maximum is exactly 0.0. Still a normal
+# bf16 number (smallest normal ~1.18e-38) and orders of magnitude below one ULP of any real logit,
+# so it never perturbs a non-zero maximum.
+TIEBREAK_DELTA_FLOOR = 1e-30
+
 
 class TTSampling(LightweightModule):
     """
@@ -221,6 +233,19 @@ class TTSampling(LightweightModule):
             layout=ttnn.ROW_MAJOR_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._param_dims, mesh_shape=self.cluster_shape),
         )
+        # Persistent per-user ARGMAX mask [1,1,N,1] (1.0 where k==1), distributed like k_tensor. Used by
+        # _adjust_values_for_tiebreak to boost the lowest-index tied-max for greedy users only. Built
+        # host-side and kept in sync in reset_sampling_params (an on-device reshape of the [N] k_tensor
+        # to [1,1,N,1] is not sub-device-safe). float32 TILE so it broadcasts over the candidate width.
+        self._greedy_col = ttnn.from_torch(
+            (torch.as_tensor(k).reshape(1, 1, -1, 1) == 1).to(torch.float32),
+            device=self.mesh_device,
+            dtype=ttnn.float32,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device, dims=self._greedy_col_dims(), mesh_shape=self.cluster_shape
+            ),
+        )
 
         # Create device offset indices for global indexing
         self._create_indices_tensors()
@@ -243,9 +268,11 @@ class TTSampling(LightweightModule):
             device=self.mesh_device,
             dtype=ttnn.uint32,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._param_dims, mesh_shape=self.cluster_shape)
-            if self._sampling_dp > 1
-            else None,
+            mesh_mapper=(
+                ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._param_dims, mesh_shape=self.cluster_shape)
+                if self._sampling_dp > 1
+                else None
+            ),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
         self.user_ids_tt_tensor = ttnn.as_tensor(
@@ -321,13 +348,25 @@ class TTSampling(LightweightModule):
         self._invalid_vocab_tail_width = 0
 
         vocab_shard_dims = get_vocab_shard_dims(self.cluster_shape, self.sampling_all_gather_axis)
-        tail_mask = build_tail_invalid_vocab_mask(
-            self.vocab_size,
-            self.padded_vocab_size,
-            self.max_batch_size,
-            self.cluster_shape,
-            self.sampling_all_gather_axis,
-            tile_size=ttnn.TILE_SIZE,
+        # The compact tail-mask path masks only the padded tail, but it has to slice the
+        # logits and concat them back. ttnn.concat only honours sub_core_grids when the
+        # input is unsharded and the output is interleaved; otherwise it falls through to
+        # the "massaged" untilize/transpose path, which is invoked without sub_core_grids
+        # and so runs on the full Tensix grid. The sampling logits are width-sharded
+        # (DECODE_LOGITS_MEMCFG), so on a sampling sub-core grid the concat escapes the
+        # sub-device. Use the plain full-width additive mask (one elementwise add, no
+        # reassembly) whenever a sub-core grid is in use.
+        tail_mask = (
+            build_tail_invalid_vocab_mask(
+                self.vocab_size,
+                self.padded_vocab_size,
+                self.max_batch_size,
+                self.cluster_shape,
+                self.sampling_all_gather_axis,
+                tile_size=ttnn.TILE_SIZE,
+            )
+            if self.sub_core_grids is None
+            else None
         )
         if tail_mask is not None:
             self._invalid_vocab_tail_width = tail_mask.tail_width
@@ -416,6 +455,10 @@ class TTSampling(LightweightModule):
             [valid_logits, masked_tail_logits],
             dim=3,
             memory_config=logits.memory_config(),
+            # Match the slices above: run concat on the sampling sub-device cores,
+            # otherwise the concat program is placed on the full Tensix grid and
+            # fails with "Kernel group cores do not match sub device cores"
+            # (TT_FATAL num_intersections == num_cores).
             sub_core_grids=self.sub_core_grids,
         )
         ttnn.deallocate(valid_logits)
@@ -545,9 +588,109 @@ class TTSampling(LightweightModule):
             ttnn.copy_host_to_device_tensor(self.p_tensor_new, self.p_tensor)
             ttnn.copy_host_to_device_tensor(self.temp_tensor_new, self.temp_tensor)
 
+            # Keep the greedy tie-break mask (1.0 where k==1) in sync with k, distributed like k_tensor.
+            self._greedy_col_new = ttnn.from_torch(
+                (torch.tensor(k).reshape(1, 1, -1, 1) == 1).to(torch.float32),
+                device=None,
+                dtype=ttnn.float32,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=(
+                    ttnn.ShardTensor2dMesh(
+                        self.mesh_device, dims=self._greedy_col_dims(), mesh_shape=self.cluster_shape
+                    )
+                    if self._sampling_dp > 1
+                    else None
+                ),
+            )
+            ttnn.copy_host_to_device_tensor(self._greedy_col_new, self._greedy_col)
+
         self.log_probs_calculator.set_log_probs_mode(
             enable_log_probs, num_logprobs=num_logprobs, empty_slots=empty_slots
         )
+
+    def _greedy_col_dims(self):
+        """Map the 1-D k_tensor shard dims (self._param_dims, batch on dim0) to the [1,1,N,1] greedy
+        mask's dims (batch on dim2), so self._greedy_col is distributed exactly like self.k_tensor."""
+        return tuple(2 if d == 0 else d for d in self._param_dims)
+
+    def _adjust_values_for_tiebreak(self, gathered_values, gathered_global_indices):
+        """Return gathered_values with, for ARGMAX users (k==1) ONLY, the single lowest-GLOBAL-INDEX
+        candidate among the tied maxima boosted just past the tie, so ttnn.sampling's argmax selects
+        it deterministically. This fixes ttnn.sampling's array-position tie-break (it breaks exact
+        value ties by all_gather/device order, which varies run-to-run/slot-to-slot and flips the
+        greedy token) by correcting the sampling INPUT in the TILE domain -- avoiding an in-place
+        write into the ROW_MAJOR output buffer, which NO ttnn op supports on a restricted
+        sub-device. Random users (k>1) get boost==0 => their values are bit-identical => their
+        sampling is byte-for-byte unchanged. All ops honor self.sub_core_grids.
+
+        WORKAROUND for tenstorrent/tt-metal#33492 (stable top-k is unreliable). Remove this method,
+        `_greedy_col` and `_greedy_col_dims` once that issue is fixed and validated on device.
+
+        With a working stable top-k this pass is redundant, because candidate position and global
+        token id are ordered the same way BY CONSTRUCTION: the gathered buffer is laid out as one
+        contiguous block per device, and `_create_indices_tensors` derives each global id as
+        `local_topk_index + device_id * padded_per_device` from that same layout. Across blocks the
+        two orders therefore agree unconditionally. WITHIN a block they agree only if the per-device
+        top-k emitted its tied maxima in ascending local-index order -- i.e. only if `stable=True`
+        actually works. It currently may not (#33492: `ttnn.sort` rejects `stable=True` outright, the
+        LLK top-k test skips every stable case, and this tree still carries the double-SFPSWAP
+        scheme rather than the index-aware comparator from tt-llk#1340), which is why this exists.
+
+        KNOWN LIMITATION: this picks the lowest global id among the GATHERED candidates. If a single
+        device shard holds more than `max_top_k` (32) maxima tied at the same value, its top-k drops
+        all but 32 of them by the same unreliable network, so the true lowest-id token may never
+        reach the gathered set and this pass cannot recover it. Fixing #33492 is the real fix; this
+        only narrows the window.
+
+        is_winner = (value == rowmax) AND (global_index == lowest_index_among_maxima)  # exactly one candidate
+            lowest_index_among_maxima = min(global_index + (rowmax - value)*LARGE)     # == idx at maxima, huge else
+        Validated on a restricted active sub-device by
+        tests/ttnn/unit_tests/operations/reduce/test_tiebreak_input_adjust.py.
+        """
+        scg = self.sub_core_grids
+        BIG = 1.0e9  # >> max vocab index; EXACT binary offset (no bf16 (maxv-value) magnitude dependence)
+        # Every intermediate is deallocated as soon as its last reader is issued: this runs once per
+        # decode step, so leaving them to Python refcounting would hold ~9 extra buffers per step.
+        maxv = ttnn.max(gathered_values, dim=3, keepdim=True, sub_core_grids=scg)  # [1,1,B,1] bf16
+        idx_f = ttnn.typecast(gathered_global_indices, ttnn.float32, sub_core_grids=scg)
+        is_max = ttnn.eq(gathered_values, maxv, sub_core_grids=scg)  # 1.0 at the (tied) maxima, exact
+        not_max = ttnn.lt(gathered_values, maxv, sub_core_grids=scg)  # 1.0 strictly below max
+
+        # Per-row boost, >= 2 bf16 ULP of that row's maximum whatever its magnitude or sign.
+        abs_max = ttnn.abs(maxv, sub_core_grids=scg)
+        ttnn.deallocate(maxv)
+        delta_scaled = ttnn.multiply(abs_max, TIEBREAK_DELTA_SCALE, sub_core_grids=scg)
+        ttnn.deallocate(abs_max)
+        delta = ttnn.add(delta_scaled, TIEBREAK_DELTA_FLOOR, sub_core_grids=scg)  # [1,1,B,1] bf16
+        ttnn.deallocate(delta_scaled)
+
+        # lowest global index among the maxima: push non-maxima up by BIG (exact, robust), then min.
+        not_max_scaled = ttnn.multiply(not_max, BIG, sub_core_grids=scg)
+        ttnn.deallocate(not_max)
+        masked_idx = ttnn.add(idx_f, not_max_scaled, sub_core_grids=scg)
+        ttnn.deallocate(not_max_scaled)
+        greedy_i = ttnn.min(masked_idx, dim=3, keepdim=True, sub_core_grids=scg)  # [1,1,B,1] f32
+        ttnn.deallocate(masked_idx)
+
+        is_lowidx = ttnn.eq(idx_f, greedy_i, sub_core_grids=scg)  # broadcast over W
+        ttnn.deallocate(idx_f)
+        ttnn.deallocate(greedy_i)
+        is_winner = ttnn.multiply(is_max, is_lowidx, sub_core_grids=scg)  # 1.0 at exactly one candidate
+        ttnn.deallocate(is_max)
+        ttnn.deallocate(is_lowidx)
+
+        # gate by k==1 (self._greedy_col [1,1,B,1]); random users get boost 0 => values unchanged
+        winner_gated = ttnn.multiply(is_winner, self._greedy_col, sub_core_grids=scg)
+        ttnn.deallocate(is_winner)
+        winner_bf16 = ttnn.typecast(winner_gated, ttnn.bfloat16, sub_core_grids=scg)
+        ttnn.deallocate(winner_gated)
+        boost = ttnn.multiply(winner_bf16, delta, sub_core_grids=scg)  # delta broadcasts over W
+        ttnn.deallocate(winner_bf16)
+        ttnn.deallocate(delta)
+
+        adjusted = ttnn.add(gathered_values, boost, sub_core_grids=scg)
+        ttnn.deallocate(boost)
+        return adjusted
 
     def forward(
         self,
@@ -627,6 +770,12 @@ class TTSampling(LightweightModule):
                     dim=-1,
                     sub_core_grids=self.sub_core_grid_topk,
                     indices_tensor=indices_tensor_list[i],
+                    # Break exact-value ties by lowest index instead of array position, so which
+                    # of a set of tied candidates enters the top-k does not depend on placement.
+                    # Best effort only -- the stable bitonic network is still an open LLK issue
+                    # (tenstorrent/tt-metal#33492); _adjust_values_for_tiebreak is what actually
+                    # guarantees the greedy pick.
+                    stable=True,
                 )
                 topk_values_list.append(topk_values)
                 topk_indices_list.append(topk_indices)
@@ -660,6 +809,12 @@ class TTSampling(LightweightModule):
                 dim=-1,
                 sub_core_grids=self.sub_core_grid_topk,
                 indices_tensor=self.tt_indices_tensor,
+                # Break exact-value ties by lowest index instead of array position, so which
+                # of a set of tied candidates enters the top-k does not depend on placement.
+                # Best effort only -- the stable bitonic network is still an open LLK issue
+                # (tenstorrent/tt-metal#33492); _adjust_values_for_tiebreak is what actually
+                # guarantees the greedy pick.
+                stable=True,
             )
 
             # For 1D meshes use `cluster_axis=None`. For 2D meshes, use the configured gather axis.
@@ -738,9 +893,19 @@ class TTSampling(LightweightModule):
             user_ids=self.user_ids_tt_tensor,
             sub_core_grids=self._sampling_sub_core_grids,
         )
-        # Perform the actual sampling with top-k, top-p, and temperature
+        # Perform the actual sampling with top-k, top-p, and temperature.
+        # WORKAROUND for tenstorrent/tt-metal#33492 (stable top-k unreliable), to be removed with it:
+        # for argmax users (k==1) only, boost the single lowest-GLOBAL-INDEX tied maximum in the
+        # sampling INPUT so ttnn.sampling's argmax picks it regardless of how the top-k network
+        # ordered the tied candidates. Random users are byte-for-byte unchanged. Correcting the INPUT
+        # (not the RM output buffer) is required: no ttnn op writes an interleaved ROW_MAJOR tensor
+        # in-place on a restricted sub-device. See _adjust_values_for_tiebreak for the full rationale
+        # and its known limitation (>max_top_k maxima tied within one device shard).
+        sampling_values = self._adjust_values_for_tiebreak(
+            topk_values_gathered_bf16_interleaved, topk_global_indices_interleaved
+        )
         tt_out_tok = ttnn.sampling(
-            topk_values_gathered_bf16_interleaved,
+            sampling_values,
             topk_global_indices_interleaved_untilised,
             k=self.k_tensor,
             p=self.p_tensor,
@@ -764,6 +929,7 @@ class TTSampling(LightweightModule):
         else:
             self.tt_log_probs = None
 
+        ttnn.deallocate(sampling_values)
         ttnn.deallocate(topk_values_gathered_bf16_interleaved)
         ttnn.deallocate(topk_global_indices_interleaved)
         ttnn.deallocate(topk_global_indices_interleaved_untilised)

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -29,6 +29,11 @@ TIEBREAK_DELTA_SCALE = 2**-6
 # bf16 number (smallest normal ~1.18e-38) and orders of magnitude below one ULP of any real logit,
 # so it never perturbs a non-zero maximum.
 TIEBREAK_DELTA_FLOOR = 1e-30
+# Added to the global index of every non-maximum candidate so the row min over the masked indices can
+# only ever land on a tied maximum. A power of two, so the mask that carries it (built in bfloat16)
+# holds it exactly; larger than any padded vocabulary size, which __init__ asserts; and small enough
+# that sentinel + index cannot overflow the int32 the min reduce runs in.
+TIEBREAK_INDEX_SENTINEL = 2**24
 
 
 class TTSampling(LightweightModule):
@@ -233,14 +238,22 @@ class TTSampling(LightweightModule):
             layout=ttnn.ROW_MAJOR_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._param_dims, mesh_shape=self.cluster_shape),
         )
+        # The tie-break sentinel has to outrank every real global index. Vocabularies this large are
+        # far beyond anything shipped, but a silent wrap would corrupt the greedy token rather than
+        # fail, so it is worth one assert at construction.
+        assert self.padded_vocab_size <= TIEBREAK_INDEX_SENTINEL, (
+            f"padded_vocab_size {self.padded_vocab_size} exceeds the greedy tie-break sentinel "
+            f"{TIEBREAK_INDEX_SENTINEL}; raise TIEBREAK_INDEX_SENTINEL (keeping it a power of two)"
+        )
         # Persistent per-user ARGMAX mask [1,1,N,1] (1.0 where k==1), distributed like k_tensor. Used by
         # _adjust_values_for_tiebreak to boost the lowest-index tied-max for greedy users only. Built
         # host-side and kept in sync in reset_sampling_params (an on-device reshape of the [N] k_tensor
-        # to [1,1,N,1] is not sub-device-safe). float32 TILE so it broadcasts over the candidate width.
+        # to [1,1,N,1] is not sub-device-safe). bfloat16 TILE so it broadcasts over the candidate width
+        # and multiplies the (bfloat16) winner mask without a dtype mix; 0.0/1.0 are exact in bf16.
         self._greedy_col = ttnn.from_torch(
-            (torch.as_tensor(k).reshape(1, 1, -1, 1) == 1).to(torch.float32),
+            (torch.as_tensor(k).reshape(1, 1, -1, 1) == 1).to(torch.bfloat16),
             device=self.mesh_device,
-            dtype=ttnn.float32,
+            dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 self.mesh_device, dims=self._greedy_col_dims(), mesh_shape=self.cluster_shape
@@ -590,9 +603,9 @@ class TTSampling(LightweightModule):
 
             # Keep the greedy tie-break mask (1.0 where k==1) in sync with k, distributed like k_tensor.
             self._greedy_col_new = ttnn.from_torch(
-                (torch.tensor(k).reshape(1, 1, -1, 1) == 1).to(torch.float32),
+                (torch.tensor(k).reshape(1, 1, -1, 1) == 1).to(torch.bfloat16),
                 device=None,
-                dtype=ttnn.float32,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.TILE_LAYOUT,
                 mesh_mapper=(
                     ttnn.ShardTensor2dMesh(
@@ -643,16 +656,19 @@ class TTSampling(LightweightModule):
         only narrows the window.
 
         is_winner = (value == rowmax) AND (global_index == lowest_index_among_maxima)  # exactly one candidate
-            lowest_index_among_maxima = min(global_index + (rowmax - value)*LARGE)     # == idx at maxima, huge else
-        Validated on a restricted active sub-device by
+            lowest_index_among_maxima = min(global_index + not_max * SENTINEL)          # == idx at maxima, huge else
+
+        The value half runs in bfloat16 and the index half in int32, and neither dtype is incidental --
+        see the comments on each block. Validated on a restricted active sub-device by
         tests/ttnn/unit_tests/operations/reduce/test_tiebreak_input_adjust.py.
         """
         scg = self.sub_core_grids
-        BIG = 1.0e9  # >> max vocab index; EXACT binary offset (no bf16 (maxv-value) magnitude dependence)
         # Every intermediate is deallocated as soon as its last reader is issued: this runs once per
         # decode step, so leaving them to Python refcounting would hold ~9 extra buffers per step.
+
+        # Value domain, bfloat16: gathered_values is bf16, so the max reduce and the comparisons
+        # against its result are exact -- bf16 survives the FPU's source-register truncation intact.
         maxv = ttnn.max(gathered_values, dim=3, keepdim=True, sub_core_grids=scg)  # [1,1,B,1] bf16
-        idx_f = ttnn.typecast(gathered_global_indices, ttnn.float32, sub_core_grids=scg)
         is_max = ttnn.eq(gathered_values, maxv, sub_core_grids=scg)  # 1.0 at the (tied) maxima, exact
         not_max = ttnn.lt(gathered_values, maxv, sub_core_grids=scg)  # 1.0 strictly below max
 
@@ -664,28 +680,43 @@ class TTSampling(LightweightModule):
         delta = ttnn.add(delta_scaled, TIEBREAK_DELTA_FLOOR, sub_core_grids=scg)  # [1,1,B,1] bf16
         ttnn.deallocate(delta_scaled)
 
-        # lowest global index among the maxima: push non-maxima up by BIG (exact, robust), then min.
-        not_max_scaled = ttnn.multiply(not_max, BIG, sub_core_grids=scg)
+        # Index domain, int32: lowest global index among the maxima. Push the non-maxima above every
+        # real index by TIEBREAK_INDEX_SENTINEL, then take the row min.
+        #
+        # This min MUST run in int32. ttnn.min/ttnn.max on a FLOAT32 tensor go to the FPU -- only
+        # int32 and the opt-in accurate fp32 mean take the SFPU reduce path (see
+        # ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp:use_sfpu_reduce_path) -- and the
+        # FPU truncates its source registers to a 10-bit mantissa. Every index above 2**11 therefore
+        # comes back rounded to a value that equals NO actual index, the winner mask comes out empty,
+        # and the boost silently degrades to a no-op: the tie survives and the greedy token keeps
+        # flipping. That is exactly how the first version of this pass failed on device. Int32 min/max
+        # are integer-exact at every index. Keep the reduce, the mask arithmetic and the equality all
+        # in int32 -- routing any of them through float32 (or uint32, which is on the FPU path too)
+        # reintroduces the same rounding. forward() hands us uint32, so cast once here.
+        idx = ttnn.typecast(gathered_global_indices, ttnn.int32, sub_core_grids=scg)
+        offset = ttnn.multiply(not_max, TIEBREAK_INDEX_SENTINEL, sub_core_grids=scg)  # bf16, exact (2**24)
         ttnn.deallocate(not_max)
-        masked_idx = ttnn.add(idx_f, not_max_scaled, sub_core_grids=scg)
-        ttnn.deallocate(not_max_scaled)
-        greedy_i = ttnn.min(masked_idx, dim=3, keepdim=True, sub_core_grids=scg)  # [1,1,B,1] f32
+        offset_i32 = ttnn.typecast(offset, ttnn.int32, sub_core_grids=scg)
+        ttnn.deallocate(offset)
+        masked_idx = ttnn.add(idx, offset_i32, sub_core_grids=scg)  # int32
+        ttnn.deallocate(offset_i32)
+        greedy_i = ttnn.min(masked_idx, dim=3, keepdim=True, sub_core_grids=scg)  # [1,1,B,1] int32
         ttnn.deallocate(masked_idx)
 
-        is_lowidx = ttnn.eq(idx_f, greedy_i, sub_core_grids=scg)  # broadcast over W
-        ttnn.deallocate(idx_f)
+        is_lowidx_i32 = ttnn.eq(idx, greedy_i, sub_core_grids=scg)  # broadcast over W
+        ttnn.deallocate(idx)
         ttnn.deallocate(greedy_i)
+        is_lowidx = ttnn.typecast(is_lowidx_i32, ttnn.bfloat16, sub_core_grids=scg)  # 1/0 -> 1.0/0.0
+        ttnn.deallocate(is_lowidx_i32)
         is_winner = ttnn.multiply(is_max, is_lowidx, sub_core_grids=scg)  # 1.0 at exactly one candidate
         ttnn.deallocate(is_max)
         ttnn.deallocate(is_lowidx)
 
-        # gate by k==1 (self._greedy_col [1,1,B,1]); random users get boost 0 => values unchanged
+        # gate by k==1 (self._greedy_col [1,1,B,1] bf16); random users get boost 0 => values unchanged
         winner_gated = ttnn.multiply(is_winner, self._greedy_col, sub_core_grids=scg)
         ttnn.deallocate(is_winner)
-        winner_bf16 = ttnn.typecast(winner_gated, ttnn.bfloat16, sub_core_grids=scg)
+        boost = ttnn.multiply(winner_gated, delta, sub_core_grids=scg)  # delta broadcasts over W
         ttnn.deallocate(winner_gated)
-        boost = ttnn.multiply(winner_bf16, delta, sub_core_grids=scg)  # delta broadcasts over W
-        ttnn.deallocate(winner_bf16)
         ttnn.deallocate(delta)
 
         adjusted = ttnn.add(gathered_values, boost, sub_core_grids=scg)

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -119,6 +119,12 @@ class TTSampling(LightweightModule):
     ):
         super().__init__()
         self.mesh_device = mesh_device
+        # ttnn.topk rejects stable=True outright on any architecture whose LLK lacks the stable bitonic
+        # network -- only Wormhole B0 and Blackhole implement it -- so ask for it just where it exists
+        # instead of taking a TT_FATAL everywhere else. Requesting it is best effort regardless
+        # (tenstorrent/tt-metal#33492); _adjust_values_for_tiebreak is what guarantees the greedy pick,
+        # so falling back to the default network costs correctness nothing.
+        self._topk_stable = ttnn.device.is_wormhole_b0(mesh_device) or ttnn.device.is_blackhole(mesh_device)
         # Multi-step reduction is supported only on single device
         self.multi_step_reduction = list(mesh_device.shape) == [1, 1]
         self.tt_ccl = tt_ccl
@@ -239,12 +245,14 @@ class TTSampling(LightweightModule):
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._param_dims, mesh_shape=self.cluster_shape),
         )
         # The tie-break sentinel has to outrank every real global index. Vocabularies this large are
-        # far beyond anything shipped, but a silent wrap would corrupt the greedy token rather than
-        # fail, so it is worth one assert at construction.
-        assert self.padded_vocab_size <= TIEBREAK_INDEX_SENTINEL, (
-            f"padded_vocab_size {self.padded_vocab_size} exceeds the greedy tie-break sentinel "
-            f"{TIEBREAK_INDEX_SENTINEL}; raise TIEBREAK_INDEX_SENTINEL (keeping it a power of two)"
-        )
+        # far beyond anything shipped, but exceeding it would corrupt the greedy token silently rather
+        # than fail, so check it at construction. Raise rather than assert: this guards a correctness
+        # invariant and must survive python -O.
+        if self.padded_vocab_size > TIEBREAK_INDEX_SENTINEL:
+            raise ValueError(
+                f"padded_vocab_size {self.padded_vocab_size} exceeds the greedy tie-break sentinel "
+                f"{TIEBREAK_INDEX_SENTINEL}; raise TIEBREAK_INDEX_SENTINEL (keeping it a power of two)"
+            )
         # Persistent per-user ARGMAX mask [1,1,N,1] (1.0 where k==1), distributed like k_tensor. Used by
         # _adjust_values_for_tiebreak to boost the lowest-index tied-max for greedy users only. Built
         # host-side and kept in sync in reset_sampling_params (an on-device reshape of the [N] k_tensor
@@ -803,10 +811,11 @@ class TTSampling(LightweightModule):
                     indices_tensor=indices_tensor_list[i],
                     # Break exact-value ties by lowest index instead of array position, so which
                     # of a set of tied candidates enters the top-k does not depend on placement.
-                    # Best effort only -- the stable bitonic network is still an open LLK issue
+                    # Best effort only, and only where the LLK has the network at all (see
+                    # self._topk_stable) -- the stable bitonic network is an open LLK issue
                     # (tenstorrent/tt-metal#33492); _adjust_values_for_tiebreak is what actually
                     # guarantees the greedy pick.
-                    stable=True,
+                    stable=self._topk_stable,
                 )
                 topk_values_list.append(topk_values)
                 topk_indices_list.append(topk_indices)
@@ -842,10 +851,11 @@ class TTSampling(LightweightModule):
                 indices_tensor=self.tt_indices_tensor,
                 # Break exact-value ties by lowest index instead of array position, so which
                 # of a set of tied candidates enters the top-k does not depend on placement.
-                # Best effort only -- the stable bitonic network is still an open LLK issue
+                # Best effort only, and only where the LLK has the network at all (see
+                # self._topk_stable) -- the stable bitonic network is an open LLK issue
                 # (tenstorrent/tt-metal#33492); _adjust_values_for_tiebreak is what actually
                 # guarantees the greedy pick.
-                stable=True,
+                stable=self._topk_stable,
             )
 
             # For 1D meshes use `cluster_axis=None`. For 2D meshes, use the configured gather axis.

--- a/tests/ttnn/unit_tests/operations/reduce/test_tiebreak_input_adjust.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_tiebreak_input_adjust.py
@@ -22,14 +22,21 @@ import pytest
 import torch
 
 import ttnn
-from models.common.sampling.tt_sampling import TTSampling
+from models.common.sampling.tt_sampling import TIEBREAK_INDEX_SENTINEL, TTSampling
 
 NUM_USERS = 32
 NUM_CANDIDATES = 64
 # Global vocabulary indices are in the 100k range, like a real gathered candidate set. Deliberately
-# above 2**8: these values are NOT representable in bfloat16, so the test fails if any step of the
-# index comparison silently lands in bf16 instead of float32.
+# far above 2**11: the FPU reduce truncates its source registers to a 10-bit mantissa, so indices this
+# large come back rounded from a float32 ttnn.min and match no real index. Only the int32 reduce is
+# exact here, and these magnitudes are what make the test notice if the index half leaves int32.
 INDEX_BASE = 100_000
+# TTSampling.forward builds the gathered global-index tensor as uint32, so that is what these tests
+# feed by default; uint32 min/max are on the same inexact FPU reduce path as float32, and the method is
+# responsible for casting to int32 itself. INDEX_DTYPES also covers int32 in case a caller pre-casts.
+MODEL_INDEX_DTYPE = ttnn.uint32
+INDEX_DTYPES = [ttnn.uint32, ttnn.int32]
+INDEX_DTYPE_IDS = ["uint32_indices", "int32_indices"]
 
 # (tied maximum, filler). All exactly representable in bf16, filler strictly below the maximum.
 # The magnitudes matter: the boost has to be at least one bf16 ULP of the tied maximum, and bf16
@@ -51,7 +58,13 @@ DEFAULT_MAX_VALUE, DEFAULT_FILLER_VALUE = MAGNITUDES[0]
 SUB_CORE_GRIDS = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 3))})
 
 
-def _build_inputs(device, greedy_users, max_value=DEFAULT_MAX_VALUE, filler_value=DEFAULT_FILLER_VALUE):
+def _build_inputs(
+    device,
+    greedy_users,
+    max_value=DEFAULT_MAX_VALUE,
+    filler_value=DEFAULT_FILLER_VALUE,
+    index_dtype=MODEL_INDEX_DTYPE,
+):
     """Return (values_tt, global_indices_tt, greedy_col_tt, values_torch, indices_torch, tie_positions).
 
     Every user row gets three exact ties at max_value. The global indices are a
@@ -80,8 +93,8 @@ def _build_inputs(device, greedy_users, max_value=DEFAULT_MAX_VALUE, filler_valu
         greedy_col[0, 0, user, 0] = 1.0
 
     values_tt = ttnn.from_torch(values, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
-    indices_tt = ttnn.from_torch(indices, device=device, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT)
-    greedy_col_tt = ttnn.from_torch(greedy_col, device=device, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+    indices_tt = ttnn.from_torch(indices, device=device, dtype=index_dtype, layout=ttnn.TILE_LAYOUT)
+    greedy_col_tt = ttnn.from_torch(greedy_col, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
     return values_tt, indices_tt, greedy_col_tt, values, indices, tie_positions
 
 
@@ -94,6 +107,55 @@ def _adjust(values_tt, indices_tt, greedy_col_tt, sub_core_grids):
 def _expected_winner_position(indices_row, tie_positions):
     """Array position of the tied maximum holding the lowest global index."""
     return min(tie_positions, key=lambda pos: int(indices_row[pos]))
+
+
+@pytest.mark.parametrize("index_dtype", INDEX_DTYPES, ids=INDEX_DTYPE_IDS)
+def test_masked_index_min_reduce_is_exact(device, index_dtype):
+    """The index half of the tie-break must be exact at real vocabulary magnitudes.
+
+    ``ttnn.min`` on a float32 or uint32 tensor runs on the FPU, which truncates its source registers to
+    a 10-bit mantissa, so an index above 2**11 comes back rounded to a value that equals no real index:
+    the winner mask ends up empty and the whole adjustment degrades into a silent no-op. This pins the
+    int32 reduce (and the int32 broadcast equality) the implementation depends on, so a regression
+    there fails here and names itself instead of resurfacing as an unexplained tie downstream.
+
+    Runs first in this file on purpose: under ``-x`` it is the failure you want to see.
+    """
+    shape = (1, 1, NUM_USERS, NUM_CANDIDATES)
+    indices = (
+        torch.arange(INDEX_BASE + NUM_CANDIDATES - 1, INDEX_BASE - 1, -1, dtype=torch.int32).expand(shape).contiguous()
+    )
+
+    # Exactly one surviving candidate per row, at a different position in each row so a placement-
+    # dependent reduce cannot pass by accident.
+    kept_positions = [(user * 5) % NUM_CANDIDATES for user in range(NUM_USERS)]
+    not_max = torch.ones(shape, dtype=torch.float32)
+    for user, position in enumerate(kept_positions):
+        not_max[0, 0, user, position] = 0.0
+
+    indices_tt = ttnn.from_torch(indices, device=device, dtype=index_dtype, layout=ttnn.TILE_LAYOUT)
+    not_max_tt = ttnn.from_torch(not_max, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    # The same op sequence _adjust_values_for_tiebreak uses for its index half.
+    idx_tt = ttnn.typecast(indices_tt, ttnn.int32, sub_core_grids=SUB_CORE_GRIDS)
+    offset_tt = ttnn.typecast(
+        ttnn.multiply(not_max_tt, TIEBREAK_INDEX_SENTINEL, sub_core_grids=SUB_CORE_GRIDS),
+        ttnn.int32,
+        sub_core_grids=SUB_CORE_GRIDS,
+    )
+    masked_tt = ttnn.add(idx_tt, offset_tt, sub_core_grids=SUB_CORE_GRIDS)
+    row_min_tt = ttnn.min(masked_tt, dim=3, keepdim=True, sub_core_grids=SUB_CORE_GRIDS)
+    row_min = ttnn.to_torch(row_min_tt).flatten()
+    selected = ttnn.to_torch(ttnn.eq(idx_tt, row_min_tt, sub_core_grids=SUB_CORE_GRIDS))
+
+    for user, position in enumerate(kept_positions):
+        expected_index = int(indices[0, 0, user, position])
+        assert int(row_min[user]) == expected_index, (
+            f"user {user}: masked int32 row min returned {int(row_min[user])}, expected the one "
+            f"unmasked global index {expected_index}"
+        )
+        hits = selected[0, 0, user].nonzero().flatten().tolist()
+        assert hits == [position], f"user {user}: int32 broadcast equality selected {hits}, expected [{position}]"
 
 
 @pytest.mark.parametrize("max_value, filler_value", MAGNITUDES, ids=MAGNITUDE_IDS)
@@ -127,12 +189,13 @@ def test_tiebreak_boosts_lowest_global_index_for_greedy_users(device, sub_core_g
         assert changed == [expected_pos], f"user {user}: expected only position {expected_pos} to change, got {changed}"
 
 
+@pytest.mark.parametrize("index_dtype", INDEX_DTYPES, ids=INDEX_DTYPE_IDS)
 @pytest.mark.parametrize("sub_core_grids", [SUB_CORE_GRIDS, None], ids=["sub_core_grid", "full_grid"])
-def test_tiebreak_leaves_random_users_bit_identical(device, sub_core_grids):
+def test_tiebreak_leaves_random_users_bit_identical(device, sub_core_grids, index_dtype):
     """Random (k > 1) rows must be byte-for-byte unchanged, so their sampling is untouched."""
     greedy_users = list(range(0, NUM_USERS, 2))
     random_users = [user for user in range(NUM_USERS) if user not in greedy_users]
-    values_tt, indices_tt, greedy_col_tt, values, _, _ = _build_inputs(device, greedy_users)
+    values_tt, indices_tt, greedy_col_tt, values, _, _ = _build_inputs(device, greedy_users, index_dtype=index_dtype)
 
     adjusted = ttnn.to_torch(_adjust(values_tt, indices_tt, greedy_col_tt, sub_core_grids))
     original = values.to(torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/reduce/test_tiebreak_input_adjust.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_tiebreak_input_adjust.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validation for the greedy tie-break input adjustment used by TTSampling.
+
+``ttnn.sampling`` breaks exact-value ties by array position, which depends on
+all-gather/device order and therefore varies run-to-run and slot-to-slot.
+``TTSampling._adjust_values_for_tiebreak`` corrects the sampling *input* instead:
+for ARGMAX users (k == 1) it boosts the single lowest-GLOBAL-INDEX candidate among
+the tied maxima, so argmax selects it deterministically. Users with k > 1 must be
+left bit-identical.
+
+These tests drive the real method (bound to a stub carrying only the two
+attributes it reads) so they fail if the implementation drifts, and they run on a
+restricted sub-core grid, which is where the model actually hits this.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import ttnn
+from models.common.sampling.tt_sampling import TTSampling
+
+NUM_USERS = 32
+NUM_CANDIDATES = 64
+# Global vocabulary indices are in the 100k range, like a real gathered candidate set. Deliberately
+# above 2**8: these values are NOT representable in bfloat16, so the test fails if any step of the
+# index comparison silently lands in bf16 instead of float32.
+INDEX_BASE = 100_000
+
+# (tied maximum, filler). All exactly representable in bf16, filler strictly below the maximum.
+# The magnitudes matter: the boost has to be at least one bf16 ULP of the tied maximum, and bf16
+# spacing is 2.0 at 256 and 8.0 at 1024, so a fixed +1.0 boost would round away and leave the tie
+# in place for the large-magnitude rows. Negative and zero maxima are covered for the same reason.
+MAGNITUDES = [
+    (1.0, 0.25),
+    (256.0, 128.0),
+    (1024.0, 512.0),
+    (-256.0, -512.0),
+    (0.0, -1.0),
+]
+MAGNITUDE_IDS = ["max_1", "max_256", "max_1024", "max_neg256", "max_0"]
+
+DEFAULT_MAX_VALUE, DEFAULT_FILLER_VALUE = MAGNITUDES[0]
+
+# Restricted grid that does not start at (0, 0): the compact "full grid" placement
+# would not exercise the sub-device path the model runs on.
+SUB_CORE_GRIDS = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 3))})
+
+
+def _build_inputs(device, greedy_users, max_value=DEFAULT_MAX_VALUE, filler_value=DEFAULT_FILLER_VALUE):
+    """Return (values_tt, global_indices_tt, greedy_col_tt, values_torch, indices_torch, tie_positions).
+
+    Every user row gets three exact ties at max_value. The global indices are a
+    reversed permutation, so the lowest global index among the tied maxima is NOT
+    the first tied array position -- a position-based tie-break picks a different
+    element than an index-based one, which is exactly what we need to distinguish.
+    """
+    shape = (1, 1, NUM_USERS, NUM_CANDIDATES)
+    values = torch.full(shape, filler_value, dtype=torch.float32)
+
+    # Global indices descend across the row, so array position 0 holds the HIGHEST
+    # global index and the last tied position holds the lowest.
+    indices = (
+        torch.arange(INDEX_BASE + NUM_CANDIDATES - 1, INDEX_BASE - 1, -1, dtype=torch.int32).expand(shape).contiguous()
+    )
+
+    tie_positions = {}
+    for user in range(NUM_USERS):
+        # Vary the tie positions per user so a single hardcoded winner cannot pass.
+        positions = [(user + offset) % NUM_CANDIDATES for offset in (0, 7, 23)]
+        values[0, 0, user, positions] = max_value
+        tie_positions[user] = positions
+
+    greedy_col = torch.zeros((1, 1, NUM_USERS, 1), dtype=torch.float32)
+    for user in greedy_users:
+        greedy_col[0, 0, user, 0] = 1.0
+
+    values_tt = ttnn.from_torch(values, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    indices_tt = ttnn.from_torch(indices, device=device, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT)
+    greedy_col_tt = ttnn.from_torch(greedy_col, device=device, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+    return values_tt, indices_tt, greedy_col_tt, values, indices, tie_positions
+
+
+def _adjust(values_tt, indices_tt, greedy_col_tt, sub_core_grids):
+    """Call the real TTSampling method with a stub holding the attributes it reads."""
+    stub = SimpleNamespace(sub_core_grids=sub_core_grids, _greedy_col=greedy_col_tt)
+    return TTSampling._adjust_values_for_tiebreak(stub, values_tt, indices_tt)
+
+
+def _expected_winner_position(indices_row, tie_positions):
+    """Array position of the tied maximum holding the lowest global index."""
+    return min(tie_positions, key=lambda pos: int(indices_row[pos]))
+
+
+@pytest.mark.parametrize("max_value, filler_value", MAGNITUDES, ids=MAGNITUDE_IDS)
+@pytest.mark.parametrize("sub_core_grids", [SUB_CORE_GRIDS, None], ids=["sub_core_grid", "full_grid"])
+def test_tiebreak_boosts_lowest_global_index_for_greedy_users(device, sub_core_grids, max_value, filler_value):
+    """Greedy (k == 1) rows: exactly the lowest-global-index tied max becomes the strict argmax.
+
+    Parametrised over the tied maximum's magnitude because the boost must exceed one bf16 ULP at
+    that magnitude: a fixed +1.0 boost is silently lost at 256 and above, leaving the tie in place.
+    """
+    greedy_users = list(range(0, NUM_USERS, 2))  # even users are greedy
+    values_tt, indices_tt, greedy_col_tt, values, indices, tie_positions = _build_inputs(
+        device, greedy_users, max_value, filler_value
+    )
+
+    adjusted = ttnn.to_torch(_adjust(values_tt, indices_tt, greedy_col_tt, sub_core_grids)).float()
+    original = values.to(torch.bfloat16).float()
+
+    for user in greedy_users:
+        expected_pos = _expected_winner_position(indices[0, 0, user], tie_positions[user])
+
+        # The winner is the strict argmax after the boost...
+        assert int(torch.argmax(adjusted[0, 0, user])) == expected_pos, (
+            f"user {user}: expected argmax at position {expected_pos} "
+            f"(global index {int(indices[0, 0, user, expected_pos])}), "
+            f"got position {int(torch.argmax(adjusted[0, 0, user]))}"
+        )
+
+        # ...and it is the ONLY element that changed.
+        changed = (adjusted[0, 0, user] != original[0, 0, user]).nonzero().flatten().tolist()
+        assert changed == [expected_pos], f"user {user}: expected only position {expected_pos} to change, got {changed}"
+
+
+@pytest.mark.parametrize("sub_core_grids", [SUB_CORE_GRIDS, None], ids=["sub_core_grid", "full_grid"])
+def test_tiebreak_leaves_random_users_bit_identical(device, sub_core_grids):
+    """Random (k > 1) rows must be byte-for-byte unchanged, so their sampling is untouched."""
+    greedy_users = list(range(0, NUM_USERS, 2))
+    random_users = [user for user in range(NUM_USERS) if user not in greedy_users]
+    values_tt, indices_tt, greedy_col_tt, values, _, _ = _build_inputs(device, greedy_users)
+
+    adjusted = ttnn.to_torch(_adjust(values_tt, indices_tt, greedy_col_tt, sub_core_grids))
+    original = values.to(torch.bfloat16)
+
+    for user in random_users:
+        assert torch.equal(adjusted[0, 0, user], original[0, 0, user]), f"user {user}: k>1 row was modified"
+
+
+def test_tiebreak_is_repeatable(device):
+    """Repeated calls on the same input produce identical adjusted values."""
+    greedy_users = list(range(NUM_USERS))
+    values_tt, indices_tt, greedy_col_tt, _, _, _ = _build_inputs(device, greedy_users)
+
+    first = ttnn.to_torch(_adjust(values_tt, indices_tt, greedy_col_tt, SUB_CORE_GRIDS))
+    second = ttnn.to_torch(_adjust(values_tt, indices_tt, greedy_col_tt, SUB_CORE_GRIDS))
+
+    assert torch.equal(first, second), "tie-break adjustment is not repeatable"
+
+
+@pytest.mark.parametrize("max_value, filler_value", MAGNITUDES, ids=MAGNITUDE_IDS)
+def test_sampling_picks_lowest_global_index_after_adjust(device, max_value, filler_value):
+    """End-to-end: ttnn.sampling with k == 1 selects the lowest-global-index tied maximum.
+
+    Without the adjustment the pick is whichever tied maximum happens to sit first in
+    the array, which is placement-dependent; with it, the pick is the lowest global index.
+    """
+    greedy_users = list(range(NUM_USERS))
+    values_tt, indices_tt, greedy_col_tt, _, indices, tie_positions = _build_inputs(
+        device, greedy_users, max_value, filler_value
+    )
+
+    adjusted_tt = _adjust(values_tt, indices_tt, greedy_col_tt, SUB_CORE_GRIDS)
+
+    # ttnn.sampling reads the index tensor in ROW_MAJOR, matching the model's call.
+    indices_rm_tt = ttnn.from_torch(indices, device=device, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)
+    k_tt = ttnn.from_torch(
+        torch.ones(NUM_USERS, dtype=torch.int32), device=device, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT
+    )
+    p_tt = ttnn.from_torch(torch.zeros(NUM_USERS), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+    temp_tt = ttnn.from_torch(torch.ones(NUM_USERS), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    sampled = ttnn.to_torch(
+        ttnn.sampling(adjusted_tt, indices_rm_tt, k=k_tt, p=p_tt, temp=temp_tt, seed=1234)
+    ).flatten()
+
+    for user in range(NUM_USERS):
+        expected_pos = _expected_winner_position(indices[0, 0, user], tie_positions[user])
+        expected_index = int(indices[0, 0, user, expected_pos])
+        assert (
+            int(sampled[user]) == expected_index
+        ), f"user {user}: expected sampled global index {expected_index}, got {int(sampled[user])}"

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
@@ -212,7 +212,8 @@ template <
     uint32_t values_dfb_index,
     uint32_t output_ind_dfb_index,
     uint32_t tile_width,
-    bool first_call>
+    bool first_call,
+    bool stable_sort>
 void top_k() {
     // dest indices for where to unpack the tiles for the llk
     // the input goes in index 0,1 and the index goes in index 2,3
@@ -255,7 +256,9 @@ void top_k() {
             transpose_tile(index_dfb_index, 1, 3);
 
             // llk_topk_sort -> inplace
-            ckernel::topk_local_sort(0, (int)ascending, logk - 1);
+            // stable_sort: equal values keep their original (lowest) position, so the candidate the
+            // top-k keeps for a tie does not depend on how the bitonic network happens to swap.
+            ckernel::topk_local_sort<stable_sort>(0, (int)ascending, logk - 1);
 
             tile_regs_commit();
 
@@ -301,9 +304,9 @@ void top_k() {
                 copy_tile(index_transposed_dfb_index, right_ind, index_dest_end);
 
                 // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
-                ckernel::topk_merge(0, m_iter, K);
+                ckernel::topk_merge<false, stable_sort>(0, m_iter, K);
                 // sort within the larger 32 values
-                ckernel::topk_rebuild(0, (uint32_t)a, m_iter, K, logk, true);
+                ckernel::topk_rebuild<stable_sort>(0, (uint32_t)a, m_iter, K, logk, true);
 
                 tile_regs_commit();
                 tile_regs_wait();
@@ -434,6 +437,11 @@ void kernel_main() {
     constexpr uint32_t dfb_local_vals = get_compile_time_arg_val(16);
     constexpr uint32_t temp_dfb_index = get_compile_time_arg_val(17);
     constexpr uint32_t tile_width = get_compile_time_arg_val(18);
+    // Stable top-k: on exact value ties the candidate at the lowest position wins, so the sampled
+    // token does not depend on how the bitonic network happens to swap equal values. Set by the
+    // host only on architectures whose top-k LLK implements a stable network; elsewhere it is 0
+    // and ties keep the previous (network-order) behaviour rather than failing to compile.
+    constexpr bool stable_sort = get_compile_time_arg_val(19) == 1;
     generate_rand_tile(rand_tile_index, seed);
 
     const uint32_t nearest32_K = 32;
@@ -454,7 +462,8 @@ void kernel_main() {
         values_dfb_index,
         output_ind_dfb_index,
         tile_width,
-        true>();
+        true,
+        stable_sort>();
     constexpr uint32_t Kt = nearest32_K / tile_width;
 
     // scale temperature

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -43,6 +43,13 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     // is gated on !(WH || BH) so new architectures default to the safe 32-bit path.
     const bool use_32bit_index = !(device->arch() == tt::ARCH::WORMHOLE_B0 || device->arch() == tt::ARCH::BLACKHOLE);
 
+    // The stable bitonic top-k network (ties keep the lowest candidate position, so the sampled
+    // token id for an exact tie does not depend on how the network swaps equal values) is only
+    // implemented in the WH/BH LLKs; the Quasar LLK static_asserts STABLE_SORT == false. Gate on
+    // the architectures that implement it so new architectures fall back to the unstable network
+    // instead of failing to build the kernel.
+    const bool stable_sort = (device->arch() == tt::ARCH::WORMHOLE_B0 || device->arch() == tt::ARCH::BLACKHOLE);
+
     tt::DataFormat input_values_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(input_values_tensor.dtype());
     tt::DataFormat input_indices_cb_data_format =
@@ -434,7 +441,8 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
             random_seed,
             cb_local_vals_index,
             temp_cb_index,
-            tile_width};
+            tile_width,
+            static_cast<uint32_t>(stable_sort)};
 
         KernelDescriptor compute_desc;
         compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp";

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -132,6 +132,7 @@ void kernel_main() {
     constexpr uint32_t Wt = get_compile_time_arg_val(9);                        // Width in tiles
     constexpr uint32_t output_tiles = get_compile_time_arg_val(10);             // Number of output tiles (ceil(K/32))
     constexpr uint32_t largest = get_compile_time_arg_val(11);                  // 1 for largest K, 0 for smallest K
+    constexpr bool stable_sort = get_compile_time_arg_val(12) == 1;             // Ties keep the lowest index
 
     // Initialize kernel components
     compute_kernel_hw_startup(input_val_dfb_index, input_ind_dfb_index, output_val_dfb_index);
@@ -345,7 +346,7 @@ void kernel_main() {
                 // Merge and sort 64 elements (32 existing + 32 new) using topk_local_sort
                 // Results: dest reg 0 = top 32 elements, dest reg 1 = bottom 32 elements
                 // largest flag determines ascending (0) vs descending (1) sort order
-                ckernel::topk_local_sort(0, (int)!largest, end_phase);
+                ckernel::topk_local_sort<stable_sort>(0, (int)!largest, end_phase);
 
                 // Pack sorted results: dest reg 0 -> result buffer, dest reg 1 -> secondary buffer
                 tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
@@ -6,6 +6,11 @@
 
 #include "api/dataflow/dataflow_buffer.h"
 
+// stable_sort selects the LLK's stable bitonic network: equal values keep the lowest index, so ties
+// are broken deterministically rather than by array position. It defaults to false so every existing
+// caller (ttnn.topk, the deepseek grouped-gate/MoE kernels) keeps its current behaviour; only callers
+// that explicitly instantiate with true opt in.
+template <bool stable_sort = false>
 void process_and_sort_tiles(
     uint32_t input_dfb_index,
     uint32_t index_dfb_index,
@@ -45,7 +50,7 @@ void process_and_sort_tiles(
             transpose_tile(index_dfb_index, 1, 3);
         }
         // llk_topk_sort -> inplace
-        ckernel::topk_local_sort(0, (int)ascending, end_phase);
+        ckernel::topk_local_sort<stable_sort>(0, (int)ascending, end_phase);
         tile_regs_commit();
 
         input_dfb.pop_front(tiles_to_wait);
@@ -72,6 +77,7 @@ void process_and_sort_tiles(
     index_transposed_dfb.push_back(Wt);
 }
 
+template <bool stable_sort = false>
 void process_tile_pair(
     uint32_t left_ind,
     uint32_t right_ind,
@@ -103,7 +109,7 @@ void process_tile_pair(
 
     // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
     // sort within the larger 32 values
-    ckernel::topk_rebuild(0, (uint32_t)ascending, m_iter, K, logk, target_tiles_is_one);
+    ckernel::topk_rebuild<stable_sort>(0, (uint32_t)ascending, m_iter, K, logk, target_tiles_is_one);
 
     tile_regs_commit();
     tile_regs_wait();
@@ -125,6 +131,7 @@ void process_tile_pair(
     tile_regs_release();
 }
 
+template <bool stable_sort = false>
 void process_tiles(
     uint32_t m_iter,
     uint32_t K,
@@ -165,9 +172,9 @@ void process_tiles(
 
             // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
             if (largest) {
-                ckernel::topk_merge<false>(0, m_iter, K);
+                ckernel::topk_merge<false, stable_sort>(0, m_iter, K);
             } else {
-                ckernel::topk_merge<true>(0, m_iter, K);
+                ckernel::topk_merge<true, stable_sort>(0, m_iter, K);
             }
 
             // ckernel::topk_merge(0, m_iter, K);
@@ -190,6 +197,7 @@ void process_tiles(
     }
 }
 
+template <bool stable_sort = false>
 void process_iteration(
     uint32_t m_iter,
     uint32_t K,
@@ -213,7 +221,7 @@ void process_iteration(
     input_transposed_dfb.wait_front(Wt);
     index_transposed_dfb.wait_front(Wt);
 
-    process_tiles(
+    process_tiles<stable_sort>(
         m_iter,
         K,
         Wt,
@@ -258,7 +266,7 @@ void process_iteration(
             sel_tile_id[sel_tile_id_ptr] = left_ind;
             sel_tile_id_ptr++;
             if (sel_tile_id_ptr == target_tiles) {
-                process_tile_pair(
+                process_tile_pair<stable_sort>(
                     sel_tile_id[0],
                     sel_tile_id[1],
                     input_transposed_dfb_index,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
@@ -58,6 +58,7 @@ void kernel_main() {
     constexpr uint32_t logWt = get_compile_time_arg_val(11);
     constexpr uint32_t largest = get_compile_time_arg_val(12);
     constexpr uint32_t sorted = get_compile_time_arg_val(13);
+    constexpr bool stable_sort = get_compile_time_arg_val(14) == 1;  // Ties keep the lowest index
 
     // dest indices for where to unpack the tiles for the llk
     // the input goes in index 0,1 and the index goes in index 2,3
@@ -136,7 +137,7 @@ void kernel_main() {
         // - Iteration 1: Merge (0,2), (4,6), (8,10), ... across core boundaries
         // - Final iteration: Global TopK across all cores' contributions
         for (uint32_t m_iter = 0; m_iter < logWt; ++m_iter) {
-            process_iteration(
+            process_iteration<stable_sort>(
                 m_iter,                      // Current merge iteration
                 K,                           // TopK value
                 Wt,                          // Total width tiles (from all cores)

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
@@ -106,6 +106,7 @@ void kernel_main() {
     constexpr uint32_t logWt = get_compile_time_arg_val(11);
     constexpr uint32_t largest = get_compile_time_arg_val(12);
     constexpr uint32_t sorted = get_compile_time_arg_val(13);
+    constexpr bool stable_sort = get_compile_time_arg_val(14) == 1;  // Ties keep the lowest index
 
     // Runtime args
     uint32_t direction_init = get_arg_val<uint32_t>(0);
@@ -138,7 +139,7 @@ void kernel_main() {
         bool ascending = !largest;  // Sort direction for bitonic sequence properties
 
         // Initial bitonic sort on local width chunk
-        process_and_sort_tiles(
+        process_and_sort_tiles<stable_sort>(
             input_dfb_index,             // Input values buffer (double-buffered)
             index_dfb_index,             // Input indices buffer (double-buffered)
             input_transposed_dfb_index,  // Transposed values staging buffer
@@ -157,7 +158,7 @@ void kernel_main() {
         // - Iteration n: Compare tiles with distance 2^n → groups of 64*(2^(n+1)) elements
         // Final iteration produces locally sorted TopK results for this width chunk.
         for (uint32_t m_iter = 0; m_iter < logWt; ++m_iter) {
-            process_iteration(
+            process_iteration<stable_sort>(
                 m_iter,                      // Current merge iteration (0 to logWt-1)
                 K,                           // TopK value (number of elements to find)
                 Wt,                          // Width tiles in local chunk

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
@@ -133,6 +133,18 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
 
     TT_FATAL(args.k != 0, "K must be non-zero");
 
+    // The stable bitonic network is only implemented in the WH/BH LLKs; the Quasar LLK
+    // static_asserts STABLE_SORT == false. Reject it here so the caller gets an actionable error
+    // instead of a kernel JIT failure.
+    if (args.stable) {
+        const auto arch = input_tensor.device()->arch();
+        TT_FATAL(
+            arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE,
+            "TopK stable=true is not supported on {}: the bitonic top-k LLK only implements the stable "
+            "network on Wormhole and Blackhole",
+            arch);
+    }
+
     {
         const int8_t logical_rank = static_cast<int8_t>(input_tensor.logical_shape().rank());
         const int8_t last_dim = logical_rank - 1;
@@ -300,6 +312,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> topk(
     int8_t dim,
     bool largest,
     bool sorted,
+    bool stable,
     const tt::tt_metal::MemoryConfig& memory_config,
     const tt::tt_metal::CoreRangeSet& sub_core_grids,
     const std::optional<Tensor>& indices_tensor,
@@ -310,6 +323,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> topk(
             .dim = dim,
             .largest = largest,
             .sorted = sorted,
+            .stable = stable,
             .output_memory_config = memory_config,
             .sub_core_grids = sub_core_grids},
         TopkInputs{

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.hpp
@@ -52,6 +52,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> topk(
     int8_t dim,
     bool largest,
     bool sorted,
+    bool stable,
     const tt::tt_metal::MemoryConfig& memory_config,
     const tt::tt_metal::CoreRangeSet& sub_core_grids,
     const std::optional<Tensor>& indices_tensor = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation_types.hpp
@@ -16,6 +16,10 @@ struct TopkParams {
     int8_t dim{};
     bool largest{};
     bool sorted{};
+    // When true, the bitonic sort/merge/rebuild stages keep the lowest index among equal values, so
+    // ties are broken deterministically instead of by array position. Off by default: it changes
+    // which index is returned for tied values, so callers must opt in.
+    bool stable{};
     tt::tt_metal::MemoryConfig output_memory_config;
     tt::tt_metal::CoreRangeSet sub_core_grids;
 };

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -449,6 +449,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
         static_cast<std::uint32_t>(std::log2(Wt_local)),  // log2(width) for merge iterations
         static_cast<std::uint32_t>(args.largest),         // Sort direction (largest=1, smallest=0)
         static_cast<std::uint32_t>(args.sorted),          // Output sorting requirement
+        static_cast<std::uint32_t>(args.stable),          // Stable sort: ties keep the lowest index
     };
 
     KernelDescriptor compute_local_desc;
@@ -478,6 +479,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
         static_cast<std::uint32_t>(std::log2(Wt_final)),  // log2(final_width) for merge iterations
         static_cast<std::uint32_t>(args.largest),         // Sort direction (largest=1, smallest=0)
         static_cast<std::uint32_t>(args.sorted),          // Output sorting requirement
+        static_cast<std::uint32_t>(args.stable),          // Stable sort: ties keep the lowest index
     };
 
     KernelDescriptor compute_final_desc;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -240,6 +240,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKSingleCoreProgramFactor
         Wt,                                        // Width in tiles
         Ktiles,                                    // K value in tiles
         static_cast<std::uint32_t>(args.largest),  // Sort order: largest (true) or smallest (false)
+        static_cast<std::uint32_t>(args.stable),   // Stable sort: ties keep the lowest index
     };
 
     KernelDescriptor compute_desc;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -194,7 +194,8 @@ std::vector<Tensor> topk(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<Tensor>& indices_tensor,
-    std::optional<std::tuple<Tensor&, Tensor&>> preallocated_output_tensors) {
+    std::optional<std::tuple<Tensor&, Tensor&>> preallocated_output_tensors,
+    const bool stable) {
     // Store original shape for final output validation
     const ttnn::Shape& original_lshape = input_tensor.logical_shape();
 
@@ -371,6 +372,7 @@ std::vector<Tensor> topk(
         -1,
         largest,
         sorted,
+        stable,
         input_memory_config,
         used_sub_core_grids,
         indices_tensor,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
@@ -23,7 +23,8 @@ struct ExecuteTopK {
         const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
         const std::optional<Tensor>& indices_tensor = std::nullopt,
-        std::optional<std::tuple<Tensor&, Tensor&>> preallocated_output_tensors = std::nullopt);
+        std::optional<std::tuple<Tensor&, Tensor&>> preallocated_output_tensors = std::nullopt,
+        bool stable = false);
 };
 }  // namespace ttnn::operations::reduction::topk
 
@@ -38,6 +39,7 @@ std::vector<Tensor> topk(
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
     const std::optional<Tensor>& indices_tensor = std::nullopt,
-    std::optional<std::tuple<Tensor&, Tensor&>> preallocated_output_tensors = std::nullopt);
+    std::optional<std::tuple<Tensor&, Tensor&>> preallocated_output_tensors = std::nullopt,
+    bool stable = false);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
@@ -46,6 +46,7 @@ void bind_reduction_topk_operation(nb::module_& mod) {
                 output_tensor (tuple[ttnn.Tensor, ttnn.Tensor], optional): A tuple with preallocated output tensors for the values and indices. If specified, must be on the same device as :attr:`input_tensor`. Defaults to (`None`, `None`).
                 sub_core_grids (ttnn.CoreRangeSet, optional): Core range set to run the operation on. Defaults to `None`.
                 indices_tensor (ttnn.Tensor, optional): Input tensor containing pre-computed index values. When provided, the operation reads indices from this tensor instead of generating them. Defaults to `None`.
+                stable (bool, optional): whether equal values break ties by lowest index instead of by array position. Off by default, since it changes which index is returned for tied values. Defaults to `False`.
 
             Returns:
                 tuple[ttnn.Tensor, ttnn.Tensor]: a tuple of (values_tensor, indices_tensor).
@@ -100,7 +101,8 @@ void bind_reduction_topk_operation(nb::module_& mod) {
         nb::arg("memory_config") = nb::none(),
         nb::arg("sub_core_grids") = nb::none(),
         nb::arg("indices_tensor") = nb::none(),
-        nb::arg("output_tensor") = nb::none());
+        nb::arg("output_tensor") = nb::none(),
+        nb::arg("stable") = false);
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
@@ -46,7 +46,7 @@ void bind_reduction_topk_operation(nb::module_& mod) {
                 output_tensor (tuple[ttnn.Tensor, ttnn.Tensor], optional): A tuple with preallocated output tensors for the values and indices. If specified, must be on the same device as :attr:`input_tensor`. Defaults to (`None`, `None`).
                 sub_core_grids (ttnn.CoreRangeSet, optional): Core range set to run the operation on. Defaults to `None`.
                 indices_tensor (ttnn.Tensor, optional): Input tensor containing pre-computed index values. When provided, the operation reads indices from this tensor instead of generating them. Defaults to `None`.
-                stable (bool, optional): whether equal values break ties by lowest index instead of by array position. Off by default, since it changes which index is returned for tied values. Defaults to `False`.
+                stable (bool, optional): EXPERIMENTAL, best effort only -- do not rely on this for correctness. Asks the LLK's stable bitonic network to break exact-value ties by lowest index rather than by array position. The stable network is an open issue (tenstorrent/tt-metal#33492): it can still return incorrect indices for tied values, and every stable case in the LLK test suite is currently skipped, so a caller passing `True` may get either tie-break. Only Wormhole B0 and Blackhole implement it at all; other architectures raise. Off by default. Defaults to `False`.
 
             Returns:
                 tuple[ttnn.Tensor, ttnn.Tensor]: a tuple of (values_tensor, indices_tensor).


### PR DESCRIPTION
### PR Category
Bug fix

### Sanity tests
https://github.com/tenstorrent/tt-metal/actions/runs/31017605948

### Summary
Relands #50687 (commit `3cff0510b9e`, reverted by #52088) and fixes the reason it was reverted.

Three commits, deliberately kept separate:
1. **Reapply `3cff0510b9e` verbatim** — a plain revert of the revert, so the diff against the original is empty.
2. **The actual fix** — the greedy tie-break's index reduce now runs in int32 instead of float32.
3. Minor changes to the fix.

### What actually broke
`ttnn reduce group` failed on all three SKUs in [run 30805637715](https://github.com/tenstorrent/tt-metal/actions/runs/30805637715), in the test the original PR added:

```
FAILED test_tiebreak_input_adjust.py::test_tiebreak_boosts_lowest_global_index_for_greedy_users[sub_core_grid-max_1]
  AssertionError: user 0: expected argmax at position 23 (global index 100040), got position 0
```

The adjusted values came back **completely unmodified** — all three tied maxima still at `1.0000` — so argmax fell back to array position 0 instead of the lowest-global-index candidate.

### Root cause: precision, not sub-core placement
`_adjust_values_for_tiebreak` found the lowest global index among the tied maxima with

```python
greedy_i = ttnn.min(masked_idx_float32, dim=3, keepdim=True, sub_core_grids=scg)
```

`ttnn.min` on a `FLOAT32` tensor takes the **FPU** reduce path — only int32 and the opt-in accurate fp32 mean are routed to the SFPU (`use_sfpu_reduce_path`, `reduction/generic/device/common.hpp`). The FPU truncates its source registers to a 10-bit mantissa, so a 100k-range vocabulary index comes back rounded to a value that **equals no actual index**. The following `eq()` matched nothing, the winner mask was all zeros, the boost multiplied out to zero, and the pass degraded into a silent no-op — precisely the non-determinism it exists to prevent, with no error raised.

`sub_core_grids` was a red herring. It is plumbed and honoured correctly by the reduce, binary, unary and typecast paths for interleaved TILE tensors. The sub-core cases simply run first, and `pytest -x` aborted there before any `full_grid` case executed — the full-grid path was failing identically.

Worth noting for the original PR: **`PR - Sanity tests` was skipped on the `sampling-topk-kernel` branch**, so this test had never run on hardware before it merged to main. Its green CI badges proved nothing about it.

### The fix
- Keep the index half in **int32 end to end** — int32 min/max are integer-exact via the SFPU path (dedicated `reduce_w_neg` kernel, int32 pad sentinels, `eq_int_tile<DataFormat::Int32>` returning integer 1/0).
- Cast the **uint32** tensor `forward()` supplies to int32 once, up front. uint32 is on the same inexact FPU reduce path as float32, so this was a second latent hazard: the merged test fed int32 while the model feeds uint32.
- The mask offset is a power-of-two sentinel (`2**24`) so the bfloat16 mask carrying it stays exact; `__init__` asserts `padded_vocab_size` cannot reach it.
- `_greedy_col` becomes bfloat16 so the gating multiply is no longer a mixed-dtype op, which also drops a typecast. **Net op count is unchanged.**
- The value half stays in bfloat16, where the max reduce and the comparisons against it are exact.

### Tests
- New `test_masked_index_min_reduce_is_exact` pins the int32 reduce, the int32 broadcast equality and both typecasts **directly**, and runs first in the file so under `-x` it is the failure you see rather than an unexplained tie downstream.
- Existing tests now default to the **uint32** index dtype `forward()` actually passes, with int32 kept as a parametrised case.
- `test_topk.py` sorts after `test_tiebreak_input_adjust.py`, so it never ran in the reverted run either; the topk `stable_sort` template changes default to `false` against LLK templates that already carry that default, so behaviour there is unchanged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/sampling-topk-determinism-reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/sampling-topk-determinism-reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/sampling-topk-determinism-reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/sampling-topk-determinism-reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/sampling-topk-determinism-reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/sampling-topk-determinism-reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/sampling-topk-determinism-reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/sampling-topk-determinism-reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/sampling-topk-determinism-reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/sampling-topk-determinism-reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/sampling-topk-determinism-reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/sampling-topk-determinism-reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/sampling-topk-determinism-reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/sampling-topk-determinism-reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/sampling-topk-determinism-reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/sampling-topk-determinism-reland)

### Scope of the determinism guarantee
Worth stating precisely, since the original PR description was looser about it. This makes the greedy pick deterministic for ties **within the gathered candidate set**: given the candidates that reached the all-gather, the boosted winner is always the lowest global index, independent of placement or run.

It does **not** fix the case where a single device shard holds more than `max_top_k` (32) maxima tied at the same value. There the local top-k can drop the true lowest global id before this pass ever sees it, and the token can still vary with placement. That needs tenstorrent/tt-metal#33492 — a working stable network, or resolving ties before truncating to `max_top_k` — and is out of scope for a reland. The pass strictly narrows the window rather than closing it; the `KNOWN LIMITATION` paragraph in `_adjust_values_for_tiebreak`'s docstring has always said so.

### Review follow-ups (29f2a68)
- `ttnn.topk(stable=True)` was passed unconditionally from both top-k call sites, but `TopKDeviceOperation` `TT_FATAL`s on any arch without the stable bitonic network — so the sampling path would have hard-failed on Quasar. Now resolved once in `__init__` and requested only on Wormhole B0 / Blackhole.
- The `padded_vocab_size` sentinel bound was an `assert` (stripped under `python -O`) guarding a silent-corruption case; now raises `ValueError`.
- `ttnn.topk`'s `stable` docstring promised lowest-index ties as a supported contract while #33492 is open and every stable case in the LLK suite is skipped. Reworded as experimental / best-effort, naming the issue and the arch restriction.
