### PR TITLE
[ttnn/experimental] Generalize multi_scale_deformable_attn for D multiples of 16

### DIFF
--- a/tests/ttnn/unit_tests/operations/experimental/test_multi_scale_deformable_attn.py
+++ b/tests/ttnn/unit_tests/operations/experimental/test_multi_scale_deformable_attn.py
@@ -36,7 +36,7 @@ def _reference_msda(value: torch.Tensor, grid: torch.Tensor, attn: torch.Tensor,
 
 @pytest.mark.parametrize("N", [1, 4])
 @pytest.mark.parametrize("h_in,w_in", [(10, 10), (32, 32)])
-@pytest.mark.parametrize("D", [32])
+@pytest.mark.parametrize("D", [16, 32, 64])
 @pytest.mark.parametrize("Q", [16, 64])
 @pytest.mark.parametrize("P", [4, 8])
 @pytest.mark.parametrize("align_corners", [False, True])
@@ -60,3 +60,23 @@ def test_msda_correctness(device, N, h_in, w_in, D, Q, P, align_corners):
     out = ttnn.to_torch(out_t)
 
     assert_with_pcc(ref, out.to(torch.float32), pcc=0.99)
+
+
+@pytest.mark.parametrize("D", [8, 24, 40])
+def test_msda_rejects_non_multiple_of_16_d(device, D):
+    """D must be a positive multiple of 16; other widths fail validation."""
+    N, h_in, w_in, Q, P = 1, 8, 8, 16, 4
+    value_t = ttnn.from_torch(
+        torch.randn(N, h_in, w_in, D, dtype=torch.bfloat16), device=device, layout=ttnn.ROW_MAJOR_LAYOUT
+    )
+    grid_t = ttnn.from_torch(
+        torch.rand(N, Q * P, 1, 2, dtype=torch.bfloat16) * 2 - 1, device=device, layout=ttnn.ROW_MAJOR_LAYOUT
+    )
+    attn_t = ttnn.from_torch(
+        torch.softmax(torch.randn(N, Q, P, dtype=torch.float32), dim=-1).to(torch.bfloat16),
+        device=device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+
+    with pytest.raises(RuntimeError, match="multiple of 16"):
+        ttnn.experimental.multi_scale_deformable_attn(value_t, grid_t, attn_t)

--- a/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/kernels/compute/msda_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/kernels/compute/msda_compute.cpp
@@ -4,7 +4,8 @@
 
 // Compute kernel for fused multi-scale deformable attention.
 //
-// Per output tile (up to 32 queries packed vertically, one per row):
+// Per output query-group (up to 32 queries packed vertically, one per row),
+// for each D-width tile (NUM_D_TILES; 1 for D≤32, 2 for D=64):
 //   For each of REDUCTION_SIZE (= 4 * P) (input_tile, scalar_tile) pairs:
 //     dest[h, w] = input_tile[h, w] * scalar_tile[h, 0]   (COL broadcast)
 //     pack into output_cb with L1 accumulate (after first iter)
@@ -33,9 +34,10 @@ constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
 constexpr uint32_t scalar_cb_index = get_compile_time_arg_val(1);
 constexpr uint32_t output_cb_index = get_compile_time_arg_val(2);
 constexpr uint32_t reduction_size = get_compile_time_arg_val(3);  // = 4 * P
+constexpr uint32_t num_d_tiles = get_compile_time_arg_val(4);
 
 void kernel_main() {
-    const uint32_t num_output_tiles = get_arg_val<uint32_t>(0);
+    const uint32_t num_output_groups = get_arg_val<uint32_t>(0);
 
     CircularBuffer input_cb(input_cb_index);
     CircularBuffer scalar_cb(scalar_cb_index);
@@ -43,39 +45,41 @@ void kernel_main() {
 
     init_bcast<EltwiseBinaryType::ELWMUL, BroadcastType::COL>(input_cb_index, scalar_cb_index, output_cb_index);
 
-    for (uint32_t out = 0; out < num_output_tiles; ++out) {
-        // Reserve one output tile slot; we accumulate into it via L1 acc.
-        output_cb.reserve_back(1);
+    for (uint32_t out = 0; out < num_output_groups; ++out) {
+        for (uint32_t d_tile = 0; d_tile < num_d_tiles; ++d_tile) {
+            // Reserve one output tile slot; we accumulate into it via L1 acc.
+            output_cb.reserve_back(1);
 
-        for (uint32_t i = 0; i < reduction_size; ++i) {
-            if (i == 0) {
-                pack_reconfig_l1_acc(0);  // first iter: overwrite L1
-            } else if (i == 1) {
-                pack_reconfig_l1_acc(1);  // subsequent: accumulate into L1
+            for (uint32_t i = 0; i < reduction_size; ++i) {
+                if (i == 0) {
+                    pack_reconfig_l1_acc(0);  // first iter: overwrite L1
+                } else if (i == 1) {
+                    pack_reconfig_l1_acc(1);  // subsequent: accumulate into L1
+                }
+
+                input_cb.wait_front(1);
+                scalar_cb.wait_front(1);
+
+                tile_regs_acquire();
+                mul_tiles_bcast<BroadcastType::COL>(input_cb_index, scalar_cb_index, 0, 0, 0);
+                tile_regs_commit();
+
+                tile_regs_wait();
+                // out_of_order_output=true so every iteration packs to the same
+                // tile slot (= 0). The L1-acc mode (pack_reconfig_l1_acc) then
+                // decides between overwrite and accumulate. Default (=false)
+                // would auto-advance the write pointer and clobber out-of-range
+                // L1 after iter 1.
+                pack_tile<true>(0, output_cb_index, 0);
+                tile_regs_release();
+
+                input_cb.pop_front(1);
+                scalar_cb.pop_front(1);
             }
 
-            input_cb.wait_front(1);
-            scalar_cb.wait_front(1);
-
-            tile_regs_acquire();
-            mul_tiles_bcast<BroadcastType::COL>(input_cb_index, scalar_cb_index, 0, 0, 0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            // out_of_order_output=true so every iteration packs to the same
-            // tile slot (= 0). The L1-acc mode (pack_reconfig_l1_acc) then
-            // decides between overwrite and accumulate. Default (=false)
-            // would auto-advance the write pointer and clobber out-of-range
-            // L1 after iter 1.
-            pack_tile<true>(0, output_cb_index, 0);
-            tile_regs_release();
-
-            input_cb.pop_front(1);
-            scalar_cb.pop_front(1);
+            // Reset L1-acc mode for the next output tile.
+            pack_reconfig_l1_acc(0);
+            output_cb.push_back(1);
         }
-
-        // Reset L1-acc mode for the next output tile.
-        pack_reconfig_l1_acc(0);
-        output_cb.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/kernels/dataflow/reader_msda.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/kernels/dataflow/reader_msda.cpp
@@ -4,12 +4,17 @@
 
 // Reader kernel for fused multi-scale deformable attention.
 //
-// Produces one (input_tile, scalar_tile) pair per (p, corner) per output
-// tile, where one output tile carries up to 32 queries (all from the same
-// batch index n). The compute kernel multiplies them via
+// Produces (input_tile, scalar_tile) pairs per (d_tile, p, corner) per output
+// query-group, where one query-group carries up to 32 queries (all from the
+// same batch index n). The compute kernel multiplies them via
 // mul_tiles_bcast<COL>: result[h, w] = input[h, w] * scalar[h, 0], so row h
-// must hold query h's value-stick and scalar col-0 row h must hold that
+// must hold query h's value-stick chunk and scalar col-0 row h must hold that
 // query's combined weight (attn * bilinear_corner).
+//
+// D (value last dim) is packed into 32-wide tile columns. When D > 32 the
+// reader emits one tile per 32-wide chunk (d_tile), reading each chunk via
+// the NoC byte offset into the stick. When D < 32 (e.g. D=16) a single
+// partial tile is emitted and only the occupied face-halves are filled.
 //
 // Tile face layout (bf16, 32x32 tile = 4 faces of 16x16, 512 B per face,
 // 2048 B per tile):
@@ -25,7 +30,8 @@
 // compute kernel calls mul_tiles_bcast<COL> with clear_fp32_dst_acc=true so
 // DST is cleared on entry and only col-0 broadcasts contribute.
 //
-// Per-tile runtime args (3 per tile): (n, q_start, v_rows). 1 ≤ v_rows ≤ 32.
+// Per-tile runtime args (3 per query-group): (n, q_start, v_rows).
+// 1 ≤ v_rows ≤ 32.
 // Zero-fill contract:
 //   * scalar tile: col 0 is explicitly written for all 32 rows. Tail rows
 //     (r ≥ v_rows) and OOB-corner rows get bf16 0, so their contribution
@@ -67,6 +73,28 @@ inline uint16_t float_to_bf16(float value) {
     return static_cast<uint16_t>(tmp >> 16);
 }
 
+// Scatter `nbytes` from a stick chunk into tile row `r`, walking face-halves
+// (16 bf16 = 32 B each). For a full 32-wide chunk this fills lo then hi; for
+// D=16 it fills only lo.
+inline void copy_stick_chunk_to_tile_row(
+    uint32_t tile_l1, uint32_t r, uint32_t stick_chunk_l1, uint32_t nbytes) {
+    constexpr uint32_t FACE_ROW_NBYTES = msda_tile_layout::WITHIN_FACE_ROW_STRIDE;
+    constexpr uint32_t FACE_ROW_WORDS = FACE_ROW_NBYTES / sizeof(uint32_t);
+
+    const uint32_t num_halves = nbytes / FACE_ROW_NBYTES;
+    const auto off = msda_tile_layout::tile_row_offsets(r);
+    CoreLocalMem<volatile uint32_t> src(stick_chunk_l1);
+
+    for (uint32_t h = 0; h < num_halves; ++h) {
+        const uint32_t dst_off = (h == 0) ? off.lo : off.hi;
+        CoreLocalMem<volatile uint32_t> dst(tile_l1 + dst_off);
+        const uint32_t src_word = h * FACE_ROW_WORDS;
+        for (uint32_t i = 0; i < FACE_ROW_WORDS; ++i) {
+            dst[i] = src[src_word + i];
+        }
+    }
+}
+
 }  // namespace
 
 constexpr uint32_t value_scratch_cb_index = get_compile_time_arg_val(0);
@@ -90,8 +118,9 @@ constexpr auto grid_args = TensorAccessorArgs<value_args.next_compile_time_args_
 constexpr auto attn_args = TensorAccessorArgs<grid_args.next_compile_time_args_offset()>();
 
 constexpr uint32_t TILE_MAX_ROWS = 32;
-constexpr uint32_t HALF_STICK_NBYTES = 32;  // 16 bf16 per row half (TL or TR portion of one row)
-constexpr uint32_t HALF_WORDS = HALF_STICK_NBYTES / sizeof(uint32_t);
+constexpr uint32_t ELEMENT_SIZE = 2;  // bf16
+constexpr uint32_t TILE_WIDTH = 32;
+constexpr uint32_t NUM_D_TILES = (D + TILE_WIDTH - 1) / TILE_WIDTH;
 
 void kernel_main() {
     const uint32_t value_addr = get_arg_val<uint32_t>(0);
@@ -157,120 +186,119 @@ void kernel_main() {
 
         const uint32_t n_off = n * static_cast<uint32_t>(h_in_i * w_in_i);
 
-        for (uint32_t p = 0; p < P; ++p) {
-            // Precompute per-row geometry for this p.
-            for (uint32_t r = 0; r < v_rows; ++r) {
-                CoreLocalMem<volatile uint16_t> grid_ptr(grid_scratch_l1 + (r * P + p) * grid_stick_nbytes);
-                CoreLocalMem<volatile uint16_t> attn_ptr(attn_scratch_l1 + r * attn_stick_nbytes);
+        // d_tile is outermost over the reduction so compute can accumulate one
+        // width-tile of D at a time (D=64 => two face-pair tiles per group).
+        for (uint32_t d_tile = 0; d_tile < NUM_D_TILES; ++d_tile) {
+            const uint32_t d_start = d_tile * TILE_WIDTH;
+            const uint32_t d_chunk = (D - d_start) < TILE_WIDTH ? (D - d_start) : TILE_WIDTH;
+            const uint32_t chunk_nbytes = d_chunk * ELEMENT_SIZE;
+            const uint32_t chunk_offset = d_start * ELEMENT_SIZE;
 
-                const float gx = bf16_to_float(grid_ptr[0]);
-                const float gy = bf16_to_float(grid_ptr[1]);
-                w_attn_arr[r] = bf16_to_float(attn_ptr[p]);
-
-                // align_corners selects the pixel-coord mapping (mmcv default
-                // is false: pixel = (g+1)*size/2 - 0.5; true variant uses
-                // pixel = (g+1)*(size-1)/2).
-                float px, py;
-                if constexpr (ALIGN_CORNERS) {
-                    px = (gx + 1.0f) * 0.5f * static_cast<float>(w_in_i - 1);
-                    py = (gy + 1.0f) * 0.5f * static_cast<float>(h_in_i - 1);
-                } else {
-                    px = (gx + 1.0f) * 0.5f * static_cast<float>(w_in_i) - 0.5f;
-                    py = (gy + 1.0f) * 0.5f * static_cast<float>(h_in_i) - 0.5f;
-                }
-
-                const int32_t x0 = static_cast<int32_t>(std::floor(px));
-                const int32_t y0 = static_cast<int32_t>(std::floor(py));
-                const float dx = px - static_cast<float>(x0);
-                const float dy = py - static_cast<float>(y0);
-
-                x0_arr[r] = x0;
-                y0_arr[r] = y0;
-                x0v_arr[r] = (x0 >= 0) && (x0 < w_in_i);
-                x1v_arr[r] = (x0 + 1 >= 0) && (x0 + 1 < w_in_i);
-                y0v_arr[r] = (y0 >= 0) && (y0 < h_in_i);
-                y1v_arr[r] = (y0 + 1 >= 0) && (y0 + 1 < h_in_i);
-                w_nw_arr[r] = (1.0f - dx) * (1.0f - dy);
-                w_ne_arr[r] = dx * (1.0f - dy);
-                w_sw_arr[r] = (1.0f - dx) * dy;
-                w_se_arr[r] = dx * dy;
-            }
-
-            for (uint32_t c = 0; c < 4; ++c) {
-                // Hoist all c-invariant selectors out of the per-r loops below:
-                // c picks which y/x validity array, which corner-weight array,
-                // and the (dy, dx) offset to the corner.
-                const int32_t dy_off = (c < 2) ? 0 : 1;
-                const int32_t dx_off = (c & 1) ? 1 : 0;
-                const bool* yv_arr = (c < 2) ? y0v_arr : y1v_arr;
-                const bool* xv_arr = (c & 1) ? x1v_arr : x0v_arr;
-                const float* w_corner_arr = (c == 0) ? w_nw_arr : (c == 1) ? w_ne_arr : (c == 2) ? w_sw_arr : w_se_arr;
-
-                // ---- INPUT TILE ----
-                input_tile_cb.reserve_back(1);
-                const uint32_t tile_l1 = input_tile_cb.get_write_ptr();
-
-                // Issue NoC reads for all valid rows.
+            for (uint32_t p = 0; p < P; ++p) {
+                // Precompute per-row geometry for this p (independent of d_tile).
+                // Recomputed per d_tile; cheap vs NoC and keeps nesting simple.
                 for (uint32_t r = 0; r < v_rows; ++r) {
-                    if (!(yv_arr[r] && xv_arr[r])) {
-                        continue;
+                    CoreLocalMem<volatile uint16_t> grid_ptr(grid_scratch_l1 + (r * P + p) * grid_stick_nbytes);
+                    CoreLocalMem<volatile uint16_t> attn_ptr(attn_scratch_l1 + r * attn_stick_nbytes);
+
+                    const float gx = bf16_to_float(grid_ptr[0]);
+                    const float gy = bf16_to_float(grid_ptr[1]);
+                    w_attn_arr[r] = bf16_to_float(attn_ptr[p]);
+
+                    // align_corners selects the pixel-coord mapping (mmcv default
+                    // is false: pixel = (g+1)*size/2 - 0.5; true variant uses
+                    // pixel = (g+1)*(size-1)/2).
+                    float px, py;
+                    if constexpr (ALIGN_CORNERS) {
+                        px = (gx + 1.0f) * 0.5f * static_cast<float>(w_in_i - 1);
+                        py = (gy + 1.0f) * 0.5f * static_cast<float>(h_in_i - 1);
+                    } else {
+                        px = (gx + 1.0f) * 0.5f * static_cast<float>(w_in_i) - 0.5f;
+                        py = (gy + 1.0f) * 0.5f * static_cast<float>(h_in_i) - 0.5f;
                     }
-                    const uint32_t cy = static_cast<uint32_t>(y0_arr[r] + dy_off);
-                    const uint32_t cx = static_cast<uint32_t>(x0_arr[r] + dx_off);
-                    const uint32_t stick_idx = n_off + cy * w_in_i + cx;
-                    CoreLocalMem<uint32_t> dst(value_scratch_l1 + r * value_stick_nbytes);
-                    noc.async_read(value_acc, dst, value_stick_nbytes, {.page_id = stick_idx}, {.offset_bytes = 0});
+
+                    const int32_t x0 = static_cast<int32_t>(std::floor(px));
+                    const int32_t y0 = static_cast<int32_t>(std::floor(py));
+                    const float dx = px - static_cast<float>(x0);
+                    const float dy = py - static_cast<float>(y0);
+
+                    x0_arr[r] = x0;
+                    y0_arr[r] = y0;
+                    x0v_arr[r] = (x0 >= 0) && (x0 < w_in_i);
+                    x1v_arr[r] = (x0 + 1 >= 0) && (x0 + 1 < w_in_i);
+                    y0v_arr[r] = (y0 >= 0) && (y0 < h_in_i);
+                    y1v_arr[r] = (y0 + 1 >= 0) && (y0 + 1 < h_in_i);
+                    w_nw_arr[r] = (1.0f - dx) * (1.0f - dy);
+                    w_ne_arr[r] = dx * (1.0f - dy);
+                    w_sw_arr[r] = (1.0f - dx) * dy;
+                    w_se_arr[r] = dx * dy;
                 }
-                noc.async_read_barrier();
 
-                // Scatter sticks into face rows. Invalid corners have stale staging
-                // data but their scalar entry is zero — the multiply contributes 0.
-                for (uint32_t r = 0; r < v_rows; ++r) {
-                    if (!(yv_arr[r] && xv_arr[r])) {
-                        continue;
+                for (uint32_t c = 0; c < 4; ++c) {
+                    // Hoist all c-invariant selectors out of the per-r loops below:
+                    // c picks which y/x validity array, which corner-weight array,
+                    // and the (dy, dx) offset to the corner.
+                    const int32_t dy_off = (c < 2) ? 0 : 1;
+                    const int32_t dx_off = (c & 1) ? 1 : 0;
+                    const bool* yv_arr = (c < 2) ? y0v_arr : y1v_arr;
+                    const bool* xv_arr = (c & 1) ? x1v_arr : x0v_arr;
+                    const float* w_corner_arr =
+                        (c == 0) ? w_nw_arr : (c == 1) ? w_ne_arr : (c == 2) ? w_sw_arr : w_se_arr;
+
+                    // ---- INPUT TILE ----
+                    input_tile_cb.reserve_back(1);
+                    const uint32_t tile_l1 = input_tile_cb.get_write_ptr();
+
+                    // Issue NoC reads for all valid rows (one D-chunk per stick).
+                    for (uint32_t r = 0; r < v_rows; ++r) {
+                        if (!(yv_arr[r] && xv_arr[r])) {
+                            continue;
+                        }
+                        const uint32_t cy = static_cast<uint32_t>(y0_arr[r] + dy_off);
+                        const uint32_t cx = static_cast<uint32_t>(x0_arr[r] + dx_off);
+                        const uint32_t stick_idx = n_off + cy * w_in_i + cx;
+                        CoreLocalMem<uint32_t> dst(value_scratch_l1 + r * value_stick_nbytes);
+                        noc.async_read(
+                            value_acc,
+                            dst,
+                            chunk_nbytes,
+                            {.page_id = stick_idx},
+                            {.offset_bytes = chunk_offset});
                     }
-                    const auto off = msda_tile_layout::tile_row_offsets(r);
-                    CoreLocalMem<volatile uint32_t> s(value_scratch_l1 + r * value_stick_nbytes);
-                    CoreLocalMem<volatile uint32_t> dl(tile_l1 + off.lo);
-                    CoreLocalMem<volatile uint32_t> dh(tile_l1 + off.hi);
-                    for (uint32_t i = 0; i < HALF_WORDS; ++i) {
-                        dl[i] = s[i];
+                    noc.async_read_barrier();
+
+                    // Scatter stick chunks into face-halves of each row.
+                    for (uint32_t r = 0; r < v_rows; ++r) {
+                        if (!(yv_arr[r] && xv_arr[r])) {
+                            continue;
+                        }
+                        copy_stick_chunk_to_tile_row(
+                            tile_l1, r, value_scratch_l1 + r * value_stick_nbytes, chunk_nbytes);
                     }
-                    for (uint32_t i = 0; i < HALF_WORDS; ++i) {
-                        dh[i] = s[HALF_WORDS + i];
+
+                    // Tail rows (r ≥ v_rows) and OOB-corner rows are left untouched:
+                    // their scalar entry is zero (see scalar tile below), so any stale
+                    // bytes in input row r contribute 0 to L1 accumulation.
+                    input_tile_cb.push_back(1);
+
+                    // ---- SCALAR TILE ----
+                    // Same scalar for every d_tile of this (p, corner): COL bcast
+                    // broadcasts one weight across the whole tile width.
+                    scalar_tile_cb.reserve_back(1);
+                    const uint32_t s_tile_l1 = scalar_tile_cb.get_write_ptr();
+
+                    for (uint32_t r = 0; r < TILE_MAX_ROWS; ++r) {
+                        uint16_t bf = 0;
+                        if (r < v_rows) {
+                            const float combined =
+                                (yv_arr[r] && xv_arr[r]) ? (w_attn_arr[r] * w_corner_arr[r]) : 0.0f;
+                            bf = float_to_bf16(combined);
+                        }
+                        CoreLocalMem<volatile uint16_t> p16(s_tile_l1 + msda_tile_layout::tile_col0_offset(r));
+                        p16[0] = bf;
                     }
+                    scalar_tile_cb.push_back(1);
                 }
-
-                // Tail rows (r ≥ v_rows) and OOB-corner rows are left untouched:
-                // their scalar entry is zero (see scalar tile below), so any stale
-                // bytes in input row r contribute 0 to L1 accumulation. Saves a
-                // 16-row × 64-byte memset for tail tiles and skips work on full
-                // tiles entirely.
-                input_tile_cb.push_back(1);
-
-                // ---- SCALAR TILE ----
-                // LLK COL bcast reads only col 0 of TL face (rows 0..15) and BL
-                // face (rows 16..31). Non-col-0 lanes are unused mathematically
-                // (mul_tiles_bcast<COL> uses clear_fp32_dst_acc=true, so DST is
-                // cleared on entry and only the col-0 broadcast contributes).
-                // We therefore skip the 2-KiB full zero-fill and only write the
-                // 32 col-0 bf16 lanes — 32× less L1 traffic per iter.
-                scalar_tile_cb.reserve_back(1);
-                const uint32_t s_tile_l1 = scalar_tile_cb.get_write_ptr();
-
-                for (uint32_t r = 0; r < TILE_MAX_ROWS; ++r) {
-                    uint16_t bf = 0;
-                    if (r < v_rows) {
-                        const float combined = (yv_arr[r] && xv_arr[r]) ? (w_attn_arr[r] * w_corner_arr[r]) : 0.0f;
-                        bf = float_to_bf16(combined);
-                    }
-                    // Rows ≥ v_rows OR invalid corners: bf stays 0 — explicitly
-                    // overwrite col 0 because the CB slot may contain non-zero
-                    // bf16 left by a previous tile where this row was valid.
-                    CoreLocalMem<volatile uint16_t> p16(s_tile_l1 + msda_tile_layout::tile_col0_offset(r));
-                    p16[0] = bf;
-                }
-                scalar_tile_cb.push_back(1);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/kernels/dataflow/writer_msda.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/kernels/dataflow/writer_msda.cpp
@@ -4,15 +4,17 @@
 
 // Writer kernel for fused multi-scale deformable attention (FPU path,
 // 32-query batched). Each output tile from compute carries up to 32
-// query outputs stacked vertically. For each tile, copy v_rows rows out
-// of the tile faces and NoC-write each as one output stick (D=32 bf16).
+// query outputs stacked vertically for one D-width chunk (≤ 32 channels).
+// For each query-group, copy v_rows rows out of each d_tile's faces and
+// NoC-write them into the matching byte offset of each output stick.
 //
 // Tile face layout (bf16, 32x32 = 4 faces of 16x16, 2048 B):
 //   row r ∈ [0, 16): TL[r*32..r*32+31] + TR[512+r*32..512+r*32+31]
 //   row r ∈ [16, 32): BL[1024+(r-16)*32..] + BR[1536+(r-16)*32..]
-// One row = 32 bf16 = D values laid out as the two 32-byte halves above.
+// One full-width row = 32 bf16 laid out as two 32-byte face-halves.
+// D=16 uses only the lo half; D=64 emits two tiles (two face pairs).
 //
-// Per-tile runtime args (2 per tile): (start_stick_id, v_rows).
+// Per-group runtime args (2 per group): (start_stick_id, v_rows).
 // start_stick_id_t = n_t * Q + q_start_t; rows 0..v_rows-1 are written
 // to consecutive sticks starting at that id.
 
@@ -27,11 +29,34 @@
 constexpr uint32_t output_tile_cb_index = get_compile_time_arg_val(0);
 constexpr uint32_t output_scratch_cb_index = get_compile_time_arg_val(1);
 constexpr uint32_t output_stick_nbytes = get_compile_time_arg_val(2);
+constexpr uint32_t D = get_compile_time_arg_val(3);
 
-constexpr auto output_args = TensorAccessorArgs<3>();
+constexpr auto output_args = TensorAccessorArgs<4>();
 
-constexpr uint32_t HALF_STICK_NBYTES = 32;
-constexpr uint32_t HALF_WORDS = HALF_STICK_NBYTES / sizeof(uint32_t);
+constexpr uint32_t ELEMENT_SIZE = 2;  // bf16
+constexpr uint32_t TILE_WIDTH = 32;
+constexpr uint32_t NUM_D_TILES = (D + TILE_WIDTH - 1) / TILE_WIDTH;
+
+// Gather `nbytes` from tile row `r` into a linear scratch stick chunk,
+// walking face-halves (16 bf16 = 32 B each).
+inline void copy_tile_row_to_stick_chunk(
+    uint32_t scratch_l1, uint32_t tile_l1, uint32_t r, uint32_t nbytes) {
+    constexpr uint32_t FACE_ROW_NBYTES = msda_tile_layout::WITHIN_FACE_ROW_STRIDE;
+    constexpr uint32_t FACE_ROW_WORDS = FACE_ROW_NBYTES / sizeof(uint32_t);
+
+    const uint32_t num_halves = nbytes / FACE_ROW_NBYTES;
+    const auto off = msda_tile_layout::tile_row_offsets(r);
+    CoreLocalMem<volatile uint32_t> dst(scratch_l1);
+
+    for (uint32_t h = 0; h < num_halves; ++h) {
+        const uint32_t src_off = (h == 0) ? off.lo : off.hi;
+        CoreLocalMem<volatile uint32_t> src(tile_l1 + src_off);
+        const uint32_t dst_word = h * FACE_ROW_WORDS;
+        for (uint32_t i = 0; i < FACE_ROW_WORDS; ++i) {
+            dst[dst_word + i] = src[i];
+        }
+    }
+}
 
 void kernel_main() {
     const uint32_t output_addr = get_arg_val<uint32_t>(0);
@@ -51,29 +76,29 @@ void kernel_main() {
         const uint32_t start_id = get_arg_val<uint32_t>(arg_idx++);
         const uint32_t v_rows = get_arg_val<uint32_t>(arg_idx++);
 
-        output_tile_cb.wait_front(1);
-        const uint32_t tile_l1 = output_tile_cb.get_read_ptr();
+        for (uint32_t d_tile = 0; d_tile < NUM_D_TILES; ++d_tile) {
+            const uint32_t d_start = d_tile * TILE_WIDTH;
+            const uint32_t d_chunk = (D - d_start) < TILE_WIDTH ? (D - d_start) : TILE_WIDTH;
+            const uint32_t chunk_nbytes = d_chunk * ELEMENT_SIZE;
+            const uint32_t chunk_offset = d_start * ELEMENT_SIZE;
 
-        for (uint32_t r = 0; r < v_rows; ++r) {
-            const auto off = msda_tile_layout::tile_row_offsets(r);
-            const uint32_t src_lo = tile_l1 + off.lo;
-            const uint32_t src_hi = tile_l1 + off.hi;
+            output_tile_cb.wait_front(1);
+            const uint32_t tile_l1 = output_tile_cb.get_read_ptr();
 
-            CoreLocalMem<volatile uint32_t> dst(scratch_l1);
-            CoreLocalMem<volatile uint32_t> sl(src_lo);
-            CoreLocalMem<volatile uint32_t> sh(src_hi);
-            for (uint32_t i = 0; i < HALF_WORDS; ++i) {
-                dst[i] = sl[i];
+            for (uint32_t r = 0; r < v_rows; ++r) {
+                copy_tile_row_to_stick_chunk(scratch_l1, tile_l1, r, chunk_nbytes);
+
+                CoreLocalMem<uint32_t> src(scratch_l1);
+                noc.async_write(
+                    src,
+                    output_acc,
+                    chunk_nbytes,
+                    {.offset_bytes = chunk_offset},
+                    {.page_id = start_id + r});
+                noc.async_writes_flushed();
             }
-            for (uint32_t i = 0; i < HALF_WORDS; ++i) {
-                dst[HALF_WORDS + i] = sh[i];
-            }
-
-            CoreLocalMem<uint32_t> src(scratch_l1);
-            noc.async_write(src, output_acc, output_stick_nbytes, {.offset_bytes = 0}, {.page_id = start_id + r});
-            noc.async_writes_flushed();
+            noc.async_write_barrier();
+            output_tile_cb.pop_front(1);
         }
-        noc.async_write_barrier();
-        output_tile_cb.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/multi_scale_deformable_attn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/multi_scale_deformable_attn_device_operation.cpp
@@ -65,13 +65,13 @@ void MSDAOperation::validate_on_program_cache_miss(const operation_attributes_t&
     TT_FATAL(as[1] > 0, "Q must be > 0");
     TT_FATAL(as[2] > 0, "P must be > 0");
 
-    // TODO: generalize the kernel to support arbitrary D (multiple of 16). The
-    // reader/writer currently assume D=32: a single tile row is split into
-    // exactly two 32-byte halves placed in TL+TR (or BL+BR) faces, and
-    // HALF_STICK_NBYTES is hardcoded to 32 in the kernels. Supporting D=64
-    // or D=16 means deriving the per-row layout from element_size + D and
-    // looping over multiple (half-)faces per row.
-    TT_FATAL(vs[-1] == 32, "value's last dim (D) must be 32, got {}", static_cast<uint32_t>(vs[-1]));
+    // D is the per-head channel width. Reader/writer pack it into one or more
+    // 32-wide tile faces (16-wide half-faces). D must be a multiple of 16 so
+    // each chunk lands on a face-half boundary (bf16 face row = 16 elements).
+    TT_FATAL(
+        vs[-1] > 0 && vs[-1] % 16 == 0,
+        "value's last dim (D) must be a positive multiple of 16, got {}",
+        static_cast<uint32_t>(vs[-1]));
 
     const uint32_t qp = static_cast<uint32_t>(gs[1]);
     const uint32_t q = static_cast<uint32_t>(as[1]);

--- a/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/multi_scale_deformable_attn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/multi_scale_deformable_attn_program_factory.cpp
@@ -57,6 +57,9 @@ ProgramDescriptor MSDAOperation::create_descriptor(
     const uint32_t reduction_size = 4 * P;
 
     constexpr uint32_t TILE_MAX_ROWS = 32;
+    constexpr uint32_t TILE_WIDTH = 32;
+    // D is packed into one or more 32-wide tiles (partial last tile when D % 32 != 0).
+    const uint32_t num_d_tiles = (D + TILE_WIDTH - 1) / TILE_WIDTH;
 
     // Build the list of output tiles: each tile holds up to 32 contiguous
     // queries from a single batch index n. Q is not required to divide 32 —
@@ -172,7 +175,7 @@ ProgramDescriptor MSDAOperation::create_descriptor(
         "ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/kernels/compute/msda_compute.cpp";
     compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = {input_tile_cb, scalar_tile_cb, output_tile_cb, reduction_size};
+    compute_desc.compile_time_args = {input_tile_cb, scalar_tile_cb, output_tile_cb, reduction_size, num_d_tiles};
     compute_desc.config = ComputeConfigDescriptor{};
 
     // Writer kernel descriptor.
@@ -180,6 +183,7 @@ ProgramDescriptor MSDAOperation::create_descriptor(
         output_tile_cb,
         output_scratch_cb,
         output_stick_aligned,
+        D,
     };
     TensorAccessorArgs(*output.buffer()).append_to(writer_ct);
 

--- a/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/multi_scale_deformable_attn.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/multi_scale_deformable_attn.hpp
@@ -18,6 +18,7 @@ namespace ttnn::experimental {
 //
 // Inputs:
 //   value:  (N, h_in, w_in, D) ROW_MAJOR bfloat16, where N = B * num_heads
+//           and D is a positive multiple of 16
 //   grid:   (N, Q*P, 1, 2)     ROW_MAJOR bfloat16, normalized to [-1, 1]
 //   attn:   (N, Q, P)          ROW_MAJOR bfloat16
 //

--- a/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/multi_scale_deformable_attn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/multi_scale_deformable_attn_nanobind.cpp
@@ -20,7 +20,7 @@ void bind_multi_scale_deformable_attn(nb::module_& mod) {
         Fused multi-scale deformable attention (num_levels == 1 fast path).
 
         Args:
-            * :attr:`value`: (N, h_in, w_in, D) ROW_MAJOR bfloat16, N = B * num_heads
+            * :attr:`value`: (N, h_in, w_in, D) ROW_MAJOR bfloat16, N = B * num_heads, D multiple of 16
             * :attr:`grid`: (N, Q*P, 1, 2) ROW_MAJOR bfloat16, normalized to [-1, 1]
             * :attr:`attn`: (N, Q, P) ROW_MAJOR bfloat16
             * :attr:`memory_config`: output memory config


### PR DESCRIPTION
### PR Category
Feature

### Summary
Fixes #52328

Generalize `ttnn.experimental.multi_scale_deformable_attn` so value last-dim `D` can be any positive multiple of 16 (not only 32).

- Relax validation from `D == 32` to `D % 16 == 0`
- Reader/writer copy by face-halves derived from `D` (`D=16` partial face, `D=64` two width tiles)
- Compute/program factory nest an outer `d_tile` loop
- Extend correctness tests to `D ∈ {16, 32, 64}` and add rejection tests for non-multiples of 16

### Notes for reviewers
`D=32` still uses a single width tile. Device CI should cover `tests/ttnn/unit_tests/operations/experimental/test_multi_scale_deformable_attn.py`.