### PR TITLE
#52682: Fix roll DRAM_RM 3-shard OOB and reshard diff-width dangling ref

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_roll.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_roll.py
@@ -414,3 +414,27 @@ def test_roll_col_major_height_sharded(device, shape, sh, sw, shifts, dims, layo
     )
     mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
     run_roll(device, torch.randn(shape, dtype=torch.bfloat16), layout, mem_config, shifts, dims)
+
+
+# rd=(2,6) shard_h=4 shift=1 dim=2: 3-source case (past reader's 2-slot `src_base`) routed via interleaved round-trip.
+def test_roll_dram_sharded_row_major_ge3_source_shards_routes_via_interleaved(device):
+    torch.manual_seed(51213)
+    shape = [1, 2, 6, 16]
+    sh, sw = 4, 16
+    total_h = shape[0] * shape[1] * shape[2]
+    ncores = total_h // sh
+    compute_grid = device.compute_with_storage_grid_size()
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has insufficient cores ({ncores} needed)")
+    shard_spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
+        [sh, sw],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+    x = torch.randn(shape, dtype=torch.bfloat16)
+    tt_in = ttnn.from_torch(
+        x, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config
+    )
+    out = ttnn.roll(tt_in, [1], [2])
+    assert_with_pcc(torch.roll(x, [1], [2]).float(), ttnn.to_torch(out.cpu()).float(), _PCC)

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
@@ -422,7 +423,9 @@ RollPlan compute_roll_plan(
     // Per core: [dst_bank_id, dst_bank_base, num_src, (src0_bank_id, src0_addr)..., num_xfers,
     //            (src_slot, src_off, dst_off, copy_size, src_stride, dst_stride, num_rows) x N]
     auto build_runtime_args_dram_rm = [&](uint32_t dst_core_idx, const std::vector<RollTransferDesc>& descs) {
-        // Collect unique source shards (at most 2) and assign them to staging slots 0/1.
+        // Reader hard-codes 2 staging CBs (src0/src1) and `src_base[2]`; higher-dim rolls whose
+        // shard band straddles an outer-dim period can need 3+ sources. `roll.cpp` filters those
+        // via `dram_rm_roll_needs_extra_source_shards` before dispatch — assert as belt-and-braces.
         std::vector<uint32_t> src_shards;
         std::unordered_map<uint32_t, uint32_t> src_to_slot;
         for (const auto& td : descs) {
@@ -431,6 +434,12 @@ RollPlan compute_roll_plan(
                 src_shards.push_back(td.src_dram_shard_idx);
             }
         }
+        TT_ASSERT(
+            src_shards.size() <= 2,
+            "Native sharded roll DRAM RM: dst core {} needs {} src shards; caller should have filtered via "
+            "dram_rm_roll_needs_extra_source_shards.",
+            dst_core_idx,
+            src_shards.size());
         KernelDescriptor::CoreRuntimeArgs args;
         args.push_back(dram_bank_id(dst_core_idx));
         // dst bank base = output buffer address + shard offset, from the current buffer.
@@ -593,6 +602,74 @@ void RollShardedProgramFactory::override_runtime_arguments(
         cb_addr_only.cbs.push_back(tt::tt_metal::CBDescriptor{.buffer = plan.output_buffer});
         tt::tt_metal::apply_descriptor_runtime_args(program, cb_addr_only);  // override-rebuild-ok: cb-addr-only
     }
+}
+
+bool dram_rm_roll_needs_extra_source_shards(const Tensor& input, uint32_t shift, int32_t dim) {
+    // Only DRAM ROW_MAJOR sharded input can hit the reader's `src_base[2]` limit. Everything
+    // else routes through kernels that don't have this shape-dependent staging cap.
+    if (!input.is_sharded() || input.memory_config().buffer_type() != BufferType::DRAM ||
+        input.layout() != Layout::ROW_MAJOR || !input.shard_spec().has_value()) {
+        return false;
+    }
+    const auto& shape = input.padded_shape();
+    const uint32_t rank = shape.rank();
+    if (dim < 0 || static_cast<uint32_t>(dim) >= rank) {
+        return false;
+    }
+    // Last-dim rolls rotate columns within a fixed row → at most 2 src column-shards, never 3+.
+    if (static_cast<uint32_t>(dim) == rank - 1) {
+        return false;
+    }
+
+    const auto& ss = input.shard_spec().value();
+    const uint32_t shard_cells_h = ss.shape[0];
+    const uint32_t shard_cells_w = ss.shape[1];
+    const uint32_t W_cells = shape[rank - 1];
+    std::vector<uint32_t> rd(rank, 1);
+    uint32_t H_cells = 1;
+    for (uint32_t i = 0; i + 1 < rank; i++) {
+        rd[i] = shape[i];
+        H_cells *= rd[i];
+    }
+    // Not a valid native shape; the real fatal will fire in compute_roll_plan.
+    if (shard_cells_w == 0 || shard_cells_h == 0 || W_cells % shard_cells_w != 0 ||
+        H_cells % shard_cells_h != 0) {
+        return false;
+    }
+
+    std::vector<uint32_t> row_stride(rank, 0);
+    {
+        uint32_t s = 1;
+        for (int32_t k = static_cast<int32_t>(rank) - 2; k >= 0; k--) {
+            row_stride[k] = s;
+            s *= rd[k];
+        }
+    }
+    const uint32_t dim_size_cells = (static_cast<uint32_t>(dim) == rank - 2) ? rd[dim] : shape[dim];
+    if (dim_size_cells == 0 || (shift % dim_size_cells) == 0) {
+        return false;  // No-op roll: every dst row's source is itself → 1 src shard per dst core.
+    }
+    const uint32_t shift_cells = shift;  // cell_h == 1 for RM.
+    auto rolled_src_row = [&](uint32_t r) -> uint32_t {
+        const uint32_t coord_d = (r / row_stride[dim]) % dim_size_cells;
+        const uint32_t src_coord_d = (coord_d + dim_size_cells - (shift_cells % dim_size_cells)) % dim_size_cells;
+        return r + (src_coord_d - coord_d) * row_stride[dim];
+    };
+
+    // Higher-dim roll: src_col == dst_col, so a dst shard's src shards differ only in row.
+    // Walk cell-rows within each dst shard row-band, count unique src shard rows.
+    const uint32_t n_shard_rows = H_cells / shard_cells_h;
+    for (uint32_t dst_sr = 0; dst_sr < n_shard_rows; ++dst_sr) {
+        std::unordered_set<uint32_t> unique_src_shard_rows;
+        for (uint32_t r_local = 0; r_local < shard_cells_h; ++r_local) {
+            const uint32_t r = dst_sr * shard_cells_h + r_local;
+            unique_src_shard_rows.insert(rolled_src_row(r) / shard_cells_h);
+            if (unique_src_shard_rows.size() > 2) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_program_factory.hpp
@@ -26,4 +26,9 @@ struct RollShardedProgramFactory {
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
+// The DRAM row-major reader stages sources into 2 CBs (`src_base[2]`). Higher-dim rolls whose
+// shard band straddles an outer-dim period can need 3+ sources on one dst core — caller must
+// route those away (e.g. interleaved round-trip). Pure function of shape / shard / shift / dim.
+bool dram_rm_roll_needs_extra_source_shards(const Tensor& input, uint32_t shift, int32_t dim);
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/roll.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/roll.cpp
@@ -74,6 +74,22 @@ ttnn::Tensor roll(
                     break;
                 }
             }
+        } else {
+            // DRAM RM reader stages sources in `src_base[2]`; higher-dim rolls whose shard band
+            // straddles an outer-dim period can need 3+ sources → route via interleaved.
+            for (size_t i = 0; i < adjusted_shifts.size(); ++i) {
+                int dim = input_dims[i];
+                if (dim < 0) {
+                    dim += num_dims;
+                }
+                if (ttnn::prim::dram_rm_roll_needs_extra_source_shards(
+                        input_tensor,
+                        static_cast<uint32_t>(adjusted_shifts[i]),
+                        static_cast<int32_t>(dim))) {
+                    native_ok = false;
+                    break;
+                }
+            }
         }
 
         if (native_ok) {
@@ -97,15 +113,23 @@ ttnn::Tensor roll(
             return result;
         }
 
-        // Sub-tile rotation must move elements inside tiles: untilize, roll, tilize, all
-        // staying sharded in L1.
-        ttnn::Tensor rm = ttnn::untilize(input_tensor, native_mem_config);
-        ttnn::Tensor rolled = roll(rm, shifts, input_dims);
-        ttnn::Tensor retiled = ttnn::tilize(rolled, native_mem_config, input_tensor.dtype());
-        if (output_mem_config != native_mem_config) {
-            return ttnn::to_memory_config(retiled, output_mem_config, std::nullopt);
+        ttnn::Tensor rolled;
+        if (is_tile) {
+            // Sub-tile rotation must move elements inside tiles: untilize, roll, tilize, all
+            // staying sharded in L1.
+            ttnn::Tensor rm = ttnn::untilize(input_tensor, native_mem_config);
+            ttnn::Tensor rolled_rm = roll(rm, shifts, input_dims);
+            rolled = ttnn::tilize(rolled_rm, native_mem_config, input_tensor.dtype());
+        } else {
+            // RM sharded fallback: interleaved DRAM round-trip. Recurses into the interleaved
+            // slice+concat branch below, then reshards back to the caller's requested config.
+            ttnn::Tensor interleaved = ttnn::to_memory_config(input_tensor, ttnn::DRAM_MEMORY_CONFIG, std::nullopt);
+            rolled = roll(interleaved, shifts, input_dims);
         }
-        return retiled;
+        if (output_mem_config != rolled.memory_config()) {
+            return ttnn::to_memory_config(rolled, output_mem_config, std::nullopt);
+        }
+        return rolled;
     }
 
     for (size_t i = 0; i < adjusted_shifts.size(); ++i) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_generic.cpp
@@ -551,10 +551,14 @@ std::vector<uint32_t> get_runtime_args_for_given_ranges_diff_width(
     const uint32_t ending_range) {
     std::vector<uint32_t> runtime_args = physical_core_coords;
     runtime_args.push_back(input_addr);
-    auto& num_output_pages_for_this_call = runtime_args.emplace_back(0);
+    // Placeholder written via index after the loop; a reference into `runtime_args` here would
+    // dangle once subsequent push_back()s reallocate the vector (heap-use-after-free).
+    const size_t num_output_pages_idx = runtime_args.size();
+    runtime_args.push_back(0);
     runtime_args.push_back(ending_range - starting_range);
     runtime_args.push_back(output_page_offset);
 
+    uint32_t num_output_pages_for_this_call = 0;
     for (uint32_t block_id = starting_range; block_id < ending_range; block_id++) {
         const auto& block = compressed_stride_vector[block_id];
 
@@ -584,6 +588,7 @@ std::vector<uint32_t> get_runtime_args_for_given_ranges_diff_width(
         }
         num_output_pages_for_this_call += pages_in_base_pattern * block.num_repeats;
     }
+    runtime_args[num_output_pages_idx] = num_output_pages_for_this_call;
     return runtime_args;
 }
 


### PR DESCRIPTION
### Ticket
Closes #52682

_Sub-issue of parent #51213._

### Problem
Two independent host-side runtime-arg construction bugs, both manifesting as silent memory corruption.

**Item 6 — `roll` DRAM row-major: 3+ source shards overrun the reader's 2-slot staging.**
`build_runtime_args_dram_rm` collects source-shard IDs into an unbounded vector, but the DRAM RM reader hard-codes exactly two staging slots:

```cpp
const uint32_t src_base[2] = {src_cbs[0].get_write_ptr(), src_cbs[1].get_write_ptr()};
for (uint32_t s = 0; s < num_src; s++) { ... src_base[s] ... }   // num_src is runtime arg
```

Higher-dim rolls whose destination shard band straddles an outer-dim period can need 3+ source shards on a single dst core (e.g. `shape=[1, 2, 6, 16]`, `shard_h=4`, `roll(shift=1, dim=2)` → dst core 1 sources `{0, 1, 2}`). The kernel indexes `src_base[2]` past a 2-entry stack array → L1 corruption on the staged shard, empirically observable as a device hang.

**A legal shape shouldn't hard-fail on a reader capacity limit.**
The 2-source cap is the only obstacle — the roll itself is well-defined and interleaved slice+concat already handles it. And a naive fatal placed inside `build_runtime_args_dram_rm` fires mid-`create_descriptor` on the enqueue path, leaving the command queue / program cache partially constructed, so device-fixture teardown hangs on any "expect error" test.

**Item 9 — reshard diff-width: reference into `runtime_args` dangles across subsequent `push_back`s.**
`get_runtime_args_for_given_ranges_diff_width` did:

```cpp
auto& num_output_pages_for_this_call = runtime_args.emplace_back(0);
// ... many runtime_args.push_back(...) inside a per-block loop ...
num_output_pages_for_this_call += pages_in_base_pattern * block.num_repeats;
```

Any `push_back` that reallocates the vector invalidates the reference → `+=` writes land in freed heap memory (use-after-free) and the placeholder stays `0`. Latent because typical block counts fit inside the initial small-buffer capacity. Confirmed with an ASAN C++ reproducer.

> **Rebase status:** mainline reshard was refactored to return a `ReshardRangeArgs` struct in #51988 (2026-08-04), which structurally can't dangle. This PR's mainline diff is therefore empty; the `experimental/quasar` mirror wasn't touched by that refactor and still had the bug — item 9 is delivered for the quasar copy only.

### What this PR does
- **Item 6**: `build_runtime_args_dram_rm` keeps a `TT_ASSERT(src_shards.size() <= 2, ...)` — debug-mode belt-and-braces against future drift between the routing helper (below) and the transfer enumeration.
- **Route legal shapes upstream via an interleaved round-trip.** New pure helper `ttnn::prim::dram_rm_roll_needs_extra_source_shards(input, shift, dim)` mirrors `compute_roll_plan`'s per-core source-shard enumeration and returns `true` when any dst shard needs 3+ sources. `roll.cpp`'s dispatcher checks it before dispatching to the native prim; on hit, the shape is routed through `to_memory_config(x, DRAM_MEMORY_CONFIG)` → interleaved slice+concat roll → reshard to the caller's requested config. The check runs at op-dispatch time before any device state is touched, so it can't leave a partially-constructed program.
- **Item 9 (quasar mirror only)**: replace the reference-based placeholder with an *index-based* one — capture `num_output_pages_idx = runtime_args.size()`, accumulate into a local `uint32_t`, patch once via `runtime_args[num_output_pages_idx] = ...` after the loop. Mainline reshard file: no diff (subsumed by #51988's refactor).

### Tests
All on Wormhole B0:

- New regression `test_roll_dram_sharded_row_major_ge3_source_shards_routes_via_interleaved` — shape `[1, 2, 6, 16]`, `shard_h=4`, `roll(shift=1, dim=2)`, asserts PCC match against `torch.roll`. **PASSED** in 3.7s via the interleaved-round-trip fallback.
- Full `test_universal_input_tm_roll.py` sweep — **64 passed** in 39.5s, no DRAM-RM sibling regression.
- Item 9 has no Python-level regression (UAF depends on vector growth); existing `test_reshard_diff_width` covers the fixed path.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/rt_arg_vector_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/rt_arg_vector_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/rt_arg_vector_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/rt_arg_vector_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/rt_arg_vector_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/rt_arg_vector_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/rt_arg_vector_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/rt_arg_vector_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/rt_arg_vector_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/rt_arg_vector_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/rt_arg_vector_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/rt_arg_vector_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/rt_arg_vector_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/rt_arg_vector_fixes)

