### PR TITLE
Update per-core allocation tensor spec test expectation

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
@@ -181,8 +181,8 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
     auto dest_spec = TensorSpec(
         shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), dest_memory, Alignment({32, 32})));
 
-    // Spec equality ignores per_core, but exact-spec predicate must not early-out.
-    EXPECT_TRUE(source.tensor_spec() == dest_spec);
+    // Spec equality must include per_core_allocation because it changes allocator semantics.
+    EXPECT_FALSE(source.tensor_spec() == dest_spec);
     EXPECT_FALSE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(source.tensor_spec(), dest_spec));
 
     auto result = host_tensor_to_tensor_spec_with_pad_value<float>(source, dest_spec, /*pad_value=*/77.f);


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`HostTensorToTensorSpec.PerCoreOnlyMismatchFullRewrite` was failing because the test still expected two `TensorSpec`s that differ only in `per_core_allocation` to compare equal. That assumption is now stale: `per_core_allocation` changes allocator semantics, so `MemoryConfig` equality correctly treats it as part of the spec. This change updates the setup assertion and comment to expect the source and destination specs to compare unequal before the rewrite, while still verifying that `host_tensor_to_tensor_spec_with_pad_value` produces a result matching the destination spec and preserves the logical data. The targeted gtest now passes after rebuilding `unit_tests_tensor`.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/tensor-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/tensor-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/tensor-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/tensor-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/tensor-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/tensor-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/tensor-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/tensor-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/tensor-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/tensor-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/tensor-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/tensor-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/tensor-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/tensor-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/tensor-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/tensor-core-allocation)