### PR TITLE
[skip ci] Fix publish-release-image: dynamic tool list + stop bypassing the proxy for Harbor

### DIFF
--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -59,31 +59,21 @@ jobs:
           # This runner's proxy isn't inherited by the isolated buildx builder
           # (see docker-run/action.yml's forward_civ2_proxy_env_vars).
           #
-          # Deliberately NOT setting NO_PROXY here (previously "tenstorrent.net").
-          # That suffix matches harbor.ci.tenstorrent.net, which made BuildKit
-          # bypass the proxy and dial Harbor's ingress VIP directly - a path
-          # that silently blackholes (dial tcp ...: i/o timeout, no RST/ICMP,
-          # confirmed via live packet capture) due to a NetworkPolicy/DNAT
-          # ordering issue on the runner's cluster (infra-side; the egress
-          # ipBlock rule for Harbor's VIP has apparently never actually
-          # worked. Every path that reaches Harbor successfully today, e.g.
-          # the runner's own dockerd, goes via the proxy instead, since
-          # dockerd's own NO_PROXY entry for Harbor is a malformed pattern
-          # that never matches and so never takes the broken direct route).
-          # Routing everything through the proxy, same as dockerd already
-          # does, is what actually works - see run 31018713433, job
-          # 92352981018 for the failure this avoids.
+          # Do not set NO_PROXY here. A previous value of "tenstorrent.net"
+          # matched harbor.ci.tenstorrent.net. That made the builder skip
+          # the proxy and connect to Harbor directly, which times out.
+          # Root cause: MINFRA-1408. Routing through the proxy works, the
+          # same way the runner's own docker daemon already reaches Harbor.
+          # See run 31018713433, job 92352981018 for the failure this avoids.
           echo "PROXY_HTTP=${HTTP_PROXY:-${http_proxy:-}}" >> "$GITHUB_ENV"
           echo "PROXY_HTTPS=${HTTPS_PROXY:-${https_proxy:-}}" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
-          # network=host: shares the runner's own network namespace instead
-          # of the docker-container driver's default bridge. Doesn't fix the
-          # Harbor timeout above (that's a proxy-routing issue, not a bridge
-          # NAT-hop issue - confirmed by reproducing the same failure with
-          # this in place), but it's a reasonable simplification with one
-          # fewer layer of network indirection, so left in.
+          # network=host: builder uses the runner's own network namespace
+          # instead of the docker-container driver's default bridge. Does
+          # not fix the Harbor timeout above. Confirmed by reproducing the
+          # same failure with this option set. Kept as a small simplification.
           driver-opts: |
             network=host
             env.HTTP_PROXY=${{ env.PROXY_HTTP }}
@@ -137,15 +127,13 @@ jobs:
           HARBOR_PREFIX: ${{ inputs.harbor-prefix }}
           PROXY_HTTP: ${{ env.PROXY_HTTP }}
           PROXY_HTTPS: ${{ env.PROXY_HTTPS }}
-          PROXY_NO_PROXY: ${{ env.PROXY_NO_PROXY }}
         run: |
           set -euo pipefail
           TARGET="${{ inputs.image }}"
-          # Derived from docker-bake.hcl's "${TARGET}" contexts instead of a
-          # hardcoded list, so a new tool (e.g. curl/oras) is picked up
-          # automatically instead of silently falling back to an unproxied
-          # local build - see .github/scripts/get-target-tools.sh and its
-          # existing use in build-docker-artifact.yaml.
+          # Tool list comes from docker-bake.hcl via get-target-tools.sh
+          # instead of a hardcoded list. A new tool (e.g. curl, oras) is
+          # picked up automatically. build-docker-artifact.yaml already
+          # uses this script.
           TOOLS=($(.github/scripts/get-target-tools.sh "$TARGET"))
           SET=""
           for tool in "${TOOLS[@]}"; do
@@ -159,13 +147,12 @@ jobs:
           SET+="${TARGET}.args.UBUNTU_VERSION=${UBUNTU_VERSION}"$'\n'
           SET+="${TARGET}.args.PYTHON_VERSION=${PYTHON_VERSION}"$'\n'
           SET+="${TARGET}.args.GIT_REF=${{ github.ref_name || 'main' }}"$'\n'
-          # RUN steps (apt-get, curl, uv pip) need the proxy too - BuildKit
-          # auto-propagates these build-arg names into every RUN with no ARG
+          # RUN steps (apt-get, curl, uv pip) need the proxy too. BuildKit
+          # sets these build args in every RUN automatically, no ARG
           # declaration needed.
           if [ -n "$PROXY_HTTP" ]; then
             SET+="${TARGET}.args.HTTP_PROXY=${PROXY_HTTP}"$'\n'
             SET+="${TARGET}.args.HTTPS_PROXY=${PROXY_HTTPS}"$'\n'
-            SET+="${TARGET}.args.NO_PROXY=${PROXY_NO_PROXY}"$'\n'
           fi
           {
             echo "set<<EOF"

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -58,30 +58,36 @@ jobs:
         run: |
           # This runner's proxy isn't inherited by the isolated buildx builder
           # (see docker-run/action.yml's forward_civ2_proxy_env_vars).
-          # NO_PROXY is one entry, no comma - docker buildx create --driver-opt
-          # can't handle commas in a value (docker/buildx#1133).
+          #
+          # Deliberately NOT setting NO_PROXY here (previously "tenstorrent.net").
+          # That suffix matches harbor.ci.tenstorrent.net, which made BuildKit
+          # bypass the proxy and dial Harbor's ingress VIP directly - a path
+          # that silently blackholes (dial tcp ...: i/o timeout, no RST/ICMP,
+          # confirmed via live packet capture) due to a NetworkPolicy/DNAT
+          # ordering issue on the runner's cluster (infra-side; the egress
+          # ipBlock rule for Harbor's VIP has apparently never actually
+          # worked. Every path that reaches Harbor successfully today, e.g.
+          # the runner's own dockerd, goes via the proxy instead, since
+          # dockerd's own NO_PROXY entry for Harbor is a malformed pattern
+          # that never matches and so never takes the broken direct route).
+          # Routing everything through the proxy, same as dockerd already
+          # does, is what actually works - see run 31018713433, job
+          # 92352981018 for the failure this avoids.
           echo "PROXY_HTTP=${HTTP_PROXY:-${http_proxy:-}}" >> "$GITHUB_ENV"
           echo "PROXY_HTTPS=${HTTPS_PROXY:-${https_proxy:-}}" >> "$GITHUB_ENV"
-          echo "PROXY_NO_PROXY=tenstorrent.net" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
-          # network=host: the docker-container driver runs BuildKit as its
-          # own nested container on a Docker bridge network, not the
-          # runner's host network. Proxied traffic (ghcr.io etc.) still
-          # reaches its destination fine via the proxy above, but anything
-          # NO_PROXY excludes - i.e. harbor.ci.tenstorrent.net, which is on
-          # the runner's internal VLAN - has to route directly out of that
-          # bridge instead, and that path has been observed to silently
-          # time out (dial tcp ...: i/o timeout) even though a plain `docker
-          # pull` from the runner's own dockerd reaches the same host fine
-          # in the same job (run 31015384936, job 92342670213). Putting the
-          # builder on host networking removes that extra NAT hop entirely.
+          # network=host: shares the runner's own network namespace instead
+          # of the docker-container driver's default bridge. Doesn't fix the
+          # Harbor timeout above (that's a proxy-routing issue, not a bridge
+          # NAT-hop issue - confirmed by reproducing the same failure with
+          # this in place), but it's a reasonable simplification with one
+          # fewer layer of network indirection, so left in.
           driver-opts: |
             network=host
             env.HTTP_PROXY=${{ env.PROXY_HTTP }}
             env.HTTPS_PROXY=${{ env.PROXY_HTTPS }}
-            env.NO_PROXY=${{ env.PROXY_NO_PROXY }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -123,7 +123,7 @@ jobs:
         run: |
           set -euo pipefail
           TARGET="${{ inputs.image }}"
-          TOOLS=(ccache mold doxygen clangbuildanalyzer gdb cmake yq zstd sfpi openmpi)
+          TOOLS=(ccache mold doxygen clangbuildanalyzer gdb cmake yq zstd sfpi openmpi curl oras)
           SET=""
           for tool in "${TOOLS[@]}"; do
             tag=$(echo "$TOOL_TAGS" | jq -r ".\"${tool}-tag\"")

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -62,18 +62,13 @@ jobs:
           # Do not set NO_PROXY here. A previous value of "tenstorrent.net"
           # matched harbor.ci.tenstorrent.net. That made the builder skip
           # the proxy and connect to Harbor directly, which times out.
-          # Root cause: MINFRA-1408. Routing through the proxy works, the
-          # same way the runner's own docker daemon already reaches Harbor.
-          # See run 31018713433, job 92352981018 for the failure this avoids.
           echo "PROXY_HTTP=${HTTP_PROXY:-${http_proxy:-}}" >> "$GITHUB_ENV"
           echo "PROXY_HTTPS=${HTTPS_PROXY:-${https_proxy:-}}" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           # network=host: builder uses the runner's own network namespace
-          # instead of the docker-container driver's default bridge. Does
-          # not fix the Harbor timeout above. Confirmed by reproducing the
-          # same failure with this option set. Kept as a small simplification.
+          # instead of the docker-container driver's default bridge.
           driver-opts: |
             network=host
             env.HTTP_PROXY=${{ env.PROXY_HTTP }}
@@ -131,9 +126,6 @@ jobs:
           set -euo pipefail
           TARGET="${{ inputs.image }}"
           # Tool list comes from docker-bake.hcl via get-target-tools.sh
-          # instead of a hardcoded list. A new tool (e.g. curl, oras) is
-          # picked up automatically. build-docker-artifact.yaml already
-          # uses this script.
           TOOLS=($(.github/scripts/get-target-tools.sh "$TARGET"))
           SET=""
           for tool in "${TOOLS[@]}"; do

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -66,7 +66,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
+          # network=host: the docker-container driver runs BuildKit as its
+          # own nested container on a Docker bridge network, not the
+          # runner's host network. Proxied traffic (ghcr.io etc.) still
+          # reaches its destination fine via the proxy above, but anything
+          # NO_PROXY excludes - i.e. harbor.ci.tenstorrent.net, which is on
+          # the runner's internal VLAN - has to route directly out of that
+          # bridge instead, and that path has been observed to silently
+          # time out (dial tcp ...: i/o timeout) even though a plain `docker
+          # pull` from the runner's own dockerd reaches the same host fine
+          # in the same job (run 31015384936, job 92342670213). Putting the
+          # builder on host networking removes that extra NAT hop entirely.
           driver-opts: |
+            network=host
             env.HTTP_PROXY=${{ env.PROXY_HTTP }}
             env.HTTPS_PROXY=${{ env.PROXY_HTTPS }}
             env.NO_PROXY=${{ env.PROXY_NO_PROXY }}

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -123,7 +123,12 @@ jobs:
         run: |
           set -euo pipefail
           TARGET="${{ inputs.image }}"
-          TOOLS=(ccache mold doxygen clangbuildanalyzer gdb cmake yq zstd sfpi openmpi curl oras)
+          # Derived from docker-bake.hcl's "${TARGET}" contexts instead of a
+          # hardcoded list, so a new tool (e.g. curl/oras) is picked up
+          # automatically instead of silently falling back to an unproxied
+          # local build - see .github/scripts/get-target-tools.sh and its
+          # existing use in build-docker-artifact.yaml.
+          TOOLS=($(.github/scripts/get-target-tools.sh "$TARGET"))
           SET=""
           for tool in "${TOOLS[@]}"; do
             tag=$(echo "$TOOL_TAGS" | jq -r ".\"${tool}-tag\"")


### PR DESCRIPTION
## Summary

- The tool list in `publish-release-image.yaml` is no longer hardcoded. It now comes from `.github/scripts/get-target-tools.sh`, which reads it from `docker-bake.hcl`.
- The buildx builder no longer excludes Harbor from the proxy. It was connecting to Harbor directly, which times out.
- The buildx builder now runs on host networking (`network=host`). This did not fix the Harbor issue. Kept as a small simplification.

## Fix 1: dynamic tool list

Job [91822888729](https://github.com/tenstorrent/tt-metal/actions/runs/30853515680/job/91822888729) failed to build the `curl` tool image. The error was `exit code: 4`, wget's network failure code, during the curl download.

`curl` and `oras` were added as tool targets in `docker-bake.hcl` and `compute-tool-tags.sh`, but not added to the hardcoded tool list in `publish-release-image.yaml`. So the workflow built `curl` locally instead of using the prebuilt image. The local build has no proxy set, so it could reach `github.com` but not `curl.se`.

The workflow now calls `get-target-tools.sh` to build the tool list. `build-docker-artifact.yaml` already uses this script. A new tool added to `docker-bake.hcl` is picked up automatically, no separate list to update.

## Fix 2: stop excluding Harbor from the proxy

Two later runs, [job 92342670213](https://github.com/tenstorrent/tt-metal/actions/runs/31015384936/job/92342670213) and [job 92352981018](https://github.com/tenstorrent/tt-metal/actions/runs/31018713433/job/92352981018), failed to pull the `syft-scanner` tool image through Harbor:

```
dial tcp 172.21.23.201:443: i/o timeout
```

Root cause: the buildx builder was set to bypass the proxy for `NO_PROXY=tenstorrent.net`. This matches `harbor.ci.tenstorrent.net`, so the builder connected to Harbor's address directly. That address is the cluster's own ingress VIP, and the direct connection times out.

In the same job, a plain `docker pull` of a Harbor image succeeds within seconds, using the runner's own Docker daemon. That daemon also excludes Harbor from its proxy, but with an invalid pattern (`harbor.*.tenstorrent.net`) that does not match anything. So its traffic goes through the proxy instead, and works.

Fix: stop setting `NO_PROXY` for the buildx builder, so Harbor traffic goes through the proxy, the same working path the Docker daemon already uses.

- [x] https://github.com/tenstorrent/tt-metal/actions/runs/31023759956/job/92369417417

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/0-fix-curl-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-fix-curl-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsexton/0-fix-curl-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsexton/0-fix-curl-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nsexton/0-fix-curl-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nsexton/0-fix-curl-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-fix-curl-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-fix-curl-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsexton/0-fix-curl-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsexton/0-fix-curl-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-fix-curl-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-fix-curl-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-fix-curl-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-fix-curl-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-fix-curl-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-fix-curl-release)