### PR TITLE
Extend release-models image to include migration-layer files

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -39,20 +39,16 @@ ARG TT_SMI_VERSION=5.2.0
 # PYTHON_VERSION can be explicitly set or auto-detected from UBUNTU_VERSION:
 # Ubuntu 22.04 -> Python 3.10
 # Ubuntu 24.04 -> Python 3.12
-# Defaults to 3.10 (matches UBUNTU_VERSION=22.04) so the release-models mig-client
-# selector below has a valid default base name; Bake always passes the real value.
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION=""
 # Fallback UV_IMAGE for standalone `docker build` without Bake.
 # The single source of truth is docker-bake.hcl variable "UV_IMAGE".
 # When upgrading uv, update docker-bake.hcl first, then sync this default.
 ARG UV_IMAGE=ghcr.io/astral-sh/uv@sha256:9a23023be68b2ed09750ae636228e903a54a05ea56ed03a934d00fe9fbeded4b
-# Prebuilt tt-llm-engine migration image + the path its _migration_client lives at.
-# Baked into release-models on the 3.10 build so it doubles as the disaggregated-
-# prefill worker (see the mig-client stages before the release-models stage).
-# Declared global because TT_LLM_ENGINE_IMAGE is used in a FROM. Single source of
-# truth for the image is docker-bake.hcl variable "TT_LLM_ENGINE_IMAGE".
+# Prebuilt tt-llm-engine migration image that release-models bakes _migration_client
+# out of on the 3.10 build (see the mig-client stages before release-models), so that
+# image doubles as the disaggregated-prefill worker. Global because it is used in a
+# FROM. Single source of truth is docker-bake.hcl variable "TT_LLM_ENGINE_IMAGE".
 ARG TT_LLM_ENGINE_IMAGE=ghcr.io/tenstorrent/tt-llm-engine/migration-worker:598154ddb3b838e5a516c220db83442340a72f74
-ARG MIG_CLIENT_DIR=/opt/tt-llm-engine/disaggregation/migration/build_RelWithDebInfo/python
 
 #############################################################
 # Tool and venv layers (resolved by docker-bake.hcl contexts)
@@ -409,18 +405,12 @@ RUN umask 000 && \
 # release-models doubles as the disaggregated-prefill worker by baking in
 # tt-llm-engine's _migration_client - a nanobind extension, hence Python-version
 # specific. The engine image is built for Python 3.10, so it's only valid on the
-# 3.10 (Ubuntu 22.04) build: the selector below resolves to the real engine image
-# on 3.10 and to an empty dir otherwise, so on 3.12 nothing ships and the ~7GB
-# engine image is never pulled. Only release-models consumes `mig-client`, so the
-# dev / ci-* targets are unaffected (BuildKit prunes these stages for them).
-# TT_LLM_ENGINE_IMAGE / MIG_CLIENT_DIR / PYTHON_VERSION are declared global at the
-# top of this file (they must precede the first FROM to be usable in a FROM).
+# 3.10 (Ubuntu 22.04) build
 # -----------------------------------------------------------------------------
 FROM ${TT_LLM_ENGINE_IMAGE} AS mig-client-3.10
 FROM base AS mig-client-3.12
-ARG MIG_CLIENT_DIR
-RUN mkdir -p "${MIG_CLIENT_DIR}"
-FROM mig-client-${PYTHON_VERSION} AS mig-client
+RUN mkdir -p /opt/tt-llm-engine/disaggregation/migration/build_RelWithDebInfo/python
+FROM mig-client-${PYTHON_VERSION:-3.10} AS mig-client
 
 #############################################################
 # Release models image
@@ -472,18 +462,12 @@ RUN apt-get update && apt-get install -y \
     libsndfile1 \
     && rm -rf /var/lib/apt/lists/*
 
-# Bake in tt-llm-engine's _migration_client so this image doubles as the
-# disaggregated-prefill worker. On the 3.10 build `mig-client` is the prebuilt
-# engine image (the module is copied and import-checked); on 3.12 it is an empty
-# dir, so all three steps below are no-ops and release-models ships unchanged.
-ARG MIG_CLIENT_DIR
-COPY --from=mig-client ${MIG_CLIENT_DIR}/ ${MIG_CLIENT_DIR}/
-# Keep only the client module (drop e.g. _device_metal_verify if the engine image
-# shipped it); no-op when the dir is empty.
-RUN find "${MIG_CLIENT_DIR}" -maxdepth 1 -type f ! -name '_migration_client*.so' -delete 2>/dev/null || true
-# Fail the build if the client is present but won't import under the release venv.
-RUN if ls "${MIG_CLIENT_DIR}"/_migration_client*.so >/dev/null 2>&1; then \
-      "$PYTHON_ENV_DIR/bin/python3" -c "import sys; sys.path.insert(0, '${MIG_CLIENT_DIR}'); import _migration_client; print('OK _migration_client:', _migration_client.__file__); assert hasattr(_migration_client, 'MigrationLayerClient'), 'MigrationLayerClient missing'"; \
+COPY --from=mig-client \
+     /opt/tt-llm-engine/disaggregation/migration/build_RelWithDebInfo/python/ \
+     /opt/tt-llm-engine/disaggregation/migration/build_RelWithDebInfo/python/
+RUN find /opt/tt-llm-engine/disaggregation/migration/build_RelWithDebInfo/python -maxdepth 1 -type f ! -name '_migration_client*.so' -delete 2>/dev/null || true
+RUN if ls /opt/tt-llm-engine/disaggregation/migration/build_RelWithDebInfo/python/_migration_client*.so >/dev/null 2>&1; then \
+      "$PYTHON_ENV_DIR/bin/python3" -c "import sys; sys.path.insert(0, '/opt/tt-llm-engine/disaggregation/migration/build_RelWithDebInfo/python'); import _migration_client; print('OK _migration_client:', _migration_client.__file__); assert hasattr(_migration_client, 'MigrationLayerClient'), 'MigrationLayerClient missing'"; \
     else \
       echo 'No _migration_client (non-3.10 build) - release-models ships without the disaggregated-prefill client.'; \
     fi

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -39,11 +39,20 @@ ARG TT_SMI_VERSION=5.2.0
 # PYTHON_VERSION can be explicitly set or auto-detected from UBUNTU_VERSION:
 # Ubuntu 22.04 -> Python 3.10
 # Ubuntu 24.04 -> Python 3.12
-ARG PYTHON_VERSION=""
+# Defaults to 3.10 (matches UBUNTU_VERSION=22.04) so the release-models mig-client
+# selector below has a valid default base name; Bake always passes the real value.
+ARG PYTHON_VERSION=3.10
 # Fallback UV_IMAGE for standalone `docker build` without Bake.
 # The single source of truth is docker-bake.hcl variable "UV_IMAGE".
 # When upgrading uv, update docker-bake.hcl first, then sync this default.
 ARG UV_IMAGE=ghcr.io/astral-sh/uv@sha256:9a23023be68b2ed09750ae636228e903a54a05ea56ed03a934d00fe9fbeded4b
+# Prebuilt tt-llm-engine migration image + the path its _migration_client lives at.
+# Baked into release-models on the 3.10 build so it doubles as the disaggregated-
+# prefill worker (see the mig-client stages before the release-models stage).
+# Declared global because TT_LLM_ENGINE_IMAGE is used in a FROM. Single source of
+# truth for the image is docker-bake.hcl variable "TT_LLM_ENGINE_IMAGE".
+ARG TT_LLM_ENGINE_IMAGE=ghcr.io/tenstorrent/tt-llm-engine/migration-worker:598154ddb3b838e5a516c220db83442340a72f74
+ARG MIG_CLIENT_DIR=/opt/tt-llm-engine/disaggregation/migration/build_RelWithDebInfo/python
 
 #############################################################
 # Tool and venv layers (resolved by docker-bake.hcl contexts)
@@ -394,6 +403,25 @@ RUN umask 000 && \
     umask 000 && \
     uv pip install $WHEEL_FILENAME
 
+# -----------------------------------------------------------------------------
+# Disaggregated-prefill client source (selected by Python version)
+#
+# release-models doubles as the disaggregated-prefill worker by baking in
+# tt-llm-engine's _migration_client - a nanobind extension, hence Python-version
+# specific. The engine image is built for Python 3.10, so it's only valid on the
+# 3.10 (Ubuntu 22.04) build: the selector below resolves to the real engine image
+# on 3.10 and to an empty dir otherwise, so on 3.12 nothing ships and the ~7GB
+# engine image is never pulled. Only release-models consumes `mig-client`, so the
+# dev / ci-* targets are unaffected (BuildKit prunes these stages for them).
+# TT_LLM_ENGINE_IMAGE / MIG_CLIENT_DIR / PYTHON_VERSION are declared global at the
+# top of this file (they must precede the first FROM to be usable in a FROM).
+# -----------------------------------------------------------------------------
+FROM ${TT_LLM_ENGINE_IMAGE} AS mig-client-3.10
+FROM base AS mig-client-3.12
+ARG MIG_CLIENT_DIR
+RUN mkdir -p "${MIG_CLIENT_DIR}"
+FROM mig-client-${PYTHON_VERSION} AS mig-client
+
 #############################################################
 # Release models image
 #############################################################
@@ -443,3 +471,19 @@ RUN apt-get update && apt-get install -y \
     libgl1 \
     libsndfile1 \
     && rm -rf /var/lib/apt/lists/*
+
+# Bake in tt-llm-engine's _migration_client so this image doubles as the
+# disaggregated-prefill worker. On the 3.10 build `mig-client` is the prebuilt
+# engine image (the module is copied and import-checked); on 3.12 it is an empty
+# dir, so all three steps below are no-ops and release-models ships unchanged.
+ARG MIG_CLIENT_DIR
+COPY --from=mig-client ${MIG_CLIENT_DIR}/ ${MIG_CLIENT_DIR}/
+# Keep only the client module (drop e.g. _device_metal_verify if the engine image
+# shipped it); no-op when the dir is empty.
+RUN find "${MIG_CLIENT_DIR}" -maxdepth 1 -type f ! -name '_migration_client*.so' -delete 2>/dev/null || true
+# Fail the build if the client is present but won't import under the release venv.
+RUN if ls "${MIG_CLIENT_DIR}"/_migration_client*.so >/dev/null 2>&1; then \
+      "$PYTHON_ENV_DIR/bin/python3" -c "import sys; sys.path.insert(0, '${MIG_CLIENT_DIR}'); import _migration_client; print('OK _migration_client:', _migration_client.__file__); assert hasattr(_migration_client, 'MigrationLayerClient'), 'MigrationLayerClient missing'"; \
+    else \
+      echo 'No _migration_client (non-3.10 build) - release-models ships without the disaggregated-prefill client.'; \
+    fi

--- a/dockerfile/docker-bake.hcl
+++ b/dockerfile/docker-bake.hcl
@@ -81,6 +81,15 @@ variable "UV_IMAGE" {
   default = "ghcr.io/astral-sh/uv@sha256:9a23023be68b2ed09750ae636228e903a54a05ea56ed03a934d00fe9fbeded4b"
 }
 
+variable "TT_LLM_ENGINE_IMAGE" {
+  # Prebuilt tt-llm-engine migration image that the release-models target bakes
+  # _migration_client out of, so release-models doubles as the disaggregated-prefill
+  # worker. Only pulled on the 3.10 (Ubuntu 22.04) build; the Dockerfile's selector
+  # resolves to an empty stage on 3.12. Pin by full SHA, and match the tag tt-blaze's
+  # decode worker uses so the P and D sides speak the same migration protocol.
+  default = "ghcr.io/tenstorrent/tt-llm-engine/migration-worker:598154ddb3b838e5a516c220db83442340a72f74"
+}
+
 # =============================================================================
 # Tool targets (from Dockerfile.tools)
 #
@@ -324,6 +333,11 @@ target "release-models" {
   inherits = ["_main-common"]
   target   = "release-models"
   tags     = ["tt-metalium-release-models:local"]
+  args = {
+    # Baked into release-models on the 3.10 build so it doubles as the
+    # disaggregated-prefill worker (see dockerfile/Dockerfile mig-client stages).
+    TT_LLM_ENGINE_IMAGE = TT_LLM_ENGINE_IMAGE
+  }
 }
 
 group "main" {

--- a/dockerfile/docker-bake.hcl
+++ b/dockerfile/docker-bake.hcl
@@ -82,11 +82,6 @@ variable "UV_IMAGE" {
 }
 
 variable "TT_LLM_ENGINE_IMAGE" {
-  # Prebuilt tt-llm-engine migration image that the release-models target bakes
-  # _migration_client out of, so release-models doubles as the disaggregated-prefill
-  # worker. Only pulled on the 3.10 (Ubuntu 22.04) build; the Dockerfile's selector
-  # resolves to an empty stage on 3.12. Pin by full SHA, and match the tag tt-blaze's
-  # decode worker uses so the P and D sides speak the same migration protocol.
   default = "ghcr.io/tenstorrent/tt-llm-engine/migration-worker:598154ddb3b838e5a516c220db83442340a72f74"
 }
 
@@ -334,8 +329,6 @@ target "release-models" {
   target   = "release-models"
   tags     = ["tt-metalium-release-models:local"]
   args = {
-    # Baked into release-models on the 3.10 build so it doubles as the
-    # disaggregated-prefill worker (see dockerfile/Dockerfile mig-client stages).
     TT_LLM_ENGINE_IMAGE = TT_LLM_ENGINE_IMAGE
   }
 }


### PR DESCRIPTION
Extend the release-models version of the Dockerfile to include several migration_layer files from tt-llm-engine repo. This will allow us to use the same version of the image for P/D

Successful image build: https://github.com/tenstorrent/tt-metal/actions/runs/31106295981/job/92632222157?pr=52303

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vm/include_prefill_worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vm/include_prefill_worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vm/include_prefill_worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vm/include_prefill_worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=vm/include_prefill_worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:vm/include_prefill_worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vm/include_prefill_worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vm/include_prefill_worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vm/include_prefill_worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vm/include_prefill_worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vm/include_prefill_worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vm/include_prefill_worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vm/include_prefill_worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vm/include_prefill_worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vm/include_prefill_worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vm/include_prefill_worker)