### PR TITLE
Fix all_gather TT_FATAL on stale Shard dim from a rank-reducing reshape

### DIFF
--- a/models/demos/minimax_m3/tt/topk.py
+++ b/models/demos/minimax_m3/tt/topk.py
@@ -119,7 +119,12 @@ class TopKRouter:
     def __call__(self, hidden_states, use_throughput_experts):
         # Actual token count from volume (shape[0] after reshape is tile-padded).
         actual_tokens = hidden_states.volume() // self.hidden_dim
-        hidden_states = ttnn.reshape(hidden_states, (-1, self.hidden_dim))
+        # hidden_states is [1,1,S,H] (S may be SP-sharded, dim 2). Drop the two leading batch dims with
+        # squeeze rather than a blanket ttnn.reshape(-1, H): squeeze shifts a mesh Shard's recorded dim
+        # down to match each removed axis, so a dim-2 SP shard correctly becomes dim 0 here. A plain
+        # reshape instead carries the pre-squeeze TensorTopology forward unchanged, leaving a stale
+        # Shard{dim=2} that no longer indexes this tensor's rank once flattened to 2D.
+        hidden_states = ttnn.squeeze(ttnn.squeeze(hidden_states, 0), 0)
 
         # L1 for decode (small), DRAM for prefill (large sequences).
         is_decode = actual_tokens <= 128

--- a/models/demos/minimax_m3/tt/topk.py
+++ b/models/demos/minimax_m3/tt/topk.py
@@ -119,11 +119,6 @@ class TopKRouter:
     def __call__(self, hidden_states, use_throughput_experts):
         # Actual token count from volume (shape[0] after reshape is tile-padded).
         actual_tokens = hidden_states.volume() // self.hidden_dim
-        # hidden_states is [1,1,S,H] (S may be SP-sharded, dim 2). Drop the two leading batch dims with
-        # squeeze rather than a blanket ttnn.reshape(-1, H): squeeze shifts a mesh Shard's recorded dim
-        # down to match each removed axis, so a dim-2 SP shard correctly becomes dim 0 here. A plain
-        # reshape instead carries the pre-squeeze TensorTopology forward unchanged, leaving a stale
-        # Shard{dim=2} that no longer indexes this tensor's rank once flattened to 2D.
         hidden_states = ttnn.squeeze(ttnn.squeeze(hidden_states, 0), 0)
 
         # L1 for decode (small), DRAM for prefill (large sequences).

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -103,17 +103,11 @@ AllGatherDeviceOperation::topology_return_value_t AllGatherDeviceOperation::comp
 
     // For each distribution dimension, if sharded on the gather dim, make it replicated
     const auto& logical_shape = input_tensor.logical_shape();
-    const int32_t rank = static_cast<int32_t>(logical_shape.rank());
     const uint32_t gather_dim = logical_shape.get_normalized_index(args.dim_from_end);
     for (auto& output_placement : output_placements) {
         if (auto* shard = std::get_if<tt::tt_metal::distributed::MeshMapperConfig::Shard>(&output_placement)) {
-            // Shard::dim is always unnormalized by construction, so normalize here. It can also be stale:
-            // ops that reduce a tensor's rank (reshape, squeeze, ...) copy the mesh topology forward as-is,
-            // so a Shard recorded against a higher-rank ancestor can carry a dim that no longer indexes this
-            // tensor's rank. Such a shard obviously isn't on the current gather dim, so skip it instead of
-            // letting get_normalized_index() assert.
-            if (shard->dim >= -rank && shard->dim < rank &&
-                logical_shape.get_normalized_index(shard->dim) == gather_dim) {
+            // Shard::dim is always unnormalized by construction, so normalize here
+            if (logical_shape.get_normalized_index(shard->dim) == gather_dim) {
                 output_placement = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
             }
         }

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -103,11 +103,17 @@ AllGatherDeviceOperation::topology_return_value_t AllGatherDeviceOperation::comp
 
     // For each distribution dimension, if sharded on the gather dim, make it replicated
     const auto& logical_shape = input_tensor.logical_shape();
+    const int32_t rank = static_cast<int32_t>(logical_shape.rank());
     const uint32_t gather_dim = logical_shape.get_normalized_index(args.dim_from_end);
     for (auto& output_placement : output_placements) {
         if (auto* shard = std::get_if<tt::tt_metal::distributed::MeshMapperConfig::Shard>(&output_placement)) {
-            // Shard::dim is always unnormalized by construction, so normalize here
-            if (logical_shape.get_normalized_index(shard->dim) == gather_dim) {
+            // Shard::dim is always unnormalized by construction, so normalize here. It can also be stale:
+            // ops that reduce a tensor's rank (reshape, squeeze, ...) copy the mesh topology forward as-is,
+            // so a Shard recorded against a higher-rank ancestor can carry a dim that no longer indexes this
+            // tensor's rank. Such a shard obviously isn't on the current gather dim, so skip it instead of
+            // letting get_normalized_index() assert.
+            if (shard->dim >= -rank && shard->dim < rank &&
+                logical_shape.get_normalized_index(shard->dim) == gather_dim) {
                 output_placement = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
             }
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
@@ -3,8 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "squeeze.hpp"
+#include <algorithm>
 #include <tt_stl/small_vector.hpp>
+#include <ttnn/distributed/distributed_configs.hpp>
+#include <ttnn/distributed/tensor_topology.hpp>
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn {
 
@@ -36,6 +40,9 @@ ttnn::Tensor squeeze(const ttnn::Tensor& input_tensor, const ttsl::SmallVector<i
         TT_THROW("Dimension out of range (expected to be of [-1, 0], but got {})", dims[0]);
     }
 
+    // Dims actually erased below (a requested dim is skipped if its size isn't 1) -- needed after the
+    // reshape to shift any Shard placement's dim down by however many erased dims precede it.
+    ttsl::SmallVector<int32_t> erased_dims;
     for (size_t i = 0; i < dims.size(); ++i) {
         const auto dim = dims[i];
         // Check duplicate dimensions
@@ -56,6 +63,7 @@ ttnn::Tensor squeeze(const ttnn::Tensor& input_tensor, const ttsl::SmallVector<i
 
         new_logical_shape.erase(new_logical_shape.begin() + dim);
         new_padded_shape.erase(new_padded_shape.begin() + dim);
+        erased_dims.push_back(dim);
     }
 
     // Note: don't have to check padded too
@@ -63,8 +71,44 @@ ttnn::Tensor squeeze(const ttnn::Tensor& input_tensor, const ttsl::SmallVector<i
         return input_tensor;
     }
 
-    return ttnn::reshape(
+    auto output = ttnn::reshape(
         input_tensor, ttnn::Shape(std::move(new_logical_shape)), ttnn::Shape(std::move(new_padded_shape)));
+
+    // reshape()'s underlying view() carries the input's mesh TensorTopology forward unchanged (it's a
+    // pure metadata reinterpretation -- no cross-device data movement), but squeezing removes dims from
+    // the logical shape, so a Shard recorded on a dim above an erased one is now off by however many
+    // erased dims precede it. Shift those dims down to keep the topology valid for the squeezed rank.
+    std::sort(erased_dims.begin(), erased_dims.end());
+    const auto& input_topology = input_tensor.tensor_topology();
+    auto placements = input_topology.placements();
+    bool topology_changed = false;
+    for (auto& placement : placements) {
+        if (auto* shard = std::get_if<tt::tt_metal::distributed::MeshMapperConfig::Shard>(&placement)) {
+            // Shard::dim is unnormalized by construction (may be negative); normalize against the
+            // PRE-squeeze rank, since that's what it was recorded against.
+            const auto normalized_dim = static_cast<int32_t>(original_logical_shape.get_normalized_index(shard->dim));
+            TT_FATAL(
+                std::find(erased_dims.begin(), erased_dims.end(), normalized_dim) == erased_dims.end(),
+                "squeeze: dim {} is both squeezed away (size 1) and mesh-sharded; ambiguous how to remap "
+                "its Shard placement",
+                normalized_dim);
+            const int32_t shift = static_cast<int32_t>(
+                std::count_if(erased_dims.begin(), erased_dims.end(), [normalized_dim](int32_t erased) {
+                    return erased < normalized_dim;
+                }));
+            const int32_t new_dim = normalized_dim - shift;
+            if (new_dim != shard->dim) {
+                shard->dim = new_dim;
+                topology_changed = true;
+            }
+        }
+    }
+    if (topology_changed) {
+        output.update_tensor_topology(tt::tt_metal::TensorTopology(
+            input_topology.distribution_shape(), placements, input_topology.mesh_coords()));
+    }
+
+    return output;
 }
 
 ttnn::Tensor squeeze(const ttnn::Tensor& input_tensor, int dim) {

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
@@ -88,11 +88,10 @@ ttnn::Tensor squeeze(const ttnn::Tensor& input_tensor, const ttsl::SmallVector<i
             // PRE-squeeze rank, since that's what it was recorded against.
             const auto normalized_dim = static_cast<int32_t>(original_logical_shape.get_normalized_index(shard->dim));
             if (std::find(erased_dims.begin(), erased_dims.end(), normalized_dim) != erased_dims.end()) {
-                // A squeezed dim is size 1 per device, so a Shard here means that mesh axis's devices
-                // each held exactly one (degenerate) slice along it -- a real, valid layout (e.g. an
-                // evenly-divided expert/dispatch-group axis), not a bug. There's no tensor dim left to
-                // anchor the placement to once it's squeezed away, so Replicate is the only placement
-                // that still accurately describes this axis.
+                // A squeezed dim is size 1 per device (e.g. an evenly-divided expert/dispatch-group
+                // axis, one slice per device); once it's erased there's no tensor dim left to anchor
+                // the placement to, so Replicate is the only placement that still accurately
+                // describes this mesh axis.
                 placement = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
                 topology_changed = true;
                 continue;

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
@@ -87,11 +87,16 @@ ttnn::Tensor squeeze(const ttnn::Tensor& input_tensor, const ttsl::SmallVector<i
             // Shard::dim is unnormalized by construction (may be negative); normalize against the
             // PRE-squeeze rank, since that's what it was recorded against.
             const auto normalized_dim = static_cast<int32_t>(original_logical_shape.get_normalized_index(shard->dim));
-            TT_FATAL(
-                std::find(erased_dims.begin(), erased_dims.end(), normalized_dim) == erased_dims.end(),
-                "squeeze: dim {} is both squeezed away (size 1) and mesh-sharded; ambiguous how to remap "
-                "its Shard placement",
-                normalized_dim);
+            if (std::find(erased_dims.begin(), erased_dims.end(), normalized_dim) != erased_dims.end()) {
+                // A squeezed dim is size 1 per device, so a Shard here means that mesh axis's devices
+                // each held exactly one (degenerate) slice along it -- a real, valid layout (e.g. an
+                // evenly-divided expert/dispatch-group axis), not a bug. There's no tensor dim left to
+                // anchor the placement to once it's squeezed away, so Replicate is the only placement
+                // that still accurately describes this axis.
+                placement = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
+                topology_changed = true;
+                continue;
+            }
             const int32_t shift = static_cast<int32_t>(
                 std::count_if(erased_dims.begin(), erased_dims.end(), [normalized_dim](int32_t erased) {
                     return erased < normalized_dim;


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-metal/issues/52282 

squeeze/reshape doesn't respect mesh placement: it carries a tensor's Shard forward unchanged across a rank-reducing reshape, so a Shard's recorded dim can end up pointing past the tensor's current rank. That was harmless until #51515 added a bounds check in `all_gather`'s `compute_output_topologies`, which now asserts on it — that's what broke MiniMax-M3's prefill CI ([job](https://github.com/tenstorrent/tt-metal/actions/runs/31075640482/job/92547299091)): an SP-sharded dim 2 survives a 4D->2D squeeze in the router and trips the new assert. Fix: squeeze now properly renormalizes (or drops to Replicate) each Shard's dim when it erases dims, instead of carrying it forward blindly.

### CI Status
https://github.com/tenstorrent/tt-metal/actions/runs/31190963267