### PR TITLE
Fix ttnn.all_gather topology creation with invalid shard dims

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -104,8 +104,14 @@ AllGatherDeviceOperation::topology_return_value_t AllGatherDeviceOperation::comp
     // For each distribution dimension, if sharded on the gather dim, make it replicated
     const auto& logical_shape = input_tensor.logical_shape();
     const uint32_t gather_dim = logical_shape.get_normalized_index(args.dim_from_end);
+    const int32_t rank = static_cast<int32_t>(logical_shape.rank());
     for (auto& output_placement : output_placements) {
         if (auto* shard = std::get_if<tt::tt_metal::distributed::MeshMapperConfig::Shard>(&output_placement)) {
+            // Temp workaround for #52331:
+            // Rank-changing ops don't renumber Shard::dim, so skip over invalid shard dims.
+            if (shard->dim >= rank || shard->dim < -rank) {
+                continue;
+            }
             // Shard::dim is always unnormalized by construction, so normalize here
             if (logical_shape.get_normalized_index(shard->dim) == gather_dim) {
                 output_placement = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -108,7 +108,7 @@ AllGatherDeviceOperation::topology_return_value_t AllGatherDeviceOperation::comp
     for (auto& output_placement : output_placements) {
         if (auto* shard = std::get_if<tt::tt_metal::distributed::MeshMapperConfig::Shard>(&output_placement)) {
             // Temp workaround for #52331:
-            // Rank-changing ops don't renumber Shard::dim, so skip over invalid shard dims.
+            // Rank-changing ops don't renumber Shard::dim, so skip over invalid shard dims
             if (shard->dim >= rank || shard->dim < -rank) {
                 continue;
             }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Temporary workaround for https://github.com/tenstorrent/tt-metal/issues/52331.
Skip over invalid shard dims produced by upstream data_movement ops.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/fix-ag-topo)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-ag-topo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=scardoza/fix-ag-topo)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:scardoza/fix-ag-topo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=scardoza/fix-ag-topo)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:scardoza/fix-ag-topo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/fix-ag-topo)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-ag-topo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=scardoza/fix-ag-topo)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:scardoza/fix-ag-topo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/fix-ag-topo)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-ag-topo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/fix-ag-topo)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-ag-topo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/fix-ag-topo)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-ag-topo)