### PR TITLE
[Bug fix] Stride the dispatcher's paged write bank walk by the aligned page size

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1391,7 +1391,17 @@ INSTANTIATE_TEST_SUITE_P(
         // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (L1)
         PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
         // Testcase: 100 pages x 8192 bytes (high BW) (DRAM)
-        PagedWriteParams{8192, 100, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
+        PagedWriteParams{8192, 100, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        // Testcase: 40 pages x 4112 bytes (DRAM). A page occupies a whole allocation-aligned slot in its bank, so the
+        // in-bank stride between rows of pages is the page size rounded up to that alignment. 4112 is not a multiple
+        // of either DRAM alignment -- 32 B on Wormhole, 64 B on Blackhole -- so the stride differs from the page size
+        // on both, and being larger than a 4 KB dispatch buffer page it also splits across the data the dispatcher has
+        // available, which reaches the row advance on the split-page path as well as the whole-page one. 40 pages
+        // wraps the bank cycle at least three times on either arch.
+        PagedWriteParams{4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        // Testcase: 40 pages x 4112 bytes (L1). The control for the case above: L1 is 16 B aligned, so the same page
+        // size strides by itself and only the DRAM case can tell the two strides apart.
+        PagedWriteParams{4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false}),
     [](const testing::TestParamInfo<PagedWriteParams>& info) {
         std::stringstream ss;
         ss << "page_size" << info.param.page_size << "_np" << info.param.num_pages << "_iter"
@@ -1557,7 +1567,10 @@ INSTANTIATE_TEST_SUITE_P(
         PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         PagedWriteParams{4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
-        PagedWriteParams{8192, 100, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
+        PagedWriteParams{8192, 100, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        // Page size that is not a multiple of either DRAM alignment, so the in-bank row stride differs from it; see
+        // the FD instantiation above.
+        PagedWriteParams{4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
     [](const testing::TestParamInfo<PagedWriteParams>& info) {
         return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
                std::to_string(info.param.num_iterations) + "iter_" + (info.param.is_dram ? "dram" : "l1");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -70,6 +70,11 @@ struct LinearWriteParams {
     bool is_mcast{};  // Whether to use multicast or unicast
 };
 
+// How the paged write test reads PagedWriteParams::page_size. Random draws a size per run with
+// page_size as the ceiling, so those cases sweep sizes across runs; Exact emits page_size itself,
+// for cases that cover a property of one particular size.
+enum class PageSizeMode : uint8_t { Random, Exact };
+
 // Params that control the data volume, iteration count, and DRAM/L1
 // for the paged write test
 struct PagedWriteParams {
@@ -77,7 +82,8 @@ struct PagedWriteParams {
     uint32_t num_pages{};       // Number of pages
     uint32_t num_iterations{};  // Number of iterations for the test
     uint32_t dram_data_size_words{};
-    bool is_dram{};  // Whether to use DRAM or L1
+    bool is_dram{};                                      // Whether to use DRAM or L1
+    PageSizeMode page_size_mode = PageSizeMode::Random;  // Whether page_size is a ceiling or the size to emit
 };
 
 // Params that control the data volume, iteration count
@@ -350,6 +356,7 @@ class DispatchPagedWriteTestFixture : public BaseDispatchTestFixture,
     uint32_t num_iterations_{};
     uint32_t dram_data_size_words_{};
     bool is_dram_{};
+    PageSizeMode page_size_mode_ = PageSizeMode::Random;
 
     // Get the logical core for this bank
     CoreCoord get_bank_core(uint32_t bank_id) const {
@@ -372,6 +379,7 @@ protected:
         num_iterations_ = p.num_iterations;
         dram_data_size_words_ = p.dram_data_size_words;
         is_dram_ = p.is_dram;
+        page_size_mode_ = p.page_size_mode;
     }
 
 public:
@@ -393,6 +401,16 @@ public:
         // This vector stores commands related information for each iteration
         std::vector<HostMemDeviceCommand> commands_per_iteration;
         const uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
+
+        // A whole page has to fit in one command for the chunk loop below to make progress. Random
+        // page sizes are bounded by MAX_XFER_SIZE_16B; a PageSizeMode::Exact case is bounded only by
+        // what it asks for.
+        TT_FATAL(
+            page_size_bytes <= max_payload_per_cmd_bytes,
+            "Paged write page size of {} B exceeds the {} B payload one command can carry; lower the page size or "
+            "raise the fetch size",
+            page_size_bytes,
+            max_payload_per_cmd_bytes);
 
         uint32_t remaining_pages = num_pages_;
         uint32_t absolute_start_page = 0;
@@ -460,6 +478,7 @@ public:
     }
 
     uint32_t get_page_size() const { return page_size_; }
+    PageSizeMode get_page_size_mode() const { return page_size_mode_; }
     uint32_t get_num_pages() const { return num_pages_; }
     uint32_t get_num_iterations() const { return num_iterations_; }
     uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
@@ -486,9 +505,11 @@ public:
         const uint32_t num_banks = device_->allocator_impl()->get_num_banks(buf_type);
         const tt::CoreType core_type = is_dram ? tt::CoreType::DRAM : tt::CoreType::WORKER;
 
-        uint32_t max_allowed = MAX_XFER_SIZE_16B - 1;
-        uint32_t page_size_bytes =
-            payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, page_size_bytes_param);
+        const uint32_t max_allowed = MAX_XFER_SIZE_16B - 1;
+        const uint32_t page_size_bytes =
+            get_page_size_mode() == PageSizeMode::Exact
+                ? page_size_bytes_param
+                : payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, page_size_bytes_param);
 
         DeviceCommandCalculator cmd_calc;
         cmd_calc.add_dispatch_write_paged<inline_data_>(page_size_bytes, 0);
@@ -497,7 +518,7 @@ public:
 
         log_info(
             tt::LogTest,
-            "Paged Write test to {} - random page_size: {} bytes, num_pages_per_cmd: {}, iterations: {}",
+            "Paged Write test to {} - page_size: {} bytes, num_pages_per_cmd: {}, iterations: {}",
             is_dram ? "DRAM" : "L1",
             page_size_bytes,
             num_pages_per_cmd,
@@ -1384,8 +1405,10 @@ INSTANTIATE_TEST_SUITE_P(
         PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         // Testcase: 128 pages x 2048 bytes (L1)
         PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
-        // Testcase: 10 pages x 4128 bytes (not 4K-aligned) (DRAM)
-        PagedWriteParams{4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        // Testcase: 10 pages x 4128 bytes (not 4K-aligned) (DRAM). Exact: a smaller drawn size would be 4K-aligned or
+        // no longer straddle a dispatch buffer page, either of which drops the property being covered.
+        PagedWriteParams{
+            4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true, PageSizeMode::Exact},
         // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (DRAM)
         PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (L1)
@@ -1397,11 +1420,15 @@ INSTANTIATE_TEST_SUITE_P(
         // of either DRAM alignment -- 32 B on Wormhole, 64 B on Blackhole -- so the stride differs from the page size
         // on both, and being larger than a 4 KB dispatch buffer page it also splits across the data the dispatcher has
         // available, which reaches the row advance on the split-page path as well as the whole-page one. 40 pages
-        // wraps the bank cycle at least three times on either arch.
-        PagedWriteParams{4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        // wraps the bank cycle at least three times on either arch. Exact, since every one of those properties is a
+        // property of 4112 specifically.
+        PagedWriteParams{
+            4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true, PageSizeMode::Exact},
         // Testcase: 40 pages x 4112 bytes (L1). The control for the case above: L1 is 16 B aligned, so the same page
-        // size strides by itself and only the DRAM case can tell the two strides apart.
-        PagedWriteParams{4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false}),
+        // size strides by itself and only the DRAM case can tell the two strides apart. Exact for the same reason, and
+        // so the two cases are guaranteed to run the same page size.
+        PagedWriteParams{
+            4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false, PageSizeMode::Exact}),
     [](const testing::TestParamInfo<PagedWriteParams>& info) {
         std::stringstream ss;
         ss << "page_size" << info.param.page_size << "_np" << info.param.num_pages << "_iter"
@@ -1479,7 +1506,8 @@ INSTANTIATE_TEST_SUITE_P(
         // Testcase: 128 pages x 2048 bytes (L1)
         PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
         // Testcase: 10 pages x 4128 bytes (not 4K-aligned) (DRAM)
-        PagedWriteParams{4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{
+            4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true, PageSizeMode::Exact},
         // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (DRAM)
         PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (L1)
@@ -1565,12 +1593,14 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
-        PagedWriteParams{4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{
+            4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true, PageSizeMode::Exact},
         PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         PagedWriteParams{8192, 100, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         // Page size that is not a multiple of either DRAM alignment, so the in-bank row stride differs from it; see
         // the FD instantiation above.
-        PagedWriteParams{4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
+        PagedWriteParams{
+            4112, 40, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true, PageSizeMode::Exact}),
     [](const testing::TestParamInfo<PagedWriteParams>& info) {
         return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
                std::to_string(info.param.num_iterations) + "iter_" + (info.param.is_dram ? "dram" : "l1");

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -617,10 +617,17 @@ __attribute__((noinline)) void process_write_paged() {
     // Interleaved pages round-robin the banks, so walking them in page order steps the bank index by one and only
     // advances the in-bank offset when it wraps. TensorAccessor::get_noc_addr instead recovers both from the page id
     // every page, at the cost of two magic-multiply divisions by the bank count.
+    //
+    // A page occupies a whole allocator-aligned slot in its bank, so the row stride is the page size rounded up to
+    // that alignment, not the page size itself. The two differ only for a command whose page size is not already
+    // aligned, which no buffer write generates -- EnqueueWriteBuffer sends the aligned page size -- but the command
+    // permits, and test_dispatcher sends.
     constexpr uint32_t num_banks = is_dram ? NUM_DRAM_BANKS : NUM_L1_BANKS;
+    const uint32_t aligned_page_size =
+        align_power_of_2(page_size, interleaved_addr_gen::get_allocator_alignment<is_dram>());
     uint32_t walk_row = interleaved_addr_gen::get_bank_offset_index<is_dram>(page_id);
     uint32_t walk_bank = interleaved_addr_gen::get_bank_index<is_dram>(page_id, walk_row);
-    uint32_t walk_row_addr = base_addr + walk_row * page_size;
+    uint32_t walk_row_addr = base_addr + walk_row * aligned_page_size;
 
     // DPRINT("process_write_paged - pages: {} page_size: {} dispatch_cb_page_size: {}\n", pages, page_size,
     // dispatch_cb_page_size);
@@ -651,7 +658,7 @@ __attribute__((noinline)) void process_write_paged() {
                 page_id++;
                 if (++walk_bank == num_banks) {
                     walk_bank = 0;
-                    walk_row_addr += page_size;
+                    walk_row_addr += aligned_page_size;
                 }
                 data_ptr += page_size;
                 write_length -= page_size;
@@ -682,7 +689,7 @@ __attribute__((noinline)) void process_write_paged() {
             dst_addr_offset = 0;
             if (++walk_bank == num_banks) {
                 walk_bank = 0;
-                walk_row_addr += page_size;
+                walk_row_addr += aligned_page_size;
             }
         }
 


### PR DESCRIPTION
### PR Category

Bug fix.

### Summary

Closes #52165 (Blackhole) and #52166 (Wormhole) — one bug, reported once per arch. `test_dispatcher`'s `DispatchPagedWriteTestFixture.PagedWrite` DRAM cases have failed validation in `runtime_fd2` on both since 2026-08-04. A regression from #51812, which replaced `TensorAccessor::get_noc_addr` in `process_write_paged` with a hand-rolled walk of the bank cycle.

A page occupies a whole allocator-aligned slot in its bank, so the in-bank stride between rows is the page size rounded up to that alignment. The walk strode by the raw page size, so for a command whose page size is not already aligned, every row after the first landed short. `InterleavedAddrGen` — behind the accessor the walk replaced — keeps an `aligned_page_size` for exactly this, so the walk was the only thing in the write path reading the layout differently.

The fix is to stride by `align_power_of_2(page_size, allocator_alignment)`. It costs nothing: the multiply is once per command, outside the loop, and the in-loop increment is the same instruction on a different register.

That explains which cases fail. DRAM alignment is 32 B on Wormhole and 64 B on Blackhole; L1 is 16 B on both:

| page size | WH DRAM (32 B) | BH DRAM (64 B) | L1 (16 B) |
|---|---|---|---|
| 16 | unaligned → **fail** | unaligned → **fail** | aligned → pass |
| 4128 | 4128 % 32 = 0 → pass | 4128 % 64 = 32 → **fail** | aligned → pass |

Two failures on Wormhole, three on Blackhole, and no L1 failures — which is what both issues report.

The second commit adds the coverage that was missing rather than the coverage that already caught this. Every case that failed writes each page in one whole-page transfer; the split-page path advances the row too, and nothing reached it with a stride that differs from the page size, since 4128 B is unaligned only against Blackhole and everything above it is a multiple of both alignments. The new case is 40 pages of 4112 B, a multiple of neither alignment and larger than a 4 KB dispatch buffer page, so it splits across the data the dispatcher has available, wraps the bank cycle at least three times on either arch, and spans more than one command so a chunk starts part way into a bank row. Its L1 twin pins the same page size where the two strides agree. Both fail on the old stride and pass on the new one, in fast dispatch and in slow dispatch.

### Notes for reviewers

**How it escaped.** No buffer write reaches this: `EnqueueWriteBuffer` sends the aligned page size, so #51812's watcher-enabled verification — the `UnitMeshCQSingleCard*BufferFixture*` suite, which compiles in an `ASSERT` comparing every computed address against `addr_gen.get_noc_addr` — never saw a page size the two disagreed on. `test_dispatcher` does send such page sizes, but CI does not run it under watcher, so the assert was compiled out and the escape arrived as a data mismatch instead of an assert. The assert is not blind to this: restoring the old stride and running `page_size16_np13_iter1_DRAM` with `TT_METAL_WATCHER=1` trips it at `cq_dispatch.cpp:700`.

Worth considering separately: running `test_dispatcher` under watcher in one CI leg would have turned this into an assert at the offending page rather than a hex diff. The paged *read* path had the same defect, unmerged, in #51793 — fixed there, and it had no unaligned-page case at all, since `test_prefetcher` only ever sends 1024 B pages.

**Verification** on a p150b (Blackhole), with `TT_METAL_WATCHER=1` so the address comparison is compiled in:

- `test_dispatcher --gtest_filter='-*SlowDispatch*'` — the failing CI command — 20 passed / 18 skipped (Quasar simulator) / 0 failed. The three cases in the issues pass; before the fix they fail exactly as reported.
- `TT_METAL_SLOW_DISPATCH_MODE=1 test_dispatcher --gtest_filter='SlowDispatch/DispatchPagedWriteSDTestFixture*'` — 6/6.
- `unit_tests_dispatch --gtest_filter='UnitMeshCQSingleCard*BufferFixture*'` — 58/58, confirming the aligned path is unchanged.

The mismatch dump identifies the stride directly: the value expected at word 64 (byte 256, row 4 at a 64 B stride) was found at word 16 (byte 64 = 4 × 16), the raw-page-size stride.

Wormhole is not measured here — no n150 on hand — but the stride is arch-independent and only the alignment constant differs.

Unrelated to this change, found while verifying: `test_prefetcher`'s `RandomTestFixture.RandomTest` trips the NoC sanitizer with a zero-length dispatcher write under `TT_METAL_WATCHER=1`, seed-dependently, on pristine `main` as well. Not filed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fix-paged-write-row-stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fix-paged-write-row-stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/fix-paged-write-row-stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/fix-paged-write-row-stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/fix-paged-write-row-stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/fix-paged-write-row-stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-paged-write-row-stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-paged-write-row-stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/fix-paged-write-row-stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/fix-paged-write-row-stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fix-paged-write-row-stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fix-paged-write-row-stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fix-paged-write-row-stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fix-paged-write-row-stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fix-paged-write-row-stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fix-paged-write-row-stride)