### PR TITLE
Fix protobufs visibility issues by avoiding exporting scaleout_tools symbols

### DIFF
--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -139,17 +139,25 @@ set(TEST_TT_FABRIC_SOURCES
 
 add_executable(test_tt_fabric ${TEST_TT_FABRIC_SOURCES})
 
+# Previously (#48783) this target deliberately took TT::ScaleoutTools headers WITHOUT linking it,
+# because scaleout_tools' protobuf symbols were exported from libtt_metal.so: linking a second copy
+# meant both copies shared one exported descriptor_table_* object, so whichever module initialised
+# first consumed its call_once flag and registered the file into only its own descriptor pool,
+# tripping a libprotobuf fatal ("CHECK failed: file != nullptr") on the Torus paths. Now that those
+# symbols are hidden (see tools/scaleout/CMakeLists.txt) nothing is shared, each module resolves to
+# its own copy and its own pool, and linking normally is both safe and required -- the symbols are
+# no longer available from libtt_metal.so.
 target_link_libraries(
     test_tt_fabric
     PRIVATE
+        TT::ScaleoutTools
         tt_metal
         test_common_libs
         yaml-cpp::yaml-cpp
 )
 
-# NOTE(#48783): Take only TT::ScaleoutTools headers, do NOT link it. Its protobuf sources
-# are already in libtt_metal.so; linking again duplicates the descriptor pool and trips a
-# libprotobuf fatal on the Torus paths. Symbols resolve from libtt_metal.so at link/run time.
+# Redundant with the link above for the include path itself, but kept so these headers stay marked
+# SYSTEM (link-propagated interface directories are not) and do not raise warnings here.
 target_include_directories(
     test_tt_fabric
     SYSTEM

--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -85,6 +85,38 @@ target_link_libraries(
         $<BUILD_INTERFACE:protobuf::libprotobuf>
 )
 
+# Do not export scaleout_tools' symbols from the shared libraries it is linked into (libtt_metal.so
+# via TT::Metalium and TT::Metalium::Fabric). This extends to the generated protobuf message classes
+# the same treatment libprotobuf already gets in third_party/CMakeLists.txt ("Setting visibility to
+# hidden to avoid symbol conflicts with other protobuf libraries when tt-metal package is used").
+#
+# libprotobuf being hidden is not sufficient on its own. Every generated .pb.cc also defines a
+# `descriptor_table_<file>_2eproto` object plus an AddDescriptorsRunner static initializer, and those
+# were still exported with default visibility. Any consumer that compiles these same schemas against
+# its own protobuf -- which it must, because we forward-declare the message types in public headers
+# (e.g. CablingGenerator::generate_factory_system_descriptor returns one by value) and do not install
+# the generated headers -- ends up defining the same symbols. The executable wins the global symbol
+# lookup scope, so libtt_metal.so's references to its own descriptor tables get preempted by the
+# consumer's; shared library initializers run first, so our protobuf calls AddDescriptors on THEIR
+# table, consumes its call_once flag, and registers the file into OUR descriptor pool. Their pool is
+# left empty and their first reflection-based call (TextFormat::ParseFromString, say) aborts in
+# AssignDescriptorsImpl on "CHECK failed: file != nullptr"
+# (generated_message_reflection.cc:3012). Hiding these symbols makes each module resolve to its own
+# copy and register into its own pool.
+#
+# NOTE: run_fabric_manager and the tools/tests/scaleout targets already link TT::ScaleoutTools
+# directly, so they are unaffected -- they get their own copy of these objects. Targets that reach
+# scaleout_tools only transitively through tt_metal must link TT::ScaleoutTools explicitly; see
+# run_cluster_validation below and test_link_retraining in tools/tests/scaleout/CMakeLists.txt.
+set_target_properties(
+    scaleout_tools
+    PROPERTIES
+        CXX_VISIBILITY_PRESET
+            "hidden"
+        VISIBILITY_INLINES_HIDDEN
+            TRUE
+)
+
 # We are adding yaml-cpp include like this to avoid including
 # scaleout_tools headers because that would cause protobuf issues.
 target_include_directories(
@@ -94,9 +126,13 @@ target_include_directories(
         $<TARGET_PROPERTY:yaml-cpp::yaml-cpp,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
+# TT::ScaleoutTools is required explicitly: this target's sources call into scaleout_tools (and
+# include its generated protobuf headers), and those symbols are no longer exported from
+# libtt_metal.so. Matches how run_fabric_manager already links.
 target_link_libraries(
     run_cluster_validation
     PRIVATE
+        TT::ScaleoutTools
         enchantum::enchantum
         protobuf::libprotobuf
         tt_metal

--- a/tools/tests/scaleout/CMakeLists.txt
+++ b/tools/tests/scaleout/CMakeLists.txt
@@ -88,9 +88,14 @@ target_include_directories(
         "$<TARGET_PROPERTY:TT::Metalium,INCLUDE_DIRECTORIES>"
 )
 
+# TT::ScaleoutTools is required explicitly. generate_mgd_lib is an OBJECT library, so its own
+# PUBLIC link to scaleout_tools does not propagate those objects to consumers -- only usage
+# requirements. These symbols used to be satisfied by libtt_metal.so's exports, which are now
+# hidden (see the visibility comment in tools/scaleout/CMakeLists.txt).
 target_link_libraries(
     test_cabling_descriptor_mgd_generation
     PRIVATE
+        TT::ScaleoutTools
         test_common_libs
         tt_metal
         generate_mgd_lib

--- a/tools/tests/scaleout/CMakeLists.txt
+++ b/tools/tests/scaleout/CMakeLists.txt
@@ -58,9 +58,13 @@ target_include_directories(
         ${Metalium_BINARY_DIR}/tools/scaleout # For generated protobuf headers
 )
 
+# TT::ScaleoutTools is required explicitly: this target includes <factory_system_descriptor/utils.hpp>
+# and calls into scaleout_tools, whose symbols are no longer exported from libtt_metal.so (see the
+# visibility comment in tools/scaleout/CMakeLists.txt). The sibling test targets already link it.
 target_link_libraries(
     test_link_retraining
     PRIVATE
+        TT::ScaleoutTools
         test_common_libs
         tt_metal
         protobuf::libprotobuf


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

scaleout_tools exports its generated protobuf symbols from libtt_metal.so with default visibility, which corrupts descriptor registration in any process that also carries its own copy of these schemas. third_party/CMakeLists.txt already hides libprotobuf for precisely this reason ("Setting visibility to hidden to avoid symbol conflicts with other protobuf libraries when tt-metal package is used"), but the generated message classes never got the same treatment, and every generated .pb.cc additionally defines a descriptor_table_<file>_2eproto object plus an AddDescriptorsRunner static initializer. Consumers are forced to duplicate these schemas: cabling_generator.hpp forward-declares the message types while CablingGenerator::generate_factory_system_descriptor() returns fsd::proto::FactorySystemDescriptor by value, so a complete type is required at the call site, yet the generated headers aren't installed and protobuf::libprotobuf is $<BUILD_INTERFACE:...> PRIVATE. Once duplicated the failure is deterministic: the executable wins the global symbol lookup scope, so libtt_metal.so's references to its own descriptor tables are preempted by the consumer's; shared-library initializers run before the executable's, so tt-metal's protobuf calls AddDescriptors on the consumer's table, consumes its call_once flag, and registers the file into tt-metal's pool â leaving the consumer's pool empty, so its first reflection-based call (e.g. TextFormat::ParseFromString) aborts on CHECK failed: file != nullptr (generated_message_reflection.cc:3012). Found via tt-telemetry, where every --fsd <file>.textproto run aborts before the file is read. This PR sets CXX_VISIBILITY_PRESET hidden + VISIBILITY_INLINES_HIDDEN on scaleout_tools so each module resolves to its own copy and its own descriptor pool, and adds the now-required explicit TT::ScaleoutTools link to run_cluster_validation (tools/scaleout/CMakeLists.txt) and test_link_retraining (tools/tests/scaleout/CMakeLists.txt).

### Notes for reviewers

The main thing to weigh is that this reduces libtt_metal.so's exported ABI: I surveyed every in-tree consumer and run_fabric_manager, 2d_big_mesh_cabling_gen, run_cabling_generator, run_regen_descriptors, generate_cluster_descriptor, generate_mgd/generate_mgd_lib and the four test_* targets that touch the protos all link the object library directly and are unaffected â only the two above reached it transitively through tt_metal â but whether any out-of-tree consumer depends on these exports is the call I can't make, and that's the review question. Those two link additions are the parts most likely to be wrong and aren't exercised by a plain build_metal.sh (tests off, and run_cluster_validation may not be in the default target set), so please make sure CI builds the tools and tools/tests/scaleout targets here; the fix itself is confirmed with nm -D build_Release/lib/libtt_metal.so | grep descriptor_table_, which should no longer list the four scaleout tables. Two other things worth knowing: run_fabric_manager may already hit this today, since it links both TT::ScaleoutTools and tt_metal and therefore has two copies of the classes and two statically-linked protobuf runtimes â structurally identical to the downstream case, though I haven't run it to confirm â and tools/scaleout/CMakeLists.txt already carries the comment "We are adding yaml-cpp include like this to avoid including scaleout_tools headers because that would cause protobuf issues", so the same conflict has been worked around in-tree before. On scope: this makes the current vendor-the-schemas arrangement safe rather than making the public API usable, and it locks that arrangement in since consumers can no longer link these symbols at all; the real fixes are installing the generated headers with protobuf as a public dependency, or exposing a protobuf-free public API so protobuf never crosses the ABI boundary â happy to file that separately if you'd rather go straight there.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bart/fix-protobuf-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bart/fix-protobuf-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bart/fix-protobuf-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bart/fix-protobuf-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=bart/fix-protobuf-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:bart/fix-protobuf-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bart/fix-protobuf-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bart/fix-protobuf-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bart/fix-protobuf-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bart/fix-protobuf-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bart/fix-protobuf-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bart/fix-protobuf-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bart/fix-protobuf-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bart/fix-protobuf-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bart/fix-protobuf-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bart/fix-protobuf-visibility)