### PR TITLE
[Bug fix] Draw the random packed write payload in whole words, and stop the clamp converging on none

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -19,6 +19,7 @@
 #include "tt_metal/impl/dispatch/command_queue_common.hpp"
 
 #include "llrt.hpp"
+#include "env_lib.hpp"
 #include <tt-metalium/tt_align.hpp>
 
 #include "llrt/hal.hpp"
@@ -908,7 +909,9 @@ inline std::vector<CQDispatchWritePackedUnicastSubCmd> build_sub_cmds(
     return sub_cmds;
 }
 
-// Clamp xfer_size to fit within max_fetch_bytes_
+// Largest transfer size no greater than xfer_size_bytes whose packed write command fits in max_fetch_bytes, or 0 if
+// even one alignment unit does not fit. A caller that gets 0 must not emit the command: a packed write of no payload
+// makes the dispatcher issue zero-length NOC writes, which the watcher NOC sanitizer stops the device for.
 inline uint32_t clamp_to_max_fetch(
     uint32_t max_fetch_bytes,
     uint32_t xfer_size_bytes,
@@ -916,32 +919,35 @@ inline uint32_t clamp_to_max_fetch(
     uint32_t packed_write_max_unicast_sub_cmds,
     bool no_stride,
     uint32_t l1_alignment) {
-    // Calculate the command size
-    DeviceCommandCalculator cmd_calc;
-    cmd_calc.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
-        num_sub_cmds,     // num_sub_cmds
-        xfer_size_bytes,  // packed_data_sizeB
-        packed_write_max_unicast_sub_cmds,
-        no_stride  // no_stride
-    );
-    uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
-
-    // If the command size is less than max_fetch_bytes_, return the transfer size
-    if (command_size_bytes <= max_fetch_bytes) {
-        return xfer_size_bytes;
-    }
-
-    // Else, linearly decrement by alignment until it fits
-    uint32_t result = xfer_size_bytes;
-    while (result > 0 && command_size_bytes > max_fetch_bytes) {
-        result -= l1_alignment;
+    // Each size gets its own calculator. DeviceCommandCalculator accumulates, so asking one calculator about a second
+    // size reports what both commands would occupy together -- the measurement then only grows as the loop below tries
+    // smaller transfers, no size ever looks like it fits, and the loop walks the transfer down to nothing.
+    const auto command_size_bytes = [&](uint32_t payload_bytes) {
+        DeviceCommandCalculator cmd_calc;
         cmd_calc.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
-            num_sub_cmds,  // num_sub_cmds
-            result,        // packed_data_sizeB
+            num_sub_cmds,   // num_sub_cmds
+            payload_bytes,  // packed_data_sizeB
             packed_write_max_unicast_sub_cmds,
             no_stride  // no_stride
         );
-        command_size_bytes = cmd_calc.write_offset_bytes();
+        return cmd_calc.write_offset_bytes();
+    };
+
+    if (command_size_bytes(xfer_size_bytes) <= max_fetch_bytes) {
+        return xfer_size_bytes;
+    }
+
+    // Else step down an alignment unit at a time until it fits. The step is taken through a helper because a transfer
+    // size that is not a multiple of the alignment would otherwise wrap past zero on its last step.
+    const auto step_down = [l1_alignment](uint32_t size) {
+        const uint32_t remainder = size % l1_alignment;
+        const uint32_t step = remainder != 0 ? remainder : l1_alignment;
+        return size > step ? size - step : 0;
+    };
+
+    uint32_t result = step_down(xfer_size_bytes);
+    while (result != 0 && command_size_bytes(result) > max_fetch_bytes) {
+        result = step_down(result);
     }
 
     return result;
@@ -1131,9 +1137,10 @@ protected:
         pgcfg.min_xfer_size_bytes = cfg_.min_xfer_size_bytes;
         pgcfg.max_xfer_size_bytes = cfg_.max_xfer_size_bytes;
 
-        // Handle Seeding
+        // Handle Seeding. TT_METAL_SEED replays a particular run: these tests generate their command streams from the
+        // seed, so a failure that only some streams provoke is only reproducible if the seed it logged can be set back.
         std::random_device rd;
-        pgcfg.seed = rd();
+        pgcfg.seed = tt::parse_env("TT_METAL_SEED", static_cast<uint32_t>(rd()));
         return pgcfg;
     }
 
@@ -1146,7 +1153,7 @@ protected:
         // Initialize Generator
         const DispatchPayloadGenerator::Config pgcfg = payload_generator_config();
         payload_generator_ = std::make_unique<DispatchPayloadGenerator>(pgcfg);
-        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
+        log_info(tt::LogTest, "Random seed set to {} (set TT_METAL_SEED to replay)", pgcfg.seed);
 
         // These are used for test logic (loops, alignment, etc.) rather than generation
         dispatch_buffer_page_size_ = cfg_.dispatch_buffer_page_size;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -19,6 +19,7 @@
 #include "tt_metal/impl/dispatch/command_queue_common.hpp"
 
 #include "llrt.hpp"
+#include "env_lib.hpp"
 #include <tt-metalium/tt_align.hpp>
 
 #include "llrt/hal.hpp"
@@ -908,7 +909,9 @@ inline std::vector<CQDispatchWritePackedUnicastSubCmd> build_sub_cmds(
     return sub_cmds;
 }
 
-// Clamp xfer_size to fit within max_fetch_bytes_
+// Largest transfer size no greater than xfer_size_bytes whose packed write command fits in max_fetch_bytes, or 0 if
+// even one alignment unit does not fit. A caller that gets 0 must not emit the command: a packed write of no payload
+// makes the dispatcher issue zero-length NOC writes, which the watcher NOC sanitizer stops the device for.
 inline uint32_t clamp_to_max_fetch(
     uint32_t max_fetch_bytes,
     uint32_t xfer_size_bytes,
@@ -916,32 +919,35 @@ inline uint32_t clamp_to_max_fetch(
     uint32_t packed_write_max_unicast_sub_cmds,
     bool no_stride,
     uint32_t l1_alignment) {
-    // Calculate the command size
-    DeviceCommandCalculator cmd_calc;
-    cmd_calc.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
-        num_sub_cmds,     // num_sub_cmds
-        xfer_size_bytes,  // packed_data_sizeB
-        packed_write_max_unicast_sub_cmds,
-        no_stride  // no_stride
-    );
-    uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
-
-    // If the command size is less than max_fetch_bytes_, return the transfer size
-    if (command_size_bytes <= max_fetch_bytes) {
-        return xfer_size_bytes;
-    }
-
-    // Else, linearly decrement by alignment until it fits
-    uint32_t result = xfer_size_bytes;
-    while (result > 0 && command_size_bytes > max_fetch_bytes) {
-        result -= l1_alignment;
+    // Each size gets its own calculator. DeviceCommandCalculator accumulates, so asking one calculator about a second
+    // size reports what both commands would occupy together -- the measurement then only grows as the loop below tries
+    // smaller transfers, no size ever looks like it fits, and the loop walks the transfer down to nothing.
+    const auto command_size_bytes = [&](uint32_t payload_bytes) {
+        DeviceCommandCalculator cmd_calc;
         cmd_calc.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
-            num_sub_cmds,  // num_sub_cmds
-            result,        // packed_data_sizeB
+            num_sub_cmds,   // num_sub_cmds
+            payload_bytes,  // packed_data_sizeB
             packed_write_max_unicast_sub_cmds,
             no_stride  // no_stride
         );
-        command_size_bytes = cmd_calc.write_offset_bytes();
+        return cmd_calc.write_offset_bytes();
+    };
+
+    if (command_size_bytes(xfer_size_bytes) <= max_fetch_bytes) {
+        return xfer_size_bytes;
+    }
+
+    // Else step down an alignment unit at a time until it fits. The step is taken through a helper because a transfer
+    // size that is not a multiple of the alignment would otherwise wrap past zero on its last step.
+    const auto step_down = [l1_alignment](uint32_t size) {
+        const uint32_t remainder = size % l1_alignment;
+        const uint32_t step = remainder != 0 ? remainder : l1_alignment;
+        return size > step ? size - step : 0;
+    };
+
+    uint32_t result = step_down(xfer_size_bytes);
+    while (result != 0 && command_size_bytes(result) > max_fetch_bytes) {
+        result = step_down(result);
     }
 
     return result;
@@ -1128,13 +1134,14 @@ protected:
         pgcfg.min_xfer_size_bytes = cfg_.min_xfer_size_bytes;
         pgcfg.max_xfer_size_bytes = cfg_.max_xfer_size_bytes;
 
-        // Handle Seeding
+        // Handle Seeding. TT_METAL_SEED replays a particular run: these tests generate their command streams from the
+        // seed, so a failure that only some streams provoke is only reproducible if the seed it logged can be set back.
         std::random_device rd;
-        pgcfg.seed = rd();
+        pgcfg.seed = tt::parse_env("TT_METAL_SEED", static_cast<uint32_t>(rd()));
 
         // Initialize Generator
         payload_generator_ = std::make_unique<DispatchPayloadGenerator>(pgcfg);
-        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
+        log_info(tt::LogTest, "Random seed set to {} (set TT_METAL_SEED to replay)", pgcfg.seed);
 
         // These are used for test logic (loops, alignment, etc.) rather than generation
         dispatch_buffer_page_size_ = cfg_.dispatch_buffer_page_size;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2474,8 +2474,16 @@ protected:
                     device_data.relevel(tt::CoreType::WORKER);
 
                     // Size and Clamp
-                    uint32_t xfer_size_bytes =
-                        payload_generator_->get_random_size(dispatch_buffer_page_size_, 1, remaining_bytes);
+                    // The payload is staged as a vector<uint32_t>, so a size that is not a whole number of words
+                    // rounds down -- and a size below one word rounds down to no payload at all, which reaches the
+                    // dispatcher as a packed write of size 0 and one zero-length NOC write per sub-command. Draw whole
+                    // words, and skip the command when less than a word is left to send.
+                    constexpr uint32_t payload_unit = sizeof(uint32_t);
+                    uint32_t xfer_size_bytes = payload_generator_->get_random_size(
+                        dispatch_buffer_page_size_ / payload_unit, payload_unit, remaining_bytes);
+                    if (xfer_size_bytes < payload_unit) {
+                        return std::nullopt;
+                    }
 
                     bool no_stride = payload_generator_->get_rand_bool();
 
@@ -2496,17 +2504,13 @@ protected:
                         packed_write_max_unicast_sub_cmds_,
                         no_stride,
                         l1_alignment_);
-                    if (xfer_size_bytes == 0) {
-                        // No payload fits alongside this many sub-commands. Emitting the command anyway would give the
-                        // dispatcher a zero-length write to issue per sub-command.
-                        return std::nullopt;
-                    }
 
                     const CoreCoord& fw = worker_cores[0];
                     // Capture address before updating device_data
                     uint32_t addr = device_data.get_result_data_addr(fw, 0);
                     // Generate Payload
                     std::vector<uint32_t> payload = payload_generator_->generate_payload_with_core(fw, xfer_size_bytes);
+                    TT_FATAL(!payload.empty(), "Generated payload size is 0, xfer_size_bytes: {}", xfer_size_bytes);
                     // Update expected device_data for all cores
                     Common::DeviceDataUpdater::update_packed_write(payload, device_data, worker_cores, l1_alignment_);
 
@@ -2640,9 +2644,9 @@ public:
         pgcfg.min_xfer_size_bytes = this->cfg_.min_xfer_size_bytes;
         pgcfg.max_xfer_size_bytes = this->cfg_.max_xfer_size_bytes;
         std::random_device rd;
-        pgcfg.seed = tt::parse_env("TT_METAL_SEED", static_cast<uint32_t>(rd()));
+        pgcfg.seed = rd();
         this->payload_generator_ = std::make_unique<Common::DispatchPayloadGenerator>(pgcfg);
-        log_info(tt::LogTest, "Random seed set to {} (set TT_METAL_SEED to replay)", pgcfg.seed);
+        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
 
         this->dispatch_buffer_page_size_ = this->cfg_.dispatch_buffer_page_size;
         this->send_to_all_ = this->cfg_.send_to_all;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2484,8 +2484,16 @@ protected:
                     device_data.relevel(tt::CoreType::WORKER);
 
                     // Size and Clamp
-                    uint32_t xfer_size_bytes =
-                        payload_generator_->get_random_size(dispatch_buffer_page_size_, 1, remaining_bytes);
+                    // The payload is staged as a vector<uint32_t>, so a size that is not a whole number of words
+                    // rounds down -- and a size below one word rounds down to no payload at all, which reaches the
+                    // dispatcher as a packed write of size 0 and one zero-length NOC write per sub-command. Draw whole
+                    // words, and skip the command when less than a word is left to send.
+                    constexpr uint32_t payload_unit = sizeof(uint32_t);
+                    uint32_t xfer_size_bytes = payload_generator_->get_random_size(
+                        dispatch_buffer_page_size_ / payload_unit, payload_unit, remaining_bytes);
+                    if (xfer_size_bytes < payload_unit) {
+                        return std::nullopt;
+                    }
 
                     bool no_stride = payload_generator_->get_rand_bool();
 
@@ -2506,17 +2514,13 @@ protected:
                         packed_write_max_unicast_sub_cmds_,
                         no_stride,
                         l1_alignment_);
-                    if (xfer_size_bytes == 0) {
-                        // No payload fits alongside this many sub-commands. Emitting the command anyway would give the
-                        // dispatcher a zero-length write to issue per sub-command.
-                        return std::nullopt;
-                    }
 
                     const CoreCoord& fw = worker_cores[0];
                     // Capture address before updating device_data
                     uint32_t addr = device_data.get_result_data_addr(fw, 0);
                     // Generate Payload
                     std::vector<uint32_t> payload = payload_generator_->generate_payload_with_core(fw, xfer_size_bytes);
+                    TT_FATAL(!payload.empty(), "Generated payload size is 0, xfer_size_bytes: {}", xfer_size_bytes);
                     // Update expected device_data for all cores
                     Common::DeviceDataUpdater::update_packed_write(payload, device_data, worker_cores, l1_alignment_);
 
@@ -2650,9 +2654,9 @@ public:
         pgcfg.min_xfer_size_bytes = this->cfg_.min_xfer_size_bytes;
         pgcfg.max_xfer_size_bytes = this->cfg_.max_xfer_size_bytes;
         std::random_device rd;
-        pgcfg.seed = tt::parse_env("TT_METAL_SEED", static_cast<uint32_t>(rd()));
+        pgcfg.seed = rd();
         this->payload_generator_ = std::make_unique<Common::DispatchPayloadGenerator>(pgcfg);
-        log_info(tt::LogTest, "Random seed set to {} (set TT_METAL_SEED to replay)", pgcfg.seed);
+        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
 
         this->dispatch_buffer_page_size_ = this->cfg_.dispatch_buffer_page_size;
         this->send_to_all_ = this->cfg_.send_to_all;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2496,6 +2496,11 @@ protected:
                         packed_write_max_unicast_sub_cmds_,
                         no_stride,
                         l1_alignment_);
+                    if (xfer_size_bytes == 0) {
+                        // No payload fits alongside this many sub-commands. Emitting the command anyway would give the
+                        // dispatcher a zero-length write to issue per sub-command.
+                        return std::nullopt;
+                    }
 
                     const CoreCoord& fw = worker_cores[0];
                     // Capture address before updating device_data
@@ -2635,9 +2640,9 @@ public:
         pgcfg.min_xfer_size_bytes = this->cfg_.min_xfer_size_bytes;
         pgcfg.max_xfer_size_bytes = this->cfg_.max_xfer_size_bytes;
         std::random_device rd;
-        pgcfg.seed = rd();
+        pgcfg.seed = tt::parse_env("TT_METAL_SEED", static_cast<uint32_t>(rd()));
         this->payload_generator_ = std::make_unique<Common::DispatchPayloadGenerator>(pgcfg);
-        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
+        log_info(tt::LogTest, "Random seed set to {} (set TT_METAL_SEED to replay)", pgcfg.seed);
 
         this->dispatch_buffer_page_size_ = this->cfg_.dispatch_buffer_page_size;
         this->send_to_all_ = this->cfg_.send_to_all;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2506,6 +2506,11 @@ protected:
                         packed_write_max_unicast_sub_cmds_,
                         no_stride,
                         l1_alignment_);
+                    if (xfer_size_bytes == 0) {
+                        // No payload fits alongside this many sub-commands. Emitting the command anyway would give the
+                        // dispatcher a zero-length write to issue per sub-command.
+                        return std::nullopt;
+                    }
 
                     const CoreCoord& fw = worker_cores[0];
                     // Capture address before updating device_data
@@ -2645,9 +2650,9 @@ public:
         pgcfg.min_xfer_size_bytes = this->cfg_.min_xfer_size_bytes;
         pgcfg.max_xfer_size_bytes = this->cfg_.max_xfer_size_bytes;
         std::random_device rd;
-        pgcfg.seed = rd();
+        pgcfg.seed = tt::parse_env("TT_METAL_SEED", static_cast<uint32_t>(rd()));
         this->payload_generator_ = std::make_unique<Common::DispatchPayloadGenerator>(pgcfg);
-        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
+        log_info(tt::LogTest, "Random seed set to {} (set TT_METAL_SEED to replay)", pgcfg.seed);
 
         this->dispatch_buffer_page_size_ = this->cfg_.dispatch_buffer_page_size;
         this->send_to_all_ = this->cfg_.send_to_all;


### PR DESCRIPTION
### PR Category

Bug fix.

### Summary

Fixes #52233 — the dispatcher intermittently issuing a zero-length NoC write, which parks the dispatch core in `while(1)` under `TT_METAL_WATCHER=1`. Three changes to the dispatch microbenchmark test utilities; the first is the cause.

**1. Draw the random packed write payload in whole words.** A packed write payload is staged as a `vector<uint32_t>` sized `xfer_size_bytes / sizeof(uint32_t)`, so a size that is not a whole number of words rounds down, and a size below one word rounds down to no payload at all. The dispatcher receives a packed write of `size == 0` and issues one zero-length NoC write per sub-command.

This is the same hole #36459 reported in January. #37233 fixed it for `test_dispatcher` by drawing in 4-byte units and left `test_prefetcher`'s draw — the only remaining byte-granular one in either file — as it was.

It is the **tail of the fill loop** that reaches it, not a 1-in-4096 draw. Because sizes here are byte-granular, `remaining_bytes` loses any alignment as the loop runs and can land on 1, 2 or 3. At that point this is the only branch that still emits anything: the paged branch needs a DRAM alignment's worth and returns `nullopt`, the linear branch already skips below a word. So the loop tends to *end* by emitting exactly the broken command — which is why it appeared roughly once in twenty runs of the suite rather than once in a thousand.

Drawing whole words also keeps `remaining_bytes` a multiple of four throughout, since every other branch consumes word- or DRAM-aligned amounts, so the `< payload_unit` guard is belt and braces. The added `TT_FATAL` mirrors the one `test_dispatcher` already carries, so a future variant becomes a host-side error rather than a hung dispatch core.

**2. `clamp_to_max_fetch` could only converge on no payload.** It measured every candidate size on a single `DeviceCommandCalculator`, which accumulates (`cmd_write_offsetB += ...`), so the second measurement reported what both commands would occupy together and every further step only grew it. No size ever looked like it fit, so the loop ran until the transfer reached zero — or, for a size that is not a multiple of `l1_alignment`, stepped past zero and wrapped. Measured on a p150b, 4 sub-commands against a 2 KB fetch limit:

| request | before | after |
|---|---|---|
| 4096 B (aligned) | **0** | 496 |
| 4095 B (not aligned) | **4238396479** | 496 |
| 100 B, 16 B (already fit) | unchanged | unchanged |

496 is maximal: its command occupies exactly the 2048 B available, and 512 does not fit. A 0 here is the same defect as (1) by another route; the loop is only reachable where the fetch limit is small — the slow-dispatch fixture takes it from `scratch_db_size()`, eth dispatch is a quarter of the worker limit — which is why the sizes these tests usually generate never entered it.

**3. The random tests could not be replayed.** Both fixtures seeded from `std::random_device` with no override, so the seed they logged was useless for reproducing a failure that only some command streams provoke — the position #52233 was in for most of this investigation. `TT_METAL_SEED` now overrides it, matching the convention in `tests/tt_metal/distributed/`.

### Notes for reviewers

The zero-length write is harmless on hardware — it moves nothing — so this is invisible without watcher and fatal with it. That matters because watcher is what compiles in the dispatcher's in-kernel address assertions, so it is the tool you reach for when debugging a dispatch data-integrity problem, and it could die on this instead.

### Verification

On a p150b:

- **Cause confirmed deterministically.** Forcing a 2 B packed payload reproduces the reported failure on the first run — same device, same core, same signature as the intermittent hits — with no instrumentation in the dispatch kernel. That forced line is not part of this change.
- With the fix, 18 consecutive packed draws were all whole words, minimum 20 B, none below a word.
- `test_prefetcher --gtest_filter='PrefetcherTests*'` — 27 passed / 2 skipped.
- `test_dispatcher --gtest_filter='-*SlowDispatch*'` — 18 passed / 18 skipped (Quasar simulator).
- Seed replay: two runs at `TT_METAL_SEED=987654321` produced byte-identical command streams (685824 B each); an unset seed produced a different stream (8384 B).
- The clamp table above came from a temporary probe calling `clamp_to_max_fetch` directly with a small fetch limit, alongside a calculator measuring the returned size and the next size up. The probe is not part of this change.

Regression soak: **30 consecutive runs** of `test_prefetcher --gtest_filter='PrefetcherTests*'` under `TT_METAL_WATCHER=1`, 0 hits, watching for both the sanitizer message and the new `TT_FATAL`. That is 120 `RandomTest` instances against a pre-fix rate of about 1 in 27 instances, so P(0 hits | unfixed) is roughly 1%. The deterministic forced repro and the fact that every draw is now a whole word by construction are the stronger evidence; the soak is the sanity check on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fix-packed-write-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fix-packed-write-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/fix-packed-write-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/fix-packed-write-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/fix-packed-write-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/fix-packed-write-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-packed-write-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-packed-write-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/fix-packed-write-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/fix-packed-write-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fix-packed-write-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fix-packed-write-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fix-packed-write-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fix-packed-write-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fix-packed-write-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fix-packed-write-clamp)