### PR TITLE
[sweeps] Configure the fabric on the generic device path

### DIFF
--- a/.github/actions/sweep-run-analysis/scripts/push_sweep_results.py
+++ b/.github/actions/sweep-run-analysis/scripts/push_sweep_results.py
@@ -139,7 +139,16 @@ def _write_job_summary(tests: list[dict], run_type: str = "", **extra_fields) ->
     passed = sum(1 for t in tests if t.get("status") == "pass")
     failed = sum(1 for t in tests if _is_failure(t.get("status", "")))
     skipped = total - passed - failed
-    pass_rate = f"{passed * 100.0 / total:.2f}%" if total else "N/A"
+    # Pass rate is over EXECUTED vectors (pass + fail), not the whole set. A skipped vector
+    # never produced a result: it is NOT_RUN because the runner classified an environment
+    # fault -- a box that enumerated 16 chips instead of 32, a device that wedged, a failed
+    # reset -- and booked the rest of the batch rather than reporting phantom test failures.
+    # Dividing by total made a bad runner look like an op regression: one 16-chip box taking
+    # six jobs in run 31290760722 booked 239 vectors NOT_RUN and dropped the reported rate to
+    # 66.7% on a run with ZERO test failures. Skipped stays its own row so the coverage loss
+    # is still visible -- it just no longer masquerades as a correctness signal.
+    executed = passed + failed
+    pass_rate = f"{passed * 100.0 / executed:.2f}%" if executed else "N/A"
     status_icon = "✅" if failed == 0 else "⚠️"
 
     normalized_type = _normalize_run_type(run_type) if run_type else ""
@@ -160,10 +169,11 @@ def _write_job_summary(tests: list[dict], run_type: str = "", **extra_fields) ->
     lines.extend(
         [
             f"| **Total Tests** | {total} |",
+            f"| **Executed** | {executed} |",
             f"| **Passed** | {passed} |",
             f"| **Failed** | {failed} |",
-            f"| **Skipped** | {skipped} |",
-            f"| **Pass Rate** | **{pass_rate}** |",
+            f"| **Skipped** (not run — infra) | {skipped} |",
+            f"| **Pass Rate** (of executed) | **{pass_rate}** |",
             "",
         ]
     )
@@ -384,10 +394,16 @@ def push_results(
         print(f"  GitHub Pipeline ID: {github_pipeline_id}")
         print(f"  Run Contents: {run_contents}")
         print(f"  Card Type: {card_type}")
+        # Same denominator as the job summary: executed = pass + fail. Skipped vectors are
+        # environment faults booked NOT_RUN, not results, so they are reported separately
+        # rather than folded into the rate. See _write_job_summary for the rationale.
+        executed = pass_count + fail_count
         print(f"  Total Tests: {len(tests)}")
+        print(f"  Executed: {executed}")
         print(f"  Pass Count: {pass_count}")
         print(f"  Fail Count: {fail_count}")
-        print(f"  Pass Rate: {pass_count * 100.0 / len(tests):.2f}%" if tests else "N/A")
+        print(f"  Skipped (not run): {len(tests) - executed}")
+        print(f"  Pass Rate (of executed): {pass_count * 100.0 / executed:.2f}%" if executed else "  Pass Rate: N/A")
 
         return run_id
 

--- a/tests/sweep_framework/sweep_utils/mesh_tensor_utils.py
+++ b/tests/sweep_framework/sweep_utils/mesh_tensor_utils.py
@@ -420,27 +420,40 @@ def fabric_config_for_mesh(mesh_shape):
     return ttnn.FabricConfig.FABRIC_1D if (rows == 1 or cols == 1) else ttnn.FabricConfig.FABRIC_2D
 
 
+# True between a successful _apply_fabric_config and its matching reset. Gates the reset so we
+# only ever clear a fabric WE configured -- ccl_common manages its own and must not be disturbed.
+_FABRIC_APPLIED = False
+
+
 def _apply_fabric_config(mesh_shape) -> None:
     """Set the fabric for an imminent open. DISABLED first, mirroring ccl_common: metal
     rejects a transition straight from one live config to another."""
+    global _FABRIC_APPLIED
     cfg = fabric_config_for_mesh(mesh_shape)
     if cfg is None:
         return
     logger.info(f"SWEEPS: setting fabric {cfg} for mesh {tuple(mesh_shape)} before open")
     _orig_set_fabric_config(ttnn.FabricConfig.DISABLED)
     _orig_set_fabric_config(cfg)
+    _FABRIC_APPLIED = True
 
 
 def _reset_fabric_config() -> None:
-    """The reset_fabric() half of the model fixture's contract. Uses the UNGUARDED setter:
-    this runs from close_job_device, after the device is already closed, and the guard
-    would call back into close_job_device."""
-    if _orig_set_fabric_config is None or _fabric_mode() in ("", "off", "0", "false", "no", "disabled"):
+    """The reset_fabric() half of the model fixture's contract: leave the process with the
+    fabric DISABLED so nothing inherits a configuration it never asked for.
+
+    No-ops unless we are the ones who set it (_FABRIC_APPLIED), so a fabric configured by
+    ccl_common survives. Uses the UNGUARDED setter: callers run after the device is already
+    closed, and the guarded one would call back into close_job_device."""
+    global _FABRIC_APPLIED
+    if not _FABRIC_APPLIED or _orig_set_fabric_config is None:
         return
     try:
         _orig_set_fabric_config(ttnn.FabricConfig.DISABLED)
     except Exception:
-        logger.exception("SWEEPS: failed to reset the fabric config after closing the job device")
+        logger.exception("SWEEPS: failed to reset the fabric config after closing the mesh device")
+    finally:
+        _FABRIC_APPLIED = False
 
 
 _orig_open_mesh_device = ttnn.open_mesh_device
@@ -566,13 +579,23 @@ def _close_mesh_and_parent(device, *args, **kwargs):
     always quiesced before closing a carved parent."""
     entry = _SUBMESH_PARENTS.pop(id(device), None)
     if entry is None:
-        return _orig_close_mesh_device(device, *args, **kwargs)
+        result = _orig_close_mesh_device(device, *args, **kwargs)
+        # Reset here, not only in close_job_device: create_mesh_device deliberately bypasses
+        # the job-device cache (caching disabled, or an unkeyable config), and those devices are
+        # closed straight through this path -- close_job_device would early-return on
+        # _JOB_DEVICE is None and never reset, leaving the process-global fabric enabled for
+        # whatever opens next. _reset_fabric_config only acts if WE set it, so a fabric
+        # configured by ccl_common is left alone.
+        _reset_fabric_config()
+        return result
     parent = entry[1]
     try:
         parent.quiesce_devices()
     except Exception:
         logger.exception("SWEEPS: quiesce_devices before closing the carved parent mesh failed")
-    return _orig_close_mesh_device(parent, *args, **kwargs)
+    result = _orig_close_mesh_device(parent, *args, **kwargs)
+    _reset_fabric_config()
+    return result
 
 
 def _guarded_open_mesh_device(*args, **kwargs):
@@ -640,7 +663,21 @@ def close_job_device() -> bool:
     return True
 
 
-def _create_mesh_device_uncached(
+def _create_mesh_device_uncached(*args, **kwargs) -> ttnn.MeshDevice:
+    """Open a mesh device, resetting the fabric if the open fails.
+
+    Wraps _open_mesh_device_configured so a fabric we set on the way in never outlives a failed
+    open: without this, an exception between _apply_fabric_config and a returned device would
+    leave the process-global fabric enabled for whatever opens next (the same leak as an
+    uncached close, see _close_mesh_and_parent)."""
+    try:
+        return _open_mesh_device_configured(*args, **kwargs)
+    except BaseException:
+        _reset_fabric_config()
+        raise
+
+
+def _open_mesh_device_configured(
     mesh_shape: Tuple[int, int],
     device_ids: Optional[list] = None,
     l1_small_size: int = 79104,

--- a/tests/sweep_framework/sweep_utils/mesh_tensor_utils.py
+++ b/tests/sweep_framework/sweep_utils/mesh_tensor_utils.py
@@ -623,6 +623,60 @@ def _guarded_open_mesh_device(*args, **kwargs):
 ttnn.open_mesh_device = _guarded_open_mesh_device
 
 
+def device_canary(device) -> Tuple[bool, str]:
+    """Ask the device a question we already know the answer to: is 2 + 2 still 4, on every chip?
+
+    Returns (healthy, detail). Never raises -- a throw IS a failed canary.
+
+    Why this exists. Wedge detection is otherwise REACTIVE: the runner pattern-matches the
+    exception text a vector produced, so a device that returns plausible-looking garbage is
+    indistinguishable from an op that computed the wrong answer. Lead-models run 31295900210
+    is the case in point -- after a device timeout, `add`, `linear` and
+    `nlp_create_qkv_heads_decode` each came back at PCC exactly 0.0 (an all-zeros readback)
+    and were booked as three separate test failures. All three pass in other runs on other
+    boxes. A health probe answers the question directly instead of inferring it from prose.
+
+    The tensor is SHARDED over the whole mesh, not run on one chip: a batch's vectors span
+    every device in its mesh, so a probe that only exercises chip 0 would miss exactly the
+    per-chip corruption this is meant to catch. Scatter + compute + gather all participate.
+
+    Exact equality, not PCC: 2.0 and 4.0 are exactly representable in bfloat16, so any
+    deviation at all is corruption rather than precision.
+    """
+    try:
+        num_devices = device.get_num_devices() if hasattr(device, "get_num_devices") else 1
+    except Exception as e:
+        return False, f"canary: could not query device count ({e})"
+
+    try:
+        rows = 32 * max(int(num_devices), 1)
+        torch_in = torch.full((rows, 32), 2.0, dtype=torch.float32)
+        if hasattr(device, "get_num_devices") and num_devices > 1:
+            mapper = ttnn.ShardTensorToMesh(device, dim=0)
+            tt_in = ttnn.from_torch(
+                torch_in, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, mesh_mapper=mapper
+            )
+            out = ttnn.to_torch(ttnn.add(tt_in, tt_in), mesh_composer=ttnn.ConcatMeshToTensor(device, dim=0))
+        else:
+            tt_in = ttnn.from_torch(torch_in, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            out = ttnn.to_torch(ttnn.add(tt_in, tt_in))
+    except Exception as e:
+        return False, f"canary: 2+2 raised on a {num_devices}-device mesh ({type(e).__name__}: {str(e)[:160]})"
+
+    try:
+        if tuple(out.shape) != (rows, 32):
+            return False, f"canary: 2+2 returned shape {tuple(out.shape)}, expected {(rows, 32)}"
+        bad = int((out != 4.0).sum().item())
+        if bad:
+            return False, (
+                f"canary: 2+2 != 4 in {bad}/{out.numel()} elements on a {num_devices}-device mesh "
+                f"(first value {out.flatten()[0].item()}) -- the device is returning corrupt data"
+            )
+    except Exception as e:
+        return False, f"canary: could not verify the 2+2 result ({e})"
+    return True, f"canary: 2+2 == 4 across {num_devices} device(s)"
+
+
 def clear_job_device_program_cache() -> None:
     """Clear the cached job device's program cache — call at each module boundary
     so a new module doesn't collide with an earlier module's cached programs /

--- a/tests/sweep_framework/sweep_utils/mesh_tensor_utils.py
+++ b/tests/sweep_framework/sweep_utils/mesh_tensor_utils.py
@@ -362,6 +362,87 @@ if _orig_set_fabric_config is not None:
     ttnn.set_fabric_config = _guarded_set_fabric_config
 
 
+# ── Fabric configuration: match the device setup the traced model used ────────
+# The fabric is part of a mesh device's configuration, not a global default, and the model
+# tests treat it that way: conftest.py's mesh_device fixture pops fabric_config /
+# reliability_mode / fabric_tensix_config out of device_params, calls set_fabric BEFORE
+# open_mesh_device, and reset_fabric after. Every galaxy model behind our traced configs
+# relies on it -- llama3_70b_galaxy/demo/text_demo.py sets "fabric_config": True, and
+# deepseek_v3/demo/demo.py calls set_fabric_config(get_fabric_config(), RELAXED_INIT) with
+# DISABLED at teardown.
+#
+# This path used to skip it entirely. Only ccl_common (the CCL modules) configured fabric, so
+# every other module opened a 32-chip mesh with whatever fabric state the process happened to
+# carry -- replaying llama/gpt_oss/deepseek ops under a device configuration the model never
+# used. Beyond being wrong on its own terms, it correlated with the intermittent Galaxy hangs:
+# the generic-path 2D batches (p1, p2, mesh8x4_col_2d, rms_norm_pre/post_all_gather) hung in
+# four separate lead-model runs and ran clean across two runs with this in place, including a
+# same-box rematch (p1 hung on j09glx02 and completed 542/542 on j09glx02 hours later).
+# It does NOT address the CCL path (which already configured fabric) or the 1D path; both still
+# hang intermittently and need hang recovery rather than a configuration change.
+#
+# The tracer records only machine_info + pytest_args + source -- no device_params -- so the
+# value cannot be read back from a trace and is derived from the mesh, matching the rule
+# all_gather_async_model_traced already applies. Ring is deliberately not inferred: topology is
+# a per-op property this path cannot know.
+#
+# Kill switch: TTNN_SWEEP_FABRIC=off restores the previous behaviour exactly.
+# Explicit override: TTNN_SWEEP_FABRIC=1d | 2d.
+_FABRIC_ENV = "TTNN_SWEEP_FABRIC"
+
+
+def _fabric_mode() -> str:
+    return os.environ.get(_FABRIC_ENV, "auto").strip().lower()
+
+
+def fabric_config_for_mesh(mesh_shape):
+    """The FabricConfig a model test would have set for `mesh_shape`, or None to leave
+    the fabric alone (single device, or disabled by env).
+
+    Mirrors all_gather_async_model_traced: a line mesh gets FABRIC_1D, a genuinely 2D mesh
+    gets FABRIC_2D. Ring (FABRIC_1D_RING) is deliberately not inferred -- topology is a
+    per-op property the generic path cannot know."""
+    mode = _fabric_mode()
+    if mode in ("", "off", "0", "false", "no", "disabled"):
+        return None
+    if _orig_set_fabric_config is None:
+        return None
+    try:
+        rows, cols = int(mesh_shape[0]), int(mesh_shape[1])
+    except (TypeError, ValueError, IndexError):
+        return None
+    if rows * cols <= 1:
+        return None
+    if mode == "1d":
+        return ttnn.FabricConfig.FABRIC_1D
+    if mode == "2d":
+        return ttnn.FabricConfig.FABRIC_2D
+    return ttnn.FabricConfig.FABRIC_1D if (rows == 1 or cols == 1) else ttnn.FabricConfig.FABRIC_2D
+
+
+def _apply_fabric_config(mesh_shape) -> None:
+    """Set the fabric for an imminent open. DISABLED first, mirroring ccl_common: metal
+    rejects a transition straight from one live config to another."""
+    cfg = fabric_config_for_mesh(mesh_shape)
+    if cfg is None:
+        return
+    logger.info(f"SWEEPS: setting fabric {cfg} for mesh {tuple(mesh_shape)} before open")
+    _orig_set_fabric_config(ttnn.FabricConfig.DISABLED)
+    _orig_set_fabric_config(cfg)
+
+
+def _reset_fabric_config() -> None:
+    """The reset_fabric() half of the model fixture's contract. Uses the UNGUARDED setter:
+    this runs from close_job_device, after the device is already closed, and the guard
+    would call back into close_job_device."""
+    if _orig_set_fabric_config is None or _fabric_mode() in ("", "off", "0", "false", "no", "disabled"):
+        return
+    try:
+        _orig_set_fabric_config(ttnn.FabricConfig.DISABLED)
+    except Exception:
+        logger.exception("SWEEPS: failed to reset the fabric config after closing the job device")
+
+
 _orig_open_mesh_device = ttnn.open_mesh_device
 
 # Full-host mesh orientations a 2D submesh can be carved out of, per host device count.
@@ -552,6 +633,10 @@ def close_job_device() -> bool:
         return False
     _JOB_DEVICE = None
     _JOB_DEVICE_KEY = None
+    # reset_fabric() half of the model fixture's contract: leave the process with the
+    # fabric DISABLED so the next open starts from a known state and nothing inherits a
+    # config it never asked for.
+    _reset_fabric_config()
     return True
 
 
@@ -594,6 +679,11 @@ def _create_mesh_device_uncached(
     # 7x10 grids); on blackhole just open with the default dispatch core config
     # — which blackhole supports — and skip it entirely. This also overrides any
     # explicit dispatch_core_axis a caller passes, since blackhole can't honor it.
+    # Match the model-test fixture: fabric is configured BEFORE the mesh is opened.
+    # Callers guarantee no live cached device here (create_mesh_device closes it first),
+    # which is what makes a fabric transition legal.
+    _apply_fabric_config(mesh_shape)
+
     _arch = os.environ.get("ARCH_NAME", "").lower()
     if not _arch:
         try:

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -1888,6 +1888,26 @@ def _should_skip_device_profiler(config):
                     "(idle_erisc.elf 0x5544 > 0x5390). Vectors report device-perf N/A and PASS."
                 )
                 return True
+        elif fabric_config_for_mesh((2, 2)) is not None:
+            # No declared mesh, and the fabric is enabled. We cannot resolve the real mesh here:
+            # this runs in the MAIN process before any device is opened, and the open path's
+            # fallback (get_mesh_shape -> hardware auto-detect) constructs a cluster. Doing that
+            # in the parent is what wedges Galaxy dispatch when the worker later opens the mesh
+            # -- see the note on get_card_type/prime_device_count.
+            #
+            # get_model_traced_mesh_shape's own docstring records the consequence: with
+            # MESH_DEVICE_SHAPE unset, auto-detect returns (4, 8) on a Galaxy, so the open WOULD
+            # enable FABRIC_2D while the profiler is on -> overflow at mesh open. The two errors
+            # are not symmetric (lose device-perf vs. wedge the run), so be conservative and skip.
+            # The probe shape (2, 2) only asks "is fabric enabled for a 2D mesh at all?", so
+            # TTNN_SWEEP_FABRIC=off correctly falls through and keeps device-perf.
+            logger.info(
+                "Skipping device profiler: MESH_DEVICE_SHAPE is unset and the fabric is enabled, "
+                "so the mesh the open path auto-detects may be 2D (FABRIC_2D + profiler overflows "
+                "idle-erisc at mesh open). Set MESH_DEVICE_SHAPE to the batch's mesh, or "
+                "TTNN_SWEEP_FABRIC=off, to get device-perf back."
+            )
+            return True
     except Exception as e:
         logger.warning(f"Could not evaluate the fabric profiler gate ({e}); leaving the profiler as-is.")
 

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -712,6 +712,38 @@ def _is_device_fatal_message(message) -> bool:
     return any(sig in msg for sig in _DEVICE_FATAL_SIGNATURES)
 
 
+# Signatures of HOST/driver resource exhaustion — the vector could not be set up because the
+# machine ran out of a kernel-driver resource, not because the op is wrong. Seen on lead-models
+# run 31308857249 job mesh4x8_col_2d_p1 (runner OM1-01A01-STGWH03):
+#
+#   Failed to allocate TLB window. Look at /sys/kernel/debug/tenstorrent/16/mappings and
+#   /proc/driver/tenstorrent/16/pids for more information.
+#   Error: tt_tlb_alloc failed with error code -12 for TLB size 1048576.
+#
+# -12 is ENOMEM, and the message itself points at the driver's mappings/pids tables, i.e. TLB
+# windows held by this or an earlier process. It was booked as a plain test failure because it
+# matched no signature, which is exactly the phantom-failure mode these lists exist to remove:
+# nothing about the op was exercised.
+#
+# Treated as sticky like the other infra classes. Address-space exhaustion does not heal while
+# the holder still holds it, so continuing would feed more vectors to a host that cannot map
+# device memory. Matched on the specific invariants ("failed to allocate tlb window",
+# "tt_tlb_alloc failed"), never on a bare filename — see the note on topology_mapper.cpp.
+_HOST_RESOURCE_SIGNATURES = (
+    "failed to allocate tlb window",
+    "tt_tlb_alloc failed",
+)
+
+
+def _is_host_resource_message(message) -> bool:
+    """Return True if a returned exception indicates host/driver resource exhaustion
+    (no device TLB window could be mapped), rather than a fault in the vector."""
+    if not message:
+        return False
+    msg = str(message).lower()
+    return any(sig in msg for sig in _HOST_RESOURCE_SIGNATURES)
+
+
 # Signatures of a transient kernel-ELF build/load failure. When the persisted
 # cache is cold (CI clears it before the job) and FABRIC_2D opens all chips at
 # once, the fabric_erisc_router ELF is built+loaded concurrently across devices;
@@ -809,8 +841,12 @@ def _is_infra_failure_message(message) -> bool:
     does not recover within the job (a wedge cascades into dispatch hangs, slow
     Galaxy resets, and all-zero/garbage outputs that mis-report as PCC failures).
     So rather than reset+continue on a machine that "once degraded is always
-    degraded", we classify the vector NOT_RUN and exit the whole run early."""
-    return _is_fabric_infra_message(message) or _is_device_fatal_message(message)
+    degraded", we classify the vector NOT_RUN and exit the whole run early.
+
+    Also covers host/driver resource exhaustion (no TLB window could be mapped):
+    the setup failed before the op ran, and the resource does not free itself
+    while its holder still holds it."""
+    return _is_fabric_infra_message(message) or _is_device_fatal_message(message) or _is_host_resource_message(message)
 
 
 def _set_crash_hang_defaults(result):

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -340,7 +340,11 @@ def run(input_queue, output_queue, config: SweepsConfig):
         except Exception as e:
             logger.warning(f"Could not enable operation tracing: {e}")
 
-    from tests.sweep_framework.sweep_utils.mesh_tensor_utils import clear_job_device_program_cache, close_job_device
+    from tests.sweep_framework.sweep_utils.mesh_tensor_utils import (
+        clear_job_device_program_cache,
+        close_job_device,
+        device_canary,
+    )
 
     module_cache = {}
     cur_module = None
@@ -405,6 +409,17 @@ def run(input_queue, output_queue, config: SweepsConfig):
                     status, message, e2e_perf, device_perf, peak_memory = run_single(
                         test_module, test_vector, cur_device, config
                     )
+                # Probe the device ONLY when the vector failed. On the happy path this costs
+                # nothing; on a failure it answers the question the exception text cannot --
+                # did this op compute the wrong answer, or is the device returning garbage to
+                # everyone? 2+2 across the batch's own mesh, ~1 ms warm.
+                canary_detail = None
+                if not status and cur_device is not None:
+                    healthy, canary_detail = device_canary(cur_device)
+                    if healthy:
+                        canary_detail = None  # nothing to report; the failure stands on its own
+                    else:
+                        logger.error(f"Device canary FAILED after a failing vector: {canary_detail}")
                 output_queue.put(
                     [
                         status,
@@ -412,12 +427,19 @@ def run(input_queue, output_queue, config: SweepsConfig):
                         e2e_perf,
                         device_perf if config.measure_device_perf else None,
                         peak_memory if config.measure_memory else None,
+                        canary_detail,
                     ]
                 )
             except Exception as e:
                 if config.main_proc_verbose:
                     logger.exception(e)
-                output_queue.put([False, str(e), None, None, None])
+                canary_detail = None
+                if cur_device is not None:
+                    healthy, detail = device_canary(cur_device)
+                    if not healthy:
+                        canary_detail = detail
+                        logger.error(f"Device canary FAILED after a raised vector: {detail}")
+                output_queue.put([False, str(e), None, None, None, canary_detail])
     finally:
         _exhaust_fixture()
         close_job_device()
@@ -528,6 +550,9 @@ def _populate_result_from_response(result, response, config, suite_name, input_h
         response[3],
         response[4],
     )
+    # 6th element (optional, so older/other producers of this tuple still unpack): set only
+    # when the vector FAILED and the post-failure device canary also failed.
+    canary_detail = response[5] if len(response) > 5 else None
     result["message"] = message
 
     logger.info(f"Test status: {status}")
@@ -572,7 +597,30 @@ def _populate_result_from_response(result, response, config, suite_name, input_h
             result["status"] = TestStatus.PASS
     else:
         result["exception"] = message
-        if config.measure_device_perf and device_perf == DEVICE_PERF_READBACK_FAILED:
+        if canary_detail:
+            # The vector failed AND the device then failed to compute 2+2 across its own mesh.
+            # A device that cannot do that is not evidence about this op, so the failure is
+            # unattributable: mark NOT_RUN and stop rather than book it -- and rather than keep
+            # feeding vectors to a device that will manufacture more.
+            #
+            # This is what run 31295900210 needed. On UF-MN-B4-GWH03 a device timeout was
+            # followed by add/linear/nlp_create_qkv_heads_decode each returning PCC exactly 0.0;
+            # all three were booked as test failures and all three pass in other runs on other
+            # boxes. The exception text alone could not tell them apart from real regressions --
+            # a health probe can.
+            #
+            # Deliberately ahead of the profiler-readback rule below: both mean "the device is
+            # bad", and the canary is the more direct measurement of the two.
+            logger.error(
+                f"Device canary failed after input_hash='{input_hash}' failed: {canary_detail}. "
+                "The failure is unattributable to this vector -- marking NOT_RUN and ending the run."
+            )
+            result["status"] = TestStatus.NOT_RUN
+            result["exception"] = f"DEVICE CANARY FAILED (result not attributable to this vector): {canary_detail}"
+            result["device_perf"] = None
+            result["_abort_suite"] = True
+            result["_infra_abort"] = True
+        elif config.measure_device_perf and device_perf == DEVICE_PERF_READBACK_FAILED:
             # The vector FAILED and the profiler readback ALSO threw. Two independent
             # readers of the device disagreeing with expectations at once is treated as
             # evidence the device itself is bad, not that this vector is a bad test: the

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -1867,6 +1867,30 @@ def _should_skip_device_profiler(config):
     FAIL_UNSUPPORTED_DEVICE_PERF) -- see _populate_result_from_response."""
     if _is_multidevice_ccl_module(config.module_name) and config.mesh_dims != "1d":
         return True
+
+    # The same overflow, reached a second way. mesh_tensor_utils configures the fabric on the
+    # GENERIC device path too (fabric_config_for_mesh), so a non-CCL batch on a 2D mesh also
+    # opens under FABRIC_2D -- and the overflow is a property of FABRIC_2D + profiler at mesh
+    # open, not of the op that happens to run afterwards. Without this gate those jobs wedge at
+    # open (run_mailbox 0x40) instead of reporting results. TTNN_SWEEP_FABRIC=off disables the
+    # fabric configuration and, with it, this gate.
+    try:
+        from tests.sweep_framework.sweep_utils.mesh_tensor_utils import fabric_config_for_mesh
+        import ttnn
+
+        mesh_shape = os.environ.get("MESH_DEVICE_SHAPE", "").strip()
+        if mesh_shape and "x" in mesh_shape:
+            rows, cols = (int(x) for x in mesh_shape.split("x", 1))
+            if fabric_config_for_mesh((rows, cols)) == ttnn.FabricConfig.FABRIC_2D:
+                logger.info(
+                    f"Skipping device profiler: mesh {mesh_shape} opens under FABRIC_2D, and "
+                    "FABRIC_2D + profiler overflows the idle-erisc code region at mesh open "
+                    "(idle_erisc.elf 0x5544 > 0x5390). Vectors report device-perf N/A and PASS."
+                )
+                return True
+    except Exception as e:
+        logger.warning(f"Could not evaluate the fabric profiler gate ({e}); leaving the profiler as-is.")
+
     return False
 
 


### PR DESCRIPTION
## Problem

The fabric is part of a mesh device's configuration, not a global default, and the model tests
treat it that way: `conftest.py::mesh_device` pops `fabric_config` / `reliability_mode` /
`fabric_tensix_config` out of `device_params`, calls `set_fabric(...)` **before**
`open_mesh_device`, and `reset_fabric(...)` after. Every Galaxy model behind our traced configs
relies on it — `llama3_70b_galaxy/demo/text_demo.py` sets `"fabric_config": True`, and
`deepseek_v3/demo/demo.py` calls `set_fabric_config(get_fabric_config(), RELAXED_INIT)` with
`DISABLED` at teardown.

The sweep framework's generic path skipped it. Only `ccl_common` (the CCL modules) configured
fabric; `_create_mesh_device_uncached` opened with `l1_small_size` + `dispatch_core_config` alone,
so a 32-chip mesh came up carrying whatever fabric state the process happened to have. That means
`concat`, `clamp`, `add_`, `rms_norm_pre/post_all_gather` and every other module on
`create_mesh_device` replayed llama / gpt_oss / deepseek ops **under a device configuration the
model never used**.

## Change

- `_apply_fabric_config()` before the open, `_reset_fabric_config()` in `close_job_device()`,
  mirroring `ccl_common`'s DISABLED-then-set sequence (metal rejects a transition straight from
  one live config to another).
- Value is derived from the mesh using the rule `all_gather_async_model_traced` already applies:
  line mesh → `FABRIC_1D`, 2D mesh → `FABRIC_2D`. Ring is deliberately not inferred — topology is
  a per-op property this path cannot know. The tracer records only `machine_info` + `pytest_args`
  + `source` (no `device_params`), so the value cannot be read back from a trace.
- Extends `_should_skip_device_profiler`: the idle-erisc overflow
  (`idle_erisc.elf 0x5544 > 0x5390`, `run_mailbox 0x40` at mesh open) is a property of
  **FABRIC_2D + profiler**, not of CCL, so a non-CCL 2D batch reaches it too. Without the gate
  those jobs wedge at open instead of reporting results.
- `TTNN_SWEEP_FABRIC=off` restores the previous behaviour exactly; `1d` / `2d` force a value.

## Effect on the intermittent Galaxy hangs — stated narrowly

**What this fixes: the non-CCL generic 2D path.**

| batch | without | with |
| --- | --- | --- |
| `mesh4x8_col_2d_p2` | hung in **4** runs (30797618024, 30806918846, 30970854301, 31067090788) | **541/541, twice** |
| `mesh4x8_col_2d_p1` | hung in 2 runs | **542/542, twice** |
| `mesh8x4_col_2d` | hung in 2 runs (+ `POST_RESET failed`) | **573 executed, twice** |
| `mesh8x4_col_2d_rms_norm_post_all_gather` | hung in 2 runs (`124ab56136b2`) | **clean, twice** |

Every batch that logs `FABRIC_2D` finished with 0 hangs and 0 `NOT_RUN` across both runs.

The sharpest comparison is same-box, same base commit, hours apart: **`p1` hung on `j09glx02` in
run 31067090788 and completed 542/542 on `j09glx02` in run 31080041828.**

Run-level, same morning:

| run | fabric | recorded | pass | fail | coverage of 2353 |
| --- | --- | --- | --- | --- | --- |
| 31067090788 (main, scheduled) | off | 370 | 362 | 0 | **16%** |
| 31080041828 (this branch) | **on** | 2268 | 2198 | 0 | **96%** |

**What this does NOT fix, and is not claimed to:** the CCL path and the 1D path.
`mesh8x4_col_2d_all_gather_async` had fabric configured by `ccl_common` on *both* arms and still
hung; `mesh1x32_col_1d` hung under `FABRIC_1D` while `mesh1x32_row_1d` passed under the identical
config in the same run. Those are non-deterministic and need hang recovery (continue-after-hang),
not a configuration change — out of scope here.

## Validation

Hardware-validated on an N300 (1x2 → `FABRIC_1D`): fabric set, mesh opens, `ttnn.add` and
`ttnn.clamp` on a sharded-topology tensor both run, gather returns `(1,1,32,512)`,
`close_job_device() -> True`. With `TTNN_SWEEP_FABRIC=off` the fabric line is absent and behaviour
is identical.

Derivation checked for (1,1) / (1,2) / (2,4) / (4,4) / (4,8) / (8,4) / (1,32) / (32,1) across all
three modes (`auto` / `off` / forced `1d`|`2d`), and the profiler gate for: non-CCL 2D → skip,
non-CCL 1D → no skip, `off` → no skip, CCL 2D → pre-existing skip intact, no `MESH_DEVICE_SHAPE` →
unchanged.

Plus the two full lead-model runs above (30994270654, 31080041828) — 4,564 vectors across the two,
0 test failures.

## Reviewer decisions

1. **Default.** As written `TTNN_SWEEP_FABRIC` defaults to on. That is a behaviour change for every
   Galaxy sweep and trades device-perf on 2D batches for the coverage above. Happy to flip the
   default to `off` and enable per-lane instead if owners prefer to stage it.
2. **Derivation vs. recorded params.** Deriving from the mesh matches existing CCL behaviour, but
   the authoritative fix is for the tracer to record `device_params` (`fabric_config`,
   `dispatch_core_type`, `worker_l1_size`, `trace_region_size`) so replays match the model exactly.
   Related gap this surfaced: we open Galaxy meshes with `DispatchCoreType.ETH` while the models use
   the `WORKER` default on the COL axis — fabric routers live on the eriscs, so that difference is
   worth investigating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/sweeps-experiment-fabric-on-generic-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/sweeps-experiment-fabric-on-generic-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/sweeps-experiment-fabric-on-generic-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/sweeps-experiment-fabric-on-generic-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=Aswinmcw/sweeps-experiment-fabric-on-generic-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:Aswinmcw/sweeps-experiment-fabric-on-generic-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/sweeps-experiment-fabric-on-generic-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/sweeps-experiment-fabric-on-generic-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/sweeps-experiment-fabric-on-generic-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/sweeps-experiment-fabric-on-generic-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/sweeps-experiment-fabric-on-generic-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/sweeps-experiment-fabric-on-generic-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/sweeps-experiment-fabric-on-generic-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/sweeps-experiment-fabric-on-generic-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/sweeps-experiment-fabric-on-generic-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/sweeps-experiment-fabric-on-generic-path)