### PR TITLE
Feature: Broadcast Tensor prefetcher delivery for mcast-in1 matmul

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/global_circular_buffer.hpp>
+#include "impl/buffers/dram_sender_state_block.hpp"
 #include "impl/buffers/drisc_l1_arena.hpp"
 #include "impl/buffers/global_circular_buffer_dram_sender_internal.hpp"
 #include <tt-metalium/experimental/global_circular_buffer.hpp>
@@ -199,6 +200,205 @@ TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
                                << ", acked=" << acked << ")";
         EXPECT_GT(sent, 0u) << "Sender did not push any pages to receiver " << r;
     }
+}
+
+// Broadcast GCB: one DRISC sender multicasts one page to a 1-D row of receivers, so every
+// receiver ends up with byte-identical contents rather than its own stripe. This exercises the
+// NoC mechanism (DRISC multicast payload + per-receiver unicast credits) on its own; the
+// prefetcher's broadcast DMA/chunking loop is covered end to end by the ttnn broadcast
+// mcast-in1 tests.
+TEST_F(DramSenderGCBFixture, BroadcastOneSenderFourReceivers) {
+    constexpr uint32_t kNumReceivers = 4;
+    constexpr uint32_t kPageSize = 64;
+    constexpr uint32_t kNumPages = 1;
+    constexpr uint32_t kRemoteCBId = 31;
+    constexpr uint32_t kGcbSize = 1024;
+
+    const uint32_t bank_id = 0;
+    CoreRangeSet receiver_cores(CoreRange({0, 0}, {kNumReceivers - 1, 0}));
+    std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers = {{bank_id, receiver_cores}};
+
+    auto gcb = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
+        *mesh_device_,
+        bank_to_receivers,
+        kGcbSize,
+        BufferType::L1,
+        /*support_multi_receiver_shards=*/true);
+    const CoreCoord sender_logical = gcb.sender_receiver_core_mapping().at(0).first;
+
+    const auto& hal = MetalContext::instance().hal();
+    const uint32_t drisc_l1_unreserved = hal.get_dev_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
+    const uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
+
+    constexpr uint32_t kDriscSlotBytes = sizeof(uint32_t);
+    const uint32_t pages_sent_size = 2 * kDriscSlotBytes * kNumReceivers;
+    const uint32_t noc_xy_size = 2 * sizeof(uint32_t) * kNumReceivers;
+    const uint32_t config_size = 16;
+    auto align_up = [l1_alignment](uint32_t v) { return (v + l1_alignment - 1) & ~(l1_alignment - 1); };
+    uint32_t cursor = drisc_l1_unreserved;
+    const uint32_t pages_sent_addr = cursor;
+    cursor = align_up(cursor + pages_sent_size);
+    const uint32_t noc_xy_addr = cursor;
+    cursor = align_up(cursor + noc_xy_size);
+    const uint32_t config_addr = cursor;
+    cursor = align_up(cursor + config_size);
+    const uint32_t data_addr = cursor;
+
+    ASSERT_EQ(experimental::pages_sent_drisc_l1_base(gcb), pages_sent_addr);
+
+    // A single page; every receiver must end up with exactly these bytes.
+    std::vector<uint32_t> page(kPageSize / sizeof(uint32_t));
+    for (uint32_t w = 0; w < page.size(); ++w) {
+        page[w] = 0xBCA50000u + w;
+    }
+    auto sender_virtual = device_->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
+    const uint64_t drisc_l1_noc_addr_base =
+        hal.get_dev_noc_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
+    MetalContext::instance().get_cluster().write_core(
+        page.data(),
+        page.size() * sizeof(uint32_t),
+        tt_cxy_pair(mesh_device_->build_id(), sender_virtual),
+        drisc_l1_noc_addr_base + (data_addr - drisc_l1_unreserved));
+
+    // Multicast rectangle, derived the same way the GCB stamps it: the receivers' bounding box
+    // in virtual worker coords, min corner first.
+    const auto& receiver_phys = experimental::receiver_coords_per_sender(gcb).at(0);
+    ASSERT_EQ(receiver_phys.size(), kNumReceivers);
+    CoreCoord mcast_min = receiver_phys.front();
+    CoreCoord mcast_max = receiver_phys.front();
+    for (const auto& c : receiver_phys) {
+        mcast_min.x = std::min(mcast_min.x, c.x);
+        mcast_min.y = std::min(mcast_min.y, c.y);
+        mcast_max.x = std::max(mcast_max.x, c.x);
+        mcast_max.y = std::max(mcast_max.y, c.y);
+    }
+
+    distributed::MeshCoordinateRange device_range(distributed::MeshCoordinate(0, 0));
+    Program program = CreateProgram();
+
+    std::vector<uint32_t> sender_compile_args = {
+        kRemoteCBId,
+        kNumPages,
+        kPageSize,
+        kNumReceivers,
+        pages_sent_addr,
+        noc_xy_addr,
+        config_addr,
+        data_addr,
+        kGcbSize,
+        static_cast<uint32_t>(gcb.buffer_address()),
+        static_cast<uint32_t>(experimental::pages_sent_worker_l1_base(gcb)),
+        static_cast<uint32_t>(mcast_min.x),
+        static_cast<uint32_t>(mcast_min.y),
+        static_cast<uint32_t>(mcast_max.x),
+        static_cast<uint32_t>(mcast_max.y),
+    };
+    KernelHandle sender_kernel_id = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_sender.cpp",
+        sender_logical,
+        DramConfig{.noc = NOC::NOC_0, .compile_args = sender_compile_args, .defines = {{"BROADCAST", "1"}}});
+
+    std::vector<uint32_t> sender_rt_args;
+    sender_rt_args.reserve(2 * kNumReceivers);
+    for (const auto& c : receiver_phys) {
+        sender_rt_args.push_back(c.x);
+        sender_rt_args.push_back(c.y);
+    }
+    SetRuntimeArgs(program, sender_kernel_id, sender_logical, sender_rt_args);
+
+    CircularBufferConfig cb_config(kPageSize);
+    cb_config.remote_index(kRemoteCBId).set_page_size(kPageSize).set_data_format(tt::DataFormat::Float16_b);
+    experimental::CreateCircularBuffer(program, receiver_cores, cb_config, gcb);
+
+    std::vector<uint32_t> receiver_compile_args = {kRemoteCBId, kNumPages};
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_receiver.cpp",
+        receiver_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0, .compile_args = receiver_compile_args});
+
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, false);
+    distributed::Finish(mesh_device_->mesh_command_queue());
+
+    // Every receiver must hold the same page -- that is what "broadcast" means.
+    auto receivers_vec = corerange_to_cores(receiver_cores);
+    for (uint32_t r = 0; r < receivers_vec.size(); ++r) {
+        std::vector<uint32_t> result;
+        tt::tt_metal::detail::ReadFromDeviceL1(
+            device_, receivers_vec[r], gcb.buffer_address(), kPageSize, result, CoreType::WORKER);
+        for (uint32_t w = 0; w < page.size(); ++w) {
+            EXPECT_EQ(result[w], page[w]) << "Receiver " << r << " word " << w << " differs from the broadcast page";
+        }
+    }
+
+    // Credits must still balance per receiver even though one multicast carried the payload.
+    std::vector<uint32_t> pages_buf(2 * kNumReceivers, 0);
+    MetalContext::instance().get_cluster().read_core(
+        pages_buf.data(),
+        pages_buf.size() * sizeof(uint32_t),
+        tt_cxy_pair(mesh_device_->build_id(), sender_virtual),
+        drisc_l1_noc_addr_base + (pages_sent_addr - drisc_l1_unreserved));
+    for (uint32_t r = 0; r < kNumReceivers; ++r) {
+        EXPECT_EQ(pages_buf[2 * r], pages_buf[2 * r + 1])
+            << "Pages sent/acked mismatch for receiver " << r << " (sent=" << pages_buf[2 * r]
+            << ", acked=" << pages_buf[2 * r + 1] << ")";
+        EXPECT_GT(pages_buf[2 * r], 0u) << "Sender did not credit receiver " << r;
+    }
+}
+
+// The multicast rectangle is stamped for every DRAM-sender GCB, because the receiver set is fixed
+// for the GCB's lifetime while the choice to push through it is made per tensor. Pin the encoding
+// so a struct-layout or coordinate-space change can't silently point a broadcast push at the wrong
+// cores.
+TEST_F(DramSenderGCBFixture, StampsMulticastRectangle) {
+    constexpr uint32_t kNumReceivers = 4;
+    constexpr uint32_t kGcbSize = 1024;
+    const uint32_t bank_id = 0;
+    CoreRangeSet receiver_cores(CoreRange({0, 0}, {kNumReceivers - 1, 0}));
+
+    auto gcb = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
+        *mesh_device_,
+        {{bank_id, receiver_cores}},
+        kGcbSize,
+        BufferType::L1,
+        /*support_multi_receiver_shards=*/true);
+
+    const auto& receiver_phys = experimental::receiver_coords_per_sender(gcb).at(0);
+    ASSERT_EQ(receiver_phys.size(), kNumReceivers);
+    CoreCoord expected_min = receiver_phys.front();
+    CoreCoord expected_max = receiver_phys.front();
+    for (const auto& c : receiver_phys) {
+        expected_min.x = std::min(expected_min.x, c.x);
+        expected_min.y = std::min(expected_min.y, c.y);
+        expected_max.x = std::max(expected_max.x, c.x);
+        expected_max.y = std::max(expected_max.y, c.y);
+    }
+
+    const auto& hal = MetalContext::instance().hal();
+    const uint32_t drisc_l1_unreserved = hal.get_dev_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
+    const uint64_t drisc_l1_noc_addr_base =
+        hal.get_dev_noc_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
+    const auto sender_logical = gcb.sender_receiver_core_mapping().at(0).first;
+    const auto sender_virtual = device_->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
+
+    std::vector<uint8_t> block(sizeof(DramSenderStateBlock), 0);
+    MetalContext::instance().get_cluster().read_core(
+        block.data(),
+        block.size(),
+        tt_cxy_pair(mesh_device_->build_id(), sender_virtual),
+        drisc_l1_noc_addr_base +
+            (static_cast<uint32_t>(experimental::sender_state_drisc_l1_base(gcb)) - drisc_l1_unreserved));
+    const auto* state = reinterpret_cast<const DramSenderStateBlock*>(block.data());
+
+    EXPECT_EQ(state->mcast_start_x, static_cast<uint32_t>(expected_min.x));
+    EXPECT_EQ(state->mcast_start_y, static_cast<uint32_t>(expected_min.y));
+    EXPECT_EQ(state->mcast_end_x, static_cast<uint32_t>(expected_max.x));
+    EXPECT_EQ(state->mcast_end_y, static_cast<uint32_t>(expected_max.y));
+    EXPECT_EQ(state->num_receivers, kNumReceivers);
 }
 
 // Same data flow as SmokeOneSenderFourReceivers, but the sender (DRISC) and receiver

--- a/tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_sender.cpp
@@ -9,6 +9,12 @@
 // up by the normal CB attachment path (via experimental::CreateCircularBuffer
 // receiver overload); the sender side here is hand-managed because we don't
 // allocate a sender-side CB on DRAM cores.
+//
+// With BROADCAST defined, the per-receiver unicast scatter is replaced by one NoC
+// multicast of a single page to the whole receiver rectangle, with the credit
+// increments left per-receiver and unicast. That is the NoC mechanism the broadcast
+// Tensor prefetcher uses; this kernel exercises it independently of the prefetcher's
+// own DMA/chunking loop (which the ttnn broadcast mcast-in1 tests cover end to end).
 
 #include <stdint.h>
 
@@ -85,6 +91,54 @@ void kernel_main() {
     experimental::resize_remote_sender_cb_interface<false>(remote_cb_id, page_size, noc_index);
 
     // 5) Reserve and push num_pages, one page at a time.
+#ifdef BROADCAST
+    // Multicast rectangle in virtual worker coords, min corner first (NOC0 orientation).
+    constexpr uint32_t mcast_start_x = get_compile_time_arg_val(11);
+    constexpr uint32_t mcast_start_y = get_compile_time_arg_val(12);
+    constexpr uint32_t mcast_end_x = get_compile_time_arg_val(13);
+    constexpr uint32_t mcast_end_y = get_compile_time_arg_val(14);
+    const uint32_t sx = noc_index == 0 ? mcast_start_x : mcast_end_x;
+    const uint32_t sy = noc_index == 0 ? mcast_start_y : mcast_end_y;
+    const uint32_t ex = noc_index == 0 ? mcast_end_x : mcast_start_x;
+    const uint32_t ey = noc_index == 0 ? mcast_end_y : mcast_start_y;
+    const uint32_t mcast_noc_xy = uint32_t(NOC_MULTICAST_ENCODING(
+        DYNAMIC_NOC_X(noc_index, sx),
+        DYNAMIC_NOC_Y(noc_index, sy),
+        DYNAMIC_NOC_X(noc_index, ex),
+        DYNAMIC_NOC_Y(noc_index, ey)));
+
+    for (uint32_t i = 0; i < num_pages; ++i) {
+        experimental::remote_cb_reserve_back(remote_cb_id, 1);
+        // One multicast delivers the page to every receiver at the same fifo offset.
+        noc_async_write_multicast_one_packet(
+            data_drisc_l1_base + i * page_size,
+            get_noc_addr_helper(mcast_noc_xy, iface.fifo_wr_ptr),
+            page_size,
+            num_receivers,
+            /*linked=*/false,
+            noc_index);
+        // Multicast is non-posted; wait for the acks so the data has landed before the
+        // credits that announce it.
+        noc_async_write_barrier();
+
+        // Credits stay per-receiver and unicast, exactly as prefetcher_finalize_block does.
+        const uint32_t pages_sent = page_size / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
+        volatile tt_l1_ptr uint32_t* local_sent =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.aligned_pages_sent_ptr);
+        uint32_t remote_sent_base = remote_cb_remote_pages_sent_ptr(iface.num_receivers_and_remote_pages_sent_ptr);
+        volatile tt_l1_ptr uint32_t* xy = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr);
+        for (uint32_t r = 0; r < num_receivers; ++r) {
+            const uint32_t remote_noc_xy =
+                uint32_t(NOC_XY_ENCODING(DYNAMIC_NOC_X(noc_index, xy[0]), DYNAMIC_NOC_Y(noc_index, xy[1])));
+            *local_sent += pages_sent;
+            noc_semaphore_inc<true>(get_noc_addr_helper(remote_noc_xy, remote_sent_base), pages_sent, noc_index);
+            local_sent += experimental::REMOTE_CB_LOCAL_PAGES_STRIDE / sizeof(uint32_t);
+            remote_sent_base += 2 * L1_ALIGNMENT;
+            xy += 2;
+        }
+        iface.fifo_wr_ptr += page_size;
+    }
+#else
     for (uint32_t i = 0; i < num_pages; ++i) {
         experimental::remote_cb_reserve_back(remote_cb_id, 1);
         experimental::remote_cb_push_back_and_write_pages<false>(
@@ -97,6 +151,7 @@ void kernel_main() {
             noc_index);
         noc_async_posted_writes_flushed();
     }
+#endif  // BROADCAST
 
     experimental::remote_cb_sender_barrier(remote_cb_id);
     // Production prefetcher kernels call update_remote_cb_config_in_l1() here to checkpoint

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -116,6 +116,27 @@ def make_recv_contig_weight(
     return ttnn.as_tensor(pt_weight, device=device, dtype=dtype, memory_config=mem_config, layout=ttnn.TILE_LAYOUT)
 
 
+def make_broadcast_weight(device, pt_weight, dtype, bank_idx: int = 0):
+    """Allocate ``pt_weight`` ((1, 1, K, N)) as a single-shard DRAM ND tensor pinned to one
+    DRAM bank -- the layout a broadcast (mcast-in1) Tensor prefetcher expects.
+
+    There is no per-receiver partition here: the one shard spans the whole (K, N), and the
+    prefetcher multicasts each full-width K-block to every matmul worker. The GCB must be
+    built with that same bank as its only sender.
+    """
+    K = pt_weight.shape[-2]
+    N = pt_weight.shape[-1]
+    dram_core_range_set = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(bank_idx, 0), ttnn.CoreCoord(bank_idx, 0))})
+    nd_shard = ttnn.NdShardSpec(
+        ttnn.Shape([K, N]),
+        dram_core_range_set,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        ttnn.ShardDistributionStrategy.CONTIGUOUS_1D,
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.BufferType.DRAM, nd_shard)
+    return ttnn.as_tensor(pt_weight, device=device, dtype=dtype, memory_config=mem_config, layout=ttnn.TILE_LAYOUT)
+
+
 @contextlib.contextmanager
 def tensor_prefetcher_session(device):
     """Open a Tensor prefetcher Start/Stop window. Stop (and a device sync)

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_broadcast_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_broadcast_bench.py
@@ -164,9 +164,17 @@ def _time_trace(device, run_one, trace_repeats, executions=TRACE_EXECUTIONS):
 )
 @pytest.mark.parametrize("op_name,per_core_M_tiles,k_tiles,n_tiles,dtype", BENCH_SHAPES)
 @pytest.mark.parametrize("in0_block_w", [1, 2, 4, 8], ids=lambda w: f"bw{w}")
-def test_broadcast_mcast_in1_vs_plain(device, op_name, per_core_M_tiles, k_tiles, n_tiles, dtype, in0_block_w):
+@pytest.mark.parametrize("gcb_pages", [2, 8], ids=lambda n: f"depth{n}")
+def test_broadcast_mcast_in1_vs_plain(
+    device, op_name, per_core_M_tiles, k_tiles, n_tiles, dtype, in0_block_w, gcb_pages
+):
     if k_tiles % in0_block_w != 0:
         pytest.skip(f"K ({k_tiles} tiles) not divisible by in0_block_w={in0_block_w}")
+    # depth 2 is the minimum window and matches the baseline's double-buffered in1 CB byte for
+    # byte -- the equal-L1 point. Deeper trades L1 for round batching. Cap the total so the GCB
+    # cannot crowd out in0/out.
+    if gcb_pages * in0_block_w * n_tiles * _bytes_per_tile(dtype) > 256 * 1024:
+        pytest.skip("GCB would exceed the 256 KiB budget for this shape")
     (
         M,
         K,
@@ -220,7 +228,7 @@ def test_broadcast_mcast_in1_vs_plain(device, op_name, per_core_M_tiles, k_tiles
         [program_config],
         [tt_weight_bcast],
         bank_to_receivers=[(0, worker_cores)],
-        size=2 * page_bytes,
+        size=gcb_pages * page_bytes,
     )
     block_count = k_tiles // in0_block_w
 
@@ -256,7 +264,8 @@ def test_broadcast_mcast_in1_vs_plain(device, op_name, per_core_M_tiles, k_tiles
     gcb_us = gcb_elapsed / TRACE_REPEATS * 1e6
     flops = _flops(M, K, N)
     logger.info(
-        f"[bcast_bench][{op_name} bw={in0_block_w}] M={M} K={K} N={N} workers={NUM_WORKERS} "
+        f"[bcast_bench][{op_name} bw={in0_block_w} depth={gcb_pages}] M={M} K={K} N={N} "
+        f"workers={NUM_WORKERS} "
         f"weight={weight_bytes / 1024:.0f}KiB\n"
         f"    plain mcast_in1 : {plain_us:8.2f} us/matmul  "
         f"{flops * TRACE_REPEATS / plain_elapsed / 1e12:6.3f} TFLOP/s  "
@@ -283,7 +292,16 @@ def test_repeat_count_amortization(device, trace_repeats):
     op_name, per_core_M_tiles, k_tiles, n_tiles, dtype = "m2_k32_n8_bf16", 2, 32, 8, ttnn.bfloat16
     in0_block_w = 8
     (
-        M, K, N, worker_cores, pt_weight, pt_act, tt_act, out_mem_config, program_config, compute_kernel_config,
+        M,
+        K,
+        N,
+        worker_cores,
+        pt_weight,
+        pt_act,
+        tt_act,
+        out_mem_config,
+        program_config,
+        compute_kernel_config,
     ) = _build_common(device, per_core_M_tiles, k_tiles, n_tiles, in0_block_w, dtype, seed=7)
     expected = pt_act.float() @ pt_weight.float()
 
@@ -293,8 +311,13 @@ def test_repeat_count_amortization(device, trace_repeats):
 
     def plain_linear(out=None):
         return ttnn.linear(
-            tt_act, tt_weight_dram, program_config=program_config, memory_config=out_mem_config,
-            compute_kernel_config=compute_kernel_config, dtype=dtype, optional_output_tensor=out,
+            tt_act,
+            tt_weight_dram,
+            program_config=program_config,
+            memory_config=out_mem_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+            optional_output_tensor=out,
         )
 
     plain_out = plain_linear()
@@ -306,18 +329,29 @@ def test_repeat_count_amortization(device, trace_repeats):
     tt_weight_bcast = _make_broadcast_weight(device, pt_weight, dtype=dtype)
     page_bytes = in0_block_w * n_tiles * _bytes_per_tile(dtype)
     gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
-        device, [program_config], [tt_weight_bcast], bank_to_receivers=[(0, worker_cores)], size=2 * page_bytes,
+        device,
+        [program_config],
+        [tt_weight_bcast],
+        bank_to_receivers=[(0, worker_cores)],
+        size=2 * page_bytes,
     )
 
     def gcb_linear(out=None):
         return ttnn.linear(
-            tt_act, tt_weight_bcast, program_config=program_config, global_cb=gcb, memory_config=out_mem_config,
-            compute_kernel_config=compute_kernel_config, dtype=dtype, optional_output_tensor=out,
+            tt_act,
+            tt_weight_bcast,
+            program_config=program_config,
+            global_cb=gcb,
+            memory_config=out_mem_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+            optional_output_tensor=out,
         )
 
     with tensor_prefetcher_session(device):
         ttnn.experimental.queue_tensor_prefetcher_request(
-            device, [(tt_weight_bcast, k_tiles // in0_block_w)] * (2 + (1 + TRACE_EXECUTIONS) * trace_repeats),
+            device,
+            [(tt_weight_bcast, k_tiles // in0_block_w)] * (2 + (1 + TRACE_EXECUTIONS) * trace_repeats),
             global_cb=gcb,
         )
         gcb_out = gcb_linear()
@@ -331,4 +365,73 @@ def test_repeat_count_amortization(device, trace_repeats):
         f"plain={plain_elapsed / trace_repeats * 1e6:8.2f} us/matmul  "
         f"prefetcher={gcb_elapsed / trace_repeats * 1e6:7.2f} us/matmul  "
         f"(trace totals: plain={plain_elapsed * 1e3:.2f}ms prefetcher={gcb_elapsed * 1e3:.2f}ms)"
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"trace_region_size": 90000000}],
+    indirect=True,
+)
+@pytest.mark.parametrize("gcb_pages", [2, 4, 8, 16], ids=lambda n: f"depth{n}")
+@pytest.mark.parametrize("n_tiles", [1, 8], ids=lambda n: f"n{n}")
+def test_gcb_depth_sensitivity(device, gcb_pages, n_tiles):
+    """How much of the small-in0_block_w deficit is just a shallow GCB?
+
+    The kernel batches B blocks per round, clamped by free space in the GCB. At the two-page
+    minimum B is 2, so a 32-block tensor costs 16 rounds -- and each round pays a poll, a write
+    barrier and a per-receiver credit update. A deeper window should collapse the round count.
+    """
+    per_core_M_tiles, k_tiles, in0_block_w, dtype = 2, 32, 1, ttnn.bfloat16
+    (
+        M,
+        K,
+        N,
+        worker_cores,
+        pt_weight,
+        pt_act,
+        tt_act,
+        out_mem_config,
+        program_config,
+        compute_kernel_config,
+    ) = _build_common(device, per_core_M_tiles, k_tiles, n_tiles, in0_block_w, dtype, seed=11)
+    expected = pt_act.float() @ pt_weight.float()
+
+    tt_weight_bcast = _make_broadcast_weight(device, pt_weight, dtype=dtype)
+    page_bytes = in0_block_w * n_tiles * _bytes_per_tile(dtype)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device,
+        [program_config],
+        [tt_weight_bcast],
+        bank_to_receivers=[(0, worker_cores)],
+        size=gcb_pages * page_bytes,
+    )
+
+    def gcb_linear(out=None):
+        return ttnn.linear(
+            tt_act,
+            tt_weight_bcast,
+            program_config=program_config,
+            global_cb=gcb,
+            memory_config=out_mem_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+            optional_output_tensor=out,
+        )
+
+    with tensor_prefetcher_session(device):
+        ttnn.experimental.queue_tensor_prefetcher_request(
+            device,
+            [(tt_weight_bcast, k_tiles // in0_block_w)] * (2 + (1 + TRACE_EXECUTIONS) * TRACE_REPEATS),
+            global_cb=gcb,
+        )
+        out = gcb_linear()
+        gcb_linear(out)
+        elapsed = _time_trace(device, lambda: gcb_linear(out), TRACE_REPEATS)
+        passing, out_str = comp_pcc(expected, ttnn.to_torch(out), 0.99)
+        assert passing, f"depth={gcb_pages} PCC failed: {out_str}"
+
+    logger.info(
+        f"[gcb_depth] n_tiles={n_tiles} pages={gcb_pages:3d} ({gcb_pages * page_bytes / 1024:.0f}KiB)  "
+        f"prefetcher={elapsed / TRACE_REPEATS * 1e6:7.2f} us/matmul"
     )

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_broadcast_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_broadcast_bench.py
@@ -50,7 +50,7 @@ BENCH_SHAPES = [
 ]
 
 NUM_WORKERS = 8
-TRACE_REPEATS = 32
+TRACE_REPEATS = 64
 
 
 def _flops(M, K, N):
@@ -127,8 +127,16 @@ def _build_common(device, per_core_M_tiles, k_tiles, n_tiles, in0_block_w, dtype
     )
 
 
-def _time_trace(device, run_one, trace_repeats):
-    """Capture `trace_repeats` cached dispatches, replay once, wall-clock the replay."""
+TRACE_EXECUTIONS = 4
+
+
+def _time_trace(device, run_one, trace_repeats, executions=TRACE_EXECUTIONS):
+    """Capture `trace_repeats` cached dispatches and time steady-state replay.
+
+    The FIRST execute_trace of a given trace carries a large one-off cost (several ms here), so
+    timing a single replay charges that to the matmuls and wildly inflates per-matmul time at small
+    repeat counts. Execute once to warm, then time `executions` further replays.
+    """
     trace = ttnn.begin_trace_capture(device, cq_id=0)
     out = None
     for _ in range(trace_repeats):
@@ -136,10 +144,15 @@ def _time_trace(device, run_one, trace_repeats):
     ttnn.end_trace_capture(device, trace, cq_id=0)
     assert out is not None
 
-    t0 = time.perf_counter()
+    # Warm: pay the one-off first-replay cost outside the measurement.
     ttnn.execute_trace(device, trace, cq_id=0, blocking=False)
     ttnn.synchronize_device(device)
-    elapsed = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    for _ in range(executions):
+        ttnn.execute_trace(device, trace, cq_id=0, blocking=False)
+    ttnn.synchronize_device(device)
+    elapsed = (time.perf_counter() - t0) / executions
     ttnn.release_trace(device, trace)
     return elapsed
 
@@ -224,11 +237,11 @@ def test_broadcast_mcast_in1_vs_plain(device, op_name, per_core_M_tiles, k_tiles
         )
 
     with tensor_prefetcher_session(device):
-        # One long-lived stream: 2 warmup layers + TRACE_REPEATS traced layers, queued up front so
-        # the prefetcher runs ahead of the matmuls rather than being driven by them.
+        # One long-lived stream: 2 warmup layers + one layer per traced matmul per replay, queued
+        # up front so the prefetcher runs ahead rather than being driven by the matmuls.
         ttnn.experimental.queue_tensor_prefetcher_request(
             device,
-            [(tt_weight_bcast, block_count)] * (2 + TRACE_REPEATS),
+            [(tt_weight_bcast, block_count)] * (2 + (1 + TRACE_EXECUTIONS) * TRACE_REPEATS),
             global_cb=gcb,
         )
         gcb_out = gcb_linear()
@@ -252,4 +265,70 @@ def test_broadcast_mcast_in1_vs_plain(device, op_name, per_core_M_tiles, k_tiles
         f"{flops * TRACE_REPEATS / gcb_elapsed / 1e12:6.3f} TFLOP/s  "
         f"{weight_bytes * TRACE_REPEATS / gcb_elapsed / 1e9:6.2f} GB/s in1\n"
         f"    speedup         : {plain_us / gcb_us:6.3f}x"
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"trace_region_size": 90000000}],
+    indirect=True,
+)
+@pytest.mark.parametrize("trace_repeats", [1, 4, 16, 64, 128], ids=lambda n: f"rep{n}")
+def test_repeat_count_amortization(device, trace_repeats):
+    """Is one trace of N matmuls enough to amortize per-dispatch launch cost?
+
+    If per-matmul time keeps falling as N grows, the headline numbers are polluted by a fixed
+    per-trace/per-launch cost. If it flattens, the measured time really is per matmul.
+    """
+    op_name, per_core_M_tiles, k_tiles, n_tiles, dtype = "m2_k32_n8_bf16", 2, 32, 8, ttnn.bfloat16
+    in0_block_w = 8
+    (
+        M, K, N, worker_cores, pt_weight, pt_act, tt_act, out_mem_config, program_config, compute_kernel_config,
+    ) = _build_common(device, per_core_M_tiles, k_tiles, n_tiles, in0_block_w, dtype, seed=7)
+    expected = pt_act.float() @ pt_weight.float()
+
+    tt_weight_dram = ttnn.from_torch(
+        pt_weight, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    def plain_linear(out=None):
+        return ttnn.linear(
+            tt_act, tt_weight_dram, program_config=program_config, memory_config=out_mem_config,
+            compute_kernel_config=compute_kernel_config, dtype=dtype, optional_output_tensor=out,
+        )
+
+    plain_out = plain_linear()
+    plain_linear(plain_out)
+    plain_elapsed = _time_trace(device, lambda: plain_linear(plain_out), trace_repeats)
+    passing, out_str = comp_pcc(expected, ttnn.to_torch(plain_out), 0.99)
+    assert passing, f"baseline post-trace PCC failed: {out_str}"
+
+    tt_weight_bcast = _make_broadcast_weight(device, pt_weight, dtype=dtype)
+    page_bytes = in0_block_w * n_tiles * _bytes_per_tile(dtype)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device, [program_config], [tt_weight_bcast], bank_to_receivers=[(0, worker_cores)], size=2 * page_bytes,
+    )
+
+    def gcb_linear(out=None):
+        return ttnn.linear(
+            tt_act, tt_weight_bcast, program_config=program_config, global_cb=gcb, memory_config=out_mem_config,
+            compute_kernel_config=compute_kernel_config, dtype=dtype, optional_output_tensor=out,
+        )
+
+    with tensor_prefetcher_session(device):
+        ttnn.experimental.queue_tensor_prefetcher_request(
+            device, [(tt_weight_bcast, k_tiles // in0_block_w)] * (2 + (1 + TRACE_EXECUTIONS) * trace_repeats),
+            global_cb=gcb,
+        )
+        gcb_out = gcb_linear()
+        gcb_linear(gcb_out)
+        gcb_elapsed = _time_trace(device, lambda: gcb_linear(gcb_out), trace_repeats)
+        passing, out_str = comp_pcc(expected, ttnn.to_torch(gcb_out), 0.99)
+        assert passing, f"prefetcher post-trace PCC failed: {out_str}"
+
+    logger.info(
+        f"[amortization] repeats={trace_repeats:4d}  "
+        f"plain={plain_elapsed / trace_repeats * 1e6:8.2f} us/matmul  "
+        f"prefetcher={gcb_elapsed / trace_repeats * 1e6:7.2f} us/matmul  "
+        f"(trace totals: plain={plain_elapsed * 1e3:.2f}ms prefetcher={gcb_elapsed * 1e3:.2f}ms)"
     )

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_broadcast_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_broadcast_bench.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Broadcast Tensor prefetcher vs. plain mcast-in1, same matmul.
+
+Both arms run the identical `mcast_in1` matmul on the identical worker line with the identical
+program config; only where in1 comes from differs:
+
+- **baseline**: in1 is INTERLEAVED in DRAM. The first worker reads each K-block over the NoC into
+  its own CB and multicasts it on-grid to the rest. The read sits on the critical path.
+- **prefetcher**: in1 is a single-shard NdShardSpec on one DRAM bank. That bank's DRISC reads it
+  from GDDR and multicasts each K-block straight into every worker's GCB slot, off the command
+  queue, so the read overlaps compute.
+
+Timing follows test_prefetcher_BH_bench.py: capture a trace of `trace_repeats` cached matmul
+dispatches, replay it once, and wall-clock the replay. That takes host dispatch out of the
+measurement and reports steady-state device time per matmul.
+"""
+
+import time
+
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.ttnn.unit_tests.operations.prefetcher_common import (
+    bytes_per_tile as _bytes_per_tile,
+    make_broadcast_weight as _make_broadcast_weight,
+    tensor_prefetcher_session,
+)
+
+# A broadcast page is `in0_block_w` K-rows of the FULL weight width, and the DRISC fit ladder
+# cannot split below one K-row, so `N_tiles * tile_bytes` must fit one stage third (~23.6 KB).
+# That caps N at ~11 tiles for bf16 and ~21 for bf8_b -- see the module docstring note.
+#
+# (name, M_tiles_per_worker, K_tiles, N_tiles, dtype)
+BENCH_SHAPES = [
+    ("m2_k32_n8_bf16", 2, 32, 8, ttnn.bfloat16),
+    ("m6_k32_n8_bf16", 6, 32, 8, ttnn.bfloat16),
+    ("m2_k64_n8_bf16", 2, 64, 8, ttnn.bfloat16),
+    ("m4_k32_n16_bf8", 4, 32, 16, ttnn.bfloat8_b),
+    # Weight-size sweep at fixed M/K, to separate the baseline's in1 read cost from
+    # whatever fixed cost it carries.
+    ("m2_k32_n1_bf16", 2, 32, 1, ttnn.bfloat16),
+    ("m2_k32_n2_bf16", 2, 32, 2, ttnn.bfloat16),
+    ("m2_k32_n4_bf16", 2, 32, 4, ttnn.bfloat16),
+]
+
+NUM_WORKERS = 8
+TRACE_REPEATS = 32
+
+
+def _flops(M, K, N):
+    return 2.0 * M * K * N
+
+
+def _build_common(device, per_core_M_tiles, k_tiles, n_tiles, in0_block_w, dtype, seed):
+    """Shapes, activation and program config shared by both arms."""
+    M = NUM_WORKERS * per_core_M_tiles * ttnn.TILE_SIZE
+    K = k_tiles * ttnn.TILE_SIZE
+    N = n_tiles * ttnn.TILE_SIZE
+    worker_cores = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(NUM_WORKERS - 1, 0))})
+
+    torch.manual_seed(seed)
+    pt_weight = torch.randn(1, 1, K, N)
+    pt_act = torch.randn(1, 1, M, K)
+
+    act_mem_config = ttnn.create_sharded_memory_config(
+        shape=(per_core_M_tiles * ttnn.TILE_SIZE, K),
+        core_grid=worker_cores,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    tt_act = ttnn.from_torch(pt_act, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=act_mem_config)
+    out_mem_config = ttnn.create_sharded_memory_config(
+        shape=(per_core_M_tiles * ttnn.TILE_SIZE, N),
+        core_grid=worker_cores,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    out_subblock_w = min(n_tiles, 4)
+    while n_tiles % out_subblock_w != 0:
+        out_subblock_w -= 1
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(NUM_WORKERS, 1),
+        in0_block_w=in0_block_w,
+        out_subblock_h=1,
+        out_subblock_w=out_subblock_w,
+        out_block_h=per_core_M_tiles,
+        out_block_w=n_tiles,
+        per_core_M=per_core_M_tiles,
+        per_core_N=n_tiles,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+        gather_in0=False,
+        hop_cores=ttnn.CoreRangeSet([]),
+        num_global_cb_receivers=1,
+        untilize_out=False,
+        stream_in1=False,
+    )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+        dst_full_sync_en=True,
+    )
+    return (
+        M,
+        K,
+        N,
+        worker_cores,
+        pt_weight,
+        pt_act,
+        tt_act,
+        out_mem_config,
+        program_config,
+        compute_kernel_config,
+    )
+
+
+def _time_trace(device, run_one, trace_repeats):
+    """Capture `trace_repeats` cached dispatches, replay once, wall-clock the replay."""
+    trace = ttnn.begin_trace_capture(device, cq_id=0)
+    out = None
+    for _ in range(trace_repeats):
+        out = run_one()  # named reference keeps the output buffer alive
+    ttnn.end_trace_capture(device, trace, cq_id=0)
+    assert out is not None
+
+    t0 = time.perf_counter()
+    ttnn.execute_trace(device, trace, cq_id=0, blocking=False)
+    ttnn.synchronize_device(device)
+    elapsed = time.perf_counter() - t0
+    ttnn.release_trace(device, trace)
+    return elapsed
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"trace_region_size": 23887872}],
+    indirect=True,
+)
+@pytest.mark.parametrize("op_name,per_core_M_tiles,k_tiles,n_tiles,dtype", BENCH_SHAPES)
+@pytest.mark.parametrize("in0_block_w", [1, 2, 4, 8], ids=lambda w: f"bw{w}")
+def test_broadcast_mcast_in1_vs_plain(device, op_name, per_core_M_tiles, k_tiles, n_tiles, dtype, in0_block_w):
+    if k_tiles % in0_block_w != 0:
+        pytest.skip(f"K ({k_tiles} tiles) not divisible by in0_block_w={in0_block_w}")
+    (
+        M,
+        K,
+        N,
+        worker_cores,
+        pt_weight,
+        pt_act,
+        tt_act,
+        out_mem_config,
+        program_config,
+        compute_kernel_config,
+    ) = _build_common(device, per_core_M_tiles, k_tiles, n_tiles, in0_block_w, dtype, seed=len(op_name))
+
+    expected = pt_act.float() @ pt_weight.float()
+    weight_bytes = k_tiles * n_tiles * _bytes_per_tile(dtype)
+
+    # ---- Arm A: plain mcast-in1, in1 interleaved in DRAM, relayed on-grid by worker 0. ----
+    tt_weight_dram = ttnn.from_torch(
+        pt_weight, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    def plain_linear(out=None):
+        return ttnn.linear(
+            tt_act,
+            tt_weight_dram,
+            program_config=program_config,
+            memory_config=out_mem_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+            optional_output_tensor=out,
+        )
+
+    # Allocate the reusable output, then warm the *exact* variant the trace will replay -- passing
+    # optional_output_tensor changes the program hash, so warming without it leaves the traced
+    # variant uncached and trace capture refuses to load new binaries.
+    plain_out = plain_linear()
+    plain_linear(plain_out)
+    passing, out_str = comp_pcc(expected, ttnn.to_torch(plain_out), 0.99)
+    assert passing, f"[{op_name}] baseline PCC failed: {out_str}"
+    plain_elapsed = _time_trace(device, lambda: plain_linear(plain_out), TRACE_REPEATS)
+    # Every traced iteration rewrites the same buffer, so a correct replay leaves a correct result.
+    # Without this a silently-degenerate arm (e.g. consuming stale pages) would just look fast.
+    passing, out_str = comp_pcc(expected, ttnn.to_torch(plain_out), 0.99)
+    assert passing, f"[{op_name}] baseline post-trace PCC failed: {out_str}"
+
+    # ---- Arm B: broadcast Tensor prefetcher, in1 a single shard on one bank, DRISC-multicast. ----
+    tt_weight_bcast = _make_broadcast_weight(device, pt_weight, dtype=dtype)
+    page_bytes = in0_block_w * n_tiles * _bytes_per_tile(dtype)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device,
+        [program_config],
+        [tt_weight_bcast],
+        bank_to_receivers=[(0, worker_cores)],
+        size=2 * page_bytes,
+    )
+    block_count = k_tiles // in0_block_w
+
+    def gcb_linear(out=None):
+        return ttnn.linear(
+            tt_act,
+            tt_weight_bcast,
+            program_config=program_config,
+            global_cb=gcb,
+            memory_config=out_mem_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+            optional_output_tensor=out,
+        )
+
+    with tensor_prefetcher_session(device):
+        # One long-lived stream: 2 warmup layers + TRACE_REPEATS traced layers, queued up front so
+        # the prefetcher runs ahead of the matmuls rather than being driven by them.
+        ttnn.experimental.queue_tensor_prefetcher_request(
+            device,
+            [(tt_weight_bcast, block_count)] * (2 + TRACE_REPEATS),
+            global_cb=gcb,
+        )
+        gcb_out = gcb_linear()
+        gcb_linear(gcb_out)  # warm the traced variant (see the baseline note above)
+        passing, out_str = comp_pcc(expected, ttnn.to_torch(gcb_out), 0.99)
+        assert passing, f"[{op_name}] prefetcher PCC failed: {out_str}"
+        gcb_elapsed = _time_trace(device, lambda: gcb_linear(gcb_out), TRACE_REPEATS)
+        passing, out_str = comp_pcc(expected, ttnn.to_torch(gcb_out), 0.99)
+        assert passing, f"[{op_name}] prefetcher post-trace PCC failed: {out_str}"
+
+    plain_us = plain_elapsed / TRACE_REPEATS * 1e6
+    gcb_us = gcb_elapsed / TRACE_REPEATS * 1e6
+    flops = _flops(M, K, N)
+    logger.info(
+        f"[bcast_bench][{op_name} bw={in0_block_w}] M={M} K={K} N={N} workers={NUM_WORKERS} "
+        f"weight={weight_bytes / 1024:.0f}KiB\n"
+        f"    plain mcast_in1 : {plain_us:8.2f} us/matmul  "
+        f"{flops * TRACE_REPEATS / plain_elapsed / 1e12:6.3f} TFLOP/s  "
+        f"{weight_bytes * TRACE_REPEATS / plain_elapsed / 1e9:6.2f} GB/s in1\n"
+        f"    prefetcher bcast: {gcb_us:8.2f} us/matmul  "
+        f"{flops * TRACE_REPEATS / gcb_elapsed / 1e12:6.3f} TFLOP/s  "
+        f"{weight_bytes * TRACE_REPEATS / gcb_elapsed / 1e9:6.2f} GB/s in1\n"
+        f"    speedup         : {plain_us / gcb_us:6.3f}x"
+    )

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -61,6 +61,7 @@ from tests.ttnn.unit_tests.operations.prefetcher_common import (
     bank_receivers_strided as _bank_receivers_strided,
     bank_receivers_contiguous as _bank_receivers_contiguous,
     make_recv_contig_weight as _make_recv_contig_weight,
+    make_broadcast_weight as _make_broadcast_weight,
     tensor_prefetcher_session,
 )
 
@@ -1283,3 +1284,436 @@ def test_tensor_prefetcher_streaming_mcast_in0(device, distribution_strategy):
     assert (
         device.num_program_cache_entries() == cache_entries_after_first
     ), "second mcast_in0 invocation did not hit the program cache"
+
+
+def _broadcast_mcast_in1_setup(device, num_workers, k_tiles, n_tiles, in0_block_w, dtype, seed_tag):
+    """Shared shapes/config for the broadcast mcast-in1 tests.
+
+    mcast-in1 is M-parallel: the workers form a 1-wide row, split M between them, and every one
+    of them needs the *same* full (K, N) weight. That is what makes a broadcast GCB the right
+    delivery topology -- one DRAM bank holds the whole weight and multicasts each K-block.
+    """
+    M = num_workers * ttnn.TILE_SIZE
+    K = k_tiles * ttnn.TILE_SIZE
+    N = n_tiles * ttnn.TILE_SIZE
+    worker_cores = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_workers - 1, 0))})
+
+    torch.manual_seed(zlib.crc32(seed_tag.encode()))
+    pt_weight = torch.randn(1, 1, K, N)
+    tt_weight = _make_broadcast_weight(device, pt_weight, dtype=dtype)
+
+    pt_act = torch.randn(1, 1, M, K)
+    # in0 is height-sharded: one M-tile per worker, each holding the full K.
+    act_mem_config = ttnn.create_sharded_memory_config(
+        shape=(ttnn.TILE_SIZE, K),
+        core_grid=worker_cores,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    tt_act = ttnn.from_torch(pt_act, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=act_mem_config)
+
+    out_subblock_w = min(n_tiles, 4)
+    while n_tiles % out_subblock_w != 0:
+        out_subblock_w -= 1
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(num_workers, 1),
+        in0_block_w=in0_block_w,
+        out_subblock_h=1,
+        out_subblock_w=out_subblock_w,
+        out_block_h=1,
+        out_block_w=n_tiles,
+        per_core_M=1,
+        per_core_N=n_tiles,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+        gather_in0=False,
+        hop_cores=ttnn.CoreRangeSet([]),
+        num_global_cb_receivers=1,
+        untilize_out=False,
+        stream_in1=False,
+    )
+
+    # The whole weight lives on bank 0, whose DRISC multicasts to every worker.
+    bank_to_receivers = [(0, worker_cores)]
+    page_size_bytes = in0_block_w * n_tiles * _bytes_per_tile(dtype)
+    output_mem_config = ttnn.create_sharded_memory_config(
+        shape=(ttnn.TILE_SIZE, N),
+        core_grid=worker_cores,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    return (
+        pt_weight,
+        tt_weight,
+        pt_act,
+        tt_act,
+        program_config,
+        bank_to_receivers,
+        page_size_bytes,
+        output_mem_config,
+        N,
+    )
+
+
+@pytest.mark.parametrize("num_workers", [3, 8], ids=["3cores", "8cores"])
+@pytest.mark.parametrize("use_bias", [False, True], ids=["nobias", "bias"])
+def test_tensor_prefetcher_broadcast_mcast_in1(device, num_workers, use_bias):
+    """A single DRAM bank multicasts the whole weight to a 1-D array of mcast-in1 workers."""
+    dtype = ttnn.bfloat16
+    k_tiles = 4
+    n_tiles = 2
+    in0_block_w = 1
+
+    (
+        pt_weight,
+        tt_weight,
+        pt_act,
+        tt_act,
+        program_config,
+        bank_to_receivers,
+        page_size_bytes,
+        output_mem_config,
+        N,
+    ) = _broadcast_mcast_in1_setup(
+        device, num_workers, k_tiles, n_tiles, in0_block_w, dtype, f"broadcast_mcast_in1_{num_workers}_{use_bias}"
+    )
+
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device,
+        [program_config],
+        [tt_weight],
+        bank_to_receivers=bank_to_receivers,
+        size=2 * page_size_bytes,
+    )
+
+    pt_bias = None
+    tt_bias = None
+    if use_bias:
+        pt_bias = torch.randn(1, N)
+        tt_bias = ttnn.from_torch(pt_bias, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT)
+
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+        dst_full_sync_en=True,
+    )
+
+    expected = pt_act.float() @ pt_weight.float()
+    if pt_bias is not None:
+        expected = expected + pt_bias.float()
+
+    # Run twice: the second invocation must hit the program cache, exercising the mcast-in1
+    # override path against a GCB-backed in1 CB (which a tensor-backed CB update would reject).
+    cache_entries_after_first = None
+    with tensor_prefetcher_session(device):
+        for run in range(2):
+            tt_out = ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
+                tt_act,
+                tt_weight,
+                global_cb=gcb,
+                program_config=program_config,
+                memory_config=output_mem_config,
+                compute_kernel_config=compute_kernel_config,
+                dtype=dtype,
+                bias=tt_bias,
+            )
+            if run == 0:
+                cache_entries_after_first = device.num_program_cache_entries()
+
+            out_torch = ttnn.to_torch(tt_out)
+            passing, output_str = comp_pcc(expected, out_torch, 0.999)
+            logger.info(f"[broadcast_mcast_in1 workers={num_workers} bias={use_bias} run={run}] {output_str}")
+            assert passing, f"broadcast_mcast_in1 run={run} PCC failed: {output_str}"
+
+    assert (
+        device.num_program_cache_entries() == cache_entries_after_first
+    ), "second broadcast mcast_in1 invocation did not hit the program cache"
+
+
+def test_tensor_prefetcher_broadcast_mcast_in1_rejects_multi_bank_gcb(device, expect_error):
+    """A broadcast weight is one shard on one bank, so a sender on any other bank would read
+    unrelated memory. The GCB itself is a legal topology, so this is caught when the tensor is
+    queued, not when the GCB is built."""
+    dtype = ttnn.bfloat16
+    (
+        _pt_weight,
+        tt_weight,
+        _pt_act,
+        tt_act,
+        program_config,
+        _bank_to_receivers,
+        page_size_bytes,
+        output_mem_config,
+        _N,
+    ) = _broadcast_mcast_in1_setup(device, 4, 4, 2, 1, dtype, "broadcast_reject_two_banks")
+
+    bank_to_receivers = [
+        (0, ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))})),
+        (1, ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(3, 0))})),
+    ]
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device,
+        [program_config],
+        [tt_weight],
+        bank_to_receivers=bank_to_receivers,
+        size=2 * page_size_bytes,
+    )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(), math_fidelity=ttnn.MathFidelity.HiFi4, fp32_dest_acc_en=True, packer_l1_acc=True
+    )
+    with tensor_prefetcher_session(device):
+        with expect_error(RuntimeError, "more than one bank"):
+            ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
+                tt_act,
+                tt_weight,
+                global_cb=gcb,
+                program_config=program_config,
+                memory_config=output_mem_config,
+                compute_kernel_config=compute_kernel_config,
+                dtype=dtype,
+            )
+
+
+def test_tensor_prefetcher_broadcast_mcast_in1_rejects_non_linear_receivers(device, expect_error):
+    """One multicast address names a rectangle, and we require a line.
+
+    The constraint is per *sender*, not per GCB: with the default dual senders a 2x2 receiver block
+    splits into two rows, each of which is a line, and the push is legal. Force a single sender so
+    that one sender owns the whole 2x2 block, which no single multicast address can name.
+    """
+    dtype = ttnn.bfloat16
+    num_workers = 4
+    k_tiles, n_tiles, in0_block_w = 4, 2, 1
+    M = num_workers * ttnn.TILE_SIZE
+    K = k_tiles * ttnn.TILE_SIZE
+    N = n_tiles * ttnn.TILE_SIZE
+    # 2x2 block of workers: the active worker set fills it, so the worker/receiver match passes and
+    # the geometry check is what fires.
+    worker_cores = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))})
+
+    torch.manual_seed(zlib.crc32(b"broadcast_reject_non_linear"))
+    pt_weight = torch.randn(1, 1, K, N)
+    tt_weight = _make_broadcast_weight(device, pt_weight, dtype=dtype)
+    tt_act = ttnn.from_torch(
+        torch.randn(1, 1, M, K),
+        device=device,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.create_sharded_memory_config(
+            shape=(ttnn.TILE_SIZE, K),
+            core_grid=worker_cores,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        ),
+    )
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(2, 2),
+        in0_block_w=in0_block_w,
+        out_subblock_h=1,
+        out_subblock_w=n_tiles,
+        out_block_h=1,
+        out_block_w=n_tiles,
+        per_core_M=1,
+        per_core_N=n_tiles,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+        gather_in0=False,
+        hop_cores=ttnn.CoreRangeSet([]),
+        num_global_cb_receivers=1,
+        untilize_out=False,
+        stream_in1=False,
+    )
+    output_mem_config = ttnn.create_sharded_memory_config(
+        shape=(ttnn.TILE_SIZE, N),
+        core_grid=worker_cores,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device,
+        [program_config],
+        [tt_weight],
+        bank_to_receivers=[(0, worker_cores)],
+        size=2 * in0_block_w * n_tiles * _bytes_per_tile(dtype),
+        support_multi_receiver_shards=True,
+    )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(), math_fidelity=ttnn.MathFidelity.HiFi4, fp32_dest_acc_en=True, packer_l1_acc=True
+    )
+    with tensor_prefetcher_session(device):
+        with expect_error(RuntimeError, "single row or column"):
+            ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
+                tt_act,
+                tt_weight,
+                global_cb=gcb,
+                program_config=program_config,
+                memory_config=output_mem_config,
+                compute_kernel_config=compute_kernel_config,
+                dtype=dtype,
+            )
+
+
+def test_tensor_prefetcher_broadcast_mcast_in1_rejects_undersized_window(device, expect_error):
+    """A one-page window can't double-buffer, and that is a GCB sizing error."""
+    dtype = ttnn.bfloat16
+    (
+        _pt_weight,
+        tt_weight,
+        _pt_act,
+        _tt_act,
+        program_config,
+        bank_to_receivers,
+        page_size_bytes,
+        _output_mem_config,
+        _N,
+    ) = _broadcast_mcast_in1_setup(device, 4, 4, 2, 1, dtype, "broadcast_reject_window")
+
+    with expect_error(RuntimeError, "double-buffered window"):
+        ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+            device,
+            [program_config],
+            [tt_weight],
+            bank_to_receivers=bank_to_receivers,
+            size=page_size_bytes,
+        )
+
+
+def test_tensor_prefetcher_gcb_serves_scatter_and_broadcast(device):
+    """One GCB carries both delivery modes: a scatter (mcast-in0) weight and a broadcast
+    (mcast-in1) weight, back to back against the same receiver set.
+
+    Broadcast is a property of the tensor -- a single shard every receiver reads in full, versus one
+    slab per receiver -- so the same GCB switches between the two without being rebuilt.
+    """
+    dtype = ttnn.bfloat16
+    num_workers = 4
+    worker_cores = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_workers - 1, 0))})
+    k_tiles = 4
+    K = k_tiles * ttnn.TILE_SIZE
+    in0_block_w = 1
+
+    torch.manual_seed(zlib.crc32(b"gcb_serves_scatter_and_broadcast"))
+
+    # --- Scatter half: mcast-in0, one full-K slab per receiver, all slabs on bank 0. ---
+    n_scatter_tiles = num_workers  # per_core_N == 1
+    N_scatter = n_scatter_tiles * ttnn.TILE_SIZE
+    pt_w_scatter = torch.randn(1, 1, K, N_scatter)
+    tt_w_scatter = _make_recv_contig_weight(
+        device,
+        pt_w_scatter,
+        num_dram_banks=1,
+        ring_size=num_workers,
+        dtype=dtype,
+        distribution_strategy=ttnn.ShardDistributionStrategy.CONTIGUOUS_1D,
+    )
+    pt_act_scatter = torch.randn(1, 1, ttnn.TILE_SIZE, K)
+    tt_act_scatter = ttnn.from_torch(
+        pt_act_scatter,
+        device=device,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.create_sharded_memory_config(
+            shape=(ttnn.TILE_SIZE, K // num_workers),
+            core_grid=worker_cores,
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        ),
+    )
+    pc_scatter = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(num_workers, 1),
+        in0_block_w=in0_block_w,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        out_block_h=1,
+        out_block_w=1,
+        per_core_M=1,
+        per_core_N=1,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=True,
+        gather_in0=False,
+        hop_cores=ttnn.CoreRangeSet([]),
+        num_global_cb_receivers=num_workers,
+        untilize_out=False,
+        stream_in1=False,
+    )
+    out_cfg_scatter = ttnn.create_sharded_memory_config(
+        shape=(ttnn.TILE_SIZE, N_scatter // num_workers),
+        core_grid=worker_cores,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    # --- Broadcast half: mcast-in1, one shard the whole line reads. ---
+    n_bcast_tiles = 2
+    (
+        pt_w_bcast,
+        tt_w_bcast,
+        pt_act_bcast,
+        tt_act_bcast,
+        pc_bcast,
+        bank_to_receivers,
+        bcast_page_bytes,
+        out_cfg_bcast,
+        _N,
+    ) = _broadcast_mcast_in1_setup(
+        device, num_workers, k_tiles, n_bcast_tiles, in0_block_w, dtype, "gcb_mixed_broadcast_half"
+    )
+
+    # One GCB, sized for the larger of the two page shapes, validated against both configs.
+    scatter_page_bytes = in0_block_w * pc_scatter.per_core_N * _bytes_per_tile(dtype)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device,
+        [pc_scatter, pc_bcast],
+        [tt_w_scatter, tt_w_bcast],
+        bank_to_receivers=bank_to_receivers,
+        size=2 * max(scatter_page_bytes, bcast_page_bytes),
+    )
+
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+        dst_full_sync_en=True,
+    )
+
+    with tensor_prefetcher_session(device):
+        out_scatter = ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
+            tt_act_scatter,
+            tt_w_scatter,
+            global_cb=gcb,
+            program_config=pc_scatter,
+            memory_config=out_cfg_scatter,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+        )
+        out_bcast = ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
+            tt_act_bcast,
+            tt_w_bcast,
+            global_cb=gcb,
+            program_config=pc_bcast,
+            memory_config=out_cfg_bcast,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+        )
+
+        passing, output_str = comp_pcc(pt_act_scatter.float() @ pt_w_scatter.float(), ttnn.to_torch(out_scatter), 0.999)
+        logger.info(f"[mixed gcb scatter half] {output_str}")
+        assert passing, f"scatter half PCC failed: {output_str}"
+
+        passing, output_str = comp_pcc(pt_act_bcast.float() @ pt_w_bcast.float(), ttnn.to_torch(out_bcast), 0.999)
+        logger.info(f"[mixed gcb broadcast half] {output_str}")
+        assert passing, f"broadcast half PCC failed: {output_str}"

--- a/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
@@ -56,6 +56,12 @@ enum class SenderCoreType : uint8_t {
 // single- and dual-sender banks may therefore coexist in one GCB. The Tensor prefetcher always
 // provisions both cores and routes PREFETCH requests only to this GCB's mapped sender subset.
 //
+// Broadcast delivery (one NoC multicast per chunk instead of a unicast per receiver) is NOT
+// selected here: it is a per-tensor property carried in the prefetch request, so one GCB can serve
+// scatter and broadcast tensors interchangeably. The GCB only contributes the receiver geometry
+// that a broadcast push multicasts into; the prefetcher refuses a broadcast tensor when a sender's
+// receivers do not form a single row or column.
+//
 // MeshDevice-only: the arena that backs this GCB's pages_sent allocation lives on
 // MeshDeviceImpl, so a bare IDevice cannot construct one.
 GlobalCircularBuffer CreateGlobalCircularBufferForTensorPrefetcher(

--- a/tt_metal/impl/buffers/dram_sender_state_block.hpp
+++ b/tt_metal/impl/buffers/dram_sender_state_block.hpp
@@ -50,6 +50,19 @@ struct DramSenderStateBlock {
     // uniform across senders and the host can pack every sender's page identically); the kernel
     // reads it to recover that stride. Constant across senders, unlike num_receivers above.
     uint32_t max_num_receivers;
+    // ----- Multicast rectangle -----
+    // This sender's receiver bounding box in *virtual* worker coordinates (the same space as the
+    // receiver NOC XY table below), stored in NOC0 orientation: min corner in `mcast_start_*`, max
+    // corner in `mcast_end_*`. The kernel swaps the corners when running on NOC1, whose torus flows
+    // the other way. Always stamped, because the receiver set is fixed for the GCB's lifetime;
+    // whether a given push *uses* it is a per-tensor decision (TensorPrefetcherTensorLayout's
+    // `broadcast`), so one GCB can mix scatter and broadcast tensors. Only meaningful when this
+    // sender's receivers form a single row or column — the host refuses a broadcast tensor against
+    // a GCB whose receivers don't, so the kernel can trust the rectangle whenever broadcast is set.
+    uint32_t mcast_start_x;
+    uint32_t mcast_start_y;
+    uint32_t mcast_end_x;
+    uint32_t mcast_end_y;
     // ----- Followed in L1 by the receiver NOC XY table -----
     // 2 * num_receivers uint32s (x0, y0, x1, y1, ...), appended by the caller after
     // this struct's bytes since its length is dynamic; pointed to by receiver_noc_xy_ptr.
@@ -59,7 +72,7 @@ struct DramSenderStateBlock {
     // not stamped into L1. See tensor_prefetcher_request.hpp.)
 } __attribute__((packed));
 
-static_assert(sizeof(DramSenderStateBlock) == 12 * sizeof(uint32_t), "DramSenderStateBlock layout drift");
+static_assert(sizeof(DramSenderStateBlock) == 16 * sizeof(uint32_t), "DramSenderStateBlock layout drift");
 static_assert(
     offsetof(DramSenderStateBlock, is_sender) == 6 * sizeof(uint32_t),
     "config block must stay contiguous right after the loaded interface fields");

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -272,6 +272,27 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
         hdr->num_receivers_and_remote_pages_sent_ptr =
             remote_cb_pack(this_num_receivers, static_cast<uint32_t>(pages_sent_worker_l1_base_));
 
+        // Multicast rectangle: the receivers' bounding box in the same virtual coordinate space as
+        // the NOC XY table below, stored min-corner-first (NOC0 orientation). Derived from the
+        // coords rather than the logical range so it cannot disagree with what the kernel unicasts
+        // to. Stamped unconditionally — it is a fact about this sender's receiver set, and a later
+        // request decides per tensor whether to push through it (see
+        // TensorPrefetcherTensorLayout::broadcast). It only names exactly this sender's receivers
+        // when they form a line; the prefetcher manager enforces that before accepting a broadcast
+        // tensor, so a non-linear GCB simply never uses these fields.
+        CoreCoord mcast_min = recv_phys.front();
+        CoreCoord mcast_max = recv_phys.front();
+        for (const auto& c : recv_phys) {
+            mcast_min.x = std::min(mcast_min.x, c.x);
+            mcast_min.y = std::min(mcast_min.y, c.y);
+            mcast_max.x = std::max(mcast_max.x, c.x);
+            mcast_max.y = std::max(mcast_max.y, c.y);
+        }
+        hdr->mcast_start_x = static_cast<uint32_t>(mcast_min.x);
+        hdr->mcast_start_y = static_cast<uint32_t>(mcast_min.y);
+        hdr->mcast_end_x = static_cast<uint32_t>(mcast_max.x);
+        hdr->mcast_end_y = static_cast<uint32_t>(mcast_max.y);
+
         for (uint32_t i = 0; i < max_num_receivers_per_sender; ++i) {
             const bool valid = i < this_num_receivers;
             const auto& c = valid ? recv_phys[i] : CoreCoord{0, 0};

--- a/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
+++ b/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
@@ -768,11 +768,15 @@ void kernel_main() {
                         PROF_DECL_TS(t_w1);
                         PROF_TICK(t_w0);
                         if (broadcast) {
-                            // One multicast per packet. There is no multicast set_state/with_state
-                            // pair and no posted multicast, so each packet reprograms the command
-                            // buffer and lands on the non-posted counters. Packets within a chunk
-                            // are linked so the reserved multicast path is held across the run and
-                            // released by the last one.
+                            // Multicast reserves a NoC path, and there is no multicast
+                            // set_state/with_state pair, so every transaction re-reserves it unless
+                            // it is linked to the previous one. (noc_async_write_multicast's
+                            // any-length form is no help: it forwards one `linked` value to every
+                            // burst, so it can hold the path or release it, but not "hold, then
+                            // release on the last".)
+                            // Link within the chunk and release on its last packet. Linking across
+                            // chunks measured neutral and would hold the path reservation across the
+                            // DMA wait between chunks, where we have nothing to send.
                             for (uint32_t p = 0; p < num_packets; ++p) {
                                 noc_async_write_multicast_one_packet</*enable_noc_tracing=*/false>(
                                     src_addr,

--- a/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
+++ b/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
@@ -316,6 +316,21 @@ void kernel_main() {
         // split a bank's receivers, the second core's local receiver r maps to bank-local
         // slab (recv_index_base + r). 0 for a single sender. Receiver-contiguous only.
         const uint32_t recv_index_base = state->recv_index_base;
+        // Multicast rectangle for broadcast tensors, built once per request: this sender's receiver
+        // set is fixed for the GCB's lifetime, while whether a given tensor is pushed through it is
+        // decided per tensor below (TensorPrefetcherTensorLayout::broadcast), so one GCB can mix
+        // scatter and broadcast tensors in the same request. The state block stores the box
+        // min-corner-first; NOC1 runs the opposing torus and enters at the max corner, so swap the
+        // corners there (DYNAMIC_NOC_X/Y then mirrors each coordinate).
+        const uint32_t mcast_sx = noc_index == 0 ? state->mcast_start_x : state->mcast_end_x;
+        const uint32_t mcast_sy = noc_index == 0 ? state->mcast_start_y : state->mcast_end_y;
+        const uint32_t mcast_ex = noc_index == 0 ? state->mcast_end_x : state->mcast_start_x;
+        const uint32_t mcast_ey = noc_index == 0 ? state->mcast_end_y : state->mcast_start_y;
+        const uint32_t mcast_noc_xy = uint32_t(NOC_MULTICAST_ENCODING(
+            DYNAMIC_NOC_X(noc_index, mcast_sx),
+            DYNAMIC_NOC_Y(noc_index, mcast_sy),
+            DYNAMIC_NOC_X(noc_index, mcast_ex),
+            DYNAMIC_NOC_Y(noc_index, mcast_ey)));
         // Each layout slot in the page is the geometry struct immediately followed by this GCB's
         // per-sender streaming rotation table, sized for the largest sender (max_num_receivers) so
         // the slot stride is uniform across senders. Recover that stride to index the slot table.
@@ -350,6 +365,13 @@ void kernel_main() {
             // Streaming (receiver-contiguous only) is a per-tensor layout attribute: deliver
             // this tensor's blocks in ring-rotated order so the matmul can consume them FIFO.
             const bool streaming = g->streaming != 0;
+            // Broadcast (receiver-contiguous only) is a per-tensor delivery attribute: every
+            // receiver gets byte-identical pages, so the round below makes one source visit and
+            // multicasts each chunk into mcast_noc_xy instead of walking per-receiver slabs. The
+            // host pins recv_stride_bytes to 0 for these, collapsing the slab address to
+            // tensor_base, and refuses the tensor outright if this sender's receivers are not a
+            // line (which is what makes mcast_noc_xy exact).
+            const bool broadcast = g->broadcast != 0;
             // Per-receiver streaming rotation table, appended right after this tensor's geometry
             // in the page (host-sliced for this sender). rotation_local[r] is the lead block for
             // local receiver r, so the kernel sources block (rotation_local[r] + p) mod block_count.
@@ -590,7 +612,10 @@ void kernel_main() {
                     // never wraps. (This is the two-DMA-read streaming split; the older legacy-clamp
                     // and ragged-tail/head modes have been removed.)
                     const uint32_t uniform_chunks_per_visit = (bytes_per_recv + max_chunk_bytes - 1) / max_chunk_bytes;
-                    const uint32_t total_chunks_round = num_receivers * uniform_chunks_per_visit;
+                    // Broadcast reads each block once and multicasts it, so the round is a single
+                    // source visit no matter how many receivers consume it.
+                    const uint32_t num_visits = broadcast ? 1u : num_receivers;
+                    const uint32_t total_chunks_round = num_visits * uniform_chunks_per_visit;
 
                     // ---- Depth-2 software pipeline over 3 stage slots ----
                     // Per chunk gc we: wait gc's DMA, enqueue gc's NoC writes (posted), THEN
@@ -660,7 +685,7 @@ void kernel_main() {
                         if (gen_boff >= bytes_per_recv) {
                             gen_r += 1;
                             gen_boff = 0;
-                            if (gen_r < num_receivers) {
+                            if (gen_r < num_visits) {
                                 recv_wrap(gen_r, gen_blk, gen_wrap_boff);
                             }
                         }
@@ -706,13 +731,19 @@ void kernel_main() {
                             PROF_DECL_TS(t_df0);
                             PROF_DECL_TS(t_df1);
                             PROF_TICK(t_df0);
-                            noc_async_posted_writes_flushed();
+                            // Multicast has no posted form (see the write loop below), so the
+                            // broadcast path drains the non-posted issue counter instead.
+                            if (broadcast) {
+                                noc_async_writes_flushed();
+                            } else {
+                                noc_async_posted_writes_flushed();
+                            }
                             PROF_TICK(t_df1);
                             PROF_ACC(prof_defer_flush, t_df1, t_df0);
                         }
 
-                        // ---- set_state on the first chunk of a new receiver ----
-                        if (r != cur_r) {
+                        // ---- set_state on the first chunk of a new receiver (unicast only) ----
+                        if (!broadcast && r != cur_r) {
                             cur_r = r;
                             volatile tt_l1_ptr uint32_t* xy_ptr =
                                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr) + r * 2;
@@ -736,10 +767,29 @@ void kernel_main() {
                         PROF_DECL_TS(t_w0);
                         PROF_DECL_TS(t_w1);
                         PROF_TICK(t_w0);
-                        for (uint32_t p = 0; p < num_packets; ++p) {
-                            noc_async_write_one_packet_with_state</*posted=*/true>(src_addr, dest_addr, noc_index);
-                            src_addr += t_coal_page_size;
-                            dest_addr += t_coal_page_size;
+                        if (broadcast) {
+                            // One multicast per packet. There is no multicast set_state/with_state
+                            // pair and no posted multicast, so each packet reprograms the command
+                            // buffer and lands on the non-posted counters. Packets within a chunk
+                            // are linked so the reserved multicast path is held across the run and
+                            // released by the last one.
+                            for (uint32_t p = 0; p < num_packets; ++p) {
+                                noc_async_write_multicast_one_packet</*enable_noc_tracing=*/false>(
+                                    src_addr,
+                                    get_noc_addr_helper(mcast_noc_xy, dest_addr),
+                                    t_coal_page_size,
+                                    num_receivers,
+                                    /*linked=*/(p + 1u) < num_packets,
+                                    noc_index);
+                                src_addr += t_coal_page_size;
+                                dest_addr += t_coal_page_size;
+                            }
+                        } else {
+                            for (uint32_t p = 0; p < num_packets; ++p) {
+                                noc_async_write_one_packet_with_state</*posted=*/true>(src_addr, dest_addr, noc_index);
+                                src_addr += t_coal_page_size;
+                                dest_addr += t_coal_page_size;
+                            }
                         }
                         PROF_TICK(t_w1);
                         PROF_ACC(prof_writes, t_w1, t_w0);
@@ -758,10 +808,16 @@ void kernel_main() {
                     // ---- Final flush: drain any remaining writes before finalize bumps semaphore.
                     // (Finalize's per-receiver semaphore inc rides the same NoC VC, so a
                     // drained NIU also implies data writes are committed in-order on the wire.)
+                    // Broadcast writes ride the multicast VC while the credit incs stay unicast, so
+                    // in-order delivery no longer covers them: wait for the multicast acks instead.
                     PROF_DECL_TS(t_f0);
                     PROF_DECL_TS(t_f1);
                     PROF_TICK(t_f0);
-                    noc_async_posted_writes_flushed();
+                    if (broadcast) {
+                        noc_async_write_barrier();
+                    } else {
+                        noc_async_posted_writes_flushed();
+                    }
                     PROF_TICK(t_f1);
                     PROF_ACC(prof_flush, t_f1, t_f0);
 

--- a/tt_metal/impl/buffers/prefetcher_matmul_design.md
+++ b/tt_metal/impl/buffers/prefetcher_matmul_design.md
@@ -410,6 +410,68 @@ For both contracts one page contains
 exactly match the matmul output workers, and the receiver-contiguous NdShardSpec must provide one
 full-K, `per_core_N`-wide shard per receiver.
 
+#### Broadcast delivery (mcast-in1)
+
+The two contracts above scatter: each receiver gets a distinct slab. The third 1D consumer,
+**mcast-in1** (`gather_in0=false, mcast_in0=false`), does not partition in1 at all — it is
+M-parallel, so `per_core_N == N_tiles` and every worker needs the *same* full-width weight. A
+broadcast GCB delivers that directly:
+
+```
+1 DRAM bank (one DRISC sender)
+         |  one NoC multicast per in1 K-block
+         v
+  [w0][w1][w2] ... [wn-1]       1-D array of matmul workers, each holding the
+                                 SAME [in0_block_w x N] block in its GCB slot
+```
+
+**Broadcast is a per-tensor property, not a GCB mode.** It is inferred exactly the way the layout
+itself is — from how the weight was allocated. A receiver-contiguous *scatter* weight has
+`num_shards == total_receivers` (a slab each); a *broadcast* weight has `num_shards == 1`, a single
+`(K, N)` shard every receiver reads in full. `TensorPrefetcherTensorLayout::broadcast` carries the
+decision in the request page next to `streaming`, and joins the page's layout dedup key. So one GCB
+can serve scatter and broadcast tensors in the same request, and a matmul can switch modes without
+rebuilding its GCB.
+
+What the GCB contributes is geometry: `DramSenderStateBlock` always carries each sender's receiver
+bounding box in virtual worker coordinates, min-corner first (the kernel swaps the corners on NOC1,
+whose torus flows the other way — `drisc_mcast_writes_tensix.cpp` documents the same rule). A
+broadcast push multicasts into that box, so the prefetcher accepts a broadcast tensor only when
+
+- **each sender's** receivers form a single row or column and fill their bounding box, so one
+  multicast address names exactly them. This is per sender, not per GCB: under the dual-sender split
+  a 2-D receiver block becomes two lines, and each sender broadcasts into its own; and
+- all senders sit on the one bank that physically holds the single shard, since every sender pushes
+  the same bank-local address.
+
+Geometry aside, broadcast reuses the receiver-contiguous machinery: `recv_stride_bytes` is pinned to
+0 so the slab address collapses to `tensor_base`, the round makes one source visit instead of
+`num_receivers`, and `block_count = K_tiles / in0_block_w` in natural FIFO order with
+`stream_in1=false` and a two-page window — the same as mcast-in0, but the page is the full weight
+width. Streaming rotation is rejected: it permutes which block each receiver leads with, which means
+nothing when they all get the same one.
+
+Two consequences of using the multicast NoC path:
+
+- **Writes are non-posted.** There is no posted multicast and no multicast
+  `set_state`/`with_state` pair in the public API, so the broadcast branch reprograms the command
+  buffer per packet, links packets within a chunk, and drains the non-posted counters
+  (`noc_async_writes_flushed` for stage-slot reuse, `noc_async_write_barrier` before finalize).
+  The barrier before finalize is load-bearing: broadcast payload rides the multicast VC while the
+  credit increments stay unicast, so in-order delivery no longer covers them.
+- **Credits stay per-receiver.** `prefetcher_finalize_block` still walks the receiver NOC XY table
+  issuing one unicast `noc_semaphore_inc` each, and the sender's free-space poll still takes the
+  minimum across receivers. Collapsing those into one `noc_semaphore_inc_multicast` would need
+  every receiver's `aligned_pages_sent_ptr` moved to a uniform L1 offset, and Blackhole forces
+  multicast atomics non-posted; that is a measured optimization, not a correctness requirement.
+
+On the matmul side nothing but the in1 data path changes. The in1 sender/receiver kernel split,
+the two mcast semaphores and the bias path are all untouched: `ENABLE_GLOBAL_CB_MCAST_IN1`
+suppresses only the sender's in1 multicast block, so bias is still read from DRAM once by the
+sender core and multicast to the rest. Both in1 kernels take the global-CB wait/pop discipline
+(`remote_cb_wait_front(c_31, block == 0 ? 1 : 2)` with a matching `remote_cb_pop_front`), and
+`cb_src1` becomes the local view of the GCB on every worker.
+
 #### Fit ladder (receiver-contiguous)
 
 The receiver-contiguous path rotates through three stage slots

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -81,25 +81,41 @@ enum class LayoutMode : uint32_t {
 // num_banks (one receiver per bank, num_shards == num_banks == total_receivers): the count tie
 // would route a recv-contig tensor down the K-row path, where compute_tensor_layout_krow_major
 // calls shard_spec() and TT_FATALs because the buffer only has an NdShardSpec.
-LayoutMode detect_layout_mode(const MeshTensor& t, const Buffer& buf, uint32_t total_receivers) {
+// Classification result: the DRAM layout plus, for receiver-contiguous weights, whether this tensor
+// is delivered by broadcast (one multicast reaches every receiver) or by scatter (a slab each).
+struct TensorLayoutKind {
+    LayoutMode mode = LayoutMode::KRowMajor;
+    bool broadcast = false;
+};
+
+// Broadcast is inferred the same way the layout itself is -- from how the weight was allocated. A
+// receiver-contiguous scatter weight carries one shard per receiver; a broadcast weight carries a
+// single shard that every receiver reads in full. Keeping this per-tensor rather than per-GCB is
+// what lets one GCB serve scatter and broadcast tensors in the same request. With a single receiver
+// the two are the same delivery, so that case stays on the cheaper unicast path.
+TensorLayoutKind detect_layout_mode(const MeshTensor& t, const Buffer& buf, uint32_t total_receivers) {
     // Legacy ShardSpec path: one wide shard per bank by construction. Some WIDTH_SHARDED
     // tensors also carry an NdShardSpec-like descriptor through BDS, so prefer the explicit
     // legacy shard spec before classifying a tensor as receiver-contiguous.
     if (buf.has_shard_spec()) {
-        return LayoutMode::KRowMajor;
+        return {LayoutMode::KRowMajor, false};
     }
 
     if (t.nd_shard_spec().has_value()) {
         const auto& bds_opt = buf.buffer_distribution_spec();
+        TT_FATAL(bds_opt.has_value(), "Receiver-contiguous Tensor prefetcher weight has no buffer distribution spec");
+        const uint32_t num_shards = static_cast<uint32_t>(bds_opt->num_shards());
+        const bool broadcast = num_shards == 1 && total_receivers > 1;
         TT_FATAL(
-            bds_opt.has_value() && static_cast<uint32_t>(bds_opt->num_shards()) == total_receivers,
-            "Receiver-contiguous Tensor prefetcher weight must have num_shards == total_receivers "
-            "(ring_size = {}); got {} shards.",
+            broadcast || num_shards == total_receivers,
+            "Receiver-contiguous Tensor prefetcher weight must have either num_shards == total_receivers "
+            "(ring_size = {}, one slab per receiver) or num_shards == 1 (one slab broadcast to every receiver); "
+            "got {} shards.",
             total_receivers,
-            bds_opt.has_value() ? static_cast<uint32_t>(bds_opt->num_shards()) : 0u);
-        return LayoutMode::ReceiverContiguous;
+            num_shards);
+        return {LayoutMode::ReceiverContiguous, broadcast};
     }
-    return LayoutMode::KRowMajor;
+    return {LayoutMode::KRowMajor, false};
 }
 
 // Validate a streaming (receiver-contiguous) weight and return the shard distribution strategy that
@@ -236,7 +252,7 @@ bool layout_equal(const TensorPrefetcherTensorLayout& a, const TensorPrefetcherT
 // bank-local address is carried separately in the per-tensor
 // TensorPrefetcherEntry, so identical-geometry tensors share one layout.
 TensorPrefetcherTensorLayout compute_tensor_layout_recv_contig(
-    const MeshTensor& t, uint32_t block_count, uint32_t stage_third, ContextId context_id) {
+    const MeshTensor& t, uint32_t block_count, uint32_t stage_third, bool broadcast, ContextId context_id) {
     // Read the original (non-squeezed) NdShardSpec from the MemoryConfig — the
     // BDS internally collapses adjacent matching dims, so its
     // shard_shape_in_pages() can come back rank-1 even though the caller
@@ -357,7 +373,10 @@ TensorPrefetcherTensorLayout compute_tensor_layout_recv_contig(
     g.page_bytes_per_recv = page_bytes_per_recv;
     g.layout_mode = static_cast<uint32_t>(LayoutMode::ReceiverContiguous);
     g.target_per_visit_pages = target_per_visit_pages;
-    g.recv_stride_bytes = recv_stride_bytes;
+    // Broadcast has one slab that every receiver reads, so there is no per-receiver stride to walk.
+    // Pinning it to 0 collapses the kernel's slab address to tensor_base for every visit.
+    g.recv_stride_bytes = broadcast ? 0u : recv_stride_bytes;
+    g.broadcast = broadcast ? 1u : 0u;
     g.block_count = block_count;
     return g;
 }
@@ -372,8 +391,8 @@ TensorPrefetcherTensorLayout compute_tensor_layout(
     uint32_t stage_third,
     ContextId context_id) {
     const auto* ref_buffer = t.mesh_buffer().get_reference_buffer();
-    const LayoutMode mode = detect_layout_mode(t, *ref_buffer, total_receivers);
-    if (mode == LayoutMode::KRowMajor) {
+    const TensorLayoutKind kind = detect_layout_mode(t, *ref_buffer, total_receivers);
+    if (kind.mode == LayoutMode::KRowMajor) {
         // KRowMajor is single-sender-per-bank only, so receivers_per_bank is the bank's
         // full receiver count and the bank receiver counts must be uniform. (Receiver-
         // contiguous derives its geometry from the shard shape and ignores the receiver
@@ -386,7 +405,7 @@ TensorPrefetcherTensorLayout compute_tensor_layout(
             num_banks);
         return compute_tensor_layout_krow_major(t, block_count, receivers_per_bank, ring_half, context_id);
     }
-    return compute_tensor_layout_recv_contig(t, block_count, stage_third, context_id);
+    return compute_tensor_layout_recv_contig(t, block_count, stage_third, kind.broadcast, context_id);
 }
 
 }  // namespace
@@ -626,6 +645,31 @@ std::vector<std::vector<std::vector<uint8_t>>> TensorPrefetcherManager::serializ
         total_receivers += receivers.num_cores();
     }
     TT_FATAL(num_banks_ > 0, "Tensor prefetcher: num_banks must be > 0");
+    // A broadcast tensor is multicast into each sender's receiver bounding box, which only names
+    // exactly that sender's receivers when they form a single row or column. Compute it once here;
+    // it gates broadcast tensors below, and leaves scatter tensors unaffected.
+    // Test the geometry, not the CoreRange count: a contiguous line is often represented as one
+    // range per core (the dual-sender split builds its halves that way), so a set is linear when it
+    // fills its bounding box and that box is one core wide or one core tall.
+    bool senders_are_linear = true;
+    for (const auto& [_sender, receivers] : mapping) {
+        const CoreRange bbox = receivers.bounding_box();
+        const CoreCoord grid = bbox.grid_size();
+        if (receivers.num_cores() != bbox.size() || (grid.x != 1 && grid.y != 1)) {
+            senders_are_linear = false;
+            break;
+        }
+    }
+    // A broadcast weight is a single shard, so it physically exists on exactly one bank. Every
+    // sender pushes the same bank-local address, so senders on any other bank would read whatever
+    // happens to live there. (Two senders sharing the one bank is fine.)
+    bool senders_share_one_bank = true;
+    for (const auto& [sender_logical, _receivers] : mapping) {
+        if (sender_logical.x != mapping.front().first.x) {
+            senders_share_one_bank = false;
+            break;
+        }
+    }
     // K-row-major stores one complete per-bank shard, so all receivers for a bank must
     // remain on its primary sender. Receiver-contiguous tensors may use either this
     // topology or a dual-sender split.
@@ -788,6 +832,28 @@ std::vector<std::vector<std::vector<uint8_t>>> TensorPrefetcherManager::serializ
         // rotation participates in dedup (slot_equal), so tensors that differ only in rotation get
         // distinct slots.
         layout.streaming = streaming ? 1u : 0u;
+        if (layout.broadcast != 0) {
+            // Rotation permutes which block each receiver leads with, which only means something
+            // when receivers consume different blocks; a broadcast tensor gives them all the same.
+            TT_FATAL(
+                !streaming,
+                "Tensor prefetcher: input tensor {} is a broadcast weight (a single shard delivered identically to "
+                "every receiver), so it does not support streaming (a per-receiver rotation table). Queue it without "
+                "a rotation.",
+                tensor_idx);
+            TT_FATAL(
+                senders_are_linear,
+                "Tensor prefetcher: broadcast input tensor {} needs each sender's receivers to form a single row or "
+                "column so one multicast address can name them, but this GCB's receiver topology is not linear. Use "
+                "a per-receiver sharded (scatter) weight with this GCB, or give the GCB a 1-D receiver set.",
+                tensor_idx);
+            TT_FATAL(
+                senders_share_one_bank,
+                "Tensor prefetcher: broadcast input tensor {} is a single shard, so it lives on one DRAM bank, but "
+                "this GCB has senders on more than one bank -- the off-bank senders would read unrelated memory. "
+                "Broadcast tensors need a GCB whose senders all sit on the bank holding the weight.",
+                tensor_idx);
+        }
         TT_FATAL(
             layout.layout_mode != static_cast<uint32_t>(LayoutMode::KRowMajor) || krow_compatible_mapping,
             "Tensor prefetcher: K-row-major input tensor {} requires exactly one primary sender per DRAM bank; "

--- a/tt_metal/impl/buffers/tensor_prefetcher_request.hpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_request.hpp
@@ -110,6 +110,14 @@ struct TensorPrefetcherTensorLayout {
     // appended rotation bytes extend each layout slot's stride and are deduped together with
     // the geometry, so tensors that differ only in rotation get distinct slots.
     uint32_t streaming = 0;
+    // Broadcast delivery (receiver-contiguous only): when nonzero, every receiver of a sender gets
+    // byte-identical pages, pushed by one NoC multicast per chunk to the receiver rectangle in the
+    // sender's state block instead of a per-receiver unicast scatter. The tensor is then a single
+    // (K, N) shard rather than one slab per receiver, so recv_stride_bytes is 0 and the kernel makes
+    // one source visit per round. Per-tensor, like `streaming`: the same GCB can carry scatter and
+    // broadcast tensors in the same request, since the receiver set (and therefore the multicast
+    // rectangle) is a property of the GCB while the delivery pattern is a property of the tensor.
+    uint32_t broadcast = 0;
 } __attribute__((packed));
 
 // One prefetched tensor: its bank-local address plus an index into the page's layout

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -383,12 +383,120 @@ uint32_t validate_recv_contig_weight_for_matmul_1d(
     return block_count;
 }
 
+// A FIFO consumer takes K-blocks as they land, so it only needs a double-buffered window rather
+// than the whole tensor resident.
+constexpr uint32_t kFifoMinWindowBlocks = 2;
+
+// True for the mcast-in1 consumer: in1 is not partitioned across workers at all, so every worker
+// needs the same full-width weight block. That is the one 1D mode a broadcast GCB can feed.
+bool is_mcast_in1_config(const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& config) {
+    return !config.gather_in0 && !config.mcast_in0;
+}
+
+// One broadcast GCB page is one full-width in1 K-block — the same block the matmul's in1 CB holds.
+uint32_t broadcast_page_bytes(
+    const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
+    const ttnn::Tensor& weight) {
+    const uint32_t bytes_per_tile = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(weight.dtype()));
+    return static_cast<uint32_t>(program_config.in0_block_w) * program_config.per_core_N * bytes_per_tile;
+}
+
+// Broadcast (mcast-in1) weight ↔ matmul cross-checks. Returns the number of K-blocks the prefetcher
+// must multicast. The weight is a single-shard NdShardSpec tensor: one full (K, N) slab on one DRAM
+// bank, every byte of which lands on every receiver.
+uint32_t validate_broadcast_weight_for_matmul_1d(
+    const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
+    const ttnn::Tensor& weight) {
+    TT_FATAL(
+        is_mcast_in1_config(program_config),
+        "broadcast Tensor prefetcher requires the mcast-in1 consumer (gather_in0=false and mcast_in0=false)");
+    TT_FATAL(
+        !program_config.stream_in1,
+        "mcast-in1 consumes GCB blocks in natural FIFO order and requires stream_in1=false");
+
+    TT_FATAL(weight.buffer() != nullptr && weight.buffer()->is_dram(), "weight must live in DRAM");
+    const auto& nd_opt = weight.nd_shard_spec();
+    TT_FATAL(
+        nd_opt.has_value(),
+        "broadcast weight must be allocated with an NdShardSpec (ttnn.MemoryConfig(BufferType.DRAM, "
+        "NdShardSpec(...))) holding one shard on one DRAM bank");
+    const auto& shard_shape = nd_opt->shard_shape;
+    TT_FATAL(
+        shard_shape.rank() == 2,
+        "broadcast NdShardSpec shard shape must be 2D (K, N); got rank {}",
+        shard_shape.rank());
+
+    const auto& tile = weight.tensor_spec().tile();
+    const uint32_t tile_h = tile.get_height();
+    const uint32_t tile_w = tile.get_width();
+    const uint32_t shard_K = shard_shape[0];
+    const uint32_t shard_N = shard_shape[1];
+    TT_FATAL(
+        shard_K % tile_h == 0 && shard_N % tile_w == 0,
+        "broadcast shard shape ({}, {}) must be tile-aligned (tile {}x{})",
+        shard_K,
+        shard_N,
+        tile_h,
+        tile_w);
+
+    const auto& wp = weight.padded_shape();
+    TT_FATAL(wp.rank() >= 2, "weight must be at least 2D; got rank {}", wp.rank());
+    TT_FATAL(
+        shard_K == static_cast<uint32_t>(wp[-2]) && shard_N == static_cast<uint32_t>(wp[-1]),
+        "broadcast weight must be a single shard spanning the whole tensor: shard ({}, {}) vs weight ({}, {})",
+        shard_K,
+        shard_N,
+        static_cast<uint32_t>(wp[-2]),
+        static_cast<uint32_t>(wp[-1]));
+
+    const auto& bds = weight.buffer()->buffer_distribution_spec();
+    TT_FATAL(bds.has_value(), "broadcast weight buffer must have a BufferDistributionSpec");
+    TT_FATAL(
+        static_cast<uint32_t>(bds->num_shards()) == 1,
+        "broadcast weight has {} shards; it must be a single shard so one DRAM bank holds the whole weight",
+        bds->num_shards());
+
+    const uint32_t weight_K_tiles = shard_K / tile_h;
+    const uint32_t weight_N_tiles = shard_N / tile_w;
+    // Same silent-hang / over-read guard as the other consumers: an indivisible K rounds the block
+    // width up, so the kernel reads past the weight while the matmul waits on pages that never come.
+    TT_FATAL(program_config.in0_block_w > 0, "mcast-in1 requires in0_block_w > 0");
+    TT_FATAL(
+        weight_K_tiles % program_config.in0_block_w == 0,
+        "weight K ({} tiles) must be divisible by in0_block_w ({}); remainder {}",
+        weight_K_tiles,
+        program_config.in0_block_w,
+        weight_K_tiles % program_config.in0_block_w);
+
+    // mcast-in1 is M-parallel: workers split M and each holds the full weight width, so the matmul's
+    // in1 CB page (sized from per_core_N) is exactly the broadcast page.
+    TT_FATAL(
+        weight_N_tiles == program_config.per_core_N,
+        "program_config.per_core_N ({}) must equal the full weight N ({} tiles = N {} / tile_w {}); every mcast-in1 "
+        "worker receives the whole weight width",
+        program_config.per_core_N,
+        weight_N_tiles,
+        shard_N,
+        tile_w);
+    return weight_K_tiles / static_cast<uint32_t>(program_config.in0_block_w);
+}
+
 }  // namespace
 
 uint32_t tensor_prefetcher_block_count_for_matmul_1d(
     const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
     const ttnn::Tensor& weight,
     const GlobalCircularBuffer& gcb) {
+    if (is_mcast_in1_config(program_config)) {
+        const uint32_t block_count = validate_broadcast_weight_for_matmul_1d(program_config, weight);
+        const uint32_t page_bytes = broadcast_page_bytes(program_config, weight);
+        TT_FATAL(
+            gcb.size() >= kFifoMinWindowBlocks * page_bytes,
+            "mcast-in1 global_cb requires a two-page streaming window: size {} must be at least {}",
+            gcb.size(),
+            kFifoMinWindowBlocks * page_bytes);
+        return block_count;
+    }
     const uint32_t receiver_count = gcb.receiver_cores().num_cores();
     TT_FATAL(receiver_count > 0, "global_cb has no receivers");
     return validate_recv_contig_weight_for_matmul_1d(program_config, weight, receiver_count);
@@ -440,7 +548,7 @@ static GlobalCircularBuffer build_matmul_1d_gcb_recv_contig(
         } else {
             TT_FATAL(
                 grid_capacity >= receiver_count,
-                "mcast_in0 program_configs[{}] grid {}x{} has capacity for {} workers, but bank_to_receivers has "
+                "program_configs[{}] grid {}x{} has capacity for {} workers, but bank_to_receivers has "
                 "{} receivers",
                 i,
                 grid.x,
@@ -449,18 +557,28 @@ static GlobalCircularBuffer build_matmul_1d_gcb_recv_contig(
                 receiver_count);
         }
 
-        // Per-(config, weight) recv-contig cross-checks and consumer-specific K-block count.
-        const uint32_t block_count = validate_recv_contig_weight_for_matmul_1d(cfg, weights[i], receiver_count);
+        // Per-(config, weight) cross-checks, consumer-specific K-block count, and page size. The
+        // consumer mode is per config, not per GCB: an mcast-in1 config takes a broadcast weight
+        // (one shard, full width per page) while gather-in0/mcast-in0 take a scatter weight (one
+        // slab per receiver), and both may share this GCB.
+        uint32_t block_count = 0;
+        uint32_t page_bytes = 0;
+        if (is_mcast_in1_config(cfg)) {
+            block_count = validate_broadcast_weight_for_matmul_1d(cfg, weights[i]);
+            page_bytes = broadcast_page_bytes(cfg, weights[i]);
+        } else {
+            block_count = validate_recv_contig_weight_for_matmul_1d(cfg, weights[i], receiver_count);
+            const auto& w = weights[i];
+            const auto& tile = w.tensor_spec().tile();
+            const uint32_t weight_K_tiles = static_cast<uint32_t>(w.padded_shape()[-2]) / tile.get_height();
+            const uint32_t k_block_w_tiles = weight_K_tiles / block_count;
+            const uint32_t bytes_per_tile = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(w.dtype()));
+            page_bytes = k_block_w_tiles * cfg.per_core_N * bytes_per_tile;
+        }
         max_block_count = std::max(max_block_count, block_count);
-        all_configs_fifo = all_configs_fifo && (cfg.mcast_in0 || cfg.stream_in1);
-
-        // One GCB page is one consumer K-block for one receiver.
-        const auto& w = weights[i];
-        const auto& tile = w.tensor_spec().tile();
-        const uint32_t weight_K_tiles = static_cast<uint32_t>(w.padded_shape()[-2]) / tile.get_height();
-        const uint32_t k_block_w_tiles = weight_K_tiles / block_count;
-        const uint32_t bytes_per_tile = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(w.dtype()));
-        const uint32_t page_bytes = k_block_w_tiles * cfg.per_core_N * bytes_per_tile;
+        // Only a batched gather needs the whole tensor resident; every other consumer takes blocks
+        // FIFO as they land.
+        all_configs_fifo = all_configs_fifo && (!cfg.gather_in0 || cfg.stream_in1);
         TT_FATAL(page_bytes > 0, "program_configs[{}] page_bytes computed as 0", i);
         max_page_bytes = std::max(max_page_bytes, page_bytes);
     }
@@ -472,7 +590,6 @@ static GlobalCircularBuffer build_matmul_1d_gcb_recv_contig(
     // K-row-major builder (see create_global_circular_buffer_for_matmul_1d for why kMaxCbPagesBytes
     // exists); no L1 budget check — callers size to fit their own receiver L1.
     constexpr uint32_t kMaxCbPagesBytes = 131072u * 16u;
-    constexpr uint32_t kFifoMinWindowBlocks = 2;
     const uint32_t min_blocks = all_configs_fifo ? kFifoMinWindowBlocks : max_block_count;
     const uint32_t min_size = max_page_bytes * min_blocks;
     TT_FATAL(
@@ -534,7 +651,8 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
     for (size_t i = 0; i < program_configs.size(); ++i) {
         TT_FATAL(
             program_configs[i].gather_in0,
-            "program_configs[{}] uses mcast_in0, which requires a receiver-contiguous NdShardSpec weight",
+            "program_configs[{}] uses mcast_in0 or mcast_in1, which require an NdShardSpec weight (per-receiver "
+            "shards for mcast_in0, a single shard for mcast_in1)",
             i);
     }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -1216,6 +1216,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     bool in0_is_sharded,
     bool output_is_sharded,
     bool untilize_out,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
     // currently only support transpose of the full tile
@@ -1223,6 +1224,12 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
 
     bool fuse_op = false;
+
+    // Broadcast Tensor prefetcher: in1 arrives on every worker over the global CB instead of being
+    // read from DRAM by the first core and multicast on-grid. Core roles, the mcast semaphores and
+    // the bias path are all untouched — only the in1 data path moves, so bias still costs exactly
+    // one DRAM read for the whole grid.
+    const bool use_global_cb = global_cb.has_value();
 
     uint32_t num_blocks = K / in0_block_w;
     // Only enable packer l1 accumulation when there are num_blocks > 2, otherwise
@@ -1274,7 +1281,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
     uint32_t in0_aligned_tile_size =
         in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
-    uint32_t in1_aligned_tile_size = tt::align(in1_single_tile_size, dram_alignment);
+    // Global-CB pages are packed at the natural tile size (the prefetcher writes them contiguously),
+    // so they must not be padded to the DRAM alignment the interleaved reader needs.
+    uint32_t in1_aligned_tile_size =
+        use_global_cb ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
     // Bias CB pages must be padded to the DRAM alignment so the reader's L1 write stride
     // matches the DRAM page stride (e.g. 64B on Blackhole for a 32B (1,16) bf16 bias tile).
     // Mirrors in0/in1 above and the dram_sharded factory. No-op on Wormhole and for
@@ -1575,6 +1585,15 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
     }
 
+    if (use_global_cb) {
+        // ENABLE_GLOBAL_CB swaps the in1 DRAM read for a remote-CB wait/pop on both kernels;
+        // ENABLE_GLOBAL_CB_MCAST_IN1 additionally drops the sender's in1 multicast (it has nothing
+        // to relay) while leaving the bias multicast — and its single DRAM read — in place.
+        mm_kernel_in1_sender_writer_defines["ENABLE_GLOBAL_CB"] = "1";
+        mm_kernel_in1_sender_writer_defines["ENABLE_GLOBAL_CB_MCAST_IN1"] = "1";
+        mm_kernel_in1_receiver_writer_defines["ENABLE_GLOBAL_CB_MCAST_IN1"] = "1";
+    }
+
     // Intermediate CB read
     /*
     Blackhole architecture alignment issue workaround for tiny tiles:
@@ -1795,11 +1814,34 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     }
 
     uint32_t src1_cb_index = tt::CBIndex::c_1;
-    tt_metal::CircularBufferConfig src1_cb_config =
-        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
-            .set_page_size(src1_cb_index, in1_aligned_tile_size)
-            .set_tile_dims(src1_cb_index, in1_tile);
-    tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    if (use_global_cb) {
+        // Back cb_src1 with the global CB so the prefetcher's multicast lands directly in the CB
+        // every worker's compute reads. c_31 is the remote view the in1 kernels wait/pop on; the
+        // local view keeps the same index the compute kernel already uses.
+        constexpr uint32_t remote_cb_index = tt::CBIndex::c_31;
+        const uint32_t in1_block_size_bytes = in1_block_tiles * in1_single_tile_size;
+        TT_FATAL(
+            global_cb->size() >= in1_block_size_bytes,
+            "mcast-in1 global_cb size {} must hold at least one full-width in1 K-block ({} B)",
+            global_cb->size(),
+            in1_block_size_bytes);
+        tt_metal::CircularBufferConfig remote_cb_config(
+            (global_cb->size() / in1_block_size_bytes) * in1_block_size_bytes);
+        remote_cb_config.remote_index(remote_cb_index)
+            .set_page_size(in1_block_size_bytes)
+            .set_data_format(in1_data_format);
+        remote_cb_config.index(src1_cb_index)
+            .set_page_size(in1_single_tile_size)
+            .set_data_format(in1_data_format)
+            .set_tile_dims(in1_tile);
+        tt_metal::experimental::CreateCircularBuffer(program, all_cores, remote_cb_config, *global_cb);
+    } else {
+        tt_metal::CircularBufferConfig src1_cb_config =
+            tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+                .set_page_size(src1_cb_index, in1_aligned_tile_size)
+                .set_tile_dims(src1_cb_index, in1_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    }
     log_debug(
         LogOp,
         "CB {} :: PS = {}, NP = {}, TOTAL = {}",
@@ -5369,6 +5411,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
         a.memory_config().is_sharded(),
         output.memory_config().is_sharded(),
         untilize_out,
+        global_cb,
         operations::matmul::utilities::fused_matmul_bias_row_broadcastable(bias),
         sub_device_start_core);
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -11,6 +11,9 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "api/tensor/noc_traits.h"
+#ifdef ENABLE_GLOBAL_CB_MCAST_IN1
+#include "api/remote_circular_buffer.h"
+#endif
 void kernel_main() {
     // READER
     uint32_t rt_args_idx = 0;
@@ -104,6 +107,14 @@ void kernel_main() {
     DataflowBuffer dfb_in3(dfb_id_in3);
 #endif
 
+#ifdef ENABLE_GLOBAL_CB_MCAST_IN1
+    // in1 arrives over the global CB instead of an on-grid multicast: the Tensor prefetcher
+    // multicasts each full-width K-block straight from the DRAM core into every worker's CB slot.
+    // Bias still comes from the in1 sender core, so the semaphores above stay in use for it.
+    constexpr uint32_t remote_cb_id = tt::CBIndex::c_31;
+    const uint32_t in1_fifo_tiles = get_local_cb_interface(dfb_id_in1).fifo_num_pages;
+#endif
+
     // WRITER
     const auto s = TensorAccessor(out_args, out_tensor_addr);
     // `s` is only consumed inside the `#ifndef OUT_SHARDED` write path below; mark it used so
@@ -119,6 +130,22 @@ void kernel_main() {
                     // Operand 1
                     dfb_in1.reserve_back(in1_block_num_tiles);
 
+#ifdef ENABLE_GLOBAL_CB_MCAST_IN1
+                    // Mirror of the in1 sender kernel's global-CB discipline: keep one block of
+                    // lookahead, then return the previous block's remote-CB credit to the
+                    // prefetcher once the unpacker has drained it. Every worker has its own
+                    // receiver interface, so credits flow back independently.
+                    experimental::remote_cb_wait_front(remote_cb_id, block == 0 ? 1u : 2u);
+
+                    dfb_in1.push_back(in1_block_num_tiles);
+
+                    if (block >= 1) {
+                        while (!dfb_in1.pages_reservable_at_back(in1_fifo_tiles - in1_block_num_tiles)) {
+                            invalidate_l1_cache();
+                        }
+                        experimental::remote_cb_pop_front(remote_cb_id, 1);
+                    }
+#else
                     // Set in1 semaphore value to INVALID
                     receiver_sem.set(INVALID);
 
@@ -129,7 +156,16 @@ void kernel_main() {
                     receiver_sem.wait(VALID);
 
                     dfb_in1.push_back(in1_block_num_tiles);
+#endif  // ENABLE_GLOBAL_CB_MCAST_IN1
                 }
+#ifdef ENABLE_GLOBAL_CB_MCAST_IN1
+                if (num_blocks_inner_dim > 0) {
+                    while (!dfb_in1.pages_reservable_at_back(in1_fifo_tiles)) {
+                        invalidate_l1_cache();
+                    }
+                    experimental::remote_cb_pop_front(remote_cb_id, 1);
+                }
+#endif
 
 #ifdef FUSE_BIAS
                 // Only read bias on first batch, or we have multiple output blocks
@@ -236,5 +272,9 @@ void kernel_main() {
 #if OUT_SHARDED
     dfb_out.wait_front(
         batch * out_num_nonzero_subblocks_h * out_num_nonzero_subblocks_w * out_subblock_w * out_subblock_h);
+#endif
+#ifdef ENABLE_GLOBAL_CB_MCAST_IN1
+    experimental::update_remote_cb_config_in_l1(remote_cb_id);
+    noc.async_atomic_barrier();
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -426,7 +426,11 @@ void kernel_main() {
                         noc.async_read_barrier();
 #endif  // IN1_DRAM_WIDTH_SHARDED / IN1_DRAM_HEIGHT_SHARDED / IN1_SHARDED
 
-#ifndef SKIP_MCAST
+// ENABLE_GLOBAL_CB_MCAST_IN1: the in1 block already arrived on every worker over the global CB
+// (the Tensor prefetcher multicasts it straight from the DRAM core), so this core has no in1 to
+// relay. Only the in1 multicast is suppressed — the bias multicast below still runs, keeping bias
+// at a single DRAM read for the whole grid.
+#if !defined(SKIP_MCAST) && !defined(ENABLE_GLOBAL_CB_MCAST_IN1)
                         // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr
                         // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
                         // zero for the next block
@@ -468,7 +472,7 @@ void kernel_main() {
                             in1_mcast_dest_noc_end_x,
                             in1_mcast_dest_noc_end_y,
                             in1_mcast_num_cores);
-#endif  // SKIP_MCAST
+#endif  // !SKIP_MCAST && !ENABLE_GLOBAL_CB_MCAST_IN1
 
 #ifndef IN1_SHARDED
                         dfb_in1.push_back(in1_block_num_tiles);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1075,6 +1075,92 @@ void validate_dram_sender_global_cb_mcast_in0_geometry(
         2 * in1_block_size_bytes);
 }
 
+// mcast-in1 fed by a broadcast Tensor prefetcher: one DRAM bank holds the whole weight and its DRISC
+// multicasts each full-width K-block to every matmul worker, replacing the on-grid in1 multicast
+// from the first core. The bias path is unchanged (still one DRAM read on the sender core).
+void validate_dram_sender_global_cb_broadcast_mcast_in1_geometry(
+    const tt::tt_metal::experimental::GlobalCircularBuffer& gcb,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const ttnn::Shape& a_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    TT_FATAL(
+        tt::tt_metal::experimental::sender_core_type(gcb) == tt::tt_metal::experimental::SenderCoreType::Dram,
+        "mcast-in1 global_cb requires programmable DRAM senders");
+    // Broadcast delivery is chosen per tensor by the weight's shape (a single shard), not by the
+    // GCB, so what this op has to pin down is that the GCB's geometry can actually carry it: the
+    // weight lives on one bank, and each sender's receivers form a line one multicast can name.
+    const auto& sender_mapping = gcb.sender_receiver_core_mapping();
+    TT_FATAL(!sender_mapping.empty(), "mcast-in1 global_cb has no DRAM senders");
+    for (const auto& [sender_core, receivers] : sender_mapping) {
+        TT_FATAL(
+            sender_core.x == sender_mapping.front().first.x,
+            "mcast-in1 global_cb has senders on more than one DRAM bank (banks {} and {}), but the broadcast weight "
+            "is a single shard that lives on one bank; the off-bank sender would read unrelated memory",
+            sender_mapping.front().first.x,
+            sender_core.x);
+        // Geometry, not CoreRange count: a contiguous line is often stored as one range per core.
+        const CoreRange receiver_bbox = receivers.bounding_box();
+        const CoreCoord receiver_grid = receiver_bbox.grid_size();
+        TT_FATAL(
+            receivers.num_cores() == receiver_bbox.size() && (receiver_grid.x == 1 || receiver_grid.y == 1),
+            "mcast-in1 global_cb sender {} has receivers {}, which are not a single row or column; a broadcast push "
+            "names its receivers with one multicast address, so they must be contiguous and 1-D",
+            sender_core.str(),
+            receivers);
+    }
+    TT_FATAL(
+        program_config.out_block_h == program_config.per_core_M &&
+            program_config.out_block_w == program_config.per_core_N,
+        "mcast-in1 global_cb requires one output block per worker: out_block_h ({}) must equal per_core_M ({}) "
+        "and out_block_w ({}) must equal per_core_N ({})",
+        program_config.out_block_h,
+        program_config.per_core_M,
+        program_config.out_block_w,
+        program_config.per_core_N);
+
+    // The broadcast weight <-> matmul cross-checks (single-shard DRAM NdShardSpec spanning the whole
+    // (K, N), K % in0_block_w == 0, per_core_N == full N, stream_in1 == false) and the two-page
+    // window guard are owned by the shared prefetcher helper, so the contract lives in one place.
+    ttnn::global_circular_buffer::tensor_prefetcher_block_count_for_matmul_1d(program_config, input_tensor_b, gcb);
+
+    // Every active worker must be a GCB receiver: one that isn't would wait forever on an in1 block
+    // nobody delivers. Derive the active set exactly as the program factory does.
+    const uint32_t M = operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, program_config.fuse_batch);
+    const uint32_t num_workers = tt::div_up(M, static_cast<uint32_t>(program_config.per_core_M));
+    // A single worker collapses the matmul to SKIP_MCAST (which would also drop the bias multicast)
+    // and leaves the prefetcher multicasting to a 1x1 rectangle. Neither is worth supporting: with
+    // one worker there is nothing to broadcast to, so use a plain mcast-in1 matmul.
+    TT_FATAL(
+        num_workers > 1,
+        "broadcast mcast-in1 requires at least two active matmul workers, but M={} at per_core_M={} needs only {}",
+        M,
+        program_config.per_core_M,
+        num_workers);
+    const auto& grid = program_config.compute_with_storage_grid_size;
+    CoreCoord start_core = {0, 0};
+    if (sub_device_id.has_value()) {
+        const auto sub_device_workers =
+            input_tensor_a.device()->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value());
+        start_core = sub_device_workers.bounding_box().start_coord;
+    }
+    const CoreRangeSet matmul_rect(
+        CoreRange(start_core, CoreCoord(start_core.x + grid.x - 1, start_core.y + grid.y - 1)));
+    const auto active_workers = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+        start_core, num_workers, matmul_rect, /*row_wise=*/true);
+    TT_FATAL(
+        active_workers == gcb.receiver_cores(),
+        "mcast-in1 global_cb receivers {} must be exactly the active matmul workers {} ({} workers for M={} at "
+        "per_core_M={}); a worker outside the GCB would never receive an in1 block.",
+        gcb.receiver_cores(),
+        active_workers,
+        num_workers,
+        M,
+        program_config.per_core_M);
+}
+
 // Helper: warns if a caller of MatmulDeviceOperation's static API hasn't populated
 // allowed_worker_cores on a program_config variant that supports the field. ttnn::prim::matmul()
 // normalizes its attributes before launch, but direct callers (e.g. CCL fused ops in
@@ -1761,15 +1847,23 @@ void validate_matmul_mcast1d_config(
         config_name);
 
     if (attributes.global_cb.has_value() && !program_config.gather_in0) {
-        TT_FATAL(
-            program_config.mcast_in0,
-            "{}: global_cb without gather_in0 is supported only for mcast_in0=true",
-            config_name);
-        validate_dram_sender_global_cb_mcast_in0_geometry(
-            attributes.global_cb.value(), input_tensor_b, in1_tile, program_config);
+        if (program_config.mcast_in0) {
+            validate_dram_sender_global_cb_mcast_in0_geometry(
+                attributes.global_cb.value(), input_tensor_b, in1_tile, program_config);
+        } else {
+            TT_FATAL(!attributes.transpose_b, "{}: mcast-in1 global_cb does not support transpose_b", config_name);
+            validate_dram_sender_global_cb_broadcast_mcast_in1_geometry(
+                attributes.global_cb.value(),
+                input_tensor_a,
+                input_tensor_b,
+                a_shape_padded,
+                in0_tile,
+                program_config,
+                attributes.sub_device_id);
+        }
         TT_FATAL(
             program_config.fuse_batch || get_batch_size(a_shape_padded) == 1,
-            "{}: mcast_in0 global_cb requires one effective activation batch, but fuse_batch={} and "
+            "{}: GCB-backed multicast requires one effective activation batch, but fuse_batch={} and "
             "activation batch size={}",
             config_name,
             program_config.fuse_batch,
@@ -2052,11 +2146,23 @@ void validate_matmul_mcast1d_config(
                 program_config.out_block_h,
                 per_core_N);
         }
-        TT_FATAL(
-            input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-            "{}: input B must be INTERLEAVED, got: {}",
-            config_name,
-            input_tensor_b.memory_config().memory_layout());
+        if (attributes.global_cb.has_value()) {
+            // The broadcast prefetcher reads the weight from DRAM itself, so B is a single-shard
+            // NdShardSpec tensor pinned to one bank rather than an interleaved one the matmul reads.
+            TT_FATAL(
+                input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM &&
+                    input_tensor_b.nd_shard_spec().has_value(),
+                "{}: GCB-backed mcast-in1 requires an NdShardSpec DRAM input B, got buffer type {} and layout {}",
+                config_name,
+                input_tensor_b.buffer()->buffer_type(),
+                input_tensor_b.memory_config().memory_layout());
+        } else {
+            TT_FATAL(
+                input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                "{}: input B must be INTERLEAVED, got: {}",
+                config_name,
+                input_tensor_b.memory_config().memory_layout());
+        }
     }
 }
 

--- a/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
+++ b/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
@@ -16,7 +16,9 @@ couplings nothing enforces.
 it derives ``block_count``, queues the request, then runs the consuming
 ``ttnn.linear`` with the same GCB and program config. Gather-in0 uses one block
 per ring receiver. Mcast-in0 uses ``K_tiles / in0_block_w`` natural-order blocks
-per receiver and requires a receiver-contiguous weight.
+per receiver and requires a receiver-contiguous weight. Mcast-in1 uses the same
+``K_tiles / in0_block_w`` count, but each block is the full weight width and is
+multicast to every worker from a broadcast GCB.
 
 This is a host-side composition, not a device-level fusion: the prefetch still
 runs on the DRAM-core (DRISC) path off the command queue while the matmul is
@@ -63,10 +65,12 @@ def prefetch_and_linear(
         The ``ttnn.linear`` output tensor.
     """
     device = input_tensor_a.device()
-    if program_config.mcast_in0 or program_config.stream_in1:
+    if not program_config.gather_in0 or program_config.stream_in1:
+        # Both multicast consumers and streaming gather derive their block count from the
+        # weight's K and the config's in0_block_w, so ask the validator rather than guessing.
         block_count = ttnn.experimental.tensor_prefetcher_block_count_for_matmul_1d(program_config, weight, global_cb)
     else:
-        # Gather consumes one K-block per ring position.
+        # Batched gather consumes one K-block per ring position.
         block_count = global_cb.receiver_cores().num_cores()
 
     # Streaming gather needs identity ring rotation (``rotation[r] = r``). That table is


### PR DESCRIPTION
### PR Category
Feature

### Summary

Relates to #49428 (sibling of the worker-relay approach in #50746), part of #45753 / #45751.

Adds a **broadcast** delivery mode to the Tensor prefetcher: a DRAM bank's DRISC multicasts each
full-width in1 K-block to a 1-D array of `mcast_in1` matmul workers, instead of scattering a distinct
slab to each. This is what #49428 asked for — multicast in the prefetcher itself — and it makes the
prefetcher usable by the one 1D matmul mode it could not feed before.

`mcast_in1` is M-parallel: sharded in0/out force `N == per_core_N`, so every worker needs the *same*
full `[K, N]` weight. Today only one core reads that weight from DRAM and re-multicasts it on-grid.
With a broadcast GCB the DRISC does the multicast directly, and the on-grid relay disappears:

```
1 DRAM bank (one DRISC sender)
         |  one NoC multicast per in1 K-block
         v
  [w0][w1][w2] ... [wn-1]     each worker holds the SAME [in0_block_w x N] block
```

**DRISC-sourced multicast already works on Blackhole** — `DramKernelDRISCReadFromDRAMMcastToTensix`
covers it. This reuses the same rules (stream mode; multicast entry corner chosen per NOC flow
direction). #50746's "No DRISC multicast support is added" was a scope statement, not a hardware
finding.

**Broadcast is a property of the tensor, not of the GCB.** It is inferred the way the DRAM layout
already is — from how the weight was allocated: a scatter weight has one shard per receiver, a
broadcast weight has a single `(K, N)` shard every receiver reads in full. The flag travels in the
request page next to `streaming` and joins the page's layout dedup key, so **one GCB serves both
kinds of tensor in the same request** and a matmul can switch modes without rebuilding its GCB.

What the GCB contributes is geometry: `DramSenderStateBlock` always carries each sender's receiver
bounding box. A broadcast tensor is accepted only when each sender's receivers form a line filling
that box (per *sender*, not per GCB — under the dual-sender split a 2-D receiver block becomes two
lines, one each) and when all senders sit on the bank physically holding the single shard.

### What's changed

- **Metal GCB** — always stamp each sender's receiver bounding box (virtual worker coords, min corner
  first) into `DramSenderStateBlock`. No new GCB mode or constructor argument.
- **Request wire format** — new per-tensor `TensorPrefetcherTensorLayout::broadcast`, alongside
  `streaming`.
- **Prefetcher manager** — infer broadcast from `num_shards == 1`; pin `recv_stride_bytes` to 0;
  gate on per-sender receiver linearity and single-bank senders; reject broadcast + rotation.
- **DRISC kernel** — reuses the receiver-contiguous round loop with the visit count collapsed to one
  and the chunk write swapped for `noc_async_write_multicast_one_packet`. Multicast has no posted and
  no stateful (`set_state`/`with_state`) form in the public API, so that branch reprograms the command
  buffer per packet, links packets within a chunk, and drains the non-posted counters. Credits stay
  per-receiver and unicast.
- **Matmul** — `global_cb` threaded into the `mcast_in1` factory; `cb_src1` becomes the GCB's local
  view on every worker; new `ENABLE_GLOBAL_CB_MCAST_IN1` define; broadcast geometry validator.
- **Fix** — `prefetch_and_linear` derived its block count from `mcast_in0 or stream_in1`, silently
  producing the wrong count for `mcast_in1`.

### Notes for reviewers

**Please focus on the bias path.** `ENABLE_GLOBAL_CB_MCAST_IN1` suppresses *only* the in1 multicast
block in `reader_bmm_tile_layout_in1_sender_writer_padding.cpp`. The bias multicast is a separate,
self-contained block with its own `sender_sem.wait` / mcast / `receiver_sem.set_multicast`, so it is
left running and bias still costs exactly **one** DRAM read for the whole grid. Using `SKIP_MCAST`
here would have been wrong — it kills both, turning one bias read into one per core. Core roles, both
mcast semaphores and the sender/receiver kernel split are otherwise unchanged.

Second area: the non-posted multicast in the DRISC push loop. The unicast path is posted with `set_state`/`with_state` amortization; neither exists for
multicast, so the broadcast branch reprograms the command buffer per packet and uses
`noc_async_write_barrier()` before finalize (broadcast payload rides the multicast VC while credits
stay unicast, so in-order delivery no longer covers them).

`test_prefetcher_BH_broadcast_bench.py` measures it against plain mcast-in1 on the same matmul,
same worker line, same program config (trace-replayed in steady state, both arms PCC-checked after
replay).

**The GCB window depth dominates.** The kernel batches B blocks per round, clamped by free space, so
a two-page window forces B=2 — a 32-block tensor then costs 16 rounds, each paying a free-space
poll, a write barrier and a per-receiver credit update. Sweeping depth at `in0_block_w=1`,
N=1 tile, against a 20.8 us baseline:

| GCB pages | 2 | 4 | 8 | 16 |
|---|---|---|---|---|
| us/matmul | 41.2 | 25.0 | 13.5 | **9.4** |

Same code, 0.51x to 2.2x purely on window depth. Depth 2 is the equal-L1 point — it matches the
baseline's double-buffered in1 CB byte for byte — so the honest summary is:

| | vs plain mcast-in1 |
|---|---|
| equal in1 L1 (2-page window) | 0.51x – 1.11x |
| 8-page window (4x the in1 L1) | 0.95x – 1.62x |
| each arm at its own best config | 0.99x – 1.36x |

So it buys throughput with L1 spent on the in1 window. For mcast-in1 that is usually affordable —
in1 is the small operand there — but it is a real trade, not free.

Multicast linking was checked too, since a multicast re-reserves its NoC path unless linked to the
previous transaction. The push already links within a chunk; extending the link across a whole round
measured neutral (mostly 1.00x) and would hold the reservation across the inter-chunk DMA wait, so
it stays intra-chunk.

Remaining lever if this needs to be faster: a posted and/or stateful multicast. The low-level
`ncrisc_noc_fast_write` takes `mcast` and `posted` independently, and the dispatcher's
`cq_noc_async_write_init_state<..., mcast=true>` shows a stateful multicast init.

Verified on a Blackhole p100a (firmware 19.12.0.0 — note the CI fleet is below the 19.12.0.0 floor,
so these tests **skip** in CI and green there does not exercise this code):

- broadcast PCC, 3 and 8 workers × bias: 4 passed, PCC ≥ 0.99999, incl. program-cache reuse
- one GCB serving a scatter (mcast-in0) and a broadcast (mcast-in1) tensor back to back: passed
- negatives (multi-bank senders, non-linear receivers, undersized window): 3 passed
- whole Tensor prefetcher suite: 58 passed, 3 skipped, 0 failed
- `unit_tests_api *DramKernel*:*DramSenderGCB*` (slow dispatch): 26/26
- plain non-GCB `mcast_in1` regression (`test_linear_yolov7`): 8/8
- broadcast-vs-plain benchmark: 45 configurations across shape, in0_block_w and GCB depth,
  both arms PCC-checked after trace replay
- `git clang-format --style=file main`; `pre-commit run --from-ref main --to-ref HEAD`
