### PR TITLE
[tt-train] Use HiFi3 with fp32 dest accumulation on Wormhole

### DIFF
--- a/tt-train/sources/ttml/core/compute_kernel_config.cpp
+++ b/tt-train/sources/ttml/core/compute_kernel_config.cpp
@@ -4,13 +4,20 @@
 
 #include "compute_kernel_config.hpp"
 
+#include <tt-metalium/hal.hpp>
+
 namespace ttml::core {
+
+tt::tt_metal::MathFidelity max_fidelity_with_fp32_acc() {
+    return tt::tt_metal::hal::get_arch() == tt::ARCH::WORMHOLE_B0 ? tt::tt_metal::MathFidelity::HiFi3
+                                                                  : tt::tt_metal::MathFidelity::HiFi4;
+}
 
 ttnn::WormholeComputeKernelConfig ComputeKernelConfig::precise() {
     ttnn::WormholeComputeKernelConfig config;
     config.fp32_dest_acc_en = true;
     config.math_approx_mode = false;
-    config.math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
+    config.math_fidelity = max_fidelity_with_fp32_acc();
     config.packer_l1_acc = true;
     return config;
 }
@@ -28,7 +35,7 @@ ttnn::WormholeComputeKernelConfig ComputeKernelConfig::matmul() {
     ttnn::WormholeComputeKernelConfig config;
     config.fp32_dest_acc_en = true;
     config.math_approx_mode = false;
-    config.math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
+    config.math_fidelity = max_fidelity_with_fp32_acc();
     config.packer_l1_acc = true;
     return config;
 }

--- a/tt-train/sources/ttml/core/compute_kernel_config.hpp
+++ b/tt-train/sources/ttml/core/compute_kernel_config.hpp
@@ -8,9 +8,10 @@
 
 namespace ttml::core {
 
-// Highest math fidelity that is safe to pair with fp32 dest accumulation on this arch.
+// Highest math fidelity recommended with fp32 dest accumulation on this arch.
 // Wormhole HW bug #38306: HiFi4 with fp32 dest acc corrupts occasional outputs by a power of
-// two. HiFi3 is the recommended workaround (#39562); Blackhole silicon is unaffected.
+// two. HiFi3 is the recommended workaround (#39562) and cuts the observed rate by ~550x, but
+// does not eliminate it — the RTL fault has no fix in WH silicon. Blackhole is unaffected.
 [[nodiscard]] tt::tt_metal::MathFidelity max_fidelity_with_fp32_acc();
 
 class ComputeKernelConfig {

--- a/tt-train/sources/ttml/core/compute_kernel_config.hpp
+++ b/tt-train/sources/ttml/core/compute_kernel_config.hpp
@@ -8,6 +8,11 @@
 
 namespace ttml::core {
 
+// Highest math fidelity that is safe to pair with fp32 dest accumulation on this arch.
+// Wormhole HW bug #38306: HiFi4 with fp32 dest acc corrupts occasional outputs by a power of
+// two. HiFi3 is the recommended workaround (#39562); Blackhole silicon is unaffected.
+[[nodiscard]] tt::tt_metal::MathFidelity max_fidelity_with_fp32_acc();
+
 class ComputeKernelConfig {
 public:
     static ttnn::WormholeComputeKernelConfig precise();

--- a/tt-train/sources/ttml/metal/common/program_utils.hpp
+++ b/tt-train/sources/ttml/metal/common/program_utils.hpp
@@ -7,6 +7,7 @@
 #include <bit>
 #include <cstdint>
 
+#include "core/compute_kernel_config.hpp"
 #include "metal/ttnn_all_includes.hpp"
 
 inline uint32_t get_block_size(uint32_t num_inner, const uint32_t max_block_size = 4U) {
@@ -102,7 +103,8 @@ inline tt::tt_metal::KernelHandle create_compute_kernel(
         kernel_path,
         core_ranges,
         tt::tt_metal::ComputeConfig{
-            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+            .math_fidelity =
+                fp32_dest_acc_en ? ttml::core::max_fidelity_with_fp32_acc() : tt::tt_metal::MathFidelity::HiFi4,
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .math_approx_mode = false,
             .compile_args = compile_time_args,

--- a/tt-train/sources/ttml/metal/ops/frobenius_normalize/device/frobenius_normalize_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/frobenius_normalize/device/frobenius_normalize_program_factory.cpp
@@ -8,6 +8,7 @@
 #include <enchantum/enchantum.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
+#include "core/compute_kernel_config.hpp"
 #include "frobenius_normalize_device_operation_types.hpp"
 #include "metal/common/program_utils.hpp"
 
@@ -157,7 +158,7 @@ FrobeniusNormalizeProgramFactory::cached_program_t FrobeniusNormalizeProgramFact
 
     auto make_compute_config = [&](const std::vector<uint32_t>& args, const std::map<std::string, std::string>& defs) {
         return tt::tt_metal::ComputeConfig{
-            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+            .math_fidelity = ttml::core::max_fidelity_with_fp32_acc(),
             .fp32_dest_acc_en = true,
             .unpack_to_dest_mode = unpack_to_dest,
             .math_approx_mode = false,

--- a/tt-train/sources/ttml/metal/ops/polynorm_bw/device/polynorm_bw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/polynorm_bw/device/polynorm_bw_program_factory.cpp
@@ -8,6 +8,7 @@
 #include <enchantum/enchantum.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
+#include "core/compute_kernel_config.hpp"
 #include "metal/common/program_utils.hpp"
 
 namespace {
@@ -290,7 +291,7 @@ PolyNorm3BackwardProgramFactory::cached_program_t PolyNorm3BackwardProgramFactor
         kComputeKernelPath,
         core_group_1,
         tt::tt_metal::ComputeConfig{
-            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+            .math_fidelity = ttml::core::max_fidelity_with_fp32_acc(),
             .fp32_dest_acc_en = true,
             .math_approx_mode = false,
             .compile_args = compute_group_1_args,
@@ -302,7 +303,7 @@ PolyNorm3BackwardProgramFactory::cached_program_t PolyNorm3BackwardProgramFactor
             kComputeKernelPath,
             core_group_2,
             tt::tt_metal::ComputeConfig{
-                .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+                .math_fidelity = ttml::core::max_fidelity_with_fp32_acc(),
                 .fp32_dest_acc_en = true,
                 .math_approx_mode = false,
                 .compile_args = compute_group_2_args,

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "core/compute_kernel_config.hpp"
 #include "hostdevcommon/kernel_structs.h"
 
 using namespace tt;
@@ -159,7 +160,7 @@ static tt::tt_metal::ComputeConfig precise(
     tt::tt_metal::ComputeConfig config;
     config.fp32_dest_acc_en = true;
     config.math_approx_mode = false;
-    config.math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
+    config.math_fidelity = ttml::core::max_fidelity_with_fp32_acc();
     config.compile_args = std::move(compile_time_args);
     config.defines = std::move(defines);
     return config;

--- a/tt-train/sources/ttml/metal/ops/variable_matmul/device/variable_matmul_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/variable_matmul/device/variable_matmul_device_operation.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/tt_metal.hpp>
 
+#include "core/compute_kernel_config.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "variable_matmul_program_factory.hpp"
 
@@ -311,7 +312,7 @@ ttnn::Tensor ttml_variable_matmul(
     auto kernel_config_val = init_device_compute_kernel_config(
         input_tensor.device()->arch(),
         compute_kernel_config,
-        tt::tt_metal::MathFidelity::HiFi4,
+        ttml::core::max_fidelity_with_fp32_acc(),
         false /*approx_mode*/,
         true /*fp32_acc*/,
         true /*packer_acc*/);


### PR DESCRIPTION
### PR Category

Bug fix

### Ticket

- Root cause: #38306 — Wormhole RTL bug, closed as a known HW issue, no fix for WH silicon.
- Tracking: #39562 — *"Prevent device ops from using HiFi4 with fp32 dest acc"*. This is the tt-train instance of it.

### Problem description

`SwiGLUBackwardTest.BackwardAccuracy_2x1x32x128` has been failing intermittently in the merge gate, seemingly on one particular n150. It is neither the board nor the test.

ttml requests `MathFidelity::HiFi4 + fp32_dest_acc_en` for every matmul (`ComputeKernelConfig::matmul()`), most reductions (`precise()`), and every metal kernel built through `create_compute_kernel()`. On Wormhole that is exactly the configuration in #38306, where the FPU corrupts a single output element of a matmul by a power of two. ttnn changed its own defaults to HiFi3 on WH for this reason (#40089), but that only applies when no compute config is supplied — ttml supplies one on every call, so none of it reached us. tt-train's SDPA kernels already carry a hand-written version of this workaround (#44198); `core/compute_kernel_config.cpp` never got it.

Measured on a healthy n300, HiFi4 vs HiFi3 on identical inputs:

| shape | HiFi4 + fp32acc | HiFi3 + fp32acc |
|---|---|---|
| 128x384x1024 | 415 / 31,806 (1.30%) | 0 / 31,806 |
| 64x128x128 (swiglu fwd + most bwd) | 11 / 26,862 (0.041%) | 0 |
| 128x64x128 (swiglu dW matmuls) | 4 / 27,951 (0.014%) | 0 |

The rate is constant per multiply-accumulate — ~2.6e-10, holding within noise across a 12x span in K — so it scales with work rather than shape, and no shape is immune. The failing test issues ~9 matmuls at those two shapes, i.e. **~0.26% chance per invocation on any Wormhole board**. Order-of-magnitude for training: a step of ~1e12 MACs takes on a few hundred corrupted values.

**What is observable, and what is not.** In normal operation, nothing: one wrong element in 131,072, finite, plausible in magnitude, no NaN, no error, no diagnostic. It surfaces only as an occasional accuracy-test failure or as unexplained training behaviour. What *is* observable is the *request* — ttnn's `verify_numerical_configuration()` logs once per process when a caller passes WH + HiFi4 + fp32 dest acc. That warning appears once in a pre-fix merge-gate shard and zero times after, which is a cheap way to confirm no ttml path still asks for the bad config.

### How the diagnosis was reached

Ruled out by measurement, in order:

- **Unlucky data** — 50 independent draws through the real test path put `out` in [0.00518, 0.00599]. The reported 0.03647 is 6.1x the worst draw.
- **Nondeterminism** — bit-identical across 15 repeats. Over 9,764 samples run twice per config with the fidelity order alternated, 0 nondeterministic, ordering or readback artefacts.
- **Chip harvesting / core grid** — identical results from 1x1 through 8x8, including on inputs that *do* trigger.
- **The specific board** — follows from the above; #38306 also reports *"it is deterministic: it fails on different boards"*.

Identified as #38306 by signature: exactly one corrupted element per event, with value `bf16(true − 2^n)`, n ∈ {5,6,7} — confirmed on 32 events including 25 held out from the derivation. #38306 independently reports *"errors are always negative powers of two"* and *"if scale factor is a power of two then errors happen at the same location but are scaled"*, both of which reproduce here exactly.

### What's changed

New `ttml::core::max_fidelity_with_fp32_acc()` — HiFi3 on `WORMHOLE_B0`, HiFi4 elsewhere — applied at the three places that put this config on the device:

| where | what |
|---|---|
| `core/compute_kernel_config.{hpp,cpp}` | helper; used by `ComputeKernelConfig::matmul()` and `::precise()` |
| `metal/common/program_utils.hpp` | `create_compute_kernel()`, **only when `fp32_dest_acc_en`** |
| `frobenius_normalize`, `polynorm_bw` (x2), `softmax_backward` | build `ComputeConfig` inline, so not covered by the above |

That covers all of `ttnn_fixed::matmul` / `linear_op`, the 33 `precise()` call sites, and the fourteen tt-train metal kernels that issue MVMUL/ELWMUL with fp32 accumulation: cross_entropy fw/bw, layernorm fw/bw, rmsnorm fw/bw, polynorm fw/bw, softmax, softmax_backward, silu_bw, mla_q_rope, swiglu_elemwise_bw, frobenius_normalize.

Deliberately unchanged:
- **Blackhole** — the helper returns HiFi4 on any non-WH arch. BH silicon has the fix; downgrading there would cost real precision for no benefit, and #39562 specifies Wormhole.
- `softmax()` and `fast()` — neither enables fp32 dest accumulation, so neither can hit the bug.
- `sgd`, `moe_group`, `moe_ungroup` — pass `fp32_dest_acc_en=false`, so `create_compute_kernel` leaves them on HiFi4.
- `adamw` — its compute kernel has no FPU multiply or reduce at all; math fidelity is inert there.
- SDPA's three existing inline arch checks — working code, left alone. They are now the only inline copies and could fold into the helper later.

### Verification

- Both merge-gate shards green on n300: 259 + 257 passed, 0 failed — same counts as the pre-fix baseline, so nothing was skipped. The originally-failing test passes. No tolerance anywhere in the suite turned out to be tuned to HiFi4.
- ttnn's HiFi4+fp32acc warning: 1 occurrence pre-fix, 0 post-fix in both shards.
- **Accuracy unchanged**: swiglu `out` rel_l2 median 0.005506 (HiFi3) vs 0.005508 (HiFi4) over 50 draws; every metric within 0.4%.
- **Slightly faster**: 4096^3 matmul 4.31 ms vs 5.07 ms (0.85x). HiFi3 issues three FPU fidelity passes where HiFi4 issues four. Smaller shapes are dispatch-bound and unchanged.

### What this does and does not do

Removes tt-train from the known-bad configuration and cuts observed faults by ~550x at no accuracy cost. It does **not** fix #38306, which is unfixable in Wormhole silicon. HiFi3 is a mitigation: 1 residual event in 43,380 inputs here, consistent with #39518's *"possible at lower fidelities but occurs a lot less frequently"*.

### Notes for #38306 / #39562

Three things worth picking up separately:

1. The docstring at `matmul_nanobind.cpp:731` says the bug *"can happen when the original mantissa contains all 1"*. At 128x384x1024 with Gaussian bf16 inputs that is not a **necessary** condition on the operands: removing every all-ones mantissa leaves the rate unchanged (1.295% vs 1.399%, z = −0.45), and forcing 88x more of them does not raise it significantly (1.710%, z = +1.24). Caveats — one shape only, and geometry demonstrably affects which inputs trigger, so it may hold at the `[1,128] @ [128,1]` case in #38306; and a modest contribution is not excluded (rate ratio CI [0.89, 1.68]). Worth a second look from whoever wrote it.
2. #38306's *"1 bad data point for a full 4096^3 matmul"* implies ~1.5e-11 per MAC against 2.6e-10 measured here. A single observed event carries little precision, but if the per-MAC rate held at K=4096 that run would have expected ~18 events, so either the constant does not extend that far — my sweep stopped at K=768 — or that figure was illustrative rather than a count. Worth pinning down before anyone quotes a rate.
3. PR #39040 (open) moves Deepseek RMSNorm *toward* HiFi4 + fp32 accumulation.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=imichalak/ttml_hifi3_fp32_acc_wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:imichalak/ttml_hifi3_fp32_acc_wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=imichalak/ttml_hifi3_fp32_acc_wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:imichalak/ttml_hifi3_fp32_acc_wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=imichalak/ttml_hifi3_fp32_acc_wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:imichalak/ttml_hifi3_fp32_acc_wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=imichalak/ttml_hifi3_fp32_acc_wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:imichalak/ttml_hifi3_fp32_acc_wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=imichalak/ttml_hifi3_fp32_acc_wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:imichalak/ttml_hifi3_fp32_acc_wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=imichalak/ttml_hifi3_fp32_acc_wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:imichalak/ttml_hifi3_fp32_acc_wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=imichalak/ttml_hifi3_fp32_acc_wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:imichalak/ttml_hifi3_fp32_acc_wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=imichalak/ttml_hifi3_fp32_acc_wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:imichalak/ttml_hifi3_fp32_acc_wh)