### PR TITLE
Extend matmul K-tile padding to shared-exponent dtypes

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -3391,6 +3391,183 @@ def test_matmul_height_sharded_input_with_padding(device):
     assert_with_pcc(torch_output, output, pcc=0.99)
 
 
+# Shared-exponent (block-float) K-tile padding regression tests.
+#
+# pad_last_ktile()/pad_last_transposed_ktile() zero matmul's last K-tile padding when K is not a
+# multiple of 32; they previously no-op'd for every dtype but Float32/Float16_b, so block-float
+# inputs multiplied stale L1 garbage into the accumulator.
+#
+# Each test poisons the padding with -42 so a leak is an unmissable blowup rather than a silent
+# read of already-zeroed L1.
+_BLOCK_FLOAT_PAD_DTYPES = [
+    (ttnn.bfloat8_b, 0.99),
+    (ttnn.bfloat4_b, 0.94),
+]
+
+
+@pytest.mark.parametrize("dtype,pcc", _BLOCK_FLOAT_PAD_DTYPES)
+@pytest.mark.parametrize(
+    "K",
+    [
+        80,  # last K-tile has 16 valid columns: padding starts on a face-row (16-col) boundary
+        96,  # multiple of 32: no padding at all (control)
+        100,  # last K-tile has 4 valid columns: padding starts on a byte boundary for bfloat4_b
+        99,  # 3 valid columns: for bfloat4_b the first padded element shares a byte with the
+        # last valid one, so masking must preserve the neighbouring nibble
+    ],
+    ids=["k_16_aligned", "k_no_padding", "k_byte_aligned", "k_shared_byte"],
+)
+def test_matmul_block_float_ktile_padding(device, dtype, pcc, K):
+    """Core regression: block-float matmul with a non-tile-aligned K must ignore tile padding."""
+    torch.manual_seed(0)
+    M, N = 64, 64
+
+    torch_input_a = torch.randn(M, K, dtype=torch.float32)
+    torch_input_b = torch.randn(K, N, dtype=torch.float32)
+    torch_output = torch_input_a @ torch_input_b
+
+    ttnn_input_a = ttnn.from_torch(torch_input_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn_input_b = ttnn.from_torch(torch_input_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn_input_a = ttnn.fill_implicit_tile_padding(ttnn_input_a, -42)
+    ttnn_input_b = ttnn.fill_implicit_tile_padding(ttnn_input_b, -42)
+
+    output = ttnn.to_torch(ttnn.matmul(ttnn_input_a, ttnn_input_b))
+    assert not torch.isnan(output).any(), "matmul output contains NaN"
+    assert not torch.isinf(output).any(), "matmul output contains Inf"
+    assert_with_pcc(torch_output, output, pcc=pcc)
+
+
+@pytest.mark.parametrize("dtype,pcc", _BLOCK_FLOAT_PAD_DTYPES)
+def test_matmul_block_float_ktile_padding_preserves_shared_byte(device, dtype, pcc):
+    """K=99 makes bfloat4_b's first padded element share a byte with the last valid one, so masking
+    must preserve that neighbour. All signal sits on that column to make a clobber unmissable;
+    bfloat8_b is a control (one element per byte, never masks)."""
+    torch.manual_seed(0)
+    M, K, N = 64, 99, 64
+
+    torch_input_a = torch.zeros(M, K, dtype=torch.float32)
+    torch_input_a[:, -1] = 1.0  # only the byte-sharing boundary column carries signal
+    torch_input_b = torch.randn(K, N, dtype=torch.float32)
+    torch_output = torch_input_a @ torch_input_b
+
+    ttnn_input_a = ttnn.from_torch(torch_input_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn_input_b = ttnn.from_torch(torch_input_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn_input_a = ttnn.fill_implicit_tile_padding(ttnn_input_a, -1)
+    ttnn_input_b = ttnn.fill_implicit_tile_padding(ttnn_input_b, -1)
+
+    output = ttnn.to_torch(ttnn.matmul(ttnn_input_a, ttnn_input_b))
+    assert not torch.isnan(output).any(), "matmul output contains NaN"
+    assert not torch.isinf(output).any(), "matmul output contains Inf"
+    assert_with_pcc(torch_output, output, pcc=pcc)
+
+
+@pytest.mark.parametrize("dtype,pcc", _BLOCK_FLOAT_PAD_DTYPES)
+def test_matmul_block_float_ktile_padding_transpose_a(device, dtype, pcc):
+    """transpose_a maps K to tile height, exercising pad_last_transposed_ktile's row path."""
+    torch.manual_seed(0)
+    M, K, N = 64, 100, 64
+
+    torch_input_a = torch.randn(K, M, dtype=torch.float32)  # transposed: K is the outer dim
+    torch_input_b = torch.randn(K, N, dtype=torch.float32)
+    torch_output = torch_input_a.T @ torch_input_b
+
+    ttnn_input_a = ttnn.from_torch(torch_input_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn_input_b = ttnn.from_torch(torch_input_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn_input_a = ttnn.fill_implicit_tile_padding(ttnn_input_a, -42)
+    ttnn_input_b = ttnn.fill_implicit_tile_padding(ttnn_input_b, -42)
+
+    output = ttnn.to_torch(ttnn.matmul(ttnn_input_a, ttnn_input_b, transpose_a=True))
+    assert not torch.isnan(output).any(), "matmul output contains NaN"
+    assert not torch.isinf(output).any(), "matmul output contains Inf"
+    assert_with_pcc(torch_output, output, pcc=pcc)
+
+
+@pytest.mark.parametrize("dtype,pcc", _BLOCK_FLOAT_PAD_DTYPES)
+@pytest.mark.parametrize("out_subblock_h", [1, 2], ids=["subblock_h1", "subblock_h2"])
+def test_matmul_2d_mcast_block_float_ktile_padding_subblock_h(device, out_subblock_h, dtype, pcc):
+    """The fill runs in the reader, before matmul_block's row striding, so out_subblock_h > 1 works too."""
+    torch.manual_seed(0)
+    M, K, N = 64, 100, 32
+
+    torch_input_a = torch.randn(M, K, dtype=torch.float32)
+    torch_input_b = torch.randn(K, N, dtype=torch.float32)
+    torch_output = torch_input_a @ torch_input_b
+
+    ttnn_input_a = ttnn.from_torch(torch_input_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn_input_b = ttnn.from_torch(torch_input_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn_input_a = ttnn.fill_implicit_tile_padding(ttnn_input_a, -42)
+    ttnn_input_b = ttnn.fill_implicit_tile_padding(ttnn_input_b, -42)
+
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=(1, 1),
+        in0_block_w=1,
+        out_subblock_h=out_subblock_h,
+        out_subblock_w=1,
+        out_block_h=2,
+        out_block_w=1,
+        per_core_M=2,
+        per_core_N=1,
+        transpose_mcast=False,
+        fused_activation=None,
+        fuse_batch=True,
+    )
+
+    output = ttnn.to_torch(ttnn.matmul(ttnn_input_a, ttnn_input_b, program_config=program_config))
+    assert not torch.isnan(output).any(), "matmul output contains NaN"
+    assert not torch.isinf(output).any(), "matmul output contains Inf"
+    assert_with_pcc(torch_output, output, pcc=pcc)
+
+
+@pytest.mark.parametrize("dtype,pcc", _BLOCK_FLOAT_PAD_DTYPES)
+@pytest.mark.parametrize("fp32_dest_acc_en", [False, True], ids=["fp32_acc_off", "fp32_acc_on"])
+def test_matmul_block_float_ktile_padding_fp32_dest_acc(device, fp32_dest_acc_en, dtype, pcc):
+    """The padding fill is independent of DEST accumulation precision; both settings must be clean."""
+    torch.manual_seed(0)
+    M, K, N = 64, 100, 64
+
+    torch_input_a = torch.randn(M, K, dtype=torch.float32)
+    torch_input_b = torch.randn(K, N, dtype=torch.float32)
+    torch_output = torch_input_a @ torch_input_b
+
+    ttnn_input_a = ttnn.from_torch(torch_input_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn_input_b = ttnn.from_torch(torch_input_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn_input_a = ttnn.fill_implicit_tile_padding(ttnn_input_a, -42)
+    ttnn_input_b = ttnn.fill_implicit_tile_padding(ttnn_input_b, -42)
+
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=fp32_dest_acc_en,
+        packer_l1_acc=True,
+    )
+
+    output = ttnn.to_torch(ttnn.matmul(ttnn_input_a, ttnn_input_b, compute_kernel_config=compute_kernel_config))
+    assert not torch.isnan(output).any(), "matmul output contains NaN"
+    assert not torch.isinf(output).any(), "matmul output contains Inf"
+    assert_with_pcc(torch_output, output, pcc=pcc)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bfloat16", "float32"])
+def test_matmul_ktile_padding_non_block_float(device, dtype):
+    """Control: the Float32/Float16_b padding paths this change also touches must not regress."""
+    torch.manual_seed(0)
+    M, K, N = 64, 100, 64
+
+    torch_input_a = torch.randn(M, K, dtype=torch.float32)
+    torch_input_b = torch.randn(K, N, dtype=torch.float32)
+    torch_output = torch_input_a @ torch_input_b
+
+    ttnn_input_a = ttnn.from_torch(torch_input_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn_input_b = ttnn.from_torch(torch_input_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn_input_a = ttnn.fill_implicit_tile_padding(ttnn_input_a, -42)
+    ttnn_input_b = ttnn.fill_implicit_tile_padding(ttnn_input_b, -42)
+
+    output = ttnn.to_torch(ttnn.matmul(ttnn_input_a, ttnn_input_b))
+    assert not torch.isnan(output).any(), "matmul output contains NaN"
+    assert not torch.isinf(output).any(), "matmul output contains Inf"
+    assert_with_pcc(torch_output, output, pcc=0.999)
+
+
 def test_matmul_activation_with_sharded_input(device):
     # Create input tensors
     torch.manual_seed(0)

--- a/ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp
@@ -157,26 +157,221 @@ void fill_pad_tile(uint32_t l1_tile_ptr, T fill_value) {
     }
 }
 
+// Turns a mantissa width into elements-per-byte. Unrelated to Bfp8's 8-bit mantissa.
+constexpr uint32_t BITS_PER_BYTE = 8;
+
+/**
+ * @brief Zeroes a single element of a block-float mantissa row.
+ *
+ * Elements pack little-endian within the row's byte stream (element 0 in the LSBs, see
+ * create_packed_bfp_packed_as_u32), so `col` occupies bits [bits * col, bits * (col + 1)).
+ *
+ * @tparam bits_per_element Mantissa width: 8 (Bfp8), 4 (Bfp4) or 2 (Bfp2)
+ * @param face_row_ptr Pointer to the first mantissa byte of the face row
+ * @param col The column within the face to zero
+ */
+template <uint32_t bits_per_element>
+inline void zero_blockfloat_mantissa(uint8_t* face_row_ptr, uint32_t col) {
+    constexpr uint32_t elements_per_byte = BITS_PER_BYTE / bits_per_element;
+    if constexpr (elements_per_byte == 1) {
+        // Bfp8: the element owns the whole byte, so no neighbours to preserve.
+        face_row_ptr[col] = 0;
+    } else {
+        constexpr uint8_t element_mask = static_cast<uint8_t>((1u << bits_per_element) - 1);
+        const uint32_t shift = (col % elements_per_byte) * bits_per_element;
+        face_row_ptr[col / elements_per_byte] &= static_cast<uint8_t>(~(element_mask << shift));
+    }
+}
+
+/**
+ * @brief Zeroes the padded region of one face of a block-float tile's mantissa section.
+ *
+ * Mirrors fill_pad_face's padding math exactly, but indexes into a mantissa stream whose
+ * elements are bits_per_element wide instead of a T-typed array.
+ *
+ * @tparam bits_per_element Mantissa width: 8 (Bfp8), 4 (Bfp4) or 2 (Bfp2)
+ * @tparam num_elements_unpadded_w Number of unpadded elements in the width dimension
+ * @tparam num_elements_unpadded_h Number of unpadded elements in the height dimension
+ * @tparam num_faces_w Number of faces in the width dimension
+ * @tparam num_faces_h Number of faces in the height dimension
+ * @tparam face_h The height index of the face
+ * @tparam face_w The width index of the face
+ * @param mantissa_ptr Pointer to the start of the tile's mantissa section
+ */
+template <
+    uint32_t bits_per_element,
+    uint32_t num_elements_unpadded_w,
+    uint32_t num_elements_unpadded_h,
+    uint32_t num_faces_w,
+    uint32_t num_faces_h,
+    uint32_t face_h,
+    uint32_t face_w>
+void fill_pad_face_blockfloat(uint8_t* mantissa_ptr) {
+    using namespace tt::constants;
+
+    constexpr uint32_t elements_per_byte = BITS_PER_BYTE / bits_per_element;
+    constexpr uint32_t face_row_bytes = FACE_WIDTH / elements_per_byte;
+
+    // Calculate face offset
+    constexpr uint32_t face_offset_bytes = (face_h * num_faces_w + face_w) * (FACE_HW / elements_per_byte);
+    auto face_ptr = mantissa_ptr + face_offset_bytes;
+
+    // Right padding (width padding)
+    constexpr uint32_t face_w_offset = face_w * FACE_WIDTH;
+    constexpr uint32_t face_pad_w = (num_elements_unpadded_w <= face_w_offset) ? FACE_WIDTH
+                                    : (num_elements_unpadded_w >= face_w_offset + FACE_WIDTH)
+                                        ? 0
+                                        : face_w_offset + FACE_WIDTH - num_elements_unpadded_w;
+
+    if constexpr (face_pad_w > 0) {
+        for (uint32_t row = 0; row < FACE_HEIGHT; ++row) {
+            auto row_ptr = face_ptr + row * face_row_bytes;
+#pragma GCC unroll 32
+            for (uint32_t col = FACE_WIDTH - face_pad_w; col < FACE_WIDTH; ++col) {
+                zero_blockfloat_mantissa<bits_per_element>(row_ptr, col);
+            }
+        }
+    }
+
+    // Bottom padding (height padding) - the entire row is padded, so clear its bytes directly
+    constexpr uint32_t face_h_offset = face_h * FACE_HEIGHT;
+    constexpr uint32_t face_pad_h = (num_elements_unpadded_h <= face_h_offset) ? FACE_HEIGHT
+                                    : (num_elements_unpadded_h >= face_h_offset + FACE_HEIGHT)
+                                        ? 0
+                                        : face_h_offset + FACE_HEIGHT - num_elements_unpadded_h;
+
+    if constexpr (face_pad_h > 0) {
+        for (uint32_t row = FACE_HEIGHT - face_pad_h; row < FACE_HEIGHT; ++row) {
+            auto row_ptr = face_ptr + row * face_row_bytes;
+#pragma GCC unroll 32
+            for (uint32_t byte_index = 0; byte_index < face_row_bytes; ++byte_index) {
+                row_ptr[byte_index] = 0;
+            }
+        }
+    }
+}
+
+/**
+ * @brief Fills padding regions of a block-float (shared-exponent) tile with zeros.
+ *
+ * Block-float tiles are laid out as a per-face-row exponent section followed by the mantissa
+ * section (see the packing-order comment in blockfloat_common.cpp):
+ *
+ *     [ FACE_HEIGHT exponents for face 0 ] ... [ FACE_HEIGHT exponents for face N-1 ]
+ *     [ face 0 mantissas (row-major) ]     ... [ face N-1 mantissas (row-major) ]
+ *
+ * Only mantissas are touched: a zero mantissa decodes to 0.0 whatever exponent it shares (see the
+ * man == 0 branches in blockfloat_common.cpp), so elements sharing that exponent are unaffected.
+ *
+ * @tparam bits_per_element Mantissa width: 8 (Bfp8), 4 (Bfp4) or 2 (Bfp2)
+ * @tparam num_elements_unpadded_w Number of unpadded elements in the width dimension
+ * @tparam num_elements_unpadded_h Number of unpadded elements in the height dimension
+ * @tparam num_faces_w Number of faces in the width dimension (default: TILE_WIDTH / FACE_WIDTH)
+ * @tparam num_faces_h Number of faces in the height dimension (default: TILE_HEIGHT / FACE_HEIGHT)
+ * @param l1_tile_ptr Pointer to the start of the tile in L1 memory
+ */
+template <
+    uint32_t bits_per_element,
+    uint32_t num_elements_unpadded_w,
+    uint32_t num_elements_unpadded_h,
+    uint32_t num_faces_w = tt::constants::TILE_WIDTH / tt::constants::FACE_WIDTH,
+    uint32_t num_faces_h = tt::constants::TILE_HEIGHT / tt::constants::FACE_HEIGHT>
+void fill_pad_tile_blockfloat(uint32_t l1_tile_ptr) {
+    using namespace tt::constants;
+
+    constexpr uint32_t exponent_section_bytes = num_faces_w * num_faces_h * FACE_HEIGHT;
+    auto mantissa_ptr = reinterpret_cast<uint8_t*>(l1_tile_ptr) + exponent_section_bytes;
+
+    // Face 0, 0
+    fill_pad_face_blockfloat<
+        bits_per_element,
+        num_elements_unpadded_w,
+        num_elements_unpadded_h,
+        num_faces_w,
+        num_faces_h,
+        0,
+        0>(mantissa_ptr);
+
+    // Face 0, 1
+    if constexpr (num_faces_w > 1) {
+        fill_pad_face_blockfloat<
+            bits_per_element,
+            num_elements_unpadded_w,
+            num_elements_unpadded_h,
+            num_faces_w,
+            num_faces_h,
+            0,
+            1>(mantissa_ptr);
+    }
+
+    // Face 1, 0
+    if constexpr (num_faces_h > 1) {
+        fill_pad_face_blockfloat<
+            bits_per_element,
+            num_elements_unpadded_w,
+            num_elements_unpadded_h,
+            num_faces_w,
+            num_faces_h,
+            1,
+            0>(mantissa_ptr);
+    }
+
+    // Face 1, 1
+    if constexpr (num_faces_w > 1 && num_faces_h > 1) {
+        fill_pad_face_blockfloat<
+            bits_per_element,
+            num_elements_unpadded_w,
+            num_elements_unpadded_h,
+            num_faces_w,
+            num_faces_h,
+            1,
+            1>(mantissa_ptr);
+    }
+}
+
+/**
+ * @brief Mantissa bits per element for a block-float data format, or 0 if the format is not a
+ *        block-float format.
+ */
+template <DataFormat data_format>
+constexpr uint32_t blockfloat_mantissa_bits() {
+    if constexpr (data_format == DataFormat::Bfp8 || data_format == DataFormat::Bfp8_b) {
+        return 8;
+    } else if constexpr (data_format == DataFormat::Bfp4 || data_format == DataFormat::Bfp4_b) {
+        return 4;
+    } else if constexpr (data_format == DataFormat::Bfp2 || data_format == DataFormat::Bfp2_b) {
+        return 2;
+    } else {
+        return 0;
+    }
+}
+
 /**
  * @brief Pads the last K tile in a matrix multiplication operation.
  *
  * This function handles padding for the last K tile in a matrix multiplication operation.
- * It applies zero padding based on the specified data format (Float32 or Float16_b) and
- * the unpadded width of the last K tile.
+ * It applies zero padding based on the specified data format (Float32, Float16_b, or any of the
+ * block-float formats) and the unpadded width of the last K tile.
  *
- * @tparam in0_data_format The data format of the input tensor (Float32 or Float16_b)
+ * @tparam in0_data_format The data format of the input tensor
  * @tparam in0_last_ktile_w The unpadded width of the last K tile
  * @param l1_write_addr_in0 The L1 memory address where the zeros should be written
  */
 template <DataFormat in0_data_format, uint32_t in0_last_ktile_w>
 void pad_last_ktile(uint32_t l1_write_addr_in0) {
     using namespace tt::constants;
+    // Non-zero width means block-float; blockfloat_mantissa_bits() returns 0 for everything else.
+    constexpr uint32_t mantissa_bits = blockfloat_mantissa_bits<in0_data_format>();
+    constexpr bool is_blockfloat = mantissa_bits > 0;
     if constexpr (in0_data_format == DataFormat::Float32) {
         fill_pad_tile<uint32_t, in0_last_ktile_w, /*num_elements_unpadded_h=*/TILE_HEIGHT>(
             l1_write_addr_in0, /*pad_value=*/0);
     } else if constexpr (in0_data_format == DataFormat::Float16_b) {
         fill_pad_tile<uint16_t, in0_last_ktile_w, /*num_elements_unpadded_h=*/TILE_HEIGHT>(
             l1_write_addr_in0, /*pad_value=*/0);
+    } else if constexpr (is_blockfloat) {
+        fill_pad_tile_blockfloat<mantissa_bits, in0_last_ktile_w, /*num_elements_unpadded_h=*/TILE_HEIGHT>(
+            l1_write_addr_in0);
     }
 }
 
@@ -187,18 +382,24 @@ void pad_last_ktile(uint32_t l1_write_addr_in0) {
  * This function applies zero padding to the height (rows) of the last K tile,
  * leaving width fully unpadded.
  *
- * @tparam in0_data_format The data format of the input tensor (Float32 or Float16_b)
+ * @tparam in0_data_format The data format of the input tensor
  * @tparam in0_last_ktile_h The unpadded height of the last K tile
  * @param l1_write_addr_in0 The L1 memory address where the zeros should be written
  */
 template <DataFormat in0_data_format, uint32_t in0_last_ktile_h>
 void pad_last_transposed_ktile(uint32_t l1_write_addr_in0) {
     using namespace tt::constants;
+    // Non-zero width means block-float; blockfloat_mantissa_bits() returns 0 for everything else.
+    constexpr uint32_t mantissa_bits = blockfloat_mantissa_bits<in0_data_format>();
+    constexpr bool is_blockfloat = mantissa_bits > 0;
     if constexpr (in0_data_format == DataFormat::Float32) {
         fill_pad_tile<uint32_t, /*num_elements_unpadded_w=*/TILE_WIDTH, in0_last_ktile_h>(
             l1_write_addr_in0, /*pad_value=*/0);
     } else if constexpr (in0_data_format == DataFormat::Float16_b) {
         fill_pad_tile<uint16_t, /*num_elements_unpadded_w=*/TILE_WIDTH, in0_last_ktile_h>(
             l1_write_addr_in0, /*pad_value=*/0);
+    } else if constexpr (is_blockfloat) {
+        fill_pad_tile_blockfloat<mantissa_bits, /*num_elements_unpadded_w=*/TILE_WIDTH, in0_last_ktile_h>(
+            l1_write_addr_in0);
     }
 }


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #34530.

- **Bug:** `pad_last_ktile()` / `pad_last_transposed_ktile()` handled only `Float32` and `Float16_b`. For `bfloat8_b` and `bfloat4_b`, padding was left uninitialized when `K` was not tile-aligned, causing stale L1 data to participate in the matmul reduction.
- **Fix:** Added `fill_pad_tile_blockfloat()` to correctly zero padded block-float elements while preserving the shared exponent metadata.
- **Reference** As per the [UNPACR_Regular functional model](https://github.com/tenstorrent/tt-isa-documentation/blob/main/WormholeB0/TensixTile/TensixCoprocessor/UNPACR_Regular.md#functional-model), an element whose magnitude and sign bits are zero decodes to exactly `0.0` regardless of the shared exponent. The implementation therefore clears the entire packed element, sign bit included, while leaving the shared exponents unchanged.
- **Impact:** Fixes incorrect `bfloat8_b` / `bfloat4_b` matmul results when `K` is not tile-aligned.

### Notes for reviewers

**Review focus:**
- Instead of masking in the compute kernel as suggested in the issue, this implements the fix in the reader. This keeps the change smaller, covers all `pad_last_ktile()` users, and avoids additional restrictions.
- `fill_pad_tile_blockfloat()` implementation and `zero_blockfloat_mantissa()` masking logic.
- No reader kernels changed — they already call `pad_last_ktile()`, which is why one
  header change reaches every matmul variant.

**Validation:**

- Added coverage for `bfloat8_b` and `bfloat4_b` with aligned and non-aligned `K`.
- Existing matmul test suite continues to pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/matmul_shared_exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/matmul_shared_exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/matmul_shared_exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/matmul_shared_exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/matmul_shared_exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/matmul_shared_exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/matmul_shared_exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/matmul_shared_exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/matmul_shared_exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/matmul_shared_exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/matmul_shared_exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/matmul_shared_exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/matmul_shared_exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/matmul_shared_exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/matmul_shared_exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/matmul_shared_exp)