### PR TITLE
Test Prefill Transformer Cleanup

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -14,8 +14,8 @@ Reference sources are checked in priority order:
 
 Parametrized over:
 - use_pretrained: real pretrained weights from DeepSeek-R1-0528 vs random weights
-- input_source: "random", "json_prompts", or InfiniteBench subset (passkey, kv_retrieval, etc.)
-- pcc_validation: per-stage PCC check (via return_intermediates) vs shape-only smoke test
+- (input_source, pcc_validation): coupled — only longbook_qa_eng has a golden, so only it pairs
+  with pcc_validation=True
 - n_routed_experts / gate_fallback_mode: MoE configurations
 """
 
@@ -49,13 +49,7 @@ from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, 
 from models.demos.deepseek_v3_d_p.utils.pcc_plot_utils import generate_pcc_plots, write_pcc_summary
 from models.demos.deepseek_v3_d_p.utils.test_utils import save_intermediate_output
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
-    ABC_1K_PATH,
-    ABC_SHORT_PATH,
-    P64TOK_PATH,
-    P960TOK_PATH,
-    PIE960_PATH,
     PROMPT_1K_PATH,
-    PROMPT_25K_PATH,
     ReferenceCacheKey,
     check_first_token_match,
     check_first_token_match_host_ref,
@@ -82,9 +76,8 @@ TRACE_PCC_THRESHOLD_DEVICE_FP32 = 0.95
 # Determinism: every iteration is expected to match the iter-0 baseline near-bit-exactly.
 DETERMINISM_PCC_THRESHOLD = 1.0
 
-# Input sources: "random" = random token IDs, "json_prompts" = test_prompts_1024.json,
-# or any InfiniteBench subset name (downloaded on first use via infinitebench_prompt fixture).
-INFINITEBENCH_SUBSET_NAMES = {"passkey", "kv_retrieval", "longdialogue_qa_eng", "longbook_qa_eng"}
+# Only the subset that is still a parametrized input_source; downloaded on first use.
+INFINITEBENCH_SUBSET_NAMES = {"longbook_qa_eng"}
 SEQ_LEN_1K = 1024
 SEQ_LEN_5K = 5120
 SEQ_LEN_25K = 25600
@@ -306,32 +299,8 @@ def run_model(
         if input_source == "json_prompts":
             from models.demos.deepseek_v3.demo.demo import load_prompts_from_json
 
-            prompt_text = load_prompts_from_json(str(PROMPT_1K_PATH))
-            prompt_text = prompt_text[0] if isinstance(prompt_text, list) else prompt_text
-        elif input_source == "abc_1k":
-            from models.demos.deepseek_v3.demo.demo import load_prompts_from_json
-
-            prompt_text = load_prompts_from_json(str(ABC_1K_PATH))
-        elif input_source == "abc_short":
-            from models.demos.deepseek_v3.demo.demo import load_prompts_from_json
-
-            prompt_text = load_prompts_from_json(str(ABC_SHORT_PATH))
-        elif input_source == "p64tok":
-            from models.demos.deepseek_v3.demo.demo import load_prompts_from_json
-
-            prompt_text = load_prompts_from_json(str(P64TOK_PATH))
-        elif input_source == "p960tok":
-            from models.demos.deepseek_v3.demo.demo import load_prompts_from_json
-
-            prompt_text = load_prompts_from_json(str(P960TOK_PATH))
-        elif input_source == "pie960":
-            from models.demos.deepseek_v3.demo.demo import load_prompts_from_json
-
-            prompt_text = load_prompts_from_json(str(PIE960_PATH))
-        elif input_source == "prompt_25k":
-            from models.demos.deepseek_v3.demo.demo import load_prompts_from_json
-
-            prompt_text = load_prompts_from_json(str(PROMPT_25K_PATH))
+            # The file holds two prompts; one prefill takes one.
+            prompt_text = load_prompts_from_json(str(PROMPT_1K_PATH), max_prompts=1)[0]
         elif input_source in INFINITEBENCH_SUBSET_NAMES:
             cached_path = download_infinitebench_subset(input_source)
             with open(cached_path) as f:
@@ -859,23 +828,15 @@ def run_model(
 @pytest.mark.parametrize("return_kv_cache", [True], ids=["kv_cache"])
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 @pytest.mark.parametrize(
-    "input_source",
+    "input_source, pcc_validation",
     [
-        "json_prompts",
-        "abc_1k",
-        "abc_short",
-        "p64tok",
-        "p960tok",
-        "pie960",
-        "prompt_25k",
-        "random",
-        "passkey",
-        "kv_retrieval",
-        "longdialogue_qa_eng",
-        "longbook_qa_eng",
+        ("longbook_qa_eng", True),
+        ("longbook_qa_eng", False),
+        ("json_prompts", False),
+        ("random", False),
     ],
+    ids=["pcc-longbook_qa_eng", "smoke-longbook_qa_eng", "smoke-json_prompts", "smoke-random"],
 )
-@pytest.mark.parametrize("pcc_validation", [True, False], ids=["pcc", "smoke"])
 @pytest.mark.parametrize("is_balanced", [True, False], ids=["balanced", "regular"])
 @pytest.mark.parametrize(
     "isl_total, dispatch_buffer_capacity_factor",
@@ -1001,23 +962,15 @@ def test_ds_prefill_transformer(
 @pytest.mark.parametrize("return_kv_cache", [True], ids=["kv_cache"])
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 @pytest.mark.parametrize(
-    "input_source",
+    "input_source, pcc_validation",
     [
-        "json_prompts",
-        "abc_1k",
-        "abc_short",
-        "p64tok",
-        "p960tok",
-        "pie960",
-        "prompt_25k",
-        "random",
-        "passkey",
-        "kv_retrieval",
-        "longdialogue_qa_eng",
-        "longbook_qa_eng",
+        ("longbook_qa_eng", True),
+        ("longbook_qa_eng", False),
+        ("json_prompts", False),
+        ("random", False),
     ],
+    ids=["pcc-longbook_qa_eng", "smoke-longbook_qa_eng", "smoke-json_prompts", "smoke-random"],
 )
-@pytest.mark.parametrize("pcc_validation", [True, False], ids=["pcc", "smoke"])
 @pytest.mark.parametrize("is_balanced", [False], ids=["non_balanced"])
 @pytest.mark.parametrize(
     "isl_total, dispatch_buffer_capacity_factor",

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -13,9 +13,9 @@ Reference sources are checked in priority order:
 3. HF model computation (creates HF DeepseekV3Model and runs forward on the fly)
 
 Parametrized over:
-- use_pretrained: real pretrained weights from DeepSeek-R1-0528 vs random weights
-- (input_source, pcc_validation): coupled — only longbook_qa_eng has a golden, so only it pairs
-  with pcc_validation=True
+- (input_source, pcc_validation, use_pretrained): one coupled axis. A golden is a reference only
+  for the pretrained weights it was captured from, so PCC runs pair a single source per variant
+  with pretrained weights; everything else is smoke-only.
 - n_routed_experts / gate_fallback_mode: MoE configurations
 """
 
@@ -306,7 +306,11 @@ def run_model(
             with open(cached_path) as f:
                 prompt_text = json.load(f)["prompt"]
         else:
-            raise ValueError(f"Unknown input_source: {input_source}")
+            raise ValueError(
+                f"No tokens for input_source={input_source}: it has no prompt file, and "
+                f"variant.test_prefill_trace_default ({getattr(variant, 'test_prefill_trace_default', None)}) "
+                f"did not resolve"
+            )
         token_ids, attention_mask, tokens = tokenize_prompt_to_isl(tok, max_isl=isl_total, prompt_text=prompt_text)
         profiler.end("tokenization")
         logger.info(
@@ -826,16 +830,27 @@ def run_model(
 @pytest.mark.parametrize("tokenizer", ["right", "left"], indirect=True, ids=["right_pad", "left_pad"])
 @pytest.mark.parametrize("temperature", [[0.5]], ids=["temp_sweep"])
 @pytest.mark.parametrize("return_kv_cache", [True], ids=["kv_cache"])
-@pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 @pytest.mark.parametrize(
-    "input_source, pcc_validation",
+    "input_source, pcc_validation, use_pretrained",
     [
-        ("longbook_qa_eng", True),
-        ("longbook_qa_eng", False),
-        ("json_prompts", False),
-        ("random", False),
+        # The golden was captured from the pretrained model
+        ("longbook_qa_eng", True, True),
+        ("longbook_qa_eng", False, True),
+        ("longbook_qa_eng", False, False),
+        ("json_prompts", False, True),
+        ("json_prompts", False, False),
+        ("random", False, True),
+        ("random", False, False),
     ],
-    ids=["pcc-longbook_qa_eng", "smoke-longbook_qa_eng", "smoke-json_prompts", "smoke-random"],
+    ids=[
+        "pcc-longbook_qa_eng-pretrained",
+        "smoke-longbook_qa_eng-pretrained",
+        "smoke-longbook_qa_eng-random",
+        "smoke-json_prompts-pretrained",
+        "smoke-json_prompts-random",
+        "smoke-random-pretrained",
+        "smoke-random-random",
+    ],
 )
 @pytest.mark.parametrize("is_balanced", [True, False], ids=["balanced", "regular"])
 @pytest.mark.parametrize(
@@ -960,16 +975,22 @@ def test_ds_prefill_transformer(
 @pytest.mark.parametrize("tokenizer", ["right", "left"], indirect=True, ids=["right_pad", "left_pad"])
 @pytest.mark.parametrize("temperature", [[0.5]], ids=["temp_sweep"])
 @pytest.mark.parametrize("return_kv_cache", [True], ids=["kv_cache"])
-@pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 @pytest.mark.parametrize(
-    "input_source, pcc_validation",
+    "input_source, pcc_validation, use_pretrained",
     [
-        ("longbook_qa_eng", True),
-        ("longbook_qa_eng", False),
-        ("json_prompts", False),
-        ("random", False),
+        ("code_debug", True, True),
+        ("json_prompts", False, True),
+        ("json_prompts", False, False),
+        ("random", False, True),
+        ("random", False, False),
     ],
-    ids=["pcc-longbook_qa_eng", "smoke-longbook_qa_eng", "smoke-json_prompts", "smoke-random"],
+    ids=[
+        "pcc-code_debug-pretrained",
+        "smoke-json_prompts-pretrained",
+        "smoke-json_prompts-random",
+        "smoke-random-pretrained",
+        "smoke-random-random",
+    ],
 )
 @pytest.mark.parametrize("is_balanced", [False], ids=["non_balanced"])
 @pytest.mark.parametrize(
@@ -1071,8 +1092,14 @@ def test_kimi_prefill_transformer(
 @pytest.mark.parametrize("temperature", [[0.5]], ids=["temp_sweep"])
 @pytest.mark.parametrize("return_kv_cache", [True], ids=["kv_cache"])
 @pytest.mark.parametrize("use_pretrained", [True], ids=["pretrained"])
-@pytest.mark.parametrize("input_source", ["json_prompts"])
-@pytest.mark.parametrize("pcc_validation", [True, False], ids=["pcc", "smoke"])
+@pytest.mark.parametrize(
+    "input_source, pcc_validation",
+    [
+        ("code_debug", True),
+        ("json_prompts", False),
+    ],
+    ids=["pcc-code_debug", "smoke-json_prompts"],
+)
 @pytest.mark.parametrize("is_balanced", [False], ids=["non_balanced"])
 @pytest.mark.parametrize(
     "isl_total, dispatch_buffer_capacity_factor",

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -78,6 +78,8 @@ DETERMINISM_PCC_THRESHOLD = 1.0
 
 # Only the subset that is still a parametrized input_source; downloaded on first use.
 INFINITEBENCH_SUBSET_NAMES = {"longbook_qa_eng"}
+# input_source meaning "this variant's own golden" — naming it after a prompt would go stale.
+VARIANT_DEFAULT_TRACE = "variant_default"
 SEQ_LEN_1K = 1024
 SEQ_LEN_5K = 5120
 SEQ_LEN_25K = 25600
@@ -205,15 +207,13 @@ def run_model(
         else False
     )
 
-    # Priority 1: debug trace on disk
+    # Priority 1: debug trace on disk. A golden is captured from the full pretrained model, so it is
+    # a reference only for a run with those weights and that expert count.
     trace = None
     trace_dir = None
     trace_sliced = False
-    trace_match = (
-        find_trace_dir(input_source, isl_total, padding_side, use_pretrained, n_routed_experts)
-        if pcc_validation
-        else None
-    )
+    trace_eligible = pcc_validation and use_pretrained and n_routed_experts == variant.model_config.NUM_ROUTED_EXPERTS
+    trace_match = find_trace_dir(input_source, isl_total, padding_side) if trace_eligible else None
     if trace_match is not None:
         trace_dir, trace_isl = trace_match
         trace = load_debug_trace(trace_dir, num_layers=num_layers)
@@ -226,27 +226,26 @@ def run_model(
             f"(trace n_layers={trace.metadata.get('n_layers')}, test num_layers={num_layers}, "
             f"native_isl={trace_isl}, sliced={trace_sliced})"
         )
-    # Fallback: a variant may pin an explicit golden trace via variant.test_prefill_trace_default that
-    # find_trace_dir's (R1-centric, use_pretrained/256-expert) TRACE_LOOKUP doesn't cover. load_debug_trace
-    # reads both the single_file and chunked_group_a_v1 layouts and slices to isl_total, so the single-shot
-    # test just chops the prefix it needs (e.g. the first 5120 rows == a 5120 single-shot prefill).
-    elif pcc_validation and getattr(variant, "test_prefill_trace_default", None):
-        _pinned = variant.test_prefill_trace_default
-        if _pinned and os.path.isdir(_pinned) and os.path.exists(os.path.join(_pinned, "metadata.json")):
-            trace_dir = Path(_pinned)
-            trace = load_debug_trace(trace_dir, num_layers=num_layers, isl=isl_total)
-            # load_debug_trace(isl=...) chops the per-row tensors (token_ids/decoder/kv) to isl_total, but
-            # the stored logits/next_token_id stay the full-sequence products (never isl-sliced). Mark the
-            # trace sliced when we chopped a longer golden, so the later full-model logits/first-token
-            # checks are skipped — otherwise trace_full_model stays True and they compare this shorter
-            # prefill against the 55k golden's final-token logits and false-fail.
-            native_isl = len(trace.metadata.get("token_ids", []))
-            if native_isl > isl_total:
-                trace_sliced = True
-            logger.info(
-                f"Loaded pinned debug trace from {trace_dir} "
-                f"(num_layers={num_layers}, isl={isl_total}, native_isl={native_isl}, sliced={trace_sliced})"
-            )
+    # Explicitly asked for this variant's own golden (TRACE_LOOKUP is longbook/R1-only). Not a
+    # fallback: only this input_source lands here, so no other row gets handed someone else's golden.
+    elif trace_eligible and input_source == VARIANT_DEFAULT_TRACE:
+        _pinned = getattr(variant, "test_prefill_trace_default", None)
+        assert _pinned and os.path.exists(os.path.join(_pinned, "metadata.json")), (
+            f"{variant.name}: input_source={VARIANT_DEFAULT_TRACE} needs a usable "
+            f"test_prefill_trace_default, got {_pinned}"
+        )
+        trace_dir = Path(_pinned)
+        trace = load_debug_trace(trace_dir, num_layers=num_layers, isl=isl_total)
+        # load_debug_trace(isl=...) chops the per-row tensors, but the stored logits/next_token_id stay
+        # full-sequence. Mark a chopped golden sliced so the later full-model checks are skipped instead
+        # of comparing this shorter prefill against the golden's final-token logits.
+        native_isl = len(trace.metadata.get("token_ids", []))
+        if native_isl > isl_total:
+            trace_sliced = True
+        logger.info(
+            f"Loaded {variant.name} variant golden from {trace_dir} "
+            f"(num_layers={num_layers}, isl={isl_total}, native_isl={native_isl}, sliced={trace_sliced})"
+        )
 
     cache_key = ReferenceCacheKey(
         weight_type=weight_type,
@@ -311,7 +310,7 @@ def run_model(
                 f"variant.test_prefill_trace_default ({getattr(variant, 'test_prefill_trace_default', None)}) "
                 f"did not resolve"
             )
-        token_ids, attention_mask, tokens = tokenize_prompt_to_isl(tok, max_isl=isl_total, prompt_text=prompt_text)
+        token_ids, attention_mask, _ = tokenize_prompt_to_isl(tok, max_isl=isl_total, prompt_text=prompt_text)
         profiler.end("tokenization")
         logger.info(
             f"Tokenized {input_source} input shape: {token_ids.shape}, first 10 tokens: {token_ids[0, :10].tolist()}, last 10 tokens: {token_ids[0, -10:].tolist()}"
@@ -978,14 +977,14 @@ def test_ds_prefill_transformer(
 @pytest.mark.parametrize(
     "input_source, pcc_validation, use_pretrained",
     [
-        ("code_debug", True, True),
+        (VARIANT_DEFAULT_TRACE, True, True),
         ("json_prompts", False, True),
         ("json_prompts", False, False),
         ("random", False, True),
         ("random", False, False),
     ],
     ids=[
-        "pcc-code_debug-pretrained",
+        "pcc-variant_default-pretrained",
         "smoke-json_prompts-pretrained",
         "smoke-json_prompts-random",
         "smoke-random-pretrained",
@@ -1095,10 +1094,10 @@ def test_kimi_prefill_transformer(
 @pytest.mark.parametrize(
     "input_source, pcc_validation",
     [
-        ("code_debug", True),
+        (VARIANT_DEFAULT_TRACE, True),
         ("json_prompts", False),
     ],
-    ids=["pcc-code_debug", "smoke-json_prompts"],
+    ids=["pcc-variant_default", "smoke-json_prompts"],
 )
 @pytest.mark.parametrize("is_balanced", [False], ids=["non_balanced"])
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tt/prefill_transformer_test_env_vars.md
+++ b/models/demos/deepseek_v3_d_p/tt/prefill_transformer_test_env_vars.md
@@ -59,14 +59,17 @@ names are baked in:
 
 ```python
 TRACE_DIR_BASE = Path(os.getenv("DEEPSEEK_V3_TRACE_DIR", "/mnt/MLPerf/deepseek-prefill-cache")).resolve()
-ILLIAD_1024_TRACE     = TRACE_DIR_BASE / "illiad_prefill_fa2"
-ILLIAD_25024_TRACE    = TRACE_DIR_BASE / "illiad_prefill_fa2_25024"
-ABC_1K_PAD_RIGHT_1024 = TRACE_DIR_BASE / "ABC_1k_prefill_padd_right_1024"
-ABC_1K_PAD_LEFT_1024  = TRACE_DIR_BASE / "ABC_1k_prefill_padd_left_1024"
-LONGBOOK_QA_ENG_25600 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_25600_nopad"
 LONGBOOK_QA_ENG_5120  = TRACE_DIR_BASE / "longbook_qa_eng_prefill_5120_nopad"
+LONGBOOK_QA_ENG_25600 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_25600_nopad"
 LONGBOOK_QA_ENG_56320 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_56320_nopad"
 ```
+
+Two shared filesystems, different layouts; the in-code default targets the first:
+
+| filesystem | traces sit | native lengths |
+|---|---|---|
+| `/mnt/MLPerf/deepseek-prefill-cache` (CIv1, mounted `:ro` by `blackhole-e2e-tests-impl.yaml`) | in the base | 5120, 25600 |
+| `/mnt/models/deepseek-prefill-cache` (Exabox, Blaze/Galaxy `mpirun`) | under `golden/` | 5120, 56320 |
 
 **Step 2 — the lookup table**. The key is the tuple
 `(input_source, isl_total, padding_side)`, where `isl_total` is the trace's native
@@ -74,10 +77,6 @@ LONGBOOK_QA_ENG_56320 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_56320_nopad"
 
 ```python
 TRACE_LOOKUP: dict[tuple[str, int, str], Path] = {
-    ("json_prompts",    1024,  "right"): ILLIAD_1024_TRACE,
-    ("json_prompts",    25600, "right"): ILLIAD_25024_TRACE,
-    ("abc_1k",          1024,  "right"): ABC_1K_PAD_RIGHT_1024,
-    ("abc_1k",          1024,  "left"):  ABC_1K_PAD_LEFT_1024,
     ("longbook_qa_eng", 5120,  "right"): LONGBOOK_QA_ENG_5120,
     ("longbook_qa_eng", 25600, "right"): LONGBOOK_QA_ENG_25600,
     ("longbook_qa_eng", 56320, "right"): LONGBOOK_QA_ENG_56320,
@@ -136,7 +135,7 @@ the loader reads by **fixed filenames/keys**, not by searching:
 
 - To point at a custom trace location, set `DEEPSEEK_V3_TRACE_DIR` to a base dir that
   **contains the exact hardcoded subdirectory names** above — e.g.
-  `$DEEPSEEK_V3_TRACE_DIR/ABC_1k_prefill_padd_right_1024/metadata.json`.
+  `$DEEPSEEK_V3_TRACE_DIR/longbook_qa_eng_prefill_5120_nopad/metadata.json`.
 - If no trace matches your `(input_source, padding_side)` with a native isl `>= isl_total`,
   **no trace is used regardless of the env var** — the test falls back to the reference
   cache / live HF compute.
@@ -153,8 +152,8 @@ Default `~/.cache/huggingface`.
 ## Tier 2 — optional behavior toggles
 
 ### `TT_DS_PREFILL_INFINITEBENCH_CACHE`
-Where InfiniteBench prompt subsets are cached (only relevant when `input_source` is
-`passkey`/`kv_retrieval`/`longdialogue_qa_eng`/`longbook_qa_eng`). Falls back under `HF_HOME`.
+Where the InfiniteBench subset is cached. Relevant only to `smoke-longbook_qa_eng` — the pcc row
+takes its tokens from the trace. The test's only network dependency. Falls back under `HF_HOME`.
 
 ### `TT_DS_PREFILL_DEBUG_TOKEN_COUNT`
 `1/true/yes` enables a token-count debug path inside the MoE block (`tt_moe.py`).

--- a/models/demos/deepseek_v3_d_p/tt/prefill_transformer_test_env_vars.md
+++ b/models/demos/deepseek_v3_d_p/tt/prefill_transformer_test_env_vars.md
@@ -139,9 +139,8 @@ the loader reads by **fixed filenames/keys**, not by searching:
 - If no trace matches your `(input_source, padding_side)` with a native isl `>= isl_total`,
   **no trace is used regardless of the env var** — the test falls back to the reference
   cache / live HF compute.
-- This is a different mechanism from the variant's `prefill_trace_default` field
-  (`/mnt/models/.../golden/...`), which is consumed by the *chunked* transformer test and
-  the standalone runners via `PREFILL_TRACE_DIR` — not by this `find_trace_dir` path.
+- `DEEPSEEK_V3_TRACE_DIR` covers only the table above. The `variant_default` PCC rows instead read
+  `variant.test_prefill_trace_default` — a hardcoded adapter path, with no env override here.
 
 ### `HF_HOME`
 HuggingFace cache dir used for the auto-download fallback (weights, config, tokenizer).
@@ -152,8 +151,8 @@ Default `~/.cache/huggingface`.
 ## Tier 2 — optional behavior toggles
 
 ### `TT_DS_PREFILL_INFINITEBENCH_CACHE`
-Where the InfiniteBench subset is cached. Relevant only to `smoke-longbook_qa_eng` — the pcc row
-takes its tokens from the trace. The test's only network dependency. Falls back under `HF_HOME`.
+Where the InfiniteBench subset is cached. Needed whenever a `longbook_qa_eng` run tokenizes:
+the smoke rows, and any pcc run where no golden resolved. Falls back under `HF_HOME`.
 
 ### `TT_DS_PREFILL_DEBUG_TOKEN_COUNT`
 `1/true/yes` enables a token-count debug path inside the MoE block (`tt_moe.py`).

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -64,12 +64,8 @@ PROMPT_5K_PATH = Path("models/demos/deepseek_v3_d_p/demo/test_prompt_5k.json")
 PROMPT_25K_PATH = Path("models/demos/deepseek_v3_d_p/demo/test_prompt_25k.json")
 
 TRACE_DIR_BASE = Path(os.getenv("DEEPSEEK_V3_TRACE_DIR", "/mnt/MLPerf/deepseek-prefill-cache")).resolve()
-ILLIAD_1024_TRACE = TRACE_DIR_BASE / "illiad_prefill_fa2"
-ILLIAD_25024_TRACE = TRACE_DIR_BASE / "illiad_prefill_fa2_25024"
-ABC_1K_PAD_RIGHT_1024 = TRACE_DIR_BASE / "ABC_1k_prefill_padd_right_1024"
-ABC_1K_PAD_LEFT_1024 = TRACE_DIR_BASE / "ABC_1k_prefill_padd_left_1024"
-LONGBOOK_QA_ENG_25600 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_25600_nopad"
 LONGBOOK_QA_ENG_5120 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_5120_nopad"
+LONGBOOK_QA_ENG_25600 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_25600_nopad"
 LONGBOOK_QA_ENG_56320 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_56320_nopad"
 CODE_DEBUG_5K_CHUNKED = TRACE_DIR_BASE / "code_debug_5k_chunked"
 
@@ -81,10 +77,6 @@ CODE_DEBUG_5K_CHUNKED = TRACE_DIR_BASE / "code_debug_5k_chunked"
 # back to the smallest native trace with the same (input_source, padding_side) whose
 # length is >= the requested isl, and the caller slices it (see slice_debug_trace).
 TRACE_LOOKUP: dict[tuple[str, int, str], Path] = {
-    ("json_prompts", 1024, "right"): ILLIAD_1024_TRACE,
-    ("json_prompts", 25600, "right"): ILLIAD_25024_TRACE,
-    ("abc_1k", 1024, "right"): ABC_1K_PAD_RIGHT_1024,
-    ("abc_1k", 1024, "left"): ABC_1K_PAD_LEFT_1024,
     ("longbook_qa_eng", 5120, "right"): LONGBOOK_QA_ENG_5120,
     ("longbook_qa_eng", 25600, "right"): LONGBOOK_QA_ENG_25600,
     ("longbook_qa_eng", 56320, "right"): LONGBOOK_QA_ENG_56320,

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -88,32 +88,18 @@ def _trace_dir_ready(path: Path) -> bool:
     return path.exists() and (path / "metadata.json").exists()
 
 
-def find_trace_dir(
-    input_source: str,
-    isl_total: int,
-    padding_side: str,
-    use_pretrained: bool,
-    n_routed_experts: int,
-) -> tuple[Path, int] | None:
-    """Return ``(trace_dir, trace_isl)`` for a test configuration, or ``None``.
+def find_trace_dir(input_source: str, isl_total: int, padding_side: str) -> tuple[Path, int] | None:
+    """Return ``(trace_dir, trace_isl)`` for a registered, on-disk trace, or ``None``.
 
     ``trace_isl`` is the trace's NATIVE sequence length. When it is larger than the
     requested ``isl_total`` the caller must slice the trace down to ``isl_total``
     (see :func:`slice_debug_trace`) — valid for causal, nopad prefill traces.
-
-    A trace is eligible only when:
-    - the model uses pretrained weights with 256 experts (traces were generated from
-      the full pretrained DeepSeek-R1 model)
-    - the directory exists and contains a metadata.json
 
     Resolution order:
     1. Exact ``(input_source, isl_total, padding_side)`` match (no slicing).
     2. Otherwise the smallest ready trace with the same ``(input_source, padding_side)``
        whose native isl is ``>= isl_total`` (caller slices the first ``isl_total`` tokens).
     """
-    if not use_pretrained or n_routed_experts != 256:
-        return None
-
     # 1. Exact native-length match — preferred, no slicing needed.
     exact = TRACE_LOOKUP.get((input_source, isl_total, padding_side))
     if exact is not None and _trace_dir_ready(exact):


### PR DESCRIPTION
### PR Category
Cleanup

### Issue
DS Prefill :: Cleanup of test_prefill_transformer.py tests
 #48699
 
### Summary
- Pytest combinations which ran inputs with no reference of their own and silently fell back to the longbook golden and reported a passing PCC under another input's name are gone
- The list of input sources the test offers is reduced
- The default variant trace is explicitly set
- TRACE_LOOKUP table is cleaned from not existing traces 

### Notes for reviewers
- [x] [Blaze Models Prefill tests](https://github.com/tenstorrent/tt-metal/actions/runs/31170064379) passes
- [ ] [(Release) Model Status for Console Deployment ](https://github.com/tenstorrent/tt-metal/actions/runs/31127053327) in progress

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmitrovic/prefill_transformer_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmitrovic/prefill_transformer_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmitrovic/prefill_transformer_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmitrovic/prefill_transformer_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jmitrovic/prefill_transformer_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jmitrovic/prefill_transformer_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmitrovic/prefill_transformer_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmitrovic/prefill_transformer_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmitrovic/prefill_transformer_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmitrovic/prefill_transformer_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmitrovic/prefill_transformer_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmitrovic/prefill_transformer_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmitrovic/prefill_transformer_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmitrovic/prefill_transformer_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmitrovic/prefill_transformer_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmitrovic/prefill_transformer_cleanup)