### PR TITLE
[TEN-4746] Add QuaSAR per-DFB TDMA guard to detect wait/pop and reser…

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
@@ -105,6 +105,7 @@ inline void llk_pack(
  */
 // TODO: AM; Optimize block calls by using ntiles per pack, issue #40798
 inline void llk_pack_block(std::uint32_t start_tile_index, std::uint32_t pack_output, std::uint32_t ntiles) {
+    LLK_TDMA_GUARD_NOTE_TDMA(pack_output);  // TEN-4746: real pack (PACR) disarms this dfb
     std::uint8_t output_id = get_output_id(pack_output);
     const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
@@ -79,6 +79,7 @@ inline void llk_pack_untilize(
     std::uint32_t pack_output,
     const std::uint32_t block_c_index = 0,
     const std::uint32_t tile_dst_rt_offset = 0) {
+    LLK_TDMA_GUARD_NOTE_TDMA(pack_output);  // TEN-4746: real pack (PACR) disarms this dfb
     const std::uint32_t output_id = get_output_id(pack_output);
 
     const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_unpack_binary_broadcast_operands.h"
 #include "llk_unpack_binary_operands.h"
 #include "llk_unpack_common_api.h"
@@ -59,6 +60,8 @@ inline void llk_unpack_AB(
     const std::uint32_t tile_index_b,
     [[maybe_unused]] const std::uint32_t bcast_row_idx = 0) {
     // TODO (tt-metal #42916): Once runtime asserts are added for Quasar, assert that bcast_row_idx is unused
+    LLK_TDMA_GUARD_NOTE_TDMA(operandA);  // TEN-4746: real unpack (UNPACR) disarms these dfbs
+    LLK_TDMA_GUARD_NOTE_TDMA(operandB);
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_unpack_matmul.h"
 #include "llk_unpack_common_api.h"
 #include "api/dataflow/dataflow_buffer.h"
@@ -69,6 +70,8 @@ inline void llk_unpack_AB_matmul(
     const std::uint32_t kt_dim = 1) {
     // In0/InA -> srcB
     // In1/InB -> srcA
+    LLK_TDMA_GUARD_NOTE_TDMA(operandA);  // TEN-4746: real unpack (UNPACR) disarms these dfbs
+    LLK_TDMA_GUARD_NOTE_TDMA(operandB);
 
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_unpack_common_api.h"
 #include "llk_unpack_reduce.h"
 
@@ -50,6 +51,8 @@ inline void llk_unpack_AB_reduce(
     const std::uint32_t operandB,
     const std::uint32_t tile_index_a,
     const std::uint32_t tile_index_b) {
+    LLK_TDMA_GUARD_NOTE_TDMA(operandA);  // TEN-4746: real unpack (UNPACR) disarms these dfbs
+    LLK_TDMA_GUARD_NOTE_TDMA(operandB);
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -114,6 +114,7 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest = false>
 inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_index) {
+    LLK_TDMA_GUARD_NOTE_TDMA(operand);  // TEN-4746: real unpack (UNPACR) disarms this dfb
     WAYPOINT("UPAW");
     const std::uint32_t operand_id = get_operand_id(operand);
     const LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(operand_id);
@@ -155,6 +156,7 @@ template <
     bool unpack_to_dest = false>
 inline void llk_unpack_A_block(
     const std::uint32_t operand, const std::uint32_t start_tile_index, const std::uint32_t ntiles) {
+    LLK_TDMA_GUARD_NOTE_TDMA(operand);  // TEN-4746: real unpack (UNPACR) disarms this dfb
     const std::uint32_t operand_id = get_operand_id(operand);
     const LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(operand_id);
     const std::uint32_t rd_entry_idx = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_entry_idx;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
@@ -62,6 +62,7 @@ inline void llk_unpack_tilize_init(
  */
 inline void llk_unpack_tilize_block(
     const std::uint32_t operand, const std::uint32_t block_c_tiles, const std::uint32_t input_tile_index = 0) {
+    LLK_TDMA_GUARD_NOTE_TDMA(operand);  // TEN-4746: real unpack (UNPACR) disarms this dfb
     const std::uint32_t operand_id = get_operand_id(operand);
 
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
@@ -185,6 +186,8 @@ inline void llk_unpack_tilizeA_B(
         reload_srcB,
         "reload_srcB has to be true for tilizeA_B on Quasar, due to the compatibility with the math reduce kernel.");
 
+    LLK_TDMA_GUARD_NOTE_TDMA(operandA);  // TEN-4746: real unpack (UNPACR) disarms these dfbs
+    LLK_TDMA_GUARD_NOTE_TDMA(operandB);
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_pack.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "tools/profiler/kernel_profiler.hpp"
 #include "ckernel.h"
 #include "ckernel_trisc_common.h"
@@ -18,8 +19,11 @@
  */
 inline void llk_wait_for_free_tiles(const std::int32_t dfb_id, const std::int32_t num_tiles) {
     LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(dfb_id);
-    uint32_t tc_id = dfb::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
+    std::uint32_t tc_id =
+        dfb::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
     TT_WAIT_FREE(ckernel::p_stall::STALL_PACK, num_tiles, tc_id);
+    // TEN-4746: arm this dfb; a real pack (PACR) on it must clear this before the matching push.
+    LLK_TDMA_GUARD_NOTE_WAIT(dfb_id);
 }
 
 /**
@@ -30,9 +34,13 @@ inline void llk_wait_for_free_tiles(const std::int32_t dfb_id, const std::int32_
 // Push N tiles to stream buffer (increment write pointer)
 template <std::uint8_t PACK_SEL = 0x1>
 inline void llk_push_tiles(const std::int32_t dfb_id, const std::int32_t num_tiles) {
+    // TEN-4746: pushing a dfb that was reserved but never packed (no PACR since wait_for_free) is a HW
+    // hazard -- the free-space wait can resolve before space is actually available.
+    LLK_TDMA_GUARD_ASSERT_DISARMED(
+        dfb_id, "TEN-4746: llk_push_tiles on a dfb with no pack (PACR) since llk_wait_for_free_tiles");
     LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(dfb_id);
     auto& slot = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx];
-    uint32_t tc_id = dfb::get_counter_id(slot.packed_tile_counter);
+    std::uint32_t tc_id = dfb::get_counter_id(slot.packed_tile_counter);
     // Update the tile counters values
     TT_PUSH_TILES(PACK_SEL, num_tiles, tc_id);
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "tools/profiler/kernel_profiler.hpp"
 #include "ckernel.h"
 #include "ckernel_trisc_common.h"
@@ -18,9 +19,12 @@
  */
 inline void llk_wait_tiles(const std::int32_t dfb_id, const std::uint32_t num_tiles) {
     LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(dfb_id);
-    uint32_t tc_id = dfb::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
+    std::uint32_t tc_id =
+        dfb::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
 
     TT_WAIT_TILES(ckernel::p_stall::STALL_UNPACK, num_tiles, tc_id);
+    // TEN-4746: arm this dfb; a real unpack (UNPACR) on it must clear this before the matching pop.
+    LLK_TDMA_GUARD_NOTE_WAIT(dfb_id);
 }
 
 /**
@@ -30,9 +34,13 @@ inline void llk_wait_tiles(const std::int32_t dfb_id, const std::uint32_t num_ti
  */
 template <std::uint8_t UNPACK_SEL = 0x3>
 inline void llk_pop_tiles(const std::int32_t dfb_id, const std::int32_t num_tiles) {
+    // TEN-4746: popping a dfb that was waited but never unpacked (no UNPACR since wait_tiles) is a HW
+    // hazard -- the wait can resolve before tiles are available.
+    LLK_TDMA_GUARD_ASSERT_DISARMED(
+        dfb_id, "TEN-4746: llk_pop_tiles on a dfb with no unpack (UNPACR) since llk_wait_tiles");
     LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(dfb_id);
     auto& slot = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx];
-    uint32_t tc_id = dfb::get_counter_id(slot.packed_tile_counter);
+    std::uint32_t tc_id = dfb::get_counter_id(slot.packed_tile_counter);
 
     // Wait until selected unpackers are reading from L1
     TT_POP_TILES(UNPACK_SEL, num_tiles, tc_id);

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -13,6 +13,7 @@
 #include "ckernel_template.h"
 #include "llk_assert.h"
 #include "llk_defs.h"
+#include "llk_tdma_guard.h"
 #include "tensix_types.h"
 #include "tensor_shape.h"
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_tdma_guard.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_tdma_guard.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// TEN-4746 (Quasar-only) tile-counter guard.
+//
+// HW constraint: a tile-counter WAIT (TT_WAIT_TILES / TT_WAIT_FREE) must be followed by at least one
+// real TDMA (UNPACR / PACR) that touches the same dataflow buffer before the matching counter retire
+// (TT_POP_TILES / TT_PUSH_TILES). If a POP/PUSH follows a WAIT on the same dfb with no intervening
+// TDMA on that dfb, the WAIT can resolve before tiles/space are actually available.
+//
+// This guard tracks, per TRISC and per dfb id, whether a WAIT is still "armed" (issued with no TDMA
+// on that dfb since). Arm in the WAIT, disarm in the data-moving llk_unpack_*/llk_pack_* executes,
+// assert-disarmed in the POP/PUSH. It is a debug-only aid: when LLK asserts are disabled the macros
+// compile to nothing (zero cost). This is not needed on Wormhole/Blackhole, hence it lives in the
+// Quasar-only tree rather than tt-llk/common.
+//
+// dfb ids are in [0..31], so a single uint32_t bitmask covers every dataflow buffer.
+
+#include <cstdint>
+
+#include "llk_assert.h"
+
+#if defined(ENV_LLK_INFRA) || defined(ENABLE_LLK_ASSERT_ONLY) || defined(ENABLE_LLK_ASSERT)
+
+namespace llk_tdma_guard
+{
+// One mask per TRISC (the unpack TRISC owns the unpack copy, the pack TRISC owns the pack copy).
+// Bit d set  => a WAIT armed dfb d and no TDMA has touched dfb d since.
+inline std::uint32_t& armed_mask()
+{
+    static std::uint32_t mask = 0;
+    return mask;
+}
+
+inline void note_wait(const std::uint32_t dfb)
+{
+    armed_mask() |= (static_cast<std::uint32_t>(1) << dfb);
+}
+
+inline void note_tdma(const std::uint32_t dfb)
+{
+    armed_mask() &= ~(static_cast<std::uint32_t>(1) << dfb);
+}
+
+inline bool armed(const std::uint32_t dfb)
+{
+    return (armed_mask() >> dfb) & static_cast<std::uint32_t>(1);
+}
+} // namespace llk_tdma_guard
+
+#define LLK_TDMA_GUARD_NOTE_WAIT(dfb)            llk_tdma_guard::note_wait(dfb)
+#define LLK_TDMA_GUARD_NOTE_TDMA(dfb)            llk_tdma_guard::note_tdma(dfb)
+#define LLK_TDMA_GUARD_ASSERT_DISARMED(dfb, msg) LLK_ASSERT(!llk_tdma_guard::armed(dfb), msg)
+
+#else
+
+#define LLK_TDMA_GUARD_NOTE_WAIT(dfb)            ((void)0)
+#define LLK_TDMA_GUARD_NOTE_TDMA(dfb)            ((void)0)
+#define LLK_TDMA_GUARD_ASSERT_DISARMED(dfb, msg) ((void)0)
+
+#endif

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_tdma_guard.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_tdma_guard.h
@@ -14,8 +14,7 @@
 // This guard tracks, per TRISC and per dfb id, whether a WAIT is still "armed" (issued with no TDMA
 // on that dfb since). Arm in the WAIT, disarm in the data-moving llk_unpack_*/llk_pack_* executes,
 // assert-disarmed in the POP/PUSH. It is a debug-only aid: when LLK asserts are disabled the macros
-// compile to nothing (zero cost). This is not needed on Wormhole/Blackhole, hence it lives in the
-// Quasar-only tree rather than tt-llk/common.
+// compile to nothing (zero cost).
 //
 // dfb ids are in [0..31], so a single uint32_t bitmask covers every dataflow buffer.
 


### PR DESCRIPTION
Adds a debug-only, Quasar-only guard that detects the TEN-4746 HW hazard where tile-counter LLK instructions are issued consecutively without an intervening TDMA (unpack/pack) on the same DFB, which can let TT_WAIT_TILES/TT_WAIT_FREE resolve before tiles/space are actually available.

- New guard header llk_tdma_guard.h tracks armed DFBs via a per-TRISC bitmask. Compiles out entirely unless LLK asserts are enabled.
- llk_wait_tiles / llk_wait_for_free_tiles arm the DFB.
- llk_pop_tiles / llk_push_tiles assert the DFB is disarmed (a real UNPACR/PACR ran since the wait).
- Real unpack/pack executes (A, AB, AB_matmul, AB_reduce, tilize, pack_block, pack_untilize) disarm the DFB.
- Included transitively via ckernel_trisc_common.h.

Quasar-only; does not affect WH/BH.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/ten4746-tile-counter-tdma-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/ten4746-tile-counter-tdma-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rtawfik/ten4746-tile-counter-tdma-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rtawfik/ten4746-tile-counter-tdma-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=rtawfik/ten4746-tile-counter-tdma-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:rtawfik/ten4746-tile-counter-tdma-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/ten4746-tile-counter-tdma-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/ten4746-tile-counter-tdma-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rtawfik/ten4746-tile-counter-tdma-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rtawfik/ten4746-tile-counter-tdma-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/ten4746-tile-counter-tdma-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/ten4746-tile-counter-tdma-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/ten4746-tile-counter-tdma-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/ten4746-tile-counter-tdma-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/ten4746-tile-counter-tdma-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/ten4746-tile-counter-tdma-guard)