### PR TITLE
prefill: name the packed socket metadata message consistently

### DIFF
--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -86,6 +86,10 @@ _apply_manifest_env()
 SYNC_WORKER_CORES = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))
 METADATA_SIZE_BYTES = 12
 
+# The packed [1,1,1,3] uint32 message the sockets carry is `metadata_msg` everywhere; the model's
+# `metadata` is the per-element triple of [1,1,1,1] operands the device ops take. There is no device-side
+# conversion between them, so a name that blurs the two hides a required host round trip.
+
 # LayerAck D2H FIFO. Records are METADATA_SIZE_BYTES (12 B) each; 4 KB is a PCIe-aligned
 # one-page buffer with generous headroom for in-flight records.
 LAYER_ACK_FIFO_SIZE_BYTES = int(os.environ.get("PREFILL_LAYER_ACK_FIFO_BYTES", 4 * 1024))
@@ -245,15 +249,15 @@ def _is_shutdown_sentinel(meta: dict) -> bool:
 
 def _socket_next(h2d_service) -> tuple:
     """Block on the next producer push: returns (tt_tokens, {slot_id, actual_start, actual_end},
-    tt_metadata). The device metadata tensor is returned (not discarded) so it can be propagated into
+    metadata_msg). The device metadata tensor is returned (not discarded) so it can be propagated into
     the model's per-layer ack send. Used only by the unbounded request loop (rank 0 input)."""
     import torch
 
-    tt_tokens, tt_metadata = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
+    tt_tokens, metadata_msg = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
         h2d_service, metadata_size_bytes=METADATA_SIZE_BYTES
     )
-    m = ttnn.to_torch(ttnn.get_device_tensors(tt_metadata)[0]).view(torch.int32).flatten()
-    return tt_tokens, {"slot_id": int(m[0]), "actual_start": int(m[1]), "actual_end": int(m[2])}, tt_metadata
+    m = ttnn.to_torch(ttnn.get_device_tensors(metadata_msg)[0]).view(torch.int32).flatten()
+    return tt_tokens, {"slot_id": int(m[0]), "actual_start": int(m[1]), "actual_end": int(m[2])}, metadata_msg
 
 
 def build_d2d_pipeline_endpoints(mesh_device, rank: int, num_ranks: int, chunk_size: int, hidden_size: int):
@@ -310,16 +314,16 @@ def _d2d_recv(inbound) -> tuple:
     import torch
 
     t0 = time.perf_counter()
-    act, metadata_device = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
+    act, metadata_msg = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
         inbound, metadata_size_bytes=METADATA_SIZE_BYTES
     )
-    m = ttnn.to_torch(ttnn.get_device_tensors(metadata_device)[0]).view(torch.int32).flatten()
+    m = ttnn.to_torch(ttnn.get_device_tensors(metadata_msg)[0]).view(torch.int32).flatten()
     meta = {"slot_id": int(m[0]), "actual_start": int(m[1]), "actual_end": int(m[2])}
     logger.info(
         f"[pp] RECV-d2d [{meta['actual_start']},{meta['actual_end']}) slot={meta['slot_id']} "
         f"[xfer] sync={(time.perf_counter() - t0) * 1000.0:.2f}ms"
     )
-    return act, meta, metadata_device
+    return act, meta, metadata_msg
 
 
 def _d2d_send(outbound, activation: ttnn.Tensor, rank: int, meta: dict, *, deallocate: bool = True) -> None:
@@ -396,7 +400,7 @@ def _lease_reclaim(d2d_in, d2d_out) -> None:
 
 
 def _compute_and_send(
-    runtime, kv_caches, rank: int, c: int, inp, meta: dict, d2d_out, d2h_service=None, record_dev=None
+    runtime, kv_caches, rank: int, c: int, inp, meta: dict, d2d_out, d2h_service=None, metadata_msg=None
 ) -> float:
     """Run one chunk: prefill into the engine-owned kv_caches, forward the output downstream (non-last
     rank) and grant the outbound sender so it ships over fabric. Returns the compute-start epoch
@@ -416,7 +420,7 @@ def _compute_and_send(
         actual_end=meta["actual_end"],
         request_id=c,
         d2h_service=d2h_service,
-        record_dev=record_dev,
+        metadata_msg=metadata_msg,
     )
     if SYNC_PER_CHUNK:
         # Block on device completion so the delta is this rank's forward alone, not the downstream-start
@@ -476,20 +480,20 @@ def run_request_loop(
     while not _shutdown:
         _lease_reclaim(d2d_in, d2d_out)
         if cfg.is_first_rank:
-            inp, meta, metadata_device = _socket_next(h2d_service)  # slot/start/end from the producer
+            inp, meta, metadata_msg = _socket_next(h2d_service)  # slot/start/end from the producer
         else:
-            inp, meta, metadata_device = _d2d_recv(d2d_in)
+            inp, meta, metadata_msg = _d2d_recv(d2d_in)
         if _is_shutdown_sentinel(meta):
             # End of stream: drop the throwaway payload + its metadata tensor, hand the sentinel to the
             # next rank so it too unblocks and exits, then fall through to the graceful drain below.
             logger.info(f"[pp rank {rank}] SHUTDOWN sentinel received after {c} chunks; exiting request loop")
             ttnn.deallocate(inp)
-            ttnn.deallocate(metadata_device)
+            ttnn.deallocate(metadata_msg)
             if d2d_out is not None:
                 _forward_shutdown(d2d_out, rank, hidden_size)
             break
         t = _compute_and_send(
-            runtime, kv_caches, rank, c, inp, meta, d2d_out, d2h_service=d2h_service, record_dev=metadata_device
+            runtime, kv_caches, rank, c, inp, meta, d2d_out, d2h_service=d2h_service, metadata_msg=metadata_msg
         )
         if first is None:
             first = t

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -780,10 +780,10 @@ def _run_chunked_prefill(
                     )
                     for val in (u, kv_actual, valid_end)
                 )
-            # Metadata path: pass ONLY the metadata tensor (the runner hands tt_metadata straight from
-            # inbound_socket_service_sync) -- actual_start/actual_end are read on-device, so leave them
-            # None to prove forward needs no host per-chunk scalars. cache_user_id is unused on this path
-            # (slot comes from metadata[0]).
+            # Metadata path: pass ONLY the per-element metadata operands (the runtime's _trace_metadata
+            # equivalent) -- actual_start/actual_end are read on-device, so leave them None to prove
+            # forward needs no host per-chunk scalars. cache_user_id is unused on this path (slot comes
+            # from metadata[0]).
             tt_out = mla_tt.forward(
                 hidden_states=tt_h,
                 rope_tensors=indexed_rope,

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -473,7 +473,7 @@ class TtPrefillBlock(LightweightModule):
         return_kv_cache: bool = False,
         return_intermediates: bool = False,
         d2h_service=None,
-        record_dev: Optional[ttnn.Tensor] = None,
+        metadata_msg: Optional[ttnn.Tensor] = None,
         on_layer_complete: Optional[Callable[[int], None]] = None,
         on_layer_hidden: Optional[Callable[[int, ttnn.Tensor], None]] = None,
         actual_start: Optional[int] = None,
@@ -500,8 +500,8 @@ class TtPrefillBlock(LightweightModule):
                 the chunk this block zeros the pad window past actual_end, then enqueues the ack via the
                 outbound_socket_service_sync device op on the same CQ — no host sync. This is the
                 single-host (LayerAckService) ack path; mutually exclusive with on_layer_complete.
-            record_dev: the chunk's PrefillMetadata device tensor sent as the ack record; required when
-                d2h_service is set. Distinct from `metadata`: record_dev is the socket record handed to
+            metadata_msg: the chunk's PrefillMetadata device tensor sent as the ack record; required when
+                d2h_service is set. Distinct from `metadata`: metadata_msg is the socket record handed to
                 the host, `metadata` is the per-element scalar triple read by the on-device ops.
             on_layer_complete: optional per-layer migration ack fired on the HOST. In chunked prefill,
                 after MLA writes the chunk this block zeros the pad window past actual_end, flushes, then
@@ -581,7 +581,7 @@ class TtPrefillBlock(LightweightModule):
         # cache_layer_idx is the LOCAL per-rank cache slot in both.
         if d2h_service is not None or on_layer_complete is not None:
             assert actual_end is not None or metadata is not None, "actual_end or metadata required for zero_pad"
-            assert d2h_service is None or record_dev is not None, "record_dev required when d2h_service is set"
+            assert d2h_service is None or metadata_msg is not None, "metadata_msg required when d2h_service is set"
             # zero_padded_kv_cache is a DENSE (TILE) kvpe-cache op. A DSA-sparse model's kvpe cache is
             # bf16/fp8 ROW_MAJOR (sparse_sdpa reads it natively) and the op asserts TILE, so skip it for
             # sparse.
@@ -613,10 +613,10 @@ class TtPrefillBlock(LightweightModule):
                 # Device-op ack, enqueued on the same CQ right after the zero: the record cannot reach the
                 # host before the zero has executed, so the ack implies zero-complete with no host sync —
                 # unlike the host-callback path below, which needs an explicit flush.
-                # NOT used under trace: record_dev is the per-chunk socket metadata tensor, so its address
+                # NOT used under trace: metadata_msg is the per-chunk socket metadata tensor, so its address
                 # changes every chunk and a capture would bake in a stale one. TtPrefillRuntime.prefill_chunk
                 # asserts d2h_service is None when use_trace.
-                ttnn.experimental.deepseek_prefill.outbound_socket_service_sync(d2h_service, metadata=record_dev)
+                ttnn.experimental.deepseek_prefill.outbound_socket_service_sync(d2h_service, metadata=metadata_msg)
             else:
                 # Trace path: route the ack through the controller. At capture it splits the trace here (a host
                 # shm bump cannot live inside a trace); at replay the controller fires the ack between the two

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -394,7 +394,7 @@ class TtPrefillRuntime:
         actual_end: int,
         request_id: int = 0,
         d2h_service=None,
-        record_dev: Optional[ttnn.Tensor] = None,
+        metadata_msg: Optional[ttnn.Tensor] = None,
     ) -> Optional[ttnn.Tensor]:
         """Prefill ONE chunk into user `slot_id`'s slice of the engine-owned `kv_caches`.
 
@@ -410,7 +410,7 @@ class TtPrefillRuntime:
         may be pad, so actual_end < actual_start + chunk_size). actual_end is the migration pad-zero
         boundary, passed straight through to MLA. The caller drives chunked prefill by
         calling this once per chunk, in order; a chunk's KV must be populated before the next reads
-        it. If d2h_service + record_dev are passed, the model sends one per-layer ack completion signal back
+        it. If d2h_service + metadata_msg are passed, the model sends one per-layer ack completion signal back
         to host (via the outbound_socket_service_sync device op) once each layer's KV cache is populated.
         Alternatively, if a host-side per-layer callback is registered (set_layer_ack_channel /
         set_layer_completion_sink), the model fires that once per layer instead.
@@ -435,7 +435,7 @@ class TtPrefillRuntime:
                 each layer's KV cache has been populated on device. When set, each block zeros the cache
                 pad window and enqueues the ack via the outbound_socket_service_sync device op on the same
                 CQ (no host sync). When None, no ack or zeroing.
-            record_dev: the chunk's PrefillMetadata device tensor sent as each ack record; required when
+            metadata_msg: the chunk's PrefillMetadata device tensor sent as each ack record; required when
                 d2h_service is set.
         """
         # Not gated on self.compiled: compile() warms up by calling prefill_chunk() once before
@@ -462,12 +462,12 @@ class TtPrefillRuntime:
                 "use_trace: capture_trace() must run before the first prefill_chunk(); capturing here "
                 "would stall the first request by a warm pass + capture"
             )
-            # The D2H layer-ack is not on the traced path: record_dev is the per-chunk socket metadata
+            # The D2H layer-ack is not on the traced path: metadata_msg is the per-chunk socket metadata
             # tensor, whose address changes every chunk, so the capture would bake in a stale address.
             # Fail loudly rather than silently replaying a trace that emits no acks. (Wiring it up needs
-            # record_dev to become a persistent, in-place-updated buffer like _trace_metadata.)
+            # metadata_msg to become a persistent, in-place-updated buffer like _trace_metadata.)
             assert d2h_service is None, (
-                "use_trace does not support the D2H layer-ack path yet (record_dev is a per-chunk socket "
+                "use_trace does not support the D2H layer-ack path yet (metadata_msg is a per-chunk socket "
                 "tensor, so its address cannot be captured); run with PREFILL_USE_TRACE=0 or use the "
                 "host-callback ack (set_layer_ack_channel / set_layer_completion_sink)"
             )
@@ -504,7 +504,7 @@ class TtPrefillRuntime:
             kv_caches.kvpe,
             actual_isl=actual_end - actual_start,
             d2h_service=d2h_service,
-            record_dev=record_dev,
+            metadata_msg=metadata_msg,
             on_layer_complete=on_layer_complete,
             actual_start=actual_start,
             actual_end=actual_end,

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -342,7 +342,7 @@ class TtPrefillTransformer(LightweightModule):
         read_profiler: bool = False,
         temperature: Union[float, list[float]] = 0.0,
         d2h_service=None,
-        record_dev: Optional[ttnn.Tensor] = None,
+        metadata_msg: Optional[ttnn.Tensor] = None,
         on_layer_complete: Optional[Callable[[int], None]] = None,
         on_layer_hidden: Optional[Callable[[int, ttnn.Tensor], None]] = None,
         actual_start: Optional[int] = None,
@@ -377,7 +377,7 @@ class TtPrefillTransformer(LightweightModule):
                         each layer's KV cache has been populated on device. When set, each block zeros the
                         cache pad window and enqueues the ack via the outbound_socket_service_sync device op
                         on the same CQ (no host sync). When None, no ack or zeroing.
-            record_dev: the chunk's PrefillMetadata device tensor sent as each ack record; required when
+            metadata_msg: the chunk's PrefillMetadata device tensor sent as each ack record; required when
                         d2h_service is set.
             on_layer_complete: the HOST-callback alternative to d2h_service (used by pipelined prefill's
                         layer-completion router). Called as on_layer_complete(layer_idx) after the same
@@ -456,7 +456,7 @@ class TtPrefillTransformer(LightweightModule):
                 cache_layer_idx=i,
                 return_intermediates=return_intermediates,
                 d2h_service=d2h_service,
-                record_dev=record_dev,
+                metadata_msg=metadata_msg,
                 on_layer_complete=on_layer_complete,
                 on_layer_hidden=on_layer_hidden,
                 actual_start=actual_start,


### PR DESCRIPTION
The packed `[1,1,1,3]` uint32 metadata message the prefill sockets carry
(`slot_id`, `actual_start`, `actual_end`) went by three different names depending on
which function you were in: `tt_metadata` in `_socket_next`, `metadata_device` in
`_d2d_recv`, and `record_dev` through the whole model call chain (`prefill_chunk` →
`TtPrefillTransformer.forward` → `TtPrefillBlock.forward`).

Meanwhile `metadata` means something else entirely: the per-element triple of
`[1,1,1,1]` operands that `rotary_embedding_llama`, `update_padded_kv_cache`,
`ring_mla`, and `zero_padded_kv_cache` take. There is no device-side conversion
between the two representations — going from the packed message to the operands is a
host round trip. Names that blur them hide that.

The packed message is now `metadata_msg` everywhere; the operand triple keeps
`metadata`, and `_trace_metadata` is untouched. `TtPrefillBlock.forward`'s docstring
already had to spell the distinction out; it now reads as a definition instead of a
disambiguation.

Also fixes a comment in `test_mla.py` that was not just inconsistently named but
wrong: it claimed the runner hands those tensors "straight from
`inbound_socket_service_sync`". It does not — the socket yields the packed message,
and the per-element operands only exist on the trace path as `_trace_metadata`.

Known residual, deliberately out of scope: the ttnn op kwarg is still
`outbound_socket_service_sync(d2h_service, metadata=metadata_msg)`, i.e. the C++ API
calls the packed message `metadata`. Renaming it is a signature change plus a rebuild
and would pull two D2H gtests into this PR.

**Stack** — merge bottom-up; do not merge before its base:
1. #52308 (remove standalone serving mode) → `main`
2. #52309 (drop the runner self-test / KV validation) → #52308
3. **this PR** → the one above

Pure rename plus comment fixes, no behaviour change. Verified: `metadata_msg` present
and `record_dev` absent on all four entry-point signatures; no leftover old names
outside the unrelated MoE-dispatch `tt_metadata` and the C++ gtests.
