### PR TITLE
Fix LLK xdist artifact cleanup race

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -599,8 +599,13 @@ class TestConfig:
             )
             golden_generators_module.get_golden_generator = get_golden_proxied
 
-        # Always have a fresh build when compiling
-        if TestConfig.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]:
+        # Always have a fresh build when compiling. Under xdist, only the
+        # controller may remove the shared artifact tree; workers can already
+        # be compiling variants under it.
+        if (
+            TestConfig.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]
+            and worker_id == "master"
+        ):
             shutil.rmtree(TestConfig.ARTEFACTS_DIR.absolute(), ignore_errors=True)
 
     # === Instance fields and methods ===


### PR DESCRIPTION
### PR Category
Test Only

### Summary
LLK simulator CI could fail under `pytest -n 4 --dist=loadfile` with linker errors such as `collect2: error: ld returned 1 exit status` and missing output ELF paths like `sources/fused_tests/pack_sfpu.cpp/<hash>/elf/unpack.elf`. Each xdist worker was running the normal compile-mode setup and deleting the shared LLK artifact root, so one worker could remove `/tmp/tt-llk-build` while another worker was already compiling a variant beneath it. Restrict artifact-root cleanup to the xdist controller process and let workers only recreate/use the directories, preserving the fresh-build behavior for a test run while preventing workers from deleting each other's in-progress build outputs. Verified on WH ttsim with repeated `-n 4 --dist=loadfile` runs of the tiny/non-tiny restore pair and the fused `pack_sfpu` case.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/llk-xdist-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/llk-xdist-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-xdist-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/llk-xdist-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-xdist-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/llk-xdist-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/llk-xdist-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/llk-xdist-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/llk-xdist-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/llk-xdist-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/llk-xdist-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/llk-xdist-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/llk-xdist-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/llk-xdist-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/llk-xdist-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/llk-xdist-race)