### PR TITLE
[Bug fix] Disable per-op hang detection for fabric stability tests

### DIFF
--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -316,7 +316,6 @@ jobs:
             cmd: ./build/test/tt_metal/tt_fabric/test_system_health
             timeout: 15
           - name: fabric stability nightly tests
-            # Timeout added to filter false regressions.
             cmd: TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_stability.yaml --filter 'name.*_short'
             timeout: 30
           - name: ccl nightly tests

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -316,10 +316,7 @@ jobs:
             cmd: ./build/test/tt_metal/tt_fabric/test_system_health
             timeout: 15
           - name: fabric stability nightly tests
-            # Stability traffic runs as one long program launch, and the dispatch
-            # progress counter cannot advance while it runs, so the 5s hang-detection
-            # default that setup-job applies reports a false hang. 0 disables it; a
-            # real hang is still bounded by the job timeout below (#47842).
+            # Timeout added to filter false regressions.
             cmd: TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_stability.yaml --filter 'name.*_short'
             timeout: 30
           - name: ccl nightly tests

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -316,7 +316,11 @@ jobs:
             cmd: ./build/test/tt_metal/tt_fabric/test_system_health
             timeout: 15
           - name: fabric stability nightly tests
-            cmd: ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_stability.yaml --filter 'name.*_short'
+            # Stability traffic runs as one long program launch, and the dispatch
+            # progress counter cannot advance while it runs, so the 5s hang-detection
+            # default that setup-job applies reports a false hang. 0 disables it; a
+            # real hang is still bounded by the job timeout below (#47842).
+            cmd: TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_stability.yaml --filter 'name.*_short'
             timeout: 30
           - name: ccl nightly tests
             cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -135,7 +135,6 @@
 # --- stress (continuous gate) ---
 - id: bh-fabric-stability-stress
   name: fabric stability nightly tests
-  # Timeout added to filter false regressions.
   cmd: TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_stability.yaml --filter 'name.*_short'
   skus:
     bh_loudbox:

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -135,10 +135,7 @@
 # --- stress (continuous gate) ---
 - id: bh-fabric-stability-stress
   name: fabric stability nightly tests
-  # Stability traffic runs as one long program launch, and the dispatch progress
-  # counter cannot advance while it runs, so the 5s hang-detection default that
-  # setup-job applies reports a false hang. 0 disables it; a real hang is still
-  # bounded by the SKU timeout below (#47842).
+  # Timeout added to filter false regressions.
   cmd: TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_stability.yaml --filter 'name.*_short'
   skus:
     bh_loudbox:

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -135,7 +135,11 @@
 # --- stress (continuous gate) ---
 - id: bh-fabric-stability-stress
   name: fabric stability nightly tests
-  cmd: ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_stability.yaml --filter 'name.*_short'
+  # Stability traffic runs as one long program launch, and the dispatch progress
+  # counter cannot advance while it runs, so the 5s hang-detection default that
+  # setup-job applies reports a false hang. 0 disables it; a real hang is still
+  # bounded by the SKU timeout below (#47842).
+  cmd: TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_stability.yaml --filter 'name.*_short'
   skus:
     bh_loudbox:
       timeout: 15

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -55,10 +55,7 @@
 
 - id: galaxy-fabric-multi-mesh-4x4-2x4s
   name: Galaxy Fabric Multi-Mesh 4x4 and 2x4s stability tests
-  # Stability traffic runs as one long program launch, and the dispatch progress
-  # counter cannot advance while it runs, so the 5s hang-detection default that
-  # setup-job applies reports a false hang. Multi-rank startup skew adds to that.
-  # 0 disables it; a real hang is still bounded by the SKU timeout below (#47842).
+  # Timeout added to filter false regressions.
   cmd: |
     python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
     TT_METAL_OPERATION_TIMEOUT_SECONDS=0 tt-run --rank-binding 4x4_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_multi_mesh_stability_short_running.yaml

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -60,9 +60,8 @@
   # setup-job applies reports a false hang. Multi-rank startup skew adds to that.
   # 0 disables it; a real hang is still bounded by the SKU timeout below (#47842).
   cmd: |
-    export TT_METAL_OPERATION_TIMEOUT_SECONDS=0
     python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
-    tt-run --rank-binding 4x4_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_multi_mesh_stability_short_running.yaml
+    TT_METAL_OPERATION_TIMEOUT_SECONDS=0 tt-run --rank-binding 4x4_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_multi_mesh_stability_short_running.yaml
     TT_METAL_ENABLE_FABRIC_MESH_PASS_THROUGH=1 tt-run --rank-binding 4x4_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_mesh_passthrough.yaml
   skus:
     wh_galaxy:

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -55,7 +55,6 @@
 
 - id: galaxy-fabric-multi-mesh-4x4-2x4s
   name: Galaxy Fabric Multi-Mesh 4x4 and 2x4s stability tests
-  # Timeout added to filter false regressions.
   cmd: |
     python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
     TT_METAL_OPERATION_TIMEOUT_SECONDS=0 tt-run --rank-binding 4x4_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_multi_mesh_stability_short_running.yaml
@@ -68,7 +67,6 @@
 
 - id: galaxy-fabric-multi-mesh-2x8-2x4s
   name: Galaxy Fabric Multi-mesh 2x8 and 2x4s stability tests
-  # See galaxy-fabric-multi-mesh-4x4-2x4s above for why the per-op timeout is off.
   cmd: |
     export TT_METAL_OPERATION_TIMEOUT_SECONDS=0
     python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
@@ -92,7 +90,6 @@
 
 - id: bh-galaxy-fabric-torus-stability
   name: BH Galaxy Fabric Torus Stability Tests
-  # See galaxy-fabric-multi-mesh-4x4-2x4s above for why the per-op timeout is off.
   cmd: TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_2d_torus_stability.yaml
   skus:
     bh_galaxy:

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -68,9 +68,8 @@
 - id: galaxy-fabric-multi-mesh-2x8-2x4s
   name: Galaxy Fabric Multi-mesh 2x8 and 2x4s stability tests
   cmd: |
-    export TT_METAL_OPERATION_TIMEOUT_SECONDS=0
     python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
-    tt-run --rank-binding 2x8_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_multi_mesh_stability_short_running.yaml
+    TT_METAL_OPERATION_TIMEOUT_SECONDS=0 tt-run --rank-binding 2x8_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_multi_mesh_stability_short_running.yaml
     TT_METAL_ENABLE_FABRIC_MESH_PASS_THROUGH=1 tt-run --rank-binding 2x8_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_mesh_passthrough.yaml
   skus:
     wh_galaxy:

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -55,7 +55,12 @@
 
 - id: galaxy-fabric-multi-mesh-4x4-2x4s
   name: Galaxy Fabric Multi-Mesh 4x4 and 2x4s stability tests
+  # Stability traffic runs as one long program launch, and the dispatch progress
+  # counter cannot advance while it runs, so the 5s hang-detection default that
+  # setup-job applies reports a false hang. Multi-rank startup skew adds to that.
+  # 0 disables it; a real hang is still bounded by the SKU timeout below (#47842).
   cmd: |
+    export TT_METAL_OPERATION_TIMEOUT_SECONDS=0
     python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
     tt-run --rank-binding 4x4_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_multi_mesh_stability_short_running.yaml
     TT_METAL_ENABLE_FABRIC_MESH_PASS_THROUGH=1 tt-run --rank-binding 4x4_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_mesh_passthrough.yaml
@@ -67,7 +72,9 @@
 
 - id: galaxy-fabric-multi-mesh-2x8-2x4s
   name: Galaxy Fabric Multi-mesh 2x8 and 2x4s stability tests
+  # See galaxy-fabric-multi-mesh-4x4-2x4s above for why the per-op timeout is off.
   cmd: |
+    export TT_METAL_OPERATION_TIMEOUT_SECONDS=0
     python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
     tt-run --rank-binding 2x8_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_multi_mesh_stability_short_running.yaml
     TT_METAL_ENABLE_FABRIC_MESH_PASS_THROUGH=1 tt-run --rank-binding 2x8_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_mesh_passthrough.yaml
@@ -89,7 +96,8 @@
 
 - id: bh-galaxy-fabric-torus-stability
   name: BH Galaxy Fabric Torus Stability Tests
-  cmd: ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_2d_torus_stability.yaml
+  # See galaxy-fabric-multi-mesh-4x4-2x4s above for why the per-op timeout is off.
+  cmd: TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_2d_torus_stability.yaml
   skus:
     bh_galaxy:
       timeout: 20

--- a/tests/pipeline_reorg/galaxy_health_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_health_tests.yaml
@@ -34,10 +34,7 @@
 - name: Galaxy Blackhole health
   cmd: |
     ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic --num-iterations 1
-    # Stability traffic runs as one long program launch, and the dispatch progress
-    # counter cannot advance while it runs, so the 5s hang-detection default that
-    # setup-job applies reports a false hang. 0 disables it just for this test; a
-    # real hang is still bounded by the SKU timeout below (#47842).
+    # Timeout added to filter false regressions.
     TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_2d_torus_stability.yaml --filter 'name.*_short'
   skus:
     bh_galaxy:

--- a/tests/pipeline_reorg/galaxy_health_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_health_tests.yaml
@@ -34,7 +34,6 @@
 - name: Galaxy Blackhole health
   cmd: |
     ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic --num-iterations 1
-    # Timeout added to filter false regressions.
     TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_2d_torus_stability.yaml --filter 'name.*_short'
   skus:
     bh_galaxy:

--- a/tests/pipeline_reorg/galaxy_health_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_health_tests.yaml
@@ -34,7 +34,11 @@
 - name: Galaxy Blackhole health
   cmd: |
     ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic --num-iterations 1
-    ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_2d_torus_stability.yaml --filter 'name.*_short'
+    # Stability traffic runs as one long program launch, and the dispatch progress
+    # counter cannot advance while it runs, so the 5s hang-detection default that
+    # setup-job applies reports a false hang. 0 disables it just for this test; a
+    # real hang is still bounded by the SKU timeout below (#47842).
+    TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_2d_torus_stability.yaml --filter 'name.*_short'
   skus:
     bh_galaxy:
       timeout: 10


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fabric stability tests were failing CI as false hangs.

`.github/actions/setup-job` exports `TT_METAL_OPERATION_TIMEOUT_SECONDS` from its `hang-detection-timeout` input, which defaults to `5.0`. That is a watchdog on the dispatch progress counter — if the counter does not advance for 5s, tt-triage fires and the job is reported as hung.

Stability tests push their entire traffic pattern as one long program launch (20000 packets, up to 10 `top_level_iterations`). The progress counter cannot advance while that launch is in flight, so the watchdog trips on a completely healthy run. The multi-mesh Galaxy cases additionally accumulate multi-rank startup skew.

This sets `TT_METAL_OPERATION_TIMEOUT_SECONDS=0` on those invocations, disabling the per-op watchdog for those commands only.

Relates to #47842.

### Notes for reviewers

**Tradeoff:** a real hang is still bounded, but by the coarser job / SKU timeout (`timeout: 10`–`30`) instead of the 5s watchdog. Slower detection of genuine hangs, in exchange for not failing healthy runs.

**Why some invocations are untouched:** only commands running under `setup-job` ever receive the 5s default. `fabric-multihost-exabox.yaml`, `dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh`, and `tools/scaleout/exabox/run_fabric_tests.sh` do not, so they are deliberately left alone.

### Validation runs

Dispatched against `e0e1f3a`.

- [(TM-Fabric) Fabric Tests](https://github.com/tenstorrent/tt-metal/actions/runs/31409454045) — passed
- [(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/31409432389/job/93527096311) — passed (`fabric stability nightly tests [bh_loudbox]`; the run's other red job, `ttnn ops fast unit tests (ccl, DRAM prefetcher)`, fails on `main` too and is unrelated)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sanjaysundaram/fix-stability-test-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sanjaysundaram/fix-stability-test-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sanjaysundaram/fix-stability-test-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sanjaysundaram/fix-stability-test-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sanjaysundaram/fix-stability-test-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sanjaysundaram/fix-stability-test-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sanjaysundaram/fix-stability-test-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sanjaysundaram/fix-stability-test-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sanjaysundaram/fix-stability-test-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sanjaysundaram/fix-stability-test-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sanjaysundaram/fix-stability-test-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sanjaysundaram/fix-stability-test-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sanjaysundaram/fix-stability-test-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sanjaysundaram/fix-stability-test-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sanjaysundaram/fix-stability-test-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sanjaysundaram/fix-stability-test-op-timeout)



