### PR TITLE
DO NOT MERGE: CI repro for #52290 (fork runner-setup timeout)

### DIFF
--- a/tt_metal/common/env_lib.hpp
+++ b/tt_metal/common/env_lib.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+// CI repro: no-op comment to flip the tt-metalium-changed path filter and
+// trigger runtime-examples / sdk-examples [wh_n150_civ2] for tt-metal#52290.
 #include <cstdint>
 #include <map>
 #include <vector>


### PR DESCRIPTION
**DO NOT MERGE.**

This PR exists solely to reproduce the CI infra bug described in #52290
(external-fork PR jobs exhausting the 15-minute job timeout while the
`Set up runner` hook does a full multi-branch fetch). It contains a single
no-op comment change to `tt_metal/common/env_lib.hpp`, chosen only to flip
the `tt-metalium-changed` path filter so `runtime-examples` → `sdk-examples.yaml`
→ `runtime sdk examples [wh_n150_civ2]` actually runs.

No functional change. Intended to be closed (not merged) once we've captured
the `Set up runner` timing for this run as evidence for #52290.