### PR TITLE
[Cleanup] Adding `UnitMeshFixture` to modernize single-device tests

### DIFF
--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -122,11 +122,15 @@ protected:
 
     virtual size_t num_command_queues() const { return 1; }
 
-    void create_devices() {
+    virtual void create_devices() {
         std::vector<ChipId> ids;
         for (ChipId id : tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids()) {
             ids.push_back(id);
         }
+        create_devices(ids);
+    }
+
+    void create_devices(const std::vector<ChipId>& ids) {
         const auto& dispatch_core_config =
             tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
         id_to_device_ = distributed::MeshDevice::create_unit_meshes(
@@ -164,6 +168,35 @@ protected:
 };
 
 class MeshDeviceSingleCardBufferFixture : public MeshDeviceSingleCardFixture {};
+
+// Single unit-mesh fixture: always owns exactly one MeshDevice and exposes
+// RunProgram / WriteBuffer / ReadBuffer overloads that do not take a device arg.
+class UnitMeshFixture : public MeshDeviceSingleCardFixture {
+public:
+    distributed::MeshDevice& device() { return *device_; }
+
+    void RunProgram(distributed::MeshWorkload& workload, bool skip_finish = false) {
+        MeshDispatchFixture::RunProgram(device_, workload, skip_finish);
+    }
+    void FinishCommands() { MeshDispatchFixture::FinishCommands(device_); }
+    void WriteBuffer(const std::shared_ptr<distributed::MeshBuffer>& in_buffer, std::vector<uint32_t>& src_vec) {
+        MeshDispatchFixture::WriteBuffer(device_, in_buffer, src_vec);
+    }
+    void ReadBuffer(const std::shared_ptr<distributed::MeshBuffer>& out_buffer, std::vector<uint32_t>& dst_vec) {
+        MeshDispatchFixture::ReadBuffer(device_, out_buffer, dst_vec);
+    }
+
+protected:
+    void create_devices() override {
+        const ChipId mmio_device_id = *tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().begin();
+        AnyDispatchMeshDeviceSingleCardFixture::create_devices({mmio_device_id});
+        device_ = devices_.front();
+    }
+
+    std::shared_ptr<distributed::MeshDevice> device_;
+    distributed::MeshCoordinate zero_coord_ = distributed::MeshCoordinate::zero_coordinate(2);
+    distributed::MeshCoordinateRange device_range_ = distributed::MeshCoordinateRange(zero_coord_, zero_coord_);
+};
 
 class BlackholeSingleCardFixture : public MeshDeviceSingleCardFixture {
 protected:

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -175,7 +175,9 @@ class UnitMeshFixture : public MeshDeviceSingleCardFixture {
 public:
     distributed::MeshDevice& device() { return *device_; }
 
-    void RunProgram(distributed::MeshWorkload& workload, bool skip_finish = false) {
+    void RunProgram(Program program, bool skip_finish = false) {
+        distributed::MeshWorkload workload;
+        workload.add_program(distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0)), std::move(program));
         MeshDispatchFixture::RunProgram(device_, workload, skip_finish);
     }
     void FinishCommands() { MeshDispatchFixture::FinishCommands(device_); }
@@ -186,7 +188,7 @@ public:
         MeshDispatchFixture::ReadBuffer(device_, out_buffer, dst_vec);
     }
 
-protected:
+private:
     void create_devices() override {
         const ChipId mmio_device_id = *tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().begin();
         AnyDispatchMeshDeviceSingleCardFixture::create_devices({mmio_device_id});
@@ -194,8 +196,6 @@ protected:
     }
 
     std::shared_ptr<distributed::MeshDevice> device_;
-    distributed::MeshCoordinate zero_coord_ = distributed::MeshCoordinate::zero_coordinate(2);
-    distributed::MeshCoordinateRange device_range_ = distributed::MeshCoordinateRange(zero_coord_, zero_coord_);
 };
 
 class BlackholeSingleCardFixture : public MeshDeviceSingleCardFixture {

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -13,8 +13,8 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 
@@ -23,26 +23,27 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileOutputInL1) {
-    IDevice* dev = devices_[0]->get_devices()[0];
-    Program program = CreateProgram();
-
+    auto mesh_device = devices_[0];
     CoreCoord core = {0, 0};
 
     uint32_t single_tile_size = 2 * 1024;
     uint32_t num_tiles = 1;
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-    InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
-    InterleavedBufferConfig l1_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::L1};
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::DeviceLocalBufferConfig l1_config{.page_size = dram_buffer_size, .buffer_type = BufferType::L1};
+    distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_size};
 
-    auto src0_dram_buffer = CreateBuffer(dram_config);
-    auto src1_dram_buffer = CreateBuffer(dram_config);
-    auto dst_l1_buffer = CreateBuffer(l1_config);
+    auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
+    auto src1_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
+    auto dst_l1_buffer = distributed::MeshBuffer::create(buffer_config, l1_config, mesh_device.get());
 
-    auto l1_dst_noc_xy = dev->virtual_core_from_logical_core(
-        dst_l1_buffer->allocator()->get_logical_core_from_bank_id(0), CoreType::WORKER);
+    auto l1_dst_noc_xy = mesh_device->virtual_core_from_logical_core(
+        mesh_device->allocator()->get_logical_core_from_bank_id(0), CoreType::WORKER);
+
+    distributed::MeshWorkload workload;
+    auto device_range = distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0));
+    Program program = CreateProgram();
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 1;
@@ -91,12 +92,12 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileOutputInL1) {
     auto activations_tile_layout =
         convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(tensor.get_values()));
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-    detail::WriteToBuffer(src0_dram_buffer, activations);
+    this->WriteBuffer(mesh_device, src0_dram_buffer, activations);
 
     auto identity = create_identity_matrix(32, 32, 32);
     auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-    detail::WriteToBuffer(src1_dram_buffer, weights);
+    this->WriteBuffer(mesh_device, src1_dram_buffer, weights);
 
     SetRuntimeArgs(
         program,
@@ -118,10 +119,11 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileOutputInL1) {
         core,
         {dst_l1_buffer->address(), (std::uint32_t)l1_dst_noc_xy.x, (std::uint32_t)l1_dst_noc_xy.y, num_tiles});
 
-    detail::LaunchProgram(dev, program);
+    workload.add_program(device_range, std::move(program));
+    this->RunProgram(mesh_device, workload);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_l1_buffer, result_vec);
+    this->ReadBuffer(mesh_device, dst_l1_buffer, result_vec);
 
     // Validation
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -40,7 +40,6 @@ TEST_F(UnitMeshFixture, MatmulSingleTileOutputInL1) {
     auto l1_dst_noc_xy = this->device().virtual_core_from_logical_core(
         this->device().allocator()->get_logical_core_from_bank_id(0), CoreType::WORKER);
 
-    distributed::MeshWorkload workload;
     Program program = CreateProgram();
 
     uint32_t src0_cb_index = 0;
@@ -117,8 +116,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileOutputInL1) {
         core,
         {dst_l1_buffer->address(), (std::uint32_t)l1_dst_noc_xy.x, (std::uint32_t)l1_dst_noc_xy.y, num_tiles});
 
-    workload.add_program(device_range_, std::move(program));
-    this->RunProgram(workload);
+    this->RunProgram(std::move(program));
 
     std::vector<uint32_t> result_vec;
     this->ReadBuffer(dst_l1_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -14,7 +14,6 @@
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
-#include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -22,8 +22,7 @@ using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
-TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileOutputInL1) {
-    auto mesh_device = devices_[0];
+TEST_F(UnitMeshFixture, MatmulSingleTileOutputInL1) {
     CoreCoord core = {0, 0};
 
     uint32_t single_tile_size = 2 * 1024;
@@ -34,15 +33,14 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileOutputInL1) {
     distributed::DeviceLocalBufferConfig l1_config{.page_size = dram_buffer_size, .buffer_type = BufferType::L1};
     distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_size};
 
-    auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
-    auto src1_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
-    auto dst_l1_buffer = distributed::MeshBuffer::create(buffer_config, l1_config, mesh_device.get());
+    auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto src1_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto dst_l1_buffer = distributed::MeshBuffer::create(buffer_config, l1_config, &this->device());
 
-    auto l1_dst_noc_xy = mesh_device->virtual_core_from_logical_core(
-        mesh_device->allocator()->get_logical_core_from_bank_id(0), CoreType::WORKER);
+    auto l1_dst_noc_xy = this->device().virtual_core_from_logical_core(
+        this->device().allocator()->get_logical_core_from_bank_id(0), CoreType::WORKER);
 
     distributed::MeshWorkload workload;
-    auto device_range = distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0));
     Program program = CreateProgram();
 
     uint32_t src0_cb_index = 0;
@@ -92,12 +90,12 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileOutputInL1) {
     auto activations_tile_layout =
         convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(tensor.get_values()));
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-    this->WriteBuffer(mesh_device, src0_dram_buffer, activations);
+    this->WriteBuffer(src0_dram_buffer, activations);
 
     auto identity = create_identity_matrix(32, 32, 32);
     auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-    this->WriteBuffer(mesh_device, src1_dram_buffer, weights);
+    this->WriteBuffer(src1_dram_buffer, weights);
 
     SetRuntimeArgs(
         program,
@@ -119,11 +117,11 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileOutputInL1) {
         core,
         {dst_l1_buffer->address(), (std::uint32_t)l1_dst_noc_xy.x, (std::uint32_t)l1_dst_noc_xy.y, num_tiles});
 
-    workload.add_program(device_range, std::move(program));
-    this->RunProgram(mesh_device, workload);
+    workload.add_program(device_range_, std::move(program));
+    this->RunProgram(workload);
 
     std::vector<uint32_t> result_vec;
-    this->ReadBuffer(mesh_device, dst_l1_buffer, result_vec);
+    this->ReadBuffer(dst_l1_buffer, result_vec);
 
     // Validation
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

This PR provides a pattern for removing legacy `IDevice` and `Buffer` usage in tests on the example of test_matmul_single_tile_output_in_l1.

Single-device tests can use new `UnitMeshFixture` and its methods to run programs and do read/write on a unit `MeshBuffer` instead of `Buffer`.

`MeshBuffer::create` can be used to create buffers instead of `CreateBuffer`, and there's no need for the complex device access `devices_[0]->get_devices()[0]`.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=obacherikov-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:obacherikov-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-unit-mesh-fixture)