### PR TITLE
Add reboot-on-failure self-heal to health check runner for slurm hosts

### DIFF
--- a/tools/scaleout/exabox/health_check_test_suite/HEALTH_CHECK.md
+++ b/tools/scaleout/exabox/health_check_test_suite/HEALTH_CHECK.md
@@ -201,6 +201,7 @@ tools/scaleout/exabox/health_check_test_suite/
         ├── system_info.py               # tt-smi / kmd / fw version discovery
         ├── telemetry.py                 # tt-telemetry (Prometheus) collection + formatting
         ├── report.py                    # post-reset normalization + actionable-failure verdict
+        ├── slurm_reboot.py              # reboot-on-failure gating + scontrol reboot/requeue (Slurm only)
         ├── jira_client.py               # JIRA ticket create / update / close / attach
         ├── sftp_upload.py               # CSV upload to the Data-team SFTP endpoint
         ├── secrets_loader.py            # JIRA / SFTP credential-file parsing
@@ -211,3 +212,18 @@ The `test_infrastructure/` harness previously lived in the `exabox-infra` repo a
 spun up a nested Docker container to run the diag suite. Now that the harness ships
 in the same image as the diag suite, `run_health_check.py` invokes `diag_runner.py`
 directly as a subprocess (see `diag_execution.py`) instead of via docker-in-docker.
+
+### Reboot-on-failure (Slurm self-heal)
+
+`--reboot-on-failure true` (default) makes a failed run try to self-heal once
+before it files a ticket: `run_health_check.py` arms
+`scontrol reboot ASAP nextstate=RESUME` on the node and `scontrol requeue`s the
+job, then exits immediately so the allocation frees, the node reboots, and Slurm
+reruns the same suite on the clean boot. `SLURM_RESTART_COUNT` caps this at one
+reboot, so a genuinely bad node stops looping and gets a ticket on the second
+failure (the JIRA body then notes it "persisted after 1 reboot(s)").
+
+This only fires under `--launch-mode slurm`; the orchestration (k8s) mode has no
+`scontrol`/`SLURM_JOB_ID` and reschedules pods itself. It also needs the job to
+be submitted with `sbatch --requeue` and the runner to have a passwordless
+`sudo scontrol` grant plus a `RebootProgram` configured on the node.

--- a/tools/scaleout/exabox/health_check_test_suite/HEALTH_CHECK.md
+++ b/tools/scaleout/exabox/health_check_test_suite/HEALTH_CHECK.md
@@ -201,6 +201,7 @@ tools/scaleout/exabox/health_check_test_suite/
         ├── system_info.py               # tt-smi / kmd / fw version discovery
         ├── telemetry.py                 # tt-telemetry (Prometheus) collection + formatting
         ├── report.py                    # post-reset normalization + actionable-failure verdict
+        ├── slurm_reboot.py              # reboot-on-failure gating + scontrol reboot/requeue (Slurm only)
         ├── jira_client.py               # JIRA ticket create / update / close / attach
         ├── sftp_upload.py               # CSV upload to the Data-team SFTP endpoint
         ├── secrets_loader.py            # JIRA / SFTP credential-file parsing
@@ -211,3 +212,25 @@ The `test_infrastructure/` harness previously lived in the `exabox-infra` repo a
 spun up a nested Docker container to run the diag suite. Now that the harness ships
 in the same image as the diag suite, `run_health_check.py` invokes `diag_runner.py`
 directly as a subprocess (see `diag_execution.py`) instead of via docker-in-docker.
+
+### Reboot-on-failure (Slurm self-heal)
+
+`--reboot-on-failure true` (default) makes a run with an actionable failure try
+to self-heal once before it files a ticket: `run_health_check.py` arms
+`scontrol reboot ASAP nextstate=RESUME` on the node and `scontrol requeue`s the
+job, then exits immediately so the allocation frees, the node reboots, and Slurm
+reruns the same suite on the clean boot. The trigger is the post-reset
+`effective_code`, so runs whose only failures are pre-reset/excluded checks (which
+are treated as passing) do not reboot.
+
+`SLURM_RESTART_COUNT` caps this at one self-heal attempt, so a genuinely bad node
+stops looping and gets a ticket on the next failure (the JIRA body then notes it
+"persisted after N Slurm restart(s)"). Note this counter tracks *any* Slurm
+requeue/restart, not only this reboot, so an unrelated Slurm-driven requeue can
+consume the single self-heal attempt.
+
+This only fires under `--launch-mode slurm`; the orchestration (k8s) mode has no
+`scontrol`/`SLURM_JOB_ID` and reschedules pods itself. It also needs the job to
+be submitted with `sbatch --requeue`, the runner to have a passwordless
+`sudo scontrol` grant, and a `RebootProgram` set in `slurm.conf` (Slurm runs it
+via `slurmd` on the compute node once the node drains to idle).

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -51,6 +51,7 @@ from utils.jira_client import (
 from utils.report import has_actionable_failure, normalize_health_report
 from utils.secrets_loader import load_jira_secrets, load_sftp_secrets
 from utils.sftp_upload import upload_csv_sftp
+from utils.slurm_reboot import reboot_and_requeue, should_reboot
 from utils.system_info import collect_version_info
 from utils.telemetry import (
     aggregate_telemetry_for_csv,
@@ -148,6 +149,12 @@ def parse_args() -> argparse.Namespace:
         default="true",
         help="Delete the log and results directory after the run",
     )
+    p.add_argument(
+        "--reboot-on-failure",
+        choices=("true", "false"),
+        default="true",
+        help="Reboot the node once and let Slurm rerun the suite on failure",
+    )
 
     args = p.parse_args()
     # node is used to build filesystem paths (log/results dirs); constrain it to a
@@ -157,6 +164,7 @@ def parse_args() -> argparse.Namespace:
     args.create_jira = args.create_jira == "true"
     args.upload_sftp = args.upload_sftp == "true"
     args.cleanup = args.cleanup == "true"
+    args.reboot_on_failure = args.reboot_on_failure == "true"
     return args
 
 
@@ -336,6 +344,29 @@ def main() -> int:
             )
             effective_code = 0
 
+    # Self-heal on failure, Slurm only. Gate on effective_code so non-actionable
+    # (pre-reset/excluded) failures don't reboot. SLURM_RESTART_COUNT counts any
+    # Slurm restart, so cap=1 self-heals at most once.
+    reboot_cap = 1
+    restart_count = int(os.environ.get("SLURM_RESTART_COUNT", "0") or "0")
+    if launch_mode == "slurm" and should_reboot(
+        exit_code=effective_code,
+        enabled=args.reboot_on_failure,
+        slurm_job_id=slurm_job_id,
+        restart_count=restart_count,
+        cap=reboot_cap,
+    ):
+        log.info(
+            "Test failed (exit %d); rebooting and requeuing for a clean rerun " "(restart_count=%d, cap=%d)",
+            effective_code,
+            restart_count,
+            reboot_cap,
+        )
+        if reboot_and_requeue(node, slurm_job_id):
+            log.info("Reboot armed and job requeued; exiting so the node reboots and reruns")
+            return effective_code
+        log.warning("Reboot/requeue could not be issued; proceeding to JIRA ticketing")
+
     # JIRA ticket creation (failure only)
     ticket_key = None
     if effective_code != 0:
@@ -378,6 +409,7 @@ def main() -> int:
                         telemetry_summary=prom_output,
                         test_output=full_output,
                         attachment_names=attachment_names,
+                        restart_count=restart_count,
                     )
                 )
                 add_comment_to_jira(
@@ -408,6 +440,7 @@ def main() -> int:
                     versions=versions,
                     telemetry_summary=prom_output,
                     attachment_names=attachment_names,
+                    restart_count=restart_count,
                 )
                 if ticket_key:
                     transition_jira_ticket(

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -51,6 +51,7 @@ from utils.jira_client import (
 from utils.report import has_actionable_failure, normalize_health_report
 from utils.secrets_loader import load_jira_secrets, load_sftp_secrets
 from utils.sftp_upload import upload_csv_sftp
+from utils.slurm_reboot import reboot_and_requeue, should_reboot
 from utils.system_info import collect_version_info
 from utils.telemetry import (
     aggregate_telemetry_for_csv,
@@ -148,6 +149,12 @@ def parse_args() -> argparse.Namespace:
         default="true",
         help="Delete the log and results directory after the run",
     )
+    p.add_argument(
+        "--reboot-on-failure",
+        choices=("true", "false"),
+        default="true",
+        help="Reboot the node once and let Slurm rerun the suite on failure",
+    )
 
     args = p.parse_args()
     # node is used to build filesystem paths (log/results dirs); constrain it to a
@@ -157,6 +164,7 @@ def parse_args() -> argparse.Namespace:
     args.create_jira = args.create_jira == "true"
     args.upload_sftp = args.upload_sftp == "true"
     args.cleanup = args.cleanup == "true"
+    args.reboot_on_failure = args.reboot_on_failure == "true"
     return args
 
 
@@ -336,6 +344,28 @@ def main() -> int:
             )
             effective_code = 0
 
+    # Reboot-and-requeue on failure (Slurm deployments only; orchestration/k8s
+    # reschedules pods itself and has no scontrol/SLURM_JOB_ID to drive this).
+    reboot_cap = 1
+    restart_count = int(os.environ.get("SLURM_RESTART_COUNT", "0") or "0")
+    if launch_mode == "slurm" and should_reboot(
+        exit_code=exit_code,
+        enabled=args.reboot_on_failure,
+        slurm_job_id=slurm_job_id,
+        restart_count=restart_count,
+        cap=reboot_cap,
+    ):
+        log.info(
+            "Test failed (exit %d); rebooting and requeuing for a clean rerun " "(restart_count=%d, cap=%d)",
+            exit_code,
+            restart_count,
+            reboot_cap,
+        )
+        if reboot_and_requeue(node, slurm_job_id):
+            log.info("Reboot armed and job requeued; exiting so the node reboots and reruns")
+            return effective_code
+        log.warning("Reboot/requeue could not be issued; proceeding to JIRA ticketing")
+
     # JIRA ticket creation (failure only)
     ticket_key = None
     if effective_code != 0:
@@ -378,6 +408,7 @@ def main() -> int:
                         telemetry_summary=prom_output,
                         test_output=full_output,
                         attachment_names=attachment_names,
+                        restart_count=restart_count,
                     )
                 )
                 add_comment_to_jira(
@@ -408,6 +439,7 @@ def main() -> int:
                     versions=versions,
                     telemetry_summary=prom_output,
                     attachment_names=attachment_names,
+                    restart_count=restart_count,
                 )
                 if ticket_key:
                     transition_jira_ticket(

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
@@ -29,11 +29,16 @@ def _build_failure_body(
     telemetry_summary: str,
     test_output: str,
     attachment_names: list[str] | None = None,
+    restart_count: int = 0,
 ) -> str:
     """Build the shared failure detail block used by both a new ticket's
     description and a recurring-failure comment, so the two never drift."""
     fail_date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
     log_tail = test_output[-4096:]
+
+    reboot_line = ""
+    if restart_count > 0:
+        reboot_line = f"*Reboot recovery:* failure persisted after {restart_count} reboot(s)\n"
 
     telemetry_section = ""
     if telemetry_summary:
@@ -49,6 +54,7 @@ def _build_failure_body(
         f"*Date:* {fail_date}\n"
         f"*Slurm Job ID:* {slurm_job_id}\n"
         f"*Exit Code:* {exit_code}\n"
+        f"{reboot_line}"
         f"*TT-SMI Version:* {versions['tt_smi']}\n"
         f"*TT-KMD Version:* {versions['tt_kmd']}\n"
         f"*Firmware Version:* {versions['fw_bundle']}\n"
@@ -204,6 +210,7 @@ def create_jira_ticket(
     versions: dict[str, str],
     telemetry_summary: str = "",
     attachment_names: list[str] | None = None,
+    restart_count: int = 0,
 ) -> str | None:
     """Create a JIRA ticket for a failed health check. Returns ticket key or None."""
 
@@ -215,6 +222,7 @@ def create_jira_ticket(
         telemetry_summary=telemetry_summary,
         test_output=test_output,
         attachment_names=attachment_names,
+        restart_count=restart_count,
     )
 
     payload = {

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
@@ -29,11 +29,17 @@ def _build_failure_body(
     telemetry_summary: str,
     test_output: str,
     attachment_names: list[str] | None = None,
+    restart_count: int = 0,
 ) -> str:
     """Build the shared failure detail block used by both a new ticket's
     description and a recurring-failure comment, so the two never drift."""
     fail_date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
     log_tail = test_output[-4096:]
+
+    reboot_line = ""
+    if restart_count > 0:
+        # SLURM_RESTART_COUNT counts any Slurm restart, not just our reboot.
+        reboot_line = f"*Reboot recovery:* failure persisted after {restart_count} Slurm restart(s)\n"
 
     telemetry_section = ""
     if telemetry_summary:
@@ -49,6 +55,7 @@ def _build_failure_body(
         f"*Date:* {fail_date}\n"
         f"*Slurm Job ID:* {slurm_job_id}\n"
         f"*Exit Code:* {exit_code}\n"
+        f"{reboot_line}"
         f"*TT-SMI Version:* {versions['tt_smi']}\n"
         f"*TT-KMD Version:* {versions['tt_kmd']}\n"
         f"*Firmware Version:* {versions['fw_bundle']}\n"
@@ -204,6 +211,7 @@ def create_jira_ticket(
     versions: dict[str, str],
     telemetry_summary: str = "",
     attachment_names: list[str] | None = None,
+    restart_count: int = 0,
 ) -> str | None:
     """Create a JIRA ticket for a failed health check. Returns ticket key or None."""
 
@@ -215,6 +223,7 @@ def create_jira_ticket(
         telemetry_summary=telemetry_summary,
         test_output=test_output,
         attachment_names=attachment_names,
+        restart_count=restart_count,
     )
 
     payload = {

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/slurm_reboot.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/slurm_reboot.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Slurm self-heal: reboot a failing node once and let Slurm rerun the suite.
+
+Only meaningful under the bare-Slurm (exabox) deployment; the orchestration
+(k8s) launch mode reschedules pods itself and has no ``scontrol``/``SLURM_JOB_ID``
+to drive this, so the runner gates the call on ``launch_mode == "slurm"``.
+Stdlib-only (like ``report.py``) to stay importable without the runner's deps.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+
+log = logging.getLogger(__name__)
+
+# Allowlists for the values that reach the scontrol argv (job ids may carry an
+# array-task `123_4` or het-job `123+0` suffix).
+_NODE_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9.-]*")
+_JOB_ID_RE = re.compile(r"[0-9]+(?:[_+][0-9]+)?")
+
+
+def should_reboot(*, exit_code: int, enabled: bool, slurm_job_id: str, restart_count: int, cap: int) -> bool:
+    """Reboot-and-rerun only when the run failed, the feature is enabled, we're
+    under Slurm, and still under the cap (SLURM_RESTART_COUNT stops a bad node
+    from looping forever)."""
+    return exit_code != 0 and enabled and slurm_job_id != "unknown" and restart_count < cap
+
+
+def reboot_and_requeue(node: str, slurm_job_id: str) -> bool:
+    """Arm a reboot (`scontrol reboot ASAP nextstate=RESUME` drains then
+    auto-resumes the node) and `scontrol requeue` the job. The caller must return
+    immediately without blocking: an earlier version slept and wedged the node at
+    ALLOCATED+DRAIN+REBOOT_REQUESTED. Reboot needs sudo; `-n` fails fast so the
+    caller can fall through to ticketing.
+    """
+    # Allowlist-validate and pass only the matched substring into the argv. No
+    # shell=True, so this is defense-in-depth; it also clears the Cycode taint.
+    node_match = _NODE_RE.fullmatch(node)
+    if not node_match:
+        log.warning("Refusing to reboot: invalid node name %r", node)
+        return False
+    job_match = _JOB_ID_RE.fullmatch(slurm_job_id)
+    if not job_match:
+        log.warning("Refusing to requeue: invalid Slurm job id %r", slurm_job_id)
+        return False
+    safe_node = node_match.group(0)
+    safe_job_id = job_match.group(0)
+
+    commands = (
+        [
+            "sudo",
+            "-n",
+            "scontrol",
+            "reboot",
+            "ASAP",
+            "nextstate=RESUME",
+            "reason=fabric_hc_self_heal",
+            safe_node,
+        ],
+        ["scontrol", "requeue", safe_job_id],
+    )
+    for cmd in commands:
+        log.info("Running `%s` ...", " ".join(cmd))
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            log.warning("Could not run `%s`: %s", " ".join(cmd), exc)
+            return False
+        if result.returncode != 0:
+            log.warning(
+                "`%s` failed (rc=%d): %s",
+                " ".join(cmd),
+                result.returncode,
+                (result.stderr or result.stdout).strip(),
+            )
+            return False
+    return True

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/slurm_reboot.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/slurm_reboot.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Slurm self-heal: reboot a failing node once and let Slurm rerun the suite.
+
+Only meaningful under the bare-Slurm (exabox) deployment; the orchestration
+(k8s) launch mode reschedules pods itself and has no ``scontrol``/``SLURM_JOB_ID``
+to drive this, so the runner gates the call on ``launch_mode == "slurm"``.
+
+Kept stdlib-only (like ``report.py``) so the gating/command logic can be
+unit-tested without the runner's runtime deps (requests/paramiko/prometheus).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+
+log = logging.getLogger(__name__)
+
+# Slurm hostnames and job ids as they feed the scontrol argv below. Job ids are
+# numeric with an optional array-task (`123_4`) or het-job (`123+0`) suffix.
+_NODE_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9.-]*")
+_JOB_ID_RE = re.compile(r"[0-9]+(?:[_+][0-9]+)?")
+
+
+def should_reboot(*, exit_code: int, enabled: bool, slurm_job_id: str, restart_count: int, cap: int) -> bool:
+    """Reboot-and-rerun only when the run failed, the feature is enabled, we're
+    under Slurm, and still under the cap (SLURM_RESTART_COUNT stops a bad node
+    from looping forever)."""
+    return exit_code != 0 and enabled and slurm_job_id != "unknown" and restart_count < cap
+
+
+def reboot_and_requeue(node: str, slurm_job_id: str) -> bool:
+    """Arm a reboot (`scontrol reboot ASAP nextstate=RESUME` drains then
+    auto-resumes the node) and `scontrol requeue` the job. The caller must return
+    immediately without blocking: an earlier version slept and wedged the node at
+    ALLOCATED+DRAIN+REBOOT_REQUESTED. Reboot needs sudo; `-n` fails fast so the
+    caller can fall through to ticketing.
+    """
+    # subprocess.run is invoked with an argv list (never shell=True), so there is
+    # no shell to inject into; still, allowlist-validate both values against the
+    # shapes Slurm produces and pass only the matched substring to the OS command.
+    # Sourcing the argv from the regex match (not the raw input) also silences the
+    # Cycode SAST "unsanitized user input in OS command" taint on subprocess below.
+    node_match = _NODE_RE.fullmatch(node)
+    if not node_match:
+        log.warning("Refusing to reboot: invalid node name %r", node)
+        return False
+    job_match = _JOB_ID_RE.fullmatch(slurm_job_id)
+    if not job_match:
+        log.warning("Refusing to requeue: invalid Slurm job id %r", slurm_job_id)
+        return False
+    safe_node = node_match.group(0)
+    safe_job_id = job_match.group(0)
+
+    commands = (
+        [
+            "sudo",
+            "-n",
+            "scontrol",
+            "reboot",
+            "ASAP",
+            "nextstate=RESUME",
+            "reason=fabric_hc_self_heal",
+            safe_node,
+        ],
+        ["scontrol", "requeue", safe_job_id],
+    )
+    for cmd in commands:
+        log.info("Running `%s` ...", " ".join(cmd))
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            log.warning("Could not run `%s`: %s", " ".join(cmd), exc)
+            return False
+        if result.returncode != 0:
+            log.warning(
+                "`%s` failed (rc=%d): %s",
+                " ".join(cmd),
+                result.returncode,
+                (result.stderr or result.stdout).strip(),
+            )
+            return False
+    return True


### PR DESCRIPTION
### PR Category
Feature

### Summary

- Adds `--reboot-on-failure` (default `true`) to `run_health_check.py`: on failure it arms `scontrol reboot ASAP nextstate=RESUME` + `scontrol requeue`, then exits so Slurm reruns the suite on a clean boot. `SLURM_RESTART_COUNT` caps it at one reboot before ticketing.
- Slurm-only: gated on `launch_mode == "slurm"` (+ requires `SLURM_JOB_ID`); orchestration/k8s never touches `scontrol`. Logic lives in new stdlib-only `utils/slurm_reboot.py`.
- `jira_client.py`: failure body notes `persisted after N reboot(s)`.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-reboot-slurm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/hc-reboot-slurm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-reboot-slurm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/hc-reboot-slurm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-reboot-slurm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jpanasiuk/hc-reboot-slurm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/hc-reboot-slurm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/hc-reboot-slurm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/hc-reboot-slurm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/hc-reboot-slurm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/hc-reboot-slurm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/hc-reboot-slurm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/hc-reboot-slurm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/hc-reboot-slurm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/hc-reboot-slurm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/hc-reboot-slurm)