### PR TITLE
#52681: Clamp tilize retile shrink-case output tile-rows to buffer capacity

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/retile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/retile.cpp
@@ -38,7 +38,9 @@ ALWI void fill_zeros_pages(DataflowBuffer& dfb, uint32_t num_pages, uint32_t pag
 void kernel_main() {
     const uint32_t num_input_blocks = get_arg_val<uint32_t>(0);
     const uint32_t num_real_input_rows = get_arg_val<uint32_t>(1);
-    if (num_input_blocks == 0) {
+    // Shrink-case output cap: emit real rows only. Padded rows would OOB the output DRAM buffer.
+    const uint32_t num_real_output_rows = get_arg_val<uint32_t>(2);
+    if (num_input_blocks == 0 || num_real_output_rows == 0) {
         return;
     }
 
@@ -75,6 +77,8 @@ void kernel_main() {
     DataflowBuffer mid(mid_cb);
     DataflowBuffer out_dfb(out_cb);
 
+    uint32_t emitted_output_rows = 0;
+
     for (uint32_t b = 0; b < num_iters; ++b) {
         // Rows beyond num_real_input_rows are grow-case height padding: they don't exist in DRAM,
         // so they are zero-filled into the intermediate instead of untilized from the input.
@@ -109,10 +113,14 @@ void kernel_main() {
         pack_reconfig_data_format(mid_cb, out_cb);
         tilize_init(mid_view_cb, tiles_per_block, out_cb);
         for (uint32_t r = 0; r < out_rows_per_iter; ++r) {
+            if (emitted_output_rows >= num_real_output_rows) {
+                break;
+            }
             UNPACK({ get_local_cb_interface(mid_view_cb).fifo_rd_ptr = block_rd_ptr + r * words_per_out_tile_row; })
             out_dfb.reserve_back(tiles_per_block);
             tilize_block(mid_view_cb, tiles_per_block, out_cb);
             out_dfb.push_back(tiles_per_block);
+            ++emitted_output_rows;
         }
         tilize_uninit(mid_view_cb, out_cb);
 
@@ -120,5 +128,9 @@ void kernel_main() {
 
         reconfig_data_format_srca(mid_view_cb, src_cb);
         pack_reconfig_data_format(out_cb, mid_cb);
+
+        if (emitted_output_rows >= num_real_output_rows) {
+            break;
+        }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_retile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_retile_program_factory.cpp
@@ -84,6 +84,8 @@ ProgramDescriptor TilizeMultiCoreRetileProgramFactory::create_descriptor(
     // tile-rows don't exist in DRAM. Only these real rows are read; the compute kernel zero-fills
     // the rest rather than reading invalid input.
     const uint32_t num_real_input_tile_rows = a.physical_volume() / tensor_width / in_tile_height;
+    // Shrink-case dual of the reader clamp: bounds the writer so surplus rows don't OOB past `output`.
+    const uint32_t num_real_output_tile_rows = output.physical_volume() / tensor_width / out_tile_height;
 
     const uint32_t ratio = shrink ? (in_tile_height / out_tile_height) : (out_tile_height / in_tile_height);
 
@@ -247,28 +249,43 @@ ProgramDescriptor TilizeMultiCoreRetileProgramFactory::create_descriptor(
     uint32_t output_tile_start_id = 0;
     const auto& cores = corerange_to_cores(all_cores);
 
+    auto derive_per_core_counts = [&](uint32_t input_rows, uint32_t output_rows) {
+        const uint32_t core_input_row_start = input_tile_start_id / tiles_per_block;
+        const uint32_t real_input_rows = core_input_row_start >= num_real_input_tile_rows
+                                             ? 0u
+                                             : std::min(num_real_input_tile_rows - core_input_row_start, input_rows);
+        const uint32_t core_output_row_start = output_tile_start_id / tiles_per_block;
+        const uint32_t real_output_rows =
+            core_output_row_start >= num_real_output_tile_rows
+                ? 0u
+                : std::min(num_real_output_tile_rows - core_output_row_start, output_rows);
+        // Hang-free invariant: both clamps zero together (both derive from same H via ceil(H/tile_h)).
+        TT_FATAL(
+            (real_input_rows == 0) == (real_output_rows == 0),
+            "tilize retile clamps out of sync: real_in={}, real_out={} (would hang reader)",
+            real_input_rows,
+            real_output_rows);
+        return std::make_pair(real_input_rows, real_output_rows);
+    };
+
     for (uint32_t i = 0; i < ncores_full; ++i) {
         const CoreCoord& core = cores[i];
         // nblocks_per_core is in split units (input tile-rows if shrink, output tile-rows if grow).
         const uint32_t input_rows = shrink ? nblocks_per_core : nblocks_per_core * ratio;
         const uint32_t output_rows = shrink ? nblocks_per_core * ratio : nblocks_per_core;
         const uint32_t num_input_blocks = input_rows;
-        // Padding is always at the tail (highest rows), so this core's real rows are a prefix.
-        const uint32_t core_row_start = input_tile_start_id / tiles_per_block;
-        const uint32_t real_rows = core_row_start >= num_real_input_tile_rows
-                                       ? 0u
-                                       : std::min(num_real_input_tile_rows - core_row_start, input_rows);
-        const uint32_t num_input_tiles = real_rows * tiles_per_block;  // only real tiles are read
-        const uint32_t num_output_tiles = output_rows * tiles_per_block;
+        auto [real_rows, real_output_rows] = derive_per_core_counts(input_rows, output_rows);
+        const uint32_t num_input_tiles = real_rows * tiles_per_block;
+        const uint32_t num_output_tiles = real_output_rows * tiles_per_block;
 
         reader_ref.emplace_runtime_args(core, {src0_buffer, num_input_tiles, input_tile_start_id});
         writer_ref.emplace_runtime_args(core, {dst_buffer, num_output_tiles, output_tile_start_id});
         if (full_compute_idx >= 0) {
-            desc.kernels[full_compute_idx].emplace_runtime_args(core, {num_input_blocks, real_rows});
+            desc.kernels[full_compute_idx].emplace_runtime_args(core, {num_input_blocks, real_rows, real_output_rows});
         }
 
         input_tile_start_id += input_rows * tiles_per_block;
-        output_tile_start_id += num_output_tiles;
+        output_tile_start_id += output_rows * tiles_per_block;
     }
 
     if (has_cliff) {
@@ -276,17 +293,14 @@ ProgramDescriptor TilizeMultiCoreRetileProgramFactory::create_descriptor(
         const uint32_t input_rows = shrink ? nblocks_per_core_cliff : nblocks_per_core_cliff * ratio;
         const uint32_t output_rows = shrink ? nblocks_per_core_cliff * ratio : nblocks_per_core_cliff;
         const uint32_t num_input_blocks = input_rows;
-        const uint32_t core_row_start = input_tile_start_id / tiles_per_block;
-        const uint32_t real_rows = core_row_start >= num_real_input_tile_rows
-                                       ? 0u
-                                       : std::min(num_real_input_tile_rows - core_row_start, input_rows);
-        const uint32_t num_input_tiles = real_rows * tiles_per_block;  // only real tiles are read
-        const uint32_t num_output_tiles = output_rows * tiles_per_block;
+        auto [real_rows, real_output_rows] = derive_per_core_counts(input_rows, output_rows);
+        const uint32_t num_input_tiles = real_rows * tiles_per_block;
+        const uint32_t num_output_tiles = real_output_rows * tiles_per_block;
 
         reader_ref.emplace_runtime_args(core, {src0_buffer, num_input_tiles, input_tile_start_id});
         writer_ref.emplace_runtime_args(core, {dst_buffer, num_output_tiles, output_tile_start_id});
         if (cliff_compute_idx >= 0) {
-            desc.kernels[cliff_compute_idx].emplace_runtime_args(core, {num_input_blocks, real_rows});
+            desc.kernels[cliff_compute_idx].emplace_runtime_args(core, {num_input_blocks, real_rows, real_output_rows});
         }
     }
 


### PR DESCRIPTION
### Ticket
Closes #52681

_Sub-issue of parent #51213 (which tracks all 9 items in this series)._

### Problem
`TilizeMultiCoreRetileProgramFactory` (interleaved retile path, `is_retile` in `tilize_device_operation.cpp`) handles the shrink case (input tile-height > output tile-height, `ratio = in_th / out_th`) by splitting work in **input tile-rows** and computing per-core:

```cpp
input_rows  = nblocks_per_core;
output_rows = nblocks_per_core * ratio;      // shrink: one input row -> `ratio` output rows
...
num_input_tiles  = real_rows * tiles_per_block;   // clamped to num_real_input_tile_rows
num_output_tiles = output_rows * tiles_per_block; // NOT clamped -- bug
```

The reader side already clamps against `num_real_input_tile_rows = a.physical_volume() / tensor_width / in_tile_height` so the reader never reads past the input's `physical_volume`. There is no analogous clamp on the writer side.

When the logical H is not a multiple of the *input* tile-height (i.e. `round_up(H, in_th) > round_up(H, out_th)`), the padded input contributes more input tile-rows than the output actually holds output tile-rows. The writer runtime arg `num_output_tiles = output_rows * tiles_per_block` therefore exceeds `output.physical_volume() / out_tile_hw`, and the writer NOC-writes real bytes into DRAM addresses past the output buffer's allocated slot.

Canonical case from the issue -- `[1, 1, 16, 128] × in(32, 32) → out(16, 32)`:
- `num_input_tile_rows = round_up(16, 32) / 32 = 1`, `ratio = 32 / 16 = 2`, `tiles_per_block = 128 / 32 = 4`.
- Pre-fix `num_output_tiles = 1 * 2 * 4 = 8` pages.
- Real output slots: `output.physical_volume() / out_tile_hw = 16*128 / (16*32) = 4` pages.
- Pages 4..7 overshoot the buffer by 4096 bytes (bf16), clobbering whatever the DRAM allocator placed next.

Additionally the pre-fix host code advances `output_tile_start_id += num_output_tiles`, so in a multi-core split the OOB cascades into subsequent cores' write regions.

Silent from `to_torch(output)`'s perspective because it only reads the valid `physical_volume`; the corruption lives in the neighbouring DRAM allocation. Blast radius is on Blackhole today (WH-B0 skips the shrink-retile family in tests -- see #52175); any BH model that shrink-retiles a tensor whose H is not a multiple of the input tile-height silently clobbers a neighbour.

### What this PR does
- **Derive `num_real_output_tile_rows` once** in `tilize_multi_core_retile_program_factory.cpp` as `output.physical_volume() / tensor_width / out_tile_height`, mirroring the existing `num_real_input_tile_rows` reader-side clamp.
- **Fold both per-core clamps into `derive_per_core_counts(input_rows, output_rows)`**, returning `(real_input_rows, real_output_rows)` clamped against the respective `num_real_*_tile_rows` starting at each core's slot. Applied in both the full and `has_cliff` branches.
- **Writer runtime arg becomes `real_output_rows * tiles_per_block`** so the NOC writer only issues the pages that actually fit in the buffer.
- **Advance `output_tile_start_id` by the padded slot (`output_rows * tiles_per_block`)** rather than the clamped count -- only the per-core *emitted* count shrinks; the per-core *slot* stays the same so downstream cores' page-ids stay aligned with the buffer stride the writer expects.
- **Thread `num_real_output_rows` as a runtime arg into `retile.cpp` compute**; add an `emitted_output_rows` counter and break out of both the inner (`out_rows_per_iter`) and outer (`num_iters`) loops once the cap is reached, and early-return when `num_real_output_rows == 0`. Surplus rows would push past the output CB into the writer chain otherwise.

### Tests
No new unit test in this PR. A synthetic OOB regression test would need to reliably place a neighbour tensor exactly where the buggy writer's overshoot lands -- DRAM interleaved allocator ordering + per-channel page-striping makes that non-deterministic across arches, so any such test is at best a probabilistic smoke check rather than a real detector.

Existing coverage that will catch reintroduction of the unclamped `num_output_tiles`:
- Parent `tests/ttnn/unit_tests/operations/data_movement/test_tilize.py::test_tilize_retile` family on Blackhole nightly -- exercises the shrink retile path across every `(input_tile_shape, output_tile_shape)` pair. A regression that OOB-writes into a neighbouring live allocation surfaces as PCC failure on the neighbour's downstream consumer.
- Any BH model / demo that pairs `tilize` with a non-`in_th`-aligned H hits the same path; a regression manifests as functional divergence downstream of the shrink retile.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/tilize_retile_shrink_oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/tilize_retile_shrink_oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/tilize_retile_shrink_oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/tilize_retile_shrink_oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/tilize_retile_shrink_oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/tilize_retile_shrink_oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/tilize_retile_shrink_oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/tilize_retile_shrink_oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/tilize_retile_shrink_oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/tilize_retile_shrink_oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/tilize_retile_shrink_oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/tilize_retile_shrink_oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/tilize_retile_shrink_oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/tilize_retile_shrink_oob)


