### PR TITLE
prefill: add 8-galaxy connected MGD + 8-rank D2D rank binding

### DIFF
--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_8galaxy_connected_mesh_graph_descriptor.textproto
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_8galaxy_connected_mesh_graph_descriptor.textproto
@@ -1,0 +1,70 @@
+# CONNECTED 8-galaxy mesh graph descriptor for the D2D-socket pipeline prefill.
+#
+# Eight 8x4 BH-galaxy meshes chained mesh 0 <-> 1 <-> ... <-> 7 by inter-galaxy fabric links, one per
+# pipeline boundary (rank r sends to rank r+1). Same connection format as the 4-galaxy MGD, extended
+# to eight consecutive mesh_ids.
+#
+# Host order matters: discovery maps mesh 0 -> first --host, mesh 1 -> second, etc., and the chained
+# connections require consecutive hosts to be physically cabled as a single 8-hop path. List the
+# --host slots in that cabling order (verify with the UMD topology tool if a boundary fails to train).
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 8, 4 ] dim_types: [ LINE, RING ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  # mesh 3<->4 is the inter-rack boundary (glx-120: c07u20<->c08u20), physically a single reciprocated
+  # link. count:8 with RELAXED trains over whatever links exist, so the D2D socket forms over the 1 link.
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    channels { count: 8 policy: RELAXED }
+  }
+}
+
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_8rank_d2d.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_8rank_d2d.yaml
@@ -1,0 +1,56 @@
+# tt-run rank binding for the 8-rank pipeline prefill over the D2D socket transport.
+#
+# Eight 8x4 galaxies, one rank each, chained rank 0 -> 1 -> ... -> 7 by inter-galaxy MeshSockets over
+# the connected 8-galaxy MGD. The model's layers split evenly across the eight ranks; the hidden state
+# hops device-to-device at each boundary (no host/NFS round-trip).
+#
+# Launch on the 8-galaxy chain (model chosen via PREFILL_MANIFEST). Host order must match the physical
+# cabling chain (mesh 0 -> first --host, ... mesh 7 -> last); reorder the --host slots if a boundary's
+# fabric fails to train. Proven chain on glx-120 (the mesh 3<->4 boundary is the single-link inter-rack
+# bridge c07u20<->c08u20, which trains fine and is not the pipeline bottleneck):
+#   PREFILL_MANIFEST=models/demos/deepseek_v3_d_p/tt/runners/manifests/kimi27.json \
+#     ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
+#     models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_8rank_d2d.yaml \
+#     bh-glx-120-c07u02:1,bh-glx-120-c07u08:1,bh-glx-120-c07u14:1,bh-glx-120-c07u20:1,bh-glx-120-c08u20:1,bh-glx-120-c08u14:1,bh-glx-120-c08u08:1,bh-glx-120-c08u02:1
+
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+    env_overrides: {}
+  - rank: 1
+    mesh_id: 1
+    mesh_host_rank: 0
+    env_overrides: {}
+  - rank: 2
+    mesh_id: 2
+    mesh_host_rank: 0
+    env_overrides: {}
+  - rank: 3
+    mesh_id: 3
+    mesh_host_rank: 0
+    env_overrides: {}
+  - rank: 4
+    mesh_id: 4
+    mesh_host_rank: 0
+    env_overrides: {}
+  - rank: 5
+    mesh_id: 5
+    mesh_host_rank: 0
+    env_overrides: {}
+  - rank: 6
+    mesh_id: 6
+    mesh_host_rank: 0
+    env_overrides: {}
+  - rank: 7
+    mesh_id: 7
+    mesh_host_rank: 0
+    env_overrides: {}
+
+# Connected 8x 8x4 BH-galaxy MGD: inter-galaxy links 0<->1<->...<->7.
+mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_8galaxy_connected_mesh_graph_descriptor.textproto
+
+# Topology + transport only — model and run-profile (PCC, chunk count, model knobs) come from PREFILL_MANIFEST.
+global_env:
+  PREFILL_STANDALONE: "1"   # standalone bring-up/pipeline mode, not the production request loop
+  PREFILL_FABRIC_MODE: "2d"  # D2D pipeline transport needs FABRIC_2D


### PR DESCRIPTION
Extends the 2/4-galaxy pipeline-prefill topology set to 8 ranks chained 0..7 over inter-galaxy MeshSockets. Validated end-to-end on glx-120 (c07u02..c08u02); the mesh 3<->4 boundary is the single physical inter-rack link and trains under count:8 RELAXED. Requires the #51490 RoPE interleaved-prefill JIT fix to run on BH.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/8glx-pipeline-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/8glx-pipeline-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/8glx-pipeline-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/8glx-pipeline-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jjovicic/8glx-pipeline-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jjovicic/8glx-pipeline-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/8glx-pipeline-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/8glx-pipeline-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/8glx-pipeline-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/8glx-pipeline-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/8glx-pipeline-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/8glx-pipeline-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/8glx-pipeline-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/8glx-pipeline-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/8glx-pipeline-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/8glx-pipeline-prefill)