### PR TITLE
[Cleanup] Pass MetalEnvImpl into DataCollector and ProfilerStateManager constructors

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -273,7 +273,7 @@ void MetalContext::initialize(
         profiler_state_manager_ = std::make_unique<ProfilerStateManager>();
     }
 
-    data_collector_ = std::make_unique<DataCollector>();
+    data_collector_ = std::make_unique<DataCollector>(MetalEnvAccessor(*this->env_).impl());
 
     // Minimal setup, don't initialize FW/Dispatch/etc.
     if (minimal) {

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -270,7 +270,7 @@ void MetalContext::initialize(
     }
 
     if (rtoptions().get_profiler_enabled()) {
-        profiler_state_manager_ = std::make_unique<ProfilerStateManager>();
+        profiler_state_manager_ = std::make_unique<ProfilerStateManager>(MetalEnvAccessor(*this->env_).impl());
     }
 
     data_collector_ = std::make_unique<DataCollector>(MetalEnvAccessor(*this->env_).impl());

--- a/tt_metal/impl/dispatch/data_collector.cpp
+++ b/tt_metal/impl/dispatch/data_collector.cpp
@@ -8,15 +8,16 @@
 #include <enchantum/enchantum.hpp>
 #include <enchantum/generators.hpp>
 #include <enchantum/iostream.hpp>
-#include <exception>
 #include <filesystem>
 #include <tt-logger/tt-logger.hpp>
-#include "impl/context/metal_context.hpp"
+#include "impl/context/metal_env_impl.hpp"
 #include "impl/kernels/kernel.hpp"
 #include "tt-metalium/program.hpp"
 
 using tt::tt_metal::detail::ProgramImpl;
 namespace tt::tt_metal {
+
+DataCollector::DataCollector(MetalEnvImpl& env) : env_(env) {}
 
 // Class to track stats for DispatchData
 class DispatchStats {
@@ -139,7 +140,7 @@ void DataCollector::RecordProgramMetadata(ProgramImpl& program) {
     auto [it, inserted] = program_id_to_kernel_sources_.try_emplace(program_id);
     if (inserted) {
         auto& kernel_sources = it->second;
-        const auto& hal = MetalContext::instance().hal();
+        const auto& hal = env_.get_hal();
         for (uint32_t i = 0; i < hal.get_programmable_core_type_count(); i++) {
             for (const auto& [handle, kernel] : program.get_kernels(i)) {
                 // insert(const string&) allocates only on a miss; on a hit it just returns the

--- a/tt_metal/impl/dispatch/data_collector.hpp
+++ b/tt_metal/impl/dispatch/data_collector.hpp
@@ -22,6 +22,8 @@
 
 namespace tt::tt_metal {
 
+class MetalEnvImpl;
+
 // Class to hold dispatch write data for the DataCollector
 class DispatchData {
 public:
@@ -42,7 +44,7 @@ private:
 // Class to manage & dump dispatch data for each program
 class DataCollector {
 public:
-    DataCollector() = default;
+    explicit DataCollector(MetalEnvImpl& env);
     ~DataCollector() = default;
 
     void RecordData(
@@ -103,6 +105,8 @@ private:
         std::vector<KernelData> kernels;
         CoreRangeSet core_ranges;
     };
+
+    MetalEnvImpl& env_;
     std::map<uint64_t, std::vector<DispatchData>> program_id_to_dispatch_data;
     std::map<uint64_t, std::map<HalProgrammableCoreType, std::vector<KernelGroupData>>> program_id_to_kernel_groups;
     std::map<uint64_t, int> program_id_to_call_count;

--- a/tt_metal/impl/profiler/profiler_state_manager.cpp
+++ b/tt_metal/impl/profiler/profiler_state_manager.cpp
@@ -10,6 +10,7 @@
 #include <tt_stl/assert.hpp>
 #include "hostdevcommon/profiler_common.h"
 #include "context/metal_context.hpp"
+#include "impl/context/metal_env_impl.hpp"
 #include "math.hpp"
 #include "tt_cluster.hpp"
 #include <tt-metalium/device.hpp>
@@ -83,7 +84,7 @@ uint32_t get_profiler_dram_bank_size_for_hal_allocation(llrt::RunTimeOptions& rt
     return per_buffer_size;
 }
 
-ProfilerStateManager::ProfilerStateManager() : do_sync_on_close(true) {}
+ProfilerStateManager::ProfilerStateManager(MetalEnvImpl& env) : env_(env), do_sync_on_close(true) {}
 
 void ProfilerStateManager::cleanup_device_profilers() {
     // This thread only exists when debug dump is enabled
@@ -214,7 +215,7 @@ void ProfilerStateManager::start_debug_dump_thread(
                     auto profiler_it = this->device_profiler_map.find(device->id());
                     TT_ASSERT(profiler_it != this->device_profiler_map.end());
                     DeviceProfiler& profiler = profiler_it->second;
-                    if (MetalContext::instance().rtoptions().get_profiler_trace_only() || was_force_read) {
+                    if (this->env_.get_rtoptions().get_profiler_trace_only() || was_force_read) {
                         profiler.processResults(
                             device,
                             virtual_cores_map.at(device->id()),

--- a/tt_metal/impl/profiler/profiler_state_manager.hpp
+++ b/tt_metal/impl/profiler/profiler_state_manager.hpp
@@ -24,6 +24,8 @@ class RunTimeOptions;
 
 namespace tt_metal {
 
+class MetalEnvImpl;
+
 namespace detail {
 void ReadDeviceProfilerResultsInternal(
     distributed::MeshDevice* mesh_device,
@@ -41,7 +43,7 @@ uint32_t get_profiler_dram_bank_size_for_hal_allocation(llrt::RunTimeOptions& rt
 
 struct ProfilerStateManager {
 public:
-    ProfilerStateManager();
+    explicit ProfilerStateManager(MetalEnvImpl& env);
 
     ~ProfilerStateManager() = default;
 
@@ -63,6 +65,7 @@ public:
 
     static constexpr CoreCoord SYNC_CORE = {0, 0};
 
+    MetalEnvImpl& env_;
     std::unordered_map<ChipId, DeviceProfiler> device_profiler_map;
     mutable std::recursive_mutex device_profiler_map_mutex;
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Part of #52020

These are components owned by MetalContext.  Internally they make calls to MetalContext::instance() which should be removed.  This PR fixes that by passing MetalEnvImpl to the constructor, similar to other components owned by MetalContext.

### Notes for reviewers
The free function `uint32_t get_profiler_dram_bank_size_per_risc_bytes()` still has a call to MetalContext::instance().  This will be cleaned up at a later stage when the call sites are fixed.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/metal_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/metal_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/metal_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/metal_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ruizhang/metal_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ruizhang/metal_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/metal_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/metal_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/metal_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/metal_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/metal_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/metal_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/metal_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/metal_context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/metal_context)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/metal_context)
