### PR TITLE
Remove fixed sleeps from LLK stream polling

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/stream.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/stream.py
@@ -101,7 +101,6 @@ class Stream:
                 raise TimeoutError(
                     f"Stream: timed out after {timeout}s waiting for free space"
                 )
-            time.sleep(0.001)
 
     def _consumer_poll_avail(self) -> int:
         """Poll for number of available bytes."""
@@ -123,7 +122,6 @@ class Stream:
                 raise TimeoutError(
                     f"Stream: timed out after {timeout}s waiting for data"
                 )
-            time.sleep(0.001)
 
     def init(self) -> None:
         """Initialize the stream. Should be called only once, before all operations."""


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`test_stream_integration.py` timed out on WH ttsim for the host-to-RISC and RISC-to-host stream cases because the Python stream helper slept for 1ms after each unsuccessful poll. Device reads already provide the polling throttle, and on ttsim each read also advances simulated execution by one cycle, so the fixed sleep limited simulator progress to far too few cycles before the wall-clock timeout expired. Remove the sleeps from the producer and consumer wait loops while keeping the existing timeout checks, allowing the stream helper to poll as fast as the device access path permits. Verified on WH ttsim that all three stream integration tests pass.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/llk-stream-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/llk-stream-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-stream-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/llk-stream-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-stream-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/llk-stream-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/llk-stream-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/llk-stream-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/llk-stream-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/llk-stream-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/llk-stream-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/llk-stream-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/llk-stream-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/llk-stream-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/llk-stream-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/llk-stream-timeout)