### PR TITLE
[Bug fix] emule: fabric route ordering race, $TMPDIR JIT scratch, and two triage diagnostics

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2770,6 +2770,46 @@ extern "C" void __emule_fabric_teleport(const void* packet_header, const void* p
             }
         }
     }
+    // EMULE_FABRIC_XFER=<file>: one compact line per payload-carrying send — the SOURCE L1
+    // offset (bridge_l1-relative, so it is directly comparable to a kernel's get_write_ptr),
+    // the sending core, each destination chip + destination L1 offset, and the payload's first
+    // word. Enough to reconstruct a whole CCL's wiring offline and diff it against the ring the
+    // op intends, which is how a misrouting bug gets localized without a device.
+    //
+    // Deliberately much cheaper than EMULE_FABRIC_DEBUG: that one is too verbose to leave on
+    // without perturbing the very race under study.
+    //
+    // Caveat: the fopen/fprintf/fclose widens the window between reading the payload word and
+    // the delivery memcpy, so under an active race the logged first word can disagree with the
+    // bytes actually delivered. Trust the addresses and targets from this trace; get delivered
+    // contents from a tensor dump.
+    if (payload != nullptr && size > 0) {
+        static const char* xfer_path = std::getenv("EMULE_FABRIC_XFER");
+        if (xfer_path != nullptr) {
+            const uint64_t noc_address = *reinterpret_cast<const uint64_t*>(h + 0);
+            const uint64_t src_off = static_cast<uint64_t>(
+                reinterpret_cast<const uint8_t*>(payload) - __emule_self->bridge_l1);
+            uint32_t w0 = 0;
+            std::memcpy(&w0, payload, sizeof(uint32_t));
+            std::string ts;
+            for (auto t : targets) {
+                ts += " " + std::to_string(t);
+            }
+            static std::mutex xfer_mu;
+            std::lock_guard<std::mutex> lk(xfer_mu);
+            FILE* fp = std::fopen(xfer_path, "a");
+            if (fp != nullptr) {
+                std::fprintf(fp,
+                             "[XFER] src_chip=%u core=(%u,%u) proc=%u src_off=0x%llx size=%u "
+                             "dst_noc=0x%llx w0=0x%08x targets=[%s ]\n",
+                             src_chip, (unsigned)__emule_self->core->logical_x,
+                             (unsigned)__emule_self->core->logical_y, (unsigned)__emule_self->processor_id,
+                             (unsigned long long)src_off, size,
+                             (unsigned long long)noc_address, w0, ts.c_str());
+                std::fclose(fp);
+            }
+        }
+    }
     // One target for unicast; the line members for a multicast. Replay the terminal NOC op to each.
     for (uint32_t dst_chip : targets) {
         __emule_fabric_deliver(dst_chip, h, payload, size, noc_send_type, dbg);

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -930,12 +930,20 @@ static std::function<void()> jit_compile_kernel(
     }
     std::string abs_kernel = std::filesystem::absolute(kernel_src_path).string();
 
-    // 2. Create temp directory
-    char tmpdir[] = "/tmp/tt_emule_jit_XXXXXX";
-    if (!mkdtemp(tmpdir)) {
+    // 2. Create temp directory. Honor $TMPDIR so the JIT scratch can be placed on a
+    // reaper-safe filesystem (a /tmp cleanup reaper wiping these dirs mid-compile
+    // causes "named_args_generated.h not found" / "ld: cannot open output" failures).
+    std::string tmpl = (std::getenv("TMPDIR") ? std::string(std::getenv("TMPDIR")) : std::string("/tmp"));
+    if (!tmpl.empty() && tmpl.back() == '/') {
+        tmpl.pop_back();
+    }
+    tmpl += "/tt_emule_jit_XXXXXX";
+    std::vector<char> tmpdir(tmpl.begin(), tmpl.end());
+    tmpdir.push_back('\0');
+    if (!mkdtemp(tmpdir.data())) {
         throw std::runtime_error("jit_compile_kernel: mkdtemp failed");
     }
-    std::string dir(tmpdir);
+    std::string dir(tmpdir.data());
 
     // 2b. Preprocess the kernel source for x86: rewrite RISC-V inline asm
     // (mhartid, fence) and raw L1 arg-val pointer casts. -I kernel_dir (below)

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2361,8 +2361,14 @@ struct ConnRoute {
 };
 static std::mutex g_conn_route_mu;
 // Keyed by SRC CHIP only (line direction is a per-chip property; the connection-owner core can differ from
-// the sender, so a per-core key would miss). Deduped by direction; append order makes index 0=fwd, 1=bwd.
-// See tt-emule docs/fabric-ccl-emulation.md.
+// the sender, so a per-core key would miss). Deduped by direction and kept sorted by RoutingDirection
+// (N=0,E=1,S=2,W=3,Z=4), i.e. COMPASS order — which is the order the kernel's own connection open sequence
+// walks the active directions, so the sender's per-fiber open-sequence index (ConnRoute::dir_index below)
+// selects the direction it actually opened. Sorted, NOT append order: many fibers on one src chip record
+// concurrently at TT_EMULE_FIBER_WORKERS > 1, so append order is a race — whichever fiber won put its
+// direction at index 0, flipping fwd/bwd for every sender that indexes by open-sequence and teleporting
+// whole slices to the wrong chip (nondeterministic CCL PCC; invisible at K=1, where append order is the
+// deterministic fiber order). See tt-emule docs/fabric-ccl-emulation.md.
 static std::unordered_map<uint32_t, std::vector<ConnRoute>> g_conn_route;
 // Persistent UNDIRECTED ring adjacency (chip -> ring-neighbor chips), accumulated across ALL ops and never
 // reset: the physical ethernet ring is static, but each op's senders open only the connection(s) they use,
@@ -2399,12 +2405,18 @@ extern "C" void __emule_fabric_record_conn(uint32_t src, uint32_t wx, uint32_t w
     g_ring_adj[src].insert(neighbor);
     g_ring_adj[neighbor].insert(src);
     auto& v = g_conn_route[src];
-    for (const auto& c : v) {
-        if (c.dir == dir) {
+    // Insert in compass order (see g_conn_route's comment): the position must be a function of `dir`
+    // alone, never of which fiber recorded first.
+    auto at = v.begin();
+    for (; at != v.end(); ++at) {
+        if (at->dir == dir) {
             return;  // already recorded this direction for src
         }
+        if (at->dir > dir) {
+            break;
+        }
     }
-    v.push_back(ConnRoute{dir, neighbor});
+    v.insert(at, ConnRoute{dir, neighbor});
 }
 
 // Ordered ring members at distance 1,2,... from `src` in `start_dir`: first hop from g_conn_route[src], then

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -8,6 +8,8 @@
 
 #include <ucontext.h>
 #include <sys/mman.h>
+#include <dlfcn.h>   // dladdr, for the parked-fiber op census
+#include <cxxabi.h>  // demangle the op symbol
 #include <unistd.h>
 
 #include <atomic>
@@ -481,10 +483,54 @@ void FiberScheduler::spawn(std::function<void()> entry, std::unique_ptr<ThreadCo
     p_->all_.push_back(std::move(f));   // home + ready-queue placement happens in run_until_idle
 }
 
+
+// Conservative stack scan naming the blaze op a parked fiber sits in.
+// Walks the fiber's saved stack for words that dladdr resolves to a symbol, and
+// returns the first demangled blaze::...::Op<...> frame. Env-gated
+// (EMULE_PARK_STACKS=1) and best-effort: a false positive is a stale return address,
+// never a crash (every deref is bounds-checked against the fiber's own mapping).
+static std::string emule_park_op_name(const Fiber* f) {
+    if (!f || !f->map_base || f->map_bytes == 0) {
+        return {};
+    }
+    auto sp = static_cast<uintptr_t>(f->ctx.uc_mcontext.gregs[REG_RSP]);
+    auto lo = reinterpret_cast<uintptr_t>(f->map_base);
+    auto hi = lo + f->map_bytes;
+    if (sp < lo || sp >= hi) {
+        return {};
+    }
+    for (uintptr_t p = sp; p + sizeof(void*) <= hi; p += sizeof(void*)) {
+        void* word = *reinterpret_cast<void* const*>(p);
+        if (!word) {
+            continue;
+        }
+        Dl_info info{};
+        if (!dladdr(word, &info) || !info.dli_sname) {
+            continue;
+        }
+        int status = 0;
+        char* dem = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
+        std::string name = (status == 0 && dem) ? dem : info.dli_sname;
+        std::free(dem);
+        if (name.find("blaze::") != std::string::npos && name.find("::Op<") != std::string::npos) {
+            auto cut = name.find(">::");
+            return cut == std::string::npos ? name : name.substr(0, cut + 1);
+        }
+    }
+    return {};
+}
+
 std::string FiberSchedulerImpl::dump_parked() {
     std::ostringstream os;
     os << "  " << parked_.size() << " distinct wait-key(s); parked fibers:\n";
+    const bool park_stacks = std::getenv("EMULE_PARK_STACKS") != nullptr;
     for (auto& [key, head] : parked_) {
+        if (park_stacks) {
+            std::string op = emule_park_op_name(head);
+            if (!op.empty()) {
+                os << "    [op] " << op << "\n";
+            }
+        }
         for (Fiber* f = head; f; f = f->park_link) {
             os << "    core(log " << f->id.logical_x << "," << f->id.logical_y
                << " phys " << int(f->id.phys_x) << "," << int(f->id.phys_y) << ")"
@@ -495,13 +541,42 @@ std::string FiberSchedulerImpl::dump_parked() {
             // Best-effort key naming: a CB if the key lands in this fiber's cbs[] array.
             const auto* ctx = f->owned_ctx.get();
             const char* name = nullptr;
-            char buf[64];
+            char buf[192];
             if (ctx && ctx->cbs) {
                 auto base = reinterpret_cast<uintptr_t>(ctx->cbs);
                 auto k = reinterpret_cast<uintptr_t>(key);
                 if (k >= base && k < base + sizeof(tt_emule::CBSyncState) * __EMULE_CTX_MAX_CBS) {
-                    std::snprintf(buf, sizeof(buf), "CB %zu",
-                                  (k - base) / sizeof(tt_emule::CBSyncState));
+                    const size_t cbid = (k - base) / sizeof(tt_emule::CBSyncState);
+                    // Append the ASAN-recorded call site so a parked CB names the exact
+                    // kernel line, not just the op. A producer (cb_reserve_back) and a
+                    // consumer (cb_wait_front) park on the SAME address, so pick the side
+                    // that is actually blocked: ASAN sets the dangling flag on entry, before
+                    // the blocking wait, and clears it on the matching push/pop. Reporting
+                    // the wait site unconditionally mislabels a stuck producer with a
+                    // consumer line, usually a stale one from a call that already completed.
+                    const bool res_blocked = ctx->san.cb_reserve_dangling[cbid];
+                    const bool wait_blocked = ctx->san.cb_wait_dangling[cbid];
+                    auto basename = [](const char* p) {
+                        const char* s = std::strrchr(p, '/');
+                        return s ? s + 1 : p;
+                    };
+                    // Both can be outstanding when one fiber is both producer and consumer
+                    // of this CB; name both rather than guessing which one is stuck.
+                    if (res_blocked && wait_blocked && ctx->san.cb_reserve_file[cbid] && ctx->san.cb_wait_file[cbid]) {
+                        std::snprintf(buf, sizeof(buf), "CB %zu @ reserve %s:%u / wait %s:%u", cbid,
+                                      basename(ctx->san.cb_reserve_file[cbid]), ctx->san.cb_reserve_line[cbid],
+                                      basename(ctx->san.cb_wait_file[cbid]), ctx->san.cb_wait_line[cbid]);
+                    } else if (res_blocked && ctx->san.cb_reserve_file[cbid]) {
+                        std::snprintf(buf, sizeof(buf), "CB %zu @ reserve %s:%u", cbid,
+                                      basename(ctx->san.cb_reserve_file[cbid]), ctx->san.cb_reserve_line[cbid]);
+                    } else if (wait_blocked && ctx->san.cb_wait_file[cbid]) {
+                        std::snprintf(buf, sizeof(buf), "CB %zu @ wait %s:%u", cbid,
+                                      basename(ctx->san.cb_wait_file[cbid]), ctx->san.cb_wait_line[cbid]);
+                    } else {
+                        // Neither side outstanding: any recorded site is stale, so don't
+                        // print one — a wrong line is worse than no line.
+                        std::snprintf(buf, sizeof(buf), "CB %zu", cbid);
+                    }
                     name = buf;
                 }
             }


### PR DESCRIPTION
### PR Category

Bug fix (plus two env-gated diagnostics).

### Summary

Four commits in `tt_metal/impl/emulation/`, all inside `if(TT_METAL_USE_EMULE)` in `tt_metal/impl/sources.cmake` — **no effect on a non-emule build**.

**1. `emule: record fabric connection routes in compass order, not append order`** — the substantive fix.

`g_conn_route[src]` is indexed by a sender's per-fiber connection *open-sequence index* (intent: `0=fwd, 1=bwd`), but the vector was built with `push_back`. Many fibers on one source chip record connections concurrently, so append order was a race — whichever fiber won put its direction at index 0, flipping fwd/bwd for every sender that resolves direction by open-sequence index, and teleporting whole payloads to the wrong chip.

```mermaid
sequenceDiagram
    participant A as fiber A (opens bwd first)
    participant B as fiber B (opens fwd first)
    participant V as g_conn_route[src]
    A->>V: push_back(bwd)
    B->>V: push_back(fwd)
    Note over V: index 0 = bwd — but senders read index 0 as fwd
    V-->>B: resolves fwd → wrong chip
```

Invisible at one worker thread, where append order *is* the deterministic fiber order. Fixed by inserting sorted by `RoutingDirection` (N=0, E=1, S=2, W=3, Z=4) — compass order, which is the order a kernel's own connection-open sequence walks the active directions — so an entry's position is a function of `dir` alone.

**2. `emule: honor $TMPDIR for the JIT compile scratch dir`** — it was hardcoded to `/tmp/tt_emule_jit_XXXXXX`. A host `/tmp` reaper deletes those mid-compile, surfacing as `named_args_generated.h not found` or `ld: cannot open output file` during a long fused-graph compile.

**3–4. `EMULE_FABRIC_XFER` and `EMULE_PARK_STACKS`** — two env-gated diagnostics, inert when unset. One line per payload-carrying fabric send (source L1 offset, sending core, destination chip + offset, first payload word), and a parked-fiber op census that resolves each stuck fiber to a demangled blaze op frame plus the kernel `file:line` of the CB it is waiting on.

These are proposed as permanent rather than reverted because they are what made two hard bugs tractable: the census turns "no global progress" plus opaque wait keys into named ops, and the send trace let a cross-core write-after-read hazard in a CCL be reconstructed offline and diffed against the ring the op intends. `EMULE_FABRIC_DEBUG` cannot substitute — it is verbose enough to perturb the races it would be used to study.

### Notes for reviewers

- The only behavior change on any existing path is commit 1. Commits 3–4 are `getenv`-guarded and do nothing unless the variable is set.
- `EMULE_FABRIC_XFER`'s own `fopen`/`fprintf` widens the window between reading the payload word and the delivery memcpy, so under an active race the logged first word can disagree with the bytes delivered. That caveat is in the comment: trust the addresses and routes, get contents from a tensor dump.
- **Not built against `main`.** These are verified on the emule fork (`emule-blaze-metal-fork`), where they carry a GLM-5.1 one-layer dense decoder to a passing end-to-end result on an 8-chip mock mesh, plus green emule p150 (506 passed / 2 skipped) and loudbox (25/25 files) regressions. They cherry-picked onto `main` with no conflicts and every symbol they touch is present, but CI here is the first build against `main` — please flag anything it catches.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sgholamiTT/emule-runner-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sgholamiTT/emule-runner-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sgholamiTT/emule-runner-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sgholamiTT/emule-runner-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sgholamiTT/emule-runner-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sgholamiTT/emule-runner-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sgholamiTT/emule-runner-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sgholamiTT/emule-runner-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sgholamiTT/emule-runner-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sgholamiTT/emule-runner-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sgholamiTT/emule-runner-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sgholamiTT/emule-runner-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sgholamiTT/emule-runner-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sgholamiTT/emule-runner-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sgholamiTT/emule-runner-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sgholamiTT/emule-runner-fixes)