### PR TITLE
Correct ISA selection

### DIFF
--- a/tt_metal/jit_build/fake_kernels_target/CMakeLists.txt
+++ b/tt_metal/jit_build/fake_kernels_target/CMakeLists.txt
@@ -52,10 +52,7 @@ message(STATUS "Found ${ALL_KERNEL_FILES_LEN} kernel files")
 if(NOT DEFINED ARCH_NAME)
     set(ARCH_NAME "wormhole_b0")
 endif()
-set(TOLOWER
-    "${ARCH_NAME}"
-    ARCH_NAME_LOWER
-)
+string(TOLOWER "${ARCH_NAME}" ARCH_NAME_LOWER)
 
 if(ARCH_NAME_LOWER MATCHES "wormhole")
     set(ARCH_NAME_PREFIX "wormhole")

--- a/tt_metal/jit_build/fake_kernels_target/CMakeLists.txt
+++ b/tt_metal/jit_build/fake_kernels_target/CMakeLists.txt
@@ -97,7 +97,6 @@ target_compile_options(
     jit_kernels_index
     PRIVATE
         -O2
-        -mcpu=tt-wh
         -std=c++20
         -flto=auto
         -ffast-math
@@ -142,6 +141,7 @@ target_compile_definitions(
 )
 
 if(ARCH_NAME_LOWER MATCHES "wormhole")
+    target_compile_options(jit_kernels_index PRIVATE -mcpu=tt-wh)
     target_compile_definitions(
         jit_kernels_index
         PRIVATE
@@ -150,6 +150,7 @@ if(ARCH_NAME_LOWER MATCHES "wormhole")
             NUM_L1_BANKS=64
     )
 elseif(ARCH_NAME_LOWER MATCHES "blackhole")
+    target_compile_options(jit_kernels_index PRIVATE -mcpu=tt-bh)
     target_compile_definitions(
         jit_kernels_index
         PRIVATE


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
I noticed that fake kernels are unconditionally using `-mcpu=tt-wh`, which I think we get away with because bh is sufficiently similar for fake kernels.  But still wrong.

Select tt-wh or tt-bh, and I guess down the road tt-qsr32

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/fake-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/fake-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/fake-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/fake-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nsidwell/fake-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nsidwell/fake-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/fake-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/fake-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/fake-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/fake-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/fake-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/fake-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/fake-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/fake-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/fake-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/fake-kernels)