### PR TITLE
[Cleanup] Migrate multicast semaphores to Semaphore::set_multicast / inc_multicast

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
@@ -9,10 +9,32 @@
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "tt_metal/fabric/hw/inc/linear/api.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
+#include "api/dataflow/noc.h"
 #include "ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
 #include "ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 
 namespace ttnn::operations::ccl::common {
+
+// Multicast a Semaphore<>'s local value to a rectangle with proper coordinate ordering for
+// NOC 0 vs NOC 1 (same policy as get_safe_multicast_noc_addr applies to raw addresses).
+// NOC 0: start = (min_x, min_y), end = (max_x, max_y)
+// NOC 1: start = (max_x, max_y), end = (min_x, min_y) - coordinates need to be swapped
+template <NocOptions opts = NocOptions::DEFAULT, typename SemaphoreT>
+FORCE_INLINE void set_multicast_safe(
+    SemaphoreT& sem,
+    const Noc& noc,
+    uint32_t noc_x_start,
+    uint32_t noc_y_start,
+    uint32_t noc_x_end,
+    uint32_t noc_y_end,
+    uint32_t num_dests,
+    bool linked = false) {
+    if (noc.get_noc_id() == 0) {
+        sem.template set_multicast<opts>(noc, noc_x_start, noc_y_start, noc_x_end, noc_y_end, num_dests, linked);
+    } else {
+        sem.template set_multicast<opts>(noc, noc_x_end, noc_y_end, noc_x_start, noc_y_start, num_dests, linked);
+    }
+}
 
 enum class Polarity : uint8_t {
     NEGATIVE,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_receiver.cpp
@@ -23,12 +23,6 @@ void kernel_main() {
         get_compile_time_arg_val(6),
         get_compile_time_arg_val(7),
     };
-    std::array<uint32_t, 4> fused_op_receiver_signal_semaphore_addr = {
-        get_semaphore(fused_op_receiver_signal_semaphore_id[0]),
-        get_semaphore(fused_op_receiver_signal_semaphore_id[1]),
-        get_semaphore(fused_op_receiver_signal_semaphore_id[2]),
-        get_semaphore(fused_op_receiver_signal_semaphore_id[3]),
-    };
     // runtime args
     size_t arg_idx = 0;
     const uint32_t signal_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
@@ -83,8 +77,7 @@ void kernel_main() {
     noc_async_write_multicast_loopback_src(
         l1_read_addr, multicast_addr, intermediate_tensor_shard_num_pages * tensor0_page_size, bbox_size, true);
 
-    uint64_t multicast_sema_addr = multicast_addr_noc | (uint64_t)fused_op_receiver_signal_semaphore_addr[core_id];
-    noc_semaphore_set_multicast_loopback_src(
-        fused_op_receiver_signal_semaphore_addr[core_id], multicast_sema_addr, bbox_size, false);
+    fused_op_receiver_signal_semaphore.set_multicast<NocOptions::MCAST_INCL_SRC>(
+        noc_obj, bbox_start_x, bbox_start_y, bbox_end_x, bbox_end_y, bbox_size, /*linked=*/false);
     noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -370,7 +370,6 @@ void kernel_main() {
     // Device 2.0 migration: legacy primitives retained: these raw L1 semaphore addresses are
     // used as bases for multicast destinations (set_multicast / get_safe_multicast_noc_addr /
     // get_noc_addr) and for inter-core semaphore inc with precomposed uint64_t addresses.
-    uint32_t metadata_ready_semaphore_addr = get_semaphore(metadata_ready_semaphore_id);
     const uint32_t combine_sync_addr = get_semaphore(combine_sync_semaphore_id);
 
     // Noc typed wrapper (reader uses default noc_index)
@@ -866,23 +865,29 @@ void kernel_main() {
             // First, set the local semaphore to 1 - this is the value that will be multicast
             metadata_ready_sem.set(1);
 
-            uint64_t semaphore_mcast_addr = get_safe_multicast_noc_addr(
-                tilize_mcast_start_x,
-                tilize_mcast_start_y,
-                tilize_mcast_end_x,
-                tilize_mcast_end_y,
-                metadata_ready_semaphore_addr);
-
             // Flush writes since we change the local value of metadata_ready_semaphore when signalling
             // to the matmul cores (vs here where we signal to the non-drain-sync tilize cores )
             noc_obj.async_writes_flushed();
 
             // Multicast the value 1 to all non-drain tilize cores
-            // Device 2.0 migration: legacy primitive retained: multicast loopback semaphore set with
-            // precomposed uint64_t multicast destination (get_safe_multicast_noc_addr) and raw local
-            // sem address as source
-            noc_semaphore_set_multicast(
-                metadata_ready_semaphore_addr, semaphore_mcast_addr, tilize_bounding_box_num_cores - 1);
+            // NOC1 needs the multicast rectangle corners swapped; see get_safe_multicast_noc_addr
+            if constexpr (noc_index == 0) {
+                metadata_ready_sem.set_multicast(
+                    noc_obj,
+                    tilize_mcast_start_x,
+                    tilize_mcast_start_y,
+                    tilize_mcast_end_x,
+                    tilize_mcast_end_y,
+                    tilize_bounding_box_num_cores - 1);
+            } else {
+                metadata_ready_sem.set_multicast(
+                    noc_obj,
+                    tilize_mcast_end_x,
+                    tilize_mcast_end_y,
+                    tilize_mcast_start_x,
+                    tilize_mcast_start_y,
+                    tilize_bounding_box_num_cores - 1);
+            }
         }
 
         volatile tt_l1_ptr uint32_t* num_tokens_per_expert =
@@ -911,19 +916,24 @@ void kernel_main() {
         // Signal readiness via semaphore
         metadata_ready_sem.set(1);
 
-        // get mcast address for semaphore
-        uint64_t matmul_metadata_ready_semaphore_mcast_addr = get_safe_multicast_noc_addr(
-            matmul_mcast_start_x,
-            matmul_mcast_start_y,
-            matmul_mcast_end_x,
-            matmul_mcast_end_y,
-            metadata_ready_semaphore_addr);
-
-        // multicast semaphore
-        // Device 2.0 migration: legacy primitive retained: multicast loopback semaphore set with
-        // precomposed uint64_t multicast destination
-        noc_semaphore_set_multicast(
-            metadata_ready_semaphore_addr, matmul_metadata_ready_semaphore_mcast_addr, matmul_bounding_box_num_cores);
+        // multicast semaphore (NOC1 needs corners swapped; see get_safe_multicast_noc_addr)
+        if constexpr (noc_index == 0) {
+            metadata_ready_sem.set_multicast(
+                noc_obj,
+                matmul_mcast_start_x,
+                matmul_mcast_start_y,
+                matmul_mcast_end_x,
+                matmul_mcast_end_y,
+                matmul_bounding_box_num_cores);
+        } else {
+            metadata_ready_sem.set_multicast(
+                noc_obj,
+                matmul_mcast_end_x,
+                matmul_mcast_end_y,
+                matmul_mcast_start_x,
+                matmul_mcast_start_y,
+                matmul_bounding_box_num_cores);
+        }
     }  // End of is_drain_tilize_core block
     else {
         // ========== NON-DRAIN tilize CORE: Step 4 - Send counts to drain ==========

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -870,24 +870,14 @@ void kernel_main() {
             noc_obj.async_writes_flushed();
 
             // Multicast the value 1 to all non-drain tilize cores
-            // NOC1 needs the multicast rectangle corners swapped; see get_safe_multicast_noc_addr
-            if constexpr (noc_index == 0) {
-                metadata_ready_sem.set_multicast(
-                    noc_obj,
-                    tilize_mcast_start_x,
-                    tilize_mcast_start_y,
-                    tilize_mcast_end_x,
-                    tilize_mcast_end_y,
-                    tilize_bounding_box_num_cores - 1);
-            } else {
-                metadata_ready_sem.set_multicast(
-                    noc_obj,
-                    tilize_mcast_end_x,
-                    tilize_mcast_end_y,
-                    tilize_mcast_start_x,
-                    tilize_mcast_start_y,
-                    tilize_bounding_box_num_cores - 1);
-            }
+            set_multicast_safe(
+                metadata_ready_sem,
+                noc_obj,
+                tilize_mcast_start_x,
+                tilize_mcast_start_y,
+                tilize_mcast_end_x,
+                tilize_mcast_end_y,
+                tilize_bounding_box_num_cores - 1);
         }
 
         volatile tt_l1_ptr uint32_t* num_tokens_per_expert =
@@ -916,24 +906,15 @@ void kernel_main() {
         // Signal readiness via semaphore
         metadata_ready_sem.set(1);
 
-        // multicast semaphore (NOC1 needs corners swapped; see get_safe_multicast_noc_addr)
-        if constexpr (noc_index == 0) {
-            metadata_ready_sem.set_multicast(
-                noc_obj,
-                matmul_mcast_start_x,
-                matmul_mcast_start_y,
-                matmul_mcast_end_x,
-                matmul_mcast_end_y,
-                matmul_bounding_box_num_cores);
-        } else {
-            metadata_ready_sem.set_multicast(
-                noc_obj,
-                matmul_mcast_end_x,
-                matmul_mcast_end_y,
-                matmul_mcast_start_x,
-                matmul_mcast_start_y,
-                matmul_bounding_box_num_cores);
-        }
+        // multicast semaphore
+        set_multicast_safe(
+            metadata_ready_sem,
+            noc_obj,
+            matmul_mcast_start_x,
+            matmul_mcast_start_y,
+            matmul_mcast_end_x,
+            matmul_mcast_end_y,
+            matmul_bounding_box_num_cores);
     }  // End of is_drain_tilize_core block
     else {
         // ========== NON-DRAIN tilize CORE: Step 4 - Send counts to drain ==========

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -194,9 +194,7 @@ void kernel_main() {
     // Device 2.0 migration: legacy primitives retained: these raw L1 semaphore addresses are
     // used as bases for multicast destinations (set_multicast / get_safe_multicast_noc_addr /
     // get_noc_addr) and for direct noc_semaphore_set with the legacy address-taking overload.
-    uint32_t matmul_chunk_available_semaphore_addr = get_semaphore(matmul_chunk_available_semaphore_id);
     uint32_t tilize_chunk_ready_semaphore_addr = get_semaphore(tilize_chunk_ready_semaphore_id);
-    uint32_t matmul_chunk_ready_semaphore_addr = get_semaphore(matmul_chunk_ready_semaphore_id);
 
     // Noc typed wrappers
     Noc noc_obj(noc_index);
@@ -430,23 +428,9 @@ void kernel_main() {
     // Semaphore all tilize cores wait on to indicate we cand send another chunk
     // Matmul sends to tilize drain sync core, which propagates it to the tilize non-drain-sync cores
     uint32_t matmul_chunk_available_semaphore_wait_value = num_matmul_cores;
-    uint64_t matmul_chunk_available_semaphore_tilize_mcast_addr = get_safe_multicast_noc_addr(
-        tilize_mcast_start_x,
-        tilize_mcast_start_y,
-        tilize_mcast_end_x,
-        tilize_mcast_end_y,
-        matmul_chunk_available_semaphore_addr,
-        noc_index);
 
     // Semaphore we use to signal to matmul cores that a chunk has arrived
     uint32_t matmul_chunk_ready_semaphore_set_value = 1;
-    uint64_t matmul_chunk_ready_semaphore_mcast_addr = get_safe_multicast_noc_addr(
-        matmul_mcast_start_x,
-        matmul_mcast_start_y,
-        matmul_mcast_end_x,
-        matmul_mcast_end_y,
-        matmul_chunk_ready_semaphore_addr,
-        noc_index);
 
     // How many chunks we've sent to matmul so far
     uint32_t num_chunks_sent = 0;
@@ -462,13 +446,6 @@ void kernel_main() {
     uint32_t tilize_chunk_ready_wait_value = num_tilize_cores - 1;
     uint64_t tilize_chunk_ready_drain_semaphore_noc_addr =
         get_noc_addr(drain_core_noc_x, drain_core_noc_y, tilize_chunk_ready_semaphore_addr, noc_index);
-    uint64_t tilize_chunk_ready_mcast_addr = get_safe_multicast_noc_addr(
-        tilize_mcast_start_x,
-        tilize_mcast_start_y,
-        tilize_mcast_end_x,
-        tilize_mcast_end_y,
-        tilize_chunk_ready_semaphore_addr,
-        noc_index);
 
     // mcast address for the first half of the buffer
     uint64_t first_half_buffer_matmul_chunk_input_mcast_addr = get_safe_multicast_noc_addr(
@@ -551,15 +528,27 @@ void kernel_main() {
                 if (is_drain_tilize_core && num_tilize_cores > 1) {
                     // use the local value of the semaphore, which is the value we just waited on (no need to set local
                     // value)
-                    // Device 2.0 migration: legacy primitive retained: multicast loopback op using
-                    // a precomposed multicast NOC address that honors the NOC1 coordinate-swap
-                    // convention via get_safe_multicast_noc_addr
-                    noc_semaphore_set_multicast(
-                        matmul_chunk_available_semaphore_addr,
-                        matmul_chunk_available_semaphore_tilize_mcast_addr,
-                        tilize_bounding_box_num_cores - 1,
-                        false,
-                        noc_index);
+                    // NOC1 needs the multicast rectangle corners swapped (start<->end); see
+                    // get_safe_multicast_noc_addr. noc_index is a compile-time constant.
+                    if constexpr (noc_index == 0) {
+                        matmul_chunk_available_sem.set_multicast(
+                            noc_obj,
+                            tilize_mcast_start_x,
+                            tilize_mcast_start_y,
+                            tilize_mcast_end_x,
+                            tilize_mcast_end_y,
+                            tilize_bounding_box_num_cores - 1,
+                            /*linked=*/false);
+                    } else {
+                        matmul_chunk_available_sem.set_multicast(
+                            noc_obj,
+                            tilize_mcast_end_x,
+                            tilize_mcast_end_y,
+                            tilize_mcast_start_x,
+                            tilize_mcast_start_y,
+                            tilize_bounding_box_num_cores - 1,
+                            /*linked=*/false);
+                    }
                 }
             }
 
@@ -719,29 +708,52 @@ void kernel_main() {
                 matmul_chunk_ready_sem.set(matmul_chunk_ready_semaphore_set_value);
                 matmul_chunk_ready_semaphore_set_value++;
 
-                // mcast sem set
-                // Device 2.0 migration: legacy primitive retained: multicast loopback set
-                // (noc_semaphore_set_multicast) uses precomposed multicast NoC address and is not yet
-                // wrapped by Semaphore<>::set_multicast in a way that takes a raw L1 source addr
-                noc_semaphore_set_multicast(
-                    matmul_chunk_ready_semaphore_addr,
-                    matmul_chunk_ready_semaphore_mcast_addr,
-                    matmul_bounding_box_num_cores,
-                    false,
-                    noc_index);
+                // mcast sem set (NOC1 needs corners swapped; see get_safe_multicast_noc_addr)
+                if constexpr (noc_index == 0) {
+                    matmul_chunk_ready_sem.set_multicast(
+                        noc_obj,
+                        matmul_mcast_start_x,
+                        matmul_mcast_start_y,
+                        matmul_mcast_end_x,
+                        matmul_mcast_end_y,
+                        matmul_bounding_box_num_cores,
+                        /*linked=*/false);
+                } else {
+                    matmul_chunk_ready_sem.set_multicast(
+                        noc_obj,
+                        matmul_mcast_end_x,
+                        matmul_mcast_end_y,
+                        matmul_mcast_start_x,
+                        matmul_mcast_start_y,
+                        matmul_bounding_box_num_cores,
+                        /*linked=*/false);
+                }
 
                 // == 10 ==
                 if (num_tilize_cores > 1) {
                     // Signal to non-drain-sync cores that they can start sending the next chunk
                     // Use local semaphore value (no need to explicitly set it)
                     // Local value is from when drain-sync waits until gather process is done (8a and 5b)
-                    // Device 2.0 migration: legacy primitive retained: multicast loopback set
-                    noc_semaphore_set_multicast(
-                        tilize_chunk_ready_semaphore_addr,
-                        tilize_chunk_ready_mcast_addr,
-                        tilize_bounding_box_num_cores - 1,
-                        false,
-                        noc_index);
+                    // NOC1 needs corners swapped; see get_safe_multicast_noc_addr
+                    if constexpr (noc_index == 0) {
+                        tilize_chunk_ready_sem.set_multicast(
+                            noc_obj,
+                            tilize_mcast_start_x,
+                            tilize_mcast_start_y,
+                            tilize_mcast_end_x,
+                            tilize_mcast_end_y,
+                            tilize_bounding_box_num_cores - 1,
+                            /*linked=*/false);
+                    } else {
+                        tilize_chunk_ready_sem.set_multicast(
+                            noc_obj,
+                            tilize_mcast_end_x,
+                            tilize_mcast_end_y,
+                            tilize_mcast_start_x,
+                            tilize_mcast_start_y,
+                            tilize_bounding_box_num_cores - 1,
+                            /*linked=*/false);
+                    }
                 }
             } else {
                 // == 11 ==

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -528,27 +528,14 @@ void kernel_main() {
                 if (is_drain_tilize_core && num_tilize_cores > 1) {
                     // use the local value of the semaphore, which is the value we just waited on (no need to set local
                     // value)
-                    // NOC1 needs the multicast rectangle corners swapped (start<->end); see
-                    // get_safe_multicast_noc_addr. noc_index is a compile-time constant.
-                    if constexpr (noc_index == 0) {
-                        matmul_chunk_available_sem.set_multicast(
-                            noc_obj,
-                            tilize_mcast_start_x,
-                            tilize_mcast_start_y,
-                            tilize_mcast_end_x,
-                            tilize_mcast_end_y,
-                            tilize_bounding_box_num_cores - 1,
-                            /*linked=*/false);
-                    } else {
-                        matmul_chunk_available_sem.set_multicast(
-                            noc_obj,
-                            tilize_mcast_end_x,
-                            tilize_mcast_end_y,
-                            tilize_mcast_start_x,
-                            tilize_mcast_start_y,
-                            tilize_bounding_box_num_cores - 1,
-                            /*linked=*/false);
-                    }
+                    set_multicast_safe(
+                        matmul_chunk_available_sem,
+                        noc_obj,
+                        tilize_mcast_start_x,
+                        tilize_mcast_start_y,
+                        tilize_mcast_end_x,
+                        tilize_mcast_end_y,
+                        tilize_bounding_box_num_cores - 1);
                 }
             }
 
@@ -708,52 +695,29 @@ void kernel_main() {
                 matmul_chunk_ready_sem.set(matmul_chunk_ready_semaphore_set_value);
                 matmul_chunk_ready_semaphore_set_value++;
 
-                // mcast sem set (NOC1 needs corners swapped; see get_safe_multicast_noc_addr)
-                if constexpr (noc_index == 0) {
-                    matmul_chunk_ready_sem.set_multicast(
-                        noc_obj,
-                        matmul_mcast_start_x,
-                        matmul_mcast_start_y,
-                        matmul_mcast_end_x,
-                        matmul_mcast_end_y,
-                        matmul_bounding_box_num_cores,
-                        /*linked=*/false);
-                } else {
-                    matmul_chunk_ready_sem.set_multicast(
-                        noc_obj,
-                        matmul_mcast_end_x,
-                        matmul_mcast_end_y,
-                        matmul_mcast_start_x,
-                        matmul_mcast_start_y,
-                        matmul_bounding_box_num_cores,
-                        /*linked=*/false);
-                }
+                // mcast sem set
+                set_multicast_safe(
+                    matmul_chunk_ready_sem,
+                    noc_obj,
+                    matmul_mcast_start_x,
+                    matmul_mcast_start_y,
+                    matmul_mcast_end_x,
+                    matmul_mcast_end_y,
+                    matmul_bounding_box_num_cores);
 
                 // == 10 ==
                 if (num_tilize_cores > 1) {
                     // Signal to non-drain-sync cores that they can start sending the next chunk
                     // Use local semaphore value (no need to explicitly set it)
                     // Local value is from when drain-sync waits until gather process is done (8a and 5b)
-                    // NOC1 needs corners swapped; see get_safe_multicast_noc_addr
-                    if constexpr (noc_index == 0) {
-                        tilize_chunk_ready_sem.set_multicast(
-                            noc_obj,
-                            tilize_mcast_start_x,
-                            tilize_mcast_start_y,
-                            tilize_mcast_end_x,
-                            tilize_mcast_end_y,
-                            tilize_bounding_box_num_cores - 1,
-                            /*linked=*/false);
-                    } else {
-                        tilize_chunk_ready_sem.set_multicast(
-                            noc_obj,
-                            tilize_mcast_end_x,
-                            tilize_mcast_end_y,
-                            tilize_mcast_start_x,
-                            tilize_mcast_start_y,
-                            tilize_bounding_box_num_cores - 1,
-                            /*linked=*/false);
-                    }
+                    set_multicast_safe(
+                        tilize_chunk_ready_sem,
+                        noc_obj,
+                        tilize_mcast_start_x,
+                        tilize_mcast_start_y,
+                        tilize_mcast_end_x,
+                        tilize_mcast_end_y,
+                        tilize_bounding_box_num_cores - 1);
                 }
             } else {
                 // == 11 ==

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
@@ -246,7 +246,6 @@ void kernel_main() {
     Semaphore<> metadata_ready_sem(metadata_ready_semaphore_id);
     Semaphore<> previous_chunk_sent_sem(previous_chunk_sent_semaphore_id);
 
-    uint32_t metadata_ready_semaphore_addr = get_semaphore(metadata_ready_semaphore_id);
     uint32_t previous_chunk_sent_semaphore_addr = get_semaphore(previous_chunk_sent_semaphore_id);
 
     // Noc typed wrapper
@@ -744,20 +743,25 @@ void kernel_main() {
             // First, set the local semaphore to 1 - this is the value that will be multicast
             metadata_ready_sem.set(1);
 
-            uint64_t semaphore_mcast_addr = get_safe_multicast_noc_addr(
-                tilize_mcast_start_x,
-                tilize_mcast_start_y,
-                tilize_mcast_end_x,
-                tilize_mcast_end_y,
-                metadata_ready_semaphore_addr);
-
             // Multicast the value 1 to all non-drain tilize cores
-            // Device 2.0 migration: legacy primitive retained: noc_semaphore_set_multicast targets a
-            // precomposed multicast uint64_t NoC address (semaphore_mcast_addr) and uses raw local
-            // sem address as source; Semaphore<>::set_multicast does not provide a wrapper that takes
-            // both
-            noc_semaphore_set_multicast(
-                metadata_ready_semaphore_addr, semaphore_mcast_addr, tilize_bounding_box_num_cores - 1);
+            // NOC1 needs the multicast rectangle corners swapped; see get_safe_multicast_noc_addr
+            if constexpr (noc_index == 0) {
+                metadata_ready_sem.set_multicast(
+                    noc_obj,
+                    tilize_mcast_start_x,
+                    tilize_mcast_start_y,
+                    tilize_mcast_end_x,
+                    tilize_mcast_end_y,
+                    tilize_bounding_box_num_cores - 1);
+            } else {
+                metadata_ready_sem.set_multicast(
+                    noc_obj,
+                    tilize_mcast_end_x,
+                    tilize_mcast_end_y,
+                    tilize_mcast_start_x,
+                    tilize_mcast_start_y,
+                    tilize_bounding_box_num_cores - 1);
+            }
 
             // Flush writes since we change the local value of metadata_ready_semaphore when signalling
             // to the matmul cores (vs here where we signal to the non-drain-sync tilize cores )
@@ -807,17 +811,24 @@ void kernel_main() {
 
         metadata_ready_sem.set(1);
 
-        uint64_t matmul_metadata_ready_semaphore_mcast_addr = get_safe_multicast_noc_addr(
-            matmul_mcast_start_x,
-            matmul_mcast_start_y,
-            matmul_mcast_end_x,
-            matmul_mcast_end_y,
-            metadata_ready_semaphore_addr);
-
-        // Device 2.0 migration: legacy primitive retained: noc_semaphore_set_multicast targets a
-        // precomposed multicast uint64_t NoC address
-        noc_semaphore_set_multicast(
-            metadata_ready_semaphore_addr, matmul_metadata_ready_semaphore_mcast_addr, matmul_bounding_box_num_cores);
+        // multicast semaphore (NOC1 needs corners swapped; see get_safe_multicast_noc_addr)
+        if constexpr (noc_index == 0) {
+            metadata_ready_sem.set_multicast(
+                noc_obj,
+                matmul_mcast_start_x,
+                matmul_mcast_start_y,
+                matmul_mcast_end_x,
+                matmul_mcast_end_y,
+                matmul_bounding_box_num_cores);
+        } else {
+            metadata_ready_sem.set_multicast(
+                noc_obj,
+                matmul_mcast_end_x,
+                matmul_mcast_end_y,
+                matmul_mcast_start_x,
+                matmul_mcast_start_y,
+                matmul_bounding_box_num_cores);
+        }
     }  // End of is_drain_tilize_core block
     else {
         // ========== NON-DRAIN tilize CORE: Step 4 - Send counts to drain ==========

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
@@ -744,24 +744,14 @@ void kernel_main() {
             metadata_ready_sem.set(1);
 
             // Multicast the value 1 to all non-drain tilize cores
-            // NOC1 needs the multicast rectangle corners swapped; see get_safe_multicast_noc_addr
-            if constexpr (noc_index == 0) {
-                metadata_ready_sem.set_multicast(
-                    noc_obj,
-                    tilize_mcast_start_x,
-                    tilize_mcast_start_y,
-                    tilize_mcast_end_x,
-                    tilize_mcast_end_y,
-                    tilize_bounding_box_num_cores - 1);
-            } else {
-                metadata_ready_sem.set_multicast(
-                    noc_obj,
-                    tilize_mcast_end_x,
-                    tilize_mcast_end_y,
-                    tilize_mcast_start_x,
-                    tilize_mcast_start_y,
-                    tilize_bounding_box_num_cores - 1);
-            }
+            set_multicast_safe(
+                metadata_ready_sem,
+                noc_obj,
+                tilize_mcast_start_x,
+                tilize_mcast_start_y,
+                tilize_mcast_end_x,
+                tilize_mcast_end_y,
+                tilize_bounding_box_num_cores - 1);
 
             // Flush writes since we change the local value of metadata_ready_semaphore when signalling
             // to the matmul cores (vs here where we signal to the non-drain-sync tilize cores )
@@ -811,24 +801,15 @@ void kernel_main() {
 
         metadata_ready_sem.set(1);
 
-        // multicast semaphore (NOC1 needs corners swapped; see get_safe_multicast_noc_addr)
-        if constexpr (noc_index == 0) {
-            metadata_ready_sem.set_multicast(
-                noc_obj,
-                matmul_mcast_start_x,
-                matmul_mcast_start_y,
-                matmul_mcast_end_x,
-                matmul_mcast_end_y,
-                matmul_bounding_box_num_cores);
-        } else {
-            metadata_ready_sem.set_multicast(
-                noc_obj,
-                matmul_mcast_end_x,
-                matmul_mcast_end_y,
-                matmul_mcast_start_x,
-                matmul_mcast_start_y,
-                matmul_bounding_box_num_cores);
-        }
+        // multicast semaphore
+        set_multicast_safe(
+            metadata_ready_sem,
+            noc_obj,
+            matmul_mcast_start_x,
+            matmul_mcast_start_y,
+            matmul_mcast_end_x,
+            matmul_mcast_end_y,
+            matmul_bounding_box_num_cores);
     }  // End of is_drain_tilize_core block
     else {
         // ========== NON-DRAIN tilize CORE: Step 4 - Send counts to drain ==========

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_writer.cpp
@@ -158,9 +158,7 @@ void kernel_main() {
     Semaphore<> previous_chunk_sent_sem(previous_chunk_sent_semaphore_id);
     Semaphore<> initial_gather_sem(initial_gather_semaphore_id);
 
-    uint32_t matmul_chunk_available_semaphore_addr = get_semaphore(matmul_chunk_available_semaphore_id);
     uint32_t tilize_chunk_ready_semaphore_addr = get_semaphore(tilize_chunk_ready_semaphore_id);
-    uint32_t matmul_chunk_ready_semaphore_addr = get_semaphore(matmul_chunk_ready_semaphore_id);
     uint32_t previous_chunk_sent_semaphore_addr = get_semaphore(previous_chunk_sent_semaphore_id);
     uint32_t initial_gather_semaphore_addr = get_semaphore(initial_gather_semaphore_id);
 
@@ -409,22 +407,8 @@ void kernel_main() {
     /************************************************************************/
 
     uint32_t matmul_chunk_available_semaphore_wait_value = num_matmul_cores;
-    uint64_t matmul_chunk_available_semaphore_tilize_mcast_addr = get_safe_multicast_noc_addr(
-        tilize_mcast_start_x,
-        tilize_mcast_start_y,
-        tilize_mcast_end_x,
-        tilize_mcast_end_y,
-        matmul_chunk_available_semaphore_addr,
-        noc_index);
 
     uint32_t matmul_chunk_ready_semaphore_set_value = 1;
-    uint64_t matmul_chunk_ready_semaphore_mcast_addr = get_safe_multicast_noc_addr(
-        matmul_mcast_start_x,
-        matmul_mcast_start_y,
-        matmul_mcast_end_x,
-        matmul_mcast_end_y,
-        matmul_chunk_ready_semaphore_addr,
-        noc_index);
 
     uint32_t num_chunks_sent = 0;
 
@@ -439,13 +423,6 @@ void kernel_main() {
     // core target for semaphore increment)
     uint64_t tilize_chunk_ready_drain_semaphore_noc_addr =
         get_noc_addr(drain_core_noc_x, drain_core_noc_y, tilize_chunk_ready_semaphore_addr, noc_index);
-    uint64_t tilize_chunk_ready_mcast_addr = get_safe_multicast_noc_addr(
-        tilize_mcast_start_x,
-        tilize_mcast_start_y,
-        tilize_mcast_end_x,
-        tilize_mcast_end_y,
-        tilize_chunk_ready_semaphore_addr,
-        noc_index);
 
     uint64_t first_half_buffer_matmul_chunk_input_mcast_addr = get_safe_multicast_noc_addr(
         matmul_mcast_start_x,
@@ -525,14 +502,26 @@ void kernel_main() {
                 if (is_drain_tilize_core && num_tilize_cores > 1) {
                     // use the local value of the semaphore, which is the value we just waited on (no need to set local
                     // value)
-                    // Device 2.0 migration: legacy primitive retained: noc_semaphore_set_multicast targets a
-                    // precomposed multicast uint64_t NoC address with raw local sem address as source.
-                    noc_semaphore_set_multicast(
-                        matmul_chunk_available_semaphore_addr,
-                        matmul_chunk_available_semaphore_tilize_mcast_addr,
-                        tilize_bounding_box_num_cores - 1,
-                        false,
-                        noc_index);
+                    // NOC1 needs the multicast rectangle corners swapped; see get_safe_multicast_noc_addr
+                    if constexpr (noc_index == 0) {
+                        matmul_chunk_available_sem.set_multicast(
+                            noc_obj,
+                            tilize_mcast_start_x,
+                            tilize_mcast_start_y,
+                            tilize_mcast_end_x,
+                            tilize_mcast_end_y,
+                            tilize_bounding_box_num_cores - 1,
+                            /*linked=*/false);
+                    } else {
+                        matmul_chunk_available_sem.set_multicast(
+                            noc_obj,
+                            tilize_mcast_end_x,
+                            tilize_mcast_end_y,
+                            tilize_mcast_start_x,
+                            tilize_mcast_start_y,
+                            tilize_bounding_box_num_cores - 1,
+                            /*linked=*/false);
+                    }
                 }
             }
             // ALL SUBSEQUENT ITERATIONS
@@ -585,29 +574,52 @@ void kernel_main() {
                 matmul_chunk_ready_sem.set(matmul_chunk_ready_semaphore_set_value);
                 matmul_chunk_ready_semaphore_set_value++;
 
-                // mcast sem set
-                // Device 2.0 migration: legacy primitive retained: noc_semaphore_set_multicast targets a
-                // precomposed multicast uint64_t NoC address with raw local sem address as source.
-                noc_semaphore_set_multicast(
-                    matmul_chunk_ready_semaphore_addr,
-                    matmul_chunk_ready_semaphore_mcast_addr,
-                    matmul_bounding_box_num_cores,
-                    false,
-                    noc_index);
+                // mcast sem set (NOC1 needs corners swapped; see get_safe_multicast_noc_addr)
+                if constexpr (noc_index == 0) {
+                    matmul_chunk_ready_sem.set_multicast(
+                        noc_obj,
+                        matmul_mcast_start_x,
+                        matmul_mcast_start_y,
+                        matmul_mcast_end_x,
+                        matmul_mcast_end_y,
+                        matmul_bounding_box_num_cores,
+                        /*linked=*/false);
+                } else {
+                    matmul_chunk_ready_sem.set_multicast(
+                        noc_obj,
+                        matmul_mcast_end_x,
+                        matmul_mcast_end_y,
+                        matmul_mcast_start_x,
+                        matmul_mcast_start_y,
+                        matmul_bounding_box_num_cores,
+                        /*linked=*/false);
+                }
 
                 // == 10 ==
                 if (num_tilize_cores > 1) {
                     // Signal to non-drain-sync cores that they can start sending the next chunk
                     // Use local semaphore value (no need to explicitly set it)
                     // Local value is from when drain-sync waits until gather process is done (8a and 5b)
-                    // Device 2.0 migration: legacy primitive retained: noc_semaphore_set_multicast targets a
-                    // precomposed multicast uint64_t NoC address with raw local sem address as source.
-                    noc_semaphore_set_multicast(
-                        tilize_chunk_ready_semaphore_addr,
-                        tilize_chunk_ready_mcast_addr,
-                        tilize_bounding_box_num_cores - 1,
-                        false,
-                        noc_index);
+                    // NOC1 needs corners swapped; see get_safe_multicast_noc_addr
+                    if constexpr (noc_index == 0) {
+                        tilize_chunk_ready_sem.set_multicast(
+                            noc_obj,
+                            tilize_mcast_start_x,
+                            tilize_mcast_start_y,
+                            tilize_mcast_end_x,
+                            tilize_mcast_end_y,
+                            tilize_bounding_box_num_cores - 1,
+                            /*linked=*/false);
+                    } else {
+                        tilize_chunk_ready_sem.set_multicast(
+                            noc_obj,
+                            tilize_mcast_end_x,
+                            tilize_mcast_end_y,
+                            tilize_mcast_start_x,
+                            tilize_mcast_start_y,
+                            tilize_bounding_box_num_cores - 1,
+                            /*linked=*/false);
+                    }
                 }
             } else {
                 // == 11 ==

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_writer.cpp
@@ -502,26 +502,14 @@ void kernel_main() {
                 if (is_drain_tilize_core && num_tilize_cores > 1) {
                     // use the local value of the semaphore, which is the value we just waited on (no need to set local
                     // value)
-                    // NOC1 needs the multicast rectangle corners swapped; see get_safe_multicast_noc_addr
-                    if constexpr (noc_index == 0) {
-                        matmul_chunk_available_sem.set_multicast(
-                            noc_obj,
-                            tilize_mcast_start_x,
-                            tilize_mcast_start_y,
-                            tilize_mcast_end_x,
-                            tilize_mcast_end_y,
-                            tilize_bounding_box_num_cores - 1,
-                            /*linked=*/false);
-                    } else {
-                        matmul_chunk_available_sem.set_multicast(
-                            noc_obj,
-                            tilize_mcast_end_x,
-                            tilize_mcast_end_y,
-                            tilize_mcast_start_x,
-                            tilize_mcast_start_y,
-                            tilize_bounding_box_num_cores - 1,
-                            /*linked=*/false);
-                    }
+                    set_multicast_safe(
+                        matmul_chunk_available_sem,
+                        noc_obj,
+                        tilize_mcast_start_x,
+                        tilize_mcast_start_y,
+                        tilize_mcast_end_x,
+                        tilize_mcast_end_y,
+                        tilize_bounding_box_num_cores - 1);
                 }
             }
             // ALL SUBSEQUENT ITERATIONS
@@ -574,52 +562,29 @@ void kernel_main() {
                 matmul_chunk_ready_sem.set(matmul_chunk_ready_semaphore_set_value);
                 matmul_chunk_ready_semaphore_set_value++;
 
-                // mcast sem set (NOC1 needs corners swapped; see get_safe_multicast_noc_addr)
-                if constexpr (noc_index == 0) {
-                    matmul_chunk_ready_sem.set_multicast(
-                        noc_obj,
-                        matmul_mcast_start_x,
-                        matmul_mcast_start_y,
-                        matmul_mcast_end_x,
-                        matmul_mcast_end_y,
-                        matmul_bounding_box_num_cores,
-                        /*linked=*/false);
-                } else {
-                    matmul_chunk_ready_sem.set_multicast(
-                        noc_obj,
-                        matmul_mcast_end_x,
-                        matmul_mcast_end_y,
-                        matmul_mcast_start_x,
-                        matmul_mcast_start_y,
-                        matmul_bounding_box_num_cores,
-                        /*linked=*/false);
-                }
+                // mcast sem set
+                set_multicast_safe(
+                    matmul_chunk_ready_sem,
+                    noc_obj,
+                    matmul_mcast_start_x,
+                    matmul_mcast_start_y,
+                    matmul_mcast_end_x,
+                    matmul_mcast_end_y,
+                    matmul_bounding_box_num_cores);
 
                 // == 10 ==
                 if (num_tilize_cores > 1) {
                     // Signal to non-drain-sync cores that they can start sending the next chunk
                     // Use local semaphore value (no need to explicitly set it)
                     // Local value is from when drain-sync waits until gather process is done (8a and 5b)
-                    // NOC1 needs corners swapped; see get_safe_multicast_noc_addr
-                    if constexpr (noc_index == 0) {
-                        tilize_chunk_ready_sem.set_multicast(
-                            noc_obj,
-                            tilize_mcast_start_x,
-                            tilize_mcast_start_y,
-                            tilize_mcast_end_x,
-                            tilize_mcast_end_y,
-                            tilize_bounding_box_num_cores - 1,
-                            /*linked=*/false);
-                    } else {
-                        tilize_chunk_ready_sem.set_multicast(
-                            noc_obj,
-                            tilize_mcast_end_x,
-                            tilize_mcast_end_y,
-                            tilize_mcast_start_x,
-                            tilize_mcast_start_y,
-                            tilize_bounding_box_num_cores - 1,
-                            /*linked=*/false);
-                    }
+                    set_multicast_safe(
+                        tilize_chunk_ready_sem,
+                        noc_obj,
+                        tilize_mcast_start_x,
+                        tilize_mcast_start_y,
+                        tilize_mcast_end_x,
+                        tilize_mcast_end_y,
+                        tilize_bounding_box_num_cores - 1);
                 }
             } else {
                 // == 11 ==

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/dm1.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
@@ -140,6 +141,8 @@ void kernel_main() {
     //-------------------------------------------------------------------------
     uint32_t semaphore_addr = get_semaphore(partial_semaphore);
     volatile tt_l1_ptr uint32_t* my_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
+    Semaphore<> partial_sem(partial_semaphore);
+    Noc noc_obj(1);
 
     const uint64_t partial_semaphore_noc_addr1 =
         get_noc_addr(neighbor1_physical_x, neighbor1_physical_y, semaphore_addr);
@@ -190,9 +193,6 @@ void kernel_main() {
     const uint32_t local_group_masks_addr = cb_w2c_in5.get_write_ptr();
     const uint64_t group_masks_noc_addr = get_noc_multicast_addr(
         first_physical_x, first_physical_y, collector_physical_x, collector_physical_y, local_group_masks_addr);
-    const uint64_t group_semaphore_noc_addr = get_noc_multicast_addr(
-        first_physical_x, first_physical_y, collector_physical_x, collector_physical_y, semaphore_addr);
-
     //-------------------------------------------------------------------------
     // Top8 partials (7 cores -> 1 collector core)
     //-------------------------------------------------------------------------
@@ -383,8 +383,14 @@ void kernel_main() {
 
         // Set the semaphore to let the clients know they got the data
         *my_semaphore_ptr = 1;
-        noc_semaphore_set_multicast(
-            semaphore_addr, group_semaphore_noc_addr, /*num_dests=*/7, /*linked=*/false, /*noc=*/1);
+        partial_sem.set_multicast(
+            noc_obj,
+            first_physical_x,
+            first_physical_y,
+            collector_physical_x,
+            collector_physical_y,
+            /*num_dests=*/7,
+            /*linked=*/false);
 
         cb_w2c_in5.pop_front(1);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -161,11 +161,10 @@ void kernel_main() {
     uint32_t mcast_end_x = get_arg_val<uint32_t>(rt_args++);
     uint32_t mcast_end_y = get_arg_val<uint32_t>(rt_args++);
     uint32_t untilizer_counter_l1_offset = get_write_ptr(cb_dispatched_metadata_id);
-    uint32_t counter_ready_sem_l1_offset = get_semaphore(counter_ready_semaphore_id);
     uint64_t mcast_counter_noc_addr =
         get_noc_multicast_addr(mcast_start_x, mcast_start_y, mcast_end_x, mcast_end_y, untilizer_counter_l1_offset);
-    uint64_t mcast_counter_sem_noc_addr =
-        get_noc_multicast_addr(mcast_start_x, mcast_start_y, mcast_end_x, mcast_end_y, counter_ready_sem_l1_offset);
+    Semaphore<> counter_ready_sem(counter_ready_semaphore_id);
+    Noc noc_obj;
 
     // Per-untilizer semaphores (each scoped to just the (this sender, untilizer) pair):
     //   data_ready: untilizer ++ after each non-local row it writes into receive_buf.  We do
@@ -253,7 +252,8 @@ void kernel_main() {
             off += chunk;
         }
         noc_async_write_barrier();
-        noc_semaphore_inc_multicast(mcast_counter_sem_noc_addr, 1, num_untilizer_cores_group);
+        counter_ready_sem.inc_multicast(
+            noc_obj, mcast_start_x, mcast_start_y, mcast_end_x, mcast_end_y, /*value=*/1, num_untilizer_cores_group);
     }
 
     uint32_t untilize_base = get_write_ptr(cb_untilize_id);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/worker_writer.cpp
@@ -47,11 +47,11 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t reduction_semaphore_send_id = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t reduction_semaphore_send_addr = get_semaphore(reduction_semaphore_send_id);
     const uint32_t num_mcast_ranges = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t link = get_arg_val<uint32_t>(arg_idx++);
 
     // Set up for mcasting to reduction workers
+    Noc noc_obj;
     Semaphore<> reduction_semaphore_send(reduction_semaphore_send_id);
     reduction_semaphore_send.set(VALID);
 
@@ -175,18 +175,14 @@ void kernel_main() {
     // loop over mcast ranges
     for (uint32_t i = 0; i < num_mcast_ranges; i++) {
         // Signal the reduction workers
-        const uint64_t reduction_semaphore_recv_noc_addr = get_noc_multicast_addr(
+        reduction_semaphore_send.set_multicast(
+            noc_obj,
             mcast_dest_noc_start_x[i],
             mcast_dest_noc_start_y[i],
             mcast_dest_noc_end_x[i],
             mcast_dest_noc_end_y[i],
-            reduction_semaphore_send_addr);
-
-        noc_semaphore_set_multicast(
-            reduction_semaphore_send_addr,
-            reduction_semaphore_recv_noc_addr,
             i == 0 ? num_mcast_cores : 0,
-            false);  // linked = false
+            /*linked=*/false);
     }
 
     // 4. global semaphore reset


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Contributes to #45003. Phase D of the free-function semaphore to Device 2.0 `Semaphore<>` migration: migrate the 14 free-function multicast semaphore sites to the `Semaphore<>` wrapper:

- `set_multicast` for all_reduce_create_qkv_heads, moe_gate_mm and the 10 moe_compute/moe_gpt tilize sites
- `set_multicast<MCAST_INCL_SRC>` (loopback) for llama_all_gather_matmul_async
- `inc_multicast` (atomic mcast increment) for deepseek_prefill/combine

### Notes for reviewers

- The moe_compute/moe_gpt tilize kernels build their mcast rectangle via `get_safe_multicast_noc_addr`, which swaps the corner coordinates on NOC1. `Semaphore<>::set_multicast` does not, so each of those 10 sites reproduces the swap with a compile-time `if constexpr (noc_index == 0)` branch.
- Also drops the now-dead precomposed `*_mcast_addr` locals and the raw `*_semaphore_addr` locals that only fed them.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/phase-d-multicast-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/phase-d-multicast-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/phase-d-multicast-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/phase-d-multicast-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/phase-d-multicast-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/phase-d-multicast-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/phase-d-multicast-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/phase-d-multicast-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/phase-d-multicast-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/phase-d-multicast-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/phase-d-multicast-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/phase-d-multicast-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/phase-d-multicast-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/phase-d-multicast-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/phase-d-multicast-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/phase-d-multicast-semaphores)