### PR TITLE
[Feature] Add common-field accessors to ComputeHardwareConfig in Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -17,6 +17,8 @@
 //   7. Aggregate type enforcement (designated initializers must work!)
 // Wormhole (Gen1):
 //   8. Gen1 specific tests
+// Device-free:
+//   9. ComputeHardwareConfig common-field accessors
 //
 //---------------------------------------------------------------------------------
 // These unit tests use shortcut functions to create minimal valid ProgramSpec
@@ -32,6 +34,8 @@
 #include <filesystem>
 #include <optional>
 #include <type_traits>
+#include <utility>
+#include <variant>
 
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -4665,5 +4669,181 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnInconsistentBorrowedFrom) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("inconsistent borrowed_from")));
 }
 
+//---------------------------------------------------------------------------------
+// 9. ComputeHardwareConfig common-field accessors
+//
+// Device-free; no fixture needed.
+//
+// ComputeHardwareConfig is a std::variant<ComputeGen1Config, ComputeGen2Config>, and the accessors
+// exist to hide that variant for the fields both alternatives share. The failure they can plausibly
+// hide is a copy-paste one: an accessor wired to the wrong member, or one that happens to work for
+// the alternative someone tested and not the other.
+//
+// Two things below are load-bearing against exactly that:
+//   - Every check runs against BOTH alternatives, via helpers templated on the alternative type, so
+//     neither generation can be covered by accident alone.
+//   - The two bool fields are checked at values OPPOSITE each other (and opposite their defaults),
+//     so an accessor pointing at the wrong bool cannot pass. Their differing defaults
+//     (enable_32_bit_dest = false, double_buffer_dest = true) make even the untouched-config read
+//     discriminating.
+//
+// The static_asserts pin the return types, which are a deliberate design decision rather than an
+// accident: the mutable accessors return references so callers can assign through them, the const
+// accessors return the small scalars by value (no reference into a temporary variant, no pointless
+// indirection) and unpack_modes by const reference (it is a container; copying it on every read
+// would be wasteful, and callers expect a view).
+//---------------------------------------------------------------------------------
+
+// Non-default values for every common field. Each differs from the field's default, so an accessor
+// that read a hardcoded default, or that never wrote, fails. The bools are opposite each other.
+constexpr MathFidelity kAccessorFidelity = MathFidelity::LoFi;    // default HiFi4
+constexpr Precision kAccessorPrecision = Precision::Approximate;  // default Precise
+constexpr bool kAccessor32BitDest = true;                         // default false
+constexpr bool kAccessorDoubleBuffer = false;                     // default true
+
+const DFBSpecName kAccessorDfbA{"accessor_dfb_a"};
+const DFBSpecName kAccessorDfbB{"accessor_dfb_b"};
+
+using MutableComputeConfig = ComputeHardwareConfig&;
+using ConstComputeConfig = const ComputeHardwareConfig&;
+
+static_assert(std::is_same_v<decltype(fpu_math_fidelity(std::declval<MutableComputeConfig>())), MathFidelity&>);
+static_assert(std::is_same_v<decltype(fpu_math_fidelity(std::declval<ConstComputeConfig>())), MathFidelity>);
+static_assert(std::is_same_v<decltype(sfpu_precision_mode(std::declval<MutableComputeConfig>())), Precision&>);
+static_assert(std::is_same_v<decltype(sfpu_precision_mode(std::declval<ConstComputeConfig>())), Precision>);
+static_assert(std::is_same_v<decltype(enable_32_bit_dest(std::declval<MutableComputeConfig>())), bool&>);
+static_assert(std::is_same_v<decltype(enable_32_bit_dest(std::declval<ConstComputeConfig>())), bool>);
+static_assert(std::is_same_v<decltype(double_buffer_dest(std::declval<MutableComputeConfig>())), bool&>);
+static_assert(std::is_same_v<decltype(double_buffer_dest(std::declval<ConstComputeConfig>())), bool>);
+static_assert(std::is_same_v<decltype(unpack_modes(std::declval<MutableComputeConfig>())), ComputeUnpackModes&>);
+static_assert(std::is_same_v<decltype(unpack_modes(std::declval<ConstComputeConfig>())), const ComputeUnpackModes&>);
+
+// unpack_modes is the one accessor returning a reference from a const config, so it carries a
+// deleted rvalue overload to stop a caller binding that reference into a temporary. Assert the
+// deletion bites — and assert the lvalue forms still compile, because without those positive
+// controls a mere typo here would satisfy the negative assertion vacuously.
+template <typename Config>
+concept UnpackModesAcceptsLvalue = requires(Config& config) { unpack_modes(config); };
+template <typename Config>
+concept UnpackModesAcceptsRvalue = requires(Config config) { unpack_modes(std::move(config)); };
+
+static_assert(UnpackModesAcceptsLvalue<ComputeHardwareConfig>);
+static_assert(UnpackModesAcceptsLvalue<const ComputeHardwareConfig>);
+static_assert(!UnpackModesAcceptsRvalue<ComputeHardwareConfig>);
+static_assert(!UnpackModesAcceptsRvalue<const ComputeHardwareConfig>);
+
+// Reading an untouched config through the accessors must yield the alternative's own defaults.
+template <typename GenConfig>
+void CheckAccessorDefaultsReadThrough() {
+    const ComputeHardwareConfig config{GenConfig{}};
+    const GenConfig defaults{};
+
+    EXPECT_EQ(fpu_math_fidelity(config), defaults.fpu_math_fidelity);
+    EXPECT_EQ(sfpu_precision_mode(config), defaults.sfpu_precision_mode);
+    EXPECT_EQ(enable_32_bit_dest(config), defaults.enable_32_bit_dest);
+    EXPECT_EQ(double_buffer_dest(config), defaults.double_buffer_dest);
+    EXPECT_TRUE(unpack_modes(config).empty());
+}
+
+// Writing through the mutable accessors must land on the held alternative's actual members, and the
+// const accessors must read back what was written.
+template <typename GenConfig>
+void CheckAccessorWritesLandOnHeldAlternative() {
+    ComputeHardwareConfig config{GenConfig{}};
+
+    fpu_math_fidelity(config) = kAccessorFidelity;
+    sfpu_precision_mode(config) = kAccessorPrecision;
+    enable_32_bit_dest(config) = kAccessor32BitDest;
+    double_buffer_dest(config) = kAccessorDoubleBuffer;
+
+    // Bind the returned reference and use it repeatedly — the usage the header documents.
+    auto& dfb_unpack_modes = unpack_modes(config);
+    dfb_unpack_modes.emplace(kAccessorDfbA, UnpackMode::UnpackToDest);
+    dfb_unpack_modes.emplace(kAccessorDfbB, UnpackMode::UnpackToSrc);
+
+    // Reach past the accessors: the writes must be visible on the held alternative itself. This is
+    // what catches an accessor that targets the wrong member.
+    const GenConfig& held = std::get<GenConfig>(config);
+    EXPECT_EQ(held.fpu_math_fidelity, kAccessorFidelity);
+    EXPECT_EQ(held.sfpu_precision_mode, kAccessorPrecision);
+    EXPECT_EQ(held.enable_32_bit_dest, kAccessor32BitDest);
+    EXPECT_EQ(held.double_buffer_dest, kAccessorDoubleBuffer);
+
+    const ComputeUnpackModes expected_modes{
+        {kAccessorDfbA, UnpackMode::UnpackToDest},
+        {kAccessorDfbB, UnpackMode::UnpackToSrc},
+    };
+    EXPECT_EQ(held.unpack_modes, expected_modes)
+        << "unpack_modes() handed back a copy rather than a view onto the held alternative";
+
+    // And the const accessors report the same values.
+    const ComputeHardwareConfig& const_config = config;
+    EXPECT_EQ(fpu_math_fidelity(const_config), kAccessorFidelity);
+    EXPECT_EQ(sfpu_precision_mode(const_config), kAccessorPrecision);
+    EXPECT_EQ(enable_32_bit_dest(const_config), kAccessor32BitDest);
+    EXPECT_EQ(double_buffer_dest(const_config), kAccessorDoubleBuffer);
+    EXPECT_EQ(unpack_modes(const_config), expected_modes);
+}
+
+// An accessor must never reach into the alternative that is NOT held. Assigning a fresh alternative
+// over the variant has to be reflected immediately. This is the retargeting case that makes
+// std::get<ComputeGen1Config> throw, and the reason these accessors exist.
+template <typename FromConfig, typename ToConfig>
+void CheckAccessorsFollowTheHeldAlternative() {
+    ComputeHardwareConfig config{FromConfig{}};
+    fpu_math_fidelity(config) = kAccessorFidelity;
+    enable_32_bit_dest(config) = kAccessor32BitDest;
+
+    config = ToConfig{};  // switch alternatives; the accessors must now see ToConfig's defaults
+
+    const ToConfig defaults{};
+    EXPECT_EQ(fpu_math_fidelity(config), defaults.fpu_math_fidelity);
+    EXPECT_EQ(enable_32_bit_dest(config), defaults.enable_32_bit_dest);
+
+    // ...and writing still works after the switch.
+    fpu_math_fidelity(config) = kAccessorFidelity;
+    EXPECT_EQ(std::get<ToConfig>(config).fpu_math_fidelity, kAccessorFidelity);
+}
+
+TEST(ComputeHardwareConfigAccessors, Gen1DefaultsReadThrough) { CheckAccessorDefaultsReadThrough<ComputeGen1Config>(); }
+
+TEST(ComputeHardwareConfigAccessors, Gen2DefaultsReadThrough) { CheckAccessorDefaultsReadThrough<ComputeGen2Config>(); }
+
+TEST(ComputeHardwareConfigAccessors, Gen1WritesLandOnHeldAlternative) {
+    CheckAccessorWritesLandOnHeldAlternative<ComputeGen1Config>();
+}
+
+TEST(ComputeHardwareConfigAccessors, Gen2WritesLandOnHeldAlternative) {
+    CheckAccessorWritesLandOnHeldAlternative<ComputeGen2Config>();
+}
+
+TEST(ComputeHardwareConfigAccessors, FollowsSwitchFromGen1ToGen2) {
+    CheckAccessorsFollowTheHeldAlternative<ComputeGen1Config, ComputeGen2Config>();
+}
+
+TEST(ComputeHardwareConfigAccessors, FollowsSwitchFromGen2ToGen1) {
+    CheckAccessorsFollowTheHeldAlternative<ComputeGen2Config, ComputeGen1Config>();
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::experimental
+
+namespace {
+
+// Op code calls these accessors unqualified from its own namespace, which only works if they are
+// found by ADL on ComputeHardwareConfig. The checks above cannot show that: they live inside
+// tt::tt_metal::experimental, where ordinary lookup finds the accessors regardless. This probe sits
+// outside that namespace, so ADL is the only thing that can resolve the names.
+template <typename Config>
+concept ComputeAccessorsFoundByAdl = requires(Config& config) {
+    fpu_math_fidelity(config);
+    sfpu_precision_mode(config);
+    enable_32_bit_dest(config);
+    double_buffer_dest(config);
+    unpack_modes(config);
+};
+
+static_assert(ComputeAccessorsFoundByAdl<tt::tt_metal::experimental::ComputeHardwareConfig>);
+static_assert(ComputeAccessorsFoundByAdl<const tt::tt_metal::experimental::ComputeHardwareConfig>);
+
+}  // namespace

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
@@ -252,7 +252,9 @@ inline const ComputeUnpackModes& unpack_modes(const ComputeHardwareConfig& confi
     return std::visit([](const auto& cfg) -> const ComputeUnpackModes& { return cfg.unpack_modes; }, config);
 }
 
-// Delete the rvalue overload of unpack_modes to prevent dangling references.
+// Delete the rvalue overload of unpack_modes to prevent dangling references
+// (The mutable accessors can't bind a temporary, and the const scalars return by value,
+// so only this one needs it.)
 inline const ComputeUnpackModes& unpack_modes(const ComputeHardwareConfig&&) = delete;
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
@@ -188,7 +188,7 @@ using ComputeHardwareConfig = std::variant<ComputeGen1Config, ComputeGen2Config>
 //  Common-field accessors
 // ----------------------------------------------------------------------------
 //
-// Many compute settings are common to Gen1 and Gen2 archictures.
+// Many compute settings are common to Gen1 and Gen2 architectures.
 //
 // Reaching a common field through the variant is syntactically awkward; you should not need
 // to know which alternative is held. For convenience, each common field is given an accessor

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
@@ -194,15 +194,20 @@ using ComputeHardwareConfig = std::variant<ComputeGen1Config, ComputeGen2Config>
 // to know which alternative is held. For convenience, each common field is given an accessor
 // helper function here. (Generation-specific fields are not given accessors.)
 //
-// The accessor returns a reference. You can bind it and use it multiple times, e.g.:
+// Each field has a mutable and a const accessor.
+//
+// The mutable accessor returns a reference, so you can assign through it:
+//
+//     enable_32_bit_dest(compute_hw) = true;
+//
+// or bind it and use it multiple times:
 //
 //     auto& dfb_unpack_modes = unpack_modes(compute_hw);
 //     dfb_unpack_modes.emplace(dfb1, UnpackMode::UnpackToDest);
 //     dfb_unpack_modes.emplace(dfb2, UnpackMode::UnpackToSrc);
 //
-// or assign a whole value outright, e.g.:
-//
-//     enable_32_bit_dest(compute_hw) = true;
+// The const accessor returns the scalar fields by value, and unpack_modes (a container) by
+// const reference.
 //
 // For common fields, prefer this syntax over e.g. std::get<ComputeGen1Config>(config).field,
 // which throws if the wrong architecture is targeted.
@@ -211,32 +216,32 @@ inline MathFidelity& fpu_math_fidelity(ComputeHardwareConfig& config) {
     return std::visit([](auto& cfg) -> MathFidelity& { return cfg.fpu_math_fidelity; }, config);
 }
 
-inline const MathFidelity& fpu_math_fidelity(const ComputeHardwareConfig& config) {
-    return std::visit([](const auto& cfg) -> const MathFidelity& { return cfg.fpu_math_fidelity; }, config);
+inline MathFidelity fpu_math_fidelity(const ComputeHardwareConfig& config) {
+    return std::visit([](const auto& cfg) -> MathFidelity { return cfg.fpu_math_fidelity; }, config);
 }
 
 inline Precision& sfpu_precision_mode(ComputeHardwareConfig& config) {
     return std::visit([](auto& cfg) -> Precision& { return cfg.sfpu_precision_mode; }, config);
 }
 
-inline const Precision& sfpu_precision_mode(const ComputeHardwareConfig& config) {
-    return std::visit([](const auto& cfg) -> const Precision& { return cfg.sfpu_precision_mode; }, config);
+inline Precision sfpu_precision_mode(const ComputeHardwareConfig& config) {
+    return std::visit([](const auto& cfg) -> Precision { return cfg.sfpu_precision_mode; }, config);
 }
 
 inline bool& enable_32_bit_dest(ComputeHardwareConfig& config) {
     return std::visit([](auto& cfg) -> bool& { return cfg.enable_32_bit_dest; }, config);
 }
 
-inline const bool& enable_32_bit_dest(const ComputeHardwareConfig& config) {
-    return std::visit([](const auto& cfg) -> const bool& { return cfg.enable_32_bit_dest; }, config);
+inline bool enable_32_bit_dest(const ComputeHardwareConfig& config) {
+    return std::visit([](const auto& cfg) -> bool { return cfg.enable_32_bit_dest; }, config);
 }
 
 inline bool& double_buffer_dest(ComputeHardwareConfig& config) {
     return std::visit([](auto& cfg) -> bool& { return cfg.double_buffer_dest; }, config);
 }
 
-inline const bool& double_buffer_dest(const ComputeHardwareConfig& config) {
-    return std::visit([](const auto& cfg) -> const bool& { return cfg.double_buffer_dest; }, config);
+inline bool double_buffer_dest(const ComputeHardwareConfig& config) {
+    return std::visit([](const auto& cfg) -> bool { return cfg.double_buffer_dest; }, config);
 }
 
 inline ComputeUnpackModes& unpack_modes(ComputeHardwareConfig& config) {
@@ -246,5 +251,8 @@ inline ComputeUnpackModes& unpack_modes(ComputeHardwareConfig& config) {
 inline const ComputeUnpackModes& unpack_modes(const ComputeHardwareConfig& config) {
     return std::visit([](const auto& cfg) -> const ComputeUnpackModes& { return cfg.unpack_modes; }, config);
 }
+
+// Delete the rvalue overload of unpack_modes to prevent dangling references.
+inline const ComputeUnpackModes& unpack_modes(const ComputeHardwareConfig&&) = delete;
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
@@ -188,27 +188,24 @@ using ComputeHardwareConfig = std::variant<ComputeGen1Config, ComputeGen2Config>
 //  Common-field accessors
 // ----------------------------------------------------------------------------
 //
-// Most compute settings are common to every generation; only bfp_pack_precision_mode (Gen1) and
-// enable_2x_src_register (Gen2) are generation-specific. Reaching a common field through the
-// variant should not require knowing which alternative is held, so each one has an accessor here.
+// Many compute settings are common to Gen1 and Gen2 archictures.
 //
-// Prefer these to std::get<ComputeGen1Config>(config).field. That form is correct only on the
-// generation it names, and throws std::bad_variant_access on any other — a runtime failure on a
-// path that a Gen1 test run cannot reach. These accessors resolve the alternative for you and
-// cannot select the wrong one.
+// Reaching a common field through the variant is syntactically awkward; you should not need
+// to know which alternative is held. For convenience, each common field is given an accessor
+// helper function here. (Generation-specific fields are not given accessors.)
 //
-// Each returns a reference. Bind it once and use it like any other field, which is usually what
-// you want when setting several entries:
+// The accessor returns a reference. You can bind it and use it multiple times, e.g.:
 //
-//     auto& modes = unpack_modes(compute_hw);
-//     modes.emplace(dfb, UnpackMode::UnpackToDest);
+//     auto& dfb_unpack_modes = unpack_modes(compute_hw);
+//     dfb_unpack_modes.emplace(dfb1, UnpackMode::UnpackToDest);
+//     dfb_unpack_modes.emplace(dfb2, UnpackMode::UnpackToSrc);
 //
-// or assign a whole value outright, for a field set once:
+// or assign a whole value outright, e.g.:
 //
 //     enable_32_bit_dest(compute_hw) = true;
 //
-// A generation-specific field has no accessor by design: naming it forces you to be explicit
-// about the generation you mean, which is exactly right when the field exists on only one.
+// For common fields, prefer this syntax over e.g. std::get<ComputeGen1Config>(config).field,
+// which throws if the wrong architecture is targeted.
 
 inline MathFidelity& fpu_math_fidelity(ComputeHardwareConfig& config) {
     return std::visit([](auto& cfg) -> MathFidelity& { return cfg.fpu_math_fidelity; }, config);

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
@@ -184,4 +184,70 @@ struct ComputeGen2Config {
 // A compute kernel's hardware config holds exactly one generation's config.
 using ComputeHardwareConfig = std::variant<ComputeGen1Config, ComputeGen2Config>;
 
+// ----------------------------------------------------------------------------
+//  Common-field accessors
+// ----------------------------------------------------------------------------
+//
+// Most compute settings are common to every generation; only bfp_pack_precision_mode (Gen1) and
+// enable_2x_src_register (Gen2) are generation-specific. Reaching a common field through the
+// variant should not require knowing which alternative is held, so each one has an accessor here.
+//
+// Prefer these to std::get<ComputeGen1Config>(config).field. That form is correct only on the
+// generation it names, and throws std::bad_variant_access on any other — a runtime failure on a
+// path that a Gen1 test run cannot reach. These accessors resolve the alternative for you and
+// cannot select the wrong one.
+//
+// Each returns a reference. Bind it once and use it like any other field, which is usually what
+// you want when setting several entries:
+//
+//     auto& modes = unpack_modes(compute_hw);
+//     modes.emplace(dfb, UnpackMode::UnpackToDest);
+//
+// or assign a whole value outright, for a field set once:
+//
+//     enable_32_bit_dest(compute_hw) = true;
+//
+// A generation-specific field has no accessor by design: naming it forces you to be explicit
+// about the generation you mean, which is exactly right when the field exists on only one.
+
+inline MathFidelity& fpu_math_fidelity(ComputeHardwareConfig& config) {
+    return std::visit([](auto& cfg) -> MathFidelity& { return cfg.fpu_math_fidelity; }, config);
+}
+
+inline const MathFidelity& fpu_math_fidelity(const ComputeHardwareConfig& config) {
+    return std::visit([](const auto& cfg) -> const MathFidelity& { return cfg.fpu_math_fidelity; }, config);
+}
+
+inline Precision& sfpu_precision_mode(ComputeHardwareConfig& config) {
+    return std::visit([](auto& cfg) -> Precision& { return cfg.sfpu_precision_mode; }, config);
+}
+
+inline const Precision& sfpu_precision_mode(const ComputeHardwareConfig& config) {
+    return std::visit([](const auto& cfg) -> const Precision& { return cfg.sfpu_precision_mode; }, config);
+}
+
+inline bool& enable_32_bit_dest(ComputeHardwareConfig& config) {
+    return std::visit([](auto& cfg) -> bool& { return cfg.enable_32_bit_dest; }, config);
+}
+
+inline const bool& enable_32_bit_dest(const ComputeHardwareConfig& config) {
+    return std::visit([](const auto& cfg) -> const bool& { return cfg.enable_32_bit_dest; }, config);
+}
+
+inline bool& double_buffer_dest(ComputeHardwareConfig& config) {
+    return std::visit([](auto& cfg) -> bool& { return cfg.double_buffer_dest; }, config);
+}
+
+inline const bool& double_buffer_dest(const ComputeHardwareConfig& config) {
+    return std::visit([](const auto& cfg) -> const bool& { return cfg.double_buffer_dest; }, config);
+}
+
+inline ComputeUnpackModes& unpack_modes(ComputeHardwareConfig& config) {
+    return std::visit([](auto& cfg) -> ComputeUnpackModes& { return cfg.unpack_modes; }, config);
+}
+
+inline const ComputeUnpackModes& unpack_modes(const ComputeHardwareConfig& config) {
+    return std::visit([](const auto& cfg) -> const ComputeUnpackModes& { return cfg.unpack_modes; }, config);
+}
+
 }  // namespace tt::tt_metal::experimental


### PR DESCRIPTION
## PR Category
Feature

## Summary
This PR adds helper functions for setting `ComputeHardwareConfig` fields.

Why? Because the Metal 2.0 `ComputeHardwareConfig` makes a very awkward design compromise: 
 - We chose to make individual, generation-specific configs: `ComputeHardwareConfig`  is a std::variant of `ComputeGen1Config` and `ComputeGen2Config`. Why?
      - To protect against future hardware uncertainty 
      - To protect against a then-fluctuating Quasar config (now stabler)
      - To match the `DataMovementHardwareConfig` structure (there the Gen1 and Gen2 configs are orthogonal)
 - However, the majority of the compute hardware config's struct fields are common to both hardware gens.

This leads to some truly hideous variant-handling in generation-agnostic user code. There's no way to simply set a common config for both Gen1 and Gen2 without writing ugly code to handle the underlying variant.

```
    // Eeeew
    std::get<ComputeGen1Config>(compute_hw).unpack_modes = ...; 
    // Worse: this throws std::bad_variant if you try to switch your tt::arch to QUASAR
```

The obvious solution is to commonize the shared fields on the base struct, and use a variant sub-struct for that which differs. We had discarded this approach because it bakes in the assumption that future hardware generations will share the same configs that Gen1 and Gen2 share. 

Instead, this PR introduces helper accessor functions to hide the variant-ness of the common configs.

## Notes for Reviewers
 - You could argue that making the common fields shared on a base struct is the cleaner solution, hypothetic future hardware generations be damned. And you might be right. Even if this somewhat icky accessor thing proves to be an interim bandaid solution, it's still one that simplifies op porting and makes it much easier to swap in the common struct solution later.
 - There are a few existing Metal 2.0 op ports with the "eeew" pattern. I'm deliberately not fixing it in this PR, as I'm providing an "easy Quasar fixups" recipe that will address this instead.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/compute-config-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/compute-config-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/compute-config-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/compute-config-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=akertesz/compute-config-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:akertesz/compute-config-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/compute-config-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/compute-config-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/compute-config-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/compute-config-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/compute-config-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/compute-config-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/compute-config-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/compute-config-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/compute-config-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/compute-config-accessors)