### PR TITLE
[Bug fix] Overflow-safe logaddexp/logaddexp2 lowering

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/binary/logaddexp/logaddexp.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/logaddexp/logaddexp.py
@@ -59,10 +59,10 @@ def run(
     torch.manual_seed(0)
 
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-64, high=64, dtype=torch.float32), input_a_dtype
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
     torch_input_tensor_b = gen_func_with_cast_tt(
-        partial(torch_random, low=-64, high=64, dtype=torch.float32), input_b_dtype
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
     )(input_shape)
 
     golden_function = ttnn.get_golden_function(ttnn.logaddexp)

--- a/tests/sweep_framework/sweeps/eltwise/binary/logaddexp2/logaddexp2.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/logaddexp2/logaddexp2.py
@@ -59,10 +59,10 @@ def run(
     torch.manual_seed(0)
 
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-60, high=100, dtype=torch.float32), input_a_dtype
+        partial(torch_random, low=-150, high=150, dtype=torch.float32), input_a_dtype
     )(input_shape)
     torch_input_tensor_b = gen_func_with_cast_tt(
-        partial(torch_random, low=-60, high=100, dtype=torch.float32), input_b_dtype
+        partial(torch_random, low=-150, high=150, dtype=torch.float32), input_b_dtype
     )(input_shape)
 
     golden_function = ttnn.get_golden_function(ttnn.logaddexp2)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
@@ -221,8 +221,8 @@ def test_add_fp32_input_activ(device, shape):
 
 
 def test_logaddexp_fp32(device):
-    x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
-    y_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
+    x_torch = torch.tensor([[1, 90, 100, -120, 10000, -10000]], dtype=torch.float32)
+    y_torch = torch.tensor([[1, 88, 95, -118, 9999, -10000]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.logaddexp)
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
@@ -230,13 +230,14 @@ def test_logaddexp_fp32(device):
     z_tt_out = ttnn.logaddexp(x_tt, y_tt)
     tt_out = ttnn.to_torch(z_tt_out)
 
+    assert torch.isfinite(tt_out).all()
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
     assert status
 
 
 def test_logaddexp2_fp32(device):
-    x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
-    y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
+    x_torch = torch.tensor([[1, 120, 130, -150, 10000, -10000]], dtype=torch.float32)
+    y_torch = torch.tensor([[2, 118, 125, -148, 9999, -10000]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.logaddexp2)
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
@@ -244,6 +245,7 @@ def test_logaddexp2_fp32(device):
     z_tt_out = ttnn.logaddexp2(x_tt, y_tt)
     tt_out = ttnn.to_torch(z_tt_out)
 
+    assert torch.isfinite(tt_out).all()
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
     assert status
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py
@@ -52,13 +52,41 @@ def test_ldexp(device, h, w):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_logaddexp(device, h, w):
-    run_elt_binary_test_range(device, h, w, ttnn.logaddexp, -80, 80)
+    run_elt_binary_test_range(device, h, w, ttnn.logaddexp, -100, 100)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_logaddexp2(device, h, w):
-    run_elt_binary_test_range(device, h, w, ttnn.logaddexp2, -60, 100, pcc=0.993)
+    run_elt_binary_test_range(device, h, w, ttnn.logaddexp2, -150, 150, pcc=0.993)
+
+
+def run_elt_binary_extreme_bf16_test(device, ttnn_function, x_torch, y_torch, *, pcc=0.9999):
+    golden_fn = ttnn.get_golden_function(ttnn_function)
+    torch_output_tensor = golden_fn(x_torch, y_torch)
+
+    input_tensor_a = ttnn.from_torch(x_torch, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(y_torch, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn_function(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.isfinite(output_tensor).all()
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+def test_logaddexp_extreme_bf16(device):
+    x_torch = torch.tensor([[1, 90, 100, -120, 10000, -10000]], dtype=torch.bfloat16)
+    y_torch = torch.tensor([[1, 88, 95, -118, 9999, -10000]], dtype=torch.bfloat16)
+    run_elt_binary_extreme_bf16_test(device, ttnn.logaddexp, x_torch, y_torch)
+
+
+def test_logaddexp2_extreme_bf16(device):
+    x_torch = torch.tensor([[1, 120, 130, -150, 10000, -10000]], dtype=torch.bfloat16)
+    y_torch = torch.tensor([[2, 118, 125, -148, 9999, -10000]], dtype=torch.bfloat16)
+    run_elt_binary_extreme_bf16_test(device, ttnn.logaddexp2, x_torch, y_torch, pcc=0.993)
 
 
 @pytest.mark.parametrize("h", [64])

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -128,13 +128,8 @@ std::map<std::string, std::string> get_defines(
             defines.merge(get_defines(UnaryOpType::GELU, std::vector<float>{0}, "0", idst));
             break;
         case BinaryOpType::LOGADDEXP:
-            // PRE_IN0_0 ===> Applies prescaling for first input
-            // PRE_IN1_0 ====> Applies prescaling for second input
-            defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN0_0"));
-            defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN1_0"));
-            op_name = "add_tiles";
-            op_binary_type = "EltwiseBinaryType::ELWADD";
-            defines.merge(get_defines(UnaryOpType::LOG, std::nullopt, "0", idst));
+            op_name = "stable_logaddexp_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWSUB";
             break;
         case BinaryOpType::RSUB:
             //  rsub(a,b) = b - a
@@ -168,11 +163,8 @@ std::map<std::string, std::string> get_defines(
             op_binary_type = "EltwiseBinaryType::ELWMUL";
             break;
         case BinaryOpType::LOGADDEXP2:
-            defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN0_0"));
-            defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
-            op_name = "add_tiles";
-            op_binary_type = "EltwiseBinaryType::ELWADD";
-            defines.merge(get_defines(UnaryOpType::LOG2, std::nullopt, "0", idst));
+            op_name = "stable_logaddexp2_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWSUB";
             break;
         case BinaryOpType::HYPOT:
             // Hypot: sqrt(a^2 + b^2)
@@ -399,20 +391,12 @@ std::map<std::string, std::string> get_defines_fp32(
             op_name = "lcm_tile";
             break;
         case BinaryOpType::LOGADDEXP:
-            // PRE_IN0_0 ===> Applies prescaling for first input
-            // PRE_IN1_0 ====> Applies prescaling for second input
-            new_defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN0_0"));
-            new_defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN1_0"));
-            new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
-            op_name = "add_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::LOG, std::nullopt, "0", idst1));
+            new_defines.insert({"BINOP_INIT", "stable_logaddexp_tile_init();"});
+            op_name = "stable_logaddexp_tile";
             break;
         case BinaryOpType::LOGADDEXP2:
-            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN0_0"));
-            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
-            new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
-            op_name = "add_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::LOG2, std::nullopt, "0", idst1));
+            new_defines.insert({"BINOP_INIT", "stable_logaddexp2_tile_init();"});
+            op_name = "stable_logaddexp2_tile";
             break;
         case BinaryOpType::LDEXP:
             new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
@@ -8,6 +8,7 @@
 
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 #define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -26,6 +26,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/binary_comp.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 #define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "api/compute/binary_max_min.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/compute/eltwise_unary/exp.h"
+#include "api/compute/eltwise_unary/log1p.h"
+#include "api/compute/tile_move_copy.h"
+
+namespace ckernel {
+
+namespace stable_logaddexp_detail {
+constexpr uint32_t kStableLogaddexpMaxDstOffset = 4;
+constexpr uint32_t kStableLogaddexpRhsDstOffset = 8;
+constexpr uint32_t kInvLn2Bits = 0x3fb8aa3bu;
+
+ALWI void copy_tile_to_dst_init_short_cross_format(uint32_t old_cb, uint32_t new_cb) {
+#ifndef ARCH_QUASAR
+    copy_tile_to_dst_init_short_with_dt(old_cb, new_cb);
+#else
+    copy_tile_to_dst_init_short(new_cb);
+#endif
+}
+}  // namespace stable_logaddexp_detail
+
+ALWI void stable_logaddexp_tile_init() {}
+
+ALWI void stable_logaddexp2_tile_init() {}
+
+ALWI void stable_logaddexp_tile(uint32_t lhs_dst, uint32_t rhs_dst, uint32_t out_dst) {
+    const uint32_t max_dst = out_dst + stable_logaddexp_detail::kStableLogaddexpMaxDstOffset;
+
+    binary_max_tile_init();
+    binary_max_tile(lhs_dst, rhs_dst, max_dst);
+    binary_min_tile_init();
+    binary_min_tile(lhs_dst, rhs_dst, rhs_dst);
+    sub_binary_tile_init();
+    sub_binary_tile(rhs_dst, max_dst, rhs_dst);
+    exp_tile_init<false>();
+    exp_tile<false>(rhs_dst);
+    log1p_tile_init<false>();
+    log1p_tile<false>(rhs_dst);
+    add_binary_tile_init();
+    add_binary_tile(max_dst, rhs_dst, out_dst);
+}
+
+ALWI void stable_logaddexp2_tile(uint32_t lhs_dst, uint32_t rhs_dst, uint32_t out_dst) {
+    const uint32_t max_dst = out_dst + stable_logaddexp_detail::kStableLogaddexpMaxDstOffset;
+
+    binary_max_tile_init();
+    binary_max_tile(lhs_dst, rhs_dst, max_dst);
+    binary_min_tile_init();
+    binary_min_tile(lhs_dst, rhs_dst, rhs_dst);
+    sub_binary_tile_init();
+    sub_binary_tile(rhs_dst, max_dst, rhs_dst);
+    exp2_tile_init();
+    exp2_tile(rhs_dst);
+    log1p_tile_init<false>();
+    log1p_tile<false>(rhs_dst);
+    binop_with_scalar_tile_init();
+    mul_unary_tile(rhs_dst, stable_logaddexp_detail::kInvLn2Bits);
+    add_binary_tile_init();
+    add_binary_tile(max_dst, rhs_dst, out_dst);
+}
+
+ALWI void stable_logaddexp_tiles(
+    uint32_t lhs_cb, uint32_t rhs_cb, uint32_t lhs_tile, uint32_t rhs_tile, uint32_t out_dst) {
+    const uint32_t rhs_dst = out_dst + stable_logaddexp_detail::kStableLogaddexpRhsDstOffset;
+
+    copy_tile_to_dst_init_short(lhs_cb);
+    copy_tile(lhs_cb, lhs_tile, out_dst);
+    stable_logaddexp_detail::copy_tile_to_dst_init_short_cross_format(lhs_cb, rhs_cb);
+    copy_tile(rhs_cb, rhs_tile, rhs_dst);
+
+    stable_logaddexp_tile(out_dst, rhs_dst, out_dst);
+}
+
+ALWI void stable_logaddexp2_tiles(
+    uint32_t lhs_cb, uint32_t rhs_cb, uint32_t lhs_tile, uint32_t rhs_tile, uint32_t out_dst) {
+    const uint32_t rhs_dst = out_dst + stable_logaddexp_detail::kStableLogaddexpRhsDstOffset;
+
+    copy_tile_to_dst_init_short(lhs_cb);
+    copy_tile(lhs_cb, lhs_tile, out_dst);
+    stable_logaddexp_detail::copy_tile_to_dst_init_short_cross_format(lhs_cb, rhs_cb);
+    copy_tile(rhs_cb, rhs_tile, rhs_dst);
+
+    stable_logaddexp2_tile(out_dst, rhs_dst, out_dst);
+}
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -932,8 +932,6 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
         // binary operands produces incorrect results.  Adding a typecast for
         // LHS forces it through a Float16_b intermediate CB so both operands
         // use the same format.
-        // Note: LOGADDEXP / LOGADDEXP2 are not affected because they process
-        // both sides (EXP/EXP2), so lhs_activations is never empty for them.
         if (!is_sfpu_op && lhs_activations.empty() && !rhs_activations.empty() && op_type == BinaryOpType::LDEXP &&
             (a_dtype == DataType::BFLOAT8_B || a_dtype == DataType::BFLOAT4_B)) {
             lhs_activations.push_back({
@@ -1001,6 +999,9 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
         enable_multi_tile = true;
     }
 
+    const bool is_stable_logaddexp =
+        op_type == BinaryOpType::LOGADDEXP || op_type == BinaryOpType::LOGADDEXP2;
+
     if (enable_multi_tile && !is_where_op) {
         if (!is_sfpu_op) {
             // FPU kernels: 16-bit types can handle 8 tiles,
@@ -1010,10 +1011,12 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
             // no document and example to show why 4 does not work, need further investigation
             num_tiles_per_cycle = 2;
         }
+        if (is_stable_logaddexp && !is_sfpu_op) {
+            num_tiles_per_cycle = 4;
+        }
     }
 
-    bool op_has_exp =
-        op_type == BinaryOpType::LOGADDEXP || op_type == BinaryOpType::LDEXP || op_type == BinaryOpType::LOGADDEXP2;
+    bool op_has_exp = op_type == BinaryOpType::LDEXP;
     const bool inputs_row_major =
         CMAKE_UNIQUE_NAMESPACE::should_use_row_major_path(operation_attributes, b, has_sharding);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -150,7 +150,7 @@ std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_w
 template <class EnumT>
 OpConfig::OpConfig(
     BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, [[maybe_unused]] std::optional<DataType> dtype) :
-    binary_op(EnumT::SUB) {
+    binary_op_type(binary_op_type), binary_op(EnumT::SUB) {
     switch (binary_op_type) {
         case BinaryOpType::ADD: binary_op = EnumT::ADD; break;
         case BinaryOpType::SUB: break;
@@ -247,19 +247,15 @@ OpConfig::OpConfig(
             process_rhs = unary::UnaryOpType::EXP2;
             binary_op = EnumT::MUL;
             break;
-        // log( exp(a) + exp(b) )
         case BinaryOpType::LOGADDEXP:
-            process_lhs = unary::UnaryOpType::EXP;
-            process_rhs = unary::UnaryOpType::EXP;
-            binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::LOG;
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LOGADDEXP;
+            }
             break;
-        // log2( 2**a + 2**b )
         case BinaryOpType::LOGADDEXP2:
-            process_lhs = unary::UnaryOpType::EXP2;
-            process_rhs = unary::UnaryOpType::EXP2;
-            binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::LOG2;
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LOGADDEXP2;
+            }
             break;
         case BinaryOpType::BITWISE_AND:
             if (is_sfpu_op()) {
@@ -551,6 +547,8 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             return {"where_tile_init();", fmt::format("where_tile<DataFormat::{}>", data_format)};
         }
         case ISCLOSE: return {"isclose_binary_tile_init();", "isclose_binary_tile<(bool)ISCLOSE_EQUAL_NAN>"};
+        case LOGADDEXP: return {"stable_logaddexp_tile_init();", "stable_logaddexp_tile"};
+        case LOGADDEXP2: return {"stable_logaddexp2_tile_init();", "stable_logaddexp2_tile"};
         default: TT_THROW("Unsupported sfpu binary op {}", sfpu_binary_op);
     }
 }
@@ -559,6 +557,18 @@ std::map<std::string, std::string> OpConfig::as_defines(DataType dtype) const {
     std::map<std::string, std::string> defines;
 
     if (!is_sfpu_op()) {
+        if (binary_op_type == BinaryOpType::LOGADDEXP) {
+            defines["BINARY_OP"] = "stable_logaddexp_tiles";
+            defines["BINARY_OP_TYPE"] = "EltwiseBinaryType::ELWSUB";
+            return defines;
+        }
+
+        if (binary_op_type == BinaryOpType::LOGADDEXP2) {
+            defines["BINARY_OP"] = "stable_logaddexp2_tiles";
+            defines["BINARY_OP_TYPE"] = "EltwiseBinaryType::ELWSUB";
+            return defines;
+        }
+
         auto fpu_binary_op = std::get<FpuBinaryOp>(binary_op);
         auto binary_op_str = enchantum::to_string(fpu_binary_op);
         defines["BINARY_OP"] = fmt::format("{}_tiles", Lowercase{binary_op_str});

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -88,6 +88,8 @@ struct OpConfig {
         EQ,
         NE,
         ISCLOSE,
+        LOGADDEXP,
+        LOGADDEXP2,
     };
 
     template <class EnumT>
@@ -98,6 +100,7 @@ struct OpConfig {
     std::optional<unary::UnaryOpType> process_lhs;
     std::optional<unary::UnaryOpType> process_rhs;
     std::optional<unary::UnaryOpType> postprocess;
+    BinaryOpType binary_op_type;
     std::variant<FpuBinaryOp, SfpuBinaryOp> binary_op;
     bool is_sfpu_op() const;
 };

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
@@ -9,6 +9,7 @@
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 ALWI void process_tile(
     tt::CBIndex cb_pre_lhs_id,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
@@ -8,6 +8,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -8,6 +8,7 @@
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -24,6 +24,7 @@
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
 #include "api/compute/binary_comp.h"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -28,6 +28,7 @@
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 FORCE_INLINE void process_sfpu_tiles(
     uint32_t n,
     uint32_t cb_pre_lhs_id,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 // Process n LHS tiles against a scalar tile at index 0 in cb_post_rhs
 FORCE_INLINE void process_sfpu_scalar_tiles(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
@@ -9,6 +9,7 @@
 
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 // DataflowBuffer for the op's own buffers; CircularBuffer (via eltwise_utils.hpp) is
 // still used for the shared preprocess_*_impl helper call sites (see PREPROCESS below).
 #include "api/dataflow/dataflow_buffer.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
@@ -10,6 +10,7 @@
 
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 #include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
@@ -10,6 +10,7 @@
 
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 #include "api/dataflow/circular_buffer.h"
 
 ALWI void process_tile(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
@@ -9,6 +9,7 @@
 
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 // DataflowBuffer for the op's own buffers; CircularBuffer (via eltwise_utils.hpp) is
 // still used for the shared preprocess_*_impl helper call sites (see PREPROCESS below).
 #include "api/dataflow/dataflow_buffer.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
@@ -28,6 +28,7 @@
 #include "api/compute/bcast.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 // DataflowBuffer for the op's own buffers; CircularBuffer (via eltwise_utils.hpp) is
 // still used for the shared preprocess_*_impl helper call sites (see PREPROCESS below).
 #include "api/dataflow/dataflow_buffer.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -28,6 +28,7 @@
 #include "api/compute/bcast.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 #include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -27,6 +27,7 @@
 #include "api/compute/isclose.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 #include "api/compute/bcast.h"
 #include "api/dataflow/circular_buffer.h"
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
@@ -28,6 +28,7 @@
 #include "api/compute/bcast.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 // DataflowBuffer for the op's own buffers; CircularBuffer (via eltwise_utils.hpp) is
 // still used for the shared preprocess_*_impl helper call sites (see PREPROCESS below).
 #include "api/dataflow/dataflow_buffer.h"

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/common/binary_op_utils.cpp
@@ -93,13 +93,8 @@ std::map<std::string, std::string> get_defines(
             defines.merge(get_defines(UnaryOpType::GELU, std::vector<float>{0}, "0", idst));
             break;
         case BinaryOpType::LOGADDEXP:
-            // PRE_IN0_0 ===> Applies prescaling for first input
-            // PRE_IN1_0 ====> Applies prescaling for second input
-            defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN0_0"));
-            defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN1_0"));
-            op_name = "add_tiles";
-            op_binary_type = "EltwiseBinaryType::ELWADD";
-            defines.merge(get_defines(UnaryOpType::LOG, std::nullopt, "0", idst));
+            op_name = "stable_logaddexp_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWSUB";
             break;
         case BinaryOpType::RSUB:
             //  rsub(a,b) = b - a
@@ -133,11 +128,8 @@ std::map<std::string, std::string> get_defines(
             op_binary_type = "EltwiseBinaryType::ELWMUL";
             break;
         case BinaryOpType::LOGADDEXP2:
-            defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN0_0"));
-            defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
-            op_name = "add_tiles";
-            op_binary_type = "EltwiseBinaryType::ELWADD";
-            defines.merge(get_defines(UnaryOpType::LOG2, std::nullopt, "0", idst));
+            op_name = "stable_logaddexp2_tiles";
+            op_binary_type = "EltwiseBinaryType::ELWSUB";
             break;
         case BinaryOpType::HYPOT:
             // Hypot: sqrt(a^2 + b^2)
@@ -364,20 +356,12 @@ std::map<std::string, std::string> get_defines_fp32(
             op_name = "lcm_tile";
             break;
         case BinaryOpType::LOGADDEXP:
-            // PRE_IN0_0 ===> Applies prescaling for first input
-            // PRE_IN1_0 ====> Applies prescaling for second input
-            new_defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN0_0"));
-            new_defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN1_0"));
-            new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
-            op_name = "add_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::LOG, std::nullopt, "0", idst1));
+            new_defines.insert({"BINOP_INIT", "stable_logaddexp_tile_init();"});
+            op_name = "stable_logaddexp_tile";
             break;
         case BinaryOpType::LOGADDEXP2:
-            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN0_0"));
-            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
-            new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
-            op_name = "add_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::LOG2, std::nullopt, "0", idst1));
+            new_defines.insert({"BINOP_INIT", "stable_logaddexp2_tile_init();"});
+            op_name = "stable_logaddexp2_tile";
             break;
         case BinaryOpType::LDEXP:
             new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/compute/eltwise_binary_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/compute/eltwise_binary_kernel.cpp
@@ -9,6 +9,7 @@
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 #define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -27,6 +27,7 @@
 #include "api/compute/binary_comp.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 #define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_metal_v2_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_metal_v2_factory.cpp
@@ -498,8 +498,7 @@ ProgramArtifacts create_no_bcast_artifacts(
 
     const bool has_lhs_act = !compute_defines["PROCESS_LHS_ACTIVATIONS(i)"].empty();
     const bool has_rhs_act = !compute_defines["PROCESS_RHS_ACTIVATIONS(i)"].empty();
-    const bool op_has_exp =
-        op_type == BinaryOpType::LOGADDEXP || op_type == BinaryOpType::LDEXP || op_type == BinaryOpType::LOGADDEXP2;
+    const bool op_has_exp = op_type == BinaryOpType::LDEXP;
 
     // --- num_tiles_per_cycle: DST register capacity per tile_regs_acquire (mirrors the descriptor
     // factory + the shipped factory's min(.,shard_tiles) cap). Multi-tile only when EVERY operand is borrowed
@@ -510,6 +509,9 @@ ProgramArtifacts create_no_bcast_artifacts(
     uint32_t num_tiles_per_cycle = 1;
     if (all_borrowed) {
         num_tiles_per_cycle = std::min<uint32_t>(is_sfpu ? 2u : 8u, c_full_shard_tiles);
+        if ((op_type == BinaryOpType::LOGADDEXP || op_type == BinaryOpType::LOGADDEXP2) && !is_sfpu) {
+            num_tiles_per_cycle = std::min<uint32_t>(4u, c_full_shard_tiles);
+        }
     }
 
     // --- DFB names. compute uses pre_lhs/pre_rhs/out (+post_lhs/post_rhs when activations); reader/

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_program_factory.cpp
@@ -476,8 +476,6 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
         // binary operands produces incorrect results.  Adding a typecast for
         // LHS forces it through a Float16_b intermediate CB so both operands
         // use the same format.
-        // Note: LOGADDEXP / LOGADDEXP2 are not affected because they process
-        // both sides (EXP/EXP2), so lhs_activations is never empty for them.
         if (!is_sfpu_op && lhs_activations.empty() && !rhs_activations.empty() && op_type == BinaryOpType::LDEXP &&
             (a_dtype == DataType::BFLOAT8_B || a_dtype == DataType::BFLOAT4_B)) {
             lhs_activations.push_back({
@@ -554,10 +552,12 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
             // no document and example to show why 4 does not work, need further investigation
             num_tiles_per_cycle = 2;
         }
+        if ((op_type == BinaryOpType::LOGADDEXP || op_type == BinaryOpType::LOGADDEXP2) && !is_sfpu_op) {
+            num_tiles_per_cycle = 4;
+        }
     }
 
-    bool op_has_exp =
-        op_type == BinaryOpType::LOGADDEXP || op_type == BinaryOpType::LDEXP || op_type == BinaryOpType::LOGADDEXP2;
+    bool op_has_exp = op_type == BinaryOpType::LDEXP;
     const bool inputs_row_major =
         CMAKE_UNIQUE_NAMESPACE::should_use_row_major_path(operation_attributes, b, has_sharding);
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.cpp
@@ -150,7 +150,7 @@ std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_w
 //  EnumT can either be FpuBinaryOp or SfpuBinaryOp
 template <class EnumT>
 OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std::optional<DataType> dtype) :
-    binary_op(EnumT::SUB) {
+    binary_op_type(binary_op_type), binary_op(EnumT::SUB) {
     switch (binary_op_type) {
         case BinaryOpType::ADD: binary_op = EnumT::ADD; break;
         case BinaryOpType::SUB: break;
@@ -247,19 +247,15 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std
             process_rhs = unary::UnaryOpType::EXP2;
             binary_op = EnumT::MUL;
             break;
-        // log( exp(a) + exp(b) )
         case BinaryOpType::LOGADDEXP:
-            process_lhs = unary::UnaryOpType::EXP;
-            process_rhs = unary::UnaryOpType::EXP;
-            binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::LOG;
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LOGADDEXP;
+            }
             break;
-        // log2( 2**a + 2**b )
         case BinaryOpType::LOGADDEXP2:
-            process_lhs = unary::UnaryOpType::EXP2;
-            process_rhs = unary::UnaryOpType::EXP2;
-            binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::LOG2;
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LOGADDEXP2;
+            }
             break;
         case BinaryOpType::BITWISE_AND:
             if (is_sfpu_op()) {
@@ -547,6 +543,8 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             return {"where_tile_init();", fmt::format("where_tile<DataFormat::{}>", data_format)};
         }
         case ISCLOSE: return {"isclose_binary_tile_init();", "isclose_binary_tile<(bool)ISCLOSE_EQUAL_NAN>"};
+        case LOGADDEXP: return {"stable_logaddexp_tile_init();", "stable_logaddexp_tile"};
+        case LOGADDEXP2: return {"stable_logaddexp2_tile_init();", "stable_logaddexp2_tile"};
         default: TT_THROW("Unsupported sfpu binary op {}", sfpu_binary_op);
     }
 }
@@ -555,6 +553,18 @@ std::map<std::string, std::string> OpConfig::as_defines(DataType dtype) const {
     std::map<std::string, std::string> defines;
 
     if (!is_sfpu_op()) {
+        if (binary_op_type == BinaryOpType::LOGADDEXP) {
+            defines["BINARY_OP"] = "stable_logaddexp_tiles";
+            defines["BINARY_OP_TYPE"] = "EltwiseBinaryType::ELWSUB";
+            return defines;
+        }
+
+        if (binary_op_type == BinaryOpType::LOGADDEXP2) {
+            defines["BINARY_OP"] = "stable_logaddexp2_tiles";
+            defines["BINARY_OP_TYPE"] = "EltwiseBinaryType::ELWSUB";
+            return defines;
+        }
+
         auto fpu_binary_op = std::get<FpuBinaryOp>(binary_op);
         auto binary_op_str = enchantum::to_string(fpu_binary_op);
         defines["BINARY_OP"] = fmt::format("{}_tiles", Lowercase{binary_op_str});

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.hpp
@@ -88,6 +88,8 @@ struct OpConfig {
         EQ,
         NE,
         ISCLOSE,
+        LOGADDEXP,
+        LOGADDEXP2,
     };
 
     template <class EnumT>
@@ -98,6 +100,7 @@ struct OpConfig {
     std::optional<unary::UnaryOpType> process_lhs;
     std::optional<unary::UnaryOpType> process_rhs;
     std::optional<unary::UnaryOpType> postprocess;
+    BinaryOpType binary_op_type;
     std::variant<FpuBinaryOp, SfpuBinaryOp> binary_op;
     bool is_sfpu_op() const;
 };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary.cpp
@@ -10,6 +10,7 @@
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 ALWI void process_tile(
     tt::CBIndex cb_pre_lhs_id,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
@@ -9,6 +9,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -9,6 +9,7 @@
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -28,6 +28,7 @@
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 ALWI void process_tile(
     tt::CBIndex cb_pre_lhs_id,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -29,6 +29,7 @@
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 FORCE_INLINE void process_sfpu_tiles(
     uint32_t n,
     uint32_t cb_pre_lhs_id,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 // Process n LHS tiles against a scalar tile at index 0 in cb_post_rhs
 FORCE_INLINE void process_sfpu_scalar_tiles(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_col_bcast_dfb.cpp
@@ -30,6 +30,7 @@
 #include "experimental/kernel_args.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_dfb.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 // One tile-row's worth of work: expand the broadcast operand's column tile once into llk_post, then run
 // the binary op freq times (reusing the expanded tile) against the streamed OTHER operand. Mirrors the CB

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_no_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_no_bcast_dfb.cpp
@@ -22,6 +22,7 @@
 #include "experimental/kernel_args.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_dfb.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 void kernel_main() {
     const uint32_t num_tiles = get_arg(args::num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_row_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_row_bcast_dfb.cpp
@@ -24,6 +24,7 @@
 #include "experimental/kernel_args.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_dfb.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 void kernel_main() {
     const uint32_t num_tiles = get_arg(args::num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_row_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_row_col_bcast_dfb.cpp
@@ -34,6 +34,7 @@
 #include "experimental/kernel_args.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_dfb.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 // One tile-row's worth of work. The COL operand (BCAST_OP) was delivered pre-expanded by the reader
 // software-fill, so it is preprocessed ONCE and reused across the row; the ROW operand (OTHER_OP) streams

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_bcast_dfb.cpp
@@ -33,6 +33,7 @@
 #include "experimental/kernel_args.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_dfb.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 // One (N,C) slab's worth of work: expand the broadcast operand's single-element tile once into llk_post,
 // then run the binary op freq times (reusing the expanded tile) against the streamed OTHER operand. Mirrors

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_dfb.cpp
@@ -23,6 +23,7 @@
 #include "experimental/kernel_args.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_dfb.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 void kernel_main() {
     const uint32_t num_tiles = get_arg(args::num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_col_bcast_dfb.cpp
@@ -56,6 +56,7 @@
 #include "experimental/kernel_args.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu_dfb.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 // One tile-row's worth of work: expand the broadcast operand's column tile once into llk_post, then run
 // the SFPU binary op freq times (reusing the expanded tile) against the streamed OTHER operand. Mirrors

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_no_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_no_bcast_dfb.cpp
@@ -46,6 +46,7 @@
 #include "experimental/kernel_args.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu_dfb.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 FORCE_INLINE void process_sfpu_tiles(
     uint32_t n,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_bcast_dfb.cpp
@@ -53,6 +53,7 @@
 #include "experimental/kernel_args.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu_dfb.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 void kernel_main() {
     const uint32_t num_tiles = get_arg(args::num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_col_bcast_dfb.cpp
@@ -58,6 +58,7 @@
 #include "experimental/kernel_args.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu_dfb.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 // One tile-row's worth of work. The COL operand (BCAST_OP) was delivered pre-expanded by the reader
 // software-fill, so it is preprocessed ONCE and reused across the row; the ROW operand (OTHER_OP) streams

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_bcast_dfb.cpp
@@ -57,6 +57,7 @@
 #include "experimental/kernel_args.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu_dfb.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 // One (N,C) slab's worth of work: expand the broadcast operand's single-element tile once into llk_post,
 // then run the SFPU binary op freq times (reusing the expanded tile) against the streamed OTHER operand.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_dfb.cpp
@@ -52,6 +52,7 @@
 #include "experimental/kernel_args.h"
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu_dfb.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 // Process n LHS tiles against the scalar tile parked at index 0 in dfb_post_rhs.
 FORCE_INLINE void process_sfpu_scalar_tiles(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
@@ -10,6 +10,7 @@
 
 #include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 ALWI void process_tile(
     tt::CBIndex cb_bcast,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 ALWI void process_tile(
     tt::CBIndex cb_pre_lhs,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
@@ -10,6 +10,7 @@
 
 #include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 ALWI void process_tile(
     tt::CBIndex cb_bcast,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -30,6 +30,7 @@
 #include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -30,6 +30,7 @@
 #include "api/compute/bcast.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 ALWI void process_tile(
     tt::CBIndex cb_pre_lhs,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
@@ -29,6 +29,7 @@
 #include "api/compute/bcast.h"
 #include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "ttnn/operations/eltwise/binary/device/kernels/compute/stable_logaddexp.hpp"
 
 ALWI void process_tile(
     tt::CBIndex cb_bcast,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #52037 by replacing the `LOGADDEXP` / `LOGADDEXP2` exp-add-log decompositions with stable tile helpers:

- `logaddexp(a, b) = max(a, b) + log1p(exp(min(a, b) - max(a, b)))`
- `logaddexp2(a, b) = max(a, b) + log1p(exp2(min(a, b) - max(a, b))) / ln2`

This keeps exponent inputs <= 0 and avoids intermediate overflow while preserving finite outputs for large finite inputs.

### Coverage
- `binary_ng` FPU/SFPU lowering
- legacy `binary/common` define builders
- Quasar `binary_ng`, Metal v2 DFB, and legacy copies
- fp32 and bf16 edge tests including +/-10000
- widened `logaddexp` / `logaddexp2` sweeps beyond +/-88.7

### Notes for reviewers
#52107 already exists and fixes the issue by adding ckernel enum cases for SFPU. This PR is an alternate host-level stable lowering that avoids adding new ckernel enum values and covers the legacy FPU/common and Quasar composition paths as well.

### Testing
- `git diff --check`
- `python -m py_compile tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py tests/sweep_framework/sweeps/eltwise/binary/logaddexp/logaddexp.py tests/sweep_framework/sweeps/eltwise/binary/logaddexp2/logaddexp2.py`
