### PR TITLE
[Cleanup] Migrate copy row-major kernels to Device 2.0 data-movement API

### DIFF
--- a/ttnn/cpp/ttnn/kernel/dataflow/reader_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/reader_unary_stick_layout_interleaved_start_id.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -16,6 +19,9 @@ void kernel_main() {
 
     const auto s0 = TensorAccessor(src0_args, src_addr);
 
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_sticks;
     for (uint32_t i = start_id; i != end_id; --i) {
@@ -23,11 +29,9 @@ void kernel_main() {
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
 #endif
-        cb_reserve_back(cb_id_in0, 1);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        uint64_t src_noc_addr = s0.get_noc_addr(i);
-        noc_async_read(src_noc_addr, l1_write_addr, stick_size);
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, 1);
+        cb_in0.reserve_back(1);
+        noc.async_read(s0, cb_in0, stick_size, {.page_id = i, .offset_bytes = 0}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in0.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_same_memory_config_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_same_memory_config_program_factory.cpp
@@ -16,8 +16,6 @@
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/work_split.hpp>
 
-#include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
-
 namespace ttnn::prim {
 
 using namespace tt::constants;
@@ -59,10 +57,8 @@ ProgramDescriptor CopyDeviceOperation::SameMemoryConfig::create_descriptor(
 
     const bool tilized = output.layout() == Layout::TILE;
     const bool sharded = input.memory_config().memory_layout() != TensorMemoryLayout::INTERLEAVED;
-    // The tilized reader/writer kernels use the unified TensorAccessor, which addresses both
-    // interleaved and sharded tensors, so they no longer need the ShardedAddrGen path. The
-    // row-major (stick) kernels still rely on ShardedAddrGen for sharded tensors.
-    const bool use_sharded_addrgen = sharded && !tilized;
+    // Both the tilized and the row-major (stick) reader/writer kernels use the unified
+    // TensorAccessor, which addresses interleaved and sharded tensors transparently.
     const tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(input.dtype());
     uint32_t input_unit_size =
         tilized ? tt::tile_size(input_cb_data_format) : input.padded_shape()[-1] * input.element_size();
@@ -135,14 +131,8 @@ ProgramDescriptor CopyDeviceOperation::SameMemoryConfig::create_descriptor(
         writer_compile_time_args = {static_cast<uint32_t>(output_cb_index), static_cast<uint32_t>(output_unit_size)};
     }
     std::map<std::string, std::string> kernel_defines;
-    if (use_sharded_addrgen) {
-        kernel_defines["SHARDED"] = "1";
-        shard_builder::extend_sharding_compile_time_args(input, writer_compile_time_args);
-        shard_builder::extend_sharding_compile_time_args(input, reader_compile_time_args);
-    } else {
-        TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
-        TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-    }
+    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
     if (backwards) {
         kernel_defines["BACKWARDS"] = "1";
     }
@@ -183,14 +173,6 @@ ProgramDescriptor CopyDeviceOperation::SameMemoryConfig::create_descriptor(
             writer_ra.push_back(dst_buffer);
             writer_ra.push_back(num_units_per_core);
             writer_ra.push_back(start_id);
-            if (use_sharded_addrgen) {
-                std::vector<uint32_t> reader_tail;
-                std::vector<uint32_t> writer_tail;
-                shard_builder::extend_sharding_run_time_args(input, reader_tail);
-                shard_builder::extend_sharding_run_time_args(input, writer_tail);
-                reader_ra.append(reader_tail);
-                writer_ra.append(writer_tail);
-            }
             reader_desc.emplace_runtime_args(core, reader_ra);
             writer_desc.emplace_runtime_args(core, writer_ra);
         } else {
@@ -206,14 +188,6 @@ ProgramDescriptor CopyDeviceOperation::SameMemoryConfig::create_descriptor(
             writer_ra.push_back(num_units_per_core);
             writer_ra.push_back(start_id);
             writer_ra.push_back(full_output_row / output_unit_size);
-            if (use_sharded_addrgen) {
-                std::vector<uint32_t> reader_tail;
-                std::vector<uint32_t> writer_tail;
-                shard_builder::extend_sharding_run_time_args(input, reader_tail);
-                shard_builder::extend_sharding_run_time_args(input, writer_tail);
-                reader_ra.append(reader_tail);
-                writer_ra.append(writer_tail);
-            }
             reader_desc.emplace_runtime_args(core, reader_ra);
             writer_desc.emplace_runtime_args(core, writer_ra);
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
@@ -25,13 +25,15 @@ void kernel_main() {
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_sticks;
     for (uint32_t i = start_id; i != end_id; --i) {
-        for (uint32_t k = num_shards - 1; k >= 0; k--) {
+        for (uint32_t k = num_shards; k > 0; --k) {
+            uint32_t shard_idx = k - 1;
 #else
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
         for (uint32_t k = 0; k < num_shards; k++) {
+            uint32_t shard_idx = k;
 #endif
-            uint32_t stick_index = i * num_shards + k;
+            uint32_t stick_index = i * num_shards + shard_idx;
             dfb_in0.reserve_back(1);
             noc.async_read(s0, dfb_in0, stick_size, {.page_id = stick_index, .offset_bytes = 0}, {.offset_bytes = 0});
             noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
@@ -4,9 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
-#include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -16,22 +16,11 @@ void kernel_main() {
     uint32_t num_shards = get_arg_val<uint32_t>(4);
 
     constexpr uint32_t dfb_id_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr auto src_args = TensorAccessorArgs<2>();
     DataflowBuffer dfb_in0(dfb_id_in0);
 
-    typedef ShardedInfo<
-        get_compile_time_arg_val(2),
-        get_compile_time_arg_val(3),
-        get_compile_time_arg_val(4),
-        get_compile_time_arg_val(5),
-        get_compile_time_arg_val(6),
-        get_compile_time_arg_val(7),
-        get_compile_time_arg_val(8)>
-        tensor_shard_info;
-
-    const auto [mapping_table, rt_increment] =
-        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(5));
-    experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = src_addr, .shard_array = mapping_table};
+    Noc noc;
+    const auto s0 = TensorAccessor(src_args, src_addr);
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_sticks;
@@ -44,10 +33,8 @@ void kernel_main() {
 #endif
             uint32_t stick_index = i * num_shards + k;
             dfb_in0.reserve_back(1);
-            uint32_t l1_write_addr = dfb_in0.get_write_ptr();
-            uint64_t src_noc_addr = s0.get_noc_addr(stick_index);
-            noc_async_read(src_noc_addr, l1_write_addr, stick_size);
-            noc_async_read_barrier();
+            noc.async_read(s0, dfb_in0, stick_size, {.page_id = stick_index, .offset_bytes = 0}, {.offset_bytes = 0});
+            noc.async_read_barrier();
             dfb_in0.push_back(1);
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
@@ -25,13 +25,15 @@ void kernel_main() {
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_sticks;
     for (uint32_t i = start_id; i != end_id; --i) {
-        for (uint32_t k = num_shards - 1; k >= 0; k--) {
+        for (uint32_t k = num_shards; k > 0; --k) {
+            uint32_t shard_idx = k - 1;
 #else
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
         for (uint32_t k = 0; k < num_shards; k++) {
+            uint32_t shard_idx = k;
 #endif
-            uint32_t stick_index = i * num_shards + k;
+            uint32_t stick_index = i * num_shards + shard_idx;
             dfb_out0.wait_front(1);
             noc.async_write(dfb_out0, s0, stick_size, {.offset_bytes = 0}, {.page_id = stick_index, .offset_bytes = 0});
             noc.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
@@ -4,9 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
-#include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -16,22 +16,11 @@ void kernel_main() {
     uint32_t num_shards = get_arg_val<uint32_t>(4);
 
     constexpr uint32_t dfb_id_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr auto dst_args = TensorAccessorArgs<2>();
     DataflowBuffer dfb_out0(dfb_id_out0);
 
-    typedef ShardedInfo<
-        get_compile_time_arg_val(2),
-        get_compile_time_arg_val(3),
-        get_compile_time_arg_val(4),
-        get_compile_time_arg_val(5),
-        get_compile_time_arg_val(6),
-        get_compile_time_arg_val(7),
-        get_compile_time_arg_val(8)>
-        tensor_shard_info;
-
-    const auto [mapping_table, rt_increment] =
-        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(5));
-    experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = dst_addr, .shard_array = mapping_table};
+    Noc noc;
+    const auto s0 = TensorAccessor(dst_args, dst_addr);
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_sticks;
@@ -44,10 +33,8 @@ void kernel_main() {
 #endif
             uint32_t stick_index = i * num_shards + k;
             dfb_out0.wait_front(1);
-            uint32_t l1_read_addr = dfb_out0.get_read_ptr();
-            uint64_t dst_noc_addr = s0.get_noc_addr(stick_index);
-            noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
-            noc_async_write_barrier();
+            noc.async_write(dfb_out0, s0, stick_size, {.offset_bytes = 0}, {.page_id = stick_index, .offset_bytes = 0});
+            noc.async_write_barrier();
             dfb_out0.pop_front(1);
         }
     }


### PR DESCRIPTION
### PR Category
Cleanup — migrate the copy row-major (stick) kernels from the legacy `ShardedAddrGen` / free-function NoC API to the Device 2.0 `TensorAccessor` / `Noc` API.

### Summary
Ports the last remaining un-ported row-major (stick-layout) kernels in `data_movement/copy/` to the Device 2.0 data-movement API.

- `reader_unary_stick_start_id.cpp` / `writer_unary_stick_start_id.cpp` (local sharded stick kernels): replace `ShardedAddrGen` with `TensorAccessor`, and raw `noc_async_*` calls with `Noc` wrapper methods.
- `reader_unary_stick_layout_interleaved_start_id.cpp` (shared interleaved stick reader): add `Noc` + `CircularBuffer` wrappers around the existing free-function calls.
- `copy_same_memory_config_program_factory.cpp`: remove the `ShardedAddrGen` host-side compile/runtime-arg paths (`shard_builder::extend_sharding_*`) and unify on `TensorAccessorArgs` for all memory configs (interleaved + sharded), since `TensorAccessor` addresses both transparently.

After this change, zero legacy NoC / `ShardedAddrGen` APIs remain anywhere under `ttnn/cpp/ttnn/operations/data_movement/copy/`.

### Notes for reviewers
- The tilized path and the other 4 local copy kernels were already on Device 2.0; this PR completes the row-major path.
- The shared interleaved stick reader is also used by other operations; its compile-time arg layout is unchanged (still `TensorAccessorArgs<2>()`), so there is no cross-op impact.
- This is the kernel-level Device 2.0 data-movement API migration only. A full Metal 2.0 host-side port (`ProgramArtifacts` / named kernel args) of the three program factories is a separate effort and out of scope for this PR.

### Test coverage
Run with `TT_METAL_LLK_ASSERTS=1` on Wormhole:
- `tests/ttnn/unit_tests/base_functionality/test_copy.py`: 542 passed, 1 skipped (FP8_E4M3 is Blackhole-only)
- `tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py`: 232 passed, 50 skipped

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/XXXXX/device2-data_movement/copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/XXXXX/device2-data_movement/copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gchoudhary/XXXXX/device2-data_movement/copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gchoudhary/XXXXX/device2-data_movement/copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/XXXXX/device2-data_movement/copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/XXXXX/device2-data_movement/copy)