### PR TITLE
Correct fast-math options

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -164,8 +164,17 @@ void JitBuildEnv::init(
 
     // Flags
     string common_flags =
-        "-std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval -ftt-no-dyninit "
-        "-flto=auto -ffast-math "
+        // Use C++17, plus some specific C++20 features we've enabled
+        "-std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval "
+        // Ban dynamic initializations, via a check we've added
+        "-ftt-no-dyninit "
+        // Rely on Link Time Optimization (removes globally unreachable code)
+        "-flto=auto "
+        // Fast math allows non-IEEE compliant optimizations ...
+        "-ffast-math "
+        // ... but we require these IEEE behaviors
+        "-fno-finite-math-only -fsigned-zeros -fno-associative-math "
+        // No exceptions or rtti emission, and no using cxa-atexit for cleanups
         "-fno-exceptions -fno-rtti -fno-use-cxa-atexit ";
 
     if (rtoptions.get_jit_analytics_enabled()) {
@@ -179,11 +188,14 @@ void JitBuildEnv::init(
     this->cflags_ = common_flags;
     this->cflags_ +=
         "-MMD "
+        // Extra warnings and make them fatal
         "-Wall -Werror "
+        // But don't die for these warnings
         "-Wno-error=deprecated-declarations "
         "-Wno-error=multistatement-macros -Wno-error=parentheses "
-        "-Wno-error=unused-but-set-variable -Wno-unused-variable "
-        "-Wno-unused-function ";
+        "-Wno-error=unused-but-set-variable "
+        // And don't detect these issues
+        "-Wno-unused-variable -Wno-unused-function ";
 
     // Defines
     this->defines_ = "";

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -452,7 +452,9 @@ class TestConfig:
         TestConfig.OPTIONS_ALL = (
             f"{debug_flag}-O3 "
             "-std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval -ftt-no-dyninit "
-            "-ffast-math -fno-exceptions -fno-rtti -fno-use-cxa-atexit "
+            "-ffast-math "
+            "-fno-finite-math-only -fsigned-zeros -fno-associative-math "
+            "-fno-exceptions -fno-rtti -fno-use-cxa-atexit "
         )
         TestConfig.WITH_COVERAGE = with_coverage
         StimuliConfig.WITH_COVERAGE = with_coverage


### PR DESCRIPTION
### PR Category
Bug Fix https://github.com/tenstorrent/tt-metal/issues/48708

### Summary
We compile with `-ffast-math`, which allows a number of non-IEEE compliant optimizations.  But, we rely on some of those behaviors (that are not guaranteed with this flag).  We got away with it because the SFPU part of the compiler didn't know better (but the SFPI library itself did know).

I implemented some optimizations that took advantage of `-ffast-math`, and lo, some tests failed.  So this patch turns back on the IEEE behaviors for some of the `-fast-math` optimizations.

* We don't want reassociation -- SFPI library relies on `(a + b) - b` not being treated as `a  + (b - b)` for instance.
* We care about the sign of zero (not sure why, but as I said tests fail, so we can't treat `a + 0.0` as `a`)
* We care about infinities and nans (so `a * 0.0` is not necessarily `0.0`)

BTW we do not care about signalling nans, and that's good because the BH & QSR MAC unit allows one to flip the signs of the inputs, and IIUC disregards the input's NaNess. And the sfpi library negates values by flipping the sign bit with the same disregard.

I do not know if this is the complete set of non-ieee `-ffast-math` behavior we have to disable.
ETA: only fixing the flags I know right now, not going on a hunt for all of them.

[*] I find caring about the sign of zero is weird in general, and here specifically because the multiply/add unit always computes `a * b + c`, with add having `b` as one and multiply having `c` as zero.  That add affects the sign of a multiply result.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/strength-49763)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/strength-49763)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/strength-49763)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/strength-49763)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nsidwell/strength-49763)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nsidwell/strength-49763)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/strength-49763)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/strength-49763)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/strength-49763)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/strength-49763)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/strength-49763)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/strength-49763)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/strength-49763)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/strength-49763)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/strength-49763)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/strength-49763)