### PR TITLE
[Bug fix] fix(data_movement): pad packs a float32 pad value as two bfloat16 halves

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -42,7 +42,7 @@ def random_torch_tensor(dtype, shape):
     ],
 )
 @pytest.mark.parametrize("value", [0, 1])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32, ttnn.uint16])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32, ttnn.uint16, ttnn.float32])
 def test_pad_rm(device, n, c, h, w, padding, torch_padding, value, dtype):
     torch.manual_seed(0)
 
@@ -1284,3 +1284,33 @@ def test_pad_nd_sharded_front_padding_tile_layout_not_supported(device, dtype):
             use_multicore=True,
             memory_config=output_memory_config,
         )
+
+
+@pytest.mark.parametrize(
+    "padding,torch_padding",
+    [
+        (((0, 0), (0, 0), (0, 16)), (0, 16, 0, 0, 0, 0)),
+    ],
+)
+@pytest.mark.parametrize("value", [float("-inf"), float("inf")])
+def test_pad_rm_non_finite_value_float32(device, padding, torch_padding, value):
+    """A float32 pad value must reach the padding as its own 32-bit pattern.
+
+    -inf is the ordinary way to build an attention mask, and it is the case where a
+    16-bit packing is not merely imprecise: two bfloat16 halves of -inf form
+    0xFF80FF80, which is a NaN, and a NaN in a mask poisons the whole row after
+    softmax. A PCC comparison cannot see this, so this test compares exactly.
+    """
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((1, 4, 16), dtype=torch.float32)
+    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, torch_padding, mode="constant", value=value)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.float32)
+    output_tensor = ttnn.to_torch(ttnn.pad(input_tensor, padding=padding, value=value))
+
+    assert not torch.isnan(output_tensor).any(), (
+        f"pad(value={value}) produced NaN in the padding: "
+        f"{int(torch.isnan(output_tensor).sum())} of {output_tensor.numel()} elements"
+    )
+    assert torch.equal(torch_output_tensor, output_tensor)

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "pad_rm_reader_writer_multi_core_default_program_factory.hpp"
 
+#include <bit>
 #include <algorithm>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -106,6 +107,11 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
         packed_pad_value = pad_value;
     } else if (a.dtype() == DataType::UINT16) {
         packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
+    } else if (a.dtype() == DataType::FLOAT32) {
+        // FLOAT32 needs the raw 32-bit pattern: the branch below packs two 16-bit halves,
+        // which is correct for the 16-bit dtypes and wrong here. Matches
+        // pad_tile_multicore_program_factory.cpp.
+        packed_pad_value = std::bit_cast<uint32_t>(pad_value);
     } else {
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_rm_reader_writer_multi_core_program_factory.hpp"
+#include <bit>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -253,6 +254,11 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
         packed_pad_value = pad_value;
     } else if (a.dtype() == DataType::UINT16) {
         packed_pad_value = pack_two_uint16_into_uint32({0, float_to_uint16(pad_value)});
+    } else if (a.dtype() == DataType::FLOAT32) {
+        // FLOAT32 needs the raw 32-bit pattern: the branch below packs two 16-bit halves,
+        // which is correct for the 16-bit dtypes and wrong here. Matches
+        // pad_tile_multicore_program_factory.cpp.
+        packed_pad_value = std::bit_cast<uint32_t>(pad_value);
     } else {
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(0.0f), bfloat16(pad_value)});
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_rm_reader_writer_program_factory.hpp"
+#include <bit>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -89,6 +90,11 @@ ProgramDescriptor build_pad_rm_sc_program_descriptor(
         packed_pad_value = pad_value;
     } else if (a.dtype() == DataType::UINT16) {
         packed_pad_value = pack_two_uint16_into_uint32({0, float_to_uint16(pad_value)});
+    } else if (a.dtype() == DataType::FLOAT32) {
+        // FLOAT32 needs the raw 32-bit pattern: the branch below packs two 16-bit halves,
+        // which is correct for the 16-bit dtypes and wrong here. Matches
+        // pad_tile_multicore_program_factory.cpp.
+        packed_pad_value = std::bit_cast<uint32_t>(pad_value);
     } else {
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(0.0f), bfloat16(pad_value)});
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_rm_sharded_height_only_program_factory.hpp"
+#include <bit>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
@@ -328,6 +329,11 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
         packed_pad_value = pad_value;
     } else if (a.dtype() == DataType::UINT16) {
         packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
+    } else if (a.dtype() == DataType::FLOAT32) {
+        // FLOAT32 needs the raw 32-bit pattern: the branch below packs two 16-bit halves,
+        // which is correct for the 16-bit dtypes and wrong here. Matches
+        // pad_tile_multicore_program_factory.cpp.
+        packed_pad_value = std::bit_cast<uint32_t>(pad_value);
     } else {
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_tile_program_factory.hpp"
+#include <bit>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/host_api.hpp>
@@ -73,6 +74,11 @@ ProgramDescriptor PadTileCoreProgramFactory::create_descriptor(
         packed_pad_value = pad_value;
     } else if (a.dtype() == DataType::UINT16) {
         packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
+    } else if (a.dtype() == DataType::FLOAT32) {
+        // FLOAT32 needs the raw 32-bit pattern: the branch below packs two 16-bit halves,
+        // which is correct for the 16-bit dtypes and wrong here. Matches
+        // pad_tile_multicore_program_factory.cpp.
+        packed_pad_value = std::bit_cast<uint32_t>(pad_value);
     } else {
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
     }


### PR DESCRIPTION
### What is wrong

The pad-value packing in five of the `pad` program factories has branches for `INT32`/`UINT32` and for `UINT16`, and nothing for `FLOAT32`. A float32 tensor therefore falls through to the bfloat16 branch, and the padding is filled with a 16-bit rounded constant instead of the value that was asked for.

```cpp
// pad_rm_reader_writer_multi_core_default_program_factory.cpp
uint32_t packed_pad_value;
if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
    packed_pad_value = pad_value;
} else if (a.dtype() == DataType::UINT16) {
    packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
} else {                       // <-- FLOAT32 lands here
    packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
}
```

The kernel writes that word into every 4-byte slot of the padding region (`fill_pad_cb_with_val`, `reader_pad_dims_rm_interleaved_v2.cpp:16-26`), so each float32 padding element receives it verbatim.

### The five are not equally wrong, and the difference matters

Two distinct packings are in play, so the report is split accordingly.

**Three factories pack `{bf16(v), bf16(v)}`** — the rounded value in *both* halves of the word. This is correct for a bfloat16 tensor, where the word holds two elements, and it is destructive for float32:

```
pad(value=1.0)     -> 0x3F803F80 = 1.0019378662109375     (torch: 1.0)
pad(value=3.0)     -> 0x40404040 = 3.003921509            (torch: 3.0)
pad(value=65536.0) -> 65679.0                             (torch: 65536.0)
pad(value=-inf)    -> 0xFF80FF80 = NaN                    (torch: -inf)
```

Over 25 pad values (0, ±1, 2, 3, 0.5, 8, 3.7, −2.5, 1e−5, 1e30, 6, 100, 1/3, π, 1e−40, 1.4e−45, ±inf, 65504, 1e−8, 255, 0.1, 1e−3, 65536), **24 are wrong**. `0.0` is the only one that survives, which is why CI is green.

The three are `pad_rm_reader_writer_multi_core_default_program_factory.cpp`, `pad_rm_sharded_height_only_program_factory.cpp` and `pad_tile_program_factory.cpp`. **The first is the default row-major path** (`use_multicore` defaults to true, `pad_device_operation.cpp:99-102`).

**The other two pack `{bf16(0), bf16(v)}`** — zero in the low half, so the word keeps the float32 layout and only the mantissa is truncated to 8 bits. `±inf` survives correctly there. 11 of the same 25 values are still wrong: 3.7 → 3.703125, 0.1 → 0.1000976562, 65504 → 65536, 1.4e−45 → 0.

Controls, so the measurement is not trivially one-sided: the same packing on a **bfloat16** tensor is correct for all 25, and the `std::bit_cast` sibling is correct for all 25.

### The `-inf` case is the one worth acting on

`-inf` is the ordinary way to build an attention mask. Two bfloat16 halves of `-inf` form `0xFF80FF80`, which is a **NaN**, and a NaN in a mask poisons the whole row through softmax. That is a wrong answer produced silently, not a rounding difference.

### The repository already contains the correct branch, in three places

- `pad_tile_multicore_program_factory.cpp:107` — `case DataType::FLOAT32: packed_pad_value = std::bit_cast<uint32_t>(pad_value); break;`
- `tilize_with_val_padding_factory_helper.cpp:31-33`
- `fill_pad_program_factory.hpp:62-63`

And `pad_device_operation.cpp:162-168` explicitly whitelists `FLOAT32` for the row-major path, so this is a supported configuration rather than an unsupported one that happens to run.

### This is known, and was routed around rather than fixed

PR **#50699** (`[codegen-port] pad`, open) documents it verbatim in `pad_codegen_supported.cpp`:

> *"Native's RM pad-value packing has no FLOAT32 case and falls through to the BFLOAT16 one, so it fills with a bf16-rounded constant for every nonzero float32 value (3.0 lands as 3.00392, 65536.0 as 65679.0) while codegen is exact. Demoting these would buy speed with a wrong answer, so they stay on codegen at whatever the staging path costs."*

That PR keeps float32-with-a-nonzero-pad-value on the codegen path to avoid the wrong answer. This PR fixes the native path instead, so the workaround is no longer load-bearing. Issue **#15511** (closed) was the same symptom in TILE and was fixed only in `pad_tile_multicore_program_factory.cpp`; the other five factories were never updated.

### Why no test caught it

`tests/ttnn/unit_tests/operations/data_movement/test_pad.py:45` parametrises `test_pad_rm` over `[bfloat16, int32, uint16]` — exactly the three branches the if/else does handle. `float32` is absent, and the sweep at `tests/sweep_framework/sweeps/data_movement/pad/pad.py:36` restricts dtype the same way.

The tests that do use float32 with `ttnn.pad` all pad with `0`, the one value that comes out right — except `test_pad_rm_sharded_stickwise`, which pads with `3.0` and compares with `assert_with_pcc(..., 0.99)`. With a fill of `3.0039215` against `3.0` the PCC is **exactly 1.0**, because there are only two distinct values and the relation is affine; `torch.equal` on the same pair is `False`. That test touches the broken region and cannot see it.

### What this PR changes

- Adds the `FLOAT32` branch to the five factories, using `std::bit_cast<uint32_t>` as `pad_tile_multicore_program_factory.cpp` already does. The bfloat16 branch is left exactly as it was, since it is correct for the 16-bit dtypes.
- `#include <bit>` in each of the five. `pad_tile_multicore_program_factory.cpp` uses `std::bit_cast` today without it and compiles on a transitive include; I would rather not extend that.
- `test_pad_rm` gains `ttnn.float32`. It already parametrises `value=1` and asserts with `torch.equal`, so no new test body is needed for the general case.
- A new `test_pad_rm_non_finite_value_float32` for `±inf`, asserting no NaN appears in the output and then comparing exactly. A PCC comparison cannot express that check.

I do not have a board: the numbers above come from replicating `bfloat16::from_float` (`bfloat16.cpp:19-30`, round-to-nearest-even) and `pack_two_bfloat16_into_uint32` (`common.cpp:516-519`) in Python and comparing against `torch.nn.functional.pad`. The mechanism itself is visible in the source quoted above and does not depend on that measurement.
