### PR TITLE
Re-enable performance-inefficient-vector-operation clang-tidy check in tt-train

### DIFF
--- a/tt-train/.clang-tidy
+++ b/tt-train/.clang-tidy
@@ -80,7 +80,6 @@ Checks: >
   -misc-confusable-identifiers,
   -readability-static-definition-in-anonymous-namespace,
   -readability-inconsistent-declaration-parameter-name,
-  -performance-inefficient-vector-operation,
   -bugprone-argument-comment,
   -modernize-use-equals-default,
   -performance-move-const-arg

--- a/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/k_split_gram_matmul_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/k_split_gram_matmul_program_factory.cpp
@@ -194,6 +194,7 @@ KSplitGramMatmulProgramFactory::cached_program_t KSplitGramMatmulProgramFactory:
 
     // Col senders: y=0 (all x)
     std::vector<tt::tt_metal::CoreCoord> col_senders;
+    col_senders.reserve(grid_dim);
     for (uint32_t x = 0; x < grid_dim; x++) col_senders.push_back({x, 0});
 
     // Row receivers (RISCV_0, x>0): ALL use receiver_writer (including y=0 edge)
@@ -513,6 +514,7 @@ KSplitGramMatmulProgramFactory::cached_program_t KSplitGramMatmulProgramFactory:
 
     // Diagonal: REDUCE_SENDER
     std::vector<tt::tt_metal::CoreCoord> sender_diag_cores;
+    sender_diag_cores.reserve(grid_dim);
     for (uint32_t d = 0; d < grid_dim; d++) sender_diag_cores.push_back({d, d});
     CreateKernel(
         program, compute_matmul_path, make_core_range_set(sender_diag_cores), compute_cfg({{"REDUCE_SENDER", "1"}}));
@@ -732,9 +734,11 @@ KSplitGramMatmulProgramFactory::cached_program_t KSplitGramMatmulProgramFactory:
     for (uint32_t y = 1; y < grid_dim; y++) row_sender_cores_list.push_back({0, y});
 
     std::vector<tt::tt_metal::CoreCoord> col_sender_cores_list;
+    col_sender_cores_list.reserve(grid_dim);
     for (uint32_t x = 0; x < grid_dim; x++) col_sender_cores_list.push_back({x, 0});
 
     std::vector<tt::tt_metal::CoreCoord> helper_cores_list;
+    helper_cores_list.reserve(grid_dim);
     for (uint32_t y = 0; y < grid_dim; y++) helper_cores_list.push_back({grid_dim, y});
 
     return {


### PR DESCRIPTION
## Summary
- tt-train's `.clang-tidy` disabled `performance-inefficient-vector-operation` with no documented rationale, unlike every other entry in the "Incremental Opt-Outs" list, which carries an explanation and a plan to fix. Removes the opt-out line so the check runs again.

## Context
Flagged by Wilder as an important performance check that shouldn't be silently disabled. A separate PR apparently touched tt-train to be compliant with this rule already, but that hasn't been independently verified here — this PR relies on CI's clang-tidy job to confirm there are zero violations before merging. If CI surfaces violations, they'll need to be fixed (or, if they're false positives, documented with a rationale comment like the other opt-outs) before this merges.

**Note:** `pr-gate.yaml`'s `code-analysis` job only runs when `find-changed-files.outputs.any-code-changed == 'true'` — a `.clang-tidy`-only change doesn't count as "code changed" by that check, so the automatic clang-tidy scan was skipped on this PR (looks like a gap in that gating logic, since `code-analysis.yaml` internally *does* special-case `clang-tidy-config-changed` for exactly this scenario, but the outer gate in `pr-gate.yaml` never lets it get that far). Manually dispatched the "Code analysis" workflow with `force-scan=true` against this branch to get the real signal:

- **Manually triggered clang-tidy run:** https://github.com/tenstorrent/tt-metal/actions/runs/31084415290

## Test plan
- [ ] Manually-dispatched clang-tidy run above passes with 0 violations for `performance-inefficient-vector-operation`
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=wilder/enable-perf-inefficient-vector-operation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:wilder/enable-perf-inefficient-vector-operation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=wilder/enable-perf-inefficient-vector-operation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:wilder/enable-perf-inefficient-vector-operation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=wilder/enable-perf-inefficient-vector-operation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:wilder/enable-perf-inefficient-vector-operation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=wilder/enable-perf-inefficient-vector-operation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:wilder/enable-perf-inefficient-vector-operation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=wilder/enable-perf-inefficient-vector-operation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:wilder/enable-perf-inefficient-vector-operation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=wilder/enable-perf-inefficient-vector-operation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:wilder/enable-perf-inefficient-vector-operation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=wilder/enable-perf-inefficient-vector-operation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:wilder/enable-perf-inefficient-vector-operation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=wilder/enable-perf-inefficient-vector-operation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:wilder/enable-perf-inefficient-vector-operation)