### PR TITLE
[Test Escalation] Reassign test owner_id per 2026-08-06 escalation (#52275)

### DIFF
--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -30,7 +30,7 @@
       timeout: 15
     bh_quietbox_2:
       timeout: 15
-  owner_id: U0883RN6CRE # William Ly
+  owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
 
 - id: bh-ccl-nightly-integration
@@ -58,7 +58,7 @@
       timeout: 15
     bh_quietbox_2:
       timeout: 15
-  owner_id: U0883RN6CRE # William Ly
+  owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
 
 # --- unit ---
@@ -74,7 +74,7 @@
       timeout: 20
     bh_quietbox_2:
       timeout: 20
-  owner_id: U0883RN6CRE # William Ly
+  owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
 
 - id: bh-grid-20-cores-ttnn-sharding
@@ -104,7 +104,7 @@
       timeout: 15
     bh_quietbox_2:
       timeout: 15
-  owner_id: U0883RN6CRE # William Ly
+  owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
 
 - id: bh-ttnn-ops-fast-unit
@@ -143,7 +143,7 @@
       timeout: 15
     bh_quietbox_2:
       timeout: 15
-  owner_id: U0883RN6CRE # William Ly
+  owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
 
 - id: bh-ttnn-stress

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -230,7 +230,7 @@
   skus:
     bh_galaxy:
       timeout: 15
-  owner_id: U081GCJ8NDN # Nour Ardo
+  owner_id: U03PUAKE719 # Miguel Tairum
   team: models
 
 # ============================================================================

--- a/tests/pipeline_reorg/galaxy_unit_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_unit_tests.yaml
@@ -17,6 +17,7 @@
   name: Galaxy UMD unit tests
   model: unit
   team: umd
+  owner_id: U09769N29BN # Aleksa Marković
   # owner: see issue #29677
   auto_triage: true
   cmd: ./build/test/umd/galaxy/unit_tests_glx
@@ -28,6 +29,7 @@
   name: UMD API tests
   model: unit
   team: umd
+  owner_id: U09769N29BN # Aleksa Marković
   auto_triage: true
   cmd: ./build/test/umd/api/api_tests
   skus:

--- a/tests/pipeline_reorg/llk_bit_exact_tests.yaml
+++ b/tests/pipeline_reorg/llk_bit_exact_tests.yaml
@@ -24,7 +24,7 @@
   skus:
     wh_n150_civ2:
       timeout: 90
-  owner_id: U07J3K6KS1K # LLK team
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_bit_exact_blackhole group 1/2
   split_group: 1
@@ -42,7 +42,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 90
-  owner_id: U07J3K6KS1K # LLK team
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_bit_exact_blackhole group 2/2
   split_group: 2
@@ -60,4 +60,4 @@
   skus:
     bh_p150b_civ2:
       timeout: 90
-  owner_id: U07J3K6KS1K # LLK team
+  owner_id: U09UC143684 # Nemanja Divnic

--- a/tests/pipeline_reorg/llk_e2e_tests.yaml
+++ b/tests/pipeline_reorg/llk_e2e_tests.yaml
@@ -30,7 +30,7 @@
   skus:
     wh_n150_civ2:
       timeout: 38
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_e2e_wormhole group 2/5
   split_group: 2
@@ -61,7 +61,7 @@
   skus:
     wh_n150_civ2:
       timeout: 38
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_e2e_wormhole group 3/5
   split_group: 3
@@ -92,7 +92,7 @@
   skus:
     wh_n150_civ2:
       timeout: 38
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_e2e_wormhole group 4/5
   split_group: 4
@@ -123,7 +123,7 @@
   skus:
     wh_n150_civ2:
       timeout: 38
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_e2e_wormhole group 5/5
   split_group: 5
@@ -154,7 +154,7 @@
   skus:
     wh_n150_civ2:
       timeout: 38
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_e2e_blackhole group 1/5
   split_group: 1
@@ -185,7 +185,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 55
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_e2e_blackhole group 2/5
   split_group: 2
@@ -216,7 +216,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 55
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_e2e_blackhole group 3/5
   split_group: 3
@@ -247,7 +247,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 55
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_e2e_blackhole group 4/5
   split_group: 4
@@ -278,7 +278,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 55
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_e2e_blackhole group 5/5
   split_group: 5
@@ -309,4 +309,4 @@
   skus:
     bh_p150b_civ2:
       timeout: 55
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic

--- a/tests/pipeline_reorg/llk_e2e_tests.yaml
+++ b/tests/pipeline_reorg/llk_e2e_tests.yaml
@@ -30,7 +30,7 @@
   skus:
     wh_n150_civ2:
       timeout: 38
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_e2e_wormhole group 2/5
   split_group: 2
@@ -61,7 +61,7 @@
   skus:
     wh_n150_civ2:
       timeout: 38
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_e2e_wormhole group 3/5
   split_group: 3
@@ -92,7 +92,7 @@
   skus:
     wh_n150_civ2:
       timeout: 38
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_e2e_wormhole group 4/5
   split_group: 4
@@ -123,7 +123,7 @@
   skus:
     wh_n150_civ2:
       timeout: 38
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_e2e_wormhole group 5/5
   split_group: 5
@@ -154,7 +154,7 @@
   skus:
     wh_n150_civ2:
       timeout: 38
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_e2e_blackhole group 1/5
   split_group: 1
@@ -185,7 +185,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 55
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_e2e_blackhole group 2/5
   split_group: 2
@@ -216,7 +216,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 55
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_e2e_blackhole group 3/5
   split_group: 3
@@ -247,7 +247,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 55
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_e2e_blackhole group 4/5
   split_group: 4
@@ -278,7 +278,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 55
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_e2e_blackhole group 5/5
   split_group: 5
@@ -309,4 +309,4 @@
   skus:
     bh_p150b_civ2:
       timeout: 55
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684

--- a/tests/pipeline_reorg/llk_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/llk_merge_gate_tests.yaml
@@ -11,6 +11,7 @@
     wh_n150_civ2:
       timeout: 10
   team: llk
+  owner_id: U09UC143684 # Nemanja Divnic
   arch: wormhole_b0
   dispatch_mode: fd
   gtest_shard_total: 4
@@ -22,6 +23,7 @@
     wh_n150_civ2:
       timeout: 10
   team: llk
+  owner_id: U09UC143684 # Nemanja Divnic
   arch: wormhole_b0
   dispatch_mode: fd
   gtest_shard_total: 4
@@ -33,6 +35,7 @@
     wh_n150_civ2:
       timeout: 10
   team: llk
+  owner_id: U09UC143684 # Nemanja Divnic
   arch: wormhole_b0
   dispatch_mode: fd
   gtest_shard_total: 4
@@ -44,6 +47,7 @@
     wh_n150_civ2:
       timeout: 10
   team: llk
+  owner_id: U09UC143684 # Nemanja Divnic
   arch: wormhole_b0
   dispatch_mode: fd
   gtest_shard_total: 4
@@ -55,6 +59,7 @@
     bh_p150b_civ2_viommu:
       timeout: 10
   team: llk
+  owner_id: U09UC143684 # Nemanja Divnic
   arch: blackhole
   dispatch_mode: fd
   gtest_shard_total: 2
@@ -66,6 +71,7 @@
     bh_p150b_civ2_viommu:
       timeout: 10
   team: llk
+  owner_id: U09UC143684 # Nemanja Divnic
   arch: blackhole
   dispatch_mode: fd
   gtest_shard_total: 2
@@ -78,6 +84,7 @@
     wh_n150_civ2:
       timeout: 10
   team: llk
+  owner_id: U09UC143684 # Nemanja Divnic
   arch: wormhole_b0
   dispatch_mode: sd
 
@@ -87,5 +94,6 @@
     bh_p150b_civ2_viommu:
       timeout: 10
   team: llk
+  owner_id: U09UC143684 # Nemanja Divnic
   arch: blackhole
   dispatch_mode: sd

--- a/tests/pipeline_reorg/llk_perf_tests.yaml
+++ b/tests/pipeline_reorg/llk_perf_tests.yaml
@@ -17,7 +17,7 @@
   skus:
     wh_n150_civ2:
       timeout: 90
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_perf_wormhole group 2/5
   split_group: 2
@@ -28,7 +28,7 @@
   skus:
     wh_n150_civ2:
       timeout: 90
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_perf_wormhole group 3/5
   split_group: 3
@@ -39,7 +39,7 @@
   skus:
     wh_n150_civ2:
       timeout: 90
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_perf_wormhole group 4/5
   split_group: 4
@@ -50,7 +50,7 @@
   skus:
     wh_n150_civ2:
       timeout: 90
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_perf_wormhole group 5/5
   split_group: 5
@@ -61,7 +61,7 @@
   skus:
     wh_n150_civ2:
       timeout: 90
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_perf_blackhole group 1/5
   split_group: 1
@@ -72,7 +72,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 150
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_perf_blackhole group 2/5
   split_group: 2
@@ -83,7 +83,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 150
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_perf_blackhole group 3/5
   split_group: 3
@@ -94,7 +94,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 150
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_perf_blackhole group 4/5
   split_group: 4
@@ -105,7 +105,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 150
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_perf_blackhole group 5/5
   split_group: 5
@@ -116,4 +116,4 @@
   skus:
     bh_p150b_civ2:
       timeout: 150
-  owner_id: U09UC143684
+  owner_id: U09UC143684 # Nemanja Divnic

--- a/tests/pipeline_reorg/llk_perf_tests.yaml
+++ b/tests/pipeline_reorg/llk_perf_tests.yaml
@@ -17,7 +17,7 @@
   skus:
     wh_n150_civ2:
       timeout: 90
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_perf_wormhole group 2/5
   split_group: 2
@@ -28,7 +28,7 @@
   skus:
     wh_n150_civ2:
       timeout: 90
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_perf_wormhole group 3/5
   split_group: 3
@@ -39,7 +39,7 @@
   skus:
     wh_n150_civ2:
       timeout: 90
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_perf_wormhole group 4/5
   split_group: 4
@@ -50,7 +50,7 @@
   skus:
     wh_n150_civ2:
       timeout: 90
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_perf_wormhole group 5/5
   split_group: 5
@@ -61,7 +61,7 @@
   skus:
     wh_n150_civ2:
       timeout: 90
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_perf_blackhole group 1/5
   split_group: 1
@@ -72,7 +72,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 150
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_perf_blackhole group 2/5
   split_group: 2
@@ -83,7 +83,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 150
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_perf_blackhole group 3/5
   split_group: 3
@@ -94,7 +94,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 150
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_perf_blackhole group 4/5
   split_group: 4
@@ -105,7 +105,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 150
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684
 
 - name: llk_perf_blackhole group 5/5
   split_group: 5
@@ -116,4 +116,4 @@
   skus:
     bh_p150b_civ2:
       timeout: 150
-  owner_id: U07J3K6KS1K
+  owner_id: U09UC143684

--- a/tests/pipeline_reorg/llk_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/llk_pr_gate_tests.yaml
@@ -20,7 +20,7 @@
   skus:
     wh_n150_civ2:
       timeout: 15
-  owner_id: U07J3K6KS1K # Bryan Lozano
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_smoke_blackhole group 1/2
   split_group: 1
@@ -37,7 +37,7 @@
   skus:
     bh_p150b_civ2_viommu:
       timeout: 15
-  owner_id: U07J3K6KS1K # Bryan Lozano
+  owner_id: U09UC143684 # Nemanja Divnic
 
 - name: llk_smoke_blackhole group 2/2
   split_group: 2
@@ -54,4 +54,4 @@
   skus:
     bh_p150b_civ2_viommu:
       timeout: 15
-  owner_id: U07J3K6KS1K # Bryan Lozano
+  owner_id: U09UC143684 # Nemanja Divnic

--- a/tests/pipeline_reorg/llk_unit_tests.yaml
+++ b/tests/pipeline_reorg/llk_unit_tests.yaml
@@ -17,6 +17,7 @@
     wh_n300_civ2:
       timeout: 40
   team: llk
+  owner_id: U09UC143684 # Nemanja Divnic
   arch: wormhole_b0
   dispatch_mode: sd
 
@@ -28,5 +29,6 @@
     bh_p100:
       timeout: 40
   team: llk
+  owner_id: U09UC143684 # Nemanja Divnic
   arch: blackhole
   dispatch_mode: sd

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -101,7 +101,7 @@
     wh_galaxy_perf:
       timeout: 20
       tier: 1
-  owner_id: U08BH66EXAL # Radoica Draskic
+  owner_id: U03PUAKE719 # Miguel Tairum
   team: models
 
 - name: Llama 3.2-1B e2e tests

--- a/tests/pipeline_reorg/ops_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ops_sanity_tests.yaml
@@ -18,7 +18,7 @@
   skus:
     wh_n300_civ2:
       timeout: 5
-  owner_id: U0837MYG788 # Marko Radosavljevic
+  owner_id: U03PUAKE719 # Miguel Tairum
   team: models
   slow_dispatch: false
 

--- a/tests/pipeline_reorg/release_tests.yaml
+++ b/tests/pipeline_reorg/release_tests.yaml
@@ -22,7 +22,7 @@
   skus:
     wh_n150:
       timeout: 18
-  owner_id: U0837MYG788 # Marko Radosavljevic
+  owner_id: U03PUAKE719 # Miguel Tairum
   team: models
   model-name: resnet
 
@@ -40,7 +40,7 @@
   skus:
     wh_n150:
       timeout: 45
-  owner_id: U0837MYG788 # Marko Radosavljevic
+  owner_id: U03PUAKE719 # Miguel Tairum
   team: models
   model-name: sdxl
 
@@ -49,7 +49,7 @@
   skus:
     wh_n150:
       timeout: 24
-  owner_id: U0837MYG788 # Marko Radosavljevic
+  owner_id: U03PUAKE719 # Miguel Tairum
   team: models
   model-name: resnet
 
@@ -177,7 +177,7 @@
   skus:
     wh_n300:
       timeout: 18
-  owner_id: U0837MYG788 # Marko Radosavljevic
+  owner_id: U03PUAKE719 # Miguel Tairum
   team: models
   model-name: resnet
 
@@ -274,7 +274,7 @@
   skus:
     wh_llmbox_perf:
       timeout: 12
-  owner_id: U0837MYG788 # Marko Radosavljevic
+  owner_id: U03PUAKE719 # Miguel Tairum
   team: models
   model-name: resnet50
 
@@ -450,7 +450,7 @@
   skus:
     wh_galaxy:
       timeout: 20
-  owner_id: U08BH66EXAL # Radoica Draskic
+  owner_id: U03PUAKE719 # Miguel Tairum
   team: models
 
 - name: Galaxy Llama 3.3-70B e2e tests

--- a/tests/pipeline_reorg/t3k_demo_tests.yaml
+++ b/tests/pipeline_reorg/t3k_demo_tests.yaml
@@ -14,7 +14,7 @@
   skus:
     wh_llmbox_perf:
       timeout: 10
-  owner_id: U0837MYG788 # Marko Radosavljevic
+  owner_id: U03PUAKE719 # Miguel Tairum
   team: models
   model-name: resnet50
 

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -38,7 +38,7 @@
   skus:
     wh_llmbox:
       timeout: 10
-  owner_id: U08LD7UCKDF # Tomer Levin
+  owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
 
 - name: t3k_dispatch_unit_tests

--- a/tests/pipeline_reorg/t3k_perf_tests.yaml
+++ b/tests/pipeline_reorg/t3k_perf_tests.yaml
@@ -16,7 +16,7 @@
   skus:
     wh_llmbox_perf:
       timeout: 75
-  owner_id: U0837MYG788 # Marko Radosavljevic
+  owner_id: U03PUAKE719 # Miguel Tairum
   team: models
   model-name: resnet50
   model-type: CNN

--- a/tests/pipeline_reorg/umd_sanity_tests.yaml
+++ b/tests/pipeline_reorg/umd_sanity_tests.yaml
@@ -19,3 +19,4 @@
     bh_p150b_civ2_viommu:
       timeout: 15
   team: umd
+  owner_id: U09769N29BN # Aleksa Marković

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -386,7 +386,7 @@
     wh_llmbox:
       timeout: 52
       tier: 2
-  owner_id: U03PUAKE719 # Miguel Tairum
+  owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
 
 - name: "Qwen3-VL-32B-Instruct"

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -386,7 +386,7 @@
     wh_llmbox:
       timeout: 52
       tier: 2
-  owner_id: U07RY6B5FLJ # Gongyu Wang
+  owner_id: U03PUAKE719 # Miguel Tairum
   team: models
 
 - name: "Qwen3-VL-32B-Instruct"


### PR DESCRIPTION
## Summary

Applies the test-ownership reassignments from the daily test escalation issue:
**https://github.com/tenstorrent/tt-metal/issues/52275** — `[2026-08-06] Test Escalation Assignment`

Closes #52275

**Category: Bug Fix**

56 tests across 17 `tests/pipeline_reorg/*.yaml` files had their `owner_id` (Slack ID) updated. Only `owner_id` lines are touched — 43 existing values updated and 13 new `owner_id` lines inserted after the `team:` line for tests that previously had no owner assigned. No other YAML content, ordering, or formatting was changed.

**Correction (post-push, per Theran):** `vllm_model_tests.yaml`'s "Qwen2.5-VL-72B-Instruct" test was originally escalated because its `owner_id` (`U07RY6B5FLJ`) didn't resolve — but that was a stale/legacy Slack ID for **Gongyu Wang**, not an actual ownership gap. Reverted to Gongyu Wang using his current Slack ID `U08JFM3CFA4` (cross-checked against his `owner_id` elsewhere in `tests/pipeline_reorg/*.yaml`) instead of reassigning to the models team lead. Counts below reflect this correction.

## Affected owners

| Owner | GitHub handle | Slack ID | Tests | Reassigned (existing `owner_id`) | Newly added (no prior owner) |
|---|---|---|---|---|---|
| Nemanja Divnic | @ndivnicTT | `U09UC143684` | **36** | 26 | 10 |
| Miguel Tairum | @mtairum | `U03PUAKE719` | **11** | 11 | 0 |
| Joseph Chu | @cfjchu | `U07D5N7QL4U` | **6** | 6 | 0 |
| Aleksa Marković | @aleksamarkovicTT | `U09769N29BN` | **3** | 0 | 3 |
| | | **Total** | **56** | **43** | **13** |

Slack IDs and display names were taken from `.github/TESTOWNERS` on `main` and independently cross-checked against Slack. (Gongyu Wang keeps ownership of the corrected test above and isn't a newly-assigned owner, so he's not in this table.)

## Newly assigned developers

@ndivnicTT @mtairum @cfjchu @aleksamarkovicTT

## Requested reviewers: please run an inventory sanity check

@ndivnicTT @mtairum @cfjchu @aleksamarkovicTT — before approving, please run the **`test-owner-query.yaml`** workflow with **your own Slack ID** (from the table above) and review the returned inventory of tests attributed to you.

This is a sanity check in both directions:
- confirm you are **not missing** tests you should own, and
- confirm you are **not over-assigned** tests that actually belong to another owner or team.

If the inventory looks wrong for any entry, comment here and the specific `owner_id` can be corrected before merge.

## Files changed

All under `tests/pipeline_reorg/`: `blackhole_e2e_tests.yaml`, `demo_sp_release_tests.yaml`, `galaxy_unit_tests.yaml`, `llk_bit_exact_tests.yaml`, `llk_e2e_tests.yaml`, `llk_merge_gate_tests.yaml`, `llk_perf_tests.yaml`, `llk_pr_gate_tests.yaml`, `llk_unit_tests.yaml`, `models_e2e_tests.yaml`, `ops_sanity_tests.yaml`, `release_tests.yaml`, `t3k_demo_tests.yaml`, `t3k_e2e_tests.yaml`, `t3k_perf_tests.yaml`, `umd_sanity_tests.yaml`, `vllm_model_tests.yaml`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=test-escalation-2026-08-06)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:test-escalation-2026-08-06)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=test-escalation-2026-08-06)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:test-escalation-2026-08-06)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=test-escalation-2026-08-06)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:test-escalation-2026-08-06)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=test-escalation-2026-08-06)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:test-escalation-2026-08-06)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=test-escalation-2026-08-06)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:test-escalation-2026-08-06)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=test-escalation-2026-08-06)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:test-escalation-2026-08-06)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=test-escalation-2026-08-06)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:test-escalation-2026-08-06)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=test-escalation-2026-08-06)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:test-escalation-2026-08-06)
