### PR TITLE
[Bug] Fix Wormhole NoC multicast alignment

### DIFF
--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -416,7 +416,7 @@ struct mailboxes_t {
     volatile uint32_t launch_msg_rd_ptr;  // Volatile so this can be manually reset by host. TODO: remove volatile when
                                           // dispatch init moves to one-shot.
     alignas(TT_ARCH_MAX_NOC_WRITE_ALIGNMENT) struct launch_msg_t launch[launch_msg_buffer_num_entries];
-    volatile struct go_msg_t go_messages[go_message_num_entries];
+    alignas(TT_ARCH_MAX_NOC_WRITE_ALIGNMENT) volatile struct go_msg_t go_messages[go_message_num_entries];
     uint64_t link_status_check_timestamp;  // Next timestamp to check link status (active erisc)
     volatile uint32_t go_message_index;    // Index into go_messages to use. Always 0 on unicast cores.
     volatile uint8_t shared_globals_ready[MaxNumKernels];  // WAIT/GO per processor (Quasar DM kernel startup). +4 for
@@ -430,6 +430,8 @@ struct mailboxes_t {
     alignas(TT_ARCH_MAX_NOC_WRITE_ALIGNMENT)  // CODEGEN:skip
         profiler_msg_t profiler;
 };
+
+static_assert(offsetof(mailboxes_t, go_messages) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 
 // DevicePrintMemoryLayout asserts
 static_assert(sizeof(DevicePrintMemoryLayout) == DPRINT_BUFFER_SIZE * PROCESSOR_COUNT);

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <chrono>
 #include <future>
 #include <set>
@@ -684,37 +685,35 @@ void RiscFirmwareInitializer::initialize_device_bank_to_noc_tables(
     const uint64_t mem_bank_to_noc_addr = hal_.get_dev_noc_addr(core_type, HalL1MemAddrType::BANK_TO_NOC_SCRATCH);
     const uint32_t mem_bank_to_noc_size = hal_.get_dev_size(core_type, HalL1MemAddrType::BANK_TO_NOC_SCRATCH);
 
+    const uint32_t bank_to_noc_data_size =
+        dram_to_noc_sz_in_bytes + l1_to_noc_sz_in_bytes + dram_offset_sz_in_bytes + l1_offset_sz_in_bytes;
     TT_ASSERT(
-        (dram_to_noc_sz_in_bytes + l1_to_noc_sz_in_bytes + dram_offset_sz_in_bytes + l1_offset_sz_in_bytes) <=
-            mem_bank_to_noc_size,
-        "Size of bank_to_noc table is greater than available space");
+        bank_to_noc_data_size <= mem_bank_to_noc_size, "Size of bank_to_noc table is greater than available space");
 
     if (end_core.has_value()) {
+        // The firmware consumes these tables as one tightly packed structure, but separately multicasting each table
+        // can violate Wormhole's L1-to-L1 source/destination congruence requirement. For example, the 52-byte DRAM
+        // coordinate table leaves the next destination at 4 mod 16 while UMD stages each new source at 0 mod 16.
+        // Preserve the firmware ABI and issue the packed structure as one aligned multicast.
+        std::vector<uint32_t> bank_to_noc_data(bank_to_noc_data_size / sizeof(uint32_t));
+        uint32_t offset = 0;
+        auto append_table = [&](const void* data, uint32_t size) {
+            std::memcpy(reinterpret_cast<std::byte*>(bank_to_noc_data.data()) + offset, data, size);
+            offset += size;
+        };
+        append_table(dram_noc_data, dram_to_noc_sz_in_bytes);
+        append_table(l1_noc_data, l1_to_noc_sz_in_bytes);
+        append_table(dram_bank_offset_map_[device_id].data(), dram_offset_sz_in_bytes);
+        append_table(l1_bank_offset_map_[device_id].data(), l1_offset_sz_in_bytes);
+
         auto start_core = virtual_core;
         cluster_.noc_multicast_write(
-            dram_noc_data, dram_to_noc_sz_in_bytes, device_id, start_core, end_core.value(), mem_bank_to_noc_addr);
-
-        uint64_t l1_noc_addr = mem_bank_to_noc_addr + dram_to_noc_sz_in_bytes;
-        cluster_.noc_multicast_write(
-            l1_noc_data, l1_to_noc_sz_in_bytes, device_id, start_core, end_core.value(), l1_noc_addr);
-
-        uint64_t dram_offset_addr = l1_noc_addr + l1_to_noc_sz_in_bytes;
-        cluster_.noc_multicast_write(
-            dram_bank_offset_map_[device_id].data(),
-            dram_offset_sz_in_bytes,
+            bank_to_noc_data.data(),
+            bank_to_noc_data_size,
             device_id,
             start_core,
             end_core.value(),
-            dram_offset_addr);
-
-        uint64_t l1_offset_addr = dram_offset_addr + dram_offset_sz_in_bytes;
-        cluster_.noc_multicast_write(
-            l1_bank_offset_map_[device_id].data(),
-            l1_offset_sz_in_bytes,
-            device_id,
-            start_core,
-            end_core.value(),
-            l1_offset_addr);
+            mem_bank_to_noc_addr);
     } else {
         cluster_.write_core(
             dram_noc_data, dram_to_noc_sz_in_bytes, tt_cxy_pair(device_id, virtual_core), mem_bank_to_noc_addr);
@@ -755,23 +754,25 @@ void RiscFirmwareInitializer::initialize_worker_logical_to_virtual_tables(
         (firmware_grid_size_x + logical_row_to_virtual_row_sz_in_bytes) <= logical_to_virtual_map_size,
         "Size of logical to virtual map is greater than available space");
 
-    uint64_t logical_col_to_virtual_col_addr = logical_to_virtual_map_addr;
+    // Firmware treats the column and row maps as one tightly packed structure. Multicast them together so the row map
+    // does not start a separate Wormhole NoC transaction at a potentially non-congruent address.
+    std::vector<uint8_t> logical_to_virtual_map;
+    logical_to_virtual_map.reserve(logical_col_to_virtual_col_sz_in_bytes + logical_row_to_virtual_row_sz_in_bytes);
+    logical_to_virtual_map.insert(
+        logical_to_virtual_map.end(),
+        worker_logical_col_to_virtual_col_[device_id].begin(),
+        worker_logical_col_to_virtual_col_[device_id].end());
+    logical_to_virtual_map.insert(
+        logical_to_virtual_map.end(),
+        worker_logical_row_to_virtual_row_[device_id].begin(),
+        worker_logical_row_to_virtual_row_[device_id].end());
     cluster_.noc_multicast_write(
-        worker_logical_col_to_virtual_col_[device_id].data(),
-        logical_col_to_virtual_col_sz_in_bytes,
+        logical_to_virtual_map.data(),
+        logical_to_virtual_map.size(),
         device_id,
         start_core,
         end_core,
-        logical_col_to_virtual_col_addr);
-
-    uint64_t logical_row_to_virtual_row_addr = logical_to_virtual_map_addr + (firmware_grid_size_x * sizeof(uint8_t));
-    cluster_.noc_multicast_write(
-        worker_logical_row_to_virtual_row_[device_id].data(),
-        logical_row_to_virtual_row_sz_in_bytes,
-        device_id,
-        start_core,
-        end_core,
-        logical_row_to_virtual_row_addr);
+        logical_to_virtual_map_addr);
 }
 
 uint32_t RiscFirmwareInitializer::get_active_erisc_launch_flag_addr() {
@@ -1089,6 +1090,7 @@ void RiscFirmwareInitializer::initialize_firmware(
     };
     const auto write_initial_go_launch_msg = [&]() {
         auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
+        uint32_t mailbox_addr = hal_.get_dev_addr(programmable_core_type, HalL1MemAddrType::MAILBOX);
         uint32_t launch_addr = hal_.get_dev_addr(programmable_core_type, HalL1MemAddrType::LAUNCH);
         uint32_t go_addr = hal_.get_dev_addr(programmable_core_type, HalL1MemAddrType::GO_MSG);
         uint64_t launch_msg_buffer_read_ptr_addr =
@@ -1114,9 +1116,44 @@ void RiscFirmwareInitializer::initialize_firmware(
                 launch_addr);
             cluster_.noc_multicast_write(
                 go_msg.data(), go_msg.size(), device_id, start_core, end_core.value(), go_addr);
-            uint32_t zero = 0;
+            const uint32_t l1_alignment = hal_.get_alignment(HalMemType::L1);
+            // Wormhole's remote broadcast transport emits a data block only when the destination is 32-byte aligned;
+            // otherwise it splits the transfer into independently staged words. Initialize the complete first L1
+            // block so every emitted NoC transaction remains source/destination congruent. The reset vector at zero
+            // is programmed with fw_launch_addr_value below, before reset is released.
+            const DeviceAddr mailbox_prefix_addr =
+                cluster_.arch() == ARCH::WORMHOLE_B0 ? jit_build_config.fw_launch_addr : mailbox_addr;
+            constexpr uint32_t wormhole_remote_broadcast_block_alignment = 32;
+            TT_FATAL(
+                mailbox_prefix_addr % l1_alignment == 0 && launch_addr > mailbox_prefix_addr,
+                "Mailbox prefix [0x{:x}, 0x{:x}) must begin at the architectural L1 NoC write alignment {}",
+                mailbox_prefix_addr,
+                launch_addr,
+                l1_alignment);
+            TT_FATAL(
+                cluster_.arch() != ARCH::WORMHOLE_B0 ||
+                    (mailbox_prefix_addr % wormhole_remote_broadcast_block_alignment == 0 &&
+                     (launch_addr - mailbox_prefix_addr) % wormhole_remote_broadcast_block_alignment == 0),
+                "Wormhole mailbox prefix [0x{:x}, 0x{:x}) must cover complete {}-byte remote broadcast blocks",
+                mailbox_prefix_addr,
+                launch_addr,
+                wormhole_remote_broadcast_block_alignment);
+            TT_FATAL(
+                launch_msg_buffer_read_ptr_addr >= mailbox_prefix_addr &&
+                    launch_msg_buffer_read_ptr_addr + sizeof(uint32_t) <= launch_addr,
+                "Launch message read pointer at 0x{:x} must be contained in mailbox prefix [0x{:x}, 0x{:x})",
+                launch_msg_buffer_read_ptr_addr,
+                mailbox_prefix_addr,
+                launch_addr);
+            std::vector<std::byte> zeroed_mailbox_prefix(launch_addr - mailbox_prefix_addr, std::byte{0});
             cluster_.noc_multicast_write(
-                &zero, sizeof(uint32_t), device_id, start_core, end_core.value(), launch_msg_buffer_read_ptr_addr);
+                zeroed_mailbox_prefix.data(),
+                zeroed_mailbox_prefix.size(),
+                device_id,
+                start_core,
+                end_core.value(),
+                mailbox_prefix_addr);
+            uint32_t zero = 0;
             cluster_.noc_multicast_write(
                 &zero, sizeof(uint32_t), device_id, start_core, end_core.value(), go_message_index_addr);
         }

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -3357,14 +3357,18 @@ void set_core_go_message_mapping_on_device(
     // Write done to all indices on all tensix cores. All cores should already be idle at this point, but they may have
     // garbage in the GO message entries they aren't using.
     std::vector<uint32_t> go_data(dev_msgs::go_message_num_entries, dev_msgs::RUN_MSG_DONE);
-    TT_ASSERT(
-        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG) %
-            MetalContext::instance().hal().get_alignment(HalMemType::L1) ==
-        0);
+    const auto& hal = MetalContext::instance().hal();
+    const DeviceAddr go_msg_addr = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
+    const uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
+    TT_FATAL(
+        go_msg_addr % l1_alignment == 0,
+        "GO message array address 0x{:x} must be aligned to the architectural L1 NoC write alignment {}",
+        go_msg_addr,
+        l1_alignment);
     command_sequence.add_dispatch_write_linear<true, true>(
         all_core_range_logical.size(),
         device->get_noc_multicast_encoding(noc_index, all_core_range_virtual),
-        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG),
+        go_msg_addr,
         go_msg_size,
         go_data.data());
     // Wait for previous writes before updating index.

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_eth_asserts.hpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_eth_asserts.hpp
@@ -25,6 +25,8 @@ static constexpr uint32_t ETH_PROFILER_CHECK =
     TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
 static_assert(ETH_LAUNCH_CHECK == 0);
 static_assert(ETH_PROFILER_CHECK == 0);
+static_assert((MEM_IERISC_MAILBOX_BASE + offsetof(mailboxes_t, go_messages)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+static_assert((MEM_AERISC_MAILBOX_BASE + offsetof(mailboxes_t, go_messages)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 static_assert(
     (MEM_IERISC_MAILBOX_BASE + offsetof(mailboxes_t, go_message_index)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 static_assert(

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix_asserts.hpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix_asserts.hpp
@@ -22,6 +22,7 @@ static constexpr uint32_t TENSIX_PROFILER_CHECK =
 static_assert(TENSIX_LAUNCH_CHECK == 0);
 static_assert(TENSIX_PROFILER_CHECK == 0);
 static_assert(sizeof(launch_msg_t) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+static_assert((MEM_MAILBOX_BASE + offsetof(mailboxes_t, go_messages)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 static_assert((MEM_MAILBOX_BASE + offsetof(mailboxes_t, go_message_index)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 static_assert(offsetof(subordinate_map_t, dm1) == 0);
 

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_eth_asserts.hpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_eth_asserts.hpp
@@ -28,6 +28,10 @@ static_assert(ETH_LAUNCH_CHECK == 0);
 static_assert(ETH_PROFILER_CHECK == 0);
 static_assert(MEM_IERISC_FIRMWARE_BASE % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 static_assert(
+    (eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE + offsetof(mailboxes_t, go_messages)) %
+        TT_ARCH_MAX_NOC_WRITE_ALIGNMENT ==
+    0);
+static_assert(
     (eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE + offsetof(mailboxes_t, go_message_index)) %
         TT_ARCH_MAX_NOC_WRITE_ALIGNMENT ==
     0);

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix_asserts.hpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix_asserts.hpp
@@ -28,6 +28,7 @@ static constexpr uint32_t TENSIX_PROFILER_CHECK =
 static_assert(TENSIX_LAUNCH_CHECK == 0);
 static_assert(TENSIX_PROFILER_CHECK == 0);
 static_assert(sizeof(launch_msg_t) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+static_assert((MEM_MAILBOX_BASE + offsetof(mailboxes_t, go_messages)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 static_assert((MEM_MAILBOX_BASE + offsetof(mailboxes_t, go_message_index)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 static_assert(offsetof(subordinate_map_t, dm1) == 0);
 

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_eth_asserts.hpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_eth_asserts.hpp
@@ -25,6 +25,8 @@ static constexpr uint32_t ETH_PROFILER_CHECK =
     TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
 static_assert(ETH_LAUNCH_CHECK == 0);
 static_assert(ETH_PROFILER_CHECK == 0);
+static_assert((MEM_IERISC_MAILBOX_BASE + offsetof(mailboxes_t, go_messages)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+static_assert((MEM_AERISC_MAILBOX_BASE + offsetof(mailboxes_t, go_messages)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 static_assert(MEM_IERISC_FIRMWARE_BASE % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 static_assert(MEM_AERISC_ROUTING_TABLE_BASE % 16 == 0, "Eth routing table base must be 16-byte aligned");
 static_assert(MEM_IERISC_ROUTING_TABLE_BASE % 16 == 0, "Eth routing table base must be 16-byte aligned");

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix_asserts.hpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix_asserts.hpp
@@ -21,6 +21,7 @@ static constexpr uint32_t TENSIX_PROFILER_CHECK =
     (MEM_MAILBOX_BASE + offsetof(mailboxes_t, profiler)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
 static_assert(TENSIX_LAUNCH_CHECK == 0);
 static_assert(TENSIX_PROFILER_CHECK == 0);
+static_assert((MEM_MAILBOX_BASE + offsetof(mailboxes_t, go_messages)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 static_assert(
     MaxProcessorsPerCoreType <= kernel_profiler::PROFILER_MAX_RISC_COUNT,
     "PROFILER_MAX_RISC_COUNT must be >= MaxProcessorsPerCoreType");


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
Align and validate GO message mailboxes across HAL variants. Pack firmware initialization tables and mailbox-prefix writes so remote Wormhole broadcasts retain source/destination congruence without falling back to unicast.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=micah/noc-multi)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:micah/noc-multi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=micah/noc-multi)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:micah/noc-multi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=micah/noc-multi)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:micah/noc-multi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=micah/noc-multi)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:micah/noc-multi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=micah/noc-multi)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:micah/noc-multi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=micah/noc-multi)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:micah/noc-multi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=micah/noc-multi)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:micah/noc-multi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=micah/noc-multi)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:micah/noc-multi)