### PR TITLE
sdpa perf checks: scope the is_high_power gate to the galaxy mesh

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -4613,9 +4613,11 @@ else:
 )
 @skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+# Galaxy only: the gate guards the exabox.tenstorrent.com/power=14kw label. QuietBox reports a
+# sub-130W TDP, so an unconditional gate skipped every ring-4 entry below on every CI run.
 @pytest.mark.skipif(
-    not is_high_power(),
-    reason="perf job requires a high-power (>=130W TDP) galaxy; guards the exabox.tenstorrent.com/power=14kw label",
+    MESH_CONFIG.is_galaxy and not is_high_power(),
+    reason="galaxy perf job requires a high-power (>=130W TDP) host; guards the exabox.tenstorrent.com/power=14kw label",
 )
 def test_ring_joint_attention_perf_check(
     model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util, margin
@@ -5717,9 +5719,11 @@ else:
 )
 @skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+# Galaxy only: the gate guards the exabox.tenstorrent.com/power=14kw label. QuietBox reports a
+# sub-130W TDP, so an unconditional gate skipped every ring-4 entry below on every CI run.
 @pytest.mark.skipif(
-    not is_high_power(),
-    reason="perf job requires a high-power (>=130W TDP) galaxy; guards the exabox.tenstorrent.com/power=14kw label",
+    MESH_CONFIG.is_galaxy and not is_high_power(),
+    reason="galaxy perf job requires a high-power (>=130W TDP) host; guards the exabox.tenstorrent.com/power=14kw label",
 )
 def test_ring_mla_chunked_perf_check(model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util):
     """Measure ring_mla chunked-prefill math utilization for the kimi 50k+5k galaxy chunk (a 5k Q


### PR DESCRIPTION
## What

`test_ring_joint_attention_perf_check` and `test_ring_mla_chunked_perf_check` each carry an
unconditional `is_high_power()` skipif, and each also defines a **non-galaxy config branch** for the
4-device QuietBox. QuietBox reports a sub-130W TDP, so `is_high_power()` is False there and the gate
skips the whole test — every ring-4 entry, on every CI run.

The "ring sdpa PERF tests (QB2 only)" row in `blackhole_multi_card_sanity_tests.yaml` has therefore
been asserting nothing for those two tests. The job still reports success, because a skip is not a
failure.

## Evidence

Run [30996275190](https://github.com/tenstorrent/tt-metal/actions/runs/30996275190), job
[92276490363](https://github.com/tenstorrent/tt-metal/actions/runs/30996275190/job/92276490363), on `bh_quietbox_2`:

```
test_ring_joint_attention_perf_check[wan2_2_1xGLX-q288-k512-ring4]  SKIPPED
test_ring_joint_attention_perf_check[mla_100k-q160-k320-ring4]      SKIPPED
test_ring_mla_chunked_perf_check[kimi50k-q32-k640-ring4]            SKIPPED
  perf job requires a high-power (>=130W TDP) galaxy; guards the exabox.tenstorrent.com/power=14kw label
```

In the **same job**, `test_exp_ring_joint_sdpa.py::test_exp_ring_joint_attention_perf_check` — which
has no such gate — ran and passed on QB2: `math_util=65.35%` against an expected `65.30`, and
`65.39%` against `65.60`. The realtime profiler and the utilization numbers are sound on that
hardware; only the gate was in the way.

## The fix

```python
-    not is_high_power(),
+    MESH_CONFIG.is_galaxy and not is_high_power(),
```

on both tests. `MESH_CONFIG.is_galaxy` is `num_devices == 32`, so the gate still guards exactly what
its reason string describes — the `exabox.tenstorrent.com/power=14kw` label on the galaxy runner —
and stops suppressing the QuietBox branch that was written to run alongside it.

Left alone deliberately: the two `is_high_power()` gates in
`models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py`. Those tests are
galaxy-only by construction, so the unconditional form is correct there.

## Risk — please read

This wakes three baselines that have not executed in CI for some time:

| config | committed expected_util |
|---|---|
| `wan2_2_1xGLX-q288-k512-ring4` | 68.5 |
| `mla_100k-q160-k320-ring4` | 63.2 |
| `kimi50k-q32-k640-ring4` | 66.05 |

If any has drifted since it was measured, it will now fail. **That is the point** — the correct
response is to re-measure on QB2 and update the number, not to re-hide the test. I have no QuietBox2
access, so I have not been able to run these; the first CI run on this branch is the real test plan.

## Test plan

- [x] Both gates patched identically; file compiles; no other call sites touched
- [ ] "Blackhole sanity tests" on this branch — confirm the three ring-4 cases now **run** on
      `bh_quietbox_2`, and record whether each lands in band
- [ ] Any out-of-band baseline re-measured and updated in a follow-up commit here

Note the QB2 row's budget is tight: three of the last four `main` runs of the neighbouring
"sdpa nightly tests (QB2 only)" job died on `infra:timeout` at 20 minutes. Un-skipping three perf
cases adds to the sibling "ring sdpa PERF tests" row (10 min), not to that one, but it is worth
watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/sdpa-qb2-perf-high-power-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/sdpa-qb2-perf-high-power-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sdpa-qb2-perf-high-power-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/sdpa-qb2-perf-high-power-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sdpa-qb2-perf-high-power-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/sdpa-qb2-perf-high-power-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/sdpa-qb2-perf-high-power-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/sdpa-qb2-perf-high-power-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/sdpa-qb2-perf-high-power-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/sdpa-qb2-perf-high-power-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/sdpa-qb2-perf-high-power-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/sdpa-qb2-perf-high-power-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/sdpa-qb2-perf-high-power-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/sdpa-qb2-perf-high-power-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/sdpa-qb2-perf-high-power-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/sdpa-qb2-perf-high-power-gate)