### PR TITLE
emule: enable multi-dispatch socket pipelines under host-interleaved dispatch

### DIFF
--- a/tests/tt_metal/tt_metal/api/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/api/CMakeLists.txt
@@ -125,6 +125,7 @@ set_target_properties(
 
 if(TT_METAL_USE_EMULE)
     target_link_options(unit_tests_api PRIVATE -rdynamic)
+    target_link_libraries(unit_tests_api_lib PRIVATE tt-emule::headers)
 
     # Per-fiber ASAN sanitizer-state isolation test. Its own binary because it
     # includes the emule kernel-side context header (jit_hw/internal/

--- a/tests/tt_metal/tt_metal/api/emule/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/emule/sources.cmake
@@ -22,6 +22,7 @@ list(
     ${CMAKE_CURRENT_LIST_DIR}/test_alignment_writes.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_cb_leak.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_cb_pages.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_emule_host_wait.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_host_alignment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_metadata_size.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_noc_without_barrier.cpp

--- a/tests/tt_metal/tt_metal/api/emule/test_emule_host_wait.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_emule_host_wait.cpp
@@ -1,0 +1,418 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression fence for RunOutcome::HostWait: host-resolvable stalls vs device faults. Negatives are death tests.
+
+#include <gtest/gtest.h>
+
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+
+#include "impl/emulation/emule_fiber_scheduler.hpp"
+#include "jit_hw/internal/emule_thread_ctx.h"
+
+namespace {
+
+using tt::tt_metal::emule_fiber::FiberEngineStall;
+using tt::tt_metal::emule_fiber::FiberIdentity;
+using tt::tt_metal::emule_fiber::FiberScheduler;
+using tt::tt_metal::emule_fiber::RunOutcome;
+
+// A distinct identity per fiber so a hang dump names which one wedged.
+FiberIdentity ident(uint8_t x, uint8_t y, const char* src) {
+    FiberIdentity id;
+    id.phys_x = x;
+    id.phys_y = y;
+    id.logical_x = x;
+    id.logical_y = y;
+    id.proc_id = 0;
+    id.kernel_src = src;  // static string literal — outlives the run
+    return id;
+}
+
+// The body only calls bridge ops, so a default-constructed ctx is enough: no L1, no DFBs, no device.
+void spawn_fiber(std::function<void()> body, uint8_t x, const char* src) {
+    FiberScheduler::instance().spawn(std::move(body), std::make_unique<DatamovementThreadCtx>(), ident(x, 0, src));
+}
+
+// The poll variant of socket_wait_for_pages: it cannot park, so it tags, yields, and comes back.
+std::function<void()> polling_body(const std::atomic<bool>* done, bool host_fed, std::atomic<unsigned>* entries) {
+    return [done, host_fed, entries] {
+        if (entries != nullptr) {
+            entries->fetch_add(1);  // a double-queued fiber would run its body twice
+        }
+        auto& sched = FiberScheduler::instance();
+        while (!done->load(std::memory_order_acquire)) {
+            sched.note_socket_poll_wait(/*waiting=*/true, host_fed);
+            sched.yield();
+        }
+        sched.note_socket_poll_wait(/*waiting=*/false, host_fed);  // bytes landed
+    };
+}
+
+// Threadsafe death tests (forking the engine's 64-thread pool is not safe) + a clean-registry check.
+class EmuleHostWait : public ::testing::Test {
+protected:
+    void SetUp() override { ::testing::FLAGS_gtest_death_test_style = "threadsafe"; }
+
+    void TearDown() override {
+        // A leaked fiber poisons the global registry, so every later test fails too — fix the FIRST.
+        ASSERT_EQ(FiberScheduler::instance().oldest_live_spawn_generation(), UINT64_MAX)
+            << "test left a live fiber in the process-global scheduler registry; if this is "
+               "not the first failure in EmuleHostWait.*, fix the first one first";
+    }
+
+    // Trip the tier-2 watchdog fast; re-read per run, and inherited by the death-test child.
+    static void arm_fast_watchdog() {
+        ::setenv("TT_EMULE_FIBER_PROGRESS_WINDOW", "2000", 1);
+        ::setenv("TT_EMULE_FIBER_WATCHDOG_SEC", "3", 1);
+        ::setenv("TT_EMULE_HOST_WAIT_WATCHDOG_SEC", "3", 1);  // parked time has its own, far larger, bound
+    }
+    static void disarm_fast_watchdog() {
+        ::unsetenv("TT_EMULE_FIBER_PROGRESS_WINDOW");
+        ::unsetenv("TT_EMULE_FIBER_WATCHDOG_SEC");
+        ::unsetenv("TT_EMULE_HOST_WAIT_WATCHDOG_SEC");
+    }
+};
+
+// The core contract: a host-fed poll is resumable, and pump() resumes the SAME fibers.
+TEST_F(EmuleHostWait, HostFedPollQuiescesToHostWaitAndPumpsToCompletion) {
+    std::atomic<bool> done{false};
+    std::atomic<unsigned> entries{0};
+    spawn_fiber(polling_body(&done, /*host_fed=*/true, &entries), 1, "h2d_receiver_poll");
+
+    auto& sched = FiberScheduler::instance();
+
+    // The run cannot advance without the host, and says so instead of dying.
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+    // No teardown happened: the fiber is still live, which is the entire point.
+    EXPECT_NE(sched.oldest_live_spawn_generation(), UINT64_MAX);
+    EXPECT_EQ(entries.load(), 1u);
+
+    // A pump with the socket still dry returns HostWait, without re-entering the body from the top.
+    ASSERT_EQ(sched.pump(), RunOutcome::HostWait);
+    EXPECT_EQ(entries.load(), 1u) << "pump re-ran a kernel body instead of resuming it";
+
+    // The host streamed. Now the run drains.
+    done.store(true, std::memory_order_release);
+    ASSERT_EQ(sched.pump(), RunOutcome::Completed);
+    EXPECT_EQ(entries.load(), 1u);
+}
+
+// A d2d sender is a PEER, so dying on this regex proves the attribution, not just the outcome.
+TEST_F(EmuleHostWait, PeerFedPollIsNamedAsPeerFedInTheDump) {
+    arm_fast_watchdog();
+    EXPECT_DEATH(
+        {
+            std::atomic<bool> never{false};
+            spawn_fiber(polling_body(&never, /*host_fed=*/false, nullptr), 3, "d2d_receiver_poll");
+            (void)FiberScheduler::instance().run_persistent();
+        },
+        "spin-polling a d2d socket");
+    disarm_fast_watchdog();
+}
+
+// The tag is sticky, so a kernel that LEAVES the loop must age out or it pins the run host-waiting.
+TEST_F(EmuleHostWait, StalePollTagAgesOut) {
+    arm_fast_watchdog();
+    EXPECT_DEATH(
+        {
+            // Tag once, then spin elsewhere: freshness is this fiber's own resumes, so its yields age it.
+            spawn_fiber(
+                [] {
+                    auto& sched = FiberScheduler::instance();
+                    sched.note_socket_poll_wait(/*waiting=*/true, /*host_fed=*/true);
+                    for (;;) {
+                        sched.yield();  // never re-tags
+                    }
+                },
+                4,
+                "poller_that_moved_on");
+            (void)FiberScheduler::instance().run_persistent();
+        },
+        "no global progress");
+    disarm_fast_watchdog();
+}
+
+// Parking must retire the tag: a parked fiber never resumes, so its freshness delta would freeze.
+TEST_F(EmuleHostWait, ParkingRetiresThePollTag) {
+    static uint32_t dead_key = 0;  // a key nobody will ever wake
+    std::atomic<bool> never{false};
+
+    spawn_fiber(
+        [&never] {
+            auto& sched = FiberScheduler::instance();
+            // Freshly tagged as host-waiting…
+            sched.note_socket_poll_wait(/*waiting=*/true, /*host_fed=*/true);
+            sched.yield();
+            // …then parks on a peer predicate. Loop required: quiescence force-releases before deciding.
+            while (!never.load(std::memory_order_acquire)) {
+                sched.lock();
+                sched.park_locked(&dead_key);  // releases the lock; nobody wakes this
+            }
+        },
+        5,
+        "poller_then_parked");
+
+    // Had the tag survived the park, its delta would be frozen and this would report HostWait forever.
+    EXPECT_THROW(FiberScheduler::instance().run_persistent(), FiberEngineStall);
+}
+
+// The OTHER half of any_waiting_on_host(): the path a blocking socket_wait_for_pages takes.
+TEST_F(EmuleHostWait, ParkedHostFedSocketWaitIsAHostWait) {
+    static uint32_t credit_word = 0;
+    std::atomic<bool> bytes_arrived{false};
+
+    spawn_fiber(
+        [&bytes_arrived] {
+            auto& sched = FiberScheduler::instance();
+            // Re-check on resume, as the real wait does: a force-release must re-park, not fall through.
+            while (!bytes_arrived.load(std::memory_order_acquire)) {
+                sched.lock();
+                sched.park_locked_socket(&credit_word);  // the HOST owes this one
+            }
+        },
+        6,
+        "h2d_receiver_blocking");
+
+    auto& sched = FiberScheduler::instance();
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+
+    // The host advances the credit word and wakes the receiver; the run drains.
+    bytes_arrived.store(true, std::memory_order_release);
+    sched.wake(&credit_word);
+    ASSERT_EQ(sched.pump(), RunOutcome::Completed);
+}
+
+// Nothing guarantees a next pump, so without the watchdog the job ends as a silent success.
+TEST_F(EmuleHostWait, UnpumpedHostWaitStillTripsTheWatchdog) {
+    arm_fast_watchdog();
+    EXPECT_DEATH(
+        {
+            static std::atomic<bool> never{false};
+            spawn_fiber(polling_body(&never, /*host_fed=*/true, nullptr), 15, "h2d_receiver_poll");
+            auto& sched = FiberScheduler::instance();
+            // A legitimate HostWait — this is NOT the failure. The failure is what follows.
+            if (sched.run_persistent() != RunOutcome::HostWait) {
+                std::exit(2);  // distinguishable from the abort this test expects
+            }
+            // The host walks away, so only a watchdog that outlived the return calls this a hang.
+            for (int i = 0; i < 60; ++i) {
+                ::usleep(200 * 1000);  // 12s total
+            }
+            std::exit(3);
+        },
+        "no global progress");
+    disarm_fast_watchdog();
+}
+
+// The mirror: a watchdog still ticking after the completing pump would abort the NEXT program.
+TEST_F(EmuleHostWait, CompletedRunLeavesNoWatchdogBehind) {
+    arm_fast_watchdog();
+    auto& sched = FiberScheduler::instance();
+
+    std::atomic<bool> done{false};
+    spawn_fiber(polling_body(&done, /*host_fed=*/true, nullptr), 16, "h2d_receiver_poll");
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+    done.store(true, std::memory_order_release);
+    ASSERT_EQ(sched.pump(), RunOutcome::Completed);
+
+    // Idle for longer than the armed backstop (3s). A leaked watchdog aborts the process here.
+    ::usleep(4500 * 1000);
+    disarm_fast_watchdog();
+
+    // And the engine is still usable: a fresh run works normally.
+    std::atomic<unsigned> ran{0};
+    spawn_fiber([&ran] { ran.fetch_add(1); }, 17, "post_gap_program");
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::Completed);
+    EXPECT_EQ(ran.load(), 1u);
+}
+
+// Outcome flags are per-launch: a stale host_wait_ frees the NEXT dispatch's keepalives under it.
+TEST_F(EmuleHostWait, EmptyLaunchAfterAStalledRunIsNotAHostWait) {
+    auto& sched = FiberScheduler::instance();
+
+    // Wedge a run: park on a key nobody wakes, no host-facing wait — the tier-1 teardown path.
+    static uint32_t dead_key = 0;
+    std::atomic<bool> never{false};
+    spawn_fiber(
+        [&never] {
+            auto& s = FiberScheduler::instance();
+            while (!never.load(std::memory_order_acquire)) {
+                s.lock();
+                s.park_locked(&dead_key);
+            }
+        },
+        18,
+        "wedged_kernel");
+    EXPECT_THROW(sched.run_persistent(), FiberEngineStall);
+    ASSERT_EQ(sched.oldest_live_spawn_generation(), UINT64_MAX);
+
+    // A dispatch registering nothing hits the empty-registry early return: an end, not a resume.
+    EXPECT_EQ(sched.run_persistent(), RunOutcome::Completed);
+    // And a pump against no registry stays a no-op rather than acting on a phantom run.
+    EXPECT_EQ(sched.pump(), RunOutcome::Completed);
+}
+
+// One CB slot per fiber, kept by the starving CB: recording the LAST probed points at a healthy one.
+TEST_F(EmuleHostWait, CbPollTagNamesTheStarvingCbNotTheLastProbed) {
+    arm_fast_watchdog();
+    EXPECT_DEATH(
+        {
+            spawn_fiber(
+                [] {
+                    auto& sched = FiberScheduler::instance();
+                    for (;;) {
+                        sched.note_cb_poll_wait(/*cb_id=*/3, /*n=*/2);  // wedged producer
+                        sched.note_cb_poll_wait(/*cb_id=*/9, /*n=*/1);  // healthy, momentarily empty
+                        sched.yield();
+                    }
+                },
+                19,
+                "compute_two_cb_probe");
+            (void)FiberScheduler::instance().run_persistent();
+        },
+        "spin-polling CB 3 for 2 page");
+    disarm_fast_watchdog();
+}
+
+// Generations gate the keepalive reclaim: a false "dead" frees DFB/ASAN state under a running kernel.
+TEST_F(EmuleHostWait, OldestLiveGenerationTracksLiveFibers) {
+    auto& sched = FiberScheduler::instance();
+
+    // Nothing registered.
+    ASSERT_EQ(sched.oldest_live_spawn_generation(), UINT64_MAX);
+
+    sched.begin_spawn_generation();
+    std::atomic<bool> done{false};
+    spawn_fiber(polling_body(&done, /*host_fed=*/true, nullptr), 8, "gen_a");
+
+    // Registered but not yet run: still live (not Done), so it must be reported.
+    EXPECT_NE(sched.oldest_live_spawn_generation(), UINT64_MAX);
+
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+    const uint64_t parked_gen = sched.oldest_live_spawn_generation();
+    EXPECT_NE(parked_gen, UINT64_MAX) << "a parked fiber must keep its generation alive";
+
+    // A later dispatch opens a newer generation; the parked run's older one is the floor.
+    sched.begin_spawn_generation();
+    EXPECT_EQ(sched.oldest_live_spawn_generation(), parked_gen);
+
+    done.store(true, std::memory_order_release);
+    ASSERT_EQ(sched.pump(), RunOutcome::Completed);
+    EXPECT_EQ(sched.oldest_live_spawn_generation(), UINT64_MAX);
+}
+
+// An age bound cannot express this: a parked run pins ONE generation for the whole sequence.
+TEST_F(EmuleHostWait, GenerationLivenessIsPerGenerationNotAnAgeBound) {
+    auto& sched = FiberScheduler::instance();
+
+    // Generation A parks for the duration — the socket relay.
+    std::atomic<bool> done{false};
+    const uint64_t gen_a = sched.begin_spawn_generation();
+    spawn_fiber(polling_body(&done, /*host_fed=*/true, nullptr), 20, "h2d_receiver_poll");
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+    EXPECT_TRUE(sched.spawn_generation_is_live(gen_a));
+
+    // Generation B is a compute stage dispatched on top of it; it runs to completion.
+    const uint64_t gen_b = sched.begin_spawn_generation();
+    spawn_fiber([] {}, 21, "compute_stage");
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+
+    // B's keepalives are reclaimable NOW, even though older A is still parked and pins the oldest.
+    EXPECT_FALSE(sched.spawn_generation_is_live(gen_b))
+        << "a finished generation must be reclaimable while an OLDER one is still parked";
+    EXPECT_TRUE(sched.spawn_generation_is_live(gen_a));
+    EXPECT_EQ(sched.oldest_live_spawn_generation(), gen_a);
+
+    done.store(true, std::memory_order_release);
+    ASSERT_EQ(sched.pump(), RunOutcome::Completed);
+    EXPECT_FALSE(sched.spawn_generation_is_live(gen_a));
+}
+
+// The normal host-interleaved case: integrate only the new fibers, disturbing no live one.
+TEST_F(EmuleHostWait, ResumingLaunchIntegratesNewFibersWithoutDisturbingLiveOnes) {
+    auto& sched = FiberScheduler::instance();
+
+    std::atomic<bool> done{false};
+    std::atomic<unsigned> receiver_entries{0};
+    sched.begin_spawn_generation();
+    spawn_fiber(polling_body(&done, /*host_fed=*/true, &receiver_entries), 9, "h2d_receiver_poll");
+
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+    ASSERT_EQ(receiver_entries.load(), 1u);
+    const uint64_t receiver_gen = sched.oldest_live_spawn_generation();
+    ASSERT_NE(receiver_gen, UINT64_MAX);
+
+    // A second program on top of the parked one runs to completion; the run quiesces to HostWait again.
+    std::atomic<unsigned> compute_entries{0};
+    sched.begin_spawn_generation();
+    spawn_fiber([&compute_entries] { compute_entries.fetch_add(1); }, 10, "compute_stage");
+
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+    EXPECT_EQ(compute_entries.load(), 1u) << "the newly registered fiber never ran";
+    EXPECT_EQ(receiver_entries.load(), 1u) << "the live fiber's body was re-entered";
+    // The receiver is still the oldest thing alive — the second program has finished.
+    EXPECT_EQ(sched.oldest_live_spawn_generation(), receiver_gen);
+
+    // A third dispatch: the retirement pass is the only non-teardown site that frees a 1 MiB stack.
+    std::atomic<unsigned> compute2_entries{0};
+    sched.begin_spawn_generation();
+    spawn_fiber([&compute2_entries] { compute2_entries.fetch_add(1); }, 11, "compute_stage_2");
+
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+    EXPECT_EQ(compute2_entries.load(), 1u);
+    EXPECT_EQ(receiver_entries.load(), 1u);
+
+    done.store(true, std::memory_order_release);
+    ASSERT_EQ(sched.pump(), RunOutcome::Completed);
+    EXPECT_EQ(sched.oldest_live_spawn_generation(), UINT64_MAX);
+}
+
+// drain_device() catches "will not drain" narrowly, so a kernel fault must not be that type.
+TEST_F(EmuleHostWait, EngineStallIsADistinctType) {
+    // A runtime_error, so existing broad handlers still see it…
+    EXPECT_TRUE((std::is_base_of<std::runtime_error, FiberEngineStall>::value));
+    // …but distinguishable, which is what lets a caller catch it and nothing broader.
+    try {
+        throw FiberEngineStall("stall");
+    } catch (const FiberEngineStall& e) {
+        EXPECT_STREQ(e.what(), "stall");
+    } catch (...) {
+        FAIL() << "FiberEngineStall was not caught by its own type";
+    }
+}
+
+TEST_F(EmuleHostWait, KernelFaultIsNotAnEngineStall) {
+    spawn_fiber([] { throw std::out_of_range("DFB range"); }, 12, "faulting_kernel");
+
+    // Propagates verbatim: widened to FiberEngineStall, drain_device() would swallow real faults.
+    EXPECT_THROW(FiberScheduler::instance().run_persistent(), std::out_of_range);
+}
+
+// A kernel fault outranks a host wait, or the throw lands on whichever program tears down next.
+TEST_F(EmuleHostWait, KernelFaultOutranksHostWait) {
+    std::atomic<bool> never{false};
+    spawn_fiber(polling_body(&never, /*host_fed=*/true, nullptr), 13, "h2d_receiver_poll");
+    spawn_fiber([] { throw std::out_of_range("DFB range"); }, 14, "faulting_kernel");
+
+    // Even though a host-fed poller is live and would otherwise force HostWait.
+    EXPECT_THROW(FiberScheduler::instance().run_persistent(), std::out_of_range);
+}
+
+// The drain backstop reads this rather than re-parsing the env var, which env_size reads differently.
+TEST_F(EmuleHostWait, StallLimitIsPositiveAndStable) {
+    const uint64_t a = FiberScheduler::host_wait_stall_limit();
+    EXPECT_GT(a, 0u) << "a zero bound would make pump() escalate on its first no-progress pump";
+    // Read once at first use, so it cannot drift — what lets the runner cache its floor as a static.
+    EXPECT_EQ(a, FiberScheduler::host_wait_stall_limit());
+}
+
+}  // namespace

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -52,6 +52,23 @@ bool logical_cores_intersect(
     return false;
 }
 
+#ifdef TT_METAL_USE_EMULE
+// Drive this mesh's parked run to completion. FENCE POINTS ONLY: draining a FEED path wedges it.
+void drain_emule_run(tt::tt_metal::distributed::MeshDevice* mesh_device, tt::TargetDevice target) {
+    if (target != tt::TargetDevice::Emule) {
+        return;
+    }
+    std::vector<int> device_ids;
+    device_ids.reserve(mesh_device->get_devices().size());
+    for (const auto& device : mesh_device->get_devices()) {
+        device_ids.push_back(static_cast<int>(device->id()));
+    }
+    tt::tt_metal::emule::drain_device(device_ids);
+}
+#else
+void drain_emule_run(tt::tt_metal::distributed::MeshDevice*, tt::TargetDevice) {}
+#endif
+
 }  // namespace
 
 namespace tt::tt_metal::distributed {
@@ -133,7 +150,8 @@ void SDMeshCommandQueue::read_shard_from_device(
     if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         return;  // Skip hardware read for mock devices
     }
-    // Wait for idle here to ensure that programs emitting this data are complete.
+    // Wait for idle so the programs emitting this data are complete; under emule the drain is what does it.
+    drain_emule_run(mesh_device_, get_target_device_type());
     wait_for_cores_idle();
     auto* device_buffer = buffer.get_device_buffer(device_coord);
     auto shard_view = device_buffer->view(region.value_or(BufferRegion(0, device_buffer->size())));
@@ -274,6 +292,8 @@ void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         // programs co-run in one scheduler generation and the teleport's fiber wake reaches the
         // parked receiver. Register all (deferred) sequentially (not the thread pool, to avoid a
         // fiber-registration race), then run once. See tt-emule docs/fiber-engine.md.
+        // Excludes the socket feeders' pump_device(): a dispatch onto a parked run resumes it.
+        tt::tt_metal::emule::MeshDispatchLock dispatch_lock;
         tt::tt_metal::emule::begin_mesh_dispatch();
         for (auto& [coord_range, program] : range_program_map) {
             dispatch_program(coord_range, program, /*blocking=*/false);  // register only (defer)
@@ -337,6 +357,7 @@ MeshEvent SDMeshCommandQueue::enqueue_record_event_to_host(
 
 void SDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent&) {
     auto lock = lock_api_function_();
+    drain_emule_run(mesh_device_, get_target_device_type());
     wait_for_cores_idle();
 }
 
@@ -376,6 +397,7 @@ void SDMeshCommandQueue::finish(ttsl::Span<const SubDeviceId>) {
         return;
     }
     auto lock = lock_api_function_();
+    drain_emule_run(mesh_device_, get_target_device_type());
     wait_for_cores_idle();
     for (const auto& device : mesh_device_->get_devices()) {
         tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id())

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -273,6 +273,12 @@ extern "C" void __emule_fiber_park_locked(const void* key) {
 extern "C" void __emule_fiber_park_locked_socket(const void* key) {
     efib::FiberScheduler::instance().park_locked_socket(key);
 }
+extern "C" void __emule_fiber_note_socket_poll_wait(int waiting, int host_fed) {
+    efib::FiberScheduler::instance().note_socket_poll_wait(waiting != 0, host_fed != 0);
+}
+extern "C" void __emule_fiber_note_cb_poll_wait(unsigned cb_id, unsigned n) {
+    efib::FiberScheduler::instance().note_cb_poll_wait(cb_id, n);
+}
 extern "C" void __emule_fiber_wake(const void* key) { efib::FiberScheduler::instance().wake(key); }
 extern "C" void __emule_fiber_yield(void) { efib::FiberScheduler::instance().yield(); }
 extern "C" void __emule_fiber_defer_to_quiescence(void) { efib::FiberScheduler::instance().quiescence_park(); }
@@ -3320,8 +3326,9 @@ struct EmuleSigfpeGuard {
 // execute_program_emulated REGISTERS its fibers (spawn, no run); run_mesh_dispatch then drives ONE
 // run_until_idle so all chips' fibers run concurrently. See tt-emule docs/fiber-engine.md.
 static bool g_emule_mesh_defer = false;
-static std::vector<std::vector<std::vector<std::unique_ptr<tt_emule::EmuleDFBInterface[]>>>>
-    g_mesh_dfb_keep;
+// Tagged with the dispatch's spawn generation; untagged, RSS grows monotonically with dispatch count.
+using MeshDfbKeep = std::vector<std::vector<std::unique_ptr<tt_emule::EmuleDFBInterface[]>>>;
+static std::vector<std::pair<uint64_t, MeshDfbKeep>> g_mesh_dfb_keep;
 // [MESH] ASAN snapshot keepalive. In defer mode the deferred fibers read the per-launch
 // live-range snapshot (via oob.state's pointers) only later, in run_mesh_dispatch — long
 // after dispatch_to_device's local OobStateOwner would have been destroyed. Without this
@@ -3329,13 +3336,64 @@ static std::vector<std::vector<std::vector<std::unique_ptr<tt_emule::EmuleDFBInt
 // semaphore OOB false positive). Holds each device's OobStateOwner alive until the run
 // completes; cleared alongside g_mesh_dfb_keep. std::move preserves the heap buffers the
 // pointers reference, so the captured views stay valid across the vector's own growth.
-static std::vector<tt::tt_metal::emule::OobStateOwner> g_mesh_oob_keep;
+static std::vector<std::pair<uint64_t, tt::tt_metal::emule::OobStateOwner>> g_mesh_oob_keep;
 
-// [HOST-INTERLEAVED SOCKET] Set when run_mesh_dispatch's run_persistent() returned HostWait: the mesh
-// run is parked awaiting host socket I/O, with g_mesh_dfb_keep + the scheduler's fibers kept alive.
-// pump_device() drives it forward per host socket call; the pump that completes clears this + the mesh
-// keepalives (the cleanup run_mesh_dispatch deferred). See tt-emule docs/socket-emulation.md §7.
-static bool g_emule_host_wait = false;
+// Per generation, not "older than the oldest live": a parked relay pins any age bound for the sequence.
+static uint64_t g_mesh_keep_gen = 0;
+static void reclaim_dead_mesh_keepalives() {
+    // ONE registry scan: the per-candidate query is quadratic in a full mesh's cores x RISCs fibers.
+    const auto live_gens = tt::tt_metal::emule_fiber::FiberScheduler::instance().live_spawn_generations();
+    const std::unordered_set<uint64_t> live(live_gens.begin(), live_gens.end());
+    auto dead = [&live](const auto& kv) { return live.count(kv.first) == 0; };
+    g_mesh_dfb_keep.erase(std::remove_if(g_mesh_dfb_keep.begin(), g_mesh_dfb_keep.end(), dead), g_mesh_dfb_keep.end());
+    g_mesh_oob_keep.erase(std::remove_if(g_mesh_oob_keep.begin(), g_mesh_oob_keep.end(), dead), g_mesh_oob_keep.end());
+}
+
+// Whose programs are in the registry, so one mesh's Finish cannot spend its budget on another's run.
+static std::mutex g_emule_run_device_ids_mu;
+static std::unordered_set<int> g_emule_run_device_ids;
+static void run_device_ids_insert(int id) {
+    std::lock_guard<std::mutex> g(g_emule_run_device_ids_mu);
+    g_emule_run_device_ids.insert(id);
+}
+static void run_device_ids_erase(int id) {
+    std::lock_guard<std::mutex> g(g_emule_run_device_ids_mu);
+    g_emule_run_device_ids.erase(id);
+}
+static void run_device_ids_clear() {
+    std::lock_guard<std::mutex> g(g_emule_run_device_ids_mu);
+    g_emule_run_device_ids.clear();
+}
+// True when the set is empty, or when any of `ids` is in it (i.e. this caller owns the parked run).
+static bool run_device_ids_owns(const std::vector<int>& ids) {
+    std::lock_guard<std::mutex> g(g_emule_run_device_ids_mu);
+    if (g_emule_run_device_ids.empty()) {
+        return true;
+    }
+    for (int id : ids) {
+        if (g_emule_run_device_ids.count(id) != 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Process-lifetime storage for FiberIdentity::kernel_src; node-based, so addresses survive rehash.
+static const char* intern_kernel_name(const std::string& name) {
+    if (name.empty()) {
+        return nullptr;
+    }
+    static std::mutex mu;
+    static std::unordered_set<std::string> table;
+    std::lock_guard<std::mutex> g(mu);
+    return table.insert(name).first->c_str();
+}
+
+// [HOST-INTERLEAVED SOCKET] Parked on host socket I/O, fibers alive; pump_device() drives it, the last pump clears it.
+static std::atomic<bool> g_emule_host_wait{false};
+
+// Serializes worker-pool drivers: pump_device() + MeshDispatchLock; run_persistent() returns at quiescence.
+static std::mutex g_emule_run_mu;
 
 // Resolved-program cache — emule's analogue of silicon's is_compiled(): collect + JIT compile + resolve
 // run ONCE per program (keyed by ProgramId); every device dispatches against the shared read-only result.
@@ -3347,7 +3405,8 @@ struct ResolvedProgram {
     std::map<CoreCoord, std::vector<KernelInfo>> core_kernels;
     uint32_t emule_sem_base = 0;
 };
-static std::unordered_map<ProgramId, ResolvedProgram> g_resolved_programs;
+// shared_ptr: every fiber holds a ref, so LRU eviction must drop only the CACHE's or a KernelInfo* dangles.
+static std::unordered_map<ProgramId, std::shared_ptr<ResolvedProgram>> g_resolved_programs;
 static std::deque<ProgramId> g_resolved_lru;
 static constexpr size_t kMaxResolvedPrograms = 256;
 
@@ -3370,7 +3429,9 @@ static void launch_cores(
     std::unordered_map<uint64_t, tt_emule::Core*>* core_map_ptr,
     ChipId device_id,
     bool defer_run,
-    const EmuleOobTensorState& oob_state) {
+    const EmuleOobTensorState& oob_state,
+    // What the CoreSetups' KernelInfo pointers point into; each fiber below captures a copy of the owner.
+    const std::shared_ptr<ResolvedProgram>& resolved_owner) {
 #if defined(__x86_64__) && defined(__linux__)
     EmuleSigfpeGuard sigfpe_guard;
 #endif
@@ -3476,9 +3537,8 @@ static void launch_cores(
             id.logical_x = lx;
             id.logical_y = ly;
             id.proc_id = ki.processor_id;
-            // Point at the KernelInfo's owned source-path string (lives for the program run) so the
-            // quiescent-deadlock dump names each parked fiber's kernel.
-            id.kernel_src = ki.kernel_name.empty() ? nullptr : ki.kernel_name.c_str();
+            // Interned, not ki.kernel_name.c_str(): the hang dump reads this after the closure is gone.
+            id.kernel_src = intern_kernel_name(ki.kernel_name);
 
             // The fiber entry is the kernel body. __emule_self is set by the scheduler
             // on swap-in; the no-op start-barrier of the OS-thread model is gone (a
@@ -3500,6 +3560,8 @@ static void launch_cores(
                  l1_data,
                  intent_tracker,
                  oob_state,
+                 // ki_ptr points into it, and the LRU can evict it while this fiber is parked.
+                 resolved_owner,
                  sem_base = cs.sem_base,
                  sem_size = cs.sem_size]() {
                     auto& ki = *ki_ptr;
@@ -3570,7 +3632,7 @@ static void launch_cores(
         // borrow alive until run_mesh_dispatch (the spawned ctx is already owned by the
         // scheduler; core_kernels is kept by execute_program_emulated). The SIGFPE guard
         // above is a no-op here since no kernel runs; run_mesh_dispatch installs its own.
-        g_mesh_dfb_keep.push_back(std::move(dfb_keepalive));
+        g_mesh_dfb_keep.emplace_back(g_mesh_keep_gen, std::move(dfb_keepalive));
         return;
     }
 
@@ -3584,7 +3646,7 @@ static void launch_cores(
 // ProgramId — emule's analogue of silicon's CompileProgram. The first mesh device resolves; the rest
 // reuse, taking its (homogeneous-chip-identical) compile defines. See tt-emule docs/metal-integration.md.
 // ---------------------------------------------------------------------------
-static ResolvedProgram& prepare_program(IDevice* device, Program& program) {
+static std::shared_ptr<ResolvedProgram> prepare_program(IDevice* device, Program& program) {
     // Single-writer invariant for g_resolved_programs/g_resolved_lru: this runs only on the
     // sequential dispatch thread (register phase), never inside a fiber. __emule_self is the
     // running fiber (set on worker threads, null on the dispatch thread), so off-fiber == null.
@@ -3662,13 +3724,14 @@ static ResolvedProgram& prepare_program(IDevice* device, Program& program) {
         }
     }
 
-    // LRU-bound the cache (safety net; entries are otherwise valid for the program's life).
+    // LRU-bound the cache; erasing drops only the cache's ref, so a parked run's entry survives eviction.
     if (g_resolved_programs.size() >= kMaxResolvedPrograms && !g_resolved_lru.empty()) {
         g_resolved_programs.erase(g_resolved_lru.front());
         g_resolved_lru.pop_front();
     }
     g_resolved_lru.push_back(pid);
-    return g_resolved_programs.emplace(pid, std::move(resolved)).first->second;
+    auto entry = std::make_shared<ResolvedProgram>(std::move(resolved));
+    return g_resolved_programs.emplace(pid, std::move(entry)).first->second;
 }
 
 // ---------------------------------------------------------------------------
@@ -3677,7 +3740,8 @@ static ResolvedProgram& prepare_program(IDevice* device, Program& program) {
 // chip's DRAM backing) and the bank-table globals are per device.
 // ---------------------------------------------------------------------------
 static void dispatch_to_device(
-    IDevice* device, Program& program, ResolvedProgram& resolved, bool defer_run) {
+    IDevice* device, Program& program, const std::shared_ptr<ResolvedProgram>& resolved_owner, bool defer_run) {
+    ResolvedProgram& resolved = *resolved_owner;
     auto& impl = program.impl();
     auto device_id = device->id();
     auto* sw_emu = get_sw_emulated_chip(device_id);
@@ -3694,11 +3758,11 @@ static void dispatch_to_device(
     uint8_t* dram_data = dram_core ? dram_core->l1_data() : nullptr;
 
     OobStateOwner oob = build_oob_tensor_state(device, device_id);
-    launch_cores(core_setups, dram_data, core_map_ptr, device_id, defer_run, oob.state);
+    launch_cores(core_setups, dram_data, core_map_ptr, device_id, defer_run, oob.state, resolved_owner);
     if (defer_run) {
         // Deferred fibers run later (run_mesh_dispatch); keep the snapshot vectors that
         // oob.state's ASAN range pointers reference alive until then. See g_mesh_oob_keep.
-        g_mesh_oob_keep.push_back(std::move(oob));
+        g_mesh_oob_keep.emplace_back(g_mesh_keep_gen, std::move(oob));
     }
 }
 
@@ -3714,7 +3778,7 @@ void execute_program_emulated(IDevice* device, Program& program) {
     // routes stay scoped to the current op (this op's builds already recorded before this launch).
     g_conn_route_dirty.store(true, std::memory_order_relaxed);
 
-    ResolvedProgram& resolved = prepare_program(device, program);  // compile-once (memoized)
+    std::shared_ptr<ResolvedProgram> resolved = prepare_program(device, program);  // compile-once (memoized)
 
     // Restore this program's routing into the globals before any 1D send resolves, so a program-cache hit
     // reinstates its own directions over an intervening op's. Keyed by pid (never evicted); g_worker_dir is a
@@ -3730,6 +3794,18 @@ void execute_program_emulated(IDevice* device, Program& program) {
     }
 
     const bool defer = g_emule_mesh_defer;  // mesh register phase (the run is deferred)
+    // Remember whose fibers are in the registry, so a later Finish knows if the run is its own.
+    run_device_ids_insert(static_cast<int>(device_id));
+    // The non-deferred path finishes inside dispatch_to_device, so its id must not outlive the call.
+    struct DeviceIdScope {
+        int id;
+        bool armed;
+        ~DeviceIdScope() {
+            if (armed) {
+                run_device_ids_erase(id);
+            }
+        }
+    } id_scope{static_cast<int>(device_id), !defer};
     dispatch_to_device(device, program, resolved, defer);
 
     if (defer) {
@@ -3743,10 +3819,27 @@ void execute_program_emulated(IDevice* device, Program& program) {
 // Mesh register/run split (see header). begin_mesh_dispatch puts execute_program_emulated
 // into defer mode; run_mesh_dispatch drives the single concurrent run + frees kept state.
 // ---------------------------------------------------------------------------
+MeshDispatchLock::MeshDispatchLock() { g_emule_run_mu.lock(); }
+MeshDispatchLock::~MeshDispatchLock() { g_emule_run_mu.unlock(); }
+
 void begin_mesh_dispatch() {
     g_emule_mesh_defer = true;
+    // Tag FROM the scheduler (a parallel counter drifts): a blanket clear frees arrays under live fibers.
+    g_mesh_keep_gen = tt::tt_metal::emule_fiber::FiberScheduler::instance().begin_spawn_generation();
+    reclaim_dead_mesh_keepalives();
+    // Ids from a register phase that threw before launch belong to no run; a parked one keeps its ids.
+    if (!g_emule_host_wait) {
+        run_device_ids_clear();
+    }
+}
+
+// Drop a parked run's state; pre: the registry is gone. A stale flag lets a feeder kill the next dispatch.
+static void clear_host_interleaved_state() {
+    g_emule_host_wait = false;
+    g_emule_mesh_defer = false;
     g_mesh_dfb_keep.clear();
     g_mesh_oob_keep.clear();
+    run_device_ids_clear();
 }
 
 void run_mesh_dispatch() {
@@ -3758,12 +3851,9 @@ void run_mesh_dispatch() {
     struct Cleanup {
         bool armed = true;
         ~Cleanup() {
-            if (!armed) {
-                return;
+            if (armed) {
+                clear_host_interleaved_state();
             }
-            g_emule_mesh_defer = false;
-            g_mesh_dfb_keep.clear();
-            g_mesh_oob_keep.clear();
         }
     } cleanup;
     // All devices' fibers were registered (spawned) during the per-device register phase; run them
@@ -3784,16 +3874,8 @@ void run_mesh_dispatch() {
     // Completed synchronously (no host-fed socket wait): the RAII Cleanup frees the kept state.
 }
 
-void pump_device() {
-    // Drive a parked (run_persistent) mesh run forward one scheduler quantum. No-op unless a run is
-    // parked in HostWait (set by run_mesh_dispatch). The host advanced a socket credit word by a raw
-    // L1 store, so pump() blanket-re-polls the parked fibers to re-check predicates. When every fiber
-    // reaches Done the pump returns Completed — run the mesh cleanup run_mesh_dispatch deferred.
-    //
-    // Serialize: a host program drives H2D and D2H on separate threads, so both credit-wait loops can
-    // call pump_device() concurrently; the single resumable run + g_emule_host_wait are not reentrant.
-    static std::mutex pump_mu;
-    std::lock_guard<std::mutex> pump_lk(pump_mu);
+// pre: g_emule_run_mu held. See pump_device().
+static void pump_device_locked() {
     if (!g_emule_host_wait) {
         return;
     }
@@ -3805,20 +3887,110 @@ void pump_device() {
     try {
         auto oc = tt::tt_metal::emule_fiber::FiberScheduler::instance().pump();
         if (oc == tt::tt_metal::emule_fiber::RunOutcome::Completed) {
-            g_emule_host_wait = false;
-            g_emule_mesh_defer = false;
-            g_mesh_dfb_keep.clear();
-            g_mesh_oob_keep.clear();
+            clear_host_interleaved_state();
         }
     } catch (...) {
         // pump() threw (kernel exception / host-wait stall deadlock) — the scheduler registry is torn
         // down; drop the mesh keepalives + host-wait/defer flags so a later dispatch starts clean.
-        g_emule_host_wait = false;
-        g_emule_mesh_defer = false;
-        g_mesh_dfb_keep.clear();
-        g_mesh_oob_keep.clear();
+        clear_host_interleaved_state();
         throw;
     }
+}
+
+void pump_device() {
+    // One scheduler quantum. pump() re-polls: the host's credit store was a raw L1 write with no wake.
+    std::lock_guard<std::mutex> g(g_emule_run_mu);
+    pump_device_locked();
+}
+
+// Drain backstop, defaulted above the engine's bound so a wedged run escalates there first. 0 = unbounded.
+static uint64_t drain_max_pumps() {
+    // Strict: strtoull's unsigned wrap would turn "-1" into ~1.8e19 pumps inside Finish().
+    auto parse_u64 = [](const char* name, uint64_t fallback, bool* present) -> uint64_t {
+        const char* v = std::getenv(name);
+        if (present != nullptr) {
+            *present = (v != nullptr && v[0] != '\0');
+        }
+        if (v == nullptr || v[0] == '\0') {
+            return fallback;
+        }
+        errno = 0;
+        char* end = nullptr;
+        const unsigned long long n = std::strtoull(v, &end, 10);
+        if (end == v || *end != '\0' || errno == ERANGE || std::strchr(v, '-') != nullptr) {
+            log_warning(tt::LogMetal, "{}='{}' is not a non-negative integer; using {}", name, v, fallback);
+            if (present != nullptr) {
+                *present = false;
+            }
+            return fallback;
+        }
+        return static_cast<uint64_t>(n);
+    };
+
+    // From the engine, not a re-parse: env_size and parse_u64 disagree on 0 and on trailing garbage.
+    const uint64_t engine_limit = tt::tt_metal::emule_fiber::FiberScheduler::host_wait_stall_limit();
+    // Saturating: a wrapping `engine_limit + 64` inverts the floor and abandons a healthy run.
+    const uint64_t floor_pumps = engine_limit > UINT64_MAX - 64 ? UINT64_MAX : engine_limit + 64;
+
+    bool present = false;
+    const uint64_t n = parse_u64("TT_EMULE_DRAIN_MAX_PUMPS", floor_pumps, &present);
+    if (!present) {
+        return floor_pumps;
+    }
+    if (n == 0) {
+        return UINT64_MAX;  // explicit "unbounded" — the engine's own limits still terminate it
+    }
+    if (n < floor_pumps) {
+        log_warning(
+            tt::LogMetal,
+            "TT_EMULE_DRAIN_MAX_PUMPS={} is below the engine's host-wait stall limit ({}), so a "
+            "wedged run will be abandoned still-parked instead of escalating; using it anyway",
+            n,
+            engine_limit);
+    }
+    return n;
+}
+
+void drain_device(const std::vector<int>& device_ids) {
+    if (!g_emule_host_wait) {
+        return;
+    }
+    // Finish means idle on return, and a run past its termination signal has no credit loop driving it.
+    static const uint64_t max_pumps = drain_max_pumps();
+    for (uint64_t i = 0; i < max_pumps; ++i) {
+        // Re-read every pass under the pumping lock: the run can complete and another mesh park a new one.
+        std::lock_guard<std::mutex> g(g_emule_run_mu);
+        if (!g_emule_host_wait) {
+            break;
+        }
+        if (!device_ids.empty() && !run_device_ids_owns(device_ids)) {
+            return;  // not ours (any more) — leave it to its own Finish
+        }
+        pump_device_locked();
+    }
+    // Bound hit, run still parked: hand it to the engine. Locked — this tears down the pump's registry.
+    std::lock_guard<std::mutex> g(g_emule_run_mu);
+    if (!g_emule_host_wait) {
+        return;
+    }
+    try {
+        tt::tt_metal::emule_fiber::FiberScheduler::instance().abandon_host_wait(fmt::format(
+            "EMULE fiber engine: drain_device gave up after {} pumps with the run still parked. "
+            "The engine's host-wait liveness bound ({} no-progress pumps) never escalated, so some "
+            "global progress kept resetting it while the awaited socket never advanced. The usual "
+            "cause is host ordering: a Finish/synchronize_device or a device read issued BEFORE the "
+            "socket data the parked kernels are waiting for was streamed. On silicon that ordering "
+            "hangs; here it is bounded and reported. If the feed is merely slow, raise "
+            "TT_EMULE_DRAIN_MAX_PUMPS; to get the engine's own escalation (and its dump) first, "
+            "lower TT_EMULE_HOST_WAIT_STALL_LIMIT.",
+            max_pumps,
+            tt::tt_metal::emule_fiber::FiberScheduler::host_wait_stall_limit()));
+    } catch (...) {
+        clear_host_interleaved_state();
+        throw;
+    }
+    // abandon_host_wait found no registry to tear down, so the flags outlived the run they described.
+    clear_host_interleaved_state();
 }
 
 }  // namespace tt::tt_metal::emule

--- a/tt_metal/impl/emulation/emulated_program_runner.hpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <vector>
+
 namespace tt::tt_metal {
 class IDevice;
 class Program;
@@ -24,10 +26,22 @@ void execute_program_emulated(IDevice* device, Program& program);
 void begin_mesh_dispatch();
 void run_mesh_dispatch();
 
+/// Hold across begin_mesh_dispatch()..run_mesh_dispatch(): pump() drives the same worker pool.
+class MeshDispatchLock {
+public:
+    MeshDispatchLock();
+    ~MeshDispatchLock();
+    MeshDispatchLock(const MeshDispatchLock&) = delete;
+    MeshDispatchLock& operator=(const MeshDispatchLock&) = delete;
+};
+
 /// Host-interleaved socket dispatch: drive a parked (run_persistent) device forward one scheduler
 /// quantum. Called from the host's H2D/D2H socket credit-wait loops (distributed/{h2d,d2h}_socket.cpp)
 /// so kernels blocked on a host-fed socket wait resume as the host streams tokens after program.run().
 /// No-op unless a run is parked in HostWait. See tt-emule docs/socket-emulation.md §7.
 void pump_device();
+
+/// Drive a parked run this caller owns to completion, so Finish means what it does on silicon. Throws.
+void drain_device(const std::vector<int>& device_ids);
 
 }  // namespace tt::tt_metal::emule

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -12,14 +12,19 @@
 #include <cxxabi.h>  // demangle the op symbol
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
+#include <cassert>
+#include <cerrno>
 #include <chrono>
+#include <iterator>
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <deque>
+#include <limits>
 #include <mutex>
 #include <sstream>
 #include <stdexcept>
@@ -56,6 +61,18 @@ struct Fiber {
     Fiber* park_link = nullptr;     // intrusive parked-list
     bool wait_is_socket = false;    // parked on a host-fed socket credit word (park_locked_socket):
                                     // marks a quiescence as "waiting for host I/O", not a deadlock
+    bool in_ready = false;          // already in ready_[home]; unguarded, interleaved wakes park it twice
+    // Poll tags: written only by this fiber's worker, read by peers and the watchdog, so all atomic.
+    std::atomic<bool> socket_poll_waiting{false};  // spin-polling an empty socket. Ready, not parked
+    std::atomic<bool> poll_is_host_fed{false};     // sender is the HOST (h2d); a d2d poll is never host-resumable
+    // Refreshed unlocked by this fiber's worker; locking a hot spin loop would serialize the pool.
+    std::atomic<uint64_t> own_resumes{0};      // times THIS fiber ran; freshness measures against it, not resumptions_
+    std::atomic<uint64_t> poll_wait_stamp{0};  // own_resumes at last refresh; sticky, so staleness retires the tag
+    std::atomic<bool> cb_poll_waiting{false};  // as above for cb_pages_available_at_front: peer-fed, never a host wait
+    std::atomic<uint32_t> cb_poll_id{0};
+    std::atomic<uint32_t> cb_poll_n{0};
+    std::atomic<uint64_t> cb_poll_stamp{0};
+    uint64_t spawn_gen = 0;  // dispatch generation spawned in; gates keepalive reclaim (oldest_live_spawn_generation)
     std::exception_ptr eptr;
     unsigned home = 0;              // pinned worker — a fiber NEVER migrates (the JIT kernel
                                     // caches the thread_local __emule_self address)
@@ -77,10 +94,19 @@ thread_local unsigned   t_worker = 0;      // this worker's index (== home of it
 size_t env_size(const char* name, size_t dflt) {
     if (const char* s = std::getenv(name)) {
         char* end = nullptr;
+        errno = 0;
         unsigned long long v = std::strtoull(s, &end, 10);
-        if (end != s && v > 0) return static_cast<size_t>(v);
+        // Reject out-of-range: callers derive bounds from these, and a saturated ULLONG_MAX wraps them.
+        if (end != s && errno != ERANGE && v > 0) {
+            return static_cast<size_t>(v);
+        }
     }
     return dflt;
+}
+
+// Is a sticky poll tag current? Guarded: the watchdog samples both atomics unlocked, so resumes < stamp.
+bool poll_tag_is_fresh(uint64_t resumes, uint64_t stamp, uint64_t staleness) {
+    return resumes < stamp || (resumes - stamp) <= staleness;
 }
 
 }  // namespace
@@ -97,6 +123,7 @@ struct FiberSchedulerImpl {
                                                        // at lowest priority, released only once the
                                                        // scheduler reaches quiescence (below)
     std::vector<std::unique_ptr<Fiber>> all_;          // ownership of every spawned fiber
+    size_t launched_watermark_ = 0;                    // prefix of all_ integrated; only all_[watermark..] may enqueue
 
     unsigned K_ = 1;           // persistent pool size (read once at pool creation)
     unsigned W_ = 0;           // workers ACTIVE this program = min(K_, fiber count); only
@@ -111,6 +138,9 @@ struct FiberSchedulerImpl {
     bool persistent_ = false;  // run_persistent/pump in flight: a host-fed socket wait quiescing is
                                // a resumable HostWait, not a tier-1 deadlock. See run_persistent().
     bool host_wait_ = false;   // set by inner_loop when it broke out for host I/O (vs Done/deadlock)
+    unsigned socket_poll_waiters_ = 0;  // fibers TAGGED spin-polling (under mu_). Sticky gate; freshness decides
+    uint64_t poll_wait_staleness_ = 64;  // resumes a tag stays credible unrefreshed; per-fiber, so peers can't age it
+    unsigned cb_poll_waiters_ = 0;  // as socket_poll_waiters_, but for CB probes (peer-fed)
     std::exception_ptr first_eptr_;
 
     std::atomic<uint64_t> progress_{0};      // fiber completions + published pages (tier 2)
@@ -127,6 +157,10 @@ struct FiberSchedulerImpl {
     // runs never trigger. See tt-emule docs/fiber-engine.md.
     uint64_t last_progress_val_ = 0;
     uint64_t last_progress_resump_ = 0;
+    // Force-releases that moved neither progress_ nor the fingerprint: not lost-wakeup victims.
+    unsigned barren_releases_ = 0;
+    uint64_t last_parked_sig_ = 0;
+    bool last_parked_sig_valid_ = false;
     uint64_t last_deadlock_repoll_progress_ = UINT64_MAX;  // sentinel = never re-polled
 
     // Host-wait liveness bound (reset per persistent SEQUENCE in run_persistent, NOT per launch).
@@ -135,6 +169,17 @@ struct FiberSchedulerImpl {
     // no diagnostic; pump() escalates to a tier-1 deadlock after kHostWaitNoProgressLimit such pumps.
     // See tt-emule docs/socket-emulation.md.
     uint64_t host_wait_no_progress_pumps_ = 0;
+
+    // Tier-2 watchdog. A HostWait return leaves it RUNNING (the gap's only guard); launch/teardown reaps.
+    std::thread wd_;
+    // Parked between pumps: HOST latency, so the watchdog swaps bounds and re-clocks at the park.
+    std::atomic<bool> host_wait_parked_{false};
+
+    // Stamped onto each spawned fiber; bumped by begin_spawn_generation() per dispatch register phase.
+    uint64_t spawn_gen_ = 0;
+
+    // Reason for the FiberEngineStall a teardown throws; empty = tier-1 quiescent deadlock.
+    std::string stall_reason_;
 
     size_t stack_bytes_ = 1u << 20;          // 1 MB default
 
@@ -164,8 +209,103 @@ struct FiberSchedulerImpl {
         }
         return false;
     }
+    // The tag is sticky, so filter by freshness: one dead poller would hide every later deadlock.
+    bool any_fresh_socket_poll_waiter() const {
+        if (socket_poll_waiters_ == 0) {
+            return false;
+        }
+        for (const auto& up : all_) {
+            const Fiber* f = up.get();
+            if (f->socket_poll_waiting.load(std::memory_order_relaxed) &&
+                f->poll_is_host_fed.load(std::memory_order_relaxed) && f->state != FiberState::Done &&
+                poll_tag_is_fresh(
+                    f->own_resumes.load(std::memory_order_relaxed),
+                    f->poll_wait_stamp.load(std::memory_order_relaxed),
+                    poll_wait_staleness_)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    bool any_waiting_on_host() const { return any_fresh_socket_poll_waiter() || any_parked_is_socket_wait(); }
+    // Waker is a peer, not the host: a raw-NOC d2d publish runs no __emule_fiber_wake, hence the release.
+    bool any_parked_non_socket() const {
+        for (const auto& kv : parked_) {
+            for (Fiber* f = kv.second; f; f = f->park_link) {
+                if (!f->wait_is_socket) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    // "Who is parked on what": progress_ misses a recovery that only moves a raw L1 word. pre: mu_ held.
+    uint64_t parked_signature() const {
+        // Order-independent: every release refills parked_, so iteration order changes without motion.
+        auto mix = [](uint64_t v) {
+            v ^= v >> 33;
+            v *= 0xff51afd7ed558ccdull;
+            v ^= v >> 33;
+            return v;
+        };
+        uint64_t sig = mix(parked_.size());
+        for (const auto& kv : parked_) {
+            const uint64_t k = reinterpret_cast<uintptr_t>(kv.first);
+            for (Fiber* f = kv.second; f; f = f->park_link) {
+                // Pair fiber with key: a move between two existing keys changes neither size nor key set.
+                sig += mix(k ^ mix(reinterpret_cast<uintptr_t>(f)));
+            }
+        }
+        return sig;
+    }
+    // Single idempotent funnel onto the pinned ready queue: a twice-queued fiber corrupts parked_.
+    void enqueue_ready(Fiber* f) {
+        // A queued fiber is always Ready; Parked, the write below would run it still linked into parked_.
+        assert(!f->in_ready || f->state == FiberState::Ready);
+        f->state = FiberState::Ready;
+        if (f->in_ready) {
+            return;
+        }
+        f->in_ready = true;
+        ready_[f->home].push_back(f);
+    }
+    // Wake EVERY parked fiber to re-check its predicate; spurious-wake-safe. pre: mu_ held.
+    void release_all_parked() {
+        for (auto& kv : parked_) {
+            Fiber* f = kv.second;
+            while (f) {
+                Fiber* nx = f->park_link;
+                f->park_link = nullptr;
+                f->park_key = nullptr;
+                f->wait_is_socket = false;
+                enqueue_ready(f);  // sets Ready; idempotent if already queued
+                f = nx;
+            }
+        }
+        parked_.clear();
+    }
+    // Release the quiescence-deferred set back to ready (spin release, or quiescence). pre: mu_ held.
+    void release_quiescence_deferred() {
+        for (Fiber* f : quiescence_deferred_) {
+            enqueue_ready(f);
+        }
+        quiescence_deferred_.clear();
+    }
     std::string dump_parked();               // single-threaded (post-join)
     void watchdog();                         // tier-2
+    void stop_watchdog();                    // clear run_active_ + join wd_; no-op if not running
+    // Retire this fiber's poll tags: they age on its own resumes, so an unresumed one stays fresh forever.
+    void retire_poll_tags(Fiber* f) {
+        if (f->socket_poll_waiting.load(std::memory_order_relaxed)) {
+            f->socket_poll_waiting.store(false, std::memory_order_relaxed);
+            f->poll_is_host_fed.store(false, std::memory_order_relaxed);
+            --socket_poll_waiters_;
+        }
+        if (f->cb_poll_waiting.load(std::memory_order_relaxed)) {
+            f->cb_poll_waiting.store(false, std::memory_order_relaxed);
+            --cb_poll_waiters_;
+        }
+    }
     std::atomic<bool> run_active_{false};
 };
 
@@ -179,6 +319,7 @@ static void fiber_trampoline() {
         f->eptr = std::current_exception();
     }
     impl->mu_.lock();                        // re-lock so the worker loop resumes mu_-held
+    impl->retire_poll_tags(f);               // a fiber that exits mid-poll must not leak its tally
     f->state = FiberState::Done;
     swapcontext(&f->ctx, &t_sched);          // -> worker loop (never returns here)
 }
@@ -230,6 +371,8 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
     // scheduler churns this many resumptions with zero progress. Below the tier-2
     // livelock backstop (TT_EMULE_FIBER_PROGRESS_WINDOW) and above healthy churn.
     static const uint64_t spin_release_window = env_size("TT_EMULE_SPIN_RELEASE_WINDOW", 4096);
+    // Barren releases before HostWait stops deferring to them; each costs a full window, two overrun tier-2.
+    static const uint64_t barren_release_limit = env_size("TT_EMULE_BARREN_RELEASE_LIMIT", 1);
     for (;;) {
         if (abort_flag_) break;
         // Spin-starvation release: a kernel busy-wait (do{invalidate_l1_cache();}while
@@ -238,42 +381,35 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
         // raw-store lost wakeup never re-checks. On churn past the window with zero
         // progress, force-complete the reads AND wake every parked fiber to re-poll its
         // predicate. Gated so healthy runs (progress advancing) never trigger.
-        if (!quiescence_deferred_.empty() || !parked_.empty()) {
+        // socket_poll_waiters_ is in the guard: a poll-only program parks and defers nothing.
+        if (!quiescence_deferred_.empty() || !parked_.empty() || socket_poll_waiters_ != 0 || cb_poll_waiters_ != 0) {
             uint64_t p = progress_.load(std::memory_order_relaxed);
             uint64_t r = resumptions_.load(std::memory_order_relaxed);
             if (p != last_progress_val_) {
                 last_progress_val_ = p;
                 last_progress_resump_ = r;
+                barren_releases_ = 0;  // the last release (or normal execution) got somewhere
+                last_parked_sig_valid_ = false;
             } else if (r - last_progress_resump_ > spin_release_window) {
-                // Persistent (host-interleaved) run: churn with zero progress while a host-fed socket
-                // wait is parked means the device is blocked on the host (a peer RISC yield-spins on a
-                // barrier whose other side awaits a socket token). Hand control back so the host can
-                // stream + pump(), rather than force-releasing (which only re-churns). This is the
-                // yield-spin HostWait trigger (vs the quiescence-parked one below). See run_persistent.
-                if (persistent_ && any_parked_is_socket_wait()) {
+                // Was the PREVIOUS release barren? Sample pre-release; afterwards parked_ says nothing.
+                const uint64_t sig = parked_signature();
+                if (last_parked_sig_valid_ && sig != last_parked_sig_) {
+                    barren_releases_ = 0;  // something moved; the release earned another round
+                }
+                last_parked_sig_ = sig;
+                last_parked_sig_valid_ = true;
+                // Yield-spin HostWait trigger: all waits host-fed, or peer-parked but N releases moved nothing.
+                if (persistent_ && any_waiting_on_host() &&
+                    (!any_parked_non_socket() || barren_releases_ >= barren_release_limit)) {
                     host_wait_ = true;
                     abort_flag_ = true;
                     cv_.notify_all();
                     break;
                 }
-                for (Fiber* f : quiescence_deferred_) {
-                    f->state = FiberState::Ready;
-                    ready_[f->home].push_back(f);
-                }
-                quiescence_deferred_.clear();
-                for (auto& kv : parked_) {
-                    Fiber* f = kv.second;
-                    while (f) {
-                        Fiber* nx = f->park_link;
-                        f->park_link = nullptr;
-                        f->park_key = nullptr;
-                        f->state = FiberState::Ready;
-                        ready_[f->home].push_back(f);
-                        f = nx;
-                    }
-                }
-                parked_.clear();
+                release_quiescence_deferred();
+                release_all_parked();
                 cv_.notify_all();
+                ++barren_releases_;         // provisional; cleared next round if anything moved
                 last_progress_resump_ = r;  // re-arm; don't re-fire until more churn
             }
         }
@@ -292,11 +428,7 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
                 // barrier, or a two-producer cb_wait_front letting its co-producer run).
                 // See tt-emule docs/fiber-engine.md.
                 if (!quiescence_deferred_.empty()) {
-                    for (Fiber* f : quiescence_deferred_) {
-                        f->state = FiberState::Ready;
-                        ready_[f->home].push_back(f);
-                    }
-                    quiescence_deferred_.clear();
+                    release_quiescence_deferred();
                     cv_.notify_all();
                     --idle_;
                     continue;
@@ -314,18 +446,7 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
                     uint64_t p = progress_.load(std::memory_order_relaxed);
                     if (p != last_deadlock_repoll_progress_) {
                         last_deadlock_repoll_progress_ = p;
-                        for (auto& kv : parked_) {
-                            Fiber* f = kv.second;
-                            while (f) {
-                                Fiber* nx = f->park_link;
-                                f->park_link = nullptr;
-                                f->park_key = nullptr;
-                                f->state = FiberState::Ready;
-                                ready_[f->home].push_back(f);
-                                f = nx;
-                            }
-                        }
-                        parked_.clear();
+                        release_all_parked();
                         cv_.notify_all();
                         --idle_;
                         continue;
@@ -334,7 +455,7 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
                     // host-fed socket wait parked here is not a deadlock — it is a resumable
                     // HostWait: hand control back so the host can feed the socket and pump().
                     // With no socket wait parked, it is a real deadlock (diagnostics unchanged).
-                    if (persistent_ && any_parked_is_socket_wait()) {
+                    if (persistent_ && any_waiting_on_host()) {
                         host_wait_ = true;
                         abort_flag_ = true;
                         --idle_;
@@ -356,11 +477,17 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
         }
         Fiber* f = ready_[w].front();
         ready_[w].pop_front();
+        f->in_ready = false;  // off the queue; enqueue_ready may admit it again
+        // A queue entry is a HINT: drop one no longer Ready, since the next wake re-enqueues it.
+        if (f->state != FiberState::Ready) {
+            continue;
+        }
         f->state = FiberState::Running;
         ++running_;
         t_current = f;
         install_fiber(f);
         resumptions_.fetch_add(1, std::memory_order_relaxed);
+        f->own_resumes.fetch_add(1, std::memory_order_relaxed);
         mu_.unlock();
         swapcontext(&t_sched, &f->ctx);      // run/resume f; returns with mu_ LOCKED
         --running_;
@@ -390,6 +517,9 @@ static void park_current(FiberSchedulerImpl* p, const void* key, bool is_socket)
     // wait so quiescence-with-parked is treated as a resumable HostWait, not a deadlock.
     Fiber* f = t_current;
     f->state = FiberState::Parked;
+    // Leaving Ready: drop the flag so a later wake re-enqueues; stale entries are discarded on pop.
+    f->in_ready = false;
+    p->retire_poll_tags(f);  // a parking fiber is no longer spin-polling
     f->park_key = key;
     f->wait_is_socket = is_socket;
     Fiber*& head = p->parked_[key];          // inserts nullptr if absent
@@ -399,6 +529,67 @@ static void park_current(FiberSchedulerImpl* p, const void* key, bool is_socket)
 }
 
 void FiberScheduler::park_locked(const void* key) { park_current(p_.get(), key, /*is_socket=*/false); }
+
+// Tag/untag a socket spin-poll. Edge-triggered: only transitions take mu_ to move the tally.
+void FiberScheduler::note_socket_poll_wait(bool waiting, bool host_fed) {
+    Fiber* f = t_current;
+    if (!f) {
+        return;
+    }
+    if (waiting) {
+        // Refresh EVERY iteration, not just the transition: the stamp is what proves it is still looping.
+        f->poll_wait_stamp.store(f->own_resumes.load(std::memory_order_relaxed), std::memory_order_relaxed);
+        f->poll_is_host_fed.store(host_fed, std::memory_order_relaxed);
+    }
+    if (f->socket_poll_waiting.load(std::memory_order_relaxed) == waiting) {
+        return;
+    }
+    std::lock_guard<std::mutex> g(p_->mu_);
+    f->socket_poll_waiting.store(waiting, std::memory_order_relaxed);
+    if (waiting) {
+        ++p_->socket_poll_waiters_;
+    } else {
+        f->poll_is_host_fed.store(false, std::memory_order_relaxed);
+        --p_->socket_poll_waiters_;
+    }
+}
+
+// Tag a CB spin-poll (n != 0) or clear it (n == 0). Never host-resumable: the producer is a peer.
+void FiberScheduler::note_cb_poll_wait(unsigned cb_id, unsigned n) {
+    Fiber* f = t_current;
+    if (!f) {
+        return;
+    }
+    const bool waiting = (n != 0);
+    if (waiting) {
+        // One slot per fiber: overwriting on every miss would name the CB probed LAST, not the starving one.
+        const uint64_t resumes = f->own_resumes.load(std::memory_order_relaxed);
+        const bool own_slot = !f->cb_poll_waiting.load(std::memory_order_relaxed) ||
+                              f->cb_poll_id.load(std::memory_order_relaxed) == cb_id;
+        const bool slot_stale =
+            !poll_tag_is_fresh(resumes, f->cb_poll_stamp.load(std::memory_order_relaxed), p_->poll_wait_staleness_);
+        if (own_slot || slot_stale) {
+            // Atomic: a plain store lets the hang report print a torn cb id / page count never awaited.
+            f->cb_poll_id.store(cb_id, std::memory_order_relaxed);
+            f->cb_poll_n.store(n, std::memory_order_relaxed);
+            f->cb_poll_stamp.store(resumes, std::memory_order_relaxed);
+        }
+    } else if (
+        f->cb_poll_waiting.load(std::memory_order_relaxed) && f->cb_poll_id.load(std::memory_order_relaxed) != cb_id) {
+        // A hit on a DIFFERENT CB must not clear: only the awaited one, or the stall check stays unarmed.
+        return;
+    }
+    if (f->cb_poll_waiting.load(std::memory_order_relaxed) == waiting) {
+        return;
+    }
+    std::lock_guard<std::mutex> g(p_->mu_);
+    f->cb_poll_waiting.store(waiting, std::memory_order_relaxed);
+    if (waiting) {
+        ++p_->cb_poll_waiters_;
+    } else {
+        --p_->cb_poll_waiters_;
+    }
+}
 
 // Same as park_locked, but tags the park as a host-fed socket wait (see park_current / inner_loop).
 void FiberScheduler::park_locked_socket(const void* key) { park_current(p_.get(), key, /*is_socket=*/true); }
@@ -415,6 +606,9 @@ void FiberScheduler::quiescence_park() {
     }
     p_->mu_.lock();
     f->state = FiberState::QuiescenceDeferred;
+    f->in_ready = false;  // same as park_current: leaving Ready releases the queue flag
+    // As in park_current: a deferred fiber is not resumed, so its tags would stop ageing.
+    p_->retire_poll_tags(f);
     p_->quiescence_deferred_.push_back(f);
     swapcontext(&f->ctx, &t_sched);          // -> worker loop (mu_ held); resumes mu_-UNLOCKED
 }
@@ -431,7 +625,7 @@ void FiberScheduler::wake(const void* key) {
         f->park_link = nullptr;
         f->park_key = nullptr;
         f->state = FiberState::Ready;
-        p_->ready_[f->home].push_back(f);    // back to its pinned worker
+        p_->enqueue_ready(f);  // back to its pinned worker
         f = nx;
     }
     p_->parked_.erase(it);
@@ -442,7 +636,7 @@ void FiberScheduler::yield() {
     Fiber* f = t_current;
     p_->mu_.lock();
     f->state = FiberState::Ready;
-    p_->ready_[f->home].push_back(f);        // back to its pinned worker (== this worker)
+    p_->enqueue_ready(f);  // back to its pinned worker (== this worker)
     p_->cv_.notify_all();
     swapcontext(&f->ctx, &t_sched);          // mu_ held -> worker loop; resumes mu_-UNLOCKED
 }
@@ -480,9 +674,9 @@ void FiberScheduler::spawn(std::function<void()> entry, std::unique_ptr<ThreadCo
     f->state = FiberState::Ready;
 
     std::lock_guard<std::mutex> g(p_->mu_);
+    f->spawn_gen = p_->spawn_gen_;      // stamp the dispatch generation (runner keepalive reclaim)
     p_->all_.push_back(std::move(f));   // home + ready-queue placement happens in run_until_idle
 }
-
 
 // Conservative stack scan naming the blaze op a parked fiber sits in.
 // Walks the fiber's saved stack for words that dladdr resolves to a symbol, and
@@ -518,6 +712,57 @@ static std::string emule_park_op_name(const Fiber* f) {
         }
     }
     return {};
+}
+
+uint64_t FiberScheduler::begin_spawn_generation() {
+    std::lock_guard<std::mutex> g(p_->mu_);
+    return ++p_->spawn_gen_;
+}
+
+uint64_t FiberScheduler::oldest_live_spawn_generation() const {
+    std::lock_guard<std::mutex> g(p_->mu_);
+    uint64_t oldest = UINT64_MAX;
+    for (const auto& up : p_->all_) {
+        if (up->state != FiberState::Done && up->spawn_gen < oldest) {
+            oldest = up->spawn_gen;
+        }
+    }
+    return oldest;
+}
+
+std::vector<uint64_t> FiberScheduler::live_spawn_generations() const {
+    std::lock_guard<std::mutex> g(p_->mu_);
+    std::vector<uint64_t> gens;
+    for (const auto& up : p_->all_) {
+        if (up->state != FiberState::Done) {
+            gens.push_back(up->spawn_gen);
+        }
+    }
+    std::sort(gens.begin(), gens.end());
+    gens.erase(std::unique(gens.begin(), gens.end()), gens.end());
+    return gens;
+}
+
+bool FiberScheduler::spawn_generation_is_live(uint64_t gen) const {
+    std::lock_guard<std::mutex> g(p_->mu_);
+    for (const auto& up : p_->all_) {
+        if (up->state != FiberState::Done && up->spawn_gen == gen) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void FiberScheduler::abandon_host_wait(const std::string& why) {
+    {
+        std::lock_guard<std::mutex> g(p_->mu_);
+        if (p_->all_.empty()) {
+            return;  // no registry to abandon
+        }
+        p_->deadlock_ = true;
+        p_->stall_reason_ = why;
+    }
+    teardown_and_throw();
 }
 
 std::string FiberSchedulerImpl::dump_parked() {
@@ -596,16 +841,83 @@ std::string FiberSchedulerImpl::dump_parked() {
     if (!quiescence_deferred_.empty()) {
         os << "  " << quiescence_deferred_.size() << " fiber(s) deferred to quiescence\n";
     }
+    if (socket_poll_waiters_ != 0) {
+        // Split: a stale tag means the fiber left the loop, so reporting it sends triage after nothing.
+        unsigned fresh = 0, stale = 0, peer = 0;
+        for (const auto& up : all_) {
+            const Fiber* f = up.get();
+            if (!f->socket_poll_waiting.load(std::memory_order_relaxed) || f->state == FiberState::Done) {
+                continue;
+            }
+            if (!f->poll_is_host_fed.load(std::memory_order_relaxed)) {
+                ++peer;  // d2d: sender is a peer fiber, so this is a device-side wait
+                continue;
+            }
+            (poll_tag_is_fresh(
+                 f->own_resumes.load(std::memory_order_relaxed),
+                 f->poll_wait_stamp.load(std::memory_order_relaxed),
+                 poll_wait_staleness_)
+                 ? fresh
+                 : stale)++;
+        }
+        if (fresh != 0) {
+            os << "  " << fresh << " fiber(s) spin-polling a host-fed socket with no data (awaiting host stream)\n";
+        }
+        if (stale != 0) {
+            os << "  " << stale
+               << " fiber(s) hold a stale host-socket poll tag (left the poll loop; NOT awaiting the host)\n";
+        }
+        if (peer != 0) {
+            os << "  " << peer
+               << " fiber(s) spin-polling a d2d socket (peer sender has not published; NOT a host wait)\n";
+        }
+    }
+    if (cb_poll_waiters_ != 0) {
+        // Never in parked_ (a CB probe spins), so without this a CB-stuck run dumps an empty list.
+        for (const auto& up : all_) {
+            const Fiber* f = up.get();
+            if (!f->cb_poll_waiting.load(std::memory_order_relaxed) || f->state == FiberState::Done ||
+                f->own_resumes.load(std::memory_order_relaxed) - f->cb_poll_stamp.load(std::memory_order_relaxed) >
+                    poll_wait_staleness_) {
+                continue;
+            }
+            os << "    core(log " << f->id.logical_x << "," << f->id.logical_y << " phys " << int(f->id.phys_x) << ","
+               << int(f->id.phys_y) << ")"
+               << " risc/proc " << int(f->id.proc_id);
+            if (f->id.kernel_src) {
+                os << " kernel " << f->id.kernel_src;
+            }
+            os << " spin-polling CB " << f->cb_poll_id.load(std::memory_order_relaxed) << " for "
+               << f->cb_poll_n.load(std::memory_order_relaxed) << " page(s) (peer producer has not published)\n";
+        }
+    }
     return os.str();
+}
+
+// Stop and reap the tier-2 watchdog. Idempotent, and NOT under mu_: its abort path dumps under mu_.
+void FiberSchedulerImpl::stop_watchdog() {
+    host_wait_parked_.store(false, std::memory_order_release);
+    if (!wd_.joinable()) {
+        return;
+    }
+    {  // Clear under wd_mu_ + notify so the watchdog wakes at once (no lost wakeup).
+        std::lock_guard<std::mutex> lk(wd_mu_);
+        run_active_.store(false, std::memory_order_release);
+    }
+    wd_cv_.notify_all();
+    wd_.join();
 }
 
 void FiberSchedulerImpl::watchdog() {
     const auto interval = std::chrono::milliseconds(250);
     const uint64_t window = env_size("TT_EMULE_FIBER_PROGRESS_WINDOW", 200000);
     const auto backstop = std::chrono::seconds(env_size("TT_EMULE_FIBER_WATCHDOG_SEC", 120));
+    // Parked time measures the HOST; still finite, since a run nobody pumps must not read as success.
+    const auto host_backstop = std::chrono::seconds(env_size("TT_EMULE_HOST_WAIT_WATCHDOG_SEC", 900));
     uint64_t last_progress = progress_.load();
     uint64_t last_resump = resumptions_.load();
     auto last_advance = std::chrono::steady_clock::now();
+    bool was_parked = host_wait_parked_.load(std::memory_order_acquire);
     while (run_active_.load(std::memory_order_acquire)) {
         {
             // Interruptible sleep: wake immediately when run_until_idle clears run_active_
@@ -617,6 +929,11 @@ void FiberSchedulerImpl::watchdog() {
                 break;
             }
         }
+        const bool parked = host_wait_parked_.load(std::memory_order_acquire);
+        if (parked != was_parked) {
+            was_parked = parked;
+            last_advance = std::chrono::steady_clock::now();  // the host gap starts (or ends) here
+        }
         uint64_t p = progress_.load();
         uint64_t r = resumptions_.load();
         if (p != last_progress) {
@@ -625,15 +942,24 @@ void FiberSchedulerImpl::watchdog() {
             last_advance = std::chrono::steady_clock::now();
             continue;
         }
-        // progress stalled. Fast livelock trip: many resumptions, zero progress.
-        bool livelock = (r - last_resump) > window;
-        bool wall = (std::chrono::steady_clock::now() - last_advance) > backstop;
+        // Fast livelock trip: many resumptions, zero progress. Never while parked (counters are frozen).
+        bool livelock = !parked && (r - last_resump) > window;
+        bool wall = (std::chrono::steady_clock::now() - last_advance) > (parked ? host_backstop : backstop);
         if (livelock || wall) {
-            std::fprintf(stderr,
+            std::fprintf(
+                stderr,
                 "[EMULE] fiber engine: no global progress (%s) — suspected %s.\n%s",
-                livelock ? "resumption window" : "wall-clock backstop",
-                livelock ? "livelock / wake-cycle" : "lost wakeup / hang",
-                [this] { std::lock_guard<std::mutex> g(mu_); return dump_parked(); }().c_str());
+                livelock ? "resumption window"
+                : parked ? "host-wait backstop, TT_EMULE_HOST_WAIT_WATCHDOG_SEC"
+                         : "wall-clock backstop",
+                livelock ? "livelock / wake-cycle"
+                : parked ? "the host never pumped this parked run again"
+                         : "lost wakeup / hang",
+                [this] {
+                    std::lock_guard<std::mutex> g(mu_);
+                    return dump_parked();
+                }()
+                    .c_str());
             std::abort();
         }
         last_resump = r;
@@ -646,6 +972,8 @@ void FiberSchedulerImpl::watchdog() {
 // the fibers to resume back into ready_. On return the run has reached a boundary: every fiber Done,
 // a deadlock, or (persistent) a host-wait. Teardown/throw is the caller's (teardown_and_throw).
 void FiberScheduler::launch_and_wait(bool initial) {
+    // Reap a watchdog left over a HostWait gap. Ahead of the early returns, so no exit leaves it ticking.
+    p_->stop_watchdog();
     // Lazily create the persistent worker pool on the first run (K is process-constant);
     // threads live until ~FiberScheduler. See tt-emule docs/fiber-engine.md.
     if (p_->pool_.empty()) {
@@ -661,7 +989,16 @@ void FiberScheduler::launch_and_wait(bool initial) {
         // section, so a worker released for a generation never pairs a new W_ with a stale generation_.
         // See tt-emule docs/fiber-engine.md §9.4 (the workers_done_ overshoot / done_cv_ wedge it avoids).
         std::lock_guard<std::mutex> g(p_->mu_);
-        if (initial) {
+        // `initial` means "a program was just registered", not "the registry is empty".
+        const bool resuming = initial && p_->launched_watermark_ > 0;
+        // Reset outcome flags BEFORE either early return: a stale host_wait_ reports a run that is gone.
+        p_->idle_ = 0;
+        p_->running_ = 0;
+        p_->workers_done_ = 0;
+        p_->deadlock_ = false;
+        p_->abort_flag_ = false;
+        p_->host_wait_ = false;
+        if (initial && !resuming) {
             p_->active_ = static_cast<unsigned>(p_->all_.size());
             if (p_->active_ == 0) {
                 return;   // nothing to run; the pool stays parked
@@ -670,30 +1007,65 @@ void FiberScheduler::launch_and_wait(bool initial) {
             // teardown_and_throw (its sole consumer), so it must survive across pump quanta.
             p_->first_eptr_ = nullptr;
         }
-        p_->idle_ = 0;
-        p_->running_ = 0;
-        p_->workers_done_ = 0;
-        p_->deadlock_ = false;
-        p_->abort_flag_ = false;
-        p_->host_wait_ = false;
         // Per-run recovery watermarks — reset alongside progress_/resumptions_ (below).
         // A stale last_deadlock_repoll_progress_ from a prior run can collide with this
         // run's quiescence progress and skip the recovery re-poll → spurious deadlock.
         p_->last_progress_val_ = 0;
         p_->last_progress_resump_ = 0;
+        p_->barren_releases_ = 0;
+        p_->last_parked_sig_valid_ = false;
         p_->last_deadlock_repoll_progress_ = UINT64_MAX;
-        if (initial) {
+        if (initial && !resuming) {
             p_->quiescence_deferred_.clear();
             // Activate W = min(K, fiber count) workers; pin each fiber round-robin across [0,W).
             // Surplus workers (>= W) stay parked on start_cv_, so a tiny program pays no herd.
             // See tt-emule docs/fiber-engine.md.
             W = std::min<unsigned>(p_->K_, p_->active_);
             p_->W_ = W;
-            p_->ready_.assign(W, {});
+            p_->ready_.assign(W, {});  // discards the queues, so the in_ready flags go with them
             for (size_t i = 0; i < p_->all_.size(); ++i) {
                 Fiber* f = p_->all_[i].get();
                 f->home = static_cast<unsigned>(i % W);
-                p_->ready_[f->home].push_back(f);
+                f->in_ready = false;
+                p_->enqueue_ready(f);
+            }
+        } else if (resuming) {
+            // Integrate ONLY the new fibers: re-queueing a Parked one parks it twice, re-homing breaks pinning.
+            size_t retired = 0;
+            {
+                for (auto& q : p_->ready_) {
+                    q.erase(
+                        std::remove_if(q.begin(), q.end(), [](Fiber* f) { return f->state == FiberState::Done; }),
+                        q.end());
+                }
+                auto is_done = [](const std::unique_ptr<Fiber>& f) { return f->state == FiberState::Done; };
+                const size_t before = p_->all_.size();
+                // Only the launched prefix is eligible; [watermark, size) has not run and is not Done.
+                auto prefix_end = p_->all_.begin() + static_cast<std::ptrdiff_t>(p_->launched_watermark_);
+                auto keep_end = std::remove_if(p_->all_.begin(), prefix_end, is_done);
+                retired = static_cast<size_t>(std::distance(keep_end, prefix_end));
+                if (retired != 0) {
+                    // Close the gap: remove_if already compacted the prefix, so shift the new gen down.
+                    std::move(prefix_end, p_->all_.end(), keep_end);
+                    p_->all_.resize(before - retired);
+                    p_->launched_watermark_ -= retired;
+                }
+            }
+            const size_t n_new = p_->all_.size() - p_->launched_watermark_;
+            W = std::min<unsigned>(p_->K_, p_->active_ + static_cast<unsigned>(n_new));
+            if (W < p_->W_) {
+                W = p_->W_;  // never shrink: live fibers are pinned to homes in [0, W_)
+            }
+            p_->W_ = W;
+            p_->ready_.resize(W);
+            for (size_t i = p_->launched_watermark_; i < p_->all_.size(); ++i) {
+                Fiber* f = p_->all_[i].get();
+                f->home = static_cast<unsigned>(i % W);
+                p_->enqueue_ready(f);
+                ++p_->active_;
+            }
+            if (p_->active_ == 0) {
+                return;  // nothing live and nothing new
             }
         } else {
             W = p_->W_;   // pump: reuse homing; ready_ already refilled by pump()'s re-poll
@@ -703,6 +1075,9 @@ void FiberScheduler::launch_and_wait(bool initial) {
         p_->progress_.store(0);
         p_->resumptions_.store(0);
         ++p_->generation_;
+        if (initial) {
+            p_->launched_watermark_ = p_->all_.size();
+        }
     }
     if (std::getenv("TT_EMULE_FIBER_LOG_N")) {
         std::fprintf(stderr, "[EMULE FIBER] program: %u fibers on W=%u of K=%u workers\n",
@@ -713,7 +1088,7 @@ void FiberScheduler::launch_and_wait(bool initial) {
     // there can't leave a joinable thread. (A spurious start_cv_ wakeup could start a worker in the
     // brief gap before this line — benign: the watchdog spawns at once and a hang can't complete that fast.)
     p_->run_active_.store(true, std::memory_order_release);
-    std::thread wd([this] { p_->watchdog(); });
+    p_->wd_ = std::thread([this] { p_->watchdog(); });
 
     p_->start_cv_.notify_all();
     {   // Block the dispatch thread until every active worker has finished this run.
@@ -721,32 +1096,64 @@ void FiberScheduler::launch_and_wait(bool initial) {
         p_->done_cv_.wait(lk, [&] { return p_->workers_done_ == W; });
     }
 
-    {   // Clear under wd_mu_ + notify so the watchdog wakes at once (no lost wakeup).
-        std::lock_guard<std::mutex> lk(p_->wd_mu_);
-        p_->run_active_.store(false, std::memory_order_release);
+    bool host_wait = false;
+    {  // A captured kernel fault outranks a host wait: HostWait would defer the rethrow indefinitely.
+        std::lock_guard<std::mutex> g(p_->mu_);
+        if (p_->first_eptr_ && p_->host_wait_) {
+            p_->host_wait_ = false;
+        }
+        host_wait = p_->host_wait_;
     }
-    p_->wd_cv_.notify_all();
-    wd.join();
+    // A HostWait return leaves the watchdog RUNNING (the gap's only guard); anything else ends the run.
+    p_->host_wait_parked_.store(host_wait, std::memory_order_release);
+    if (!host_wait) {
+        p_->stop_watchdog();
+    }
+    if (std::getenv("TT_EMULE_FIBER_LOG_N")) {
+        std::lock_guard<std::mutex> g(p_->mu_);
+        std::fprintf(
+            stderr,
+            "[EMULE FIBER] %s -> %s: active=%u parked_keys=%zu poll_waiters=%u progress=%llu\n",
+            initial ? "launch" : "pump",
+            p_->host_wait_ ? "HostWait" : (p_->deadlock_ ? "DEADLOCK" : "Completed"),
+            p_->active_,
+            p_->parked_.size(),
+            p_->socket_poll_waiters_,
+            (unsigned long long)p_->progress_.load());
+    }
 }
 
 // Collect results + clear the registry for the next program / mesh. Rethrows the first fiber
 // exception; throws on a quiescent deadlock. Called only after a run reaches Completed (never on a
 // resumable HostWait — then the fibers must stay alive).
 void FiberScheduler::teardown_and_throw() {
+    // Before mu_: the watchdog may still be up, and its abort path dumps under mu_.
+    p_->stop_watchdog();
     std::exception_ptr eptr;
     bool deadlock;
     std::string dump;
+    std::string reason;
     {   // workers are parked on start_cv_ now, but take mu_ anyway for clean ordering.
         std::lock_guard<std::mutex> g(p_->mu_);
         eptr = p_->first_eptr_;
+        // Consume it: latched, the resuming path (which clears only on a fresh launch) rethrows it later.
+        p_->first_eptr_ = nullptr;
         deadlock = p_->deadlock_;
         if (deadlock) {
             dump = p_->dump_parked();
+            reason = p_->stall_reason_.empty() ? "EMULE fiber engine: quiescent deadlock — all workers idle, fibers "
+                                                 "parked, none runnable."
+                                               : p_->stall_reason_;
         }
+        p_->stall_reason_.clear();
         p_->ready_.clear();
         p_->parked_.clear();
         p_->quiescence_deferred_.clear();
+        p_->socket_poll_waiters_ = 0;  // tallies are per-registry; all_ is about to go
+        p_->cb_poll_waiters_ = 0;
         p_->all_.clear();   // frees Fiber stacks via ~Fiber
+        p_->launched_watermark_ = 0;  // registry is empty again: the next launch is a fresh one
+        p_->host_wait_ = false;       // per-registry, and the registry is gone
     }
 
     // A real kernel exception is the root cause; report it before any deadlock symptom.
@@ -754,8 +1161,7 @@ void FiberScheduler::teardown_and_throw() {
         std::rethrow_exception(eptr);
     }
     if (deadlock) {
-        throw std::runtime_error("EMULE fiber engine: quiescent deadlock — all workers idle, "
-                                 "fibers parked, none runnable.\n" + dump);
+        throw FiberEngineStall(reason + "\n" + dump);
     }
 }
 
@@ -765,10 +1171,27 @@ void FiberScheduler::run_until_idle() {
     teardown_and_throw();
 }
 
+// The engine's own bound, read once; the drain backstop reads it back rather than re-parsing the env.
+static uint64_t host_wait_no_progress_limit() {
+    static const uint64_t v = env_size("TT_EMULE_HOST_WAIT_STALL_LIMIT", 8192);
+    return v;
+}
+
+uint64_t FiberScheduler::host_wait_stall_limit() { return host_wait_no_progress_limit(); }
+
 RunOutcome FiberScheduler::run_persistent() {
     p_->persistent_ = true;
-    p_->host_wait_no_progress_pumps_ = 0;   // start of a fresh host-wait sequence
+    // Reset only for a FRESH sequence: re-arming per dispatch means a wedged run never escalates.
+    const bool resuming = p_->launched_watermark_ > 0;
+    if (!resuming) {
+        p_->host_wait_no_progress_pumps_ = 0;
+    }
     launch_and_wait(/*initial=*/true);
+    return finish_or_host_wait();
+}
+
+// Shared tail of run_persistent()/pump(); pump()'s no-progress accounting must run BEFORE it.
+RunOutcome FiberScheduler::finish_or_host_wait() {
     if (p_->host_wait_) {
         return RunOutcome::HostWait;   // fibers parked awaiting host socket I/O — ALIVE, no teardown
     }
@@ -783,21 +1206,8 @@ RunOutcome FiberScheduler::pump() {
         if (p_->all_.empty()) {
             return RunOutcome::Completed;   // no persistent run in flight — no-op
         }
-        // The host advanced a credit word with a raw L1 store (no __emule_fiber_wake), so wake
-        // every parked fiber to re-check its predicate. This is the quiescence re-poll, host-driven;
-        // spurious-wake-safe (__emule_fiber_wait re-checks under the lock and re-parks).
-        for (auto& kv : p_->parked_) {
-            for (Fiber* f = kv.second; f;) {
-                Fiber* nx = f->park_link;
-                f->park_link = nullptr;
-                f->park_key = nullptr;
-                f->wait_is_socket = false;
-                f->state = FiberState::Ready;
-                p_->ready_[f->home].push_back(f);
-                f = nx;
-            }
-        }
-        p_->parked_.clear();
+        // The host's credit store was a raw L1 write with no wake, so re-poll every parked fiber.
+        p_->release_all_parked();
     }
     launch_and_wait(/*initial=*/false);
     if (p_->host_wait_) {
@@ -808,19 +1218,16 @@ RunOutcome FiberScheduler::pump() {
         // progress resets the count, so a slow-but-advancing feed is unaffected. Keying on global
         // progress_ (not the awaited socket) leaves a residual masking window — WA-3, see
         // tt-emule-blaze/.claude/skills/workarounds.
-        static const uint64_t kHostWaitNoProgressLimit = env_size("TT_EMULE_HOST_WAIT_STALL_LIMIT", 8192);
         if (p_->progress_.load() == 0) {
-            if (++p_->host_wait_no_progress_pumps_ >= kHostWaitNoProgressLimit) {
+            if (++p_->host_wait_no_progress_pumps_ >= host_wait_no_progress_limit()) {
                 p_->deadlock_ = true;
                 teardown_and_throw();  // reuses the tier-1 quiescent-deadlock diagnostic (dump_parked)
             }
         } else {
             p_->host_wait_no_progress_pumps_ = 0;
         }
-        return RunOutcome::HostWait;
     }
-    teardown_and_throw();
-    return RunOutcome::Completed;
+    return finish_or_host_wait();
 }
 
 FiberScheduler::FiberScheduler() : p_(std::make_unique<FiberSchedulerImpl>()) {
@@ -829,9 +1236,13 @@ FiberScheduler::FiberScheduler() : p_(std::make_unique<FiberSchedulerImpl>()) {
     // then runs; the mesh path spawns all devices in the defer phase, then runs once). Reading it in
     // run_until_idle would miss the first program. See tt-emule docs/fiber-engine.md.
     p_->stack_bytes_ = env_size("TT_EMULE_FIBER_STACK_BYTES", 1u << 20);
+    p_->poll_wait_staleness_ = env_size("TT_EMULE_POLL_TAG_STALENESS", 64);
 }
 
 FiberScheduler::~FiberScheduler() {
+    if (p_) {
+        p_->stop_watchdog();  // a HostWait gap watchdog can still be up if the run never completed
+    }
     if (p_ && !p_->pool_.empty()) {
         {
             std::lock_guard<std::mutex> g(p_->mu_);

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.hpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.hpp
@@ -13,10 +13,19 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "jit_hw/internal/emule_thread_ctx.h"  // ThreadCommonCtx (the fiber-owned ctx)
 
 namespace tt::tt_metal::emule_fiber {
+
+/// An engine stall (quiescent deadlock, or a host wait past its bound). Catch this, not std::exception.
+class FiberEngineStall : public std::runtime_error {
+public:
+    explicit FiberEngineStall(const std::string& what) : std::runtime_error(what) {}
+};
 
 struct FiberSchedulerImpl;  // defined in the .cpp (namespace-scope so the ucontext
                             // trampoline + per-worker thread_locals can access it)
@@ -51,21 +60,34 @@ public:
     // deadlock (tier 1); aborts with a diagnostic dump on livelock/hang (tier 2).
     void run_until_idle();
 
-    // Host-interleaved (persistent) dispatch — for a program whose kernels block on a
-    // host-fed socket. Like run_until_idle(), but if the run quiesces with a host-facing
-    // socket wait parked it returns HostWait WITHOUT tearing down (fibers stay alive);
-    // pump() then resumes them one quantum per host socket call, and Completed tears down.
-    // A quiescent deadlock with NO socket wait parked still throws (diagnostics preserved).
-    // Teardown is automatic: the pump() that observes every fiber Done returns Completed and clears
-    // the registry (driven by the host's final socket barrier / synchronize). No separate join hook.
+    // run_until_idle(), but a quiescence with a host-fed socket wait parked returns HostWait, fibers ALIVE.
     RunOutcome run_persistent();     // initial launch
-    RunOutcome pump();               // resume the SAME parked fibers one quantum (host advanced a credit word)
+    // Resume the SAME parked fibers one quantum; Completed here tears the registry down.
+    RunOutcome pump();
+    // Across a HostWait gap the tier-2 watchdog stays up on TT_EMULE_HOST_WAIT_WATCHDOG_SEC, clocked at the park.
+
+    // No-progress pumps before pump() escalates (TT_EMULE_HOST_WAIT_STALL_LIMIT, 8192); the drain sizes above it.
+    static uint64_t host_wait_stall_limit();
+
+    // Per-dispatch generation for runner keepalives. Per-generation, not an age bound: a parked run pins one.
+    uint64_t begin_spawn_generation();
+    uint64_t oldest_live_spawn_generation() const;
+    bool spawn_generation_is_live(uint64_t gen) const;
+    // Every live generation in ONE scan; per-candidate spawn_generation_is_live() rescans all_ each time.
+    std::vector<uint64_t> live_spawn_generations() const;
+
+    // Tear down a run that will not drain: throws FiberEngineStall(`why` + the parked-fiber dump).
+    void abandon_host_wait(const std::string& why);
 
     // ---- Bridge ops (called by the runner's extern-C thunks from a running fiber) ----
     void lock();
     void unlock();
     void park_locked(const void* key);         // pre: lock held; post: lock released
     void park_locked_socket(const void* key);  // as park_locked, tagged as a host-fed socket wait
+    // Tag a socket spin-poll (miss sets, hit clears); only host_fed can resolve a stall to HostWait.
+    void note_socket_poll_wait(bool waiting, bool host_fed);
+    // CB analogue: arms the stall check and names the wait, never host-resumable (peer producer). n==0 clears.
+    void note_cb_poll_wait(unsigned cb_id, unsigned n);
     void quiescence_park();              // defer to quiescence: re-queue lowest-priority, released at quiescence
     void wake(const void* key);
     void yield();
@@ -79,6 +101,7 @@ private:
     ~FiberScheduler();
     void launch_and_wait(bool initial);  // shared launch+wait tail (run_until_idle/run_persistent/pump)
     void teardown_and_throw();           // clear the registry; rethrow eptr / throw on deadlock
+    RunOutcome finish_or_host_wait();    // shared outcome tail of run_persistent()/pump()
     std::unique_ptr<FiberSchedulerImpl> p_;
 };
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Host-interleaved dispatch only holds up for a single dispatch with kernels that park on the socket (sockets are part of the fused op). A decode loop is repeated dispatches against a still-parked run, polling receivers..

- polling receivers read as livelock and abort
  - only parked socket waits counted as waiting on the host
  - the poll variant can't park; it must return so the kernel re-checks termination
  - polls now tagged, with freshness so a stale tag can't mask a later real hang
  - dumps name host-fed vs peer-fed, and which CB is starving
- dispatching onto a parked run corrupts it
  - live fibers get re-homed and re-queued
  - new fibers now integrate without touching them
- no liveness guard across the host gap
  - watchdog was joined at every return
  - now spans the gap, on a separate and much larger bound, so host latency doesn't read as a device stall
- per-dispatch keepalives never freed, RSS grows per iteration
  - now reclaimed per spawn generation, once that generation's fibers are done
- two dangling pointers under a parked run
  - LRU eviction frees a resolved program its fibers still reference
  - hang dump reads a dead kernel-name pointer
- `Finish()` returns with the run still parked, so reads land over buffers no kernel wrote
  - now drains first
- kernel fault during a host-wait is deferred
  - rethrown against whichever program tears the registry down next
  - faults now outrank the wait
- `Finish()` on one mesh drives another mesh's parked run
  - now scoped by device id
- a run that won't drain pumps forever
  - now bounded, then torn down with a diagnostic pointing at the likely host ordering mistake

### Notes for reviewers

only non-emulator file is `sd_mesh_command_queue.cpp`

Worth attention
- the predicate deciding HostWait vs deadlock (`any_waiting_on_host`, two trigger sites in the scheduler loop)
  - says deadlock when it's really a host wait → aborts a healthy run
  - says host wait when it's really a deadlock → run parks forever instead of reporting
- two separate no-progress counters, and the ordering between them
  - scheduler: N no-progress pumps → tier-1 deadlock, with the parked-fiber dump
  - runner: caps how many pumps `drain_device` will issue, then gives up with no dump
  - runner's default is the scheduler's limit + 64, so the scheduler always escalates first and you get the dump; set the runner's lower and you lose it

Tests
- 16 host-only, no device: outcome classification, tag freshness and attribution, resumable launches, watchdog across the gap, fault vs stall precedence
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vtangTT/emule-temporal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vtangTT/emule-temporal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vtangTT/emule-temporal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vtangTT/emule-temporal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=vtangTT/emule-temporal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:vtangTT/emule-temporal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vtangTT/emule-temporal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vtangTT/emule-temporal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vtangTT/emule-temporal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vtangTT/emule-temporal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vtangTT/emule-temporal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vtangTT/emule-temporal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vtangTT/emule-temporal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vtangTT/emule-temporal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vtangTT/emule-temporal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vtangTT/emule-temporal-main)