### PR TITLE
fix(generic-op): update all-gather writer ABI

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -1308,6 +1308,10 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
 
         // Writer CT args
         std::vector<uint32_t> writer_ct_args = common_ct_args;
+        // Keep this manual descriptor in sync with minimal_default_writer.cpp. The writer
+        // consumes this argument before the optional worker-mux configuration; the reader
+        // does not consume it, so it must not be part of common_ct_args.
+        writer_ct_args.push_back(ring_size - 1);  // barrier_target_count
         // fabric_mux_connection_ct_args
         writer_ct_args.push_back(mux_config.get_num_buffers(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL));
         writer_ct_args.push_back(


### PR DESCRIPTION
Fixes #52289.

## Summary
- supply `barrier_target_count` in the hand-built generic-op all-gather writer descriptor
- retain the reader descriptor ABI, which does not consume this writer-only argument

## Regression
PR #51869 added `barrier_target_count` before the worker-mux compile-time arguments in `minimal_default_writer.cpp`. The production all-gather factory was updated, but this generic-op test descriptor was not.


### Manually dispatched CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=pjosipovic/fix-generic-op-all-gather-barrier-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml?query=branch:pjosipovic/fix-generic-op-all-gather-barrier-args)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-generic-op-all-gather-barrier-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-generic-op-all-gather-barrier-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-generic-op-all-gather-barrier-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-generic-op-all-gather-barrier-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-generic-op-all-gather-barrier-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/fix-generic-op-all-gather-barrier-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-generic-op-all-gather-barrier-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-generic-op-all-gather-barrier-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-generic-op-all-gather-barrier-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-generic-op-all-gather-barrier-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-generic-op-all-gather-barrier-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-generic-op-all-gather-barrier-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-generic-op-all-gather-barrier-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-generic-op-all-gather-barrier-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-generic-op-all-gather-barrier-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-generic-op-all-gather-barrier-args)