### PR TITLE
Fix no-op bounds check in `Shape::get_normalized_index`

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_shape.cpp
+++ b/tests/tt_metal/tt_metal/api/test_shape.cpp
@@ -2,12 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
 #include <tt-metalium/shape.hpp>
 #include <tt_stl/reflection.hpp>
 
-#include "gtest/gtest.h"
-
 namespace tt::tt_metal {
+namespace {
+
+using ::testing::HasSubstr;
+using ::testing::ThrowsMessage;
 
 // Regression test: shapes with different ranks but same padded representation
 // must produce different hashes. ShapeBase::init() pads value_ to min-4D with
@@ -48,18 +55,23 @@ TEST(TensorShapeTests, IdenticalShapesProduceSameHash) {
 }
 
 TEST(TensorShapeTests, GetNormalizedIndexInRange) {
-    tt::tt_metal::Shape shape({32, 64, 128});
-
-    EXPECT_EQ(shape.get_normalized_index(2), 2u);
-    EXPECT_EQ(shape.get_normalized_index(-3), 0u);
-}
-
-TEST(TensorShapeTests, GetNormalizedIndexOutOfRangeThrows) {
     tt::tt_metal::Shape shape({32, 64});
 
-    EXPECT_ANY_THROW(shape.get_normalized_index(2));
-    // Regression: normalized_index was unsigned, so this wrapped past the `>= 0` guard.
-    EXPECT_ANY_THROW(shape.get_normalized_index(-3));
+    // Normalization is against the logical rank of 2, not the padded 4D storage.
+    EXPECT_EQ(shape.get_normalized_index(1), 1u);
+    EXPECT_EQ(shape.get_normalized_index(-2), 0u);
 }
 
+TEST(TensorShapeTests, GetNormalizedIndexOutOfRangeReportsCallerIndex) {
+    tt::tt_metal::Shape shape({32, 64});
+
+    EXPECT_THAT(
+        ([&shape]() { shape.get_normalized_index(2); }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("2 not in [-2, 2)")));
+    EXPECT_THAT(
+        ([&shape]() { shape.get_normalized_index(-3); }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("-3 not in [-2, 2)")));
+}
+
+}  // namespace
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_shape.cpp
+++ b/tests/tt_metal/tt_metal/api/test_shape.cpp
@@ -47,4 +47,19 @@ TEST(TensorShapeTests, IdenticalShapesProduceSameHash) {
     EXPECT_EQ(hash_a, hash_b);
 }
 
+TEST(TensorShapeTests, GetNormalizedIndexInRange) {
+    tt::tt_metal::Shape shape({32, 64, 128});
+
+    EXPECT_EQ(shape.get_normalized_index(2), 2u);
+    EXPECT_EQ(shape.get_normalized_index(-3), 0u);
+}
+
+TEST(TensorShapeTests, GetNormalizedIndexOutOfRangeThrows) {
+    tt::tt_metal::Shape shape({32, 64});
+
+    EXPECT_ANY_THROW(shape.get_normalized_index(2));
+    // Regression: normalized_index was unsigned, so this wrapped past the `>= 0` guard.
+    EXPECT_ANY_THROW(shape.get_normalized_index(-3));
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/common/shape.cpp
+++ b/tt_metal/common/shape.cpp
@@ -47,14 +47,16 @@ Shape Shape::to_rank(size_t new_rank) const {
 }
 
 uint32_t Shape::get_normalized_index(std::int64_t index) const {
-    std::int64_t rank = static_cast<std::int64_t>(this->rank());
-    std::uint64_t normalized_index = index >= 0 ? index : rank + index;
+    const std::int64_t rank = static_cast<std::int64_t>(this->rank());
+    // Signed type: an unsigned type wraps index < -rank to ~1.8e19, making the `>= 0` check vacuous.
+    const std::int64_t normalized_index = index >= 0 ? index : rank + index;
     TT_FATAL(
         normalized_index >= 0 and normalized_index < rank,
-        "Index is out of bounds for the rank, should be between 0 and {} however is {}",
-        rank - 1,
-        normalized_index);
-    return normalized_index;
+        "Shape index out of range. {} not in [{}, {})",
+        index,
+        -rank,
+        rank);
+    return static_cast<uint32_t>(normalized_index);
 }
 
 std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Shape& shape) {


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
`normalized_index` was stored in a `std::uint64_t`, so the `normalized_index >= 0` guard was dead code — GCC flags it with `-Wtype-limits` ("comparison of unsigned expression in '>= 0' is always true"). Out-of-range negative indices were still rejected, but by the wrong clause: the wrapped value (~1.8e19) failed `< rank` instead, and the error message printed that wrapped value.

**Fix:** Stores it as `std::int64_t` so the intended guard does the work. Message format now matches the neighbouring `ShapeBase[]` error ("ShapeBase[] index out of range. {} not in [{}, {})").

On a rank-2 shape:
| index | before | after |
|---|---|---|
| `-3` | `should be between 0 and 1 however is 18446744073709551615` | `-3 not in [-2, 2)` |
| `2` | `should be between 0 and 1 however is 2` | `2 not in [-2, 2)` |

Added unit tests for this.
Surfaced while debugging #52331.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/fix-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=scardoza/fix-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:scardoza/fix-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=scardoza/fix-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:scardoza/fix-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/fix-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=scardoza/fix-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:scardoza/fix-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/fix-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/fix-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/fix-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-shape)