### PR TITLE
[QSR Resnet] max_pool2d - flush L2 after halo pad fill

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/kernels/dataflow/halo_gather.cpp
@@ -326,6 +326,10 @@ void kernel_main() {
             noc.write_zeros_l1_barrier();
         } else {
             fill_with_val<num_elements_to_fill, pad_val>(pad_fill_cb.get_write_ptr());
+#ifdef ARCH_QUASAR
+            flush_l2_cache_range(
+                static_cast<uintptr_t>(pad_fill_cb.get_write_ptr()), static_cast<size_t>(aligned_stick_nbytes));
+#endif
         }
         pad_fill_cb.push_back(1);
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
@@ -174,7 +174,7 @@ void kernel_main() {
 #else
     constexpr uint32_t pack_target_cb_id = tilize_untilize_cb;
 #endif
-    compute_kernel_hw_startup(in_cb_id_0, in_scalar_cb_id_0, tilize_untilize_cb);
+    compute_kernel_hw_startup(in_cb_id_0, in_scalar_cb_id_0, pack_target_cb_id);
     tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter);
 
     pack_untilize_dest_init<max_tiles_per_iter>(pack_target_cb_id);


### PR DESCRIPTION
### PR Category
Bug fix

## Issue
https://github.com/tenstorrent/tt-metal/issues/51742

### Summary
`fill_with_val` writes the -inf pad row with CPU stores, which land in L2 and
were never flushed to TL1. The NOC broadcast then copied stale zeros, so `max_pool2d` reduced over 0, or other stale data if tests were running back to back.

This PR also binds `compute_kernel_hw_startup` to `pack_target_cb_id` rather than `tilize_untilize_cb`.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/resnet_maxpool_l2_cache_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/resnet_maxpool_l2_cache_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/resnet_maxpool_l2_cache_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/resnet_maxpool_l2_cache_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amokan/resnet_maxpool_l2_cache_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amokan/resnet_maxpool_l2_cache_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/resnet_maxpool_l2_cache_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/resnet_maxpool_l2_cache_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/resnet_maxpool_l2_cache_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/resnet_maxpool_l2_cache_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/resnet_maxpool_l2_cache_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/resnet_maxpool_l2_cache_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/resnet_maxpool_l2_cache_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/resnet_maxpool_l2_cache_flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/resnet_maxpool_l2_cache_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/resnet_maxpool_l2_cache_flush)