### PR TITLE
Limit LLK tilize polluter negative controls to same-format cases

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_matmul.py
@@ -33,6 +33,7 @@ The `do_restore` toggle makes this a controlled experiment:
 
 from dataclasses import dataclass
 
+import pytest
 import torch
 from conftest import skip_for_blackhole
 from helpers.format_config import DataFormat
@@ -102,6 +103,9 @@ def test_tilize_polluter_matmul(
     polluter_face_r_dim,
     do_restore,
 ):
+    if not do_restore and formats.input_format != formats.output_format:
+        pytest.skip("negative control requires matching input/output formats")
+
     torch_format = format_dict[formats.output_format]
     mm_dimensions = [32, 32]
 


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`test_tilize_polluter_matmul.py` could fail on WH ttsim in `do_restore=False` cross-format variants with simulator errors such as invalid FP16 operand interpretation, rather than the intended negative-control result mismatch. The negative-control path deliberately leaves unpacker state poisoned to prove that the restore path is load-bearing, but cross-format cases can turn that poisoned state into non-contractual operand decoding instead of a meaningful corruption check. Keep the full positive `do_restore=True` matrix intact and run the negative-control cases only when input and output formats match, preserving coverage across format, `dest_acc`, math fidelity, and polluter geometry while avoiding invalid cross-format negative controls. Verified on WH ttsim with `test_tilize_polluter_matmul.py`: `288 passed, 144 skipped`.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/llk-poisoned-negative)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/llk-poisoned-negative)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-poisoned-negative)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/llk-poisoned-negative)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-poisoned-negative)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/llk-poisoned-negative)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/llk-poisoned-negative)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/llk-poisoned-negative)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/llk-poisoned-negative)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/llk-poisoned-negative)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/llk-poisoned-negative)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/llk-poisoned-negative)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/llk-poisoned-negative)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/llk-poisoned-negative)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/llk-poisoned-negative)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/llk-poisoned-negative)