### PR TITLE
Pass tile size to matmul test-kernel TensorAccessors

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_mcast_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_mcast_receiver.cpp
@@ -63,7 +63,7 @@ void kernel_main() {
 
     constexpr auto in0_args = TensorAccessorArgs<0>();
     constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
-    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
+    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < num_blocks; b++) {
         // Operand 0

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_mcast_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_mcast_sender.cpp
@@ -74,9 +74,9 @@ void kernel_main() {
 
     constexpr auto in0_args = TensorAccessorArgs<0>();
     constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
-    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
+    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr, single_tile_size_bytes);
 
-    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
+    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < num_blocks; b++) {
         cb_reserve_back(cb_id_in0, in0_block_num_tiles);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_receiver_in1_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_receiver_in1_sender.cpp
@@ -85,7 +85,7 @@ void kernel_main() {
 
     constexpr auto in0_args = TensorAccessorArgs<0>();
     constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
-    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
+    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < num_blocks; b++) {
         // Operand 0

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_receiver.cpp
@@ -86,7 +86,7 @@ void kernel_main() {
 
     constexpr auto in0_args = TensorAccessorArgs<0>();
     constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
-    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
+    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < num_blocks; b++) {
         cb_in0.reserve_back(in0_block_num_tiles);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_sender.cpp
@@ -90,9 +90,9 @@ void kernel_main() {
 
     constexpr auto in0_args = TensorAccessorArgs<0>();
     constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
-    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
+    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr, single_tile_size_bytes);
 
-    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
+    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < num_blocks; b++) {
         cb_in0.reserve_back(in0_block_num_tiles);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in1_mcast_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in1_mcast_receiver.cpp
@@ -61,7 +61,7 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_receiver_semaphore_addr);
 
     constexpr auto in0_args = TensorAccessorArgs<0>();
-    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
+    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < num_blocks; b++) {
         // Operand 0

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in1_mcast_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in1_mcast_sender.cpp
@@ -52,16 +52,16 @@ void kernel_main() {
     constexpr uint32_t num_used_dram_ch_pow2_exponent = 3;
     constexpr uint32_t tile_size_pow2_exponent = 11;
 
-    constexpr auto in0_args = TensorAccessorArgs<0>();
-    constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
-    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
-
-    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
-
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
 
     uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
+
+    constexpr auto in0_args = TensorAccessorArgs<0>();
+    constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
+    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr, single_tile_size_bytes);
+
+    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, single_tile_size_bytes);
 
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Several `reader_matmul_tile_layout_*` dataflow test kernels still constructed `TensorAccessor` objects with only the accessor args and tensor address, which leaves the accessor relying on an implicit/default page size instead of the tile size used by the CB being read. That can generate incorrect DRAM/L1 addresses for these matmul integration kernels once the accessor path requires an explicit page size. This change passes `single_tile_size_bytes` from `get_tile_size(cb_id_in0)` into each input tensor accessor, moving that query earlier in the one kernel that needed the value before accessor construction. This keeps the sender/receiver matmul test kernels using the same explicit tile-size contract as the rest of the TensorAccessor-based test kernels.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/matmul-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/matmul-tile-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/matmul-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/matmul-tile-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/matmul-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/matmul-tile-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/matmul-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/matmul-tile-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/matmul-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/matmul-tile-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/matmul-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/matmul-tile-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/matmul-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/matmul-tile-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/matmul-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/matmul-tile-size)