### PR TITLE
Make dfb_init_timing_bench skip unsupported configurations cleanly

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
@@ -1358,6 +1358,22 @@ void print_usage(const char* argv0) {
         << "\nRequires TT_METAL_SLOW_DISPATCH_MODE=1 and TT_METAL_MEASURE_DFB_INIT_TIME=1 on Quasar.\n";
 }
 
+bool preflight_dfb_init_timing_bench() {
+    if (!std::getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+        log_info(tt::LogTest, "Skipping dfb_init_timing_bench: set TT_METAL_SLOW_DISPATCH_MODE=1 to run it");
+        return false;
+    }
+    if (MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
+        log_info(tt::LogTest, "Skipping dfb_init_timing_bench: requires Quasar");
+        return false;
+    }
+    if (!MetalContext::instance().rtoptions().get_measure_dfb_init_time_enabled()) {
+        log_info(tt::LogTest, "Skipping dfb_init_timing_bench: set TT_METAL_MEASURE_DFB_INIT_TIME=1 to run it");
+        return false;
+    }
+    return true;
+}
+
 }  // namespace tt::tt_metal
 
 int main(int argc, char** argv) {
@@ -1391,6 +1407,10 @@ int main(int argc, char** argv) {
         // {"six-debug-implicit-sync", run_benchmark_case_six_debug_implicit_sync},
         // {"six-debug-implicit-sync-program-spec", run_benchmark_case_six_debug_implicit_sync_program_spec},
     };
+
+    if (!preflight_dfb_init_timing_bench()) {
+        return 0;
+    }
 
     std::unordered_set<std::string> selected;
     if (case_name == "all") {


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`dfb_init_timing_bench` was aborting with `TT_FATAL` when run outside its required configuration, for example on Wormhole where the benchmark cannot run because it is Quasar-only. That made generic test-suite harnesses classify an unsupported benchmark configuration as a crashed test. This change adds a preflight in `main` for the benchmark's required conditions: slow dispatch, Quasar, and `TT_METAL_MEASURE_DFB_INIT_TIME=1`. If any precondition is not met, the benchmark logs a clear skip reason and exits successfully before creating the benchmark context. The WH simulator repro now exits `0` and reports `Skipping dfb_init_timing_bench: requires Quasar`.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/dfb-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/dfb-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/dfb-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/dfb-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/dfb-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/dfb-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/dfb-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/dfb-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/dfb-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/dfb-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/dfb-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/dfb-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/dfb-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/dfb-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/dfb-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/dfb-timing)