### PR TITLE
Move CCL tests from end-to-end pipelines to L2 nightly

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -91,20 +91,23 @@ ttnn:
     sim_blackhole: 680
   unit:
     wh_llmbox: 50
-    wh_galaxy: 35
+    wh_galaxy: 120
+    bh_galaxy: 40
     bh_p100: 805
     bh_p150b_civ2: 1045
     wh_n150_civ2: 1185
     wh_n300_civ2: 1175
     bh_p150b_civ2_viommu: 115
+    bh_p300: 60
+    bh_quietbox_2: 60
   e2e:
     wh_llmbox: 90
-    wh_galaxy: 120
-    bh_galaxy: 70
+    wh_galaxy: 0
+    bh_galaxy: 30
     bh_p150b_civ2: 55
-    bh_loudbox: 145
-    bh_p300: 145
-    bh_quietbox_2: 145
+    bh_loudbox: 85
+    bh_p300: 85
+    bh_quietbox_2: 85
   integration:
     wh_llmbox: 30
     wh_galaxy: 340

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -106,13 +106,10 @@ on:
         options:
           - disabled
           - all
-          - galaxy-ccl
-          - galaxy-moe
           - galaxy-fabric-unit
           - galaxy-fabric-2d-torus-nightly
           - galaxy-fabric-multi-mesh-4x4-2x4s
           - galaxy-fabric-multi-mesh-2x8-2x4s
-          - bh-galaxy-ccl
           - bh-galaxy-fabric-torus-stability
           - bh-galaxy-socket-pipeline
         default: "disabled"

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -60,6 +60,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_ccl_tests:
+        description: "Run CCL tests"
+        required: false
+        type: boolean
+        default: false
       run_triage_tests:
         description: "Run tt-triage tests"
         required: false
@@ -146,10 +151,10 @@ jobs:
           # SKU coverage spanning every L2 nightly test yaml entry.
           l2_nightly_skus=()
           if [[ "$run_wormhole" == "true" ]]; then
-            l2_nightly_skus+=("wh_n150" "wh_n300" "wh_n150_civ2" "wh_n300_civ2" "sim_wormhole_b0")
+            l2_nightly_skus+=("wh_n150" "wh_n300" "wh_n150_civ2" "wh_n300_civ2" "sim_wormhole_b0" "wh_galaxy")
           fi
           if [[ "$run_blackhole" == "true" ]]; then
-            l2_nightly_skus+=("bh_p100" "bh_p150b_civ2" "bh_p150b_civ2_viommu" "sim_blackhole")
+            l2_nightly_skus+=("bh_p100" "bh_p150b_civ2" "bh_p150b_civ2_viommu" "sim_blackhole" "bh_p300" "bh_quietbox_2" "bh_galaxy")
           fi
           l2_nightly_skus_str=$(IFS=,; echo "${l2_nightly_skus[*]}")
           echo "l2-nightly-skus=$l2_nightly_skus_str" >> $GITHUB_OUTPUT
@@ -206,7 +211,7 @@ jobs:
     needs: [build-artifact, generate-arch-matrix]
     if: |
       needs.generate-arch-matrix.outputs.l2-nightly-skus != '' && (
-        github.event_name == 'schedule' || inputs.additional_test_categories != '' || inputs.run_cpp_tests
+        github.event_name == 'schedule' || inputs.additional_test_categories != '' || inputs.run_cpp_tests || inputs.run_ccl_tests
       )
     secrets: inherit
     uses: ./.github/workflows/ops-unit-tests-impl.yaml
@@ -217,7 +222,9 @@ jobs:
       enabled-skus: ${{ needs.generate-arch-matrix.outputs.l2-nightly-skus }}
       additional_test_categories: >-
         ${{ (github.event_name == 'schedule' &&
-        'conv,matmul,fused,reduction,experimental,pool,eltwise,transformers,moreh,misc,sdpa,data_movement,docs_examples,cpp_accessor,cpp_lab_examples')
+        'conv,matmul,fused,reduction,experimental,pool,eltwise,transformers,moreh,misc,sdpa,data_movement,ccl,docs_examples,cpp_accessor,cpp_lab_examples')
+        || (inputs.run_ccl_tests && inputs.run_cpp_tests && format('{0},ccl,cpp_accessor,cpp_lab_examples', inputs.additional_test_categories))
+        || (inputs.run_ccl_tests && format('{0},ccl', inputs.additional_test_categories))
         || (inputs.run_cpp_tests && format('{0},cpp_accessor,cpp_lab_examples', inputs.additional_test_categories))
         || inputs.additional_test_categories }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -33,19 +33,6 @@
   owner_id: U0883RN6CRE # William Ly
   team: scaleout
 
-- id: bh-ccl-nightly-integration
-  name: ccl nightly tests
-  cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly
-  skus:
-    bh_loudbox:
-      timeout: 60
-    bh_p300:
-      timeout: 60
-    bh_quietbox_2:
-      timeout: 60
-  owner_id: U05ACKAJTHS # Naif Tarafdar
-  team: ttnn
-
 # --- perf ---
 - id: bh-fabric-sanity-benchmark
   name: fabric sanity benchmark

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -13,26 +13,6 @@
 # For max allowed timeout refer to .github/time_budget.yaml
 
 # Wormhole Galaxy e2e tests
-- id: galaxy-ccl
-  name: Galaxy CCL tests
-  cmd: pytest tests/nightly/tg/ccl --ignore tests/nightly/tg/ccl/moe
-  skus:
-    wh_galaxy:
-      timeout: 60
-  owner_id: U05ACKAJTHS # Naif Tarafdar
-  team: ttnn
-
-- id: galaxy-moe
-  name: Galaxy MoE tests
-  cmd: |
-    TT_MESH_GRAPH_DESC_PATH="tests/tt_metal/tt_fabric/custom_mesh_descriptors/single_galaxy_1x16_torus_graph_descriptor.textproto" pytest tests/nightly/tg/ccl/moe &&
-    TT_MESH_GRAPH_DESC_PATH="tests/tt_metal/tt_fabric/custom_mesh_descriptors/single_galaxy_1x8_torus_graph_descriptor.textproto" pytest tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
-  skus:
-    wh_galaxy:
-      timeout: 60
-  owner_id: U05ACKAJTHS # Naif Tarafdar
-  team: ttnn
-
 - id: galaxy-fabric-unit
   name: Galaxy Fabric unit tests
   cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*"
@@ -78,15 +58,6 @@
   team: scaleout
 
 # Blackhole Galaxy e2e tests
-- id: bh-galaxy-ccl
-  name: BH Galaxy CCL tests
-  cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly
-  skus:
-    bh_galaxy:
-      timeout: 40
-  owner_id: U05ACKAJTHS # Naif Tarafdar, Camilo Vega
-  team: ttnn
-
 - id: bh-galaxy-fabric-torus-stability
   name: BH Galaxy Fabric Torus Stability Tests
   cmd: ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_2d_torus_stability.yaml

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -336,6 +336,46 @@
   team: ttnn
   category: data_movement
 
+- name: ccl nightly tests
+  cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly
+  skus:
+    bh_p300:
+      timeout: 60
+    bh_quietbox_2:
+      timeout: 60
+  owner_id: U07M7QZ0BQA # Camilo Vega
+  team: ttnn
+  category: ccl
+
+- name: Galaxy CCL tests
+  cmd: pytest tests/nightly/tg/ccl --ignore tests/nightly/tg/ccl/moe
+  skus:
+    wh_galaxy:
+      timeout: 60
+  owner_id: U05ACKAJTHS # Naif Tarafdar
+  team: ttnn
+  category: ccl
+
+- name: Galaxy MoE tests
+  cmd: |
+    TT_MESH_GRAPH_DESC_PATH="tests/tt_metal/tt_fabric/custom_mesh_descriptors/single_galaxy_1x16_torus_graph_descriptor.textproto" pytest tests/nightly/tg/ccl/moe &&
+    TT_MESH_GRAPH_DESC_PATH="tests/tt_metal/tt_fabric/custom_mesh_descriptors/single_galaxy_1x8_torus_graph_descriptor.textproto" pytest tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+  skus:
+    wh_galaxy:
+      timeout: 60
+  owner_id: U05ACKAJTHS # Naif Tarafdar
+  team: ttnn
+  category: ccl
+
+- name: BH Galaxy CCL tests
+  cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly
+  skus:
+    bh_galaxy:
+      timeout: 40
+  owner_id: U07M7QZ0BQA # Camilo Vega
+  team: ttnn
+  category: ccl
+
 - name: ttnn nightly docs examples tests
   # docs_examples runs on viommu-stable SKUs.
   cmd: 'pytest tests/ttnn/docs_examples -xv -m "not disable_fast_runtime_mode" --timeout=600'


### PR DESCRIPTION
This PR moves critical tests out of the e2e pipelines that are slated to be deleted and into the nightly L2 pipeline instead

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jvega/ccl_test_reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jvega/ccl_test_reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jvega/ccl_test_reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jvega/ccl_test_reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jvega/ccl_test_reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jvega/ccl_test_reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jvega/ccl_test_reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jvega/ccl_test_reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jvega/ccl_test_reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jvega/ccl_test_reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jvega/ccl_test_reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jvega/ccl_test_reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jvega/ccl_test_reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jvega/ccl_test_reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jvega/ccl_test_reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jvega/ccl_test_reorg)