### PR TITLE
LTX-2.3 distilled AV pipeline: fabric-bound AGMM/MMRS, neighbor-pad halo and conv3d

### DIFF
--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -530,6 +530,7 @@ class RowParallelLinear(Module):
             addcmul_input_tensor1=addcmul_a,
             addcmul_input_tensor2=addcmul_b,
             dtype=dtype,
+            mm_progress_counters=self.ccl_manager.get_mm_progress_counters_buffer(),
         )
         if needs_reshape:
             output = ttnn.squeeze(output, 0)

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 from models.common.utility_functions import is_blackhole
 
-from ..utils.matmul import get_fused_mmrs_config, get_matmul_config, get_matmul_core_grid
+from ..utils.matmul import get_fabric_agmm_config, get_fused_mmrs_config, get_matmul_config, get_matmul_core_grid
 from ..utils.tensor import prepare_for_fused_swiglu
 from .module import Module, Parameter
 
@@ -140,6 +140,7 @@ class ColParallelLinear(Module):
         fsdp_mesh_axis=None,
         ccl_manager=None,
         chunks=None,
+        chunk_sizes=None,
     ):
         super().__init__()
 
@@ -162,6 +163,8 @@ class ColParallelLinear(Module):
         self.fsdp_mesh_axis = fsdp_mesh_axis
         self.ccl_manager = ccl_manager
         self.chunks = chunks
+        # Per-chunk output widths in ELEMENTS (global, pre-TP-shard); None => uniform N/chunks.
+        self.chunk_sizes = chunk_sizes
 
         if self.fsdp_mesh_axis is not None:
             assert self.mesh_axis != self.fsdp_mesh_axis
@@ -217,6 +220,49 @@ class ColParallelLinear(Module):
                 bias = permute_for_swiglu(bias)
             state["bias"] = bias
 
+    def _forward_fabric_agmm(self, x, weight, fabric_cfg, parallel_config, compute_kernel_config, dtype) -> ttnn.Tensor:
+        """Optimized fabric-bound TP all-gather-matmul via strided_all_gather_minimal_matmul_async.
+
+        The matmul runs on ``fabric_cfg.mm_core_grid`` (lower rows); the strided all-gather workers
+        run on the rows starting at ``fabric_cfg.ag_core_grid_offset`` (disjoint region). Returns the
+        single (chunks==1) matmul output; the op's first output is the gathered-K scratch.
+        """
+        mesh_axis = parallel_config.tensor_parallel.mesh_axis
+        matmul_config = ttnn.MinimalMatmulConfig(
+            M_block_size=fabric_cfg.M_block_size,
+            K_block_size=fabric_cfg.K_block_size,
+            N_block_size=fabric_cfg.N_block_size,
+            subblock_h=fabric_cfg.subblock_h,
+            subblock_w=fabric_cfg.subblock_w,
+            compute_with_storage_grid_size=fabric_cfg.mm_core_grid,
+        )
+        ag_persistent_buffer = self.ccl_manager.get_ag_ping_pong_buffer(x.shape, 3, mesh_axis, dtype=x.get_dtype())
+        ag_global_semaphores = self.ccl_manager.get_strided_ag_mm_semaphore(mesh_axis, fabric_cfg.num_workers_per_link)
+        dram = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+        outputs = ttnn.experimental.strided_all_gather_minimal_matmul_async(
+            x,
+            weight,
+            persistent_output_buffer=ag_persistent_buffer,
+            dim=3,
+            multi_device_global_semaphore=ag_global_semaphores,
+            strided_all_gather_core_grid_offset=fabric_cfg.ag_core_grid_offset,
+            num_links=self.ccl_manager.num_links,
+            memory_config_ag=dram,
+            topology=self.ccl_manager.topology,
+            cluster_axis=mesh_axis,
+            bias=self.bias.data if self.bias is not None else None,
+            fused_activation=self.fused_activation_fn,
+            config=matmul_config,
+            memory_config_mm=dram,
+            compute_kernel_config=compute_kernel_config or self.compute_config,
+            num_workers_per_link=fabric_cfg.num_workers_per_link,
+            num_buffers_per_channel=fabric_cfg.num_buffers_per_channel,
+            read_local_slice_from_input=True,
+            chunks=1,
+        )
+        # Op returns [all_gather_output, matmul_chunk_0]; take the single matmul chunk.
+        return _apply_activation_fn(outputs[1], self.activation_fn)
+
     def forward(
         self, x: ttnn.Tensor, compute_kernel_config=None, default_block_size=None, parallel_config=None, dtype=None
     ) -> ttnn.Tensor | list[ttnn.Tensor]:
@@ -238,6 +284,14 @@ class ColParallelLinear(Module):
         if parallel_config is not None and parallel_config.tensor_parallel.factor > 1:
             M, K, N = x.padded_shape[-2], weight.padded_shape[-2], weight.padded_shape[-1]
             full_grid = self.mesh_device.compute_with_storage_grid_size()
+
+            # Fabric-bound path: known shapes route to the optimized strided all-gather-matmul op.
+            # Restricted (for now) to the plain chunks==1 / no-swiglu case; other shapes fall
+            # through to the current all_gather_minimal_matmul_async path below.
+            fabric_cfg = get_fabric_agmm_config(K, N, (self.chunks or 1), full_grid)
+            if fabric_cfg is not None and self.chunks in (None, 1) and not self.fuse_swiglu:
+                return self._forward_fabric_agmm(x, weight, fabric_cfg, parallel_config, compute_kernel_config, dtype)
+
             core_grid = ttnn.CoreCoord(full_grid.x, full_grid.y - 1)
             matmul_config = get_matmul_config(M, K, N, core_grid, default_block_size)
 
@@ -264,6 +318,10 @@ class ColParallelLinear(Module):
                 num_workers_per_link=full_grid.x // self.ccl_manager.num_links,
                 num_buffers_per_channel=48 if not is_blackhole() else 24,
                 chunks=self.chunks if self.chunks is not None else 1,
+                # Op's N is per-device, so pass per-device widths (each global width is % TP == 0).
+                chunk_sizes=(
+                    [w // parallel_config.tensor_parallel.factor for w in self.chunk_sizes] if self.chunk_sizes else []
+                ),
                 dtype=dtype,
                 fuse_swiglu=self.fuse_swiglu,
             )

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -285,9 +285,7 @@ class ColParallelLinear(Module):
             M, K, N = x.padded_shape[-2], weight.padded_shape[-2], weight.padded_shape[-1]
             full_grid = self.mesh_device.compute_with_storage_grid_size()
 
-            # Fabric-bound path: known shapes route to the optimized strided all-gather-matmul op.
-            # Restricted (for now) to the plain chunks==1 / no-swiglu case; other shapes fall
-            # through to the current all_gather_minimal_matmul_async path below.
+            # Fabric-bound path: known shapes route to the optimized strided all-gather-matmul op
             fabric_cfg = get_fabric_agmm_config(K, N, (self.chunks or 1), full_grid)
             if fabric_cfg is not None and self.chunks in (None, 1) and not self.fuse_swiglu:
                 return self._forward_fabric_agmm(x, weight, fabric_cfg, parallel_config, compute_kernel_config, dtype)

--- a/models/tt_dit/models/transformers/ltx/attention_ltx.py
+++ b/models/tt_dit/models/transformers/ltx/attention_ltx.py
@@ -14,7 +14,7 @@ from ....layers.module import Module
 from ....layers.normalization import DistributedRMSNorm
 from ....parallel.config import DiTParallelConfig
 from ....parallel.manager import CCLManager
-from ....utils.matmul import get_matmul_config
+from ....utils.matmul import get_fabric_agmm_config, get_matmul_config
 from ....utils.substate import pop_substate, rename_substate
 from ....utils.tensor import bf16_tensor
 
@@ -120,10 +120,39 @@ class LTXAttention(Module):
         # fused-addcmul (to_out) paths work unchanged; runtime mode is unsupported here.
         ColCls = LoRAColParallelLinear if lora_enabled else ColParallelLinear
 
+        # Fuse the per-head gate into the QKV/Q matmul via variable-width chunks; only the fused AGMM
+        # path (TP>1 on Ring) honours them, so fall back to a standalone gate op elsewhere.
+        tp_factor = parallel_config.tensor_parallel.factor
+        uses_fused_agmm = tp_factor > 1 and ccl_manager is not None and ccl_manager.topology == ttnn.Topology.Ring
+        self.fuse_gate = apply_gated_attention and uses_fused_agmm
+
+        # Gate is num_heads/TP columns per device (sub-tile); pad to a whole tile so it's a legal chunk.
+        self.gate_width_per_device = self.n_local_heads
+        self.gate_padded_per_device = ((self.n_local_heads + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+        gate_fused_width = self.gate_padded_per_device * tp_factor
+
         if is_self:
-            self.to_qkv = ColCls(dim, 3 * dim, chunks=3, **col_parallel_kwargs)
+            if self.fuse_gate:
+                self.to_qkv = ColCls(
+                    dim,
+                    3 * dim + gate_fused_width,
+                    chunks=4,
+                    chunk_sizes=[dim, dim, dim, gate_fused_width],
+                    **col_parallel_kwargs,
+                )
+            else:
+                self.to_qkv = ColCls(dim, 3 * dim, chunks=3, **col_parallel_kwargs)
         else:
-            self.to_q = ColCls(self.query_input_dim, dim, **col_parallel_kwargs)
+            if self.fuse_gate:
+                self.to_q = ColCls(
+                    self.query_input_dim,
+                    dim + gate_fused_width,
+                    chunks=2,
+                    chunk_sizes=[dim, gate_fused_width],
+                    **col_parallel_kwargs,
+                )
+            else:
+                self.to_q = ColCls(self.query_input_dim, dim, **col_parallel_kwargs)
             self.to_kv = ColCls(self.kv_input_dim, 2 * dim, chunks=2, **col_parallel_kwargs)
 
         self.to_out = ColCls(
@@ -136,12 +165,11 @@ class LTXAttention(Module):
             ccl_manager=ccl_manager,
         )
 
-        # Per-head gate, sharded on num_heads to match the SDPA-output head layout. bf16 matches the
-        # reference (which runs the gate in the model's working dtype). Sigmoid is a standalone op:
-        # fusing it into the matmul trips minimal_matmul's sigmoid VecMode assert (needs C/RC). The
-        # ×2 stays a separate multiply (2·sigmoid is nonlinear, can't fold).
+        # Per-head gate, sharded on num_heads to match the SDPA-output head layout (bf16, sigmoid and
+        # the ×2 stay standalone ops).
         self.apply_gated_attention = apply_gated_attention
-        if apply_gated_attention:
+        if apply_gated_attention and not self.fuse_gate:
+            # Unfused fallback: standalone gate projection (FSDP-sharded to match the other projections).
             self.to_gate_logits = ColParallelLinear(
                 in_features=self.query_input_dim,
                 out_features=self.num_heads,
@@ -149,6 +177,7 @@ class LTXAttention(Module):
                 dtype=ttnn.bfloat16,
                 mesh_device=mesh_device,
                 mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+                fsdp_mesh_axis=fsdp_mesh_axis,
                 ccl_manager=ccl_manager,
             )
 
@@ -265,6 +294,38 @@ class LTXAttention(Module):
             merged = merged.reshape(merged.shape[0], len(tensors) * self.num_heads * self.head_dim)
             return merged.T
 
+        def _pad_gate_to_tile(t: torch.Tensor) -> torch.Tensor:
+            """Zero-pad each device's gate block from n_local_heads up to a whole tile (device-major)."""
+            n_dev = self.parallel_config.tensor_parallel.factor
+            pad = self.gate_padded_per_device - self.n_local_heads
+            if pad == 0:
+                return t
+            blocks = []
+            for d in range(n_dev):
+                blocks.append(t[d * self.n_local_heads : (d + 1) * self.n_local_heads])
+                blocks.append(torch.zeros(pad, *t.shape[1:], dtype=t.dtype))
+            return torch.cat(blocks, dim=0)
+
+        def _gate_state_or_zeros(reference: torch.Tensor, want_bias: bool) -> dict[str, torch.Tensor]:
+            """Gate substate, zero-filled when the checkpoint has none (zeros -> identity gating)."""
+            g = pop_substate(state, "to_gate_logits")
+            if "weight" not in g:
+                g["weight"] = torch.zeros(self.num_heads, reference.shape[1], dtype=reference.dtype)
+            if want_bias and "bias" not in g:
+                g["bias"] = torch.zeros(self.num_heads, dtype=reference.dtype)
+            return g
+
+        def _interleave_device_major(tensors: list[torch.Tensor]):
+            """Like _interleave_heads but for per-device widths that differ (q/k/v head_dim vs gate)."""
+            n_dev = self.parallel_config.tensor_parallel.factor
+            reshaped = []
+            for t in tensors:
+                t = t.T  # [in, out]
+                assert t.shape[1] % n_dev == 0, f"projection width {t.shape[1]} not divisible by TP={n_dev}"
+                reshaped.append(t.reshape(t.shape[0], n_dev, t.shape[1] // n_dev))
+            merged = torch.cat(reshaped, dim=2)
+            return merged.reshape(merged.shape[0], -1).T
+
         if self.is_self:
             q_state = pop_substate(state, "to_q")
             k_state = pop_substate(state, "to_k")
@@ -277,12 +338,30 @@ class LTXAttention(Module):
             if "bias" in k_state:
                 k_state["bias"] = _permute_qk(k_state["bias"])
 
-            state["to_qkv.weight"] = _interleave_heads([q_state["weight"], k_state["weight"], v_state["weight"]])
-            if "bias" in q_state:
-                bias = _interleave_heads(
-                    [q_state["bias"].unsqueeze(-1), k_state["bias"].unsqueeze(-1), v_state["bias"].unsqueeze(-1)]
+            if self.fuse_gate:
+                # Fold the gate in as a 4th chunk, device-major: device d holds [q_d | k_d | v_d | gate_d].
+                g_state = _gate_state_or_zeros(q_state["weight"], "bias" in q_state)
+                g_state = {k: _pad_gate_to_tile(v) for k, v in g_state.items()}
+                state["to_qkv.weight"] = _interleave_device_major(
+                    [q_state["weight"], k_state["weight"], v_state["weight"], g_state["weight"]]
                 )
-                state["to_qkv.bias"] = bias.squeeze(-1)
+                if "bias" in q_state:
+                    bias = _interleave_device_major(
+                        [
+                            q_state["bias"].unsqueeze(-1),
+                            k_state["bias"].unsqueeze(-1),
+                            v_state["bias"].unsqueeze(-1),
+                            g_state["bias"].unsqueeze(-1),
+                        ]
+                    )
+                    state["to_qkv.bias"] = bias.squeeze(-1)
+            else:
+                state["to_qkv.weight"] = _interleave_heads([q_state["weight"], k_state["weight"], v_state["weight"]])
+                if "bias" in q_state:
+                    bias = _interleave_heads(
+                        [q_state["bias"].unsqueeze(-1), k_state["bias"].unsqueeze(-1), v_state["bias"].unsqueeze(-1)]
+                    )
+                    state["to_qkv.bias"] = bias.squeeze(-1)
         else:
             k_state = pop_substate(state, "to_k")
             v_state = pop_substate(state, "to_v")
@@ -295,6 +374,15 @@ class LTXAttention(Module):
                 state["to_q.weight"] = _permute_qk(state["to_q.weight"])
             if "to_q.bias" in state:
                 state["to_q.bias"] = _permute_qk(state["to_q.bias"])
+
+            if self.fuse_gate and "to_q.weight" in state:
+                # Cross-attn: gate rides along with Q as a 2nd chunk.
+                g_state = _gate_state_or_zeros(state["to_q.weight"], "to_q.bias" in state)
+                g_state = {k: _pad_gate_to_tile(v) for k, v in g_state.items()}
+                state["to_q.weight"] = _interleave_device_major([state["to_q.weight"], g_state["weight"]])
+                if "to_q.bias" in state and "bias" in g_state:
+                    bias = _interleave_device_major([state["to_q.bias"].unsqueeze(-1), g_state["bias"].unsqueeze(-1)])
+                    state["to_q.bias"] = bias.squeeze(-1)
 
             state["to_kv.weight"] = _interleave_heads([k_state["weight"], v_state["weight"]])
             if "bias" in k_state:
@@ -325,6 +413,51 @@ class LTXAttention(Module):
         if parallel_config is not None and parallel_config.tensor_parallel.factor > 1:
             M, K, N_out = x.padded_shape[-2], weight.padded_shape[-2], weight.padded_shape[-1]
             full_grid = self.mesh_device.compute_with_storage_grid_size()
+
+            # Known shapes route the addcmul to_out to the strided AG-matmul (out = a + scalar*matmul*b);
+            # a miss falls through to the all_gather_minimal_matmul_async addcmul path below.
+            fabric_cfg = get_fabric_agmm_config(K, N_out, 1, full_grid)
+            if fabric_cfg is not None:
+                tp_axis = parallel_config.tensor_parallel.mesh_axis
+                dram = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+                fabric_matmul_config = ttnn.MinimalMatmulConfig(
+                    M_block_size=fabric_cfg.M_block_size,
+                    K_block_size=fabric_cfg.K_block_size,
+                    N_block_size=fabric_cfg.N_block_size,
+                    subblock_h=fabric_cfg.subblock_h,
+                    subblock_w=fabric_cfg.subblock_w,
+                    compute_with_storage_grid_size=fabric_cfg.mm_core_grid,
+                )
+                outputs = ttnn.experimental.strided_all_gather_minimal_matmul_async(
+                    x,
+                    weight,
+                    persistent_output_buffer=self.ccl_manager.get_ag_ping_pong_buffer(
+                        x.shape, 3, tp_axis, dtype=x.get_dtype()
+                    ),
+                    dim=3,
+                    multi_device_global_semaphore=self.ccl_manager.get_strided_ag_mm_semaphore(
+                        tp_axis, fabric_cfg.num_workers_per_link
+                    ),
+                    strided_all_gather_core_grid_offset=fabric_cfg.ag_core_grid_offset,
+                    num_links=self.ccl_manager.num_links,
+                    memory_config_ag=dram,
+                    topology=self.ccl_manager.topology,
+                    cluster_axis=tp_axis,
+                    bias=to_out.bias.data if to_out.bias is not None else None,
+                    config=fabric_matmul_config,
+                    memory_config_mm=dram,
+                    compute_kernel_config=compute_kernel_config or to_out.compute_config,
+                    num_workers_per_link=fabric_cfg.num_workers_per_link,
+                    num_buffers_per_channel=fabric_cfg.num_buffers_per_channel,
+                    read_local_slice_from_input=True,
+                    fused_ternary_input_a=addcmul_residual,
+                    fused_ternary_input_b=addcmul_gate,
+                    fused_ternary_scalar=1.0,
+                    chunks=1,
+                )
+                # Op returns [all_gather_output, matmul_chunk_0]; take the single matmul chunk.
+                return outputs[1]
+
             core_grid = ttnn.CoreCoord(full_grid.x, full_grid.y - 1)
             matmul_config = get_matmul_config(M, K, N_out, core_grid)
 
@@ -380,13 +513,23 @@ class LTXAttention(Module):
             return None
 
         gate_logits = self.to_gate_logits(spatial_1BND, parallel_config=qkv_parallel_config)
-        gate = ttnn.multiply(ttnn.sigmoid(gate_logits), 2.0)
+        return self._gate_from_logits(gate_logits)
 
-        # (1, B, N, H_local) -> (B, H_local, N, 1) in one pass: the N<->H_local swap is the real
-        # data movement, and the leading unit axis is parked into the trailing broadcast slot (over
-        # E). Replaces squeeze+transpose+unsqueeze (the unsqueeze was a retile, not a free view).
-        gate = ttnn.permute(gate, (1, 3, 2, 0))
-        return gate
+    def _unpad_gate_logits(self, gate_logits: ttnn.Tensor) -> ttnn.Tensor:
+        """Drop the tile padding from the fused gate chunk, leaving n_local_heads real columns."""
+        if self.gate_padded_per_device == self.gate_width_per_device:
+            return gate_logits
+        shape = gate_logits.shape
+        return ttnn.slice(
+            gate_logits,
+            [0, 0, 0, 0],
+            [shape[0], shape[1], shape[2], self.gate_width_per_device],
+        )
+
+    def _gate_from_logits(self, gate_logits: ttnn.Tensor) -> ttnn.Tensor:
+        """2 * sigmoid(logits) as (B, H_local, N, 1); shared by the fused and unfused paths."""
+        gate = ttnn.multiply(ttnn.sigmoid(gate_logits), 2.0)
+        return ttnn.permute(gate, (1, 3, 2, 0))
 
     def forward(
         self,
@@ -421,15 +564,23 @@ class LTXAttention(Module):
 
         qkv_parallel_config = None if use_nonfused_agmm else self.parallel_config
 
-        # Per-head gate, computed before QKV consumes spatial_1BND.
-        gate_bhne = self._compute_gate(spatial_1BND, qkv_parallel_config)
+        # When fused, the gate falls out of the QKV/Q matmul below; otherwise it's its own projection.
+        gate_bhne = None if self.fuse_gate else self._compute_gate(spatial_1BND, qkv_parallel_config)
 
         if self.is_self:
-            q_1BNF, k_1BNF, v_1BNF = self.to_qkv(
-                spatial_1BND,
-                compute_kernel_config=self.mm_compute_kernel_config,
-                parallel_config=qkv_parallel_config,
-            )
+            if self.fuse_gate:
+                q_1BNF, k_1BNF, v_1BNF, gate_logits = self.to_qkv(
+                    spatial_1BND,
+                    compute_kernel_config=self.mm_compute_kernel_config,
+                    parallel_config=qkv_parallel_config,
+                )
+                gate_bhne = self._gate_from_logits(self._unpad_gate_logits(gate_logits))
+            else:
+                q_1BNF, k_1BNF, v_1BNF = self.to_qkv(
+                    spatial_1BND,
+                    compute_kernel_config=self.mm_compute_kernel_config,
+                    parallel_config=qkv_parallel_config,
+                )
         else:
             kv_input = prompt_1BLP if prompt_1BLP is not None else spatial_1BND
             # Cross K/V: gather TP-sharded context for to_kv (replicated text prompt is already full).
@@ -444,11 +595,19 @@ class LTXAttention(Module):
                         )
                     else:
                         kv_parallel_config = self.parallel_config
-            q_1BNF = self.to_q(
-                spatial_1BND,
-                compute_kernel_config=self.mm_compute_kernel_config,
-                parallel_config=qkv_parallel_config,
-            )
+            if self.fuse_gate:
+                q_1BNF, gate_logits = self.to_q(
+                    spatial_1BND,
+                    compute_kernel_config=self.mm_compute_kernel_config,
+                    parallel_config=qkv_parallel_config,
+                )
+                gate_bhne = self._gate_from_logits(self._unpad_gate_logits(gate_logits))
+            else:
+                q_1BNF = self.to_q(
+                    spatial_1BND,
+                    compute_kernel_config=self.mm_compute_kernel_config,
+                    parallel_config=qkv_parallel_config,
+                )
             k_1BNF, v_1BNF = self.to_kv(
                 kv_input,
                 compute_kernel_config=self.mm_compute_kernel_config,

--- a/models/tt_dit/models/transformers/ltx/attention_ltx.py
+++ b/models/tt_dit/models/transformers/ltx/attention_ltx.py
@@ -120,8 +120,7 @@ class LTXAttention(Module):
         # fused-addcmul (to_out) paths work unchanged; runtime mode is unsupported here.
         ColCls = LoRAColParallelLinear if lora_enabled else ColParallelLinear
 
-        # Fuse the per-head gate into the QKV/Q matmul via variable-width chunks; only the fused AGMM
-        # path (TP>1 on Ring) honours them, so fall back to a standalone gate op elsewhere.
+        # Fuse the per-head gate into the QKV/Q matmul via variable-width chunks
         tp_factor = parallel_config.tensor_parallel.factor
         uses_fused_agmm = tp_factor > 1 and ccl_manager is not None and ccl_manager.topology == ttnn.Topology.Ring
         self.fuse_gate = apply_gated_attention and uses_fused_agmm
@@ -165,8 +164,7 @@ class LTXAttention(Module):
             ccl_manager=ccl_manager,
         )
 
-        # Per-head gate, sharded on num_heads to match the SDPA-output head layout (bf16, sigmoid and
-        # the ×2 stay standalone ops).
+        # Per-head gate, sharded on num_heads to match the SDPA-output head layout
         self.apply_gated_attention = apply_gated_attention
         if apply_gated_attention and not self.fuse_gate:
             # Unfused fallback: standalone gate projection (FSDP-sharded to match the other projections).
@@ -414,8 +412,7 @@ class LTXAttention(Module):
             M, K, N_out = x.padded_shape[-2], weight.padded_shape[-2], weight.padded_shape[-1]
             full_grid = self.mesh_device.compute_with_storage_grid_size()
 
-            # Known shapes route the addcmul to_out to the strided AG-matmul (out = a + scalar*matmul*b);
-            # a miss falls through to the all_gather_minimal_matmul_async addcmul path below.
+            # Known shapes route the addcmul to_out to the strided AG-matmul (out = a + scalar*matmul*b)
             fabric_cfg = get_fabric_agmm_config(K, N_out, 1, full_grid)
             if fabric_cfg is not None:
                 tp_axis = parallel_config.tensor_parallel.mesh_axis

--- a/models/tt_dit/models/vae/vae_ltx.py
+++ b/models/tt_dit/models/vae/vae_ltx.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import time
 from typing import TYPE_CHECKING, Sequence
 
 import torch
@@ -18,7 +19,6 @@ from safetensors import safe_open
 from safetensors.torch import load_file
 
 import ttnn
-from models.common.utility_functions import is_blackhole
 
 from ...layers.module import Module, ModuleList, Parameter
 from ...layers.normalization import RMSNorm
@@ -37,6 +37,8 @@ from ...utils.conv3d import (
 )
 from ...utils.ltx import pad_hw_replicate
 from ...utils.tensor import fast_device_to_host, float_to_uint8, typed_tensor, typed_tensor_2dshard
+from ...utils.tracing import traced_function
+from ...utils.yuv_d2h import fast_device_to_host_yuv
 
 if TYPE_CHECKING:
     from ..upsampler.latent_upsampler_ltx import LTXLatentUpsampler
@@ -57,6 +59,35 @@ def _get_w_mask(cache, x_BTHWC, logical_w, parallel_config, mesh_device, dtype):
             mesh_axis=parallel_config.width_parallel.mesh_axis,
             shard_dim=3,
             dtype=dtype,
+        )
+    return cache[key]
+
+
+def _get_pad_offset(cache, x_BTHWC, parallel_config, mesh_device, sub_h=0, sub_w=0):
+    """Per-device [h_start, w_start] global spatial offset for conv3d's in-kernel logical-pad mask.
+    Sharded so device (hi, wi) reads its own pair [hi*H_dev, wi*W_dev]; H_dev/W_dev are uniform per
+    device because conv_pad_* pads to a multiple of the mesh factor. Lets the halo path mask pad
+    positions inside the conv3d read instead of a full-tensor pre-mul. sub_h/sub_w: subtract from the
+    per-device dims when x is a PADDED buffer (copy-free path) so h_start/w_start stay INTERIOR-based."""
+    hf = parallel_config.height_parallel.factor
+    wf = parallel_config.width_parallel.factor
+    h_dev, w_dev = x_BTHWC.shape[2] - 2 * sub_h, x_BTHWC.shape[3] - 2 * sub_w
+    key = (hf, wf, h_dev, w_dev)
+    if key not in cache:
+        off = torch.zeros(hf, wf, 2, dtype=torch.int32)
+        for hi in range(hf):
+            for wi in range(wf):
+                off[hi, wi, 0] = hi * h_dev
+                off[hi, wi, 1] = wi * w_dev
+        cache[key] = typed_tensor_2dshard(
+            off,
+            mesh_device,
+            shard_mapping={
+                parallel_config.height_parallel.mesh_axis: 0,
+                parallel_config.width_parallel.mesh_axis: 1,
+            },
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.uint32,
         )
     return cache[key]
 
@@ -146,11 +177,33 @@ class LTXCausalConv3d(Module):
             W=dims_W,
         )
 
+        # Hybrid dispatch: the fused neighbor_pad+conv3d op wins only on conv-heavy shapes where the
+        # interior conv pass hides the halo exchange. get_conv3d_config marks exactly those shapes with
+        # halo_last (interior-then-boundary two-pass) or force_spatial_parallel; that per-shape table IS
+        # the calibrated threshold (a flat T cutoff can't separate the winners — every VAE stage has
+        # T >= 21). NP-light / tiny-conv shapes (conv_in, s0/s1/s2 res, upsamplers, conv_out) carry
+        # neither flag and stay on the standalone NP+conv3d path, which is faster there.
+        self._needs_halo = (self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1) or (
+            self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1
+        )
+        # Halo-aware two-dispatch (neighbor_pad_halo -> conv3d halo mode): for the NP-light shapes that skip
+        # the fused op, avoid the full-pad interior copy by feeding conv3d the compact halo buffer directly.
+        # Valid only when ALL spatial padding is external (halo-exchanged) — i.e. both spatial axes' internal
+        # padding is 0 — so every conv boundary read maps to a halo section. Off via NP_NO_HALO_CONV.
+        self._use_halo_conv = (
+            self._needs_halo
+            and self.internal_padding[1] == 0
+            and self.internal_padding[2] == 0
+            and os.environ.get("NP_NO_HALO_CONV") is None
+        )
+
+        from models.common.utility_functions import is_blackhole
+
         self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
             self.mesh_device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi4
-            if (is_blackhole() and dtype == ttnn.float32)
-            else ttnn.MathFidelity.HiFi2,  # Do not use HiFi3/4 with fp32_dest_acc on WH due to accuracy issues.
+            math_fidelity=(
+                ttnn.MathFidelity.HiFi4 if (is_blackhole() and dtype == ttnn.float32) else ttnn.MathFidelity.HiFi2
+            ),  # Do not use HiFi3/4 with fp32_dest_acc on WH due to accuracy issues.
             math_approx_mode=False,
             fp32_dest_acc_en=True,
             packer_l1_acc=False,
@@ -161,6 +214,12 @@ class LTXCausalConv3d(Module):
         self.bias = Parameter(total_shape=[1, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
 
         self._w_mask_cache: dict[tuple, ttnn.Tensor] = {}
+        self._pad_offset_cache: dict[tuple, ttnn.Tensor] = {}
+        # Persistent-padded path (default on): neighbor_pad_halo -> compact -> halo_scatter into a padded
+        # buffer -> plain (pad=0) conv with in-kernel logical masking, instead of conv3d halo-read mode.
+        # Validated PCC=1.0 and ~6% faster e2e on BH 4x8 1080p (448ms vs 477ms halo-read). Opt out with
+        # TT_LTX_NO_PERSIST_PAD for the halo-read path.
+        self._persist_pad = os.environ.get("TT_LTX_NO_PERSIST_PAD") is None
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
         # LTX-2 stores weights under "conv.weight" and "conv.bias"
@@ -207,9 +266,14 @@ class LTXCausalConv3d(Module):
         causal: bool = True,
         logical_h: int = 0,
         logical_w: int = 0,
+        cf_input_padded: bool = False,
+        cf_output_padded: bool = False,
     ) -> ttnn.Tensor:
         # x_BTHWC: (B, T, H_per_device, W_per_device, C) ROW_MAJOR, H/W fractured on the mesh.
         # logical_h/logical_w: pre-pad full spatial dims for pad masking (0 = no masking).
+        # cf_input_padded: x is already a padded [.,Hp,Wp,.] buffer (copy-free; halo reads interior
+        #   strided + border-scatter in place, no interior copy). cf_output_padded: conv writes a padded
+        #   output (output_pad) so the next conv can consume it copy-free. Both require the persist-pad path.
         assert x_BTHWC.layout == ttnn.ROW_MAJOR_LAYOUT
 
         # Temporal padding (T is not sharded — local op on every device).
@@ -230,51 +294,153 @@ class LTXCausalConv3d(Module):
         h_pad_needed = self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1
         w_pad_needed = self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1
 
-        # Width pre-conv mul-mask: zero pad columns before the halo (neighbor_pad has no W-mask).
-        if (
-            logical_w > 0
-            and self.parallel_config.width_parallel.factor > 1
-            and x_BTHWC.shape[3] * self.parallel_config.width_parallel.factor > logical_w
-        ):
+        # H-row masking (zeroing rows at/beyond logical_h) is fused into neighbor_pad via logical_h on the
+        # standalone path. The fused neighbor_pad_conv3d op has no logical_h argument, so a call that
+        # actually needs H masking must fall back to standalone to stay correct. For the production
+        # 1080p config every logical dim divides the mesh factor, so this is never triggered there.
+        h_mask_active = (
+            h_pad_needed
+            and logical_h > 0
+            and x_BTHWC.shape[2] * self.parallel_config.height_parallel.factor > logical_h
+        )
+
+        # Pre-conv pad masking. W pad columns must be zeroed on the input in BOTH paths (neighbor_pad has
+        # no W-mask). The full-pad path masks H pad rows inside neighbor_pad (logical_h=...); the compact
+        # neighbor_pad_halo op has no logical_h, so the halo path must mask H here too — folded into the
+        # SAME mul as W (one combined H&W mask) so it pays a single pre-conv mask op, not two full-tensor
+        # muls. Fires only where the physical dim exceeds the logical (e.g. 4x8's s0 pad 34->36 that
+        # propagates through the upsamples); a no-op when every logical dim divides the mesh factor (2x4).
+        wf = self.parallel_config.width_parallel.factor
+        hf = self.parallel_config.height_parallel.factor
+        w_needed = logical_w > 0 and wf > 1 and x_BTHWC.shape[3] * wf > logical_w
+        h_needed = logical_h > 0 and hf > 1 and x_BTHWC.shape[2] * hf > logical_h
+        # Halo path defers pad masking INTO conv3d (in-kernel, per-position on the interior read) via
+        # logical_h/w + a per-device offset — no full-tensor pre-mul. The full-pad path keeps its W
+        # pre-mul (neighbor_pad masks H via logical_h but has no W mask). See _get_pad_offset / conv3d.
+        conv_logical_h = 0
+        conv_logical_w = 0
+        pad_offset_tensor = None
+        if self._use_halo_conv:
+            conv_logical_h = logical_h if h_needed else 0
+            conv_logical_w = logical_w if w_needed else 0
+            if conv_logical_h or conv_logical_w:
+                pad_offset_tensor = _get_pad_offset(
+                    self._pad_offset_cache, x_BTHWC, self.parallel_config, self.mesh_device
+                )
+        elif w_needed:
             x_BTHWC = ttnn.mul(
                 x_BTHWC,
                 _get_w_mask(self._w_mask_cache, x_BTHWC, logical_w, self.parallel_config, self.mesh_device, self.dtype),
             )
 
+        # conv3d args set by the dispatch below (halo path fills halo_buffer + spatial conv_padding).
+        halo_buffer = None
+        conv_padding = self.internal_padding
         if h_pad_needed or w_pad_needed:
             dims, pad_left, pad_right = [], [], []
             axes, neighbor_sems, links = [], [], []
+            sem_getter = self.ccl_manager.get_np_ping_pong_semaphore
             if h_pad_needed:
                 dims.append(2)
                 pad_left.append(self.external_padding[1])
                 pad_right.append(self.external_padding[1])
                 axes.append(self.parallel_config.height_parallel.mesh_axis)
-                neighbor_sems.append(
-                    self.ccl_manager.get_np_ping_pong_semaphore(self.parallel_config.height_parallel.mesh_axis)
-                )
+                neighbor_sems.append(sem_getter(self.parallel_config.height_parallel.mesh_axis))
                 links.append(_neighbor_pad_num_links(self.ccl_manager, x_BTHWC, 2))
             if w_pad_needed:
                 dims.append(3)
                 pad_left.append(self.external_padding[2])
                 pad_right.append(self.external_padding[2])
                 axes.append(self.parallel_config.width_parallel.mesh_axis)
-                neighbor_sems.append(
-                    self.ccl_manager.get_np_ping_pong_semaphore(self.parallel_config.width_parallel.mesh_axis)
-                )
+                neighbor_sems.append(sem_getter(self.parallel_config.width_parallel.mesh_axis))
                 links.append(_neighbor_pad_num_links(self.ccl_manager, x_BTHWC, 3))
 
-            x_BTHWC = self.ccl_manager.neighbor_pad_persistent_buffer(
-                x_BTHWC,
-                dims=dims,
-                pad_left=pad_left,
-                pad_right=pad_right,
-                padding_mode="zeros",
-                axes=axes,
-                neighbor_sems=neighbor_sems,
-                num_links=links,
-                logical_h=(logical_h if h_pad_needed else 0),
-                t_front_pad=0,
-            )
+            if self._use_halo_conv and self._persist_pad and h_pad_needed and w_pad_needed:
+                # Persistent-padded: neighbor_pad_halo -> compact -> halo_scatter into a padded buffer ->
+                # plain (pad=0) conv. Logical-pad masking is done IN-KERNEL by the plain conv (logical+pad
+                # threshold + per-device interior offset). cf_input_padded: x is already padded -> read its
+                # interior halo (strided) + border-scatter in place (copy-free, no interior copy).
+                # cf_output_padded: conv writes a padded output so the next conv consumes it copy-free.
+                pHe, pWe = self.external_padding[1], self.external_padding[2]
+                # Interior per-device dims (x carries the padded border when cf_input_padded).
+                ih = x_BTHWC.shape[2] - (2 * pHe if cf_input_padded else 0)
+                iw = x_BTHWC.shape[3] - (2 * pWe if cf_input_padded else 0)
+                cf_h_needed = logical_h > 0 and hf > 1 and ih * hf > logical_h
+                cf_w_needed = logical_w > 0 and wf > 1 and iw * wf > logical_w
+                pp_logical_h = (logical_h + pHe) if cf_h_needed else 0
+                pp_logical_w = (logical_w + pWe) if cf_w_needed else 0
+                pp_pad_offset = None
+                if pp_logical_h or pp_logical_w:
+                    pp_pad_offset = _get_pad_offset(
+                        self._pad_offset_cache,
+                        x_BTHWC,
+                        self.parallel_config,
+                        self.mesh_device,
+                        sub_h=(pHe if cf_input_padded else 0),
+                        sub_w=(pWe if cf_input_padded else 0),
+                    )
+                # Fused exchange+scatter. cf_input_padded: x already carries the padded interior (prev
+                # conv's padded output) -> border-only in place. Else: allocate padded, fill interior+border.
+                padded = self.ccl_manager.neighbor_pad_halo_scatter(
+                    x_BTHWC,
+                    dims=dims,
+                    pad_left=pad_left,
+                    pad_right=pad_right,
+                    axes=axes,
+                    neighbor_sems=neighbor_sems,
+                    num_links=links,
+                    padding_mode="zeros",
+                    input_pad_h=(pHe if cf_input_padded else 0),
+                    input_pad_w=(pWe if cf_input_padded else 0),
+                    border_only=cf_input_padded,
+                )
+                return ttnn.experimental.conv3d(
+                    input_tensor=padded,
+                    weight_tensor=self.weight.data,
+                    bias_tensor=self.bias.data,
+                    device=self.mesh_device,
+                    config=self.conv_config,
+                    output_channels=self.out_channels,
+                    kernel_size=self.kernel_size,
+                    stride=self.stride,
+                    padding=(self.internal_padding[0], 0, 0),
+                    padding_mode="zeros",
+                    dtype=self.dtype,
+                    compute_kernel_config=self.compute_kernel_config,
+                    logical_h_mask=pp_logical_h,
+                    logical_w_mask=pp_logical_w,
+                    pad_offset_tensor=pp_pad_offset,
+                    output_pad_h=(pHe if cf_output_padded else 0),
+                    output_pad_w=(pWe if cf_output_padded else 0),
+                )
+
+            if self._use_halo_conv:
+                # Compact halo -> conv3d halo mode: conv does the spatial (external) padding by reading the
+                # neighbor's pixels from the halo buffer, skipping the full-pad interior copy.
+                halo_buffer = self.ccl_manager.neighbor_pad_halo_only(
+                    x_BTHWC,
+                    dims=dims,
+                    pad_left=pad_left,
+                    pad_right=pad_right,
+                    axes=axes,
+                    neighbor_sems=neighbor_sems,
+                    num_links=links,
+                    padding_mode="zeros",
+                )
+                conv_padding = (self.internal_padding[0], self.external_padding[1], self.external_padding[2])
+            else:
+                x_BTHWC = self.ccl_manager.neighbor_pad_persistent_buffer(
+                    x_BTHWC,
+                    dims=dims,
+                    pad_left=pad_left,
+                    pad_right=pad_right,
+                    padding_mode="zeros",
+                    axes=axes,
+                    neighbor_sems=neighbor_sems,
+                    num_links=links,
+                    logical_h=(logical_h if h_pad_needed else 0),
+                    t_front_pad=0,
+                )
 
         x_BTHWC = ttnn.experimental.conv3d(
             input_tensor=x_BTHWC,
@@ -285,10 +451,14 @@ class LTXCausalConv3d(Module):
             output_channels=self.out_channels,
             kernel_size=self.kernel_size,
             stride=self.stride,
-            padding=self.internal_padding,
+            padding=conv_padding,
             padding_mode="zeros",
             dtype=self.dtype,
             compute_kernel_config=self.compute_kernel_config,
+            halo_buffer=halo_buffer,
+            logical_h_mask=conv_logical_h,
+            logical_w_mask=conv_logical_w,
+            pad_offset_tensor=pad_offset_tensor,
         )
 
         return x_BTHWC
@@ -409,26 +579,22 @@ class LTXResnetBlock3D(Module):
         logical_h: int = 0,
         logical_w: int = 0,
     ) -> ttnn.Tensor:
+        # Copy-free: conv1 writes a PADDED output, norm2 runs on it (per-position; border is garbage),
+        # and conv2 reads it copy-free (halo interior read + border-scatter in place) — no interior copy
+        # between the two convs. norm outputs TILE; conv3d needs ROW_MAJOR.
         residual = x_BTHWC
-
-        # Main path: (norm+silu fused) → conv → (norm+silu fused) → conv. The fused norm outputs
-        # TILE; conv3d needs ROW_MAJOR.
         h = self.norm1(x_BTHWC, compute_kernel_config=self.norm_compute_kernel_config)
         h = ttnn.to_layout(h, ttnn.ROW_MAJOR_LAYOUT)
-        h = self.conv1(h, causal=causal, logical_h=logical_h, logical_w=logical_w)
+        h = self.conv1(h, causal=causal, logical_h=logical_h, logical_w=logical_w, cf_output_padded=True)
 
         h = self.norm2(h, compute_kernel_config=self.norm_compute_kernel_config)
         h = ttnn.to_layout(h, ttnn.ROW_MAJOR_LAYOUT)
-        h = self.conv2(h, causal=causal, logical_h=logical_h, logical_w=logical_w)
+        h = self.conv2(h, causal=causal, logical_h=logical_h, logical_w=logical_w, cf_input_padded=True)
 
-        # Skip connection
         if self.has_shortcut:
             residual = ttnn.layer_norm(residual, weight=self.norm3_weight.data, bias=self.norm3_bias.data)
-            residual = (
-                ttnn.to_layout(residual, ttnn.ROW_MAJOR_LAYOUT)
-                if residual.layout != ttnn.ROW_MAJOR_LAYOUT
-                else residual
-            )
+            if residual.layout != ttnn.ROW_MAJOR_LAYOUT:
+                residual = ttnn.to_layout(residual, ttnn.ROW_MAJOR_LAYOUT)
             residual = self.conv_shortcut(residual, causal=causal, logical_h=logical_h, logical_w=logical_w)
 
         return ttnn.add(residual, h)
@@ -543,6 +709,8 @@ class LTXDepthToSpaceUpsample(Module):
         """Upsample by `stride`; returns (out, new_logical_h, new_logical_w) scaled by p2/p3."""
         B, T, H, W, _ = x_BTHWC.shape
         p1, p2, p3 = self.stride
+        new_logical_h = logical_h * p2 if logical_h else 0
+        new_logical_w = logical_w * p3 if logical_w else 0
 
         # Residual path: depth-to-space the input, repeat channels to match conv output.
         if self.residual:
@@ -565,8 +733,6 @@ class LTXDepthToSpaceUpsample(Module):
         if self.residual:
             x = ttnn.add(x, x_in)
 
-        new_logical_h = logical_h * p2 if logical_h else 0
-        new_logical_w = logical_w * p3 if logical_w else 0
         return x, new_logical_h, new_logical_w
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
@@ -658,6 +824,9 @@ class LTXVideoDecoder(Module):
         self.mesh_device = mesh_device
         self.parallel_config = parallel_config
         self.ccl_manager = ccl_manager
+        # Set True by the pipeline after warmup so the first real decode captures a ttnn trace of
+        # decode_device and later decodes replay it (removing host-dispatch overhead).
+        self._vae_traced = False
         out_channels_with_patch = out_channels * patch_size**2  # 3 * 16 = 48
 
         feature_channels = base_channels * 8  # 1024
@@ -789,6 +958,36 @@ class LTXVideoDecoder(Module):
         for k in keys_to_remove:
             del state[k]
 
+    @traced_function(device=lambda self: self.mesh_device, prep_run=True, clone_prep_inputs=True)
+    def decode_device(self, sample_tt, logical_h: int, logical_w: int):
+        """Device-only decode: denorm → conv_in → up_blocks → norm_out → conv_out, on an already-sharded
+        input, returning the device output before the host gather. Split out from forward() so it can be
+        captured as a single ttnn trace (the host upload/gather must stay outside the trace).
+
+        Pass ``traced=True`` (plus a stable ``tracer_trace_key``) to capture/replay it as a ttnn trace."""
+        # Denormalize: x = x * std + mean (per-channel stats replicated on the mesh).
+        mean = self.per_channel_mean.data
+        std = self.per_channel_std.data
+        sample_tt = ttnn.add(ttnn.multiply(sample_tt, std), mean)
+        sample_tt = ttnn.to_layout(sample_tt, ttnn.ROW_MAJOR_LAYOUT)
+
+        # logical_h/logical_w scale up through each upsample so later convs mask the right region.
+        sample_tt = self.conv_in(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
+        for up_block in self.up_blocks:
+            if isinstance(up_block, LTXDepthToSpaceUpsample):
+                sample_tt, logical_h, logical_w = up_block(
+                    sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w
+                )
+            else:
+                sample_tt = up_block(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
+
+        sample_tt = self.norm_out(sample_tt, compute_kernel_config=self.norm_out_compute_kernel_config)
+        sample_tt = ttnn.to_layout(sample_tt, ttnn.ROW_MAJOR_LAYOUT)
+        out = self.conv_out(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
+        # logical_h/logical_w have grown through the upsample blocks (e.g. 34 -> 272); the caller needs
+        # these post-upsample dims to crop mesh padding, not the pre-upsample ones it passed in.
+        return out, logical_h, logical_w
+
     def forward(self, sample_BCTHW: torch.Tensor, *, output_type: str = "float") -> torch.Tensor:
         """Decode latent (B, 128, F', H', W') → video.
 
@@ -810,25 +1009,20 @@ class LTXVideoDecoder(Module):
             dtype=ttnn.bfloat16,
         )
 
-        # Denormalize: x = x * std + mean (per-channel stats replicated on the mesh).
-        mean = self.per_channel_mean.data
-        std = self.per_channel_std.data
-        sample_tt = ttnn.add(ttnn.multiply(sample_tt, std), mean)
-        sample_tt = ttnn.to_layout(sample_tt, ttnn.ROW_MAJOR_LAYOUT)
-
-        # logical_h/logical_w scale up through each upsample so later convs mask the right region.
-        sample_tt = self.conv_in(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
-        for up_block in self.up_blocks:
-            if isinstance(up_block, LTXDepthToSpaceUpsample):
-                sample_tt, logical_h, logical_w = up_block(
-                    sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w
-                )
-            else:
-                sample_tt = up_block(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
-
-        sample_tt = self.norm_out(sample_tt, compute_kernel_config=self.norm_out_compute_kernel_config)
-        sample_tt = ttnn.to_layout(sample_tt, ttnn.ROW_MAJOR_LAYOUT)
-        sample_tt = self.conv_out(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
+        _time = os.environ.get("LTX_VAE_TIME")
+        if _time:
+            ttnn.synchronize_device(self.mesh_device)
+            _t0 = time.time()
+        sample_tt, logical_h, logical_w = self.decode_device(
+            sample_tt,
+            logical_h,
+            logical_w,
+            traced=self._vae_traced,
+            tracer_trace_key=(tuple(sample_tt.shape), int(logical_h), int(logical_w)),
+        )
+        if _time:
+            ttnn.synchronize_device(self.mesh_device)
+            _t_dec = time.time()
 
         # Depth-to-space unpatch on device, output BCTHW so the gather's innermost dim stays large
         # (channels-last would gather a length-3 innermost). conv_out channels are ordered (c, p, r, q).
@@ -837,6 +1031,27 @@ class LTXVideoDecoder(Module):
         sample_tt = ttnn.reshape(sample_tt, (B_, T_, H4, W4, 3, p, r, q))
         sample_tt = ttnn.permute(sample_tt, (0, 4, 1, 5, 2, 7, 3, 6))
         sample_tt = ttnn.reshape(sample_tt, (B_, 3, T_ * p, H4 * q, W4 * r))  # (B, 3, T, H, W)
+        if _time:
+            ttnn.synchronize_device(self.mesh_device)
+            logger.info(
+                f"VAE_TIME decode_device(traced={self._vae_traced})={(_t_dec - _t0) * 1000:.1f}ms "
+                f"d2s={(time.time() - _t_dec) * 1000:.1f}ms"
+            )
+
+        if output_type == "yuv":
+            # On-device YUV 4:2:0 + fast d2h -> ffmpeg yuv420p planar uint8.
+            # logical_h/logical_w crop the global-tail mesh padding post-gather in the host planar kernel.
+            h_out, w_out = logical_h * q, logical_w * r
+            planar = fast_device_to_host_yuv(
+                sample_tt,
+                self.mesh_device,
+                ccl_manager=self.ccl_manager,
+                logical_h=h_out,
+                logical_w=w_out,
+            )
+            # Reshape flat (T, H*W*3//2) -> self-describing (T, H*3//2, W) so the exporter can
+            # recover H/W from the array alone — this IS PyAV's yuv420p ndarray layout.
+            return planar.reshape(planar.shape[0], h_out * 3 // 2, w_out)
 
         concat_dims = [None, None]
         concat_dims[self.parallel_config.height_parallel.mesh_axis] = 3

--- a/models/tt_dit/models/vae/vae_ltx.py
+++ b/models/tt_dit/models/vae/vae_ltx.py
@@ -177,19 +177,11 @@ class LTXCausalConv3d(Module):
             W=dims_W,
         )
 
-        # Hybrid dispatch: the fused neighbor_pad+conv3d op wins only on conv-heavy shapes where the
-        # interior conv pass hides the halo exchange. get_conv3d_config marks exactly those shapes with
-        # halo_last (interior-then-boundary two-pass) or force_spatial_parallel; that per-shape table IS
-        # the calibrated threshold (a flat T cutoff can't separate the winners — every VAE stage has
-        # T >= 21). NP-light / tiny-conv shapes (conv_in, s0/s1/s2 res, upsamplers, conv_out) carry
-        # neither flag and stay on the standalone NP+conv3d path, which is faster there.
+        # Hybrid dispatch: the fused neighbor_pad+conv3d op wins only on conv-heavy shapes where the interior conv
         self._needs_halo = (self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1) or (
             self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1
         )
         # Halo-aware two-dispatch (neighbor_pad_halo -> conv3d halo mode): for the NP-light shapes that skip
-        # the fused op, avoid the full-pad interior copy by feeding conv3d the compact halo buffer directly.
-        # Valid only when ALL spatial padding is external (halo-exchanged) — i.e. both spatial axes' internal
-        # padding is 0 — so every conv boundary read maps to a halo section. Off via NP_NO_HALO_CONV.
         self._use_halo_conv = (
             self._needs_halo
             and self.internal_padding[1] == 0
@@ -215,10 +207,7 @@ class LTXCausalConv3d(Module):
 
         self._w_mask_cache: dict[tuple, ttnn.Tensor] = {}
         self._pad_offset_cache: dict[tuple, ttnn.Tensor] = {}
-        # Persistent-padded path (default on): neighbor_pad_halo -> compact -> halo_scatter into a padded
-        # buffer -> plain (pad=0) conv with in-kernel logical masking, instead of conv3d halo-read mode.
-        # Validated PCC=1.0 and ~6% faster e2e on BH 4x8 1080p (448ms vs 477ms halo-read). Opt out with
-        # TT_LTX_NO_PERSIST_PAD for the halo-read path.
+        # Persistent-padded path (default on): neighbor_pad_halo -> compact -> halo_scatter into a padded buffer ->
         self._persist_pad = os.environ.get("TT_LTX_NO_PERSIST_PAD") is None
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
@@ -271,9 +260,7 @@ class LTXCausalConv3d(Module):
     ) -> ttnn.Tensor:
         # x_BTHWC: (B, T, H_per_device, W_per_device, C) ROW_MAJOR, H/W fractured on the mesh.
         # logical_h/logical_w: pre-pad full spatial dims for pad masking (0 = no masking).
-        # cf_input_padded: x is already a padded [.,Hp,Wp,.] buffer (copy-free; halo reads interior
-        #   strided + border-scatter in place, no interior copy). cf_output_padded: conv writes a padded
-        #   output (output_pad) so the next conv can consume it copy-free. Both require the persist-pad path.
+        # cf_input_padded: x is already a padded [.,Hp,Wp,.] buffer
         assert x_BTHWC.layout == ttnn.ROW_MAJOR_LAYOUT
 
         # Temporal padding (T is not sharded — local op on every device).
@@ -294,29 +281,19 @@ class LTXCausalConv3d(Module):
         h_pad_needed = self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1
         w_pad_needed = self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1
 
-        # H-row masking (zeroing rows at/beyond logical_h) is fused into neighbor_pad via logical_h on the
-        # standalone path. The fused neighbor_pad_conv3d op has no logical_h argument, so a call that
-        # actually needs H masking must fall back to standalone to stay correct. For the production
-        # 1080p config every logical dim divides the mesh factor, so this is never triggered there.
+        # H-row masking (zeroing rows at/beyond logical_h) is fused into neighbor_pad via logical_h on the standalone
         h_mask_active = (
             h_pad_needed
             and logical_h > 0
             and x_BTHWC.shape[2] * self.parallel_config.height_parallel.factor > logical_h
         )
 
-        # Pre-conv pad masking. W pad columns must be zeroed on the input in BOTH paths (neighbor_pad has
-        # no W-mask). The full-pad path masks H pad rows inside neighbor_pad (logical_h=...); the compact
-        # neighbor_pad_halo op has no logical_h, so the halo path must mask H here too — folded into the
-        # SAME mul as W (one combined H&W mask) so it pays a single pre-conv mask op, not two full-tensor
-        # muls. Fires only where the physical dim exceeds the logical (e.g. 4x8's s0 pad 34->36 that
-        # propagates through the upsamples); a no-op when every logical dim divides the mesh factor (2x4).
+        # Pre-conv pad masking
         wf = self.parallel_config.width_parallel.factor
         hf = self.parallel_config.height_parallel.factor
         w_needed = logical_w > 0 and wf > 1 and x_BTHWC.shape[3] * wf > logical_w
         h_needed = logical_h > 0 and hf > 1 and x_BTHWC.shape[2] * hf > logical_h
-        # Halo path defers pad masking INTO conv3d (in-kernel, per-position on the interior read) via
-        # logical_h/w + a per-device offset — no full-tensor pre-mul. The full-pad path keeps its W
-        # pre-mul (neighbor_pad masks H via logical_h but has no W mask). See _get_pad_offset / conv3d.
+        # Halo path defers pad masking INTO conv3d (in-kernel, per-position on the interior read) via logical_h/w +
         conv_logical_h = 0
         conv_logical_w = 0
         pad_offset_tensor = None
@@ -356,11 +333,7 @@ class LTXCausalConv3d(Module):
                 links.append(_neighbor_pad_num_links(self.ccl_manager, x_BTHWC, 3))
 
             if self._use_halo_conv and self._persist_pad and h_pad_needed and w_pad_needed:
-                # Persistent-padded: neighbor_pad_halo -> compact -> halo_scatter into a padded buffer ->
-                # plain (pad=0) conv. Logical-pad masking is done IN-KERNEL by the plain conv (logical+pad
-                # threshold + per-device interior offset). cf_input_padded: x is already padded -> read its
-                # interior halo (strided) + border-scatter in place (copy-free, no interior copy).
-                # cf_output_padded: conv writes a padded output so the next conv consumes it copy-free.
+                # Persistent-padded: neighbor_pad_halo -> compact -> halo_scatter into a padded buffer -> plain
                 pHe, pWe = self.external_padding[1], self.external_padding[2]
                 # Interior per-device dims (x carries the padded border when cf_input_padded).
                 ih = x_BTHWC.shape[2] - (2 * pHe if cf_input_padded else 0)
@@ -379,8 +352,7 @@ class LTXCausalConv3d(Module):
                         sub_h=(pHe if cf_input_padded else 0),
                         sub_w=(pWe if cf_input_padded else 0),
                     )
-                # Fused exchange+scatter. cf_input_padded: x already carries the padded interior (prev
-                # conv's padded output) -> border-only in place. Else: allocate padded, fill interior+border.
+                # Fused exchange+scatter
                 padded = self.ccl_manager.neighbor_pad_halo_scatter(
                     x_BTHWC,
                     dims=dims,
@@ -415,8 +387,7 @@ class LTXCausalConv3d(Module):
                 )
 
             if self._use_halo_conv:
-                # Compact halo -> conv3d halo mode: conv does the spatial (external) padding by reading the
-                # neighbor's pixels from the halo buffer, skipping the full-pad interior copy.
+                # Compact halo -> conv3d halo mode: conv does the spatial
                 halo_buffer = self.ccl_manager.neighbor_pad_halo_only(
                     x_BTHWC,
                     dims=dims,
@@ -579,9 +550,7 @@ class LTXResnetBlock3D(Module):
         logical_h: int = 0,
         logical_w: int = 0,
     ) -> ttnn.Tensor:
-        # Copy-free: conv1 writes a PADDED output, norm2 runs on it (per-position; border is garbage),
-        # and conv2 reads it copy-free (halo interior read + border-scatter in place) — no interior copy
-        # between the two convs. norm outputs TILE; conv3d needs ROW_MAJOR.
+        # Copy-free: conv1 writes a PADDED output, norm2 runs on it
         residual = x_BTHWC
         h = self.norm1(x_BTHWC, compute_kernel_config=self.norm_compute_kernel_config)
         h = ttnn.to_layout(h, ttnn.ROW_MAJOR_LAYOUT)
@@ -824,8 +793,7 @@ class LTXVideoDecoder(Module):
         self.mesh_device = mesh_device
         self.parallel_config = parallel_config
         self.ccl_manager = ccl_manager
-        # Set True by the pipeline after warmup so the first real decode captures a ttnn trace of
-        # decode_device and later decodes replay it (removing host-dispatch overhead).
+        # Set True by the pipeline after warmup so the first real decode captures a ttnn trace of decode_device
         self._vae_traced = False
         out_channels_with_patch = out_channels * patch_size**2  # 3 * 16 = 48
 
@@ -984,8 +952,7 @@ class LTXVideoDecoder(Module):
         sample_tt = self.norm_out(sample_tt, compute_kernel_config=self.norm_out_compute_kernel_config)
         sample_tt = ttnn.to_layout(sample_tt, ttnn.ROW_MAJOR_LAYOUT)
         out = self.conv_out(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
-        # logical_h/logical_w have grown through the upsample blocks (e.g. 34 -> 272); the caller needs
-        # these post-upsample dims to crop mesh padding, not the pre-upsample ones it passed in.
+        # logical_h/logical_w have grown through the upsample blocks
         return out, logical_h, logical_w
 
     def forward(self, sample_BCTHW: torch.Tensor, *, output_type: str = "float") -> torch.Tensor:
@@ -1039,8 +1006,7 @@ class LTXVideoDecoder(Module):
             )
 
         if output_type == "yuv":
-            # On-device YUV 4:2:0 + fast d2h -> ffmpeg yuv420p planar uint8.
-            # logical_h/logical_w crop the global-tail mesh padding post-gather in the host planar kernel.
+            # On-device YUV 4:2:0 + fast d2h -> ffmpeg yuv420p planar uint8
             h_out, w_out = logical_h * q, logical_w * r
             planar = fast_device_to_host_yuv(
                 sample_tt,
@@ -1049,8 +1015,7 @@ class LTXVideoDecoder(Module):
                 logical_h=h_out,
                 logical_w=w_out,
             )
-            # Reshape flat (T, H*W*3//2) -> self-describing (T, H*3//2, W) so the exporter can
-            # recover H/W from the array alone — this IS PyAV's yuv420p ndarray layout.
+            # Reshape flat (T, H*W*3//2) -> self-describing
             return planar.reshape(planar.shape[0], h_out * 3 // 2, w_out)
 
         concat_dims = [None, None]

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -36,6 +36,11 @@ class CCLManager:
         # keyed by the caller's shape/config key. See get_fused_norm_stats_buffer.
         self._fused_norm_stats_buffer_cache = {}
 
+        # Lazily-allocated ping-pong pool of semaphore lists for the strided all-gather-matmul op,
+        # keyed by (mesh_axis, num_workers_per_link). See get_strided_ag_mm_semaphore.
+        self._strided_ag_mm_sem_cache = {}
+        self._strided_ag_mm_sem_idx = {}
+
         # Setup semaphores
         self._init_subdevice()
 
@@ -52,8 +57,10 @@ class CCLManager:
         self.ag_ping_pong_idx = [0, 0]
         self.exp_ring_ping_pong_idx = [0, 0]
         self.np_ping_pong_idx = [0, 0]
+        self.np_fused_ping_pong_idx = [0, 0]
         self.sr_ping_pong_idx = [0, 0]
         self.barrier_idx = [0, 0]
+        self.barrier_fused_idx = [0, 0]
 
     def _init_subdevice(self):
         compute_grid_size = self.mesh_device.compute_with_storage_grid_size()
@@ -61,11 +68,6 @@ class CCLManager:
             {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
         )
 
-        _worker_sub_device = ttnn.SubDevice(
-            [
-                self.ccl_cores,
-            ]
-        )
         self.ccl_sub_device_id = ttnn.SubDeviceId(0)
 
     def _init_semaphores(self):
@@ -96,7 +98,7 @@ class CCLManager:
             1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(exp_ring_n_sems)],
         }
 
-        # Initialize neighbor pad semaphores
+        # Initialize neighbor pad semaphores (standalone NP path)
         np_n_sems = 1 * 2
         self.np_ping_pong_semaphores = {
             0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(np_n_sems)],
@@ -115,6 +117,32 @@ class CCLManager:
         self.barrier_semaphores = {
             0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
             1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
+        }
+
+        # Separate semaphores for fused NP+Conv3d path to avoid state conflicts
+        # when standalone NP and fused ops alternate in the same pipeline
+        self.np_fused_ping_pong_semaphores = {
+            0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(np_n_sems)],
+            1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(np_n_sems)],
+        }
+        self.barrier_fused_semaphores = {
+            0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
+            1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
+        }
+
+        # Per-(region,link) progress sems for fused NP+Conv3d overlap: 4 face regions
+        # {H-top, H-bot, W-left, W-right} × num_links links, indexed [region*num_links + link].
+        # That is exactly 8 on BH-LB (num_links=2); up to 16 at num_links=4 (4x8). Single bank, no host
+        # reset: the consuming kernels self-reset their own copies on-device after their final wait, so
+        # the op is trace-safe and the static addresses are baked once by the factory.
+        self._np_region_n_sems = 4 * self.num_links
+        self.np_region_progress_semaphores = {
+            0: [
+                ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(self._np_region_n_sems)
+            ],
+            1: [
+                ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(self._np_region_n_sems)
+            ],
         }
 
     def get_rs_ping_pong_buffer(self, shape, dim, mesh_axis):
@@ -253,6 +281,37 @@ class CCLManager:
         self.ag_ping_pong_idx[mesh_axis] = (cur_idx + 1) % 2
         return self.ag_ping_pong_semaphores[mesh_axis][cur_idx * n_sems : (cur_idx + 1) * n_sems]
 
+    def get_strided_ag_mm_semaphore(self, mesh_axis, num_workers_per_link):
+        """
+        Get semaphores for the strided all-gather-matmul op (strided_all_gather_minimal_matmul_async).
+
+        Unlike the 2-semaphore all-gather path, the strided op needs 2 out-ready semaphores plus
+        2 * num_links * num_workers_per_link per-worker aggregator semaphores (incremented over the
+        fabric by writer workers on the receiving device), all in a single list. A 2-deep ping-pong
+        pool is allocated lazily per (mesh_axis, num_workers_per_link) and rotated on each call.
+
+        Args:
+            mesh_axis: The mesh axis (0 or 1) to get semaphores for
+            num_workers_per_link: The op's num_workers_per_link (sets the aggregator-sem count)
+
+        Returns:
+            List of (2 + 2 * num_links * num_workers_per_link) GlobalSemaphores for this cycle
+        """
+        cache_key = (mesh_axis, num_workers_per_link)
+        if cache_key not in self._strided_ag_mm_sem_cache:
+            ttnn.synchronize_device(self.mesh_device)
+            n_sems = 2 + 2 * self.num_links * num_workers_per_link
+            self._strided_ag_mm_sem_cache[cache_key] = [
+                [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(n_sems)]
+                for _ in range(2)
+            ]
+            self._strided_ag_mm_sem_idx[cache_key] = 0
+            ttnn.synchronize_device(self.mesh_device)
+
+        cur_idx = self._strided_ag_mm_sem_idx[cache_key]
+        self._strided_ag_mm_sem_idx[cache_key] = 1 - cur_idx
+        return self._strided_ag_mm_sem_cache[cache_key][cur_idx]
+
     def get_fused_norm_stats_buffer(self, key, create_buffer):
         """Own the ping-pong pool + lifetime of the fused distributed-norm op's persistent
         stats (all-gather scratch) buffer.
@@ -302,12 +361,26 @@ class CCLManager:
 
     def get_np_ping_pong_semaphore(self, mesh_axis):
         """
-        Get semaphores for neighbor pad operations.
+        Get semaphores for standalone neighbor pad operations.
         """
         cur_idx = self.np_ping_pong_idx[mesh_axis]
         n_sems = 1
         self.np_ping_pong_idx[mesh_axis] = (cur_idx + 1) % 2
         return self.np_ping_pong_semaphores[mesh_axis][cur_idx]
+
+    def get_np_fused_ping_pong_semaphore(self, mesh_axis):
+        """
+        Get semaphores for fused NP+Conv3d operations (separate pool from standalone NP).
+        """
+        cur_idx = self.np_fused_ping_pong_idx[mesh_axis]
+        self.np_fused_ping_pong_idx[mesh_axis] = (cur_idx + 1) % 2
+        return self.np_fused_ping_pong_semaphores[mesh_axis][cur_idx]
+
+    def get_barrier_fused_semaphore(self, mesh_axis):
+        """Get barrier semaphore for fused NP+Conv3d (separate pool from standalone NP)."""
+        cur_idx = self.barrier_fused_idx[mesh_axis]
+        self.barrier_fused_idx[mesh_axis] = (cur_idx + 1) % 2
+        return self.barrier_fused_semaphores[mesh_axis][cur_idx]
 
     def get_sr_ping_pong_semaphore(self, mesh_axis):
         """
@@ -317,6 +390,182 @@ class CCLManager:
         n_sems = 1
         self.sr_ping_pong_idx[mesh_axis] = (cur_idx + 1) % 2
         return self.sr_ping_pong_semaphores[mesh_axis][cur_idx]
+
+    def get_np_region_progress_semaphores(self, mesh_axis):
+        """Get the 4*num_links per-(region,link) progress sems (static, single bank), indexed [region*num_links + link]."""
+        return self.np_region_progress_semaphores[mesh_axis]
+
+    def get_np_halo_buffer(self, input_shape, dim, padding, dtype=ttnn.bfloat16, dim2=None, padding2=0):
+        """
+        Get or create a ping-pong compact halo buffer for fabric-only NeighborPad.
+        Handles H halo and optionally W halo.
+
+        Layout: [H-top | H-bot | W-left | W-right] where H sections are
+        outer_dim × padding_h × W_dev sticks, and W sections are
+        outer_dim × padding_w × (H_dev + 2*padding_h) sticks (extended for corner fix).
+        """
+        import torch
+
+        outer_dim_size = 1
+        for d in range(dim):
+            outer_dim_size *= input_shape[d]
+        # H sticks per halo row = product of dims after dim (excluding last C dim)
+        h_sticks = 1
+        for d in range(dim + 1, len(input_shape) - 1):
+            h_sticks *= input_shape[d]
+        # W sticks per halo col = H_dev + 2*padding_h (extended to include H-padded rows for corner fix)
+        w_sticks = (input_shape[dim] + 2 * padding) if dim2 is not None else 0
+
+        h_halo_total = outer_dim_size * 2 * padding * h_sticks
+        w_halo_total = outer_dim_size * 2 * padding2 * w_sticks if dim2 is not None else 0
+        total_sticks = h_halo_total + w_halo_total
+        # Each "stick" = C channels × 2 bytes (BF16). The compact buffer must have shape
+        # [total_sticks, C] so that each 2D row = C elements = one stick page (= C×2 bytes),
+        # matching the input tensor's aligned_page_size used as stick_size in the NP factory.
+        C = input_shape[-1]  # channel dimension
+
+        cache_key = ("np_halo", tuple(input_shape), dim, padding, dim2, padding2, dtype)
+        if cache_key not in self._ping_pong_buffer_cache:
+            bufs = []
+            for _ in range(2):
+                buf = ttnn.from_torch(
+                    torch.zeros([total_sticks, C], dtype=torch.bfloat16),
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    dtype=dtype,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    device=self.mesh_device,
+                )
+                bufs.append(buf)
+            self._ping_pong_buffer_cache[cache_key] = bufs
+            self._ping_pong_buffer_indices[cache_key] = 0
+
+        cur = self._ping_pong_buffer_indices[cache_key]
+        self._ping_pong_buffer_indices[cache_key] = 1 - cur
+        return self._ping_pong_buffer_cache[cache_key][cur]
+
+    def neighbor_pad_halo_only(
+        self,
+        tensor: ttnn.Tensor,
+        *,
+        dims: list,
+        pad_left: list,
+        pad_right: list,
+        axes: list,
+        neighbor_sems: list,
+        num_links: list,
+        padding_mode: str = "zeros",
+        input_pad_h: int = 0,
+        input_pad_w: int = 0,
+        padded_output: ttnn.Tensor = None,
+    ) -> ttnn.Tensor:
+        """Fill and return the compact [H-top|H-bot|W-left|W-right] halo buffer via the standalone
+        neighbor_pad_halo op. Pair with ttnn.experimental.conv3d(halo_buffer=...) for the two-dispatch
+        halo-aware path (no full-pad interior copy). Halo-only variant of the neighbor-pad exchange.
+
+        input_pad_h/w > 0: `tensor` is a padded [.,H+2*ipad_h,W+2*ipad_w,C] buffer; exchange the halo of
+        its INTERIOR (copy-free path). The compact buffer is sized for the interior dims.
+
+        padded_output: fused mode — the op ALSO copies the interior (tensor -> padded_output) on free
+        cores CONCURRENTLY with the fabric exchange. Returns the compact buffer (still needed for the
+        border scatter); the padded interior is filled as a side effect."""
+        barrier_sem = self.get_barrier_semaphore(axes[0])
+        dim2 = dims[1] if len(dims) > 1 else None
+        padding2 = pad_left[1] if dim2 is not None else 0
+        # Compact buffer is sized from the INTERIOR shape (input_pad strips the padded border).
+        halo_shape = list(tensor.shape)
+        if input_pad_h:
+            halo_shape[dims[0]] -= 2 * input_pad_h
+        if input_pad_w and dim2 is not None:
+            halo_shape[dim2] -= 2 * input_pad_w
+        halo_buf = self.get_np_halo_buffer(
+            halo_shape, dims[0], pad_left[0], dtype=tensor.get_dtype(), dim2=dim2, padding2=padding2
+        )
+        pw = pad_left[1] if dim2 is not None and len(pad_left) > 1 else 0
+        w_sem = neighbor_sems[1] if len(neighbor_sems) > 1 else neighbor_sems[0]
+        np_pad2_left = pad_left[1] if dim2 is not None and len(pad_left) > 1 else 0
+        np_pad2_right = pad_right[1] if dim2 is not None and len(pad_right) > 1 else 0
+        np_pad_dim2_val = dim2 if dim2 is not None else 0
+        np_pad2_cluster_axis_val = axes[1] if dim2 is not None and len(axes) > 1 else 0
+        np_pad2_num_links = num_links[1] if dim2 is not None and len(num_links) > 1 else 1
+        ttnn.experimental.neighbor_pad_halo(
+            tensor,
+            halo_buf,
+            np_padding_h=pad_left[0],
+            np_padding_w=pw,
+            np_cluster_axis=axes[0],
+            np_num_links=num_links[0],
+            np_topology=self.topology,
+            h_neighbor_semaphore=neighbor_sems[0],
+            barrier_semaphore=barrier_sem,
+            w_neighbor_semaphore=w_sem,
+            np_pad_dim2=np_pad_dim2_val,
+            np_pad2_left=np_pad2_left,
+            np_pad2_right=np_pad2_right,
+            np_pad2_cluster_axis=np_pad2_cluster_axis_val,
+            np_pad2_num_links=np_pad2_num_links,
+            padding_mode=padding_mode,
+            input_pad_h=input_pad_h,
+            input_pad_w=input_pad_w,
+            padded_output=padded_output,
+        )
+        return halo_buf
+
+    def neighbor_pad_halo_scatter(
+        self,
+        tensor: ttnn.Tensor,
+        *,
+        dims: list,
+        pad_left: list,
+        pad_right: list,
+        axes: list,
+        neighbor_sems: list,
+        num_links: list,
+        padding_mode: str = "zeros",
+        input_pad_h: int = 0,
+        input_pad_w: int = 0,
+        border_only: bool = False,
+    ) -> ttnn.Tensor:
+        """Fused halo op: fabric halo exchange (into the compact buffer) then local scatter into a padded
+        [.,H+2pH,W+2pW,C] buffer, returned ready for a plain (pad=0) conv3d. Folds neighbor_pad_halo_only
+        + halo_scatter into one call.
+
+        border_only: `tensor` already carries a padded interior (previous conv's padded output), so only
+        the border is written in place (copy-free). Otherwise (repack) the padded buffer is allocated and
+        the interior copy is FUSED into the exchange op (runs concurrently on free cores), then the border
+        is scattered — overlapping the interior copy with the fabric transport instead of serializing it."""
+        pH = pad_left[0]
+        pW = pad_left[1] if len(pad_left) > 1 else 0
+        if border_only:
+            compact = self.neighbor_pad_halo_only(
+                tensor,
+                dims=dims,
+                pad_left=pad_left,
+                pad_right=pad_right,
+                axes=axes,
+                neighbor_sems=neighbor_sems,
+                num_links=num_links,
+                padding_mode=padding_mode,
+                input_pad_h=input_pad_h,
+                input_pad_w=input_pad_w,
+            )
+            return ttnn.experimental.halo_scatter(compact, tensor, np_padding_h=pH, np_padding_w=pW, border_only=True)
+
+        # Repack: allocate the padded output; the exchange op copies the interior into it concurrently.
+        padded = self.get_np_ping_pong_buffer(list(tensor.shape), dims, pad_left, pad_right, dtype=tensor.get_dtype())
+        compact = self.neighbor_pad_halo_only(
+            tensor,
+            dims=dims,
+            pad_left=pad_left,
+            pad_right=pad_right,
+            axes=axes,
+            neighbor_sems=neighbor_sems,
+            num_links=num_links,
+            padding_mode=padding_mode,
+            input_pad_h=input_pad_h,
+            input_pad_w=input_pad_w,
+            padded_output=padded,
+        )
+        return ttnn.experimental.halo_scatter(compact, padded, np_padding_h=pH, np_padding_w=pW, border_only=True)
 
     def get_barrier_semaphore(self, mesh_axis):
         """
@@ -452,11 +701,17 @@ class CCLManager:
         for axis in [0, 1]:
             for sem in self.np_ping_pong_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
+            for sem in self.np_fused_ping_pong_semaphores[axis]:
+                ttnn.reset_global_semaphore_value(sem, 0)
+            for sem in self.barrier_fused_semaphores[axis]:
+                ttnn.reset_global_semaphore_value(sem, 0)
             for sem in self.sr_ping_pong_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
             for sem in self.rs_ping_pong_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
             for sem in self.ag_ping_pong_semaphores[axis]:
+                ttnn.reset_global_semaphore_value(sem, 0)
+            for sem in self.np_region_progress_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
 
     def all_gather_persistent_buffer(

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -40,6 +40,8 @@ class CCLManager:
         # keyed by (mesh_axis, num_workers_per_link). See get_strided_ag_mm_semaphore.
         self._strided_ag_mm_sem_cache = {}
         self._strided_ag_mm_sem_idx = {}
+        # Single shared MM->RS progress counter array. See get_mm_progress_counters_buffer.
+        self._mm_progress_counters_buffer = None
 
         # Setup semaphores
         self._init_subdevice()
@@ -343,6 +345,33 @@ class CCLManager:
         buf = bufs[entry["idx"]]
         entry["idx"] = (entry["idx"] + 1) % len(bufs)
         return buf
+
+    def get_mm_progress_counters_buffer(self):
+        """Own the progress-counter array for the fused matmul -> strided reduce-scatter op's
+        per-core MM->RS signaling: one uint32 slot per matmul core, one row per core.
+
+        Same per-core row as the array the op allocates for itself, over the whole compute grid
+        rather than just the RS worker cores, and allocated once here instead of per compiled
+        program. The op's own copy is retained for as long as the program stays cached, and because
+        L1 is handed out top-down each of those small permanent blocks pins the freed space above it,
+        which eventually leaves a later op (the VAE's ring joint SDPA) short of contiguous L1 for its
+        circular buffers.
+        """
+        if self._mm_progress_counters_buffer is None:
+            grid = self.mesh_device.compute_with_storage_grid_size()
+            slots = grid.x * grid.y
+            self._mm_progress_counters_buffer = ttnn.allocate_tensor_on_device(
+                ttnn.Shape([slots, slots]),
+                ttnn.uint32,
+                ttnn.ROW_MAJOR_LAYOUT,
+                self.mesh_device,
+                ttnn.MemoryConfig(
+                    ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                    ttnn.BufferType.L1,
+                    ttnn.ShardSpec(self.ccl_cores, [1, slots], ttnn.ShardOrientation.ROW_MAJOR),
+                ),
+            )
+        return self._mm_progress_counters_buffer
 
     def get_exp_ring_ping_pong_semaphore(self, mesh_axis):
         """

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -36,8 +36,7 @@ class CCLManager:
         # keyed by the caller's shape/config key. See get_fused_norm_stats_buffer.
         self._fused_norm_stats_buffer_cache = {}
 
-        # Lazily-allocated ping-pong pool of semaphore lists for the strided all-gather-matmul op,
-        # keyed by (mesh_axis, num_workers_per_link). See get_strided_ag_mm_semaphore.
+        # Lazily-allocated ping-pong pool of semaphore lists for the strided all-gather-matmul op
         self._strided_ag_mm_sem_cache = {}
         self._strided_ag_mm_sem_idx = {}
         # Single shared MM->RS progress counter array. See get_mm_progress_counters_buffer.
@@ -121,8 +120,7 @@ class CCLManager:
             1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
         }
 
-        # Separate semaphores for fused NP+Conv3d path to avoid state conflicts
-        # when standalone NP and fused ops alternate in the same pipeline
+        # Separate semaphores for fused NP+Conv3d path to avoid state conflicts when standalone NP and fused ops
         self.np_fused_ping_pong_semaphores = {
             0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(np_n_sems)],
             1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(np_n_sems)],
@@ -132,11 +130,7 @@ class CCLManager:
             1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
         }
 
-        # Per-(region,link) progress sems for fused NP+Conv3d overlap: 4 face regions
-        # {H-top, H-bot, W-left, W-right} × num_links links, indexed [region*num_links + link].
-        # That is exactly 8 on BH-LB (num_links=2); up to 16 at num_links=4 (4x8). Single bank, no host
-        # reset: the consuming kernels self-reset their own copies on-device after their final wait, so
-        # the op is trace-safe and the static addresses are baked once by the factory.
+        # Per-(region,link) progress sems for fused NP+Conv3d overlap: 4 face regions {H-top, H-bot, W-left
         self._np_region_n_sems = 4 * self.num_links
         self.np_region_progress_semaphores = {
             0: [
@@ -448,9 +442,7 @@ class CCLManager:
         h_halo_total = outer_dim_size * 2 * padding * h_sticks
         w_halo_total = outer_dim_size * 2 * padding2 * w_sticks if dim2 is not None else 0
         total_sticks = h_halo_total + w_halo_total
-        # Each "stick" = C channels × 2 bytes (BF16). The compact buffer must have shape
-        # [total_sticks, C] so that each 2D row = C elements = one stick page (= C×2 bytes),
-        # matching the input tensor's aligned_page_size used as stick_size in the NP factory.
+        # Each "stick" = C channels × 2 bytes (BF16)
         C = input_shape[-1]  # channel dimension
 
         cache_key = ("np_halo", tuple(input_shape), dim, padding, dim2, padding2, dtype)

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx.py
@@ -769,6 +769,8 @@ class LTXPipeline:
         latent_spatial = latent_spatial.permute(0, 4, 1, 2, 3)  # BCTHW
 
         video = self.vae_decoder(latent_spatial, output_type=output_type)
+        if output_type == "yuv":
+            return video  # already a numpy (T, H*3//2, W) uint8 yuv420p planar array
         if output_type != "float":
             return video.numpy()
         return video

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx_distilled.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx_distilled.py
@@ -21,7 +21,7 @@ from ...models.vae.vae_ltx import upsample_latent
 from ...utils.ltx import load_conditioning_image
 from ...utils.patchifiers import AudioLatentShape, VideoPixelShape
 from ...utils.tensor import bf16_tensor
-from ...utils.video import export_video_audio
+from ...utils.video import export_video_audio, export_video_audio_yuv
 from .pipeline_ltx import SPATIAL_COMPRESSION, TEMPORAL_COMPRESSION, LTXPipeline, LTXTransformerState, latent_grid
 
 # Distilled sigma schedules for the two stages.
@@ -185,6 +185,11 @@ class LTXDistilledPipeline(LTXPipeline):
 
             # Compile VAE decode at full-res (only s2 feeds decode in generate).
             self._warmup_decode(num_frames, height, width)
+
+            # Programs are now compiled; let the first real decode capture a ttnn trace of
+            # decode_device and later decodes replay it (removes host-dispatch overhead).
+            if self._traced and self.vae_decoder is not None:
+                self.vae_decoder._vae_traced = True
 
             # Warm the on-device audio decode eagerly at the real latent shape: compiles kernels,
             # initializes lazy device state, and frees back to a deterministic allocator free-list,
@@ -696,8 +701,12 @@ class LTXDistilledPipeline(LTXPipeline):
             logger.info(f"VAE prepare: {time.time() - t0:.1f}s")
 
         latent_h, latent_w = height // SPATIAL_COMPRESSION, width // SPATIAL_COMPRESSION
+        # LTX_YUV_EXPORT routes the mp4 path through the on-device YUV 4:2:0 fast gather
+        # (the mp4 is yuv420p either way — this only moves the color conversion onto the device
+        # and shrinks the d2h ~8x). Off → the float RGB gather feeding host-side conversion.
+        yuv_export = output_path is not None and os.environ.get("LTX_YUV_EXPORT", "0") != "0"
         # export_video_audio needs float [-1,1]; the frame-return path uses the requested output_type.
-        decode_type = "float" if output_path is not None else output_type
+        decode_type = ("yuv" if yuv_export else "float") if output_path is not None else output_type
         t0 = time.time()
         video_pixels = self.decode_latents(s2_video, latent_frames, latent_h, latent_w, output_type=decode_type)
         t_vae_decode = time.time() - t0
@@ -716,7 +725,10 @@ class LTXDistilledPipeline(LTXPipeline):
             return video_pixels, audio_obj
 
         t0 = time.time()
-        export_video_audio(video_pixels, output_path, fps=fps, audio=audio_obj)
+        if yuv_export:
+            export_video_audio_yuv(video_pixels, output_path, fps=fps, audio=audio_obj)
+        else:
+            export_video_audio(video_pixels, output_path, fps=fps, audio=audio_obj)
         logger.info(f"Video export: {time.time() - t0:.1f}s")
         logger.info(f"Total (compute): {sum(s for _, s in timings):.1f}s | Output: {output_path}")
         return output_path

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx_distilled.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx_distilled.py
@@ -186,8 +186,7 @@ class LTXDistilledPipeline(LTXPipeline):
             # Compile VAE decode at full-res (only s2 feeds decode in generate).
             self._warmup_decode(num_frames, height, width)
 
-            # Programs are now compiled; let the first real decode capture a ttnn trace of
-            # decode_device and later decodes replay it (removes host-dispatch overhead).
+            # Programs are now compiled
             if self._traced and self.vae_decoder is not None:
                 self.vae_decoder._vae_traced = True
 
@@ -702,8 +701,6 @@ class LTXDistilledPipeline(LTXPipeline):
 
         latent_h, latent_w = height // SPATIAL_COMPRESSION, width // SPATIAL_COMPRESSION
         # LTX_YUV_EXPORT routes the mp4 path through the on-device YUV 4:2:0 fast gather
-        # (the mp4 is yuv420p either way — this only moves the color conversion onto the device
-        # and shrinks the d2h ~8x). Off → the float RGB gather feeding host-side conversion.
         yuv_export = output_path is not None and os.environ.get("LTX_YUV_EXPORT", "0") != "0"
         # export_video_audio needs float [-1,1]; the frame-return path uses the requested output_type.
         decode_type = ("yuv" if yuv_export else "float") if output_path is not None else output_type

--- a/models/tt_dit/tests/models/ltx/ltx_mesh_params.py
+++ b/models/tt_dit/tests/models/ltx/ltx_mesh_params.py
@@ -94,6 +94,9 @@ LTX_ONE_STAGE_MESH_PARAMS_DL = [
     for p in LTX_PIPELINE_MESH_PARAMS_DL
 ]
 
+# Two-stages (Pro) drives the same audio vocoder, so it needs the same pool for the same reason.
+LTX_TWO_STAGES_MESH_PARAMS_DL = LTX_ONE_STAGE_MESH_PARAMS_DL
+
 
 # ---------------------------------------------------------------------------
 # Distilled AV pipeline mesh params. Same geometry as the pipeline configs, but the audio

--- a/models/tt_dit/tests/models/ltx/ltx_mesh_params.py
+++ b/models/tt_dit/tests/models/ltx/ltx_mesh_params.py
@@ -7,7 +7,11 @@ import os
 import pytest
 
 import ttnn
-from models.tt_dit.utils.test import line_params_req_exact_devices, ring_params_req_exact_devices
+from models.tt_dit.utils.test import (
+    line_params_req_exact_devices,
+    ring_params_8k_req_exact_devices,
+    ring_params_req_exact_devices,
+)
 
 _line = line_params_req_exact_devices
 _ring = ring_params_req_exact_devices
@@ -111,7 +115,10 @@ LTX_ONE_STAGE_MESH_PARAMS_DL = [
 _line_l1small = {**_line, "l1_small_size": 32768}
 _ring_worker_l1 = {"worker_l1_size": 1344544, **_ring}
 _line_trace = {**_line, "trace_region_size": 500_000_000, "l1_small_size": 32768}
-_ring_trace = {**_ring, "trace_region_size": 500_000_000, "l1_small_size": 32768}
+#   fabric_router_config (8 KB payload): the strided all-gather packs up to 4 bf16 tiles per
+#     fabric packet (scatter-write, 4 distinct dest NoC addresses). That cap degrades to
+#     whatever the payload holds, so a smaller packet silently halves it to 2 tiles.
+_ring_trace = {**ring_params_8k_req_exact_devices, "trace_region_size": 500_000_000, "l1_small_size": 32768}
 
 LTX_DISTILLED_MESH_PARAMS_DL = [
     _with_dynamic_load(_2x2sp0tp1nl2_line_is_fsdp1, False),

--- a/models/tt_dit/tests/models/ltx/ltx_mesh_params.py
+++ b/models/tt_dit/tests/models/ltx/ltx_mesh_params.py
@@ -118,9 +118,7 @@ LTX_TWO_STAGES_MESH_PARAMS_DL = LTX_ONE_STAGE_MESH_PARAMS_DL
 _line_l1small = {**_line, "l1_small_size": 32768}
 _ring_worker_l1 = {"worker_l1_size": 1344544, **_ring}
 _line_trace = {**_line, "trace_region_size": 500_000_000, "l1_small_size": 32768}
-#   fabric_router_config (8 KB payload): the strided all-gather packs up to 4 bf16 tiles per
-#     fabric packet (scatter-write, 4 distinct dest NoC addresses). That cap degrades to
-#     whatever the payload holds, so a smaller packet silently halves it to 2 tiles.
+# fabric_router_config (8 KB payload): the strided all-gather packs up to 4 bf16 tiles per fabric packet
 _ring_trace = {**ring_params_8k_req_exact_devices, "trace_region_size": 500_000_000, "l1_small_size": 32768}
 
 LTX_DISTILLED_MESH_PARAMS_DL = [

--- a/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
+++ b/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
@@ -56,11 +56,11 @@ def _ltx_checkpoint_cached(filename: str) -> bool:
         except (LocalEntryNotFoundError, EntryNotFoundError, FileNotFoundError):
             return False
     return False
+from models.tt_dit.utils.vbench import assert_vbench_quality
 
 
-# Default-off: full AV gen needs the real LTX checkpoint + Gemma, so it skips in the default suite
-# (no checkpoint present). Runs the same prompt as the girl audio fixture (DEFAULT_LTX_PROMPT — the
-# "young woman with a guitar sings Doo-be-doo" clip the audio tests use), so e2e and audio stay aligned.
+
+# Default-off: full AV gen needs the real LTX checkpoint + Gemma, so it skips without one.
 @pytest.mark.skipif(
     not _ltx_checkpoint_cached("ltx-2.3-22b-distilled-1.1.safetensors"),
     reason="needs the LTX checkpoint (set LTX_CHECKPOINT to a local .safetensors)",

--- a/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
+++ b/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
@@ -56,8 +56,9 @@ def _ltx_checkpoint_cached(filename: str) -> bool:
         except (LocalEntryNotFoundError, EntryNotFoundError, FileNotFoundError):
             return False
     return False
-from models.tt_dit.utils.vbench import assert_vbench_quality
 
+
+from models.tt_dit.utils.vbench import assert_vbench_quality
 
 
 # Default-off: full AV gen needs the real LTX checkpoint + Gemma, so it skips without one.

--- a/models/tt_dit/tests/models/ltx/test_pipeline_ltx_two_stages.py
+++ b/models/tt_dit/tests/models/ltx/test_pipeline_ltx_two_stages.py
@@ -18,7 +18,7 @@ from models.tt_dit.utils.ltx import (
 )
 from models.tt_dit.utils.test import skip_if_unsupported_num_links
 
-from .ltx_mesh_params import LTX_PIPELINE_MESH_PARAMS_DL, LTX_TWO_STAGES_I2V_MESH_PARAMS_DL
+from .ltx_mesh_params import LTX_TWO_STAGES_I2V_MESH_PARAMS_DL, LTX_TWO_STAGES_MESH_PARAMS_DL
 
 
 def _default_distilled_lora() -> str:
@@ -43,7 +43,7 @@ def _default_distilled_lora() -> str:
 )
 @pytest.mark.parametrize(
     "mesh_device, sp_axis, tp_axis, num_links, device_params, topology, is_fsdp, dynamic_load",
-    LTX_PIPELINE_MESH_PARAMS_DL,
+    LTX_TWO_STAGES_MESH_PARAMS_DL,
     indirect=["mesh_device", "device_params"],
 )
 def test_pipeline_two_stages(

--- a/models/tt_dit/tests/models/ltx/test_transformer_ltx.py
+++ b/models/tt_dit/tests/models/ltx/test_transformer_ltx.py
@@ -33,7 +33,13 @@ from models.tt_dit.utils.check import assert_quality
 from models.tt_dit.utils.mochi import get_rot_transformation_mat
 from models.tt_dit.utils.patchifiers import AudioLatentShape, VideoPixelShape
 from models.tt_dit.utils.tensor import bf16_tensor, bf16_tensor_2dshard
-from models.tt_dit.utils.test import line_params_req_exact_devices, skip_if_unsupported_num_links
+from models.tt_dit.utils.test import (
+    line_params_req_exact_devices,
+    ring_params_4k,
+    ring_params_8k,
+    skip_if_unsupported_num_links,
+)
+from models.tt_dit.utils.tracing import Tracer
 
 from .ltx_mesh_params import LTX_TRANSFORMER_MESH_PARAMS
 
@@ -1383,3 +1389,624 @@ def test_ltx_per_token_timestep_nonuniform(
     logger.info(f"non-uniform per-token (TT vs oracle): all={pcc_all:.5f} frame0={pcc_f0:.5f} rest={pcc_rest:.5f}")
 
     assert_quality(ref_video, out_tt, pcc=0.99, relative_rmse=0.03)
+
+
+# ---------------------------------------------------------------------------
+# Trace-based perf: VIDEO stage-2 ring only (measures StridedAllGatherMinimalMatmulAsync
+# and block wall-clock at steady state under a ttnn trace). Perf-only: no PCC.
+# ---------------------------------------------------------------------------
+def _build_video_trace_setup(
+    *,
+    mesh_device,
+    sp_axis,
+    tp_axis,
+    num_links,
+    topology,
+    is_fsdp,
+    F,
+    H,
+    W,
+    has_audio=False,
+    checkpoint_variant="fast",
+    num_layers=1,
+):
+    """Build the TT model + device-only ``inner_step`` kwargs for the trace-perf test.
+
+    Mirrors the TT setup in ``_run_inner_step`` and reproduces ``LTXTransformerModel.forward``'s
+    host→device upload preamble (which ``inner_step`` normally receives), so the returned ttnn
+    kwargs can be captured/replayed directly under ttnn trace. Returns
+    ``(tt_model, inner_kwargs, video_N_real)``. Perf-only; no PCC.
+
+    Video mode uses random scaled weights. AV mode (``has_audio=True``) loads the 22B checkpoint
+    (``strict=False``) like the AV PCC path and adds the audio device tensors (audio latent,
+    audio/cross-modal rope, video pad mask) so a2v / audio shapes actually fire under the trace.
+    """
+    sp_factor = tuple(mesh_device.shape)[sp_axis]
+    video_N_real = F * H * W
+    video_N = _sp_pad_len(video_N_real, sp_factor)
+    assert video_N % (32 * sp_factor) == 0
+    audio_N = AUDIO_N
+    if has_audio:
+        assert audio_N % (32 * sp_factor) == 0
+
+    if has_audio:
+        # AV weights come from the 22B checkpoint (strict=False), same as the AV PCC path.
+        checkpoint_22b = _resolve_checkpoint_22b(checkpoint_variant)
+        state_dict = _load_22b_state_dict(num_layers=num_layers, checkpoint_path=checkpoint_22b)
+        if state_dict is None:
+            pytest.skip(f"22B checkpoint not found at {checkpoint_22b}")
+    else:
+        # Random scaled weights from the diffusers 3D video model — the video PCC path.
+        torch_model = _make_diffusers_video_model(num_layers=num_layers)
+        torch_model.eval()
+        _scale_init_(torch_model)
+        state_dict = _convert_diffusers_video_model_to_tt(
+            torch_model.state_dict(), num_heads=NUM_HEADS, head_dim=HEAD_DIM
+        )
+        state_dict = {k: v.detach().clone() for k, v in state_dict.items()}
+        del torch_model
+
+    # Real-grid latent; the TT side gets a zero-padded copy (video_N).
+    torch.manual_seed(INPUT_SEED)
+    video_lat_real = torch.randn(1, video_N_real, IN_CHANNELS, dtype=torch.float32)
+    video_lat = _pad_seq_dim(video_lat_real, video_N, dim=1)
+    video_prompt = torch.randn(1, PROMPT_LEN, CTX_DIM, dtype=torch.float32)
+    sigma_val = 0.5 if has_audio else TIMESTEP_VAL  # AV path uses production sigma=0.5
+    timestep_torch = torch.tensor([sigma_val])
+
+    audio_lat = None
+    audio_prompt = None
+    if has_audio:
+        audio_lat = torch.randn(1, audio_N, AUDIO_IN_CHANNELS, dtype=torch.float32)
+        audio_prompt = torch.randn(1, PROMPT_LEN, AUDIO_CTX_DIM, dtype=torch.float32)
+
+    ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
+    parallel_config = _make_parallel_config(mesh_device, sp_axis, tp_axis)
+    tt_model = _make_tt_model(
+        mesh_device=mesh_device,
+        ccl_manager=ccl_manager,
+        parallel_config=parallel_config,
+        is_fsdp=is_fsdp,
+        has_audio=has_audio,
+        num_layers=num_layers,
+    )
+    t0 = time.time()
+    tt_model.load_torch_state_dict(state_dict, strict=not has_audio)
+    logger.info(f"state-dict load: {time.time() - t0:.1f}s")
+
+    # Stage-constant device tensors (INTERLEAVED rope + trans_mat + prompt).
+    tt_video_prompt = bf16_tensor(video_prompt.unsqueeze(0), device=mesh_device)
+    tt_vc, tt_vs = _tt_rope(
+        _video_rope_freqs, F, H, W, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, pad_to=video_N
+    )
+    tt_trans_mat = bf16_tensor(get_rot_transformation_mat(), device=mesh_device)
+
+    # Per-step device inputs — reproduce LTXTransformerModel.forward's upload for the video path.
+    video_1BNI_torch = video_lat.unsqueeze(0)  # (1, B=1, video_N, IN_CHANNELS)
+    B_size = video_1BNI_torch.shape[1]
+    video_1BNI = bf16_tensor(video_1BNI_torch, device=mesh_device, mesh_axis=sp_axis, shard_dim=-2)
+    timestep = bf16_tensor(timestep_torch.reshape(1, 1, B_size, 1) * 1000.0, device=mesh_device)
+
+    # inner_step is keyword-only; these are exactly the device tensors it consumes.
+    inner_kwargs = dict(
+        video_1BNI=video_1BNI,
+        timestep=timestep,
+        video_prompt_1BLP=tt_video_prompt,
+        video_rope_cos=tt_vc,
+        video_rope_sin=tt_vs,
+        video_N=video_N_real,
+        trans_mat=tt_trans_mat,
+    )
+
+    if has_audio:
+        # Audio + cross-modal device tensors, mirroring the AV branch of _run_inner_step.
+        a_cos, a_sin = _tt_rope(_audio_rope_freqs, audio_N, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis)
+        vx_cos, vx_sin = _tt_rope(
+            _video_cross_pe_freqs, F, H, W, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, pad_to=video_N
+        )
+        ax_cos, ax_sin = _tt_rope(
+            _audio_cross_pe_freqs, audio_N, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis
+        )
+        ax_cos_full, ax_sin_full = _tt_rope_full(
+            _audio_cross_pe_freqs, audio_N, mesh_device=mesh_device, tp_axis=tp_axis
+        )
+        v_pad_sp = build_video_pad_mask(video_N, video_N_real, mesh_device=mesh_device, sp_axis=sp_axis)
+        audio_1BNI = bf16_tensor(audio_lat.unsqueeze(0), device=mesh_device, mesh_axis=sp_axis, shard_dim=-2)
+        inner_kwargs.update(
+            audio_1BNI=audio_1BNI,
+            audio_prompt_1BLP=bf16_tensor(audio_prompt.unsqueeze(0), device=mesh_device),
+            audio_rope_cos=a_cos,
+            audio_rope_sin=a_sin,
+            audio_N=audio_N,
+            video_cross_pe_cos=vx_cos,
+            video_cross_pe_sin=vx_sin,
+            audio_cross_pe_cos=ax_cos,
+            audio_cross_pe_sin=ax_sin,
+            audio_cross_pe_cos_full=ax_cos_full,
+            audio_cross_pe_sin_full=ax_sin_full,
+            video_padding_mask=v_pad_sp,
+        )
+    return tt_model, inner_kwargs, video_N_real
+
+
+def _build_trace_inner_kwargs(*, mesh_device, sp_axis, tp_axis, F, H, W, has_audio):
+    """Build ONLY the device inner_step kwargs for a given (F,H,W) — no model / CCLManager.
+
+    Split out so ONE model + CCLManager can be driven at multiple shapes (e.g. stage-1 then
+    stage-2) to reproduce the e2e's cross-stage device/semaphore-pool state. Mirrors the per-shape
+    tensor setup inside _build_video_trace_setup. Returns (inner_kwargs, video_N_real).
+    """
+    sp_factor = tuple(mesh_device.shape)[sp_axis]
+    video_N_real = F * H * W
+    video_N = _sp_pad_len(video_N_real, sp_factor)
+    assert video_N % (32 * sp_factor) == 0
+    audio_N = AUDIO_N
+    if has_audio:
+        assert audio_N % (32 * sp_factor) == 0
+
+    torch.manual_seed(INPUT_SEED)
+    video_lat_real = torch.randn(1, video_N_real, IN_CHANNELS, dtype=torch.float32)
+    video_lat = _pad_seq_dim(video_lat_real, video_N, dim=1)
+    video_prompt = torch.randn(1, PROMPT_LEN, CTX_DIM, dtype=torch.float32)
+    sigma_val = 0.5 if has_audio else TIMESTEP_VAL
+    timestep_torch = torch.tensor([sigma_val])
+
+    audio_lat = None
+    audio_prompt = None
+    if has_audio:
+        audio_lat = torch.randn(1, audio_N, AUDIO_IN_CHANNELS, dtype=torch.float32)
+        audio_prompt = torch.randn(1, PROMPT_LEN, AUDIO_CTX_DIM, dtype=torch.float32)
+
+    tt_video_prompt = bf16_tensor(video_prompt.unsqueeze(0), device=mesh_device)
+    tt_vc, tt_vs = _tt_rope(
+        _video_rope_freqs, F, H, W, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, pad_to=video_N
+    )
+    tt_trans_mat = bf16_tensor(get_rot_transformation_mat(), device=mesh_device)
+
+    video_1BNI_torch = video_lat.unsqueeze(0)
+    B_size = video_1BNI_torch.shape[1]
+    video_1BNI = bf16_tensor(video_1BNI_torch, device=mesh_device, mesh_axis=sp_axis, shard_dim=-2)
+    timestep = bf16_tensor(timestep_torch.reshape(1, 1, B_size, 1) * 1000.0, device=mesh_device)
+
+    inner_kwargs = dict(
+        video_1BNI=video_1BNI,
+        timestep=timestep,
+        video_prompt_1BLP=tt_video_prompt,
+        video_rope_cos=tt_vc,
+        video_rope_sin=tt_vs,
+        video_N=video_N_real,
+        trans_mat=tt_trans_mat,
+    )
+    if has_audio:
+        a_cos, a_sin = _tt_rope(_audio_rope_freqs, audio_N, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis)
+        vx_cos, vx_sin = _tt_rope(
+            _video_cross_pe_freqs, F, H, W, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, pad_to=video_N
+        )
+        ax_cos, ax_sin = _tt_rope(
+            _audio_cross_pe_freqs, audio_N, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis
+        )
+        ax_cos_full, ax_sin_full = _tt_rope_full(
+            _audio_cross_pe_freqs, audio_N, mesh_device=mesh_device, tp_axis=tp_axis
+        )
+        v_pad_sp = build_video_pad_mask(video_N, video_N_real, mesh_device=mesh_device, sp_axis=sp_axis)
+        audio_1BNI = bf16_tensor(audio_lat.unsqueeze(0), device=mesh_device, mesh_axis=sp_axis, shard_dim=-2)
+        inner_kwargs.update(
+            audio_1BNI=audio_1BNI,
+            audio_prompt_1BLP=bf16_tensor(audio_prompt.unsqueeze(0), device=mesh_device),
+            audio_rope_cos=a_cos,
+            audio_rope_sin=a_sin,
+            audio_N=audio_N,
+            video_cross_pe_cos=vx_cos,
+            video_cross_pe_sin=vx_sin,
+            audio_cross_pe_cos=ax_cos,
+            audio_cross_pe_sin=ax_sin,
+            audio_cross_pe_cos_full=ax_cos_full,
+            audio_cross_pe_sin_full=ax_sin_full,
+            video_padding_mask=v_pad_sp,
+        )
+    return inner_kwargs, video_N_real
+
+
+@pytest.mark.parametrize(
+    ("mesh_device", "sp_axis", "tp_axis", "num_links", "device_params", "topology", "is_fsdp"),
+    [
+        pytest.param((4, 8), 1, 0, 2, ring_params_4k, ttnn.Topology.Ring, False, id="ring_bh_4x8sp1tp0_4k"),
+        # 8k fabric payload variant (where stage-2 wedges at depth).
+        pytest.param((4, 8), 1, 0, 2, ring_params_8k, ttnn.Topology.Ring, False, id="ring_bh_4x8sp1tp0_8k"),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("has_audio", [pytest.param(False, id="video"), pytest.param(True, id="av")])
+@pytest.mark.parametrize("checkpoint_variant", [pytest.param("fast", id="ckpt_fast")])
+def test_ltx_transformer_crossstage_hang(
+    mesh_device,
+    sp_axis,
+    tp_axis,
+    num_links,
+    topology,
+    is_fsdp,
+    has_audio,
+    checkpoint_variant,
+    reset_seeds,
+) -> None:
+    """FAST cross-stage repro of the e2e stage-2 deadlock: drive ONE model+CCLManager through
+    stage-1 then stage-2 (eager, no VAE/Gemma), so stage-2 reuses the shared strided-AGMM pool
+    that stage-1 left mid-rotation. PASSES -> not cross-stage; HANGS -> confirmed.
+    """
+    # Stage-2 shape; full depth (env-overridable) to stack many back-to-back strided ops per forward.
+    tt_model, kwargs_s2, vN2 = _build_video_trace_setup(
+        mesh_device=mesh_device,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+        topology=topology,
+        is_fsdp=is_fsdp,
+        F=19,
+        H=34,
+        W=60,
+        has_audio=has_audio,
+        checkpoint_variant=checkpoint_variant,
+        num_layers=int(os.environ.get("CROSSSTAGE_NUM_LAYERS", "48")),
+    )
+    # Stage-1 shape (half spatial res, like the e2e's height//2,width//2) on the SAME model.
+    kwargs_s1, vN1 = _build_trace_inner_kwargs(
+        mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, F=19, H=17, W=30, has_audio=has_audio
+    )
+    logger.info(f"cross-stage: stage-1 vN={vN1} then stage-2 vN={vN2} (shared CCLManager)")
+
+    # CROSSSTAGE_SKIP_S1=1 -> run only stage-2, isolating the stage transition from full-depth big-M.
+    skip_s1 = os.environ.get("CROSSSTAGE_SKIP_S1", "0") != "0"
+    if not skip_s1:
+        # Stage 1 first (eager) — populate/rotate the shared strided-AGMM semaphore pool at stage-1 M.
+        for i in range(3):
+            _ = tt_model.inner_step(**kwargs_s1)
+            ttnn.synchronize_device(mesh_device)
+            logger.info(f"stage-1 forward {i} done")
+        logger.info("stage-1 complete; entering STAGE-2 (the e2e hang point) ...")
+    else:
+        logger.info("SKIP_S1: entering STAGE-2 directly (48 layers, no stage-1) ...")
+
+    # Stage 2 (eager) — reuses the same pool. This is where the e2e deadlocks.
+    for i in range(3):
+        _ = tt_model.inner_step(**kwargs_s2)
+        ttnn.synchronize_device(mesh_device)
+        logger.info(f"stage-2 forward {i} done")
+
+    logger.info("PASSED cross-stage: stage-1 -> stage-2 completed without deadlock")
+    del tt_model
+
+
+@pytest.mark.parametrize(
+    ("mesh_device", "sp_axis", "tp_axis", "num_links", "device_params", "topology", "is_fsdp"),
+    # VIDEO stage-2 ring config only (8k fabric payload); do NOT add AV/other-mesh params here.
+    [pytest.param((4, 8), 1, 0, 2, ring_params_8k, ttnn.Topology.Ring, False, id="ring_bh_4x8sp1tp0_8k")],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(("F", "H", "W"), [pytest.param(19, 34, 60, id="stage_2")])
+@pytest.mark.parametrize("has_audio", [pytest.param(False, id="video"), pytest.param(True, id="av")])
+@pytest.mark.parametrize("checkpoint_variant", [pytest.param("fast", id="ckpt_fast")])
+def test_ltx_transformer_trace_perf(
+    mesh_device,
+    sp_axis,
+    tp_axis,
+    num_links,
+    topology,
+    is_fsdp,
+    F,
+    H,
+    W,
+    has_audio,
+    checkpoint_variant,
+    reset_seeds,
+) -> None:
+    """Trace-based perf for LTXTransformerModel.inner_step (VIDEO stage-2 ring).
+
+    Measures StridedAllGatherMinimalMatmulAsync device time and block wall-clock at steady state
+    under a ttnn trace (gap-free replay), which the eager op-by-op path can't expose. Perf-only:
+    asserts shape/finiteness, no PCC. inner_step is @traced_function(prep_run=False), so kernels
+    are precompiled with a couple of eager warm calls before trace capture.
+    """
+    tt_model, inner_kwargs, video_N_real = _build_video_trace_setup(
+        mesh_device=mesh_device,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+        topology=topology,
+        is_fsdp=is_fsdp,
+        F=F,
+        H=H,
+        W=W,
+        has_audio=has_audio,
+        checkpoint_variant=checkpoint_variant,
+    )
+
+    # AV emits far more markers than video; keep warm/replay counts low (overridable via env) so the
+    # per-core profiler buffer doesn't overflow before the post-capture drain below.
+    n_warm = int(os.environ.get("LTX_PERF_N_WARM", "1" if has_audio else "2"))
+    n_replay = int(os.environ.get("LTX_PERF_N_REPLAY", "3" if has_audio else "5"))
+
+    # Warm / compile: eager (untraced) calls precompile kernels (prep_run=False on inner_step).
+    t0 = time.time()
+    for _ in range(n_warm):
+        _ = tt_model.inner_step(**inner_kwargs)
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"eager warm/compile ({n_warm}x): {time.time() - t0:.1f}s")
+
+    # Capture: first traced call captures the trace (and executes it once).
+    t0 = time.time()
+    _ = tt_model.inner_step(**inner_kwargs, traced=True)
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"trace capture: {time.time() - t0:.1f}s")
+
+    # Drain warm+capture markers so only the signposted replays occupy the profiler buffer.
+    ttnn.ReadDeviceProfiler(mesh_device)
+
+    # Steady-state replay under the signpost bracket for tt-perf-report --start/end-signpost.
+    signpost("start")
+    t0 = time.time()
+    result = None
+    for _ in range(n_replay):
+        result = tt_model.inner_step(**inner_kwargs, traced=True)
+    ttnn.synchronize_device(mesh_device)
+    replay_s = time.time() - t0
+    signpost("stop")
+    logger.info(f"trace replay ({n_replay}x): {replay_s:.3f}s → {replay_s / n_replay * 1e3:.2f} ms/step")
+
+    # Perf-only: crop SP-padding tail, assert shape + finiteness (no PCC).
+    # AV mode returns (video, audio); video-only returns a single tensor.
+    video_out = result[0] if isinstance(result, tuple) else result
+    tt_video = LTXTransformerModel.device_to_host(video_out).squeeze(0)[:, :video_N_real, :]
+    assert tt_video.shape == (1, video_N_real, OUT_CHANNELS), f"video shape {tt_video.shape}"
+    assert torch.isfinite(tt_video).all(), "NaN/Inf in traced video output"
+    logger.info(f"PASSED trace-perf: video {tuple(tt_video.shape)} has_audio={has_audio}")
+
+    del tt_model
+
+
+# Trace-based perf for a SINGLE transformer block (isolates one block's program order).
+def _build_block_trace_setup(
+    *, mesh_device, sp_axis, tp_axis, num_links, topology, is_fsdp, F, H, W, has_audio, checkpoint_variant="fast"
+):
+    """Build an ``LTXTransformerBlock`` + device ``forward`` kwargs for the block trace-perf test.
+
+    Mirrors the non-PCC setup of ``test_ltx_transformer_block``: AV loads the 22B checkpoint
+    (``strict=False``) and builds the full video+audio+cross-modal device tensors; video harvests
+    random scaled weights from a throwaway diffusers block. Returns
+    ``(tt_block, forward_kwargs, video_N_real, audio_N_real)``. Perf-only; no PCC.
+    """
+    checkpoint_22b = _resolve_checkpoint_22b(checkpoint_variant)
+    sp_factor = tuple(mesh_device.shape)[sp_axis]
+    # Real latent grid → SP-padded sequence (mirrors LTXPipeline). video_N is the padded device
+    # length; video_N_real is the logical token count fed to SDPA's logical_n / padding masks.
+    video_N_real = F * H * W
+    video_N = _sp_pad_len(video_N_real, sp_factor)
+    audio_N, audio_N_real = _audio_seq_lens(F, sp_factor)
+    assert video_N % (32 * sp_factor) == 0, f"video_N={video_N} not sp/tile-aligned for sp={sp_factor}"
+    assert audio_N % (32 * sp_factor) == 0, f"audio_N={audio_N} not sp/tile-aligned for sp={sp_factor}"
+
+    ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
+    parallel_config = _make_parallel_config(mesh_device, sp_axis, tp_axis)
+    tt_block = _make_tt_block(
+        mesh_device=mesh_device,
+        ccl_manager=ccl_manager,
+        parallel_config=parallel_config,
+        is_fsdp=is_fsdp,
+        has_audio=has_audio,
+    )
+
+    if has_audio:
+        sd = _load_22b_state_dict(num_layers=1, checkpoint_path=checkpoint_22b)
+        if sd is None:
+            pytest.skip(f"22B checkpoint not found at {checkpoint_22b}")
+        block_sd = {
+            k[len("transformer_blocks.0.") :]: v for k, v in sd.items() if k.startswith("transformer_blocks.0.")
+        }
+        tt_block.load_torch_state_dict(block_sd, strict=False)
+    else:
+        # video mode — harvest a shape-matching state dict from a throwaway block (perf-only).
+        dummy = _make_diffusers_video_block()
+        _scale_init_(dummy)
+        conv = _convert_diffusers_video_block_to_tt(dummy.state_dict(), num_heads=NUM_HEADS, head_dim=HEAD_DIM)
+        tt_block.load_torch_state_dict({k: v.detach().clone() for k, v in conv.items()})
+        del dummy
+
+    # Inputs (real-grid token count; the TT side gets a zero-padded copy below).
+    torch.manual_seed(INPUT_SEED)
+    x = torch.randn(1, video_N_real, DIM, dtype=torch.float32)
+    context = torch.randn(1, PROMPT_LEN, CTX_DIM, dtype=torch.float32)
+    temb = torch.randn(1, 1, 9 * DIM, dtype=torch.float32)  # 9 adaln params
+    prompt_temb = torch.randn(1, 1, 2 * DIM, dtype=torch.float32)  # 2 adaln params for prompt
+
+    # TT video tensors. Sequence SP-padded to video_N; rope pads with identity rotation; video_N_real
+    # (logical) goes to the block for SDPA masking.
+    spatial = _pad_seq_dim(x, video_N, dim=1).unsqueeze(0)
+    tt_spatial = bf16_tensor_2dshard(spatial, device=mesh_device, shard_mapping={sp_axis: 2, tp_axis: 3})
+    tt_prompt = bf16_tensor(context.unsqueeze(0), device=mesh_device)
+    tt_temb = bf16_tensor(
+        temb.reshape(9, DIM).unsqueeze(1).unsqueeze(1), device=mesh_device, mesh_axis=tp_axis, shard_dim=3
+    )
+    tt_prompt_temb = bf16_tensor(prompt_temb.reshape(2, DIM).unsqueeze(1).unsqueeze(1), device=mesh_device)
+    tt_cos, tt_sin = _tt_rope(
+        _video_rope_freqs, F, H, W, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, pad_to=video_N
+    )
+    tt_trans_mat = bf16_tensor(get_rot_transformation_mat(), device=mesh_device)
+
+    forward_kwargs = dict(
+        video_1BND=tt_spatial,
+        video_prompt=tt_prompt,
+        video_temb=tt_temb,
+        video_N=video_N_real,
+        video_rope_cos=tt_cos,
+        video_rope_sin=tt_sin,
+        trans_mat=tt_trans_mat,
+        video_prompt_temb=tt_prompt_temb,
+    )
+    if has_audio:
+        # Real tokens in [:audio_N_real], zeros in the padded tail (matches the padded audio latent).
+        a_x = torch.zeros(1, audio_N, AUDIO_DIM, dtype=torch.float32)
+        a_x[:, :audio_N_real, :] = torch.randn(1, audio_N_real, AUDIO_DIM, dtype=torch.float32)
+        a_ctx = torch.randn(1, PROMPT_LEN, AUDIO_CTX_DIM, dtype=torch.float32)
+        a_temb = torch.randn(1, 1, 9 * AUDIO_DIM, dtype=torch.float32)
+        a_prompt_temb = torch.randn(1, 1, 2 * AUDIO_DIM, dtype=torch.float32)
+        av_ca_v = torch.randn(1, 1, 5 * DIM, dtype=torch.float32)  # 4 scale-shift + 1 gate
+        av_ca_a = torch.randn(1, 1, 5 * AUDIO_DIM, dtype=torch.float32)
+
+        a_cos, a_sin = _tt_rope(_audio_rope_freqs, audio_N, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis)
+        vx_cos, vx_sin = _tt_rope(
+            _video_cross_pe_freqs, F, H, W, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, pad_to=video_N
+        )
+        ax_cos, ax_sin = _tt_rope(
+            _audio_cross_pe_freqs, audio_N, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis
+        )
+        ax_cos_full, ax_sin_full = _tt_rope_full(
+            _audio_cross_pe_freqs, audio_N, mesh_device=mesh_device, tp_axis=tp_axis
+        )
+
+        # Padding masks, same construction as the fast pipeline (audio padded, video aligned).
+        a_attn_mask, a_pad_sp, a_pad_full = build_audio_masks(
+            audio_N, audio_N_real, mesh_device=mesh_device, sp_axis=sp_axis
+        )
+        v_pad_sp = build_video_pad_mask(video_N, video_N_real, mesh_device=mesh_device, sp_axis=sp_axis)
+
+        forward_kwargs.update(
+            audio_1BND=bf16_tensor_2dshard(
+                a_x.unsqueeze(0), device=mesh_device, shard_mapping={sp_axis: 2, tp_axis: 3}
+            ),
+            audio_prompt=bf16_tensor(a_ctx.unsqueeze(0), device=mesh_device),
+            audio_temb=bf16_tensor(
+                a_temb.reshape(9, AUDIO_DIM).unsqueeze(1).unsqueeze(1),
+                device=mesh_device,
+                mesh_axis=tp_axis,
+                shard_dim=3,
+            ),
+            audio_prompt_temb=bf16_tensor(
+                a_prompt_temb.reshape(2, AUDIO_DIM).unsqueeze(1).unsqueeze(1), device=mesh_device
+            ),
+            av_ca_temb=bf16_tensor(
+                av_ca_v.reshape(5, DIM).unsqueeze(1).unsqueeze(1), device=mesh_device, mesh_axis=tp_axis, shard_dim=3
+            ),
+            av_ca_audio_temb=bf16_tensor(
+                av_ca_a.reshape(5, AUDIO_DIM).unsqueeze(1).unsqueeze(1),
+                device=mesh_device,
+                mesh_axis=tp_axis,
+                shard_dim=3,
+            ),
+            audio_N=audio_N,
+            audio_rope_cos=a_cos,
+            audio_rope_sin=a_sin,
+            video_cross_pe_cos=vx_cos,
+            video_cross_pe_sin=vx_sin,
+            audio_cross_pe_cos=ax_cos,
+            audio_cross_pe_sin=ax_sin,
+            audio_cross_pe_cos_full=ax_cos_full,
+            audio_cross_pe_sin_full=ax_sin_full,
+            audio_attn_mask=a_attn_mask,
+            audio_padding_mask=a_pad_sp,
+            audio_padding_mask_full=a_pad_full,
+            video_padding_mask=v_pad_sp,
+        )
+    return tt_block, forward_kwargs, video_N_real, audio_N_real
+
+
+@pytest.mark.parametrize(
+    ("mesh_device", "sp_axis", "tp_axis", "num_links", "device_params", "topology", "is_fsdp"),
+    # Same ring stage-2 8k config as test_ltx_transformer_trace_perf (ring_params_8k = FABRIC_1D_RING
+    # + 8192-B fabric router payload). Do NOT add other-mesh params here.
+    [pytest.param((4, 8), 1, 0, 2, ring_params_8k, ttnn.Topology.Ring, False, id="ring_bh_4x8sp1tp0_8k")],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(("F", "H", "W"), [pytest.param(19, 34, 60, id="stage_2")])
+@pytest.mark.parametrize("has_audio", [pytest.param(False, id="video"), pytest.param(True, id="av")])
+@pytest.mark.parametrize("checkpoint_variant", [pytest.param("fast", id="ckpt_fast")])
+def test_ltx_transformer_block_trace_perf(
+    mesh_device,
+    sp_axis,
+    tp_axis,
+    num_links,
+    topology,
+    is_fsdp,
+    F,
+    H,
+    W,
+    has_audio,
+    checkpoint_variant,
+    reset_seeds,
+) -> None:
+    """Trace-based perf for a SINGLE ``LTXTransformerBlock`` forward (AV stage-2 ring).
+
+    Isolates one block's program order — no model-level patch-embed / proj-out / tilize /
+    untilize / mesh-partition ops, and no multi-block scrambling — so tt-perf-report shows a clean
+    one-block, program-ordered view. Captures the block forward under a ttnn trace (via the same
+    ``Tracer`` machinery that backs ``inner_step``'s ``traced=True`` path) and replays it under the
+    same "start"/"stop" signpost bracket used by ``test_ltx_transformer_trace_perf``. Perf-only:
+    asserts shape/finiteness, no PCC.
+    """
+    tt_block, forward_kwargs, video_N_real, _audio_N_real = _build_block_trace_setup(
+        mesh_device=mesh_device,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+        topology=topology,
+        is_fsdp=is_fsdp,
+        F=F,
+        H=H,
+        W=W,
+        has_audio=has_audio,
+        checkpoint_variant=checkpoint_variant,
+    )
+
+    # Trace the block forward with the same Tracer settings inner_step uses (prep_run=False:
+    # kernels are precompiled by the eager warm calls below; clone_prep_inputs=False).
+    tracer = Tracer(tt_block.forward, device=mesh_device, prep_run=False, clone_prep_inputs=False)
+
+    # AV runs many more ops than video (audio self/cross + a2v/v2a + audio ff/RS). The per-core
+    # 12000-marker profiler DRAM buffer is drained only at end-of-run, so warm + capture + replay
+    # markers pile up and overflow. We drain the profiler after capture (below) so only the
+    # signposted replays count against the budget; AV also uses fewer warm/replays for headroom.
+    n_warm = 1 if has_audio else 2
+    n_replay = 3 if has_audio else 5
+
+    # Warm / compile: eager (untraced) calls precompile kernels before trace capture.
+    t0 = time.time()
+    for _ in range(n_warm):
+        _ = tt_block(**forward_kwargs)
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"eager warm/compile ({n_warm}x): {time.time() - t0:.1f}s")
+
+    # Capture: first traced call captures the trace (and executes it once).
+    t0 = time.time()
+    _ = tracer(**forward_kwargs, traced=True)
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"trace capture: {time.time() - t0:.1f}s")
+
+    # Drain warm+capture markers so ONLY the signposted replays occupy the profiler DRAM buffer
+    # (the AV profiler-overflow fix, mirroring test_ltx_transformer_trace_perf).
+    ttnn.ReadDeviceProfiler(mesh_device)
+
+    # Steady-state replay under the signpost bracket for tt-perf-report --start/end-signpost.
+    signpost("start")
+    t0 = time.time()
+    result = None
+    for _ in range(n_replay):
+        result = tracer(**forward_kwargs, traced=True)
+    ttnn.synchronize_device(mesh_device)
+    replay_s = time.time() - t0
+    signpost("stop")
+    logger.info(f"trace replay ({n_replay}x): {replay_s:.3f}s → {replay_s / n_replay * 1e3:.2f} ms/step")
+
+    # Perf-only: crop SP-padding tail, assert shape + finiteness (no PCC).
+    # AV mode returns (video, audio); video-only returns a single tensor.
+    tt_v = result[0] if isinstance(result, tuple) else result
+    concat_dims = [None, None]
+    concat_dims[sp_axis] = 2
+    concat_dims[tp_axis] = 3
+    tt_v_torch = ttnn.to_torch(
+        tt_v,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=concat_dims, mesh_shape=tuple(mesh_device.shape)),
+    ).squeeze(0)[:, :video_N_real, :]
+    assert tt_v_torch.shape == (1, video_N_real, DIM), f"video shape {tt_v_torch.shape}"
+    assert torch.isfinite(tt_v_torch).all(), "NaN/Inf in traced video output"
+    logger.info(f"PASSED block trace-perf: video {tuple(tt_v_torch.shape)} has_audio={has_audio}")
+
+    tracer.release_trace()
+    del tt_block

--- a/models/tt_dit/tests/models/ltx/test_transformer_ltx.py
+++ b/models/tt_dit/tests/models/ltx/test_transformer_ltx.py
@@ -1391,10 +1391,7 @@ def test_ltx_per_token_timestep_nonuniform(
     assert_quality(ref_video, out_tt, pcc=0.99, relative_rmse=0.03)
 
 
-# ---------------------------------------------------------------------------
-# Trace-based perf: VIDEO stage-2 ring only (measures StridedAllGatherMinimalMatmulAsync
-# and block wall-clock at steady state under a ttnn trace). Perf-only: no PCC.
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- Trace-based perf: VIDEO stage-2 ring
 def _build_video_trace_setup(
     *,
     mesh_device,
@@ -1720,8 +1717,7 @@ def test_ltx_transformer_trace_perf(
         checkpoint_variant=checkpoint_variant,
     )
 
-    # AV emits far more markers than video; keep warm/replay counts low (overridable via env) so the
-    # per-core profiler buffer doesn't overflow before the post-capture drain below.
+    # AV emits far more markers than video
     n_warm = int(os.environ.get("LTX_PERF_N_WARM", "1" if has_audio else "2"))
     n_replay = int(os.environ.get("LTX_PERF_N_REPLAY", "3" if has_audio else "5"))
 
@@ -1752,8 +1748,7 @@ def test_ltx_transformer_trace_perf(
     signpost("stop")
     logger.info(f"trace replay ({n_replay}x): {replay_s:.3f}s → {replay_s / n_replay * 1e3:.2f} ms/step")
 
-    # Perf-only: crop SP-padding tail, assert shape + finiteness (no PCC).
-    # AV mode returns (video, audio); video-only returns a single tensor.
+    # Perf-only: crop SP-padding tail, assert shape + finiteness (no PCC)
     video_out = result[0] if isinstance(result, tuple) else result
     tt_video = LTXTransformerModel.device_to_host(video_out).squeeze(0)[:, :video_N_real, :]
     assert tt_video.shape == (1, video_N_real, OUT_CHANNELS), f"video shape {tt_video.shape}"
@@ -1776,8 +1771,7 @@ def _build_block_trace_setup(
     """
     checkpoint_22b = _resolve_checkpoint_22b(checkpoint_variant)
     sp_factor = tuple(mesh_device.shape)[sp_axis]
-    # Real latent grid → SP-padded sequence (mirrors LTXPipeline). video_N is the padded device
-    # length; video_N_real is the logical token count fed to SDPA's logical_n / padding masks.
+    # Real latent grid → SP-padded sequence (mirrors LTXPipeline)
     video_N_real = F * H * W
     video_N = _sp_pad_len(video_N_real, sp_factor)
     audio_N, audio_N_real = _audio_seq_lens(F, sp_factor)
@@ -1817,8 +1811,7 @@ def _build_block_trace_setup(
     temb = torch.randn(1, 1, 9 * DIM, dtype=torch.float32)  # 9 adaln params
     prompt_temb = torch.randn(1, 1, 2 * DIM, dtype=torch.float32)  # 2 adaln params for prompt
 
-    # TT video tensors. Sequence SP-padded to video_N; rope pads with identity rotation; video_N_real
-    # (logical) goes to the block for SDPA masking.
+    # TT video tensors
     spatial = _pad_seq_dim(x, video_N, dim=1).unsqueeze(0)
     tt_spatial = bf16_tensor_2dshard(spatial, device=mesh_device, shard_mapping={sp_axis: 2, tp_axis: 3})
     tt_prompt = bf16_tensor(context.unsqueeze(0), device=mesh_device)
@@ -1910,8 +1903,7 @@ def _build_block_trace_setup(
 
 @pytest.mark.parametrize(
     ("mesh_device", "sp_axis", "tp_axis", "num_links", "device_params", "topology", "is_fsdp"),
-    # Same ring stage-2 8k config as test_ltx_transformer_trace_perf (ring_params_8k = FABRIC_1D_RING
-    # + 8192-B fabric router payload). Do NOT add other-mesh params here.
+    # Same ring stage-2 8k config as test_ltx_transformer_trace_perf
     [pytest.param((4, 8), 1, 0, 2, ring_params_8k, ttnn.Topology.Ring, False, id="ring_bh_4x8sp1tp0_8k")],
     indirect=["mesh_device", "device_params"],
 )
@@ -1955,14 +1947,10 @@ def test_ltx_transformer_block_trace_perf(
         checkpoint_variant=checkpoint_variant,
     )
 
-    # Trace the block forward with the same Tracer settings inner_step uses (prep_run=False:
-    # kernels are precompiled by the eager warm calls below; clone_prep_inputs=False).
+    # Trace the block forward with the same Tracer settings inner_step uses
     tracer = Tracer(tt_block.forward, device=mesh_device, prep_run=False, clone_prep_inputs=False)
 
-    # AV runs many more ops than video (audio self/cross + a2v/v2a + audio ff/RS). The per-core
-    # 12000-marker profiler DRAM buffer is drained only at end-of-run, so warm + capture + replay
-    # markers pile up and overflow. We drain the profiler after capture (below) so only the
-    # signposted replays count against the budget; AV also uses fewer warm/replays for headroom.
+    # AV runs many more ops than video (audio self/cross + a2v/v2a + audio ff/RS)
     n_warm = 1 if has_audio else 2
     n_replay = 3 if has_audio else 5
 
@@ -1980,7 +1968,6 @@ def test_ltx_transformer_block_trace_perf(
     logger.info(f"trace capture: {time.time() - t0:.1f}s")
 
     # Drain warm+capture markers so ONLY the signposted replays occupy the profiler DRAM buffer
-    # (the AV profiler-overflow fix, mirroring test_ltx_transformer_trace_perf).
     ttnn.ReadDeviceProfiler(mesh_device)
 
     # Steady-state replay under the signpost bracket for tt-perf-report --start/end-signpost.
@@ -1994,8 +1981,7 @@ def test_ltx_transformer_block_trace_perf(
     signpost("stop")
     logger.info(f"trace replay ({n_replay}x): {replay_s:.3f}s → {replay_s / n_replay * 1e3:.2f} ms/step")
 
-    # Perf-only: crop SP-padding tail, assert shape + finiteness (no PCC).
-    # AV mode returns (video, audio); video-only returns a single tensor.
+    # Perf-only: crop SP-padding tail, assert shape + finiteness (no PCC)
     tt_v = result[0] if isinstance(result, tuple) else result
     concat_dims = [None, None]
     concat_dims[sp_axis] = 2

--- a/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
+++ b/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
@@ -161,8 +161,7 @@ def run_test_linear_impl(
         if activation == "gelu":
             torch_output = torch.nn.functional.gelu(torch_output)
 
-        # Variable-width chunks split at the given per-device widths; uniform chunks are the
-        # equal-width case. torch_output is [M_global, N_per_device].
+        # Variable-width chunks split at the given per-device widths
         if chunk_sizes:
             torch_output = torch.split(torch_output, list(chunk_sizes), dim=-1)
         else:
@@ -325,8 +324,7 @@ def run_test_linear_impl(
             for i in range(device.shape[sp_axis]):
                 for j in range(device.shape[tp_axis]):
                     m_slice = slice(i * per_device_M, (i + 1) * per_device_M)
-                    # For chunk c the concatenated tensor is [M_global, width_c * TP], so each
-                    # device's slice is this chunk's own width -- not a shared N // chunks.
+                    # For chunk c the concatenated tensor is [M_global, width_c * TP]
                     chunk_width = chunk_sizes[c] if chunk_sizes else (N // chunks)
                     n_slice = slice(j * chunk_width, (j + 1) * chunk_width)
 

--- a/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
+++ b/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
@@ -70,6 +70,7 @@ def run_test_linear_impl(
     torch_addcmul_b=None,
     addcmul_scalar=1.0,
     chunks=1,
+    chunk_sizes=None,
     broadcast_gate=True,
     fuse_swiglu=False,
 ):
@@ -160,7 +161,12 @@ def run_test_linear_impl(
         if activation == "gelu":
             torch_output = torch.nn.functional.gelu(torch_output)
 
-        torch_output = torch.chunk(torch_output, chunks, dim=-1)
+        # Variable-width chunks split at the given per-device widths; uniform chunks are the
+        # equal-width case. torch_output is [M_global, N_per_device].
+        if chunk_sizes:
+            torch_output = torch.split(torch_output, list(chunk_sizes), dim=-1)
+        else:
+            torch_output = torch.chunk(torch_output, chunks, dim=-1)
 
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
@@ -253,6 +259,7 @@ def run_test_linear_impl(
                 addcmul_input_tensor1=tt_addcmul_a,
                 addcmul_input_tensor2=tt_addcmul_b,
                 chunks=chunks,
+                chunk_sizes=list(chunk_sizes) if chunk_sizes else [],
                 fuse_swiglu=fuse_swiglu,
             )
 
@@ -318,7 +325,10 @@ def run_test_linear_impl(
             for i in range(device.shape[sp_axis]):
                 for j in range(device.shape[tp_axis]):
                     m_slice = slice(i * per_device_M, (i + 1) * per_device_M)
-                    n_slice = slice(j * (N // chunks), (j + 1) * (N // chunks))
+                    # For chunk c the concatenated tensor is [M_global, width_c * TP], so each
+                    # device's slice is this chunk's own width -- not a shared N // chunks.
+                    chunk_width = chunk_sizes[c] if chunk_sizes else (N // chunks)
+                    n_slice = slice(j * chunk_width, (j + 1) * chunk_width)
 
                     if use_non_fused:
                         idx = (slice(None), slice(None), m_slice, n_slice)
@@ -383,6 +393,7 @@ def run_test_linear(
     fuse_addcmul=False,
     addcmul_scalar=1.0,
     chunks=1,
+    chunk_sizes=None,
     broadcast_gate=True,
     fuse_swiglu=False,
 ):
@@ -492,6 +503,7 @@ def run_test_linear(
         torch_addcmul_b=torch_addcmul_b,
         addcmul_scalar=addcmul_scalar,
         chunks=chunks,
+        chunk_sizes=chunk_sizes,
         broadcast_gate=broadcast_gate,
         fuse_swiglu=fuse_swiglu,
     )

--- a/models/tt_dit/utils/conv3d.py
+++ b/models/tt_dit/utils/conv3d.py
@@ -419,7 +419,13 @@ _BLOCKINGS = {
     (2, 4, 512, 512, (3, 3, 3), 75, 68, 60): (64, 256, 1, 8, 4),  # ltx_s2_res — 60810us
     (2, 4, 256, 256, (3, 3, 3), 147, 68, 60): (64, 256, 1, 8, 4),  # ltx_s3_res — 25688us
     (2, 4, 256, 512, (3, 3, 3), 147, 68, 60): (64, 256, 1, 8, 4),  # ltx_s3_chg — 48772us
-    (2, 4, 128, 128, (3, 3, 3), 147, 136, 120): (64, 128, 6, 4, 8),  # ltx_s4_res — 22798us
+    (2, 4, 128, 128, (3, 3, 3), 147, 136, 120): (
+        64,
+        128,
+        12,
+        4,
+        8,
+    ),  # ltx_s4_res — fused halo_last 23.1ms (T_out_block 12: fewer larger matmuls; beats force_spatial -4.9%)
     (2, 4, 128, 48, (3, 3, 3), 147, 136, 120): (128, 64, 6, 4, 8),  # ltx_s4_out — 13833us
     # LTX-2.3 spatial latent upsampler (x2), 2x4 BH-LB, 1080p.
     (2, 4, 128, 1024, (3, 3, 3), 21, 9, 8): (64, 256, 1, 2, 8),  # initial_conv
@@ -439,7 +445,9 @@ _BLOCKINGS = {
     (4, 8, 512, 512, (3, 3, 3), 75, 34, 30): (64, 256, 1, 8, 4),  # ltx_s2_res — 13752us
     (4, 8, 256, 256, (3, 3, 3), 147, 34, 30): (64, 256, 1, 8, 4),  # ltx_s3_res — 6145us
     (4, 8, 256, 512, (3, 3, 3), 147, 34, 30): (64, 256, 1, 8, 4),  # ltx_s3_chg — 12013us
-    (4, 8, 128, 128, (3, 3, 3), 147, 68, 60): (128, 64, 6, 2, 16),  # ltx_s4_res — 5647us
+    # This table feeds standalone conv3d (LTX VAE). Keep standalone-optimal blocking here:
+    # the fused halo_last win needs finer H3W2 (128,64,6,3,2), which regresses standalone (~6629 vs 5407us).
+    (4, 8, 128, 128, (3, 3, 3), 147, 68, 60): (128, 64, 6, 2, 16),  # ltx_s4_res — 5647us standalone
     (4, 8, 128, 48, (3, 3, 3), 147, 68, 60): (128, 64, 6, 2, 16),  # ltx_s4_out — 2914us
     # LTX-2.3 spatial latent upsampler (x2), BH Galaxy 4x8, 1080p.
     # Regenerate via bruteforce_conv3d_sweep.py -k "sweep_all and h4w8"
@@ -573,6 +581,38 @@ def register_conv3d_configs(configs: dict) -> None:
         })
     """
     _DEFAULT_BLOCKINGS.update({(c_in, c_out, _ntuple(ks, 3)): tuple(v) for (c_in, c_out, ks), v in configs.items()})
+
+
+# Shapes that run fastest with force_spatial_parallel
+_FORCE_SPATIAL_KEYS = {
+    (2, 4, 128, 48, (3, 3, 3), 147, 136, 120),  # ltx_s4_out (128->48): light C_out matmul
+    # s4_res (4x8): force_spatial beats halo_last at the fused-only finer block 6,4,4 (below); the
+    # H3W2 blocking that made halo_last win on this shape lives only in the perf-test mock and never
+    # reaches production, so production s4_res 4x8 is routed to force_spatial.
+    (4, 8, 128, 128, (3, 3, 3), 147, 68, 60),  # ltx_s4_res (4x8)
+}
+
+
+# Fused shapes fastest with halo_last (bulk-core two-phase: each conv core does its interior blocks
+# first to overlap NP, then its boundary blocks after the NP gate). The win is where conv >> NP so the
+# interior pass fully hides NP. Measured device wins vs standalone: 2x4-s3 23.3->20.5, 4x8-s3 8.5->6.8
+# (-20%), 4x8-s2 14.9->14.3. s1/s4_out do NOT win (conv too small / NP-bound + fused-op overhead).
+_HALO_LAST_KEYS = {
+    # s4_res_2x4 (large per-dev 136x120): halo_last 23100us vs force_spatial 24282us (-4.9%, MIN FW).
+    # The big interior fraction fully hides NP in the first pass; the boundary pass is a small tail.
+    (2, 4, 128, 128, (3, 3, 3), 147, 136, 120),  # ltx_s4_res (2x4)
+    (2, 4, 256, 256, (3, 3, 3), 147, 68, 60),  # ltx_s3_res (2x4)
+    (2, 4, 256, 512, (3, 3, 3), 147, 68, 60),  # ltx_s3_chg (2x4)
+    (4, 8, 512, 512, (3, 3, 3), 75, 34, 30),  # ltx_s2_res (4x8)
+    (4, 8, 256, 256, (3, 3, 3), 147, 34, 30),  # ltx_s3_res (4x8)
+    (4, 8, 256, 512, (3, 3, 3), 147, 34, 30),  # ltx_s3_chg (4x8)
+    # ltx_s1_up (512->4096): the fused conv pipeline runs ~250us faster than standalone conv on the small
+    # 4x8 per-dev (17x15) AND hides the 369us NP → fused 16.4ms vs standalone 17.1ms (-3.8%). Win holds on
+    # every fused scheme (default/halo_last/force_spatial all ~16.4ms); routed via halo_last to match the
+    # sibling 4x8 routes. Standalone-optimal blocking (128,64,5,4,8) is also fused-optimal → no override.
+    # The 2x4 variant (per-dev 34x30) is NP-light (NP 0.7ms << +10ms fused-conv overhead) and stays standalone.
+    (4, 8, 512, 4096, (3, 3, 3), 39, 17, 15),  # ltx_s1_up (4x8)
+}
 
 
 def get_conv3d_config(

--- a/models/tt_dit/utils/conv3d.py
+++ b/models/tt_dit/utils/conv3d.py
@@ -445,8 +445,7 @@ _BLOCKINGS = {
     (4, 8, 512, 512, (3, 3, 3), 75, 34, 30): (64, 256, 1, 8, 4),  # ltx_s2_res — 13752us
     (4, 8, 256, 256, (3, 3, 3), 147, 34, 30): (64, 256, 1, 8, 4),  # ltx_s3_res — 6145us
     (4, 8, 256, 512, (3, 3, 3), 147, 34, 30): (64, 256, 1, 8, 4),  # ltx_s3_chg — 12013us
-    # This table feeds standalone conv3d (LTX VAE). Keep standalone-optimal blocking here:
-    # the fused halo_last win needs finer H3W2 (128,64,6,3,2), which regresses standalone (~6629 vs 5407us).
+    # This table feeds standalone conv3d (LTX VAE)
     (4, 8, 128, 128, (3, 3, 3), 147, 68, 60): (128, 64, 6, 2, 16),  # ltx_s4_res — 5647us standalone
     (4, 8, 128, 48, (3, 3, 3), 147, 68, 60): (128, 64, 6, 2, 16),  # ltx_s4_out — 2914us
     # LTX-2.3 spatial latent upsampler (x2), BH Galaxy 4x8, 1080p.
@@ -586,31 +585,21 @@ def register_conv3d_configs(configs: dict) -> None:
 # Shapes that run fastest with force_spatial_parallel
 _FORCE_SPATIAL_KEYS = {
     (2, 4, 128, 48, (3, 3, 3), 147, 136, 120),  # ltx_s4_out (128->48): light C_out matmul
-    # s4_res (4x8): force_spatial beats halo_last at the fused-only finer block 6,4,4 (below); the
-    # H3W2 blocking that made halo_last win on this shape lives only in the perf-test mock and never
-    # reaches production, so production s4_res 4x8 is routed to force_spatial.
+    # s4_res (4x8): force_spatial beats halo_last at the fused-only finer block 6,4,4 (below)
     (4, 8, 128, 128, (3, 3, 3), 147, 68, 60),  # ltx_s4_res (4x8)
 }
 
 
-# Fused shapes fastest with halo_last (bulk-core two-phase: each conv core does its interior blocks
-# first to overlap NP, then its boundary blocks after the NP gate). The win is where conv >> NP so the
-# interior pass fully hides NP. Measured device wins vs standalone: 2x4-s3 23.3->20.5, 4x8-s3 8.5->6.8
-# (-20%), 4x8-s2 14.9->14.3. s1/s4_out do NOT win (conv too small / NP-bound + fused-op overhead).
+# Fused shapes fastest with halo_last
 _HALO_LAST_KEYS = {
-    # s4_res_2x4 (large per-dev 136x120): halo_last 23100us vs force_spatial 24282us (-4.9%, MIN FW).
-    # The big interior fraction fully hides NP in the first pass; the boundary pass is a small tail.
+    # s4_res_2x4 (large per-dev 136x120): halo_last 23100us vs force_spatial 24282us (-4.9%, MIN FW)
     (2, 4, 128, 128, (3, 3, 3), 147, 136, 120),  # ltx_s4_res (2x4)
     (2, 4, 256, 256, (3, 3, 3), 147, 68, 60),  # ltx_s3_res (2x4)
     (2, 4, 256, 512, (3, 3, 3), 147, 68, 60),  # ltx_s3_chg (2x4)
     (4, 8, 512, 512, (3, 3, 3), 75, 34, 30),  # ltx_s2_res (4x8)
     (4, 8, 256, 256, (3, 3, 3), 147, 34, 30),  # ltx_s3_res (4x8)
     (4, 8, 256, 512, (3, 3, 3), 147, 34, 30),  # ltx_s3_chg (4x8)
-    # ltx_s1_up (512->4096): the fused conv pipeline runs ~250us faster than standalone conv on the small
-    # 4x8 per-dev (17x15) AND hides the 369us NP → fused 16.4ms vs standalone 17.1ms (-3.8%). Win holds on
-    # every fused scheme (default/halo_last/force_spatial all ~16.4ms); routed via halo_last to match the
-    # sibling 4x8 routes. Standalone-optimal blocking (128,64,5,4,8) is also fused-optimal → no override.
-    # The 2x4 variant (per-dev 34x30) is NP-light (NP 0.7ms << +10ms fused-conv overhead) and stays standalone.
+    # ltx_s1_up (512->4096): the fused conv pipeline runs ~250us faster than standalone conv on the small 4x8 per-dev
     (4, 8, 512, 4096, (3, 3, 3), 39, 17, 15),  # ltx_s1_up (4x8)
 }
 

--- a/models/tt_dit/utils/cpp/planar_concat.cpp
+++ b/models/tt_dit/utils/cpp/planar_concat.cpp
@@ -1,0 +1,436 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Outer scatter loop + persistent std::thread pool for the C++ planar
+// concat path.  Inner SIMD work lives in transpose_avx2.cpp.
+
+#include "planar_concat.hpp"
+#include "transpose_avx2.hpp"
+
+#include <atomic>
+#include <condition_variable>
+#include <cstring>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include <emmintrin.h>  // SSE2 (_mm_stream_si128, _mm_sfence)
+#include <immintrin.h>  // AVX2 (_mm256_stream_si256)
+
+namespace tt_dit_planar {
+
+// ---------------------------------------------------------------------------
+// Static thread pool — created lazily on first use, kept alive for the rest
+// of the process lifetime.  Matches the warm-pool semantics of the Python
+// `_get_default_reassemble_pool()` it replaces.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+class ThreadPool {
+public:
+    explicit ThreadPool(int n_threads) : n_threads_(n_threads), stop_(false) {
+        workers_.reserve(n_threads);
+        for (int i = 0; i < n_threads; ++i) {
+            workers_.emplace_back([this] { run_worker(); });
+        }
+    }
+
+    ~ThreadPool() {
+        {
+            std::unique_lock<std::mutex> lock(mu_);
+            stop_ = true;
+        }
+        cv_.notify_all();
+        for (auto& w : workers_) {
+            w.join();
+        }
+    }
+
+    // Submit `n_tasks` tasks; each task is `fn(task_idx)`.  Blocks until all
+    // complete.  Re-entrant calls are supported but rare (the planar path
+    // doesn't recurse).
+    template <typename Fn>
+    void run(int n_tasks, Fn fn) {
+        if (n_tasks <= 0) {
+            return;
+        }
+        std::atomic<int> remaining(n_tasks);
+        std::atomic<int> next_idx(0);
+        std::mutex done_mu;
+        std::condition_variable done_cv;
+
+        {
+            std::unique_lock<std::mutex> lock(mu_);
+            for (int i = 0; i < n_tasks; ++i) {
+                tasks_.emplace([&, this] {
+                    int idx;
+                    while ((idx = next_idx.fetch_add(1, std::memory_order_relaxed)) < n_tasks) {
+                        fn(idx);
+                    }
+                    if (remaining.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+                        std::lock_guard<std::mutex> lk(done_mu);
+                        done_cv.notify_one();
+                    }
+                });
+            }
+        }
+        cv_.notify_all();
+
+        std::unique_lock<std::mutex> lk(done_mu);
+        done_cv.wait(lk, [&] { return remaining.load() == 0; });
+    }
+
+    int n_threads() const { return n_threads_; }
+
+private:
+    void run_worker() {
+        for (;;) {
+            std::function<void()> task;
+            {
+                std::unique_lock<std::mutex> lock(mu_);
+                cv_.wait(lock, [this] { return stop_ || !tasks_.empty(); });
+                if (stop_ && tasks_.empty()) {
+                    return;
+                }
+                task = std::move(tasks_.front());
+                tasks_.pop();
+            }
+            task();
+        }
+    }
+
+    int n_threads_;
+    std::vector<std::thread> workers_;
+    std::queue<std::function<void()>> tasks_;
+    std::mutex mu_;
+    std::condition_variable cv_;
+    bool stop_;
+};
+
+// Process-wide singleton.  Configured via set_thread_pool_size() before
+// first use; otherwise defaults to min(8, hardware_concurrency()).
+static int g_requested_threads = 0;
+static std::once_flag g_init_flag;
+static ThreadPool* g_pool = nullptr;
+
+ThreadPool& get_pool() {
+    std::call_once(g_init_flag, [] {
+        int n = g_requested_threads > 0 ? g_requested_threads : static_cast<int>(std::thread::hardware_concurrency());
+        if (n <= 0) {
+            n = 1;
+        }
+        if (n > 8) {
+            n = 8;
+        }
+        g_pool = new ThreadPool(n);
+    });
+    return *g_pool;
+}
+
+}  // namespace
+
+void set_thread_pool_size(int n_threads) {
+    if (n_threads > 0) {
+        g_requested_threads = n_threads;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Inner per-shard scatter kernels.
+//
+// Both kernels write a (T, h_per, w_per) destination region for one shard.
+// The dest pointer (`out_plane_base`) is the byte address of plane row 0,
+// pixel (r * h_per, c * w_per) — i.e. the upper-left of this shard's
+// rectangle in the plane.  The dest stride between successive `t` rows is
+// `row_stride` bytes; between successive `h_g` rows of one frame it's
+// `plane_W` bytes; W stride is 1 byte.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Non-temporal copy of `n` bytes: writes via SSE/AVX streaming stores so the
+// destination cache lines aren't pulled into L1/L2 (skipping read-for-
+// ownership traffic).  Caller must `_mm_sfence()` before any later read of
+// the destination region.
+//
+// Path selection by alignment:
+//   - dst & 31 == 0 and n % 32 == 0  → AVX2 32-byte streams.
+//   - dst & 15 == 0 and n % 16 == 0  → SSE2 16-byte streams.
+//   - otherwise                       → libc memcpy (fallback).
+//
+// Loads are unaligned (`loadu`) — sources come from arbitrary torch tensor
+// allocations whose alignment we don't control.  All our actual call sites
+// hit the AVX2 path (Y plane, w_per=160, dst always 32-aligned) or the SSE2
+// path (UV plane, w_per=80, dst at least 16-aligned for any c).
+static inline void stream_copy_n(uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
+    const uintptr_t addr = reinterpret_cast<uintptr_t>(dst);
+    if ((addr & 31u) == 0 && (n & 31u) == 0) {
+        for (size_t i = 0; i < n; i += 32) {
+            __m256i v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + i));
+            _mm256_stream_si256(reinterpret_cast<__m256i*>(dst + i), v);
+        }
+        return;
+    }
+    if ((addr & 15u) == 0 && (n & 15u) == 0) {
+        for (size_t i = 0; i < n; i += 16) {
+            __m128i v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i));
+            _mm_stream_si128(reinterpret_cast<__m128i*>(dst + i), v);
+        }
+        return;
+    }
+    std::memcpy(dst, src, n);
+}
+
+// CTHW: src layout is (T, h_per, w_per), W innermost (stride 1).  For each
+// (t, h), we have w_per contiguous source bytes that go to w_per
+// contiguous dest bytes — a straight copy.  We use non-temporal stores so the
+// 112 MB output buffer doesn't displace useful data from L2/L3 and so we
+// don't pay the read-for-ownership tax on every cache line written.
+void scatter_one_cthw(
+    const uint8_t* src,
+    uint8_t* dst,
+    int T,
+    int src_h_per,
+    int src_w_per,
+    int valid_h,
+    int valid_w,
+    int plane_W,
+    int row_stride) {
+    for (int t = 0; t < T; ++t) {
+        for (int h = 0; h < valid_h; ++h) {
+            stream_copy_n(
+                dst + t * static_cast<std::ptrdiff_t>(row_stride) + h * static_cast<std::ptrdiff_t>(plane_W),
+                src + (t * static_cast<std::ptrdiff_t>(src_h_per) + h) * static_cast<std::ptrdiff_t>(src_w_per),
+                static_cast<size_t>(valid_w));
+        }
+    }
+    // Drain WC buffers so subsequent readers (other threads, the Python
+    // caller) see the data.  Cheap when no streaming stores were issued
+    // (i.e. fallback memcpy path).
+    _mm_sfence();
+}
+
+// CHWT: src layout is (h_per, w_per, T), T innermost (stride 1).  Dest has
+// W innermost (stride 1) and T at stride row_stride.  Per-h slice is a
+// (w_per, T) → (T, w_per) byte transpose, tiled in 32×32 blocks.
+//
+// w_per for our case is in {160, 80}.  T is 81 (2 full 32-T tiles + a
+// 17-T tail).  We handle both:
+//   - w_chunks of 32 (Y: 5 chunks; UV: 2 full chunks + 1 tail of 16).
+//   - t_chunks of 32 (full: 2; tail: 1 of 17).
+void scatter_one_chwt(
+    const uint8_t* src,
+    uint8_t* dst,
+    int T,
+    int src_h_per,
+    int src_w_per,
+    int valid_h,
+    int valid_w,
+    int plane_W,
+    int row_stride) {
+    (void)src_h_per;  // CHWT source h-stride is src_w_per*T; h_per only bounds the loop (valid_h).
+    const std::ptrdiff_t src_w_stride = static_cast<std::ptrdiff_t>(T);  // bytes between adjacent w in source
+
+    const int n_w_full_tiles = valid_w / 32;
+    const int w_tail = valid_w - n_w_full_tiles * 32;  // padded tail cols are never written
+
+    const int n_t_full_tiles = T / 32;
+    const int t_tail = T - n_t_full_tiles * 32;
+
+    for (int h = 0; h < valid_h; ++h) {
+        const uint8_t* src_h = src + static_cast<std::ptrdiff_t>(h) * src_w_per * T;
+        uint8_t* dst_h = dst + static_cast<std::ptrdiff_t>(h) * plane_W;
+
+        // Full 32×32 (W × T) tiles.
+        for (int w_tile = 0; w_tile < n_w_full_tiles; ++w_tile) {
+            const uint8_t* src_w = src_h + static_cast<std::ptrdiff_t>(w_tile) * 32 * T;
+            uint8_t* dst_w = dst_h + static_cast<std::ptrdiff_t>(w_tile) * 32;
+
+            for (int t_tile = 0; t_tile < n_t_full_tiles; ++t_tile) {
+                const uint8_t* src_tile = src_w + t_tile * 32;
+                uint8_t* dst_tile = dst_w + static_cast<std::ptrdiff_t>(t_tile) * 32 * row_stride;
+                transpose_32x32_u8(src_tile, src_w_stride, dst_tile, row_stride);
+            }
+            if (t_tail > 0) {
+                const uint8_t* src_tile = src_w + n_t_full_tiles * 32;
+                uint8_t* dst_tile = dst_w + static_cast<std::ptrdiff_t>(n_t_full_tiles) * 32 * row_stride;
+                transpose_32xN_u8(src_tile, src_w_stride, dst_tile, row_stride, t_tail);
+            }
+        }
+
+        // W-tail (when w_per % 32 != 0).
+        //
+        // Fast path for w_tail == 16 (UV plane, w_per_uv = 80 = 2*32 + 16):
+        // 16 W-source rows × 32 T-source cols → 32 T-dest rows × 16 W-dest
+        // cols, done with two back-to-back 16×16 SSE transposes.  No bounce
+        // buffer, no zero-padding pass.
+        //
+        // General path (w_tail in [1, 31] \ {16}): zero-pad source into a
+        // 32×32 stack temp, transpose, copy only the valid w_tail cols from
+        // each output row.  Slower but covers every shape we might see.
+        // (Currently only triggered if w_tail != 16, which doesn't happen for
+        // 720p Y/UV; kept for safety.)
+        if (w_tail > 0) {
+            const uint8_t* src_w = src_h + static_cast<std::ptrdiff_t>(n_w_full_tiles) * 32 * T;
+            uint8_t* dst_w = dst_h + static_cast<std::ptrdiff_t>(n_w_full_tiles) * 32;
+
+            if (w_tail == 16) {
+                for (int t_tile = 0; t_tile < n_t_full_tiles; ++t_tile) {
+                    transpose_32x16_u8(
+                        src_w + t_tile * 32,
+                        src_w_stride,
+                        dst_w + static_cast<std::ptrdiff_t>(t_tile) * 32 * row_stride,
+                        row_stride);
+                }
+                if (t_tail > 0) {
+                    // T-tail × 16 W-cols: small enough to keep the bounce
+                    // buffer; reduces case explosion in this code path.
+                    alignas(32) uint8_t tmp_src[32 * 32];
+                    alignas(32) uint8_t tmp_dst[32 * 32];
+                    std::memset(tmp_src, 0, sizeof(tmp_src));
+                    for (int i = 0; i < 16; ++i) {
+                        std::memcpy(tmp_src + i * 32, src_w + i * src_w_stride + n_t_full_tiles * 32, t_tail);
+                    }
+                    transpose_32x32_u8(tmp_src, 32, tmp_dst, 32);
+                    uint8_t* dst_tile = dst_w + static_cast<std::ptrdiff_t>(n_t_full_tiles) * 32 * row_stride;
+                    for (int i = 0; i < t_tail; ++i) {
+                        std::memcpy(dst_tile + i * row_stride, tmp_dst + i * 32, 16);
+                    }
+                }
+            } else {
+                alignas(32) uint8_t tmp_src[32 * 32];
+                alignas(32) uint8_t tmp_dst[32 * 32];
+
+                for (int t_tile = 0; t_tile < n_t_full_tiles; ++t_tile) {
+                    std::memset(tmp_src, 0, sizeof(tmp_src));
+                    for (int i = 0; i < w_tail; ++i) {
+                        std::memcpy(tmp_src + i * 32, src_w + i * src_w_stride + t_tile * 32, 32);
+                    }
+                    transpose_32x32_u8(tmp_src, 32, tmp_dst, 32);
+                    uint8_t* dst_tile = dst_w + static_cast<std::ptrdiff_t>(t_tile) * 32 * row_stride;
+                    for (int i = 0; i < 32; ++i) {
+                        std::memcpy(dst_tile + i * row_stride, tmp_dst + i * 32, w_tail);
+                    }
+                }
+                if (t_tail > 0) {
+                    std::memset(tmp_src, 0, sizeof(tmp_src));
+                    for (int i = 0; i < w_tail; ++i) {
+                        std::memcpy(tmp_src + i * 32, src_w + i * src_w_stride + n_t_full_tiles * 32, t_tail);
+                    }
+                    transpose_32x32_u8(tmp_src, 32, tmp_dst, 32);
+                    uint8_t* dst_tile = dst_w + static_cast<std::ptrdiff_t>(n_t_full_tiles) * 32 * row_stride;
+                    for (int i = 0; i < t_tail; ++i) {
+                        std::memcpy(dst_tile + i * row_stride, tmp_dst + i * 32, w_tail);
+                    }
+                }
+            }
+        }
+    }
+}
+
+}  // namespace
+
+void scatter_component(
+    const std::vector<ShardView>& shards,
+    DimOrder dim_order,
+    uint8_t* out,
+    int T,
+    int plane_offset,
+    int plane_W,
+    int row_stride,
+    int h_per,
+    int w_per) {
+    auto& pool = get_pool();
+    const int n = static_cast<int>(shards.size());
+
+    pool.run(n, [&](int idx) {
+        const ShardView& sv = shards[idx];
+        uint8_t* dst_base = out + static_cast<std::ptrdiff_t>(plane_offset) +
+                            static_cast<std::ptrdiff_t>(sv.r) * h_per * plane_W +
+                            static_cast<std::ptrdiff_t>(sv.c) * w_per;
+
+        if (dim_order == DimOrder::CTHW) {
+            scatter_one_cthw(sv.data, dst_base, T, h_per, w_per, h_per, w_per, plane_W, row_stride);
+        } else {
+            scatter_one_chwt(sv.data, dst_base, T, h_per, w_per, h_per, w_per, plane_W, row_stride);
+        }
+    });
+}
+
+void planar_concat(
+    const std::vector<ShardView>& y_shards,
+    int y_h_per,
+    int y_w_per,
+    const std::vector<ShardView>& cb_shards,
+    int uv_h_per,
+    int uv_w_per,
+    const std::vector<ShardView>& cr_shards,
+    DimOrder dim_order,
+    int T,
+    int H,
+    int W,
+    int out_H,
+    int out_W,
+    uint8_t* out) {
+    (void)H;
+    (void)W;
+    // Output geometry is the logical (cropped) frame; sources keep the padded per-shard dims.
+    const int out_Hu = out_H / 2;
+    const int out_Wu = out_W / 2;
+    const int out_hw = out_H * out_W;
+    const int out_uv = out_Hu * out_Wu;
+    const int row_stride = out_hw + 2 * out_uv;
+
+    // Build a flat task list across all 3 components so the thread pool can
+    // load-balance Y (4× the bytes of UV) against UV.  Each entry is a
+    // resolved per-shard task.  ``bound_h``/``bound_w`` are the logical plane
+    // extents used to clamp each shard's write.
+    struct Task {
+        const ShardView* shard;
+        int plane_offset;
+        int plane_W;
+        int h_per;
+        int w_per;
+        int bound_h;
+        int bound_w;
+    };
+
+    std::vector<Task> tasks;
+    tasks.reserve(y_shards.size() + cb_shards.size() + cr_shards.size());
+
+    auto add_component =
+        [&](const std::vector<ShardView>& s, int plane_off, int plane_w_arg, int h_p, int w_p, int bnd_h, int bnd_w) {
+            for (const auto& sv : s) {
+                tasks.push_back({&sv, plane_off, plane_w_arg, h_p, w_p, bnd_h, bnd_w});
+            }
+        };
+    add_component(y_shards, 0, out_W, y_h_per, y_w_per, out_H, out_W);
+    add_component(cb_shards, out_hw, out_Wu, uv_h_per, uv_w_per, out_Hu, out_Wu);
+    add_component(cr_shards, out_hw + out_uv, out_Wu, uv_h_per, uv_w_per, out_Hu, out_Wu);
+
+    auto& pool = get_pool();
+    pool.run(static_cast<int>(tasks.size()), [&](int idx) {
+        const Task& tk = tasks[idx];
+        const ShardView& sv = *tk.shard;
+        const int r0 = sv.r * tk.h_per;
+        const int c0 = sv.c * tk.w_per;
+        const int valid_h = (tk.h_per < tk.bound_h - r0) ? tk.h_per : (tk.bound_h - r0);
+        const int valid_w = (tk.w_per < tk.bound_w - c0) ? tk.w_per : (tk.bound_w - c0);
+        if (valid_h <= 0 || valid_w <= 0) {
+            return;  // shard lies entirely in the padded tail
+        }
+        uint8_t* dst_base = out + static_cast<std::ptrdiff_t>(tk.plane_offset) +
+                            static_cast<std::ptrdiff_t>(r0) * tk.plane_W + c0;
+
+        if (dim_order == DimOrder::CTHW) {
+            scatter_one_cthw(sv.data, dst_base, T, tk.h_per, tk.w_per, valid_h, valid_w, tk.plane_W, row_stride);
+        } else {
+            scatter_one_chwt(sv.data, dst_base, T, tk.h_per, tk.w_per, valid_h, valid_w, tk.plane_W, row_stride);
+        }
+    });
+}
+
+}  // namespace tt_dit_planar

--- a/models/tt_dit/utils/cpp/planar_concat.cpp
+++ b/models/tt_dit/utils/cpp/planar_concat.cpp
@@ -21,11 +21,7 @@
 
 namespace tt_dit_planar {
 
-// ---------------------------------------------------------------------------
-// Static thread pool — created lazily on first use, kept alive for the rest
-// of the process lifetime.  Matches the warm-pool semantics of the Python
-// `_get_default_reassemble_pool()` it replaces.
-// ---------------------------------------------------------------------------
+// --------------------------------------------------------------------------- Static thread pool
 
 namespace {
 
@@ -49,9 +45,7 @@ public:
         }
     }
 
-    // Submit `n_tasks` tasks; each task is `fn(task_idx)`.  Blocks until all
-    // complete.  Re-entrant calls are supported but rare (the planar path
-    // doesn't recurse).
+    // Submit `n_tasks` tasks
     template <typename Fn>
     void run(int n_tasks, Fn fn) {
         if (n_tasks <= 0) {
@@ -110,8 +104,7 @@ private:
     bool stop_;
 };
 
-// Process-wide singleton.  Configured via set_thread_pool_size() before
-// first use; otherwise defaults to min(8, hardware_concurrency()).
+// Process-wide singleton
 static int g_requested_threads = 0;
 static std::once_flag g_init_flag;
 static ThreadPool* g_pool = nullptr;
@@ -138,33 +131,11 @@ void set_thread_pool_size(int n_threads) {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Inner per-shard scatter kernels.
-//
-// Both kernels write a (T, h_per, w_per) destination region for one shard.
-// The dest pointer (`out_plane_base`) is the byte address of plane row 0,
-// pixel (r * h_per, c * w_per) — i.e. the upper-left of this shard's
-// rectangle in the plane.  The dest stride between successive `t` rows is
-// `row_stride` bytes; between successive `h_g` rows of one frame it's
-// `plane_W` bytes; W stride is 1 byte.
-// ---------------------------------------------------------------------------
+// --------------------------------------------------------------------------- Inner per-shard scatter kernels
 
 namespace {
 
-// Non-temporal copy of `n` bytes: writes via SSE/AVX streaming stores so the
-// destination cache lines aren't pulled into L1/L2 (skipping read-for-
-// ownership traffic).  Caller must `_mm_sfence()` before any later read of
-// the destination region.
-//
-// Path selection by alignment:
-//   - dst & 31 == 0 and n % 32 == 0  → AVX2 32-byte streams.
-//   - dst & 15 == 0 and n % 16 == 0  → SSE2 16-byte streams.
-//   - otherwise                       → libc memcpy (fallback).
-//
-// Loads are unaligned (`loadu`) — sources come from arbitrary torch tensor
-// allocations whose alignment we don't control.  All our actual call sites
-// hit the AVX2 path (Y plane, w_per=160, dst always 32-aligned) or the SSE2
-// path (UV plane, w_per=80, dst at least 16-aligned for any c).
+// Non-temporal copy of `n` bytes: writes via SSE/AVX streaming stores so the destination cache lines aren't pulled
 static inline void stream_copy_n(uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
     const uintptr_t addr = reinterpret_cast<uintptr_t>(dst);
     if ((addr & 31u) == 0 && (n & 31u) == 0) {
@@ -184,11 +155,7 @@ static inline void stream_copy_n(uint8_t* __restrict dst, const uint8_t* __restr
     std::memcpy(dst, src, n);
 }
 
-// CTHW: src layout is (T, h_per, w_per), W innermost (stride 1).  For each
-// (t, h), we have w_per contiguous source bytes that go to w_per
-// contiguous dest bytes — a straight copy.  We use non-temporal stores so the
-// 112 MB output buffer doesn't displace useful data from L2/L3 and so we
-// don't pay the read-for-ownership tax on every cache line written.
+// CTHW: src layout is (T, h_per, w_per), W innermost (stride 1)
 void scatter_one_cthw(
     const uint8_t* src,
     uint8_t* dst,
@@ -207,20 +174,11 @@ void scatter_one_cthw(
                 static_cast<size_t>(valid_w));
         }
     }
-    // Drain WC buffers so subsequent readers (other threads, the Python
-    // caller) see the data.  Cheap when no streaming stores were issued
-    // (i.e. fallback memcpy path).
+    // Drain WC buffers so subsequent readers (other threads, the Python caller) see the data
     _mm_sfence();
 }
 
-// CHWT: src layout is (h_per, w_per, T), T innermost (stride 1).  Dest has
-// W innermost (stride 1) and T at stride row_stride.  Per-h slice is a
-// (w_per, T) → (T, w_per) byte transpose, tiled in 32×32 blocks.
-//
-// w_per for our case is in {160, 80}.  T is 81 (2 full 32-T tiles + a
-// 17-T tail).  We handle both:
-//   - w_chunks of 32 (Y: 5 chunks; UV: 2 full chunks + 1 tail of 16).
-//   - t_chunks of 32 (full: 2; tail: 1 of 17).
+// CHWT: src layout is (h_per, w_per, T), T innermost (stride 1)
 void scatter_one_chwt(
     const uint8_t* src,
     uint8_t* dst,
@@ -261,18 +219,7 @@ void scatter_one_chwt(
             }
         }
 
-        // W-tail (when w_per % 32 != 0).
-        //
-        // Fast path for w_tail == 16 (UV plane, w_per_uv = 80 = 2*32 + 16):
-        // 16 W-source rows × 32 T-source cols → 32 T-dest rows × 16 W-dest
-        // cols, done with two back-to-back 16×16 SSE transposes.  No bounce
-        // buffer, no zero-padding pass.
-        //
-        // General path (w_tail in [1, 31] \ {16}): zero-pad source into a
-        // 32×32 stack temp, transpose, copy only the valid w_tail cols from
-        // each output row.  Slower but covers every shape we might see.
-        // (Currently only triggered if w_tail != 16, which doesn't happen for
-        // 720p Y/UV; kept for safety.)
+        // W-tail (when w_per % 32 != 0)
         if (w_tail > 0) {
             const uint8_t* src_w = src_h + static_cast<std::ptrdiff_t>(n_w_full_tiles) * 32 * T;
             uint8_t* dst_w = dst_h + static_cast<std::ptrdiff_t>(n_w_full_tiles) * 32;
@@ -286,8 +233,7 @@ void scatter_one_chwt(
                         row_stride);
                 }
                 if (t_tail > 0) {
-                    // T-tail × 16 W-cols: small enough to keep the bounce
-                    // buffer; reduces case explosion in this code path.
+                    // T-tail × 16 W-cols: small enough to keep the bounce buffer
                     alignas(32) uint8_t tmp_src[32 * 32];
                     alignas(32) uint8_t tmp_dst[32 * 32];
                     std::memset(tmp_src, 0, sizeof(tmp_src));
@@ -384,10 +330,7 @@ void planar_concat(
     const int out_uv = out_Hu * out_Wu;
     const int row_stride = out_hw + 2 * out_uv;
 
-    // Build a flat task list across all 3 components so the thread pool can
-    // load-balance Y (4× the bytes of UV) against UV.  Each entry is a
-    // resolved per-shard task.  ``bound_h``/``bound_w`` are the logical plane
-    // extents used to clamp each shard's write.
+    // Build a flat task list across all 3 components so the thread pool can load-balance Y
     struct Task {
         const ShardView* shard;
         int plane_offset;

--- a/models/tt_dit/utils/cpp/planar_concat.hpp
+++ b/models/tt_dit/utils/cpp/planar_concat.hpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace tt_dit_planar {
+
+// Per-shard view of an input shard.  `data` is the raw uint8 byte pointer;
+// `h_per`, `w_per`, `T` are the per-shard logical dimensions.  Mesh
+// coordinates `(r, c)` index the shard into the destination plane.
+struct ShardView {
+    const uint8_t* data;
+    int r;
+    int c;
+};
+
+enum class DimOrder {
+    CHWT,  // shard memory layout: (h_per, w_per, T) — T innermost
+    CTHW,  // shard memory layout: (T, h_per, w_per) — W innermost
+};
+
+// Scatter all shards of one component into one plane region of `out`.
+//
+// `plane_offset` is the byte offset into each output frame's row at which
+// this component's plane begins (Y: 0; Cb: H*W; Cr: H*W + (H/2)*(W/2)).
+// `plane_W` is the full destination width of this plane (W for Y, W/2 for UV).
+// `row_stride` is the bytes per output frame row (= H*W + 2*(H/2)*(W/2)).
+// `T` is the temporal extent (= number of output rows).
+// `h_per`, `w_per` are per-shard heights and widths of THIS component.
+//
+// Tasks are dispatched across the static thread pool.  Returns when all
+// scatters of this component are complete.
+void scatter_component(
+    const std::vector<ShardView>& shards,
+    DimOrder dim_order,
+    uint8_t* out,
+    int T,
+    int plane_offset,
+    int plane_W,
+    int row_stride,
+    int h_per,
+    int w_per);
+
+// Top-level entry: schedule Y/Cb/Cr scatters in one batch for maximum
+// thread-pool parallelism (96 tasks for a 4×8 mesh).  Blocks until all
+// tasks finish.
+// ``out_H``/``out_W`` are the logical output dims. When the VAE pads a global
+// right/bottom tail (``out_H < H`` and/or ``out_W < W``), each shard's write
+// extent is clamped to the logical bound while its source is still addressed
+// with the full padded per-shard dims — so the padded tail is never written
+// and ``out`` is sized for the logical (cropped) frame, no separate trim pass.
+void planar_concat(
+    const std::vector<ShardView>& y_shards,
+    int y_h_per,
+    int y_w_per,
+    const std::vector<ShardView>& cb_shards,
+    int uv_h_per,
+    int uv_w_per,
+    const std::vector<ShardView>& cr_shards,
+    DimOrder dim_order,
+    int T,
+    int H,
+    int W,
+    int out_H,
+    int out_W,
+    uint8_t* out);
+
+// Optional knob — set the size of the static thread pool.  No-op after the
+// pool has been created (first call to scatter_component / planar_concat).
+void set_thread_pool_size(int n_threads);
+
+}  // namespace tt_dit_planar

--- a/models/tt_dit/utils/cpp/planar_concat.hpp
+++ b/models/tt_dit/utils/cpp/planar_concat.hpp
@@ -8,9 +8,7 @@
 
 namespace tt_dit_planar {
 
-// Per-shard view of an input shard.  `data` is the raw uint8 byte pointer;
-// `h_per`, `w_per`, `T` are the per-shard logical dimensions.  Mesh
-// coordinates `(r, c)` index the shard into the destination plane.
+// Per-shard view of an input shard
 struct ShardView {
     const uint8_t* data;
     int r;
@@ -22,17 +20,7 @@ enum class DimOrder {
     CTHW,  // shard memory layout: (T, h_per, w_per) — W innermost
 };
 
-// Scatter all shards of one component into one plane region of `out`.
-//
-// `plane_offset` is the byte offset into each output frame's row at which
-// this component's plane begins (Y: 0; Cb: H*W; Cr: H*W + (H/2)*(W/2)).
-// `plane_W` is the full destination width of this plane (W for Y, W/2 for UV).
-// `row_stride` is the bytes per output frame row (= H*W + 2*(H/2)*(W/2)).
-// `T` is the temporal extent (= number of output rows).
-// `h_per`, `w_per` are per-shard heights and widths of THIS component.
-//
-// Tasks are dispatched across the static thread pool.  Returns when all
-// scatters of this component are complete.
+// Scatter all shards of one component into one plane region of `out`
 void scatter_component(
     const std::vector<ShardView>& shards,
     DimOrder dim_order,
@@ -44,14 +32,7 @@ void scatter_component(
     int h_per,
     int w_per);
 
-// Top-level entry: schedule Y/Cb/Cr scatters in one batch for maximum
-// thread-pool parallelism (96 tasks for a 4×8 mesh).  Blocks until all
-// tasks finish.
-// ``out_H``/``out_W`` are the logical output dims. When the VAE pads a global
-// right/bottom tail (``out_H < H`` and/or ``out_W < W``), each shard's write
-// extent is clamped to the logical bound while its source is still addressed
-// with the full padded per-shard dims — so the padded tail is never written
-// and ``out`` is sized for the logical (cropped) frame, no separate trim pass.
+// Top-level entry: schedule Y/Cb/Cr scatters in one batch for maximum thread-pool parallelism
 void planar_concat(
     const std::vector<ShardView>& y_shards,
     int y_h_per,
@@ -68,8 +49,7 @@ void planar_concat(
     int out_W,
     uint8_t* out);
 
-// Optional knob — set the size of the static thread pool.  No-op after the
-// pool has been created (first call to scatter_component / planar_concat).
+// Optional knob — set the size of the static thread pool
 void set_thread_pool_size(int n_threads);
 
 }  // namespace tt_dit_planar

--- a/models/tt_dit/utils/matmul.py
+++ b/models/tt_dit/utils/matmul.py
@@ -256,11 +256,7 @@ class FusedMMRSConfig(NamedTuple):
     subblock_w: int
     num_buffers_per_channel: int | None
     chunk_width_in_mm_blocks: int
-    # Optional explicit reduce-scatter worker count. When None (default) it is derived from the
-    # RS-zone geometry below. Set it to pin the value to an op-test-tuned count so the model and
-    # the ccl op test (tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py)
-    # agree exactly -- the geometry derivation and the op test's explicit num_workers_per_link do
-    # not otherwise match (e.g. LTX ff2: derived 5 vs op-test-validated 3).
+    # Optional explicit reduce-scatter worker count
     num_workers_per_link: int | None = None
 
     def get_params(self, core_grid, num_links):
@@ -295,11 +291,7 @@ fused_mmrs_configs = {
     ttnn.CoreCoord(12, 10): {
         (9472, 3456, 5120): FusedMMRSConfig(ttnn.CoreCoord(12, 8), 8, 4, 8, 2, 1, None, 1),
         (9472 // 4, 3456, 5120): FusedMMRSConfig(ttnn.CoreCoord(12, 8), 4, 4, 8, 2, 2, None, 1),
-        # LTX video FFN ff2 (RowParallel): per-device [4864,4096]@[4096,4096]. (12,8)=96-core MM grid
-        # with op-test-tuned b756 blocking: 7x5x6 tiles (224/160/192 elem), subblock 1x3, chunk=1,
-        # RS workers on rows 8-9. num_workers_per_link pinned to 3 (geometry would derive 5) to match
-        # ltx_ff2_4864_4096_4096_x12_y8_b756 in
-        # tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py.
+        # LTX video FFN ff2 (RowParallel): per-device [4864,4096]@[4096,4096]
         (4864, 4096, 4096): FusedMMRSConfig(ttnn.CoreCoord(12, 8), 7, 5, 6, 1, 3, None, 1, 3),
     },
 }
@@ -371,16 +363,7 @@ def register_fused_mmrs_configs(configs: dict) -> None:
         fused_mmrs_configs.setdefault(core_grid, {}).update(entries)
 
 
-# =====================================================================
-# Fabric-bound all-gather-matmul (strided AGMM) configs
-# =====================================================================
-# The optimized fabric-bound op ``ttnn.experimental.strided_all_gather_minimal_matmul_async``
-# partitions the worker grid: the matmul runs on ``mm_core_grid`` (the lower rows) and the
-# strided all-gather workers run on the rows starting at ``ag_core_grid_offset`` (which must
-# start at ``mm_core_grid.y`` to keep the two regions disjoint). Only shapes registered here
-# take the fabric path; everything else falls through to the current
-# ``all_gather_minimal_matmul_async`` op. This is the seam for the eventual 3-path
-# (fabric / dram / compute) router.
+# ===================================================================== Fabric-bound all-gather-matmul
 class FabricAGMMConfig(NamedTuple):
     mm_core_grid: ttnn.CoreCoord
     ag_core_grid_offset: tuple
@@ -393,42 +376,16 @@ class FabricAGMMConfig(NamedTuple):
     num_buffers_per_channel: int
 
 
-# Keyed by device core-grid (``ttnn.CoreCoord``) then ``(K, N, chunks)``. K is the full (gathered)
-# contraction dim, N the per-TP-device output width, chunks the output-split count. M (the per-SP-
-# device sequence length) is intentionally NOT part of the key: the tuned block sizes are
-# M-independent across every LTX entry, and the model's real M for the audio/kv rows differs from
-# the video-seq proxy the op test sweeps -- keying on M would stop those shapes from ever matching.
-# Seeded from the LTX stage-1/stage-2 video + audio blocks on the Blackhole galaxy 12x10 grid.
+# Keyed by device core-grid (``ttnn.CoreCoord``) then ``(K, N, chunks)``
 fabric_agmm_configs: dict[ttnn.CoreCoord, dict[tuple, FabricAGMMConfig]] = {
     ttnn.CoreCoord(12, 10): {
-        # (K, N, chunks) -> FabricAGMMConfig(mm_core_grid, ag_core_grid_offset,
-        #                                    M_block, K_block, N_block, sub_h, sub_w, num_w/link, num_buf/chan)
-        # video to_q (cross) / to_out(plain) / to_out addcmul: N = video_dim/tp = 1024.
-        # DEVICE-VALIDATED: stage-2 video block, 3x StridedAllGatherMinimalMatmulAsync, PCC pass.
+        # (K, N, chunks) -> FabricAGMMConfig
         (4096, 1024, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 4, 2, 2, 3, 8),
-        # ---------------------------------------------------------------------------------------
-        # Remaining uncommented shapes from test_strided_all_gather_minimal_matmul_ltx_configs.
-        # Block shapes below MIRROR that op test exactly (it is the tuning source of truth) --
-        # (M_block, K_block, N_block, subblock_h, subblock_w). Validate on device via that test.
-        # ---------------------------------------------------------------------------------------
-        # video to_gate_logits: per-device N = num_heads/tp = 8, tile-padded to 32 (1 tile).
+        # --------------------------------------------------------------------------------------- Remaining
         (4096, 32, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 1, 2, 1, 3, 8),
-        # audio to_gate_logits: per-device N = num_heads/tp = 8, tile-padded to 32 (1 tile).
-        # DISABLED under global IN0_SUB_CHUNKS=2 banding: audio seq is tiny (AUDIO_N/sp = 1 M-tile),
-        # so last_m_block_tiles=1 < in0_sub_chunks=2 -> the banded path hard-asserts
-        # (minimal_matmul_fabric_bound_program_factory.cpp:522). Audio M=1 tile is also perf-negligible
-        # and can't overlap-band regardless, so keep it on the old op. Re-enable only once in0_sub_chunks
-        # is a per-config field (set to 1 for audio) rather than a global env var.
-        # (2048, 32, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 1, 2, 1, 3, 8),
-        # audio_to_video_attn.to_q (a2v cross): K = video_dim = 4096, N = audio_dim/tp = 512 (16 tiles).
-        # transpose grid -> N across grid.y=8 => 2 tiles/core. N_block MUST be 2 (subblock_w=2) so
-        # N_blocks_per_core = ceil(2/2) = 1; N_block=1 gives 2 blocks/core -> split-write DEADLOCK
-        # (device-confirmed hang at "Waiting for op"). This differs from the op test's stale value.
+        # audio to_gate_logits: per-device N = num_heads/tp = 8, tile-padded to 32 (1 tile)
         (4096, 512, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 2, 2, 2, 3, 8),
-        # audio a_kv (chunks=1 in the op test): K = audio_dim = 2048, N = 1024. Inert in-model (real
-        # to_kv is chunks=2 -> old op). Also DISABLED for the same reason as the audio gate above:
-        # in-model audio M = AUDIO_N/sp = 1 tile, which can't band under global IN0_SUB_CHUNKS=2.
-        # (2048, 1024, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 4, 2, 2, 3, 8),
+        # audio a_kv (chunks=1 in the op test): K = audio_dim = 2048, N = 1024
     },
 }
 

--- a/models/tt_dit/utils/matmul.py
+++ b/models/tt_dit/utils/matmul.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+import os
 from typing import NamedTuple
 
 from loguru import logger
@@ -255,13 +256,24 @@ class FusedMMRSConfig(NamedTuple):
     subblock_w: int
     num_buffers_per_channel: int | None
     chunk_width_in_mm_blocks: int
+    # Optional explicit reduce-scatter worker count. When None (default) it is derived from the
+    # RS-zone geometry below. Set it to pin the value to an op-test-tuned count so the model and
+    # the ccl op test (tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py)
+    # agree exactly -- the geometry derivation and the op test's explicit num_workers_per_link do
+    # not otherwise match (e.g. LTX ff2: derived 5 vs op-test-validated 3).
+    num_workers_per_link: int | None = None
 
     def get_params(self, core_grid, num_links):
-        rs_zone_capacity = (core_grid.y - self.compute_with_storage_grid_size.y) * core_grid.x
-        num_workers_per_link = rs_zone_capacity // (2 * num_links) - 1
         config_dict = self._asdict()
         num_buffers_per_channel = config_dict.pop("num_buffers_per_channel")
         chunk_width_in_mm_blocks = config_dict.pop("chunk_width_in_mm_blocks")
+        num_workers_override = config_dict.pop("num_workers_per_link")
+
+        if num_workers_override is not None:
+            num_workers_per_link = num_workers_override
+        else:
+            rs_zone_capacity = (core_grid.y - self.compute_with_storage_grid_size.y) * core_grid.x
+            num_workers_per_link = rs_zone_capacity // (2 * num_links) - 1
 
         # Order is important. Guaranteed for python 3.7+
         return {
@@ -283,6 +295,12 @@ fused_mmrs_configs = {
     ttnn.CoreCoord(12, 10): {
         (9472, 3456, 5120): FusedMMRSConfig(ttnn.CoreCoord(12, 8), 8, 4, 8, 2, 1, None, 1),
         (9472 // 4, 3456, 5120): FusedMMRSConfig(ttnn.CoreCoord(12, 8), 4, 4, 8, 2, 2, None, 1),
+        # LTX video FFN ff2 (RowParallel): per-device [4864,4096]@[4096,4096]. (12,8)=96-core MM grid
+        # with op-test-tuned b756 blocking: 7x5x6 tiles (224/160/192 elem), subblock 1x3, chunk=1,
+        # RS workers on rows 8-9. num_workers_per_link pinned to 3 (geometry would derive 5) to match
+        # ltx_ff2_4864_4096_4096_x12_y8_b756 in
+        # tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py.
+        (4864, 4096, 4096): FusedMMRSConfig(ttnn.CoreCoord(12, 8), 7, 5, 6, 1, 3, None, 1, 3),
     },
 }
 
@@ -351,3 +369,101 @@ def register_fused_mmrs_configs(configs: dict) -> None:
     """
     for core_grid, entries in configs.items():
         fused_mmrs_configs.setdefault(core_grid, {}).update(entries)
+
+
+# =====================================================================
+# Fabric-bound all-gather-matmul (strided AGMM) configs
+# =====================================================================
+# The optimized fabric-bound op ``ttnn.experimental.strided_all_gather_minimal_matmul_async``
+# partitions the worker grid: the matmul runs on ``mm_core_grid`` (the lower rows) and the
+# strided all-gather workers run on the rows starting at ``ag_core_grid_offset`` (which must
+# start at ``mm_core_grid.y`` to keep the two regions disjoint). Only shapes registered here
+# take the fabric path; everything else falls through to the current
+# ``all_gather_minimal_matmul_async`` op. This is the seam for the eventual 3-path
+# (fabric / dram / compute) router.
+class FabricAGMMConfig(NamedTuple):
+    mm_core_grid: ttnn.CoreCoord
+    ag_core_grid_offset: tuple
+    M_block_size: int
+    K_block_size: int
+    N_block_size: int
+    subblock_h: int
+    subblock_w: int
+    num_workers_per_link: int
+    num_buffers_per_channel: int
+
+
+# Keyed by device core-grid (``ttnn.CoreCoord``) then ``(K, N, chunks)``. K is the full (gathered)
+# contraction dim, N the per-TP-device output width, chunks the output-split count. M (the per-SP-
+# device sequence length) is intentionally NOT part of the key: the tuned block sizes are
+# M-independent across every LTX entry, and the model's real M for the audio/kv rows differs from
+# the video-seq proxy the op test sweeps -- keying on M would stop those shapes from ever matching.
+# Seeded from the LTX stage-1/stage-2 video + audio blocks on the Blackhole galaxy 12x10 grid.
+fabric_agmm_configs: dict[ttnn.CoreCoord, dict[tuple, FabricAGMMConfig]] = {
+    ttnn.CoreCoord(12, 10): {
+        # (K, N, chunks) -> FabricAGMMConfig(mm_core_grid, ag_core_grid_offset,
+        #                                    M_block, K_block, N_block, sub_h, sub_w, num_w/link, num_buf/chan)
+        # video to_q (cross) / to_out(plain) / to_out addcmul: N = video_dim/tp = 1024.
+        # DEVICE-VALIDATED: stage-2 video block, 3x StridedAllGatherMinimalMatmulAsync, PCC pass.
+        (4096, 1024, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 4, 2, 2, 3, 8),
+        # ---------------------------------------------------------------------------------------
+        # Remaining uncommented shapes from test_strided_all_gather_minimal_matmul_ltx_configs.
+        # Block shapes below MIRROR that op test exactly (it is the tuning source of truth) --
+        # (M_block, K_block, N_block, subblock_h, subblock_w). Validate on device via that test.
+        # ---------------------------------------------------------------------------------------
+        # video to_gate_logits: per-device N = num_heads/tp = 8, tile-padded to 32 (1 tile).
+        (4096, 32, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 1, 2, 1, 3, 8),
+        # audio to_gate_logits: per-device N = num_heads/tp = 8, tile-padded to 32 (1 tile).
+        # DISABLED under global IN0_SUB_CHUNKS=2 banding: audio seq is tiny (AUDIO_N/sp = 1 M-tile),
+        # so last_m_block_tiles=1 < in0_sub_chunks=2 -> the banded path hard-asserts
+        # (minimal_matmul_fabric_bound_program_factory.cpp:522). Audio M=1 tile is also perf-negligible
+        # and can't overlap-band regardless, so keep it on the old op. Re-enable only once in0_sub_chunks
+        # is a per-config field (set to 1 for audio) rather than a global env var.
+        # (2048, 32, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 1, 2, 1, 3, 8),
+        # audio_to_video_attn.to_q (a2v cross): K = video_dim = 4096, N = audio_dim/tp = 512 (16 tiles).
+        # transpose grid -> N across grid.y=8 => 2 tiles/core. N_block MUST be 2 (subblock_w=2) so
+        # N_blocks_per_core = ceil(2/2) = 1; N_block=1 gives 2 blocks/core -> split-write DEADLOCK
+        # (device-confirmed hang at "Waiting for op"). This differs from the op test's stale value.
+        (4096, 512, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 2, 2, 2, 3, 8),
+        # audio a_kv (chunks=1 in the op test): K = audio_dim = 2048, N = 1024. Inert in-model (real
+        # to_kv is chunks=2 -> old op). Also DISABLED for the same reason as the audio gate above:
+        # in-model audio M = AUDIO_N/sp = 1 tile, which can't band under global IN0_SUB_CHUNKS=2.
+        # (2048, 1024, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 4, 2, 2, 3, 8),
+    },
+}
+
+
+def get_fabric_agmm_config(K, N, chunks, device_core_grid) -> FabricAGMMConfig | None:
+    """Return the tuned fabric-bound strided-AGMM config for this shape, or ``None``.
+
+    ``None`` means the shape is not (known to be) fabric-bound; the caller keeps the current
+    ``all_gather_minimal_matmul_async`` path. Keyed on ``(K, N, chunks)`` only (M-independent).
+
+    A/B switch: set ``DISABLE_FABRIC_AGMM=1`` to force a miss for every shape, routing the whole
+    model back onto the old ``all_gather_minimal_matmul_async`` op. Used to get an apples-to-apples
+    old-agmm-vs-strided-sagmm baseline under the same trace/fabric config.
+    """
+    if os.environ.get("DISABLE_FABRIC_AGMM") in ("1", "true", "True"):
+        return None
+    return fabric_agmm_configs.get(device_core_grid, {}).get((K, N, chunks))
+
+
+def register_fabric_agmm_configs(configs: dict) -> None:
+    """Register additional fabric-bound strided-AGMM configs from external models.
+
+    Args:
+        configs: Mapping from ``ttnn.CoreCoord`` (device core-grid) to dict of
+            ``(K, N, chunks)`` -> :class:`FabricAGMMConfig`.
+
+    Example::
+
+        register_fabric_agmm_configs({
+            ttnn.CoreCoord(12, 10): {
+                (4096, 1024, 1): FabricAGMMConfig(
+                    ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 4, 2, 2, 3, 8
+                ),
+            },
+        })
+    """
+    for core_grid, entries in configs.items():
+        fabric_agmm_configs.setdefault(core_grid, {}).update(entries)

--- a/models/tt_dit/utils/planar_concat.py
+++ b/models/tt_dit/utils/planar_concat.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python wrapper around the C++ planar concat extension.
+
+The C++ source lives in ``models/tt_dit/utils/cpp/`` and produces
+``cpp/build/_planar_concat<abi>.so`` when built via ``cpp/build.sh``.  This
+module loads it via ``importlib.util`` so callers don't need to put the
+build directory on ``sys.path``.
+
+If the ``.so`` isn't built (or fails to import), :data:`HAS_CPP_PLANAR_CONCAT`
+is False and :func:`planar_concat_cpp` is None.  The benchmark harness in
+``test_fast_device_to_host.py`` already has a ``HAS_*`` skip pattern that
+this slots into.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from typing import TYPE_CHECKING, Sequence
+
+import numpy as np
+
+if TYPE_CHECKING:
+    pass
+
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_BUILD_DIR = os.path.join(_THIS_DIR, "cpp", "build")
+
+
+def _try_load_extension():
+    if not os.path.isdir(_BUILD_DIR):
+        return None
+    candidates = [f for f in os.listdir(_BUILD_DIR) if f.startswith("_planar_concat") and f.endswith(".so")]
+    if not candidates:
+        return None
+    so_path = os.path.join(_BUILD_DIR, candidates[0])
+    spec = importlib.util.spec_from_file_location("_planar_concat", so_path)
+    if spec is None or spec.loader is None:
+        return None
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        return None
+    return mod
+
+
+_ext = _try_load_extension()
+HAS_CPP_PLANAR_CONCAT: bool = _ext is not None
+
+
+def _to_numpy(shard) -> np.ndarray:
+    """Convert a torch tensor to a contiguous numpy uint8 array (zero-copy when possible)."""
+    if isinstance(shard, np.ndarray):
+        if not shard.flags.c_contiguous:
+            shard = np.ascontiguousarray(shard)
+        return shard
+    # torch.Tensor or anything else with .numpy()
+    if hasattr(shard, "contiguous") and hasattr(shard, "numpy"):
+        t = shard.contiguous()
+        return t.numpy()
+    raise TypeError(f"unsupported shard type: {type(shard)!r}")
+
+
+if HAS_CPP_PLANAR_CONCAT:
+
+    def planar_concat_cpp(
+        y_shards: Sequence,
+        u_shards: Sequence,
+        v_shards: Sequence,
+        dim_order: str,
+        mesh_shape: tuple[int, int] = (4, 8),
+        out: np.ndarray | None = None,
+        out_H: int | None = None,
+        out_W: int | None = None,
+    ) -> np.ndarray:
+        """Vectorized YUV 4:2:0 planar concat — C++/AVX2 implementation.
+
+        Equivalent in output to the ``planar_concat_torch_threaded``
+        reference in ``test_fast_device_to_host.py`` but runs in C++ with a
+        persistent ``std::thread`` pool and AVX2 byte-tile transposes for
+        the CHWT path.
+
+        Args:
+            y_shards, u_shards, v_shards: lists of ``TP*SP`` per-shard
+                tensors/arrays.  Per-shard shape:
+                  * CHWT: ``(1, h_per, w_per, T)`` uint8 contiguous.
+                  * CTHW: ``(1, T, h_per, w_per)`` uint8 contiguous.
+                UV shards must have ``h_per/2`` and ``w_per/2`` of the Y
+                shards' dims (4:2:0 subsampling).
+            dim_order: ``"CHWT"`` or ``"CTHW"``.
+            mesh_shape: ``(TP, SP)``.  Defaults to ``(4, 8)``.
+            out: Optional pre-allocated output buffer of shape
+                ``(T, H*W + 2*(H/2 * W/2))`` uint8.  When ``None``, a fresh
+                ``np.empty`` is allocated each call (matches the convention
+                of the other variants in the test harness).  Reusing a
+                buffer across calls eliminates ~50 ms of first-touch page
+                faults per call on systems without THP=always.
+
+        Returns:
+            ``np.ndarray`` of shape ``(T, H*W + 2*(H/2 * W/2))``, dtype
+            ``uint8``.  Per-frame layout: ``[Y plane | Cb plane | Cr plane]``.
+        """
+        y_np = [_to_numpy(s) for s in y_shards]
+        u_np = [_to_numpy(s) for s in u_shards]
+        v_np = [_to_numpy(s) for s in v_shards]
+
+        TP, SP = int(mesh_shape[0]), int(mesh_shape[1])
+        if dim_order == "CHWT":
+            _, h_per, w_per, T = y_np[0].shape
+        elif dim_order == "CTHW":
+            _, T, h_per, w_per = y_np[0].shape
+        else:
+            raise ValueError(f"dim_order must be 'CHWT' or 'CTHW', got {dim_order!r}")
+        H, W = h_per * TP, w_per * SP
+        # Logical (cropped) output: when the VAE pads a global tail, write only the valid frame.
+        oH = H if out_H is None else out_H
+        oW = W if out_W is None else out_W
+        oHu, oWu = oH // 2, oW // 2
+        row_stride = oH * oW + 2 * oHu * oWu
+
+        if out is None:
+            out = np.empty((T, row_stride), dtype=np.uint8)
+        elif out.shape != (T, row_stride) or out.dtype != np.uint8 or not out.flags.c_contiguous:
+            raise ValueError(
+                f"out must be C-contiguous uint8 with shape ({T}, {row_stride}); "
+                f"got shape {out.shape} dtype {out.dtype} c_contig={out.flags.c_contiguous}"
+            )
+
+        _ext.planar_concat(y_np, u_np, v_np, dim_order, mesh_shape, out, oH, oW)
+        return out
+
+    def set_thread_pool_size(n_threads: int) -> None:
+        """Set the C++ thread pool size.  Must be called BEFORE first scatter."""
+        _ext.set_thread_pool_size(int(n_threads))
+
+else:
+    planar_concat_cpp = None  # type: ignore[assignment]
+
+    def set_thread_pool_size(n_threads: int) -> None:  # noqa: D401
+        """No-op fallback when the C++ extension isn't built."""

--- a/models/tt_dit/utils/test.py
+++ b/models/tt_dit/utils/test.py
@@ -7,9 +7,9 @@ import pytest
 import ttnn
 
 
-def create_fabric_router_config(max_payload_size: int = 8192):
+def create_fabric_router_config(max_packet_payload_size_bytes=8192):
     config = ttnn.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = max_payload_size
+    config.max_packet_payload_size_bytes = max_packet_payload_size_bytes
     return config
 
 
@@ -31,7 +31,6 @@ line_params = {"fabric_config": ttnn.FabricConfig.FABRIC_1D}
 ring_params = {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}
 line_params_8k = {**line_params, "fabric_router_config": create_fabric_router_config()}
 ring_params_8k = {**ring_params, "fabric_router_config": create_fabric_router_config()}
-# 4 KB payload (2 tiles/packet for the strided AG): A/B control against the 8k variant.
 ring_params_4k = {**ring_params, "fabric_router_config": create_fabric_router_config(4096)}
 line_params_req_exact_devices = {**line_params, "require_exact_physical_num_devices": True}
 ring_params_req_exact_devices = {**ring_params, "require_exact_physical_num_devices": True}

--- a/models/tt_dit/utils/test.py
+++ b/models/tt_dit/utils/test.py
@@ -7,9 +7,9 @@ import pytest
 import ttnn
 
 
-def create_fabric_router_config():
+def create_fabric_router_config(max_payload_size: int = 8192):
     config = ttnn.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = 8192
+    config.max_packet_payload_size_bytes = max_payload_size
     return config
 
 
@@ -31,6 +31,8 @@ line_params = {"fabric_config": ttnn.FabricConfig.FABRIC_1D}
 ring_params = {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}
 line_params_8k = {**line_params, "fabric_router_config": create_fabric_router_config()}
 ring_params_8k = {**ring_params, "fabric_router_config": create_fabric_router_config()}
+# 4 KB payload (2 tiles/packet for the strided AG): A/B control against the 8k variant.
+ring_params_4k = {**ring_params, "fabric_router_config": create_fabric_router_config(4096)}
 line_params_req_exact_devices = {**line_params, "require_exact_physical_num_devices": True}
 ring_params_req_exact_devices = {**ring_params, "require_exact_physical_num_devices": True}
 ring_params_8k_req_exact_devices = {**ring_params_8k, "require_exact_physical_num_devices": True}

--- a/models/tt_dit/utils/video.py
+++ b/models/tt_dit/utils/video.py
@@ -93,6 +93,99 @@ def export_to_video(
     return output_video_path
 
 
+def _add_audio_stream(container, audio: Audio | None):
+    """Add an AAC audio stream to an open write container. Must run before any packet is muxed
+    (PyAV forbids adding streams once muxing starts). Returns the stream, or None if no audio."""
+    if audio is None:
+        return None
+    audio_stream = container.add_stream("aac", rate=audio.sampling_rate)
+    audio_stream.codec_context.sample_rate = audio.sampling_rate
+    audio_stream.codec_context.layout = "stereo"
+    audio_stream.codec_context.time_base = Fraction(1, audio.sampling_rate)
+    return audio_stream
+
+
+def _mux_audio(container, audio_stream, audio: Audio) -> None:
+    """Encode + mux the decoded waveform into ``audio_stream`` (created by ``_add_audio_stream``)."""
+    import av
+
+    samples = audio.waveform
+    if samples.ndim == 1:
+        samples = samples[:, None]
+    if samples.shape[1] != 2 and samples.shape[0] == 2:
+        samples = samples.T
+    if samples.shape[1] != 2:
+        logger.warning(f"Audio has {samples.shape[1]} channels, expected 2 — duplicating mono")
+        samples = samples[:, :1].repeat(1, 2)
+
+    if samples.dtype != torch.int16:
+        samples = torch.clip(samples, -1.0, 1.0)
+        samples = (samples * 32767.0).to(torch.int16)
+
+    frame_in = av.AudioFrame.from_ndarray(
+        samples.contiguous().reshape(1, -1).cpu().numpy(),
+        format="s16",
+        layout="stereo",
+    )
+    frame_in.sample_rate = audio.sampling_rate
+
+    cc = audio_stream.codec_context
+    resampler = av.audio.resampler.AudioResampler(
+        format=cc.format or "fltp",
+        layout=cc.layout or "stereo",
+        rate=cc.sample_rate or audio.sampling_rate,
+    )
+    for resampled in resampler.resample(frame_in):
+        for packet in audio_stream.encode(resampled):
+            container.mux(packet)
+    for packet in audio_stream.encode():
+        container.mux(packet)
+
+
+def export_video_audio_yuv(yuv_planar, output_path: str, fps: int = 24, audio: Audio | None = None) -> None:
+    """Export a pre-computed yuv420p planar video (+ optional audio) to MP4 — fast-path
+    counterpart to :func:`export_video_audio`.
+
+    The RGB->YUV 4:2:0 conversion already ran on-device (``fast_device_to_host_yuv``), so we
+    hand libx264 native yuv420p frames and skip both the host-side color conversion and the
+    3x-larger float/RGB device->host gather. The encoded MP4 is yuv420p either way, so this is
+    not a fidelity change — only the conversion's location moves.
+
+    Args:
+        yuv_planar: ``(T, H*3//2, W)`` uint8 — PyAV yuv420p ndarray layout, one entry per frame.
+        output_path: output .mp4 path
+        fps: frame rate
+        audio: decoded ``Audio``, or None
+    """
+    import av
+
+    t, h32, width = yuv_planar.shape
+    height = h32 * 2 // 3
+
+    container = av.open(output_path, mode="w")
+    stream = container.add_stream("libx264", rate=int(fps))
+    stream.width = width
+    stream.height = height
+    stream.pix_fmt = "yuv420p"
+    stream.options = {"preset": "veryfast", "crf": "23"}
+    stream.thread_type = "AUTO"
+
+    audio_stream = _add_audio_stream(container, audio)
+
+    for frame_array in yuv_planar:
+        frame = av.VideoFrame.from_ndarray(frame_array, format="yuv420p")
+        for packet in stream.encode(frame):
+            container.mux(packet)
+    for packet in stream.encode():
+        container.mux(packet)
+
+    if audio is not None and audio_stream is not None:
+        _mux_audio(container, audio_stream, audio)
+
+    container.close()
+    logger.info(f"Saved: {output_path} ({t}f @ {fps}fps, yuv420p fast path)")
+
+
 def export_video_audio(video_pixels: torch.Tensor, output_path: str, fps: int = 24, audio: Audio | None = None) -> None:
     """Export decoded video (and optionally audio) to MP4.
 
@@ -131,13 +224,8 @@ def export_video_audio(video_pixels: torch.Tensor, output_path: str, fps: int = 
     stream.options = {"preset": "veryfast", "crf": "23"}
     stream.thread_type = "AUTO"
 
-    # Prepare audio stream if provided
-    audio_stream = None
-    if audio is not None:
-        audio_stream = container.add_stream("aac", rate=audio.sampling_rate)
-        audio_stream.codec_context.sample_rate = audio.sampling_rate
-        audio_stream.codec_context.layout = "stereo"
-        audio_stream.codec_context.time_base = Fraction(1, audio.sampling_rate)
+    # Prepare audio stream if provided (must be added before any packet is muxed)
+    audio_stream = _add_audio_stream(container, audio)
 
     # Write video frames
     for frame_array in frames:
@@ -151,38 +239,7 @@ def export_video_audio(video_pixels: torch.Tensor, output_path: str, fps: int = 
 
     # Write audio if provided
     if audio is not None and audio_stream is not None:
-        samples = audio.waveform
-        if samples.ndim == 1:
-            samples = samples[:, None]
-        if samples.shape[1] != 2 and samples.shape[0] == 2:
-            samples = samples.T
-        if samples.shape[1] != 2:
-            logger.warning(f"Audio has {samples.shape[1]} channels, expected 2 — duplicating mono")
-            samples = samples[:, :1].repeat(1, 2)
-
-        if samples.dtype != torch.int16:
-            samples = torch.clip(samples, -1.0, 1.0)
-            samples = (samples * 32767.0).to(torch.int16)
-
-        frame_in = av.AudioFrame.from_ndarray(
-            samples.contiguous().reshape(1, -1).cpu().numpy(),
-            format="s16",
-            layout="stereo",
-        )
-        frame_in.sample_rate = audio.sampling_rate
-
-        # Resample to encoder format and write
-        cc = audio_stream.codec_context
-        resampler = av.audio.resampler.AudioResampler(
-            format=cc.format or "fltp",
-            layout=cc.layout or "stereo",
-            rate=cc.sample_rate or audio.sampling_rate,
-        )
-        for resampled in resampler.resample(frame_in):
-            for packet in audio_stream.encode(resampled):
-                container.mux(packet)
-        for packet in audio_stream.encode():
-            container.mux(packet)
+        _mux_audio(container, audio_stream, audio)
 
     container.close()
     logger.info(f"Saved: {output_path} ({frames.shape[0]}f @ {fps}fps)")

--- a/models/tt_dit/utils/yuv_d2h.py
+++ b/models/tt_dit/utils/yuv_d2h.py
@@ -22,8 +22,7 @@ from .planar_concat import HAS_CPP_PLANAR_CONCAT
 from .planar_concat import planar_concat_cpp as _planar_concat_cpp_impl
 from .tensor import _get_inter_host_axis, _host_buffer_to_torch, _to_torch_zero_copy
 
-# Persistent host-side reassembly pool — strided uint8 copies release the GIL,
-# so a few threads scale near-linearly; persistence avoids per-call startup.
+# Persistent host-side reassembly pool — strided uint8 copies release the GIL, so a few threads scale near-linearly
 _DEFAULT_REASSEMBLE_POOL: ThreadPoolExecutor | None = None
 _DEFAULT_REASSEMBLE_WORKERS = min(8, os.cpu_count() or 8)
 
@@ -38,10 +37,7 @@ def _get_default_reassemble_pool() -> ThreadPoolExecutor:
     return _DEFAULT_REASSEMBLE_POOL
 
 
-# Persistent output buffer for the C++ planar-concat fast path — fresh np.empty
-# pays first-touch page-fault overhead per call that dwarfs the kernel; reuse
-# eliminates it. The returned buffer is reused across calls (copy out / feed
-# ffmpeg before the next call). Shape changes reallocate lazily.
+# Persistent output buffer for the C++ planar-concat fast path
 _PLANAR_OUT_BUF: np.ndarray | None = None
 _PLANAR_OUT_SHAPE: tuple[int, int] | None = None
 
@@ -110,9 +106,7 @@ def _yuv_planar_d2h(
     uv = Hu * Wu
     row_stride = hw + 2 * uv
 
-    # Logical output dims: when the VAE pads (global right/bottom tail, e.g. LTX W 1920->2048),
-    # the scatter writes each shard's valid columns/rows straight into a logical-sized buffer —
-    # no separate trim copy. Defaults to the padded H/W (no crop).
+    # Logical output dims: when the VAE pads
     out_H = H if out_H is None else out_H
     out_W = W if out_W is None else out_W
 
@@ -179,17 +173,7 @@ def _yuv_planar_d2h(
         Cb_shards = _extract(host_Cb)  # each (1, h_per_uv, w_per_uv, T)
         Cr_shards = _extract(host_Cr)
 
-    # --- C++/AVX2 fast path ---------------------------------------------
-    #
-    # Drop-in replacement for the torch_threaded scatter below: same byte
-    # layout, ~2× faster with the persistent output buffer.  The C++
-    # binding assumes shards are passed in row-major (r, c) order, so we
-    # sort by coord first.  The fast path requires a complete TP_eff ×
-    # SP_eff rectangular submesh; if the local coords are sparse (could
-    # happen on irregular multi-host topologies), we fall through to the
-    # Python path which handles arbitrary coord sets.
-    # C++ path: needs a complete TP_eff x SP_eff rectangular submesh; it clamps each shard's
-    # write to out_H/out_W (the padded global tail is never written) and sizes out logically.
+    # --- C++/AVX2 fast path --------------------------------------------- Drop-in replacement for the torch_threaded
     if HAS_CPP_PLANAR_CONCAT and len(mesh_coords) == TP_eff * SP_eff:
         triples = sorted(
             zip(mesh_coords, Y_shards, Cb_shards, Cr_shards),
@@ -209,9 +193,7 @@ def _yuv_planar_d2h(
             out_W=out_W,
         )
 
-    # --- Python fallback (torch_threaded scatter) ------------------------
-    # Assemble directly into the logical-sized planar buffer; each shard's scatter is clamped to
-    # the logical bound so padded tail rows/cols are simply not written (no separate trim pass).
+    # --- Python fallback (torch_threaded scatter) ------------------------ Assemble directly into the logical-sized
     out_Hu, out_Wu = out_H // 2, out_W // 2
     out_hw, out_uv = out_H * out_W, out_Hu * out_Wu
     out_row = out_hw + 2 * out_uv
@@ -328,13 +310,7 @@ def fast_device_to_host_yuv(
     if coefficients is None:
         coefficients = _bt601_yuv_coefficients()
 
-    # NOTE: ttnn ``.shape`` on a multi-device sharded tensor returns the
-    # per-shard (local) shape, not the global logical shape.  We derive the
-    # global H, W from the mesh shape, assuming H is sharded on axis 0 and W
-    # on axis 1 (the convention this function documents).  All on-device ops
-    # (permute, reshape, yuv_conversion) operate on per-shard semantics, so
-    # we use ``h_per, w_per`` for the reshape target; ``_yuv_planar_d2h``
-    # then takes the global ``H, W`` to size the output buffer.
+    # NOTE: ttnn ``.shape`` on a multi-device sharded tensor returns the per-shard (local) shape
     mesh_shape = tuple(mesh_device.shape)
     B, C, T, h_per, w_per = tt_video_BCTHW.shape
     assert B == 1, f"fast_device_to_host_yuv requires B=1, got {B}"
@@ -364,10 +340,7 @@ def fast_device_to_host_yuv(
 
         inter_dim = concat_dims[inter_host_axis]
         if inter_dim is not None and mesh_shape[inter_host_axis] > 1:
-            # Move the gather dim out of the tile dims (last two) to position 2
-            # (dim=-3). This avoids the composite_all_gather path's tile-padded
-            # check and makes any concat fallback a cheap outer-dim memcpy.
-            # BCTHW dims: B=0 C=1 T=2 H=3 W=4. inter_dim is 3 (H) or 4 (W).
+            # Move the gather dim out of the tile dims (last two) to position 2 (dim=-3)
             if inter_dim == 4:
                 pre_dims = (0, 1, 4, 2, 3)  # BCTHW -> BCWTH
                 post_dims = (0, 1, 3, 4, 2)  # BCWTH -> BCTHW
@@ -385,8 +358,7 @@ def fast_device_to_host_yuv(
                 use_hyperparams=True,
                 use_persistent_buffer=True,
             )
-            # Drop back to ROW_MAJOR before repeat/mesh_partition so ttnn.repeat
-            # doesn't wrap itself in an Untilize → Repeat → Tilize roundtrip.
+            # Drop back to ROW_MAJOR before repeat/mesh_partition so ttnn.repeat doesn't wrap itself in an Untilize →
             tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.ROW_MAJOR_LAYOUT)
             n_hosts = int(ttnn.distributed_context_get_size())
             if n_hosts > 1:
@@ -426,9 +398,7 @@ def fast_device_to_host_yuv(
         print(f"  [yuv-d2h]   Cb: {list(tt_Cb.shape)}")
         print(f"  [yuv-d2h]   Cr: {list(tt_Cr.shape)}")
 
-    # 3+4. Batched D2H + planar concat, assembled straight into the logical-sized buffer.
-    # The VAE pads a global right/bottom tail (LTX pads W 1920->2048 on 4x8); passing
-    # out_H/out_W clamps each shard's scatter so the padded tail is never written — no trim copy.
+    # 3+4
     new_H = logical_h if logical_h is not None else H
     new_W = logical_w if logical_w is not None else W
     out = _yuv_planar_d2h(tt_Y, tt_Cb, tt_Cr, mesh_device, H, W, T, out_H=new_H, out_W=new_W, view=d2h_view, pool=pool)

--- a/models/tt_dit/utils/yuv_d2h.py
+++ b/models/tt_dit/utils/yuv_d2h.py
@@ -1,0 +1,436 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""On-device YUV 4:2:0 conversion + fast device-to-host into ffmpeg yuv420p planar bytes.
+
+Isolated from ``tensor.py`` so the LTX wiring stays decoupled from that module's
+d2h internals; reuses the shard-extraction primitives it already exposes.
+"""
+
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import torch
+
+import ttnn
+
+from .planar_concat import HAS_CPP_PLANAR_CONCAT
+from .planar_concat import planar_concat_cpp as _planar_concat_cpp_impl
+from .tensor import _get_inter_host_axis, _host_buffer_to_torch, _to_torch_zero_copy
+
+# Persistent host-side reassembly pool — strided uint8 copies release the GIL,
+# so a few threads scale near-linearly; persistence avoids per-call startup.
+_DEFAULT_REASSEMBLE_POOL: ThreadPoolExecutor | None = None
+_DEFAULT_REASSEMBLE_WORKERS = min(8, os.cpu_count() or 8)
+
+
+def _get_default_reassemble_pool() -> ThreadPoolExecutor:
+    global _DEFAULT_REASSEMBLE_POOL
+    if _DEFAULT_REASSEMBLE_POOL is None:
+        _DEFAULT_REASSEMBLE_POOL = ThreadPoolExecutor(
+            max_workers=_DEFAULT_REASSEMBLE_WORKERS,
+            thread_name_prefix="tt_dit_yuv_reassemble",
+        )
+    return _DEFAULT_REASSEMBLE_POOL
+
+
+# Persistent output buffer for the C++ planar-concat fast path — fresh np.empty
+# pays first-touch page-fault overhead per call that dwarfs the kernel; reuse
+# eliminates it. The returned buffer is reused across calls (copy out / feed
+# ffmpeg before the next call). Shape changes reallocate lazily.
+_PLANAR_OUT_BUF: np.ndarray | None = None
+_PLANAR_OUT_SHAPE: tuple[int, int] | None = None
+
+
+def _get_planar_out_buf(T: int, row_stride: int) -> np.ndarray:
+    global _PLANAR_OUT_BUF, _PLANAR_OUT_SHAPE
+    shape = (T, row_stride)
+    if _PLANAR_OUT_SHAPE != shape:
+        _PLANAR_OUT_BUF = np.empty(shape, dtype=np.uint8)
+        _PLANAR_OUT_SHAPE = shape
+    return _PLANAR_OUT_BUF
+
+
+def _bt601_yuv_coefficients():
+    """BT.601 coefficients for input in [-1, 1] -> limited-range uint8 (Y 16-235, CbCr 16-240)."""
+    return ttnn.experimental.yuv_bt601_coefficients()
+
+
+def _yuv_planar_d2h(
+    tt_Y: ttnn.Tensor,
+    tt_Cb: ttnn.Tensor,
+    tt_Cr: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    H: int,
+    W: int,
+    T: int,
+    *,
+    out_H: int | None = None,
+    out_W: int | None = None,
+    view=None,
+    pool: ThreadPoolExecutor | None = None,
+) -> np.ndarray:
+    """Batched D2H of three YUV ttnn tensors into ffmpeg yuv420p planar uint8.
+
+    Per-shard input shapes (kernel-native BHWT with C=1):
+
+      * tt_Y:        ``(1, h_per_y, w_per_y, T)``
+      * tt_Cb/tt_Cr: ``(1, h_per_uv, w_per_uv, T)``
+
+    Output: ``(T, H*W + 2*(H/2 * W/2))`` numpy uint8 — per-frame
+    ``[Y plane | Cb plane | Cr plane]`` in row-major.
+
+    Kicks off all three ``cpu(blocking=False)`` calls before a single
+    ``synchronize_device`` so the reads overlap.  Per-shard scatters then
+    take one of two paths:
+
+      * **C++/AVX2 fast path** (when ``HAS_CPP_PLANAR_CONCAT`` is True and
+        the local mesh is rectangular): one ``planar_concat_cpp`` call into
+        a module-level persistent output buffer.  ~2× faster than the
+        Python path on warm calls, but the returned buffer is **reused
+        across calls** — copy out (or feed ffmpeg) before the next call.
+      * **Python fallback**: per-shard ``_write`` tasks on the shared
+        reassembly ThreadPoolExecutor (torch's strided-copy backend).
+        Each scatter is a strided->strided copy; allocates a fresh output
+        per call.
+
+    Either way, the byte layout is identical.
+
+    Args:
+        view: Optional mesh device view for multi-host environments.
+            When provided, uses ``host_buffer()`` / ``get_shard()`` with
+            ``view.is_local()`` filtering instead of ``get_device_tensors()``.
+    """
+    Hu, Wu = H // 2, W // 2
+    hw = H * W
+    uv = Hu * Wu
+    row_stride = hw + 2 * uv
+
+    # Logical output dims: when the VAE pads (global right/bottom tail, e.g. LTX W 1920->2048),
+    # the scatter writes each shard's valid columns/rows straight into a logical-sized buffer —
+    # no separate trim copy. Defaults to the padded H/W (no crop).
+    out_H = H if out_H is None else out_H
+    out_W = W if out_W is None else out_W
+
+    # Async D2H all 3 outputs, single sync — overlaps three D2H reads.
+    host_Y = tt_Y.cpu(blocking=False)
+    host_Cb = tt_Cb.cpu(blocking=False)
+    host_Cr = tt_Cr.cpu(blocking=False)
+    ttnn.synchronize_device(mesh_device)
+
+    if view is not None:
+        # --- Multi-host: extract local shards via host_buffer/get_shard ---
+        def _extract_local(host_tensor):
+            host_mesh_coords = list(host_tensor.tensor_topology().mesh_coords())
+            distributed_buf = host_tensor.host_buffer()
+            tt_dtype = host_tensor.dtype
+            padded_shape = list(host_tensor.padded_shape)
+            logical_shape = list(host_tensor.shape)
+            trim = tuple(slice(0, d) for d in logical_shape)
+
+            coords_and_shards = []
+            for c in host_mesh_coords:
+                if not view.is_local(c):
+                    continue
+                buf = distributed_buf.get_shard(c)
+                if buf is not None:
+                    coords_and_shards.append((c, _host_buffer_to_torch(buf, padded_shape, tt_dtype)[trim]))
+            return coords_and_shards
+
+        Y_coords_shards = _extract_local(host_Y)
+        Cb_coords_shards = _extract_local(host_Cb)
+        Cr_coords_shards = _extract_local(host_Cr)
+
+        # Remap global mesh coordinates to 0-based local coordinates.
+        all_local_coords = [c for c, _ in Y_coords_shards]
+        local_row_positions = sorted({int(c[0]) for c in all_local_coords})
+        local_col_positions = sorted({int(c[1]) for c in all_local_coords})
+        row_remap = {pos: i for i, pos in enumerate(local_row_positions)}
+        col_remap = {pos: i for i, pos in enumerate(local_col_positions)}
+        TP_eff = len(local_row_positions)
+        SP_eff = len(local_col_positions)
+
+        h_per_y, w_per_y = H // TP_eff, W // SP_eff
+        h_per_uv, w_per_uv = Hu // TP_eff, Wu // SP_eff
+
+        mesh_coords = [(row_remap[int(c[0])], col_remap[int(c[1])]) for c in all_local_coords]
+        Y_shards = [s for _, s in Y_coords_shards]
+        Cb_shards = [s for _, s in Cb_coords_shards]
+        Cr_shards = [s for _, s in Cr_coords_shards]
+    else:
+        # --- Single-host: extract all shards via get_device_tensors ---
+        TP_eff, SP_eff = tuple(mesh_device.shape)
+        h_per_y, w_per_y = H // TP_eff, W // SP_eff
+        h_per_uv, w_per_uv = Hu // TP_eff, Wu // SP_eff
+
+        mesh_coords = list(tt_Y.tensor_topology().mesh_coords())
+
+        def _extract(host_tensor):
+            host_shards = ttnn.get_device_tensors(host_tensor)
+            logical_shape = list(host_shards[0].shape)
+            trim = tuple(slice(0, d) for d in logical_shape)
+            return [_to_torch_zero_copy(s)[trim] for s in host_shards]
+
+        Y_shards = _extract(host_Y)  # each (1, h_per_y, w_per_y, T)
+        Cb_shards = _extract(host_Cb)  # each (1, h_per_uv, w_per_uv, T)
+        Cr_shards = _extract(host_Cr)
+
+    # --- C++/AVX2 fast path ---------------------------------------------
+    #
+    # Drop-in replacement for the torch_threaded scatter below: same byte
+    # layout, ~2× faster with the persistent output buffer.  The C++
+    # binding assumes shards are passed in row-major (r, c) order, so we
+    # sort by coord first.  The fast path requires a complete TP_eff ×
+    # SP_eff rectangular submesh; if the local coords are sparse (could
+    # happen on irregular multi-host topologies), we fall through to the
+    # Python path which handles arbitrary coord sets.
+    # C++ path: needs a complete TP_eff x SP_eff rectangular submesh; it clamps each shard's
+    # write to out_H/out_W (the padded global tail is never written) and sizes out logically.
+    if HAS_CPP_PLANAR_CONCAT and len(mesh_coords) == TP_eff * SP_eff:
+        triples = sorted(
+            zip(mesh_coords, Y_shards, Cb_shards, Cr_shards),
+            key=lambda t: (int(t[0][0]), int(t[0][1])),
+        )
+        out_Hu, out_Wu = out_H // 2, out_W // 2
+        out_row = out_H * out_W + 2 * out_Hu * out_Wu
+        out = _get_planar_out_buf(T, out_row)
+        return _planar_concat_cpp_impl(
+            [t[1] for t in triples],
+            [t[2] for t in triples],
+            [t[3] for t in triples],
+            "CHWT",
+            (TP_eff, SP_eff),
+            out=out,
+            out_H=out_H,
+            out_W=out_W,
+        )
+
+    # --- Python fallback (torch_threaded scatter) ------------------------
+    # Assemble directly into the logical-sized planar buffer; each shard's scatter is clamped to
+    # the logical bound so padded tail rows/cols are simply not written (no separate trim pass).
+    out_Hu, out_Wu = out_H // 2, out_W // 2
+    out_hw, out_uv = out_H * out_W, out_Hu * out_Wu
+    out_row = out_hw + 2 * out_uv
+
+    out = np.empty((T, out_row), dtype=np.uint8)
+    out_t = torch.from_numpy(out)
+    y_view = out_t.as_strided((T, out_H, out_W), (out_row, out_W, 1), 0)
+    u_view = out_t.as_strided((T, out_Hu, out_Wu), (out_row, out_Wu, 1), out_hw)
+    v_view = out_t.as_strided((T, out_Hu, out_Wu), (out_row, out_Wu, 1), out_hw + out_uv)
+
+    if pool is None:
+        pool = _get_default_reassemble_pool()
+
+    def _write(view, shard, r, c, h_per, w_per, bound_h, bound_w):
+        r0, c0 = r * h_per, c * w_per
+        vh = min(h_per, bound_h - r0)
+        vw = min(w_per, bound_w - c0)
+        if vh <= 0 or vw <= 0:
+            return  # shard lies entirely in the padded tail
+        # shard (1, h_per, w_per, T) -> squeeze(0).permute(2, 0, 1) -> (T, h_per, w_per).
+        src = shard.squeeze(0).permute(2, 0, 1)[:, :vh, :vw]
+        view[:, r0 : r0 + vh, c0 : c0 + vw].copy_(src)
+
+    futures = []
+    for coord, shard in zip(mesh_coords, Y_shards):
+        r, c = int(coord[0]), int(coord[1])
+        futures.append(pool.submit(_write, y_view, shard, r, c, h_per_y, w_per_y, out_H, out_W))
+    for coord, shard in zip(mesh_coords, Cb_shards):
+        r, c = int(coord[0]), int(coord[1])
+        futures.append(pool.submit(_write, u_view, shard, r, c, h_per_uv, w_per_uv, out_Hu, out_Wu))
+    for coord, shard in zip(mesh_coords, Cr_shards):
+        r, c = int(coord[0]), int(coord[1])
+        futures.append(pool.submit(_write, v_view, shard, r, c, h_per_uv, w_per_uv, out_Hu, out_Wu))
+    for f in futures:
+        f.result()
+
+    return out
+
+
+def fast_device_to_host_yuv(
+    tt_video_BCTHW: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    *,
+    ccl_manager=None,
+    root: int | None = None,
+    coefficients=None,
+    pool: ThreadPoolExecutor | None = None,
+    debug: bool = False,
+    logical_h: int | None = None,
+    logical_w: int | None = None,
+) -> np.ndarray | None:
+    """On-device YUV 4:2:0 conversion + batched D2H + planar uint8 concat.
+
+    Takes a sharded BCTHW bf16 row-major tensor with values in ``[-1, 1]`` —
+    typically the output of the Wan VAE — and returns a single numpy uint8
+    array in ffmpeg ``AV_PIX_FMT_YUV420P`` layout.
+
+    On a single-host system, reads all per-device shards concurrently with
+    async DMA, converts each shard's YUV planes, and scatters into the
+    planar output on host.
+
+    On a multi-host (distributed) system, uses a hybrid approach: an
+    on-device all_gather for the inter-host axis only, then re-shards with
+    repeat + mesh_partition so each local device holds unique data, runs the
+    YUV conversion on the gathered data, and performs fast async DMA + planar
+    concat for local shards only.
+
+    Pipeline:
+      1. (Multi-host only) ``all_gather`` + ``repeat`` + ``mesh_partition``
+         on the inter-host axis of the bf16 BCTHW input.
+      2. Permute BCTHW -> BCHWT (T moves to the last position) and reshape to
+         drop the B=1 dim, landing in CHWT — the layout the YUV kernel expects.
+      3. ``ttnn.experimental.rgb_to_yuv`` runs on each device's local shard,
+         producing 3 uint8 outputs (Y full-res, Cb/Cr 4:2:0 subsampled).
+      4. Async ``cpu(blocking=False)`` on all three outputs followed by a
+         single ``synchronize_device`` so the D2H reads overlap.
+      5. Per-shard scatters are dispatched across the shared reassembly thread
+         pool using torch's strided-copy backend.
+
+    Output shape: ``(T, H*W + 2*(H/2 * W/2))`` numpy uint8 — one row per frame,
+    ``[Y plane | Cb plane | Cr plane]`` in row-major.
+
+    Args:
+        tt_video_BCTHW: Sharded ttnn tensor with shape ``(1, 3, T, H, W)``,
+            bfloat16, ROW_MAJOR_LAYOUT, sharded ``{axis 0: dim 3 (H), axis 1: dim 4 (W)}``.
+            Values must lie in ``[-1, 1]`` — the YUV kernel's expected range.
+        mesh_device: The mesh device.
+        ccl_manager: Optional :class:`CCLManager` instance.  Required for
+            multi-host environments where only local devices are accessible.
+        root: If set, only the host with this MPI rank performs the D2H
+            transfer and returns the assembled array; all other ranks return
+            ``None``.  If ``None`` (default), all ranks perform D2H.
+        coefficients: ``ttnn.experimental.YUVCoefficients`` to use for the
+            per-channel weights and offsets.  Defaults to BT.601 limited range.
+        pool: Optional ``ThreadPoolExecutor`` for the host-side reassembly.
+            If ``None``, the module-level lazy default pool is used.
+        debug: If ``True``, print diagnostic shape information.
+        logical_h: Optional logical (un-padded) height of the output.  When
+            the VAE pads ``H`` to a coarser size, pass the true logical height
+            here and the function will trim the bottom rows of each plane in
+            the planar buffer on host (Y -> top ``logical_h`` rows; Cb/Cr ->
+            top ``logical_h/2`` rows).  Must be even and ``<= H``.  Defaults to
+            ``None`` (no trim).
+
+    Returns:
+        ``np.ndarray`` of shape ``(T, H'*W + 2*(H'/2 * W/2))``, dtype uint8,
+        where ``H' = logical_h if logical_h is not None else H``.
+        Returns ``None`` for non-root ranks when ``root`` is set.
+
+    Raises:
+        AssertionError: if ``B != 1``, ``C != 3``, or H/W are not even.
+        ValueError: if ``logical_h`` is set and is greater than ``H`` or odd.
+    """
+    if coefficients is None:
+        coefficients = _bt601_yuv_coefficients()
+
+    # NOTE: ttnn ``.shape`` on a multi-device sharded tensor returns the
+    # per-shard (local) shape, not the global logical shape.  We derive the
+    # global H, W from the mesh shape, assuming H is sharded on axis 0 and W
+    # on axis 1 (the convention this function documents).  All on-device ops
+    # (permute, reshape, yuv_conversion) operate on per-shard semantics, so
+    # we use ``h_per, w_per`` for the reshape target; ``_yuv_planar_d2h``
+    # then takes the global ``H, W`` to size the output buffer.
+    mesh_shape = tuple(mesh_device.shape)
+    B, C, T, h_per, w_per = tt_video_BCTHW.shape
+    assert B == 1, f"fast_device_to_host_yuv requires B=1, got {B}"
+    assert C == 3, f"fast_device_to_host_yuv requires C=3 (RGB), got {C}"
+
+    TP, SP = mesh_shape
+    H, W = h_per * TP, w_per * SP
+
+    if debug:
+        print(f"  [yuv-d2h] input per-shard: {list(tt_video_BCTHW.shape)}")
+        print(f"  [yuv-d2h] global H={H}, W={W}, T={T}  (mesh TP={TP}, SP={SP})")
+
+    # Sharding convention: axis 0 -> dim 3 (H), axis 1 -> dim 4 (W).
+    concat_dims: list[int | None] = [3, 4]
+
+    # --- Multi-host: hybrid on-device collective + fast local DMA -----------
+    d2h_view = None
+    if ttnn.using_distributed_env():
+        if ccl_manager is None:
+            msg = "fast_device_to_host_yuv requires ccl_manager in a distributed (multi-host) environment"
+            raise ValueError(msg)
+
+        d2h_view = mesh_device.get_view()
+        rank = int(ttnn.distributed_context_get_rank())
+
+        inter_host_axis = _get_inter_host_axis(mesh_device, d2h_view, mesh_shape)
+
+        inter_dim = concat_dims[inter_host_axis]
+        if inter_dim is not None and mesh_shape[inter_host_axis] > 1:
+            # Move the gather dim out of the tile dims (last two) to position 2
+            # (dim=-3). This avoids the composite_all_gather path's tile-padded
+            # check and makes any concat fallback a cheap outer-dim memcpy.
+            # BCTHW dims: B=0 C=1 T=2 H=3 W=4. inter_dim is 3 (H) or 4 (W).
+            if inter_dim == 4:
+                pre_dims = (0, 1, 4, 2, 3)  # BCTHW -> BCWTH
+                post_dims = (0, 1, 3, 4, 2)  # BCWTH -> BCTHW
+            else:  # inter_dim == 3
+                pre_dims = (0, 1, 3, 2, 4)  # BCTHW -> BCHTW
+                post_dims = (0, 1, 3, 2, 4)  # BCHTW -> BCTHW (same swap)
+            ag_dim = 2
+
+            tt_video_BCTHW = ttnn.permute(tt_video_BCTHW, pre_dims)
+            tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.TILE_LAYOUT)
+            tt_video_BCTHW = ccl_manager.all_gather(
+                tt_video_BCTHW,
+                dim=ag_dim,
+                mesh_axis=inter_host_axis,
+                use_hyperparams=True,
+                use_persistent_buffer=True,
+            )
+            # Drop back to ROW_MAJOR before repeat/mesh_partition so ttnn.repeat
+            # doesn't wrap itself in an Untilize → Repeat → Tilize roundtrip.
+            tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.ROW_MAJOR_LAYOUT)
+            n_hosts = int(ttnn.distributed_context_get_size())
+            if n_hosts > 1:
+                repeat_dims = [1] * len(tt_video_BCTHW.shape)
+                repeat_dims[ag_dim] = n_hosts
+                tt_video_BCTHW = ttnn.repeat(tt_video_BCTHW, repeat_dims)
+                tt_video_BCTHW = ttnn.mesh_partition(tt_video_BCTHW, dim=ag_dim, cluster_axis=inter_host_axis)
+            tt_video_BCTHW = ttnn.permute(tt_video_BCTHW, post_dims)
+
+        # Recompute per-shard dims after gather — they may have grown.
+        B, C, T, h_per, w_per = tt_video_BCTHW.shape
+
+        if debug:
+            print(f"  [yuv-d2h] (distributed) post-gather per-shard: {list(tt_video_BCTHW.shape)}")
+
+        if root is not None and rank != root:
+            return None
+
+    assert (
+        h_per % 2 == 0 and w_per % 2 == 0
+    ), f"per-shard H and W must be even for 4:2:0 (got h_per={h_per}, w_per={w_per})"
+
+    # 1. Reorder BCTHW -> CHWT for the YUV kernel.  Shapes here are per-shard.
+    tt_BCHWT = ttnn.permute(tt_video_BCTHW, (0, 1, 3, 4, 2))
+    if debug:
+        print(f"  [yuv-d2h] after permute(0,1,3,4,2) per-shard: {list(tt_BCHWT.shape)}")
+
+    tt_CHWT = ttnn.reshape(tt_BCHWT, (C, h_per, w_per, T))
+    if debug:
+        print(f"  [yuv-d2h] after reshape to (C,h_per,w_per,T) per-shard: {list(tt_CHWT.shape)}")
+
+    # 2. On-device YUV 4:2:0 -> 3 uint8 tensors.
+    tt_Y, tt_Cb, tt_Cr = ttnn.experimental.rgb_to_yuv(tt_CHWT, coefficients=coefficients)
+    if debug:
+        print(f"  [yuv-d2h] yuv outputs per-shard:")
+        print(f"  [yuv-d2h]   Y : {list(tt_Y.shape)}")
+        print(f"  [yuv-d2h]   Cb: {list(tt_Cb.shape)}")
+        print(f"  [yuv-d2h]   Cr: {list(tt_Cr.shape)}")
+
+    # 3+4. Batched D2H + planar concat, assembled straight into the logical-sized buffer.
+    # The VAE pads a global right/bottom tail (LTX pads W 1920->2048 on 4x8); passing
+    # out_H/out_W clamps each shard's scatter so the padded tail is never written — no trim copy.
+    new_H = logical_h if logical_h is not None else H
+    new_W = logical_w if logical_w is not None else W
+    out = _yuv_planar_d2h(tt_Y, tt_Cb, tt_Cr, mesh_device, H, W, T, out_H=new_H, out_W=new_W, view=d2h_view, pool=pool)
+
+    return out

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -46,7 +46,14 @@ set -o pipefail
 # pytest's own stdout/stderr pass through unchanged.
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-DISPATCH_TIMEOUT=5
+# Dispatch-layer hang timeout (seconds). Default 5s is lean for the common case,
+# but full-mesh fabric ops (e.g. a 4x8-galaxy ring all-gather) can legitimately
+# exceed it and false-trip; override via SAFE_PYTEST_DISPATCH_TIMEOUT for those.
+DISPATCH_TIMEOUT="${SAFE_PYTEST_DISPATCH_TIMEOUT:-5}"
+# Reset command run to recover a dirty/hung device. Default suits single-chip
+# boards; a 4x8 galaxy needs `tt-smi -glx_reset` (and may require host-level
+# access), so override via SAFE_PYTEST_RESET_CMD.
+RESET_CMD="${SAFE_PYTEST_RESET_CMD:-tt-smi -r}"
 TRIAGE_SCRIPT="${REPO_DIR}/tools/tt-triage.py"
 WATCHER_LOG="${REPO_DIR}/generated/watcher/watcher.log"
 TRIAGE_LLM_DIR="${REPO_DIR}/generated/tt-triage"
@@ -142,9 +149,9 @@ if [[ "$SIM_MODE" == false ]]; then
 
     # --- Check if device needs reset from previous hang ---
     if [[ -f "$DIRTY_FLAG" ]]; then
-        echo "SAFE_PYTEST: Device marked dirty from previous hang, resetting..."
-        if ! tt-smi -r; then
-            echo "SAFE_PYTEST_ERROR: Device reset (tt-smi -r) failed"
+        echo "SAFE_PYTEST: Device marked dirty from previous hang, resetting..." >&2
+        if ! $RESET_CMD; then
+            echo "SAFE_PYTEST_ERROR: Device reset (tt-smi -r) failed" >&2
             exit 3
         fi
         rm -f "$DIRTY_FLAG"
@@ -307,8 +314,8 @@ fi
 # Hangs and crashes corrupt device state. Normal test failures (PCC mismatch,
 # assertion errors) and collection errors don't touch the device.
 if [[ "$IS_HANG" == true ]]; then
-    echo "SAFE_PYTEST: Resetting device..."
-    if tt-smi -r; then
+    echo "SAFE_PYTEST: Resetting device..." >&2
+    if $RESET_CMD; then
         sleep 2
         rm -f "$DIRTY_FLAG"
         echo "SAFE_PYTEST: Device reset complete"

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -304,6 +304,46 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
         )
     )
 
+    # LTX-2.3 distilled video self-attention (spatial, non-causal). video_dim=4096, 32 heads ->
+    # 8 local heads on TP=4, head_dim=128. seq_len is per-device (SP-padded total / sp_size); the two
+    # distilled stages use N=9728 (s1) and N=38912 (s2). Chunk sizes match attention_ltx's
+    # ring_sdpa_chunk_by_n for (blackhole, sp=8, tp=4).
+    if mesh_config.is_galaxy:
+        configs.append(
+            ModelConfig(
+                name="ltx_s1",
+                nhq=8,
+                nhk=8,
+                nhv=8,
+                d_q=128,
+                d_k=128,
+                d_v=128,
+                is_causal=False,
+                q_dtype=ttnn.bfloat16,
+                kv_dtype=ttnn.bfloat16,
+                q_chunk_sizes=[96],
+                k_chunk_sizes=[256],
+                seq_len=1216,
+            )
+        )
+        configs.append(
+            ModelConfig(
+                name="ltx_s2",
+                nhq=8,
+                nhk=8,
+                nhv=8,
+                d_q=128,
+                d_k=128,
+                d_v=128,
+                is_causal=False,
+                q_dtype=ttnn.bfloat16,
+                kv_dtype=ttnn.bfloat16,
+                q_chunk_sizes=[192],
+                k_chunk_sizes=[512],
+                seq_len=4864,
+            )
+        )
+
     return {config.name: config for config in configs}
 
 

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -304,10 +304,7 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
         )
     )
 
-    # LTX-2.3 distilled video self-attention (spatial, non-causal). video_dim=4096, 32 heads ->
-    # 8 local heads on TP=4, head_dim=128. seq_len is per-device (SP-padded total / sp_size); the two
-    # distilled stages use N=9728 (s1) and N=38912 (s2). Chunk sizes match attention_ltx's
-    # ring_sdpa_chunk_by_n for (blackhole, sp=8, tp=4).
+    # LTX-2.3 distilled video self-attention (spatial, non-causal)
     if mesh_config.is_galaxy:
         configs.append(
             ModelConfig(

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa_cross_padded.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa_cross_padded.py
@@ -1,0 +1,54 @@
+"""Padded V2A cross configs so the large transport-bound shapes RUN on the ring8 (SP=8) mesh.
+
+The committed cross test skips stage2_1080p_6s / _14s on SP=8 because their global q/kv dims
+are not multiples of SP*32 (=256). Here we round q_global/kv_global UP to the nearest SP*32
+while keeping the true logical_n, so the op attends only real keys (PCC unchanged) and we can
+measure device kernel duration for the split-forward optimization on the exposed-transport case.
+"""
+import pytest
+
+from tests.nightly.blackhole.sdpa.test_ring_joint_sdpa import (
+    MESH_CONFIG,
+    Topology,
+    run_ring_joint_sdpa_cross,
+    CROSS_PCC_THRESHOLD,
+    CROSS_RMSE_THRESHOLD,
+)
+
+
+def _round_up(x, m):
+    return ((x + m - 1) // m) * m
+
+
+# Round to the SP=8 tile-shard granularity (8*32=256). q/kv padded; logical_n = true key count.
+_SP = 8
+_M = _SP * 32
+# (id, nhq_total, head_dim, q_true, kv_true, logical_n)
+_RAW = [
+    ("ltx_v2a_stage1_6s", 32, 64, 256, 9728, 9690),
+    ("ltx_v2a_stage2_1080p_6s", 32, 64, 256, 38784, 38760),
+    ("ltx_v2a_stage2_1080p_14s", 32, 64, 384, 87808, 87720),
+]
+PADDED_CONFIGS = [
+    pytest.param(nhq, d, _round_up(q, _M), _round_up(kv, _M), logical_n, id=name)
+    for (name, nhq, d, q, kv, logical_n) in _RAW
+]
+
+
+@pytest.mark.parametrize("nhq_total, head_dim, q_global, kv_global, logical_n", PADDED_CONFIGS)
+def test_cross_padded_ring8(nhq_total, head_dim, q_global, kv_global, logical_n):
+    """is_cross ring SDPA at padded V2A shapes on the ring8 mesh (split-forward active)."""
+    run_ring_joint_sdpa_cross(
+        MESH_CONFIG,
+        nhq_total,
+        head_dim,
+        q_global,
+        kv_global,
+        logical_n,
+        q_chunk_sizes=[64, 128],
+        tp_size=4,
+        sp_size=8,
+        topology=Topology.Ring,
+        pcc_threshold=CROSS_PCC_THRESHOLD,
+        rmse_threshold=CROSS_RMSE_THRESHOLD,
+    )

--- a/tests/nightly/t3000/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
@@ -82,6 +82,7 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
     allowed_pcc=0.99,
     addcmul_scalar=None,
     broadcast_gate=True,
+    check_correctness=True,
 ):
     torch.manual_seed(0)
 
@@ -159,23 +160,25 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
         torch_input = torch.randn(input_shape, dtype=torch.float32)
         torch_weight_global = torch.randn(weight_shape_global, dtype=torch.float32)
 
-        # Golden: per-device MM outputs (each device has different weights)
-        torch_weight_chunks = torch.chunk(torch_weight_global, num_devices, dim=0)  # each [1, 1, K, N]
-        mm_outputs = []
-        for d in range(num_devices):
-            mm_out_d = torch.matmul(torch_input, torch_weight_chunks[d])
-            mm_outputs.append(mm_out_d)
-        torch_mm_output_per_device_list.append(mm_outputs)
+        # Golden: per-device MM outputs (each device has different weights). Skipped in perf/sweep
+        # mode (check_correctness=False) since the per-device torch.matmul is expensive and unused.
+        if check_correctness:
+            torch_weight_chunks = torch.chunk(torch_weight_global, num_devices, dim=0)  # each [1, 1, K, N]
+            mm_outputs = []
+            for d in range(num_devices):
+                mm_out_d = torch.matmul(torch_input, torch_weight_chunks[d])
+                mm_outputs.append(mm_out_d)
+            torch_mm_output_per_device_list.append(mm_outputs)
 
-        # Golden: RS reduce (sum across devices) then scatter
-        torch_rs_reduced = torch.sum(torch.stack(mm_outputs), dim=0)  # [1, 1, M, N]
-        torch_rs_scattered = torch.chunk(torch_rs_reduced, num_devices, dim=dim)
-        if addcmul_scalar is not None:
-            torch_rs_scattered = tuple(
-                torch.addcmul(torch_addcmul_a, chunk, torch_addcmul_b, value=addcmul_scalar)
-                for chunk in torch_rs_scattered
-            )
-        torch_rs_output_list.append(torch_rs_scattered)
+            # Golden: RS reduce (sum across devices) then scatter
+            torch_rs_reduced = torch.sum(torch.stack(mm_outputs), dim=0)  # [1, 1, M, N]
+            torch_rs_scattered = torch.chunk(torch_rs_reduced, num_devices, dim=dim)
+            if addcmul_scalar is not None:
+                torch_rs_scattered = tuple(
+                    torch.addcmul(torch_addcmul_a, chunk, torch_addcmul_b, value=addcmul_scalar)
+                    for chunk in torch_rs_scattered
+                )
+            torch_rs_output_list.append(torch_rs_scattered)
 
         # Create device tensors
         # Input: replicated (same on all devices)
@@ -345,6 +348,9 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
             logger.info(f"Done iteration {i}")
 
     ##### Verify results #####
+    if not check_correctness:
+        logger.info("Skipping correctness check (perf/sweep mode)")
+        return
     # Setup concat mesh to use 1D mesh concatenation.
     concat_mesh_shape = list(mesh_device.shape)
     concat_mesh_shape[1 - cluster_axis] = 1  # Set replicated mesh axis to 1 to prevent concatenation

--- a/tests/nightly/t3000/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
@@ -160,8 +160,7 @@ def run_minimal_matmul_strided_reduce_scatter_impl(
         torch_input = torch.randn(input_shape, dtype=torch.float32)
         torch_weight_global = torch.randn(weight_shape_global, dtype=torch.float32)
 
-        # Golden: per-device MM outputs (each device has different weights). Skipped in perf/sweep
-        # mode (check_correctness=False) since the per-device torch.matmul is expensive and unused.
+        # Golden: per-device MM outputs (each device has different weights)
         if check_correctness:
             torch_weight_chunks = torch.chunk(torch_weight_global, num_devices, dim=0)  # each [1, 1, K, N]
             mm_outputs = []

--- a/tests/nightly/t3000/ccl/test_neighbor_pad_halo.py
+++ b/tests/nightly/t3000/ccl/test_neighbor_pad_halo.py
@@ -1,0 +1,1274 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# PCC test for the standalone halo-only op ttnn.experimental.neighbor_pad_halo.
+#
+# The op emits ONLY the compact halo buffer [H-top | H-bot | W-left | W-right] (no interior copy,
+# no conv). We reuse the standalone neighbor_pad_async 2D golden (a full per-device padded tensor),
+# then slice out exactly the halo bands in the compact-buffer stick order and compare byte-for-byte
+# (bf16 copy, no arithmetic).
+
+import os
+import time
+import torch
+import pytest
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+
+from ttnn import ShardTensor2dMesh
+from tests.nightly.t3000.ccl.test_neighbor_pad_async import compute_2d_pad_golden
+
+
+def _trace_and_time(mesh_device, run_op, num_iters=30):
+    """Trace-replay wall/iter = device latency (untraced wall is host-dispatch-bound)."""
+    run_op()  # warmup + cold compile
+    ttnn.synchronize_device(mesh_device)
+    tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    run_op()
+    ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+    t0 = time.perf_counter()
+    for _ in range(num_iters):
+        ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+    ttnn.synchronize_device(mesh_device)
+    us = (time.perf_counter() - t0) * 1e6 / num_iters
+    ttnn.release_trace(mesh_device, tid)
+    return us
+
+
+def compact_halo_reference(golden, outer, H_dev, W_dev, pH, pW):
+    """Build the expected compact halo buffer [total_sticks, C] from a per-device padded golden.
+
+    golden: per-device tensor [B, T, H_dev+2pH, W_dev+2pW, C]. Sections + stick order match the
+    program factory: H sections are W_dev wide (interior W only); W sections are h_total tall
+    (include the corner/H-pad rows). Order within each section is (t, row, col), t-major.
+    """
+    C = golden.shape[-1]
+    h_total = H_dev + 2 * pH
+    g = golden.reshape(outer, H_dev + 2 * pH, W_dev + 2 * pW, C)
+    sticks = []
+    # H-top: pH rows above the chunk, interior W columns
+    for t in range(outer):
+        for pr in range(pH):
+            for w in range(W_dev):
+                sticks.append(g[t, pr, pW + w, :])
+    # H-bot: pH rows below the chunk, interior W columns
+    for t in range(outer):
+        for pr in range(pH):
+            for w in range(W_dev):
+                sticks.append(g[t, pH + H_dev + pr, pW + w, :])
+    # W-left: pW columns left of the chunk, full h_total rows (incl. corners)
+    for t in range(outer):
+        for hp in range(h_total):
+            for wc in range(pW):
+                sticks.append(g[t, hp, wc, :])
+    # W-right: pW columns right of the chunk, full h_total rows (incl. corners)
+    for t in range(outer):
+        for hp in range(h_total):
+            for wc in range(pW):
+                sticks.append(g[t, hp, pW + W_dev + wc, :])
+    return torch.stack(sticks, dim=0)  # [total_sticks, C]
+
+
+def run_neighbor_pad_halo_2d(mesh_device, input_shape, h_dim, w_dim, h_axis, w_axis, pH, pW, padding_mode, num_links):
+    mesh_shape = tuple(mesh_device.shape)
+    h_factor = mesh_shape[h_axis]
+    w_factor = mesh_shape[w_axis]
+    assert input_shape[h_dim] % h_factor == 0
+    assert input_shape[w_dim] % w_factor == 0
+
+    torch.manual_seed(42)
+    input_tensor = torch.rand(input_shape).bfloat16()
+    goldens = compute_2d_pad_golden(input_tensor, mesh_shape, h_dim, w_dim, h_axis, w_axis, pH, pW, padding_mode)
+
+    outer = 1
+    for d in range(h_dim):
+        outer *= input_shape[d]
+    H_dev = input_shape[h_dim] // h_factor
+    W_dev = input_shape[w_dim] // w_factor
+    C = input_shape[-1]
+    h_total = H_dev + 2 * pH
+    total_sticks = outer * 2 * pH * W_dev + outer * 2 * pW * h_total
+
+    # Sub-device + semaphores
+    grid = mesh_device.compute_with_storage_grid_size()
+    crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    sub = ttnn.SubDevice([crs])
+    sub_id = ttnn.SubDeviceId(0)
+    mgr = mesh_device.create_sub_device_manager([sub], 0)
+    mesh_device.load_sub_device_manager(mgr)
+    mesh_device.set_sub_device_stall_group([sub_id])
+
+    h_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    w_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    barrier_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    dims = [None, None]
+    dims[h_axis] = h_dim
+    dims[w_axis] = w_dim
+    input_tensor_mesh = ttnn.from_torch(
+        input_tensor,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem_config,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+    # Compact halo buffer: per-device [total_sticks, C], replicated (each device owns one).
+    halo_buf = ttnn.from_torch(
+        torch.zeros([total_sticks, C]).bfloat16(),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem_config,
+    )
+
+    out = ttnn.experimental.neighbor_pad_halo(
+        input_tensor_mesh,
+        halo_buf,
+        np_padding_h=pH,
+        np_padding_w=pW,
+        np_cluster_axis=h_axis,
+        np_num_links=num_links,
+        np_topology=ttnn.Topology.Linear,
+        h_neighbor_semaphore=h_sem,
+        barrier_semaphore=barrier_sem,
+        w_neighbor_semaphore=w_sem,
+        np_pad_dim2=w_dim,
+        np_pad2_left=pW,
+        np_pad2_right=pW,
+        np_pad2_cluster_axis=w_axis,
+        np_pad2_num_links=num_links,
+        padding_mode=padding_mode,
+    )
+    ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
+
+    out_host = ttnn.from_device(out)
+    dev_tensors = ttnn.get_device_tensors(out_host)
+    all_pass = True
+    for row in range(mesh_shape[0]):
+        for col in range(mesh_shape[1]):
+            device_idx = row * mesh_shape[1] + col
+            dev = ttnn.to_torch(dev_tensors[device_idx])
+            ref = compact_halo_reference(goldens[(row, col)], outer, H_dev, W_dev, pH, pW)
+            assert dev.shape == ref.shape, f"dev({row},{col}) shape {dev.shape} != ref {ref.shape}"
+            eq, msg = comp_equal(dev, ref)
+            if not eq:
+                _, pcc = comp_pcc(dev, ref, 0.0)
+                all_pass = False
+                # Per-section diagnostic: which of [H-top | H-bot | W-left | W-right] mismatches.
+                h_sec = outer * pH * W_dev
+                w_sec = outer * (H_dev + 2 * pH) * pW
+                bounds = [
+                    ("Htop", 0, h_sec),
+                    ("Hbot", h_sec, 2 * h_sec),
+                    ("Wleft", 2 * h_sec, 2 * h_sec + w_sec),
+                    ("Wright", 2 * h_sec + w_sec, 2 * h_sec + 2 * w_sec),
+                ]
+                secmsg = []
+                for name, a, b in bounds:
+                    if b <= dev.shape[0]:
+                        seq, _ = comp_equal(dev[a:b], ref[a:b])
+                        secmsg.append(f"{name}={'OK' if seq else 'BAD'}")
+                print(f"FAIL dev({row},{col}): {pcc} | sections: {' '.join(secmsg)}")
+                if os.environ.get("NP_DIAG"):
+                    import torch as _t
+
+                    h_sec = outer * pH * W_dev
+                    for nm, a, b in [("Htop", 0, h_sec), ("Hbot", h_sec, 2 * h_sec)]:
+                        sub_d, sub_r = dev[a:b], ref[a:b]
+                        bad = (~(sub_d == sub_r).all(dim=1)).nonzero().flatten().tolist()
+                        if not bad:
+                            continue
+                        frames = sorted({i // (pH * W_dev) for i in bad})
+                        cols = sorted({(i % (pH * W_dev)) % W_dev for i in bad})
+                        print(
+                            f"  {nm} bad_sticks={len(bad)}/{b-a} frames={frames[:8]}(n={len(frames)}/{outer}) "
+                            f"cols={cols}(n={len(cols)}/{W_dev}) banks={sorted({c%8 for c in cols})}"
+                        )
+                    # W sections: rows are [frame][h_row (0..H_dev+2pH)][pw]; flag which h_rows are bad and
+                    # whether they are corner rows (h_row < pH or >= pH+H_dev) — corners come from the H exchange.
+                    hh = H_dev + 2 * pH
+                    for nm, a, b in [
+                        ("Wleft", 2 * h_sec, 2 * h_sec + w_sec),
+                        ("Wright", 2 * h_sec + w_sec, 2 * h_sec + 2 * w_sec),
+                    ]:
+                        sub_d, sub_r = dev[a:b], ref[a:b]
+                        bad = (~(sub_d == sub_r).all(dim=1)).nonzero().flatten().tolist()
+                        if not bad:
+                            continue
+                        hrows = sorted({(i // pW) % hh for i in bad})
+                        corners = [r for r in hrows if r < pH or r >= pH + H_dev]
+                        wframes = sorted({i // (hh * pW) for i in bad})
+                        print(
+                            f"  {nm} bad={len(bad)}/{b-a} frames={wframes[:8]}(n={len(wframes)}/{outer}) "
+                            f"h_rows={hrows}(corner_rows={corners})"
+                        )
+            else:
+                print(f"PASS dev({row},{col})")
+
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
+    assert all_pass, "compact halo mismatch"
+
+
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("mesh_device", [(4, 8)], ids=["4x8"], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("input_shape", [[1, 8, 144, 256, 128]], ids=["s3ish"])
+def test_neighbor_pad_halo_padded_border(mesh_device, device_params, input_shape):
+    """Slice 2 validation (Architecture B): neighbor_pad_halo -> compact buffer (unchanged mux path),
+    then halo_scatter copies the compact border into a PADDED [outer,H+2,W+2,C] buffer IN PLACE. The
+    padded border must match neighbor_pad_async's full-pad buffer bit-exact. Interior stays 0 (scatter
+    writes border only); compare only the border positions."""
+    h_dim, w_dim, h_axis, w_axis, pH, pW, num_links = 2, 3, 0, 1, 1, 1, 2
+    mesh_shape = tuple(mesh_device.shape)
+    hf, wf = mesh_shape[h_axis], mesh_shape[w_axis]
+    B, T, Hf, Wf, C = input_shape
+    Hd, Wd = Hf // hf, Wf // wf
+    torch.manual_seed(0)
+    inp = torch.rand(input_shape).bfloat16()
+
+    grid = mesh_device.compute_with_storage_grid_size()
+    crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    mgr = mesh_device.create_sub_device_manager([ttnn.SubDevice([crs])], 0)
+    mesh_device.load_sub_device_manager(mgr)
+    sub_id = ttnn.SubDeviceId(0)
+    mesh_device.set_sub_device_stall_group([sub_id])
+    h_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    w_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    barrier_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    dims = [None, None]
+    dims[h_axis], dims[w_axis] = h_dim, w_dim
+    inp_mesh = ttnn.from_torch(
+        inp,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+    # full-pad reference (async persistent buffer)
+    out_shape = list(input_shape)
+    out_shape[h_dim] += hf * 2 * pH
+    out_shape[w_dim] += wf * 2 * pW
+    persist = ttnn.from_torch(
+        torch.zeros(out_shape).bfloat16(),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+    full = ttnn.experimental.neighbor_pad_async(
+        inp_mesh,
+        [h_dim, w_dim],
+        [pH, pW],
+        [pH, pW],
+        "zeros",
+        [h_axis, w_axis],
+        [h_sem, w_sem],
+        [barrier_sem],
+        num_links=[num_links, num_links],
+        memory_config=mem,
+        topology=ttnn.Topology.Linear,
+        persistent_output_buffer=persist,
+    )
+    ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
+    # Step 1: neighbor_pad_halo -> compact buffer [total_sticks, C] (mux path, unchanged).
+    h_total = Hd + 2 * pH
+    total_sticks = T * 2 * pH * Wd + T * 2 * pW * h_total
+    compact = ttnn.from_torch(
+        torch.zeros(total_sticks, C).bfloat16(),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+    )
+    ttnn.experimental.neighbor_pad_halo(
+        inp_mesh,
+        compact,
+        np_padding_h=pH,
+        np_padding_w=pW,
+        np_cluster_axis=h_axis,
+        np_num_links=num_links,
+        np_topology=ttnn.Topology.Linear,
+        h_neighbor_semaphore=h_sem,
+        barrier_semaphore=barrier_sem,
+        w_neighbor_semaphore=w_sem,
+        np_pad_dim2=w_dim,
+        np_pad2_left=pW,
+        np_pad2_right=pW,
+        np_pad2_cluster_axis=w_axis,
+        np_pad2_num_links=num_links,
+        padding_mode="zeros",
+    )
+    ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
+    # Step 2: halo_scatter allocates the padded buffer and fills interior (from inp) + border (from
+    # compact). The WHOLE padded buffer must then match neighbor_pad_async's full-pad output.
+    padded = ttnn.experimental.halo_scatter(compact, inp_mesh, np_padding_h=pH, np_padding_w=pW)
+    ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
+
+    full_dev = ttnn.get_device_tensors(ttnn.from_device(full))
+    pad_dev = ttnn.get_device_tensors(ttnn.from_device(padded))
+
+    all_pass = True
+    for i in range(mesh_shape[0] * mesh_shape[1]):
+        f = ttnn.to_torch(full_dev[i]).reshape(T, Hd + 2 * pH, Wd + 2 * pW, C)
+        p = ttnn.to_torch(pad_dev[i]).reshape(T, Hd + 2 * pH, Wd + 2 * pW, C)
+        eq, msg = comp_equal(p, f)
+        if not eq:
+            all_pass = False
+            _, pcc = comp_pcc(p, f, 0.0)
+            print(f"FAIL dev {i}: padded pcc={pcc}", flush=True)
+        else:
+            print(f"PASS dev {i}", flush=True)
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
+    assert all_pass, "repacked padded buffer != full-pad output"
+
+
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("mesh_device", [(4, 8)], ids=["4x8"], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("input_shape", [[1, 8, 144, 256, 128]], ids=["s3ish"])
+def test_neighbor_pad_halo_strided_input(mesh_device, device_params, input_shape):
+    """Copy-free primitive: neighbor_pad_halo reading a PADDED input's INTERIOR (input_pad_h/w) must
+    produce the same compact halo as reading the equivalent contiguous input (interior == unpadded).
+    Runs on the default (mux) path — its recv-authority H->W barrier makes the corner two-hop race-free,
+    so the FULL compact (incl. corners) is bit-exact. (The non-mux send-done barrier can race the corner
+    under padded timing — a pre-existing non-mux weakness; the production decode uses mux.)"""
+    h_dim, w_dim, h_axis, w_axis, pH, pW, num_links = 2, 3, 0, 1, 1, 1, 2
+    mesh_shape = tuple(mesh_device.shape)
+    hf, wf = mesh_shape[h_axis], mesh_shape[w_axis]
+    B, T, Hf, Wf, C = input_shape
+    Hd, Wd = Hf // hf, Wf // wf
+    torch.manual_seed(0)
+    inp = torch.rand(input_shape).bfloat16()
+
+    grid = mesh_device.compute_with_storage_grid_size()
+    crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    mgr = mesh_device.create_sub_device_manager([ttnn.SubDevice([crs])], 0)
+    mesh_device.load_sub_device_manager(mgr)
+    sub_id = ttnn.SubDeviceId(0)
+    mesh_device.set_sub_device_stall_group([sub_id])
+    h_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    w_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    barrier_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    dims = [None, None]
+    dims[h_axis], dims[w_axis] = h_dim, w_dim
+
+    h_total = Hd + 2 * pH
+    total_sticks = T * 2 * pH * Wd + T * 2 * pW * h_total
+    h_sec_sticks = T * 2 * pH * Wd  # Htop|Hbot span at the front of the compact buffer
+
+    def run(x_mesh, ipad_h, ipad_w):
+        compact = ttnn.from_torch(
+            torch.zeros(total_sticks, C).bfloat16(),
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=mem,
+        )
+        ttnn.experimental.neighbor_pad_halo(
+            x_mesh,
+            compact,
+            np_padding_h=pH,
+            np_padding_w=pW,
+            np_cluster_axis=h_axis,
+            np_num_links=num_links,
+            np_topology=ttnn.Topology.Linear,
+            h_neighbor_semaphore=h_sem,
+            barrier_semaphore=barrier_sem,
+            w_neighbor_semaphore=w_sem,
+            np_pad_dim2=w_dim,
+            np_pad2_left=pW,
+            np_pad2_right=pW,
+            np_pad2_cluster_axis=w_axis,
+            np_pad2_num_links=num_links,
+            padding_mode="zeros",
+            input_pad_h=ipad_h,
+            input_pad_w=ipad_w,
+        )
+        ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
+        return ttnn.get_device_tensors(ttnn.from_device(compact))
+
+    # Reference: contiguous input.
+    inp_mesh = ttnn.from_torch(
+        inp,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+    ref = run(inp_mesh, 0, 0)
+
+    # Padded input: each device's [Hd,Wd] shard padded to [Hd+2,Wd+2] (interior == its shard, border 0),
+    # tiled into a global [.,(Hd+2)*hf,(Wd+2)*wf,.] so the 2D shard hands each device its padded block.
+    xp = torch.zeros(B, T, h_total * hf, (Wd + 2 * pW) * wf, C).bfloat16()
+    for hi in range(hf):
+        for wi in range(wf):
+            dev = inp[:, :, hi * Hd : (hi + 1) * Hd, wi * Wd : (wi + 1) * Wd, :]
+            xp[
+                :,
+                :,
+                hi * h_total + pH : hi * h_total + pH + Hd,
+                wi * (Wd + 2 * pW) + pW : wi * (Wd + 2 * pW) + pW + Wd,
+                :,
+            ] = dev
+    xp_mesh = ttnn.from_torch(
+        xp,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+    test = run(xp_mesh, pH, pW)
+
+    all_pass = True
+    for i in range(mesh_shape[0] * mesh_shape[1]):
+        r = ttnn.to_torch(ref[i])
+        t = ttnn.to_torch(test[i])
+        eq, _ = comp_equal(r, t)
+        if not eq:
+            all_pass = False
+            _, pcc = comp_pcc(r, t, 0.0)
+            print(f"FAIL dev {i}: full compact pcc={pcc}", flush=True)
+        else:
+            print(f"PASS dev {i}", flush=True)
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
+    assert all_pass, "strided-input compact != contiguous-input compact"
+
+
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("mesh_device", [(4, 8)], ids=["4x8"], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("input_shape", [[1, 8, 144, 256, 128]], ids=["s3ish"])
+def test_halo_scatter_border_only(mesh_device, device_params, input_shape):
+    """Copy-free scatter: halo_scatter(border_only=True) writes ONLY the border into a padded buffer whose
+    interior is already filled (as conv3d's padded-output would leave it), preserving the interior. Result
+    must equal the repack (border_only=False) output. Validates the in-place border write for the decode."""
+    h_dim, w_dim, h_axis, w_axis, pH, pW, num_links = 2, 3, 0, 1, 1, 1, 2
+    mesh_shape = tuple(mesh_device.shape)
+    hf, wf = mesh_shape[h_axis], mesh_shape[w_axis]
+    B, T, Hf, Wf, C = input_shape
+    Hd, Wd = Hf // hf, Wf // wf
+    torch.manual_seed(0)
+    inp = torch.rand(input_shape).bfloat16()
+
+    grid = mesh_device.compute_with_storage_grid_size()
+    crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    mgr = mesh_device.create_sub_device_manager([ttnn.SubDevice([crs])], 0)
+    mesh_device.load_sub_device_manager(mgr)
+    sub_id = ttnn.SubDeviceId(0)
+    mesh_device.set_sub_device_stall_group([sub_id])
+    h_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    w_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    barrier_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    dims = [None, None]
+    dims[h_axis], dims[w_axis] = h_dim, w_dim
+    h_total = Hd + 2 * pH
+    total_sticks = T * 2 * pH * Wd + T * 2 * pW * h_total
+
+    inp_mesh = ttnn.from_torch(
+        inp,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+    compact = ttnn.from_torch(
+        torch.zeros(total_sticks, C).bfloat16(),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+    )
+    ttnn.experimental.neighbor_pad_halo(
+        inp_mesh,
+        compact,
+        np_padding_h=pH,
+        np_padding_w=pW,
+        np_cluster_axis=h_axis,
+        np_num_links=num_links,
+        np_topology=ttnn.Topology.Linear,
+        h_neighbor_semaphore=h_sem,
+        barrier_semaphore=barrier_sem,
+        w_neighbor_semaphore=w_sem,
+        np_pad_dim2=w_dim,
+        np_pad2_left=pW,
+        np_pad2_right=pW,
+        np_pad2_cluster_axis=w_axis,
+        np_pad2_num_links=num_links,
+        padding_mode="zeros",
+    )
+    ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
+
+    # Reference: repack (allocate + interior from inp + border from compact).
+    ref = ttnn.experimental.halo_scatter(compact, inp_mesh, np_padding_h=pH, np_padding_w=pW)
+    # border_only: xp = per-device padded [.,Hd+2,Wd+2,.] with interior=inp shard, border=0 (as conv would
+    # leave it); scatter writes ONLY the border in place.
+    xp = torch.zeros(B, T, h_total * hf, (Wd + 2 * pW) * wf, C).bfloat16()
+    for hi in range(hf):
+        for wi in range(wf):
+            dev = inp[:, :, hi * Hd : (hi + 1) * Hd, wi * Wd : (wi + 1) * Wd, :]
+            xp[
+                :,
+                :,
+                hi * h_total + pH : hi * h_total + pH + Hd,
+                wi * (Wd + 2 * pW) + pW : wi * (Wd + 2 * pW) + pW + Wd,
+                :,
+            ] = dev
+    xp_mesh = ttnn.from_torch(
+        xp,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+    bo = ttnn.experimental.halo_scatter(compact, xp_mesh, np_padding_h=pH, np_padding_w=pW, border_only=True)
+    ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
+
+    ref_dev = ttnn.get_device_tensors(ttnn.from_device(ref))
+    bo_dev = ttnn.get_device_tensors(ttnn.from_device(bo))
+    all_pass = True
+    for i in range(mesh_shape[0] * mesh_shape[1]):
+        r = ttnn.to_torch(ref_dev[i])
+        b = ttnn.to_torch(bo_dev[i])
+        eq, _ = comp_equal(r, b)
+        if not eq:
+            all_pass = False
+            _, pcc = comp_pcc(r, b, 0.0)
+            print(f"FAIL dev {i}: border_only pcc={pcc}", flush=True)
+        else:
+            print(f"PASS dev {i}", flush=True)
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
+    assert all_pass, "border_only scatter != repack"
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("padding_mode", ["zeros", "replicate"])
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        [1, 2, 8, 16, 16],  # per-stick W path (wright_base not 8-aligned -> W_COALESCE off)
+        [1, 4, 16, 32, 16],  # coalesce-eligible, 8-aligned rows + W_dev
+        [1, 3, 16, 24, 16],  # coalesce, NON-8-aligned rows (w_outer=30) + W_dev (6): exercises the relaxed gate
+        [1, 7, 32, 64, 32],  # mid-size, NON-8-aligned rows (63/link), W_dev=16 (s4-like ratio)
+        [1, 7, 32, 48, 32],  # mid-size, NON-8-aligned rows + W_dev=12 (s3-like non-aligned W)
+        [1, 64, 32, 64, 32],  # scale bracket: T=64 at small H/W (fast golden) to repro production-scale race
+        [1, 32, 272, 480, 128],  # s4 geometry at T=32 (the perf shape) — large H/W, moderate T
+    ],
+    ids=["perstick", "coalesce", "coalesce_nonalign", "mid_wdev16", "mid_wdev12", "scale_T64", "s4_T32"],
+)
+def test_neighbor_pad_halo_2d(mesh_device, device_params, padding_mode, input_shape):
+    # [B, T, H, W, C]; H sharded over axis 0 (2 dev), W over axis 1 (4 dev). k333 halo (pH=pW=1).
+    run_neighbor_pad_halo_2d(
+        mesh_device,
+        input_shape=input_shape,
+        h_dim=2,
+        w_dim=3,
+        h_axis=0,
+        w_axis=1,
+        pH=1,
+        pW=1,
+        padding_mode=padding_mode,
+        num_links=1,
+    )
+
+
+def _device_fw_us(mesh_device, run_op):
+    """Op-level device-FW duration (max core, max over devices), excluding the fixed per-program trace/
+    dispatch launch floor that trace-wall includes. Requires TT_METAL_DEVICE_PROFILER=1 (+ mid-run dump,
+    cpp post-process). Units are whatever the profiler reports; only used for halo-vs-async ratios."""
+    run_op()
+    ttnn.synchronize_device(mesh_device)
+    ttnn.ReadDeviceProfiler(mesh_device)
+    latest = ttnn.get_latest_programs_perf_data()
+    best = 0.0
+    for dev_id, programs in (latest or {}).items():
+        for program in programs:
+            for _name, res in program.program_analyses_results.items():
+                best = max(best, float(res.duration))
+    return best
+
+
+def run_halo_vs_async_perf(mesh_device, input_shape, h_dim, w_dim, h_axis, w_axis, pH, pW, num_links):
+    """Trace-timed device latency: halo-only op vs full-pad neighbor_pad_async on the same input."""
+    mesh_shape = tuple(mesh_device.shape)
+    h_factor, w_factor = mesh_shape[h_axis], mesh_shape[w_axis]
+    torch.manual_seed(0)
+    inp = torch.rand(input_shape).bfloat16()
+
+    outer = 1
+    for d in range(h_dim):
+        outer *= input_shape[d]
+    H_dev, W_dev, C = input_shape[h_dim] // h_factor, input_shape[w_dim] // w_factor, input_shape[-1]
+    h_total = H_dev + 2 * pH
+    total_sticks = outer * 2 * pH * W_dev + outer * 2 * pW * h_total
+
+    grid = mesh_device.compute_with_storage_grid_size()
+    crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    mgr = mesh_device.create_sub_device_manager([ttnn.SubDevice([crs])], 0)
+    mesh_device.load_sub_device_manager(mgr)
+    sub_id = ttnn.SubDeviceId(0)
+    mesh_device.set_sub_device_stall_group([sub_id])
+
+    h_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    w_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    barrier_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+
+    mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    dims = [None, None]
+    dims[h_axis], dims[w_axis] = h_dim, w_dim
+    inp_mesh = ttnn.from_torch(
+        inp,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+    halo_buf = ttnn.from_torch(
+        torch.zeros([total_sticks, C]).bfloat16(),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+    )
+    # persistent full-pad output for the async op (needed for tracing)
+    out_shape = list(input_shape)
+    out_shape[h_dim] += h_factor * 2 * pH
+    out_shape[w_dim] += w_factor * 2 * pW
+    persist = ttnn.from_torch(
+        torch.zeros(out_shape).bfloat16(),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+
+    def run_halo():
+        return ttnn.experimental.neighbor_pad_halo(
+            inp_mesh,
+            halo_buf,
+            np_padding_h=pH,
+            np_padding_w=pW,
+            np_cluster_axis=h_axis,
+            np_num_links=num_links,
+            np_topology=ttnn.Topology.Linear,
+            h_neighbor_semaphore=h_sem,
+            barrier_semaphore=barrier_sem,
+            w_neighbor_semaphore=w_sem,
+            np_pad_dim2=w_dim,
+            np_pad2_left=pW,
+            np_pad2_right=pW,
+            np_pad2_cluster_axis=w_axis,
+            np_pad2_num_links=num_links,
+            padding_mode="zeros",
+        )
+
+    def run_async():
+        return ttnn.experimental.neighbor_pad_async(
+            inp_mesh,
+            [h_dim, w_dim],
+            [pH, pW],
+            [pH, pW],
+            "zeros",
+            [h_axis, w_axis],
+            [h_sem, w_sem],
+            [barrier_sem],
+            num_links=[num_links, num_links],
+            memory_config=mem,
+            topology=ttnn.Topology.Linear,
+            persistent_output_buffer=persist,
+        )
+
+    if os.environ.get("NP_DEVTIME"):
+        # Op-level device-FW ratio: isolates op work from the fixed per-program launch floor that trace-wall
+        # includes (that floor is identical for both ops and overlaps when the op runs inside the decode trace).
+        h_dev = _device_fw_us(mesh_device, run_halo)
+        a_dev = _device_fw_us(mesh_device, run_async)
+        print(f"\n=== DEVTIME shape={input_shape} outer={outer} 2x4 ===")
+        print(f"  async device-fw: {a_dev:.1f}  halo device-fw: {h_dev:.1f}  ratio: {a_dev/max(h_dev,1e-9):.2f}x")
+        mesh_device.reset_sub_device_stall_group()
+        mesh_device.clear_loaded_sub_device_manager()
+        return
+
+    halo_us = _trace_and_time(mesh_device, run_halo)
+    async_us = _trace_and_time(mesh_device, run_async)
+    # Effective halo-transport bandwidth vs the ~50 GB/s aggregate 2-link fabric ceiling
+    # (12.5 GB/s/link/dir x 2 links x 2 dir). Bytes = the essential halo crossing the fabric per device:
+    # one H-edge (W_dev sticks) + one W-edge (H_dev sticks) per frame. The compact BUFFER is ~2x this and
+    # also holds edge zero-fill that never leaves the chip, so buffer-size/time overstates bandwidth ~4x.
+    transfer_bytes = outer * (H_dev + W_dev) * C * 2  # bf16, minimal halo transport per device
+    gbps = transfer_bytes / (halo_us * 1e-6) / 1e9
+    print(f"\n=== PERF (trace wall/iter, device latency) shape={input_shape} outer={outer} 2x4 ===")
+    print(f"  neighbor_pad_async (full-pad): {async_us:8.1f} us")
+    print(f"  neighbor_pad_halo  (compact):  {halo_us:8.1f} us")
+    print(f"  speedup: {async_us / halo_us:.2f}x")
+    print(f"  halo transfer/device: {transfer_bytes/1e6:.2f} MB;  achieved: {gbps:.1f} GB/s ({gbps/50*100:.0f}% of 50)")
+
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
+
+
+@pytest.mark.timeout(400)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112 * 64}], indirect=True
+)
+@pytest.mark.parametrize("T", [8, 32, 96], ids=["T8", "T32", "T96"])
+def test_neighbor_pad_halo_perf(mesh_device, device_params, T):
+    # s4_out-like at varying T: outer=T, per-device H=136, W=120, C=128, k333 halo. Small T is
+    # barrier-dominated; large T shifts the op toward bandwidth-bound (fixed barriers, scaling data).
+    # num_links is HARDWARE-CAPPED at 2 on BH-LB: each inter-chip hop has exactly 2 ethernet channels
+    # (num_links=4 => TT_FATAL "Requested link index 2 is out of bounds. 2 ethernet channels available").
+    # The op already uses both, so "more fabric links" is not a lever here.
+    run_halo_vs_async_perf(
+        mesh_device, input_shape=[1, T, 272, 480, 128], h_dim=2, w_dim=3, h_axis=0, w_axis=1, pH=1, pW=1, num_links=2
+    )
+
+
+# Production LTX 1080p 2x4 decoder NP-bound layers, as full [B,T,H,W,C] (per-device = H/2, W/4). All k333
+# (pH=pW=1). Verifies the mux speedup holds on the real deployed shapes, not just the synthetic sweep.
+# All distinct LTX VAE-decoder NP inputs routed on the 2x4 mesh (kernel (3,3,3) => pH=pW=1). Collapsed
+# from models/tt_dit/utils/conv3d.py LTX table (lines ~414-429): 10 conv sites -> 6 unique (T, H, W, C_in).
+# H/W here are the FULL spatial dims (H = per-dev*2 on axis-0, W = per-dev*4 on axis-1).
+_LTX_PROD_2x4 = [
+    ([1, 21, 34, 60, 128], "s0_conv_in_C128"),  # per-dev  17x15,  C_in=128
+    ([1, 21, 34, 60, 1024], "s0_res_up_C1024"),  # per-dev  17x15,  C_in=1024 (2048B page, largest)
+    ([1, 39, 68, 120, 512], "s1_res_up_C512"),  # per-dev  34x30,  C_in=512
+    ([1, 75, 136, 240, 512], "s2_res_C512"),  # per-dev  68x60,  C_in=512
+    ([1, 147, 136, 240, 256], "s3_res_chg_C256"),  # per-dev  68x60,  C_in=256 (s3_res / s3_chg)
+    ([1, 147, 272, 480, 128], "s4_res_out_C128"),  # per-dev 136x120, C_in=128 (s4_res / s4_out)
+]
+
+# 4x8 physical shapes (h_factor=4, w_factor=8), CAPTURED live from the all-standalone decode
+# (prof_vae_ltx NP_CAPTURE_SHAPES, LTX_USE_FUSED=0). The latent 34x60 pads once to 36x64 at the decode
+# input (34->36 div4=9, 60->64 div8=8) and that padding PROPAGATES through the x2 upsamples, so every
+# stage's physical dims are the per-device shard x factor: 36x64 -> 72x128 -> 144x256 -> 288x512 (the
+# masked pad region is carried, not re-trimmed). These differ from _LTX_PROD_2x4's logical dims. The
+# trailing comment is the per-call count in one decode (relative op-time weight).
+_LTX_PROD_4x8 = [
+    ([1, 21, 36, 64, 128], "s0_conv_in_C128"),  # per-dev  9x8,   C_in=128    (x1)
+    ([1, 21, 36, 64, 1024], "s0_res_up_C1024"),  # per-dev  9x8,   C_in=1024   (x5, 2048B page, largest)
+    ([1, 39, 72, 128, 512], "s1_res_up_C512"),  # per-dev 18x16,  C_in=512    (x5)
+    ([1, 75, 144, 256, 512], "s2_res_C512"),  # per-dev 36x32,  C_in=512    (x9)
+    ([1, 147, 144, 256, 256], "s3_res_chg_C256"),  # per-dev 36x32,  C_in=256    (x13, s3_res / s3_chg)
+    ([1, 147, 288, 512, 128], "s4_res_out_C128"),  # per-dev 72x64,  C_in=128    (x9, s4_res / s4_out)
+]
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("mesh_device", [(4, 8)], ids=["4x8"], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112 * 64}], indirect=True
+)
+@pytest.mark.parametrize("input_shape, shape_id", _LTX_PROD_4x8, ids=[s[1] for s in _LTX_PROD_4x8])
+def test_neighbor_pad_halo_prod_perf(mesh_device, device_params, input_shape, shape_id):
+    run_halo_vs_async_perf(
+        mesh_device, input_shape=input_shape, h_dim=2, w_dim=3, h_axis=0, w_axis=1, pH=1, pW=1, num_links=2
+    )
+
+
+# Same shapes, but with an 8 KB fabric packet payload (default is 4352 B). The factory sizes its coalesce
+# to the fabric max payload, so this ships ~2x the sticks per packet — tests whether packet count (fabric
+# forwarding overhead) is a bound on the mid/large shapes. FabricRouterConfig has no kwargs ctor; set the
+# field after default construction.
+def _fabric_router_config_8k():
+    frc = ttnn.FabricRouterConfig()
+    frc.max_packet_payload_size_bytes = int(os.environ.get("NP_FABRIC_PAYLOAD", "8192"))  # BH max 15232
+    return frc
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("mesh_device", [(4, 8)], ids=["4x8"], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 90112 * 64,
+            "fabric_router_config": _fabric_router_config_8k(),
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("input_shape, shape_id", _LTX_PROD_4x8, ids=[s[1] for s in _LTX_PROD_4x8])
+def test_neighbor_pad_halo_prod_perf_8k(mesh_device, device_params, input_shape, shape_id):
+    run_halo_vs_async_perf(
+        mesh_device, input_shape=input_shape, h_dim=2, w_dim=3, h_axis=0, w_axis=1, pH=1, pW=1, num_links=2
+    )
+
+
+# Byte-exact PCC with the 8 KB fabric payload: the coalesce forms larger (up to 32-stick) bank packets, so
+# this guards that the bigger-packet path is still exact.
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("mesh_device", [(4, 8)], ids=["4x8"], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "fabric_router_config": _fabric_router_config_8k()}],
+    indirect=True,
+)
+@pytest.mark.parametrize("input_shape, shape_id", _LTX_PROD_4x8, ids=[s[1] for s in _LTX_PROD_4x8])
+def test_neighbor_pad_halo_prod_pcc_8k(mesh_device, device_params, input_shape, shape_id):
+    run_neighbor_pad_halo_2d(
+        mesh_device,
+        input_shape=input_shape,
+        h_dim=2,
+        w_dim=3,
+        h_axis=0,
+        w_axis=1,
+        pH=1,
+        pW=1,
+        padding_mode="zeros",
+        num_links=2,
+    )
+
+
+# Scaling to longer cluster axes than 2x4 (a 4x8 mesh needs 32 chips; on an 8-chip BH-LB the runnable proxy
+# is 4x2 = H-axis length 4 with MIDDLE devices, the case never exercised at 2x4 where both H devices are
+# edges). H div by 4, W div by 2. Validates the 1-hop neighbor exchange + startup barrier on a >2 axis.
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("mesh_device", [(4, 2)], ids=["4x2"], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("padding_mode", ["zeros", "replicate"])
+@pytest.mark.parametrize("input_shape", [[1, 32, 136, 240, 128]], ids=["Hx4_mid"])
+def test_neighbor_pad_halo_4x2(mesh_device, device_params, padding_mode, input_shape):
+    run_neighbor_pad_halo_2d(
+        mesh_device,
+        input_shape=input_shape,
+        h_dim=2,
+        w_dim=3,
+        h_axis=0,
+        w_axis=1,
+        pH=1,
+        pW=1,
+        padding_mode=padding_mode,
+        num_links=2,
+    )
+
+
+# LTX-2.3 spatial latent upsampler (x2) on 2x4 (conv3d.py "spatial latent upsampler" block). Small spatial
+# (per-dev down to 9x8) and one k=(1,3,3) site — still spatial pH=pW=1. Not covered by the decoder set above.
+_LTX_UPSAMPLER_2x4 = [
+    ([1, 21, 18, 32, 128], "ups_initial_C128"),  # per-dev 9x8
+    ([1, 21, 18, 32, 1024], "ups_pre_res_C1024"),  # per-dev 9x8
+    ([1, 19, 18, 32, 1024], "ups_ups_C1024_k133"),  # per-dev 9x8, k=(1,3,3) -> spatial pH=pW=1
+    ([1, 21, 36, 64, 1024], "ups_post_res_C1024"),  # per-dev 18x16
+]
+
+
+@pytest.mark.timeout(400)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("padding_mode", ["zeros", "replicate"])
+@pytest.mark.parametrize("input_shape, shape_id", _LTX_UPSAMPLER_2x4, ids=[s[1] for s in _LTX_UPSAMPLER_2x4])
+def test_neighbor_pad_halo_upsampler_pcc(mesh_device, device_params, padding_mode, input_shape, shape_id):
+    run_neighbor_pad_halo_2d(
+        mesh_device,
+        input_shape=input_shape,
+        h_dim=2,
+        w_dim=3,
+        h_axis=0,
+        w_axis=1,
+        pH=1,
+        pW=1,
+        padding_mode=padding_mode,
+        num_links=2,
+    )
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("mesh_device", [(4, 8)], ids=["4x8"], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("padding_mode", ["zeros", "replicate"])
+@pytest.mark.parametrize("input_shape, shape_id", _LTX_PROD_4x8, ids=[s[1] for s in _LTX_PROD_4x8])
+def test_neighbor_pad_halo_prod_pcc(mesh_device, device_params, padding_mode, input_shape, shape_id):
+    # Byte-exact PCC of the compact halo buffer on the production LTX 4x8 shapes (the mux path for zeros).
+    run_neighbor_pad_halo_2d(
+        mesh_device,
+        input_shape=input_shape,
+        h_dim=2,
+        w_dim=3,
+        h_axis=0,
+        w_axis=1,
+        pH=1,
+        pW=1,
+        padding_mode=padding_mode,
+        num_links=2,
+    )
+
+
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+def test_neighbor_pad_halo_devfw(mesh_device, device_params):
+    # Non-traced dispatch (device-FW profiled via tracy) to find the bound (H cores vs W cores).
+    input_shape, h_dim, w_dim, h_axis, w_axis, pH, pW, num_links = [1, 8, 272, 480, 128], 2, 3, 0, 1, 1, 1, 2
+    mesh_shape = tuple(mesh_device.shape)
+    h_factor, w_factor = mesh_shape[h_axis], mesh_shape[w_axis]
+    torch.manual_seed(0)
+    inp = torch.rand(input_shape).bfloat16()
+    outer = input_shape[0] * input_shape[1]
+    H_dev, W_dev, C = input_shape[h_dim] // h_factor, input_shape[w_dim] // w_factor, input_shape[-1]
+    total_sticks = outer * 2 * pH * W_dev + outer * 2 * pW * (H_dev + 2 * pH)
+    grid = mesh_device.compute_with_storage_grid_size()
+    crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    mgr = mesh_device.create_sub_device_manager([ttnn.SubDevice([crs])], 0)
+    mesh_device.load_sub_device_manager(mgr)
+    sub_id = ttnn.SubDeviceId(0)
+    mesh_device.set_sub_device_stall_group([sub_id])
+    h_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    w_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    barrier_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    dims = [None, None]
+    dims[h_axis], dims[w_axis] = h_dim, w_dim
+    inp_mesh = ttnn.from_torch(
+        inp,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+    halo_buf = ttnn.from_torch(
+        torch.zeros([total_sticks, C]).bfloat16(),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+    )
+    for _ in range(6):
+        ttnn.experimental.neighbor_pad_halo(
+            inp_mesh,
+            halo_buf,
+            np_padding_h=pH,
+            np_padding_w=pW,
+            np_cluster_axis=h_axis,
+            np_num_links=num_links,
+            np_topology=ttnn.Topology.Linear,
+            h_neighbor_semaphore=h_sem,
+            barrier_semaphore=barrier_sem,
+            w_neighbor_semaphore=w_sem,
+            np_pad_dim2=w_dim,
+            np_pad2_left=pW,
+            np_pad2_right=pW,
+            np_pad2_cluster_axis=w_axis,
+            np_pad2_num_links=num_links,
+            padding_mode="zeros",
+        )
+    ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
+
+
+# Halo-aware conv3d correctness: the compact two-dispatch (neighbor_pad_halo -> conv3d halo mode) must
+# equal the current full-pad two-dispatch (neighbor_pad_async -> conv3d) on device. Same weight/input;
+# both compute conv on the neighbor-padded input, so a device-to-device match proves the halo read.
+def run_conv3d_halo_vs_fullpad_2d(mesh_device, input_shape, C_out, kernel_size, pH, pW, num_links=2):
+    h_dim, w_dim, h_axis, w_axis = 2, 3, 0, 1
+    mesh_shape = tuple(mesh_device.shape)
+    h_factor, w_factor = mesh_shape[h_axis], mesh_shape[w_axis]
+    B, T, Hf, Wf, C = input_shape
+    kT, kH, kW = kernel_size
+    pT = kT // 2
+    torch.manual_seed(0)
+    inp = torch.rand(input_shape).bfloat16()
+    H_dev, W_dev = Hf // h_factor, Wf // w_factor
+    outer = B * T
+    total_sticks = outer * 2 * pH * W_dev + outer * 2 * pW * (H_dev + 2 * pH)
+
+    grid = mesh_device.compute_with_storage_grid_size()
+    crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    mgr = mesh_device.create_sub_device_manager([ttnn.SubDevice([crs])], 0)
+    mesh_device.load_sub_device_manager(mgr)
+    sub_id = ttnn.SubDeviceId(0)
+    mesh_device.set_sub_device_stall_group([sub_id])
+    h_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    w_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    barrier_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    dims = [None, None]
+    dims[h_axis], dims[w_axis] = h_dim, w_dim
+    inp_mesh = ttnn.from_torch(
+        inp,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+
+    w = torch.rand(C_out, C, kT, kH, kW).bfloat16()
+    tt_w = ttnn.from_torch(w, dtype=ttnn.bfloat16, pad_value=0)
+    config = ttnn.Conv3dConfig(
+        weights_dtype=ttnn.bfloat16,
+        output_layout=ttnn.ROW_MAJOR_LAYOUT,
+        C_in_block=32,
+        compute_with_storage_grid_size=(grid.x, grid.y),
+    )
+    tt_w = ttnn.experimental.prepare_conv3d_weights(
+        weight_tensor=tt_w, groups=1, C_in_block=32, alignment=32, device=mesh_device
+    )
+    tt_b = ttnn.from_torch(
+        torch.rand(1, C_out).bfloat16(), device=mesh_device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, pad_value=0
+    )
+    kcfg = ttnn.init_device_compute_kernel_config(
+        mesh_device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+
+    def do_conv(inp_t, padding, halo=None):
+        return ttnn.experimental.conv3d(
+            input_tensor=inp_t,
+            weight_tensor=tt_w,
+            device=mesh_device,
+            bias_tensor=tt_b,
+            config=config,
+            dtype=ttnn.bfloat16,
+            output_channels=C_out,
+            kernel_size=kernel_size,
+            stride=(1, 1, 1),
+            padding=padding,
+            dilation=(1, 1, 1),
+            padding_mode="zeros",
+            groups=1,
+            compute_kernel_config=kcfg,
+            halo_buffer=halo,
+        )
+
+    # Golden: full-pad (neighbor_pad_async) then conv with spatial pad 0.
+    out_shape = list(input_shape)
+    out_shape[h_dim] += h_factor * 2 * pH
+    out_shape[w_dim] += w_factor * 2 * pW
+    persist = ttnn.from_torch(
+        torch.zeros(out_shape).bfloat16(),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+    full = ttnn.experimental.neighbor_pad_async(
+        inp_mesh,
+        [h_dim, w_dim],
+        [pH, pW],
+        [pH, pW],
+        "zeros",
+        [h_axis, w_axis],
+        [h_sem, w_sem],
+        [barrier_sem],
+        num_links=[num_links, num_links],
+        memory_config=mem,
+        topology=ttnn.Topology.Linear,
+        persistent_output_buffer=persist,
+    )
+    out_gold = do_conv(full, (pT, 0, 0))
+    ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
+
+    # Halo: compact (neighbor_pad_halo) then conv with spatial pad pH/pW reading the halo.
+    halo_buf = ttnn.from_torch(
+        torch.zeros([total_sticks, C]).bfloat16(),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+    )
+    ttnn.experimental.neighbor_pad_halo(
+        inp_mesh,
+        halo_buf,
+        np_padding_h=pH,
+        np_padding_w=pW,
+        np_cluster_axis=h_axis,
+        np_num_links=num_links,
+        np_topology=ttnn.Topology.Linear,
+        h_neighbor_semaphore=h_sem,
+        barrier_semaphore=barrier_sem,
+        w_neighbor_semaphore=w_sem,
+        np_pad_dim2=w_dim,
+        np_pad2_left=pW,
+        np_pad2_right=pW,
+        np_pad2_cluster_axis=w_axis,
+        np_pad2_num_links=num_links,
+        padding_mode="zeros",
+    )
+    out_halo = do_conv(inp_mesh, (pT, pH, pW), halo=halo_buf)
+    ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
+
+    if os.environ.get("NP_CONV_PERF"):
+        # Decompose the e2e halo-vs-fullpad delta: halo_path = np_halo + conv_halo_read; fullpad_path =
+        # np_async(persistent) + conv_plain. Isolates whether the halo-mode conv3d (spatial padding active
+        # -> boundary blocks skip the coalesced gather) is the net-loss source on small 4x8 shards.
+        def _np_async():
+            return ttnn.experimental.neighbor_pad_async(
+                inp_mesh,
+                [h_dim, w_dim],
+                [pH, pW],
+                [pH, pW],
+                "zeros",
+                [h_axis, w_axis],
+                [h_sem, w_sem],
+                [barrier_sem],
+                num_links=[num_links, num_links],
+                memory_config=mem,
+                topology=ttnn.Topology.Linear,
+                persistent_output_buffer=persist,
+            )
+
+        def _np_halo():
+            return ttnn.experimental.neighbor_pad_halo(
+                inp_mesh,
+                halo_buf,
+                np_padding_h=pH,
+                np_padding_w=pW,
+                np_cluster_axis=h_axis,
+                np_num_links=num_links,
+                np_topology=ttnn.Topology.Linear,
+                h_neighbor_semaphore=h_sem,
+                barrier_semaphore=barrier_sem,
+                w_neighbor_semaphore=w_sem,
+                np_pad_dim2=w_dim,
+                np_pad2_left=pW,
+                np_pad2_right=pW,
+                np_pad2_cluster_axis=w_axis,
+                np_pad2_num_links=num_links,
+                padding_mode="zeros",
+            )
+
+        a = _trace_and_time(mesh_device, _np_async)
+        hh = _trace_and_time(mesh_device, _np_halo)
+        cp = _trace_and_time(mesh_device, lambda: do_conv(full, (pT, 0, 0)))
+        ch = _trace_and_time(mesh_device, lambda: do_conv(inp_mesh, (pT, pH, pW), halo=halo_buf))
+        print(
+            f"CONV-PERF shape={input_shape} Cout={C_out} k={kernel_size}: np_async={a:.1f} np_halo={hh:.1f} "
+            f"conv_plain={cp:.1f} conv_halo_read={ch:.1f} | fullpad_path={a + cp:.1f} halo_path={hh + ch:.1f} "
+            f"delta={hh + ch - (a + cp):+.1f} us",
+            flush=True,
+        )
+        mesh_device.reset_sub_device_stall_group()
+        mesh_device.clear_loaded_sub_device_manager()
+        return
+
+    gold_dev = ttnn.get_device_tensors(ttnn.from_device(out_gold))
+    halo_dev = ttnn.get_device_tensors(ttnn.from_device(out_halo))
+    all_pass = True
+    for i in range(mesh_shape[0] * mesh_shape[1]):
+        g = ttnn.to_torch(gold_dev[i])
+        h = ttnn.to_torch(halo_dev[i])
+        ok, pcc = comp_pcc(g, h, 0.999)
+        if not ok:
+            all_pass = False
+            print(f"FAIL dev {i}: {pcc}  shapes g={tuple(g.shape)} h={tuple(h.shape)}")
+        else:
+            print(f"PASS dev {i}: {pcc}")
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
+    assert all_pass, "halo conv3d != full-pad conv3d"
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("mesh_device", [(4, 8)], ids=["4x8"], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape, C_out, kernel_size",
+    [
+        ([1, 8, 36, 64, 1024], 1024, (3, 3, 3)),  # s0 padded: per-dev 9x8, C_in=C_out=1024
+        ([1, 8, 72, 128, 512], 512, (3, 3, 3)),  # s1: per-dev 18x16
+        ([1, 8, 144, 256, 512], 512, (3, 3, 3)),  # s2: per-dev 36x32
+        ([1, 8, 144, 256, 256], 256, (3, 3, 3)),  # s3: per-dev 36x32
+        ([1, 8, 288, 512, 128], 128, (3, 3, 3)),  # s4: per-dev 72x64
+    ],
+    ids=["s0_36x64_C1024", "s1_72x128_C512", "s2_144x256_C512", "s3_144x256_C256", "s4_288x512_C128"],
+)
+def test_conv3d_halo_vs_fullpad(mesh_device, device_params, input_shape, C_out, kernel_size):
+    pH, pW = kernel_size[1] // 2, kernel_size[2] // 2
+    run_conv3d_halo_vs_fullpad_2d(
+        mesh_device, input_shape, C_out=C_out, kernel_size=kernel_size, pH=pH, pW=pW, num_links=2
+    )
+
+
+# Reuse test: the decode calls neighbor_pad_halo ~30x sharing the manager's ping-pong sems. A single-op
+# test can't catch a missing on-device self-reset — this loops the op N times reusing ONE sem set (no
+# ping-pong to mask it). If call 2+ hangs, a semaphore isn't reset between runs.
+@pytest.mark.timeout(200)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+def test_neighbor_pad_halo_reuse(mesh_device, device_params):
+    input_shape, h_dim, w_dim, h_axis, w_axis, pH, pW, num_links = [1, 8, 68, 120, 64], 2, 3, 0, 1, 1, 1, 2
+    mesh_shape = tuple(mesh_device.shape)
+    h_factor, w_factor = mesh_shape[h_axis], mesh_shape[w_axis]
+    torch.manual_seed(0)
+    inp = torch.rand(input_shape).bfloat16()
+    outer = input_shape[0] * input_shape[1]
+    H_dev, W_dev, C = input_shape[h_dim] // h_factor, input_shape[w_dim] // w_factor, input_shape[-1]
+    total_sticks = outer * 2 * pH * W_dev + outer * 2 * pW * (H_dev + 2 * pH)
+    grid = mesh_device.compute_with_storage_grid_size()
+    crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    mgr = mesh_device.create_sub_device_manager([ttnn.SubDevice([crs])], 0)
+    mesh_device.load_sub_device_manager(mgr)
+    sub_id = ttnn.SubDeviceId(0)
+    mesh_device.set_sub_device_stall_group([sub_id])
+    h_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    w_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    barrier_sem = ttnn.create_global_semaphore(mesh_device, crs, 0)
+    mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    dims = [None, None]
+    dims[h_axis], dims[w_axis] = h_dim, w_dim
+    inp_mesh = ttnn.from_torch(
+        inp,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+    halo_buf = ttnn.from_torch(
+        torch.zeros([total_sticks, C]).bfloat16(),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=mem,
+    )
+    for it in range(5):
+        ttnn.experimental.neighbor_pad_halo(
+            inp_mesh,
+            halo_buf,
+            np_padding_h=pH,
+            np_padding_w=pW,
+            np_cluster_axis=h_axis,
+            np_num_links=num_links,
+            np_topology=ttnn.Topology.Linear,
+            h_neighbor_semaphore=h_sem,
+            barrier_semaphore=barrier_sem,
+            w_neighbor_semaphore=w_sem,
+            np_pad_dim2=w_dim,
+            np_pad2_left=pW,
+            np_pad2_right=pW,
+            np_pad2_cluster_axis=w_axis,
+            np_pad2_num_links=num_links,
+            padding_mode="zeros",
+        )
+        ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
+        print(f"iter {it}: OK", flush=True)
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()

--- a/tests/nightly/t3000/ccl/test_neighbor_pad_halo.py
+++ b/tests/nightly/t3000/ccl/test_neighbor_pad_halo.py
@@ -2,12 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# PCC test for the standalone halo-only op ttnn.experimental.neighbor_pad_halo.
-#
-# The op emits ONLY the compact halo buffer [H-top | H-bot | W-left | W-right] (no interior copy,
-# no conv). We reuse the standalone neighbor_pad_async 2D golden (a full per-device padded tensor),
-# then slice out exactly the halo bands in the compact-buffer stick order and compare byte-for-byte
-# (bf16 copy, no arithmetic).
+# PCC test for the standalone halo-only op ttnn.experimental.neighbor_pad_halo
 
 import os
 import time
@@ -188,8 +183,7 @@ def run_neighbor_pad_halo_2d(mesh_device, input_shape, h_dim, w_dim, h_axis, w_a
                             f"  {nm} bad_sticks={len(bad)}/{b-a} frames={frames[:8]}(n={len(frames)}/{outer}) "
                             f"cols={cols}(n={len(cols)}/{W_dev}) banks={sorted({c%8 for c in cols})}"
                         )
-                    # W sections: rows are [frame][h_row (0..H_dev+2pH)][pw]; flag which h_rows are bad and
-                    # whether they are corner rows (h_row < pH or >= pH+H_dev) — corners come from the H exchange.
+                    # W sections: rows are [frame][h_row (0..H_dev+2pH)][pw]
                     hh = H_dev + 2 * pH
                     for nm, a, b in [
                         ("Wleft", 2 * h_sec, 2 * h_sec + w_sec),
@@ -307,8 +301,7 @@ def test_neighbor_pad_halo_padded_border(mesh_device, device_params, input_shape
         padding_mode="zeros",
     )
     ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
-    # Step 2: halo_scatter allocates the padded buffer and fills interior (from inp) + border (from
-    # compact). The WHOLE padded buffer must then match neighbor_pad_async's full-pad output.
+    # Step 2: halo_scatter allocates the padded buffer and fills interior (from inp) + border (from compact)
     padded = ttnn.experimental.halo_scatter(compact, inp_mesh, np_padding_h=pH, np_padding_w=pW)
     ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
 
@@ -408,8 +401,7 @@ def test_neighbor_pad_halo_strided_input(mesh_device, device_params, input_shape
     )
     ref = run(inp_mesh, 0, 0)
 
-    # Padded input: each device's [Hd,Wd] shard padded to [Hd+2,Wd+2] (interior == its shard, border 0),
-    # tiled into a global [.,(Hd+2)*hf,(Wd+2)*wf,.] so the 2D shard hands each device its padded block.
+    # Padded input: each device's [Hd,Wd] shard padded to [Hd+2,Wd+2] (interior == its shard, border 0)
     xp = torch.zeros(B, T, h_total * hf, (Wd + 2 * pW) * wf, C).bfloat16()
     for hi in range(hf):
         for wi in range(wf):
@@ -515,8 +507,7 @@ def test_halo_scatter_border_only(mesh_device, device_params, input_shape):
 
     # Reference: repack (allocate + interior from inp + border from compact).
     ref = ttnn.experimental.halo_scatter(compact, inp_mesh, np_padding_h=pH, np_padding_w=pW)
-    # border_only: xp = per-device padded [.,Hd+2,Wd+2,.] with interior=inp shard, border=0 (as conv would
-    # leave it); scatter writes ONLY the border in place.
+    # border_only: xp = per-device padded [.,Hd+2,Wd+2,.] with interior=inp shard, border=0
     xp = torch.zeros(B, T, h_total * hf, (Wd + 2 * pW) * wf, C).bfloat16()
     for hi in range(hf):
         for wi in range(wf):
@@ -699,8 +690,7 @@ def run_halo_vs_async_perf(mesh_device, input_shape, h_dim, w_dim, h_axis, w_axi
         )
 
     if os.environ.get("NP_DEVTIME"):
-        # Op-level device-FW ratio: isolates op work from the fixed per-program launch floor that trace-wall
-        # includes (that floor is identical for both ops and overlaps when the op runs inside the decode trace).
+        # Op-level device-FW ratio: isolates op work from the fixed per-program launch floor that trace-wall includes
         h_dev = _device_fw_us(mesh_device, run_halo)
         a_dev = _device_fw_us(mesh_device, run_async)
         print(f"\n=== DEVTIME shape={input_shape} outer={outer} 2x4 ===")
@@ -712,9 +702,6 @@ def run_halo_vs_async_perf(mesh_device, input_shape, h_dim, w_dim, h_axis, w_axi
     halo_us = _trace_and_time(mesh_device, run_halo)
     async_us = _trace_and_time(mesh_device, run_async)
     # Effective halo-transport bandwidth vs the ~50 GB/s aggregate 2-link fabric ceiling
-    # (12.5 GB/s/link/dir x 2 links x 2 dir). Bytes = the essential halo crossing the fabric per device:
-    # one H-edge (W_dev sticks) + one W-edge (H_dev sticks) per frame. The compact BUFFER is ~2x this and
-    # also holds edge zero-fill that never leaves the chip, so buffer-size/time overstates bandwidth ~4x.
     transfer_bytes = outer * (H_dev + W_dev) * C * 2  # bf16, minimal halo transport per device
     gbps = transfer_bytes / (halo_us * 1e-6) / 1e9
     print(f"\n=== PERF (trace wall/iter, device latency) shape={input_shape} outer={outer} 2x4 ===")
@@ -734,21 +721,13 @@ def run_halo_vs_async_perf(mesh_device, input_shape, h_dim, w_dim, h_axis, w_axi
 )
 @pytest.mark.parametrize("T", [8, 32, 96], ids=["T8", "T32", "T96"])
 def test_neighbor_pad_halo_perf(mesh_device, device_params, T):
-    # s4_out-like at varying T: outer=T, per-device H=136, W=120, C=128, k333 halo. Small T is
-    # barrier-dominated; large T shifts the op toward bandwidth-bound (fixed barriers, scaling data).
-    # num_links is HARDWARE-CAPPED at 2 on BH-LB: each inter-chip hop has exactly 2 ethernet channels
-    # (num_links=4 => TT_FATAL "Requested link index 2 is out of bounds. 2 ethernet channels available").
-    # The op already uses both, so "more fabric links" is not a lever here.
+    # s4_out-like at varying T: outer=T, per-device H=136, W=120, C=128, k333 halo
     run_halo_vs_async_perf(
         mesh_device, input_shape=[1, T, 272, 480, 128], h_dim=2, w_dim=3, h_axis=0, w_axis=1, pH=1, pW=1, num_links=2
     )
 
 
-# Production LTX 1080p 2x4 decoder NP-bound layers, as full [B,T,H,W,C] (per-device = H/2, W/4). All k333
-# (pH=pW=1). Verifies the mux speedup holds on the real deployed shapes, not just the synthetic sweep.
-# All distinct LTX VAE-decoder NP inputs routed on the 2x4 mesh (kernel (3,3,3) => pH=pW=1). Collapsed
-# from models/tt_dit/utils/conv3d.py LTX table (lines ~414-429): 10 conv sites -> 6 unique (T, H, W, C_in).
-# H/W here are the FULL spatial dims (H = per-dev*2 on axis-0, W = per-dev*4 on axis-1).
+# Production LTX 1080p 2x4 decoder NP-bound layers, as full [B,T,H,W,C] (per-device = H/2, W/4)
 _LTX_PROD_2x4 = [
     ([1, 21, 34, 60, 128], "s0_conv_in_C128"),  # per-dev  17x15,  C_in=128
     ([1, 21, 34, 60, 1024], "s0_res_up_C1024"),  # per-dev  17x15,  C_in=1024 (2048B page, largest)
@@ -759,11 +738,6 @@ _LTX_PROD_2x4 = [
 ]
 
 # 4x8 physical shapes (h_factor=4, w_factor=8), CAPTURED live from the all-standalone decode
-# (prof_vae_ltx NP_CAPTURE_SHAPES, LTX_USE_FUSED=0). The latent 34x60 pads once to 36x64 at the decode
-# input (34->36 div4=9, 60->64 div8=8) and that padding PROPAGATES through the x2 upsamples, so every
-# stage's physical dims are the per-device shard x factor: 36x64 -> 72x128 -> 144x256 -> 288x512 (the
-# masked pad region is carried, not re-trimmed). These differ from _LTX_PROD_2x4's logical dims. The
-# trailing comment is the per-call count in one decode (relative op-time weight).
 _LTX_PROD_4x8 = [
     ([1, 21, 36, 64, 128], "s0_conv_in_C128"),  # per-dev  9x8,   C_in=128    (x1)
     ([1, 21, 36, 64, 1024], "s0_res_up_C1024"),  # per-dev  9x8,   C_in=1024   (x5, 2048B page, largest)
@@ -786,10 +760,7 @@ def test_neighbor_pad_halo_prod_perf(mesh_device, device_params, input_shape, sh
     )
 
 
-# Same shapes, but with an 8 KB fabric packet payload (default is 4352 B). The factory sizes its coalesce
-# to the fabric max payload, so this ships ~2x the sticks per packet — tests whether packet count (fabric
-# forwarding overhead) is a bound on the mid/large shapes. FabricRouterConfig has no kwargs ctor; set the
-# field after default construction.
+# Same shapes, but with an 8 KB fabric packet payload (default is 4352 B)
 def _fabric_router_config_8k():
     frc = ttnn.FabricRouterConfig()
     frc.max_packet_payload_size_bytes = int(os.environ.get("NP_FABRIC_PAYLOAD", "8192"))  # BH max 15232
@@ -816,8 +787,7 @@ def test_neighbor_pad_halo_prod_perf_8k(mesh_device, device_params, input_shape,
     )
 
 
-# Byte-exact PCC with the 8 KB fabric payload: the coalesce forms larger (up to 32-stick) bank packets, so
-# this guards that the bigger-packet path is still exact.
+# Byte-exact PCC with the 8 KB fabric payload: the coalesce forms larger (up to 32-stick) bank packets
 @pytest.mark.timeout(300)
 @pytest.mark.parametrize("mesh_device", [(4, 8)], ids=["4x8"], indirect=True)
 @pytest.mark.parametrize(
@@ -841,9 +811,7 @@ def test_neighbor_pad_halo_prod_pcc_8k(mesh_device, device_params, input_shape, 
     )
 
 
-# Scaling to longer cluster axes than 2x4 (a 4x8 mesh needs 32 chips; on an 8-chip BH-LB the runnable proxy
-# is 4x2 = H-axis length 4 with MIDDLE devices, the case never exercised at 2x4 where both H devices are
-# edges). H div by 4, W div by 2. Validates the 1-hop neighbor exchange + startup barrier on a >2 axis.
+# Scaling to longer cluster axes than 2x4
 @pytest.mark.timeout(300)
 @pytest.mark.parametrize("mesh_device", [(4, 2)], ids=["4x2"], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
@@ -864,8 +832,7 @@ def test_neighbor_pad_halo_4x2(mesh_device, device_params, padding_mode, input_s
     )
 
 
-# LTX-2.3 spatial latent upsampler (x2) on 2x4 (conv3d.py "spatial latent upsampler" block). Small spatial
-# (per-dev down to 9x8) and one k=(1,3,3) site — still spatial pH=pW=1. Not covered by the decoder set above.
+# LTX-2.3 spatial latent upsampler (x2) on 2x4 (conv3d.py "spatial latent upsampler" block)
 _LTX_UPSAMPLER_2x4 = [
     ([1, 21, 18, 32, 128], "ups_initial_C128"),  # per-dev 9x8
     ([1, 21, 18, 32, 1024], "ups_pre_res_C1024"),  # per-dev 9x8
@@ -979,9 +946,7 @@ def test_neighbor_pad_halo_devfw(mesh_device, device_params):
     mesh_device.clear_loaded_sub_device_manager()
 
 
-# Halo-aware conv3d correctness: the compact two-dispatch (neighbor_pad_halo -> conv3d halo mode) must
-# equal the current full-pad two-dispatch (neighbor_pad_async -> conv3d) on device. Same weight/input;
-# both compute conv on the neighbor-padded input, so a device-to-device match proves the halo read.
+# Halo-aware conv3d correctness: the compact two-dispatch (neighbor_pad_halo -> conv3d halo mode) must equal
 def run_conv3d_halo_vs_fullpad_2d(mesh_device, input_shape, C_out, kernel_size, pH, pW, num_links=2):
     h_dim, w_dim, h_axis, w_axis = 2, 3, 0, 1
     mesh_shape = tuple(mesh_device.shape)
@@ -1116,9 +1081,7 @@ def run_conv3d_halo_vs_fullpad_2d(mesh_device, input_shape, C_out, kernel_size, 
     ttnn.synchronize_device(mesh_device, sub_device_ids=[sub_id])
 
     if os.environ.get("NP_CONV_PERF"):
-        # Decompose the e2e halo-vs-fullpad delta: halo_path = np_halo + conv_halo_read; fullpad_path =
-        # np_async(persistent) + conv_plain. Isolates whether the halo-mode conv3d (spatial padding active
-        # -> boundary blocks skip the coalesced gather) is the net-loss source on small 4x8 shards.
+        # Decompose the e2e halo-vs-fullpad delta: halo_path = np_halo + conv_halo_read
         def _np_async():
             return ttnn.experimental.neighbor_pad_async(
                 inp_mesh,
@@ -1207,9 +1170,7 @@ def test_conv3d_halo_vs_fullpad(mesh_device, device_params, input_shape, C_out, 
     )
 
 
-# Reuse test: the decode calls neighbor_pad_halo ~30x sharing the manager's ping-pong sems. A single-op
-# test can't catch a missing on-device self-reset — this loops the op N times reusing ONE sem set (no
-# ping-pong to mask it). If call 2+ hangs, a semaphore isn't reset between runs.
+# Reuse test: the decode calls neighbor_pad_halo ~30x sharing the manager's ping-pong sems
 @pytest.mark.timeout(200)
 @pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)

--- a/tests/nightly/t3000/ccl/test_strided_all_gather_minimal_matmul_async.py
+++ b/tests/nightly/t3000/ccl/test_strided_all_gather_minimal_matmul_async.py
@@ -15,10 +15,7 @@ from tracy import signpost
 
 
 def create_global_semaphores(mesh_device, num_devices, cores, initial_value, num_extra=0):
-    # 2 out-ready semaphores (one per direction), plus num_extra aggregator per-worker
-    # semaphores for the writer-signals-matmul path. The aggregator per-worker sems are
-    # incremented over the fabric by writer workers on the receiving device, so they must be
-    # GlobalSemaphores (mesh-consistent reserved address) just like the out-ready sems.
+    # 2 out-ready semaphores (one per direction), plus num_extra aggregator per-worker semaphores
     ccl_semaphore_handles = [
         ttnn.create_global_semaphore(mesh_device, cores, initial_value) for _ in range(2 + num_extra)
     ]
@@ -97,10 +94,7 @@ def run_strided_all_gather_minimal_matmul_impl(
     )
 
     # create global semaphore handles
-    # For the writer-signals-matmul path, the aggregator needs 2 directions x (num_links x
-    # num_workers_per_link) per-worker semaphores appended after the 2 out-ready sems. These are
-    # created unconditionally (unused/harmless when the path is off) so the address layout the
-    # device op reads is stable.
+    # For the writer-signals-matmul path, the aggregator needs 2 directions x
     num_agg_sems = 2 * num_links * (num_workers_per_link or 0)
     ccl_semaphore_handles = [
         create_global_semaphores(mesh_device, num_devices, all_cores, 0, num_extra=num_agg_sems)
@@ -179,9 +173,7 @@ def run_strided_all_gather_minimal_matmul_impl(
         bias_tensor_mesh_list.append(bias_tensor_mesh)
 
         if use_ternary:
-            # addcmul: out = ternary_a + scalar * matmul_out * ternary_b.
-            # ternary_a is output-shaped [1, 1, M, N], sharded like the matmul output (M on other_dim, N like
-            # the weight); ternary_b is [1, 1, 1, N] and broadcasts over M (replicated like bias).
+            # addcmul: out = ternary_a + scalar * matmul_out * ternary_b
             ternary_a_input = torch.randn((1, 1, M, N), dtype=torch_dtype)
             ternary_b_input = torch.randn((1, 1, 1, N), dtype=torch_dtype)
             ternary_a_tensor_mesh = ttnn.from_torch(
@@ -380,8 +372,7 @@ def run_strided_all_gather_minimal_matmul_impl(
                 logger.info(f"{output}, iteration {i}")
                 assert eq, f"iter {i} AG FAILED ag: {output}"
 
-            # Matmul output is a list of chunk tensors (one for chunks=1). Each chunk is the matching
-            # N-slice of the full golden output.
+            # Matmul output is a list of chunk tensors (one for chunks=1)
             tt_mm_out_tensors = tt_matmul_out_tensor_list[i]
             torch_mm_out_tensor = torch_matmul_output_list[i if not enable_trace else 0]
             torch_mm_chunks = torch.chunk(torch_mm_out_tensor, len(tt_mm_out_tensors), dim=-1)

--- a/tests/nightly/t3000/ccl/test_strided_all_gather_minimal_matmul_async.py
+++ b/tests/nightly/t3000/ccl/test_strided_all_gather_minimal_matmul_async.py
@@ -14,9 +14,14 @@ from models.common.utility_functions import skip_for_blackhole
 from tracy import signpost
 
 
-def create_global_semaphores(mesh_device, num_devices, cores, initial_value):
-    # create global semaphore handles
-    ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, cores, initial_value) for _ in range(2)]
+def create_global_semaphores(mesh_device, num_devices, cores, initial_value, num_extra=0):
+    # 2 out-ready semaphores (one per direction), plus num_extra aggregator per-worker
+    # semaphores for the writer-signals-matmul path. The aggregator per-worker sems are
+    # incremented over the fabric by writer workers on the receiving device, so they must be
+    # GlobalSemaphores (mesh-consistent reserved address) just like the out-ready sems.
+    ccl_semaphore_handles = [
+        ttnn.create_global_semaphore(mesh_device, cores, initial_value) for _ in range(2 + num_extra)
+    ]
     return ccl_semaphore_handles
 
 
@@ -49,7 +54,10 @@ def run_strided_all_gather_minimal_matmul_impl(
     skip_check=False,
     num_l1_banks=64,
     use_bias=False,
+    use_ternary=False,
+    ternary_scalar=0.5,
     activation=None,
+    chunks=1,
     math_fidelity=ttnn.MathFidelity.HiFi2,
     fp32_acc=True,
     mm_core_grid=None,
@@ -89,7 +97,15 @@ def run_strided_all_gather_minimal_matmul_impl(
     )
 
     # create global semaphore handles
-    ccl_semaphore_handles = [create_global_semaphores(mesh_device, num_devices, all_cores, 0) for _ in range(num_iters)]
+    # For the writer-signals-matmul path, the aggregator needs 2 directions x (num_links x
+    # num_workers_per_link) per-worker semaphores appended after the 2 out-ready sems. These are
+    # created unconditionally (unused/harmless when the path is off) so the address layout the
+    # device op reads is stable.
+    num_agg_sems = 2 * num_links * (num_workers_per_link or 0)
+    ccl_semaphore_handles = [
+        create_global_semaphores(mesh_device, num_devices, all_cores, 0, num_extra=num_agg_sems)
+        for _ in range(num_iters)
+    ]
 
     ##### All gather input setup #####
     logger.info(f"All gather output shape: {ag_output_shape}")
@@ -98,10 +114,19 @@ def run_strided_all_gather_minimal_matmul_impl(
     input_tensor_mesh_list = []
     weight_tensor_mesh_list = []
     bias_tensor_mesh_list = []
+    ternary_a_tensor_mesh_list = []
+    ternary_b_tensor_mesh_list = []
     ag_output_tensor_goldens_list = []
     torch_matmul_output_list = []
 
     shard_dims = [other_dim, dim]
+    if use_ternary:
+        assert (
+            not use_non_fused
+        ), "ternary (addcmul) is only wired into the fused strided_all_gather_minimal_matmul path"
+    if chunks > 1:
+        assert not use_non_fused, "chunks > 1 is only wired into the fused strided_all_gather_minimal_matmul path"
+        assert N % chunks == 0, f"N ({N}) must be divisible by chunks ({chunks})"
     for i in range(num_iters):
         torch_dtype = torch.float32
         ag_output_tensor = torch.randn(ag_output_shape, dtype=torch_dtype)
@@ -112,6 +137,8 @@ def run_strided_all_gather_minimal_matmul_impl(
         activation_fn = None
         if activation == "gelu":
             activation_fn = (ttnn.UnaryOpType.GELU, False)
+        elif activation == "gelu_tanh":
+            activation_fn = ttnn.UnaryOpType.GELU_TANH
         else:
             assert activation is None, f"Unsupported activation: {activation}"
 
@@ -151,12 +178,49 @@ def run_strided_all_gather_minimal_matmul_impl(
         weight_tensor_mesh_list.append(weight_tensor_mesh)
         bias_tensor_mesh_list.append(bias_tensor_mesh)
 
-        if use_bias:
-            matmul_output = torch.nn.functional.linear(
-                ag_output_tensor_goldens_list[i], weight_input.T.contiguous(), bias_input
+        if use_ternary:
+            # addcmul: out = ternary_a + scalar * matmul_out * ternary_b.
+            # ternary_a is output-shaped [1, 1, M, N], sharded like the matmul output (M on other_dim, N like
+            # the weight); ternary_b is [1, 1, 1, N] and broadcasts over M (replicated like bias).
+            ternary_a_input = torch.randn((1, 1, M, N), dtype=torch_dtype)
+            ternary_b_input = torch.randn((1, 1, 1, N), dtype=torch_dtype)
+            ternary_a_tensor_mesh = ttnn.from_torch(
+                ternary_a_input,
+                device=mesh_device,
+                layout=layout,
+                dtype=ag_input_dtype,
+                memory_config=mem_config_input,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, dims=[other_dim, dim if shard_weights else None], mesh_shape=tuple(mesh_device.shape)
+                ),
+            )
+            ternary_b_tensor_mesh = ttnn.from_torch(
+                ternary_b_input,
+                device=mesh_device,
+                layout=layout,
+                dtype=ag_input_dtype,
+                memory_config=mem_config_input,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, dims=[None, dim if shard_weights else None], mesh_shape=tuple(mesh_device.shape)
+                ),
             )
         else:
-            matmul_output = torch.matmul(ag_output_tensor_goldens_list[i], weight_input)
+            ternary_a_tensor_mesh = None
+            ternary_b_tensor_mesh = None
+        ternary_a_tensor_mesh_list.append(ternary_a_tensor_mesh)
+        ternary_b_tensor_mesh_list.append(ternary_b_tensor_mesh)
+
+        matmul_output = torch.matmul(ag_output_tensor_goldens_list[i], weight_input)
+        if use_bias:
+            # Row-broadcast bias: bias_input is [1, N] and broadcasts over the M rows, matching add_bias_block.
+            matmul_output = matmul_output + bias_input
+        if use_ternary:
+            matmul_output = ternary_a_input + ternary_scalar * matmul_output * ternary_b_input
+        # fused_activation is applied last (mutually exclusive with ternary; see the op's validate).
+        if activation == "gelu":
+            matmul_output = torch.nn.functional.gelu(matmul_output)
+        elif activation == "gelu_tanh":
+            matmul_output = torch.nn.functional.gelu(matmul_output, approximate="tanh")
         torch_matmul_output_list.append(matmul_output)
 
     ### Create persistent output buffers
@@ -223,8 +287,10 @@ def run_strided_all_gather_minimal_matmul_impl(
                 compute_kernel_config=compute_config,
                 config=matmul_config,
             )
+            # Uniform list-of-chunks interface (single output for the non-fused path).
+            tt_matmul_out_tensors = [tt_matmul_out_tensor]
         else:
-            tt_all_gather_out_tensor, tt_matmul_out_tensor = ttnn.experimental.strided_all_gather_minimal_matmul_async(
+            fused_outputs = ttnn.experimental.strided_all_gather_minimal_matmul_async(
                 input_tensor_mesh_list[i],
                 weight_tensor_mesh_list[i],
                 persistent_output_buffer=persistent_output_buffers[i],
@@ -243,8 +309,15 @@ def run_strided_all_gather_minimal_matmul_impl(
                 num_workers_per_link=num_workers_per_link,
                 num_buffers_per_channel=num_buffers_per_channel,
                 read_local_slice_from_input=read_local_slice_from_input,
+                fused_ternary_input_a=ternary_a_tensor_mesh_list[i] if use_ternary else None,
+                fused_ternary_input_b=ternary_b_tensor_mesh_list[i] if use_ternary else None,
+                fused_ternary_scalar=ternary_scalar if use_ternary else None,
+                chunks=chunks,
             )
-        return tt_all_gather_out_tensor, tt_matmul_out_tensor
+            # Op returns [all_gather_output, matmul_chunk_0, ..., matmul_chunk_{chunks-1}].
+            tt_all_gather_out_tensor = fused_outputs[0]
+            tt_matmul_out_tensors = list(fused_outputs[1:])
+        return tt_all_gather_out_tensor, tt_matmul_out_tensors
 
     if enable_trace:
         # Compile the op
@@ -307,26 +380,32 @@ def run_strided_all_gather_minimal_matmul_impl(
                 logger.info(f"{output}, iteration {i}")
                 assert eq, f"iter {i} AG FAILED ag: {output}"
 
-            tt_mm_out_tensor = tt_matmul_out_tensor_list[i]
+            # Matmul output is a list of chunk tensors (one for chunks=1). Each chunk is the matching
+            # N-slice of the full golden output.
+            tt_mm_out_tensors = tt_matmul_out_tensor_list[i]
             torch_mm_out_tensor = torch_matmul_output_list[i if not enable_trace else 0]
+            torch_mm_chunks = torch.chunk(torch_mm_out_tensor, len(tt_mm_out_tensors), dim=-1)
 
-            tt_mm_out = ttnn.from_device(tt_mm_out_tensor)
-            tt_mm_out = ttnn.to_torch(
-                tt_mm_out,
-                mesh_composer=ttnn.ConcatMesh2dToTensor(
-                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims if shard_weights else concat_dims
-                ),
-            )
-            if not shard_weights:
-                for d in range(mesh_device.shape[1]):
-                    tt_mm_out_slice = tt_mm_out[d : d + 1, :, :, :]
-                    eq, output = comp_pcc(tt_mm_out_slice, torch_mm_out_tensor)
-                logger.info(f"{output}, iteration {i}")
-                assert eq, f"iter {i} MM FAILED ag: {output}"
-            else:
-                eq, output = comp_pcc(tt_mm_out, torch_mm_out_tensor)
-                logger.info(f"{output}, iteration {i}")
-                assert eq, f"iter {i} MM FAILED ag: {output}"
+            for c, tt_mm_chunk_tensor in enumerate(tt_mm_out_tensors):
+                tt_mm_out = ttnn.from_device(tt_mm_chunk_tensor)
+                tt_mm_out = ttnn.to_torch(
+                    tt_mm_out,
+                    mesh_composer=ttnn.ConcatMesh2dToTensor(
+                        mesh_device,
+                        mesh_shape=tuple(mesh_device.shape),
+                        dims=shard_dims if shard_weights else concat_dims,
+                    ),
+                )
+                if not shard_weights:
+                    for d in range(mesh_device.shape[1]):
+                        tt_mm_out_slice = tt_mm_out[d : d + 1, :, :, :]
+                        eq, output = comp_pcc(tt_mm_out_slice, torch_mm_chunks[c])
+                    logger.info(f"{output}, iteration {i} chunk {c}")
+                    assert eq, f"iter {i} chunk {c} MM FAILED ag: {output}"
+                else:
+                    eq, output = comp_pcc(tt_mm_out, torch_mm_chunks[c])
+                    logger.info(f"{output}, iteration {i} chunk {c}")
+                    assert eq, f"iter {i} chunk {c} MM FAILED ag: {output}"
 
 
 # tiles_per_chunk needs to be divisible by num_workers_per_link

--- a/tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
@@ -2,8 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 import ttnn
+from loguru import logger
 from models.common.utility_functions import is_wormhole_b0
 
 from tests.nightly.t3000.ccl.test_minimal_matmul_strided_reduce_scatter_async import (
@@ -178,6 +181,47 @@ def _make_fabric_router_config(max_packet_payload_size_bytes):
             ),
             id="xlarge_9472_3456_5120_y7_cwimb1_rs3_fullgrid",
         ),
+        # LTX video FFN ff2 (RowParallel reduce-scatter): per-device [4864,4096]@[4096,4096]
+        # (K = ffn_dim/TP = 16384/4 = 4096, N = dim = 4096), HiFi2 (impl default).
+        # LTX has no fused_mmrs_configs entry for this shape (falls to the (8,7) default), which is a
+        # too-small grid. Start from the Wan-style (12,8)=96-core MM grid with a plain 8/8/8 blocking
+        # (subblock 2x2), leaving rows 8-9 for the RS workers; tune from here.
+        pytest.param(
+            MinimalMatmulStridedReduceScatterTestConfig(
+                M=4864,
+                K=4096,
+                N=4096,
+                dim=3,
+                mm_block_m=256,
+                mm_block_k=256,
+                mm_block_n=256,
+                mm_core_grid=ttnn.CoreCoord(12, 8),
+                chunk_width_in_mm_blocks=1,
+                subblock_h=2,
+                subblock_w=2,
+                num_workers_per_link=3,
+            ),
+            id="ltx_ff2_4864_4096_4096_x12_y8_b888",
+        ),
+        # LTX ff2, tuned: on the (12,8) grid (rows 8-9 reserved for RS workers), the default block is
+        # M/K/N = 4/5/7 tiles (subblock 4x1); run_ff2_block_sweep.py sweeps shapes to revisit.
+        pytest.param(
+            MinimalMatmulStridedReduceScatterTestConfig(
+                M=4864,
+                K=4096,
+                N=4096,
+                dim=3,
+                mm_block_m=128,  # 4 tiles
+                mm_block_k=160,  # 5 tiles
+                mm_block_n=224,  # 7 tiles
+                mm_core_grid=ttnn.CoreCoord(12, 8),
+                chunk_width_in_mm_blocks=1,
+                subblock_h=4,
+                subblock_w=1,
+                num_workers_per_link=3,
+            ),
+            id="ltx_ff2_4864_4096_4096_x12_y8_b457",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -194,13 +238,21 @@ def _make_fabric_router_config(max_packet_payload_size_bytes):
     "enable_trace, num_iters",
     [
         (False, 1),
+        # Run the op twice back-to-back (no trace): iter 0 pays program build/first-dispatch, iter 1
+        # is a program-cache hit -> use the 2nd op in the profiler to rule out compile/first-run cost.
+        (False, 2),
     ],
-    ids=["check"],
+    ids=["check", "iter2"],
 )
 @pytest.mark.parametrize(
     "rs_mode",
     [
         "fused",
+        # Unfused: run the standalone minimal_matmul (its own profiler op = the standalone matmul
+        # time) followed by a separate reduce-scatter. Note the standalone matmul uses the FULL
+        # compute grid, not the (12,8) the fused op reserves for RS workers.
+        "separate_strided",
+        "separate",
     ],
 )
 @pytest.mark.parametrize(
@@ -362,3 +414,193 @@ def test_minimal_matmul_strided_reduce_scatter_async_bh_large_packet(
         math_fidelity=ttnn.MathFidelity.HiFi2,
         fp32_acc=True,
     )
+
+
+# ---------------------------------------------------------------------------
+# Block-shape sweep: fixed LTX video ff2 shape (4864/4096/4096) on the (12,8) MM grid, HiFi2.
+# The mm_block_m / mm_block_k / mm_block_n ranges come from env vars so a driver can shard the
+# (large) sweep into small, profiler-friendly batches:
+#   SWEEP_M_BLOCKS / SWEEP_K_BLOCKS / SWEEP_N_BLOCKS  (each "lo:hi" inclusive, or "a,b,c"; tiles)
+# If none are set the parameter set is empty -> the test skips (empty_parameter_set_mark=skip),
+# so it never runs in nightly. N block is capped by the per-core N tiles (Nt // grid.x = 10 here);
+# subblock is auto-picked as the largest DST-fitting (sh*sw <= 4) divisor of the block.
+# Drive it with tests/nightly/tg/ccl/run_ff2_block_sweep.py.
+# ---------------------------------------------------------------------------
+_SWEEP_M, _SWEEP_K, _SWEEP_N = 4864, 4096, 4096
+_SWEEP_GRID = (12, 8)
+_DEFAULT_BLOCK_RANGE = tuple(range(2, 17))  # 2..16 tiles (used per-axis when its env var is unset)
+_DST_MAX_TILES = 4  # matches the subblocks the other configs in this file use (sh*sw <= 4)
+# Evaluated at collection so the sweep skips (without opening a device) unless a driver set the env.
+_HAS_SWEEP_ENV = any(os.environ.get(v) for v in ("SWEEP_M_BLOCKS", "SWEEP_K_BLOCKS", "SWEEP_N_BLOCKS"))
+
+
+def _parse_block_env(name):
+    """Parse a block-size range env var: 'lo:hi' (inclusive) or 'a,b,c'. Returns None if unset."""
+    import os
+
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return None
+    raw = raw.strip()
+    if ":" in raw:
+        lo, hi = (int(x) for x in raw.split(":"))
+        return tuple(range(lo, hi + 1))
+    return tuple(int(x) for x in raw.split(",") if x.strip())
+
+
+def _largest_valid_subblock(block_m_t, block_n_t, dst_max_tiles=_DST_MAX_TILES):
+    """Largest (subblock_h, subblock_w) that divides the block and fits the DST register;
+    ties broken toward a balanced (square-ish) subblock."""
+    best = (1, 1)
+    for sh in range(1, block_m_t + 1):
+        if block_m_t % sh:
+            continue
+        for sw in range(1, block_n_t + 1):
+            if block_n_t % sw or sh * sw > dst_max_tiles:
+                continue
+            cur, bp = sh * sw, best[0] * best[1]
+            if cur > bp or (cur == bp and abs(sh - sw) < abs(best[0] - best[1])):
+                best = (sh, sw)
+    return best
+
+
+def _gen_block_sweep_configs():
+    import math
+
+    m_blocks = _parse_block_env("SWEEP_M_BLOCKS")
+    k_blocks = _parse_block_env("SWEEP_K_BLOCKS")
+    n_blocks = _parse_block_env("SWEEP_N_BLOCKS")
+    if m_blocks is None and k_blocks is None and n_blocks is None:
+        return []  # no sweep requested -> empty parameter set skips cleanly (keeps nightly clean)
+    m_blocks = m_blocks or _DEFAULT_BLOCK_RANGE
+    k_blocks = k_blocks or _DEFAULT_BLOCK_RANGE
+    n_blocks = n_blocks or _DEFAULT_BLOCK_RANGE
+
+    TILE = 32
+    gx, gy = _SWEEP_GRID
+    mt_per_core = math.ceil((_SWEEP_M // TILE) / gy)  # fused RS-matmul: M on grid.y (no transpose)
+    kt = _SWEEP_K // TILE
+    nt_per_core = (_SWEEP_N // TILE) // gx  # matches the Nt_per_core assert in the impl/test
+    configs = []
+    for bm in m_blocks:
+        if bm > mt_per_core:
+            continue
+        for bk in k_blocks:
+            if bk > kt:
+                continue
+            for bn in n_blocks:
+                if bn > nt_per_core:
+                    continue
+                sh, sw = _largest_valid_subblock(bm, bn)
+                configs.append(
+                    MinimalMatmulStridedReduceScatterTestConfig(
+                        M=_SWEEP_M,
+                        K=_SWEEP_K,
+                        N=_SWEEP_N,
+                        dim=3,
+                        mm_block_m=bm * TILE,
+                        mm_block_k=bk * TILE,
+                        mm_block_n=bn * TILE,
+                        mm_core_grid=ttnn.CoreCoord(gx, gy),
+                        chunk_width_in_mm_blocks=1,
+                        subblock_h=sh,
+                        subblock_w=sw,
+                        num_workers_per_link=3,
+                    )
+                )
+    return configs
+
+
+@pytest.mark.parametrize("mesh_device", [(4, 8)], indirect=True, ids=["4x8"])
+@pytest.mark.parametrize("num_links", [2], ids=["2link"])
+@pytest.mark.parametrize("cluster_axis", [0], ids=["axis_0"])
+@pytest.mark.skipif(
+    not _HAS_SWEEP_ENV, reason="block sweep: set SWEEP_{M,K,N}_BLOCKS env (drive with run_ff2_block_sweep.py)"
+)
+@pytest.mark.parametrize(
+    "mem_config_input, mem_config_mm, mem_config_rs",
+    [
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        )
+    ],
+    ids=["DRAM"],
+)
+@pytest.mark.parametrize("enable_trace, num_iters", [(False, 1)], ids=["check"])
+@pytest.mark.parametrize("rs_mode", ["fused"])
+@pytest.mark.parametrize(
+    "device_params, topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
+        pytest.param(
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": _make_fabric_router_config(8192),
+                "trace_region_size": 1531456,
+            },
+            ttnn.Topology.Ring,
+            marks=pytest.mark.skipif(is_wormhole_b0(), reason="fabric_router_config=8192 not supported on wormhole_b0"),
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring", "fabric_ring_8kib_payload"],
+)
+def test_minimal_matmul_strided_reduce_scatter_block_sweep(
+    mesh_device,
+    num_links,
+    mem_config_input,
+    mem_config_mm,
+    mem_config_rs,
+    enable_trace,
+    topology,
+    num_iters,
+    rs_mode,
+    cluster_axis,
+):
+    if is_wormhole_b0() and (_SWEEP_GRID[0] > 8 or _SWEEP_GRID[1] > 8):
+        pytest.skip("core grid exceeds wormhole_b0 compute grid (8x8), blackhole-only sweep")
+    if mesh_device.shape[cluster_axis] == 1:
+        pytest.skip(f"cluster_axis={cluster_axis} has only 1 device in this mesh")
+
+    configs = _gen_block_sweep_configs()
+    if not configs:
+        pytest.skip("no SWEEP_{M,K,N}_BLOCKS env set; drive with run_ff2_block_sweep.py")
+
+    # Run every config back-to-back on the SAME device (opened once by the fixture) so the sweep is
+    # not dominated by per-config device open/close. Each op records its block config in the
+    # profiler ATTRIBUTES, so the driver still maps timings back to configs.
+    for idx, cfg in enumerate(configs):
+        logger.info(
+            f"[block sweep {idx + 1}/{len(configs)}] M_block={cfg.mm_block_m // 32} "
+            f"K_block={cfg.mm_block_k // 32} N_block={cfg.mm_block_n // 32} "
+            f"subblock=({cfg.subblock_h},{cfg.subblock_w})"
+        )
+        run_minimal_matmul_strided_reduce_scatter_impl(
+            mesh_device,
+            cfg.M,
+            cfg.K,
+            cfg.N,
+            cfg.dim,
+            num_links,
+            cfg.input_dtype,
+            cfg.layout,
+            mem_config_input,
+            mem_config_mm,
+            mem_config_rs,
+            topology=topology,
+            enable_trace=enable_trace,
+            num_iters=num_iters,
+            num_workers_per_link=cfg.num_workers_per_link,
+            mm_block_m=cfg.mm_block_m,
+            mm_block_k=cfg.mm_block_k,
+            mm_block_n=cfg.mm_block_n,
+            subblock_h=cfg.subblock_h,
+            subblock_w=cfg.subblock_w,
+            mm_core_grid=cfg.mm_core_grid,
+            chunk_width_in_mm_blocks=cfg.chunk_width_in_mm_blocks,
+            rs_mode=rs_mode,
+            cluster_axis=cluster_axis,
+            check_correctness=False,  # perf sweep: skip golden matmul + PCC
+        )

--- a/tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
@@ -182,10 +182,6 @@ def _make_fabric_router_config(max_packet_payload_size_bytes):
             id="xlarge_9472_3456_5120_y7_cwimb1_rs3_fullgrid",
         ),
         # LTX video FFN ff2 (RowParallel reduce-scatter): per-device [4864,4096]@[4096,4096]
-        # (K = ffn_dim/TP = 16384/4 = 4096, N = dim = 4096), HiFi2 (impl default).
-        # LTX has no fused_mmrs_configs entry for this shape (falls to the (8,7) default), which is a
-        # too-small grid. Start from the Wan-style (12,8)=96-core MM grid with a plain 8/8/8 blocking
-        # (subblock 2x2), leaving rows 8-9 for the RS workers; tune from here.
         pytest.param(
             MinimalMatmulStridedReduceScatterTestConfig(
                 M=4864,
@@ -203,8 +199,7 @@ def _make_fabric_router_config(max_packet_payload_size_bytes):
             ),
             id="ltx_ff2_4864_4096_4096_x12_y8_b888",
         ),
-        # LTX ff2, tuned: on the (12,8) grid (rows 8-9 reserved for RS workers), the default block is
-        # M/K/N = 4/5/7 tiles (subblock 4x1); run_ff2_block_sweep.py sweeps shapes to revisit.
+        # LTX ff2, tuned: on the (12,8) grid (rows 8-9 reserved for RS workers)
         pytest.param(
             MinimalMatmulStridedReduceScatterTestConfig(
                 M=4864,
@@ -238,8 +233,7 @@ def _make_fabric_router_config(max_packet_payload_size_bytes):
     "enable_trace, num_iters",
     [
         (False, 1),
-        # Run the op twice back-to-back (no trace): iter 0 pays program build/first-dispatch, iter 1
-        # is a program-cache hit -> use the 2nd op in the profiler to rule out compile/first-run cost.
+        # Run the op twice back-to-back (no trace): iter 0 pays program build/first-dispatch
         (False, 2),
     ],
     ids=["check", "iter2"],
@@ -248,9 +242,7 @@ def _make_fabric_router_config(max_packet_payload_size_bytes):
     "rs_mode",
     [
         "fused",
-        # Unfused: run the standalone minimal_matmul (its own profiler op = the standalone matmul
-        # time) followed by a separate reduce-scatter. Note the standalone matmul uses the FULL
-        # compute grid, not the (12,8) the fused op reserves for RS workers.
+        # Unfused: run the standalone minimal_matmul (its own profiler op = the standalone matmul time) followed
         "separate_strided",
         "separate",
     ],
@@ -416,16 +408,7 @@ def test_minimal_matmul_strided_reduce_scatter_async_bh_large_packet(
     )
 
 
-# ---------------------------------------------------------------------------
-# Block-shape sweep: fixed LTX video ff2 shape (4864/4096/4096) on the (12,8) MM grid, HiFi2.
-# The mm_block_m / mm_block_k / mm_block_n ranges come from env vars so a driver can shard the
-# (large) sweep into small, profiler-friendly batches:
-#   SWEEP_M_BLOCKS / SWEEP_K_BLOCKS / SWEEP_N_BLOCKS  (each "lo:hi" inclusive, or "a,b,c"; tiles)
-# If none are set the parameter set is empty -> the test skips (empty_parameter_set_mark=skip),
-# so it never runs in nightly. N block is capped by the per-core N tiles (Nt // grid.x = 10 here);
-# subblock is auto-picked as the largest DST-fitting (sh*sw <= 4) divisor of the block.
-# Drive it with tests/nightly/tg/ccl/run_ff2_block_sweep.py.
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- Block-shape sweep: fixed LTX video ff2
 _SWEEP_M, _SWEEP_K, _SWEEP_N = 4864, 4096, 4096
 _SWEEP_GRID = (12, 8)
 _DEFAULT_BLOCK_RANGE = tuple(range(2, 17))  # 2..16 tiles (used per-axis when its env var is unset)
@@ -568,9 +551,7 @@ def test_minimal_matmul_strided_reduce_scatter_block_sweep(
     if not configs:
         pytest.skip("no SWEEP_{M,K,N}_BLOCKS env set; drive with run_ff2_block_sweep.py")
 
-    # Run every config back-to-back on the SAME device (opened once by the fixture) so the sweep is
-    # not dominated by per-config device open/close. Each op records its block config in the
-    # profiler ATTRIBUTES, so the driver still maps timings back to configs.
+    # Run every config back-to-back on the SAME device (opened once by the fixture) so the sweep is not dominated
     for idx, cfg in enumerate(configs):
         logger.info(
             f"[block sweep {idx + 1}/{len(configs)}] M_block={cfg.mm_block_m // 32} "

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_all_gather_minimal_matmul_variable_chunks_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_all_gather_minimal_matmul_variable_chunks_bh.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Variable-width `chunks` for all_gather_minimal_matmul_async on the Blackhole galaxy.
+
+`chunk_sizes` lets the op's N-split produce chunks of differing widths (e.g. a fused QKV+gate).
+Each case asserts PCC per chunk, since the per-chunk row stride is the failure mode a shared width
+would reintroduce (chunk 0 stays correct while later chunks scatter).
+"""
+
+import pytest
+import ttnn
+from models.common.utility_functions import is_wormhole_b0
+
+from models.tt_dit.tests.models.wan2_2.test_all_gather_minimal_matmul_async import (
+    create_fabric_router_config,
+    run_test_linear,
+)
+
+# Per-device chunk widths in ELEMENTS. All must be multiples of TILE_WIDTH (32) and sum to N.
+_CHUNK_CASES = [
+    # Uniform, as a control: the variable-width code path must reproduce the legacy behaviour.
+    pytest.param(3072, [1024, 1024, 1024], id="uniform_3x1024"),
+    # The motivating shape: fused QKV + per-head gate. The gate chunk is a single tile wide, which
+    # is the degenerate stride (row stride 1) and the case a shared width would corrupt worst.
+    pytest.param(3104, [1024, 1024, 1024, 32], id="qkv_plus_gate"),
+    # Asymmetric widths whose boundaries do NOT fall on tidy multiples, so the prefix-sum scan is
+    # exercised where chunk boundaries land mid N-block rather than at block edges.
+    pytest.param(3104, [512, 1536, 1024, 32], id="asymmetric"),
+    # Two chunks, wildly unbalanced -- smallest legal chunk against a large one.
+    pytest.param(2080, [2048, 32], id="lopsided_2chunk"),
+]
+
+
+@pytest.mark.parametrize("mesh_device", [(4, 8)], indirect=True, ids=["4x8"])
+@pytest.mark.parametrize("N, chunk_sizes", _CHUNK_CASES)
+@pytest.mark.parametrize(
+    "device_params, topology",
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                # 4096-B payload: 8192 overflows the fabric mux L1 map at this client count.
+                "fabric_router_config": create_fabric_router_config(4096),
+                "trace_region_size": 90112,
+            },
+            ttnn.Topology.Ring,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+def test_all_gather_minimal_matmul_variable_chunks(mesh_device, topology, N, chunk_sizes):
+    if is_wormhole_b0():
+        pytest.skip("core grid (12, 9) exceeds wormhole_b0 compute grid (8x8), blackhole-only config")
+
+    assert sum(chunk_sizes) == N, f"chunk_sizes {chunk_sizes} must sum to N={N}"
+
+    check_result = run_test_linear(
+        mesh_device,
+        M=4864,
+        K=4096,
+        N=N,
+        chunks=len(chunk_sizes),
+        chunk_sizes=chunk_sizes,
+        M_block_size=8,
+        K_block_size=8,
+        N_block_size=8,
+        subblock_h=2,
+        subblock_w=1,
+        topology=topology,
+        core_grid=ttnn.CoreCoord(12, 9),
+        num_workers_per_link=6,
+        num_links=2,
+        use_bias=True,
+        use_non_fused=False,
+        sp_axis=1,
+        tp_axis=0,
+        cluster_axis=0,
+    )
+
+    # Per chunk, per device -- a mis-strided write shows up as one bad chunk, not a bad total.
+    for c in range(len(chunk_sizes)):
+        for i, result in enumerate(check_result[0][c]):
+            assert result["pcc"] > 0.999_500, f"chunk {c} (width {chunk_sizes[c]}), device {i}: pcc {result['pcc']}"
+            assert (
+                result["relative_rmse"] < 0.02
+            ), f"chunk {c} (width {chunk_sizes[c]}), device {i}: relative_rmse {result['relative_rmse']}"

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_all_gather_minimal_matmul_variable_chunks_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_all_gather_minimal_matmul_variable_chunks_bh.py
@@ -22,11 +22,9 @@ from models.tt_dit.tests.models.wan2_2.test_all_gather_minimal_matmul_async impo
 _CHUNK_CASES = [
     # Uniform, as a control: the variable-width code path must reproduce the legacy behaviour.
     pytest.param(3072, [1024, 1024, 1024], id="uniform_3x1024"),
-    # The motivating shape: fused QKV + per-head gate. The gate chunk is a single tile wide, which
-    # is the degenerate stride (row stride 1) and the case a shared width would corrupt worst.
+    # The motivating shape: fused QKV + per-head gate
     pytest.param(3104, [1024, 1024, 1024, 32], id="qkv_plus_gate"),
-    # Asymmetric widths whose boundaries do NOT fall on tidy multiples, so the prefix-sum scan is
-    # exercised where chunk boundaries land mid N-block rather than at block edges.
+    # Asymmetric widths whose boundaries do NOT fall on tidy multiples
     pytest.param(3104, [512, 1536, 1024, 32], id="asymmetric"),
     # Two chunks, wildly unbalanced -- smallest legal chunk against a large one.
     pytest.param(2080, [2048, 32], id="lopsided_2chunk"),

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_strided_all_gather_async_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_strided_all_gather_async_bh.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+
+from tests.nightly.t3000.ccl.test_strided_all_gather_async import (
+    run_strided_all_gather_impl,
+)
+from models.common.utility_functions import (
+    skip_for_wormhole_b0,
+    skip_for_n_or_less_dev,
+)
+
+
+def _create_cluster_submesh(mesh_device, cluster_axis):
+    """Create a 1xN (or Nx1) submesh sized to the cluster axis ring.
+
+    The op only operates along cluster_axis, so the non-cluster axis is just
+    redundant compute. Sub-meshing keeps the test focused on a single ring.
+    """
+    submesh_shape = [1, 1]
+    submesh_shape[cluster_axis] = mesh_device.shape[cluster_axis]
+    return mesh_device.create_submesh(ttnn.MeshShape(tuple(submesh_shape)))
+
+
+# Isolates the all-gather from the SP=8 / TP=4 fused matmul config in
+# test_strided_all_gather_minimal_matmul_async_bh.py, to measure AG performance alone.
+# The (8, 4) mesh puts the M shard (other_dim) on axis 0 (SP=8) and the K shard (dim) on
+# axis 1 (TP=4); the gather reconstructs full K across the TP group, riding the impl's default
+# cluster_axis=1. ag_output_shape is the activation [1, 1, M, K] with M=38912 (4864 per device).
+#
+# The AG chunk sizing mirrors the fused op's matmul: mm_cores_y = mm_core_grid.y = 8,
+# mm_block_h/32 = mm_block_m/32 = 16, mm_block_w/32 = mm_block_k/32 = 8.
+@skip_for_wormhole_b0()
+@skip_for_n_or_less_dev(1)
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+@pytest.mark.parametrize("num_links", [2], ids=["2link"])
+@pytest.mark.parametrize(
+    "ag_output_shape, dim, other_dim, num_workers_per_link, layout, ag_input_dtype, mm_cores_y, mm_block_h, mm_block_w",
+    [
+        ([1, 1, 4864, 4096], 3, 2, 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, 9, 512, 256),
+    ],
+    ids=["wan1"],
+)
+@pytest.mark.parametrize(
+    "mem_config_input, mem_config_ag",
+    [
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace,num_iters",
+    [
+        (True, 3),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}, ttnn.Topology.Ring),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+def test_strided_all_gather_async(
+    mesh_device,
+    ag_output_shape,
+    dim,
+    other_dim,
+    num_links,
+    ag_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_ag,
+    enable_trace,
+    all_gather_topology,
+    num_iters,
+    num_workers_per_link,
+    mm_cores_y,
+    mm_block_h,
+    mm_block_w,
+):
+    cluster_axis = 1
+    submesh = _create_cluster_submesh(mesh_device, cluster_axis)
+    run_strided_all_gather_impl(
+        submesh,
+        submesh.get_num_devices(),
+        ag_output_shape,
+        dim,
+        other_dim,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        num_workers_per_link=num_workers_per_link,
+        mm_cores_y=mm_cores_y,
+        mm_block_h=mm_block_h,
+        mm_block_w=mm_block_w,
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_strided_all_gather_async_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_strided_all_gather_async_bh.py
@@ -25,14 +25,7 @@ def _create_cluster_submesh(mesh_device, cluster_axis):
     return mesh_device.create_submesh(ttnn.MeshShape(tuple(submesh_shape)))
 
 
-# Isolates the all-gather from the SP=8 / TP=4 fused matmul config in
-# test_strided_all_gather_minimal_matmul_async_bh.py, to measure AG performance alone.
-# The (8, 4) mesh puts the M shard (other_dim) on axis 0 (SP=8) and the K shard (dim) on
-# axis 1 (TP=4); the gather reconstructs full K across the TP group, riding the impl's default
-# cluster_axis=1. ag_output_shape is the activation [1, 1, M, K] with M=38912 (4864 per device).
-#
-# The AG chunk sizing mirrors the fused op's matmul: mm_cores_y = mm_core_grid.y = 8,
-# mm_block_h/32 = mm_block_m/32 = 16, mm_block_w/32 = mm_block_k/32 = 8.
+# Isolates the all-gather from the SP=8 / TP=4 fused matmul config
 @skip_for_wormhole_b0()
 @skip_for_n_or_less_dev(1)
 @pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_strided_all_gather_minimal_matmul_async_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_strided_all_gather_minimal_matmul_async_bh.py
@@ -21,15 +21,7 @@ def create_fabric_router_config(max_payload_size):
     return config
 
 
-# SP=8 / TP=4 on the blackhole galaxy. The (8, 4) mesh puts the M/sequence shard (other_dim) on
-# axis 0 (SP=8) and the K/contraction shard (dim) on axis 1 (TP=4), matching the impl's
-# shard_dims = [other_dim, dim]. The all-gather reconstructs full K across the TP group, so it
-# rides axis 1 -- the impl's default cluster_axis=1. K gathers over TP=4, so per-device K is
-# 4096/4 = 32 tiles; mm_block_k is 256 (8 tiles), which divides it.
-#
-# Core-grid partition (blackhole 12x10 grid): matmul takes the lower mm_core_grid.y rows at width
-# mm_core_grid.x; the strided all-gather workers take the rows above, starting at ag_offset, so
-# ag_offset.y must equal mm_core_grid.y to keep the two regions disjoint.
+# SP=8 / TP=4 on the blackhole galaxy
 @skip_for_wormhole_b0()
 @skip_for_n_or_less_dev(1)
 @pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
@@ -83,16 +75,13 @@ def create_fabric_router_config(max_payload_size):
     ],
     ids=["fused"],
 )
-# One axis for the mutually-exclusive fused-output variants. addcmul and fused_activation cannot be
-# combined on the op (validate); chunks (output split) is exercised on the plain projection, matching how
-# LTX uses it (qkv/kv projections have no activation/addcmul). "chunks2" needs N divisible by chunks.
+# One axis for the mutually-exclusive fused-output variants
 @pytest.mark.parametrize(
     "fused_op_variant",
     [None, "addcmul", "gelu_tanh", "chunks2"],
     ids=["plain", "addcmul", "gelu_tanh", "chunks2"],
 )
-# Bias is orthogonal to the variant (LTX uses bias on every AG-matmul call). Note bias disables the
-# two-NoC split write (the !use_bias gate), so bias+chunks2 uses the single-NoC chunk write.
+# Bias is orthogonal to the variant (LTX uses bias on every AG-matmul call)
 @pytest.mark.parametrize(
     "use_bias",
     [False, True],
@@ -196,48 +185,25 @@ def test_strided_all_gather_minimal_matmul_async(
     )
 
 
-# The AG-matmul configurations the LTX transformer block actually uses (see models/tt_dit LTXAttention /
-# ParallelFeedForward), for both the video (dim=4096) and audio (dim=2048) blocks. Every call has bias; only
-# K (=dim, gathered across TP=4), the output width N, the chunk count, the fused epilogue, and the N blocking
-# differ. M reuses the wan1 sequence for all (see caveat: the real M is the text sequence for *_kv and the
-# audio sequence for a_*). N below is the FULL model width; the table uses the per-device value (full / TP=4).
-# The *_gate case (N = num_heads/TP = 8, a sub-tile width) is commented out for now — TODO.
-#   *_qkv         : attn1.to_qkv       bias, chunks=3  (Q|K|V,  N = 3*dim)
-#   *_kv          : attn2.to_kv        bias, chunks=2  (K|V,    N = 2*dim, M = context/text seq)
-#   *_q_out       : to_q / to_out      bias, chunks=1, N = dim
-#   *_out_addcmul : attn.to_out fused  bias + addcmul, chunks=1
-#   *_ff1         : ffn.ff1 / audio_ff bias + gelu_tanh, chunks=1, N = ffn_dim
-#   *_gate        : to_gate_logits     bias, chunks=1, N = num_heads = 32 (disabled)
+# The AG-matmul configurations the LTX transformer block actually uses
 @skip_for_wormhole_b0()
 @skip_for_n_or_less_dev(1)
 @pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
 @pytest.mark.parametrize(
     "ltx_layer, M, K, N, chunks, use_bias, activation, use_ternary, M_block, K_block, N_block, subblock_h, subblock_w",
     [
-        # M is the full (SP=8) sequence length; per-device M = M / 8 (e.g. 38912 -> 4864, 9728 -> 1216).
-        # M_block/K_block/N_block/subblock_h/subblock_w are in TILES. Video block (K = video_dim = 4096);
-        # q_out folds to_q / to_out(plain) / cross-attn q. N is the PER-DEVICE output width (full N / TP=4),
-        # since shard_weights=False replicates a per-device-sized weight (K is full, gathered by the AG).
-        # Multi-N-block configs (v_qkv/v_kv/v_ff1 and audio) are commented out: with N_blocks/core > 1 the split
-        # write takes the deferred path, which is not split-aware and deadlocks. These are the wide-N (compute-
-        # bound) matmuls, so the fabric-bound AG-overlap path doesn't matter for them and we don't care to run them.
-        # ("v_qkv", 38912, 4096, 3072, 3, True, None, False, 16, 8, 4, 2, 2), good
-        # ("v_kv", 38912, 4096, 2048, 2, True, None, False, 16, 8, 4, 2, 2), check this dont see it on device
+        # M is the full (SP=8) sequence length
         ("v_q_out", 38912, 4096, 1024, 1, True, None, False, 16, 8, 4, 2, 2),
         ("v_q_out_addcmul", 38912, 4096, 1024, 1, True, None, True, 16, 8, 4, 2, 2),
         ("v_q_out_s1", 9728, 4096, 1024, 1, True, None, False, 16, 8, 4, 2, 2),
         ("v_q_out_addcmul_s1", 9728, 4096, 1024, 1, True, None, True, 16, 8, 4, 2, 2),
-        # ("v_out_addcmul", 38912, 4096, 1024, 1, True, None, True, 16, 8, 4, 2, 2),
-        # ("v_ff1", 38912, 4096, 4096, 1, True, "gelu_tanh", False, 16, 8, 4, 2, 2),
+        # ("v_out_addcmul", 38912, 4096, 1024, 1, True, None, True, 16, 8, 4, 2, 2)
         ("v_gate", 38912, 4096, 8, 1, True, None, False, 16, 8, 1, 2, 1),
         ("v_gate_s1", 9728, 4096, 8, 1, True, None, False, 16, 8, 1, 2, 1),
-        # Audio block (K = audio_dim = 2048), same fusion structure with halved dims.
-        # ("a_qkv", 38912, 2048, 1536, 3, True, None, False, 16, 8, 4, 2, 2),
+        # Audio block (K = audio_dim = 2048), same fusion structure with halved dims
         ("a_kv", 38912, 2048, 1024, 1, True, None, False, 16, 8, 4, 2, 2),
         ("a_kv_s1", 9728, 2048, 1024, 1, True, None, False, 16, 8, 4, 2, 2),
-        # ("a_q_out", 38912, 2048, 512, 1, True, None, False, 16, 8, 4, 2, 2),
-        # ("a_out_addcmul", 38912, 2048, 512, 1, True, None, True, 16, 8, 4, 2, 2),
-        # ("a_ff1", 38912, 2048, 2048, 1, True, "gelu_tanh", False, 16, 8, 4, 2, 2),
+        # ("a_q_out", 38912, 2048, 512, 1, True, None, False, 16, 8, 4, 2, 2)
         ("a_gate", 38912, 2048, 8, 1, True, None, False, 16, 8, 1, 2, 1),
         ("a_gate_s1", 9728, 2048, 8, 1, True, None, False, 16, 8, 1, 2, 1),
         # N_block=2 to match the in-model registry (N_block=1 deadlocks via the split-write path).

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_strided_all_gather_minimal_matmul_async_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_strided_all_gather_minimal_matmul_async_bh.py
@@ -1,0 +1,346 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+from loguru import logger
+
+from tests.nightly.t3000.ccl.test_strided_all_gather_minimal_matmul_async import (
+    run_strided_all_gather_minimal_matmul_impl,
+)
+from models.common.utility_functions import (
+    skip_for_wormhole_b0,
+    skip_for_n_or_less_dev,
+)
+
+
+def create_fabric_router_config(max_payload_size):
+    config = ttnn._ttnn.fabric.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = max_payload_size
+    return config
+
+
+# SP=8 / TP=4 on the blackhole galaxy. The (8, 4) mesh puts the M/sequence shard (other_dim) on
+# axis 0 (SP=8) and the K/contraction shard (dim) on axis 1 (TP=4), matching the impl's
+# shard_dims = [other_dim, dim]. The all-gather reconstructs full K across the TP group, so it
+# rides axis 1 -- the impl's default cluster_axis=1. K gathers over TP=4, so per-device K is
+# 4096/4 = 32 tiles; mm_block_k is 256 (8 tiles), which divides it.
+#
+# Core-grid partition (blackhole 12x10 grid): matmul takes the lower mm_core_grid.y rows at width
+# mm_core_grid.x; the strided all-gather workers take the rows above, starting at ag_offset, so
+# ag_offset.y must equal mm_core_grid.y to keep the two regions disjoint.
+@skip_for_wormhole_b0()
+@skip_for_n_or_less_dev(1)
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+@pytest.mark.parametrize("num_links", [2], ids=["2link"])
+@pytest.mark.parametrize(
+    "M, K, N, dim, other_dim, num_workers_per_link, layout, ag_input_dtype, mm_block_m, mm_block_k, mm_block_n, subblock_h, subblock_w, mm_core_grid, shard_weights, ag_offset",
+    [
+        (
+            38912,  # 4864 per device (SP=8): 152 tiles; against a 16-tile mm_block_m this is 9.5 blocks -> ragged last M-block (hang repro)
+            4096,
+            1024,
+            3,
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            ttnn.bfloat16,
+            512,
+            256,
+            128,
+            2,
+            2,
+            ttnn.CoreCoord(12, 8),
+            False,
+            (0, 8),
+        ),
+    ],
+    ids=["wan1"],
+)
+@pytest.mark.parametrize(
+    "mem_config_input, mem_config_ag, mem_config_mm",
+    [
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace,num_iters",
+    [
+        (True, 3),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "use_non_fused",
+    [
+        False,
+    ],
+    ids=["fused"],
+)
+# One axis for the mutually-exclusive fused-output variants. addcmul and fused_activation cannot be
+# combined on the op (validate); chunks (output split) is exercised on the plain projection, matching how
+# LTX uses it (qkv/kv projections have no activation/addcmul). "chunks2" needs N divisible by chunks.
+@pytest.mark.parametrize(
+    "fused_op_variant",
+    [None, "addcmul", "gelu_tanh", "chunks2"],
+    ids=["plain", "addcmul", "gelu_tanh", "chunks2"],
+)
+# Bias is orthogonal to the variant (LTX uses bias on every AG-matmul call). Note bias disables the
+# two-NoC split write (the !use_bias gate), so bias+chunks2 uses the single-NoC chunk write.
+@pytest.mark.parametrize(
+    "use_bias",
+    [False, True],
+    ids=["no_bias", "bias"],
+)
+@pytest.mark.parametrize(
+    "read_local_slice_from_input",
+    [
+        True,
+    ],
+    ids=["read_local"],
+)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(8192),
+                "trace_region_size": 1171456,
+            },
+            ttnn.Topology.Ring,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+def test_strided_all_gather_minimal_matmul_async(
+    mesh_device,
+    M,
+    K,
+    N,
+    dim,
+    other_dim,
+    num_links,
+    ag_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_ag,
+    mem_config_mm,
+    enable_trace,
+    all_gather_topology,
+    num_iters,
+    num_workers_per_link,
+    mm_block_m,
+    mm_block_k,
+    mm_block_n,
+    subblock_h,
+    subblock_w,
+    mm_core_grid,
+    use_non_fused,
+    fused_op_variant,
+    use_bias,
+    shard_weights,
+    ag_offset,
+    read_local_slice_from_input,
+):
+    logger.info(f"fabric max payload = {ttnn._ttnn.fabric.get_tt_fabric_max_payload_size_bytes()} B")
+
+    grid = mesh_device.compute_with_storage_grid_size()
+    if grid.x < mm_core_grid.x or grid.y < ag_offset[1] + 1:
+        pytest.skip(f"Requires worker grid >= {mm_core_grid.x}x{ag_offset[1] + 1}, got {grid.x}x{grid.y}")
+
+    use_ternary = fused_op_variant == "addcmul"
+    activation = fused_op_variant if fused_op_variant == "gelu_tanh" else None
+    chunks = 2 if fused_op_variant == "chunks2" else 1
+
+    run_strided_all_gather_minimal_matmul_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        M,
+        K,
+        N,
+        dim,
+        other_dim,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        mem_config_mm,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        num_workers_per_link=num_workers_per_link,
+        num_buffers_per_channel=8,
+        mm_block_m=mm_block_m,
+        mm_block_k=mm_block_k,
+        mm_block_n=mm_block_n,
+        subblock_h=subblock_h,
+        subblock_w=subblock_w,
+        mm_core_grid=mm_core_grid,
+        use_non_fused=use_non_fused,
+        use_ternary=use_ternary,
+        activation=activation,
+        chunks=chunks,
+        use_bias=use_bias,
+        shard_weights=shard_weights,
+        ag_core_grid_offset=ag_offset,
+        read_local_slice_from_input=read_local_slice_from_input,
+    )
+
+
+# The AG-matmul configurations the LTX transformer block actually uses (see models/tt_dit LTXAttention /
+# ParallelFeedForward), for both the video (dim=4096) and audio (dim=2048) blocks. Every call has bias; only
+# K (=dim, gathered across TP=4), the output width N, the chunk count, the fused epilogue, and the N blocking
+# differ. M reuses the wan1 sequence for all (see caveat: the real M is the text sequence for *_kv and the
+# audio sequence for a_*). N below is the FULL model width; the table uses the per-device value (full / TP=4).
+# The *_gate case (N = num_heads/TP = 8, a sub-tile width) is commented out for now — TODO.
+#   *_qkv         : attn1.to_qkv       bias, chunks=3  (Q|K|V,  N = 3*dim)
+#   *_kv          : attn2.to_kv        bias, chunks=2  (K|V,    N = 2*dim, M = context/text seq)
+#   *_q_out       : to_q / to_out      bias, chunks=1, N = dim
+#   *_out_addcmul : attn.to_out fused  bias + addcmul, chunks=1
+#   *_ff1         : ffn.ff1 / audio_ff bias + gelu_tanh, chunks=1, N = ffn_dim
+#   *_gate        : to_gate_logits     bias, chunks=1, N = num_heads = 32 (disabled)
+@skip_for_wormhole_b0()
+@skip_for_n_or_less_dev(1)
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+@pytest.mark.parametrize(
+    "ltx_layer, M, K, N, chunks, use_bias, activation, use_ternary, M_block, K_block, N_block, subblock_h, subblock_w",
+    [
+        # M is the full (SP=8) sequence length; per-device M = M / 8 (e.g. 38912 -> 4864, 9728 -> 1216).
+        # M_block/K_block/N_block/subblock_h/subblock_w are in TILES. Video block (K = video_dim = 4096);
+        # q_out folds to_q / to_out(plain) / cross-attn q. N is the PER-DEVICE output width (full N / TP=4),
+        # since shard_weights=False replicates a per-device-sized weight (K is full, gathered by the AG).
+        # Multi-N-block configs (v_qkv/v_kv/v_ff1 and audio) are commented out: with N_blocks/core > 1 the split
+        # write takes the deferred path, which is not split-aware and deadlocks. These are the wide-N (compute-
+        # bound) matmuls, so the fabric-bound AG-overlap path doesn't matter for them and we don't care to run them.
+        # ("v_qkv", 38912, 4096, 3072, 3, True, None, False, 16, 8, 4, 2, 2), good
+        # ("v_kv", 38912, 4096, 2048, 2, True, None, False, 16, 8, 4, 2, 2), check this dont see it on device
+        ("v_q_out", 38912, 4096, 1024, 1, True, None, False, 16, 8, 4, 2, 2),
+        ("v_q_out_addcmul", 38912, 4096, 1024, 1, True, None, True, 16, 8, 4, 2, 2),
+        ("v_q_out_s1", 9728, 4096, 1024, 1, True, None, False, 16, 8, 4, 2, 2),
+        ("v_q_out_addcmul_s1", 9728, 4096, 1024, 1, True, None, True, 16, 8, 4, 2, 2),
+        # ("v_out_addcmul", 38912, 4096, 1024, 1, True, None, True, 16, 8, 4, 2, 2),
+        # ("v_ff1", 38912, 4096, 4096, 1, True, "gelu_tanh", False, 16, 8, 4, 2, 2),
+        ("v_gate", 38912, 4096, 8, 1, True, None, False, 16, 8, 1, 2, 1),
+        ("v_gate_s1", 9728, 4096, 8, 1, True, None, False, 16, 8, 1, 2, 1),
+        # Audio block (K = audio_dim = 2048), same fusion structure with halved dims.
+        # ("a_qkv", 38912, 2048, 1536, 3, True, None, False, 16, 8, 4, 2, 2),
+        ("a_kv", 38912, 2048, 1024, 1, True, None, False, 16, 8, 4, 2, 2),
+        ("a_kv_s1", 9728, 2048, 1024, 1, True, None, False, 16, 8, 4, 2, 2),
+        # ("a_q_out", 38912, 2048, 512, 1, True, None, False, 16, 8, 4, 2, 2),
+        # ("a_out_addcmul", 38912, 2048, 512, 1, True, None, True, 16, 8, 4, 2, 2),
+        # ("a_ff1", 38912, 2048, 2048, 1, True, "gelu_tanh", False, 16, 8, 4, 2, 2),
+        ("a_gate", 38912, 2048, 8, 1, True, None, False, 16, 8, 1, 2, 1),
+        ("a_gate_s1", 9728, 2048, 8, 1, True, None, False, 16, 8, 1, 2, 1),
+        # N_block=2 to match the in-model registry (N_block=1 deadlocks via the split-write path).
+        ("a2v_attn_s1", 9728, 4096, 512, 1, True, None, False, 16, 8, 2, 2, 2),
+        ("a2v_attn_s2", 38912, 4096, 512, 1, True, None, False, 16, 8, 2, 2, 2),
+    ],
+    ids=[
+        "v_q_out",
+        "v_q_out_addcmul",
+        "v_q_out_s1",
+        "v_q_out_addcmul_s1",
+        "v_gate",
+        "v_gate_s1",
+        "a_kv",
+        "a_kv_s1",
+        "a_gate",
+        "a_gate_s1",
+        "a2v_attn_s1",
+        "a2v_attn_s2",
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace,num_iters",
+    [
+        (True, 3),
+        (False, 1),
+        # Repeated eager invocations (no trace/warmup) to cover back-to-back sAGMM ops like the e2e.
+        (False, 8),
+    ],
+    ids=["perf", "check", "check_multi"],
+)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(8192),
+                "trace_region_size": 1171456,
+            },
+            ttnn.Topology.Ring,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+def test_strided_all_gather_minimal_matmul_ltx_configs(
+    mesh_device,
+    ltx_layer,
+    M,
+    K,
+    N,
+    chunks,
+    use_bias,
+    activation,
+    use_ternary,
+    M_block,
+    K_block,
+    N_block,
+    subblock_h,
+    subblock_w,
+    enable_trace,
+    num_iters,
+    all_gather_topology,
+):
+    mm_core_grid = ttnn.CoreCoord(12, 8)
+    ag_offset = (0, 8)
+    grid = mesh_device.compute_with_storage_grid_size()
+    if grid.x < mm_core_grid.x or grid.y < ag_offset[1] + 1:
+        pytest.skip(f"Requires worker grid >= {mm_core_grid.x}x{ag_offset[1] + 1}, got {grid.x}x{grid.y}")
+
+    dram = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    run_strided_all_gather_minimal_matmul_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        M,  # M (sequence, sharded on SP=8)
+        K,  # video_dim=4096 or audio_dim=2048, gathered across TP=4
+        N,
+        3,  # dim (AG/K shard axis)
+        2,  # other_dim (M/sequence shard axis)
+        2,  # num_links
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        dram,
+        dram,
+        dram,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        num_workers_per_link=3,
+        num_buffers_per_channel=8,
+        mm_block_m=M_block * 32,
+        mm_block_k=K_block * 32,
+        mm_block_n=N_block * 32,
+        subblock_h=subblock_h,
+        subblock_w=subblock_w,
+        mm_core_grid=mm_core_grid,
+        use_non_fused=False,
+        use_ternary=use_ternary,
+        activation=activation,
+        chunks=chunks,
+        use_bias=use_bias,
+        shard_weights=False,
+        ag_core_grid_offset=ag_offset,
+        read_local_slice_from_input=True,
+    )

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -252,6 +252,7 @@ target_link_libraries(
         TTNN::Ops::Experimental
         TTNN::Ops::Experimental::DeepSeekPrefill
         TTNN::Ops::Experimental::Transformer
+        TTNN::Ops::Experimental::NeighborPadHalo
         TTNN::Ops::Moreh
         TTNN::Ops::Transformer
 )

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
@@ -110,7 +110,7 @@ void StridedAllGatherFusedOpSignaler::push_all_gather_fused_op_rt_args(
 
     uint32_t num_workers_to_sync,
     uint32_t curr_worker_index,
-    uint32_t all_gather_direction) {
+    uint32_t signal_sem_index) {
     TT_FATAL(initialized_fused_op && initialized_all_gather, "AllGatherFusedOpSignaler not initialized fully.");
 
     out_rt_args.push_back(static_cast<uint32_t>(num_workers_to_sync));
@@ -132,8 +132,9 @@ void StridedAllGatherFusedOpSignaler::push_all_gather_fused_op_rt_args(
         out_rt_args.push_back(static_cast<uint32_t>(core.y));
     }
 
-    // Push the fused op signal semaphore addrs. Direction 0: clockwise, Direction 1: counter-clockwise
-    out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[all_gather_direction]));
+    // Push the fused op signal semaphore addr at the requested index into the matmul's semaphore vector
+    // (layout: [backward_0..N-1, forward_0..N-1, self]).
+    out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[signal_sem_index]));
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_signaler_mode == FusedOpSignalerMode::SINGLE ? 0 : 1));
 }
 
@@ -219,7 +220,9 @@ void StridedReduceScatterFusedOpSignaler::init_strided_reduce_scatter(
 void StridedReduceScatterFusedOpSignaler::push_strided_reduce_scatter_fused_op_rt_args(
     std::vector<uint32_t>& out_rt_args) const {
     TT_FATAL(initialized, "StridedReduceScatterFusedOpSignaler not initialized.");
-    out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphore));
+    // Per-core signaling: the reader takes the L1 base of the per-MM-core progress counter array
+    // (set by the RS program factory after allocating the backing buffer).
+    out_rt_args.push_back(static_cast<uint32_t>(this->mm_progress_counters_addr));
 }
 
 // Used to propagate semaphore information from matmul to all_gather in all_gather_matmul op
@@ -532,10 +535,11 @@ void MinimalMatmulFusedOpSignaler::init_fused_op(
             }
         },
         core_range_to_signal);
-    // Create the semaphores
-    this->fused_op_receiver_signal_semaphores.push_back(CreateSemaphore(program, core_range_to_signal, 0));
-    this->fused_op_receiver_signal_semaphores.push_back(CreateSemaphore(program, core_range_to_signal, 0));
-    this->fused_op_receiver_signal_semaphores.push_back(CreateSemaphore(program, core_range_to_signal, 0));
+    // Create the semaphores: N backward + N forward + 1 self (N == num_ag_workers; N==1 => legacy [b,f,s]).
+    const uint32_t num_signal_semaphores = 2 * this->num_ag_workers + 1;
+    for (uint32_t i = 0; i < num_signal_semaphores; i++) {
+        this->fused_op_receiver_signal_semaphores.push_back(CreateSemaphore(program, core_range_to_signal, 0));
+    }
 
     // Set the number of fused op cores to signal
     this->num_fused_op_cores_to_signal = this->fused_op_receiver_cores_noc.size();
@@ -557,9 +561,11 @@ void MinimalMatmulFusedOpSignaler::push_matmul_fused_op_rt_args(
     out_rt_args.push_back(static_cast<uint32_t>(this->input_tensor_Wt * this->start_ring_index));
     out_rt_args.push_back(static_cast<uint32_t>((this->input_tensor_Wt * (this->start_ring_index + 1)) - 1));
 
-    out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[0]));
-    out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[1]));
-    out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[2]));
+    // num_ag_workers followed by the 2*N+1 semaphore ids (backward[N], forward[N], self).
+    out_rt_args.push_back(static_cast<uint32_t>(this->num_ag_workers));
+    for (uint32_t sem : this->fused_op_receiver_signal_semaphores) {
+        out_rt_args.push_back(static_cast<uint32_t>(sem));
+    }
 }
 
 }  // namespace ttnn::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
@@ -133,7 +133,6 @@ void StridedAllGatherFusedOpSignaler::push_all_gather_fused_op_rt_args(
     }
 
     // Push the fused op signal semaphore addr at the requested index into the matmul's semaphore vector
-    // (layout: [backward_0..N-1, forward_0..N-1, self]).
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[signal_sem_index]));
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_signaler_mode == FusedOpSignalerMode::SINGLE ? 0 : 1));
 }
@@ -221,7 +220,6 @@ void StridedReduceScatterFusedOpSignaler::push_strided_reduce_scatter_fused_op_r
     std::vector<uint32_t>& out_rt_args) const {
     TT_FATAL(initialized, "StridedReduceScatterFusedOpSignaler not initialized.");
     // Per-core signaling: the reader takes the L1 base of the per-MM-core progress counter array
-    // (set by the RS program factory after allocating the backing buffer).
     out_rt_args.push_back(static_cast<uint32_t>(this->mm_progress_counters_addr));
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -240,15 +240,11 @@ struct MinimalMatmulFusedOpSignaler {
     /* Matmul info for All Gather */
     uint32_t num_fused_op_cores_to_signal = 0;
     std::vector<tt::tt_metal::CoreCoord> fused_op_receiver_cores_noc;
-    // Semaphore layout: [backward_0..backward_{N-1}, forward_0..forward_{N-1}, self], where
-    // N = num_ag_workers. With N==1 (default / reader-signaled path) this is [backward, forward, self],
-    // identical to the legacy 3-semaphore layout. With N>1 (writer-signals-matmul path), each AG worker
-    // in a direction increments its own semaphore so the matmul can wait for all N portions of a k-block.
+    // Semaphore layout: [backward_0..backward_{N-1}, forward_0..forward_{N-1}, self], where N = num_ag_workers
     std::vector<uint32_t> fused_op_receiver_signal_semaphores;
     FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::MULTI;
 
-    // Number of all-gather workers per direction that will independently signal the matmul. Must be set
-    // before init_fused_op(). Defaults to 1 (single aggregated signal per direction, legacy behavior).
+    // Number of all-gather workers per direction that will independently signal the matmul
     uint32_t num_ag_workers = 1;
 
     /* All Gather specs */
@@ -293,9 +289,7 @@ struct StridedReduceScatterFusedOpSignaler {
     uint32_t num_fused_op_cores_to_signal = 0;
     std::vector<tt::tt_metal::CoreCoord> fused_op_receiver_cores_noc;
     uint32_t fused_op_receiver_signal_semaphore = 0;
-    // Per-core signaling: L1 base address (identical on every RS worker core) of the per-MM-core
-    // progress counter array. Each MM core increments its own slot; the RS reader waits per-tile on
-    // the producing core's slot. Set by the RS program factory to the backing buffer's address.
+    // Per-core signaling: L1 base address (identical on every RS worker core) of the per-MM-core progress counter
     uint32_t mm_progress_counters_addr = 0;
 
     bool initialized = false;

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -96,7 +96,7 @@ struct StridedAllGatherFusedOpSignaler {
 
         uint32_t num_workers_to_sync,
         uint32_t curr_worker_index,
-        uint32_t all_gather_direction);
+        uint32_t signal_sem_index);
 };
 
 // Used to propagate semaphore information from matmul to reduce scatter in matmul_reduce_scatter op
@@ -240,8 +240,16 @@ struct MinimalMatmulFusedOpSignaler {
     /* Matmul info for All Gather */
     uint32_t num_fused_op_cores_to_signal = 0;
     std::vector<tt::tt_metal::CoreCoord> fused_op_receiver_cores_noc;
-    std::vector<uint32_t> fused_op_receiver_signal_semaphores;  // [dir0, dir1]
+    // Semaphore layout: [backward_0..backward_{N-1}, forward_0..forward_{N-1}, self], where
+    // N = num_ag_workers. With N==1 (default / reader-signaled path) this is [backward, forward, self],
+    // identical to the legacy 3-semaphore layout. With N>1 (writer-signals-matmul path), each AG worker
+    // in a direction increments its own semaphore so the matmul can wait for all N portions of a k-block.
+    std::vector<uint32_t> fused_op_receiver_signal_semaphores;
     FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::MULTI;
+
+    // Number of all-gather workers per direction that will independently signal the matmul. Must be set
+    // before init_fused_op(). Defaults to 1 (single aggregated signal per direction, legacy behavior).
+    uint32_t num_ag_workers = 1;
 
     /* All Gather specs */
     uint32_t ring_size = 0;
@@ -285,6 +293,10 @@ struct StridedReduceScatterFusedOpSignaler {
     uint32_t num_fused_op_cores_to_signal = 0;
     std::vector<tt::tt_metal::CoreCoord> fused_op_receiver_cores_noc;
     uint32_t fused_op_receiver_signal_semaphore = 0;
+    // Per-core signaling: L1 base address (identical on every RS worker core) of the per-MM-core
+    // progress counter array. Each MM core increments its own slot; the RS reader waits per-tile on
+    // the producing core's slot. Set by the RS program factory to the backing buffer's address.
+    uint32_t mm_progress_counters_addr = 0;
 
     bool initialized = false;
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
@@ -33,6 +33,7 @@ struct OpSignaler {
     Semaphore<> signal_op_sem{0};
     bool mcast_signal_op_cores = true;
     uint32_t curr_worker_is_master = 0;
+    uint32_t curr_worker_index = 0;  // this worker's row-major core id (selects its per-core counter slot)
 
     bool initialized = false;
 
@@ -41,7 +42,8 @@ struct OpSignaler {
     OpSignaler(uint32_t& rt_args_idx) {
         // Runtime args
         this->num_workers_to_sync = get_arg_val<uint32_t>(rt_args_idx++);
-        uint32_t curr_worker_index = get_arg_val<uint32_t>(rt_args_idx++);
+        this->curr_worker_index = get_arg_val<uint32_t>(rt_args_idx++);
+        const uint32_t curr_worker_index = this->curr_worker_index;
         this->worker_sync_sem = Semaphore<>(get_arg_val<uint32_t>(rt_args_idx++));
         this->workers_noc_coords = (uint32_t*)get_arg_addr(
             increment_arg_idx(rt_args_idx, this->num_workers_to_sync * 2));  // Skip over the number of workers
@@ -107,6 +109,28 @@ struct OpSignaler {
 
             // Clear the slave semaphore, so that it can be used again
             this->worker_sync_sem.set(0);
+        }
+    }
+
+    // Per-core fused-op signaling (NO worker barrier). Each worker independently increments its
+    // OWN slot in a per-core counter array on every fused-op (RS) receiver core, then continues.
+    // Unlike synchronize_workers_and_signal_op, no worker waits for any peer, so per-block skew
+    // flows into the consumer's pipeline instead of stalling the whole grid.
+    //
+    //   counter_base_l1 : base L1 address of the per-core counter array on each receiver core
+    //                     (identical on every receiver core in the same program). This worker
+    //                     increments slot curr_worker_index; the consumer computes the same
+    //                     row-major index for the producing core of each tile and waits on it.
+    void signal_op_per_core(uint32_t counter_base_l1) {
+        ASSERT(this->initialized);
+        const uint32_t counter_addr = counter_base_l1 + this->curr_worker_index * sizeof(uint32_t);
+        for (uint32_t i = 0; i < this->num_fused_op_cores_to_signal; i++) {
+            const uint64_t dst_noc_addr = ::get_noc_addr(
+                this->signal_op_cores_noc_coords[i * 2],
+                this->signal_op_cores_noc_coords[i * 2 + 1],
+                counter_addr,
+                this->noc.get_noc_id());
+            noc_semaphore_inc(dst_noc_addr, 1, this->noc.get_noc_id());
         }
     }
 };

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
@@ -112,15 +112,7 @@ struct OpSignaler {
         }
     }
 
-    // Per-core fused-op signaling (NO worker barrier). Each worker independently increments its
-    // OWN slot in a per-core counter array on every fused-op (RS) receiver core, then continues.
-    // Unlike synchronize_workers_and_signal_op, no worker waits for any peer, so per-block skew
-    // flows into the consumer's pipeline instead of stalling the whole grid.
-    //
-    //   counter_base_l1 : base L1 address of the per-core counter array on each receiver core
-    //                     (identical on every receiver core in the same program). This worker
-    //                     increments slot curr_worker_index; the consumer computes the same
-    //                     row-major index for the producing core of each tile and waits on it.
+    // Per-core fused-op signaling (NO worker barrier)
     void signal_op_per_core(uint32_t counter_base_l1) {
         ASSERT(this->initialized);
         const uint32_t counter_addr = counter_base_l1 + this->curr_worker_index * sizeof(uint32_t);

--- a/ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt
@@ -23,6 +23,7 @@ add_subdirectory(cnn)
 # metalium-developers-ops-data-movement
 add_subdirectory(ccl)
 add_subdirectory(ccl/moe_gpt)
+add_subdirectory(ccl/neighbor_pad_halo)
 
 # metalium-developers-mmfusedreduce
 add_subdirectory(matmul)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async.cpp
@@ -39,7 +39,8 @@ std::vector<ttnn::Tensor> all_gather_minimal_matmul_async(
     const std::vector<GlobalSemaphore>& fsdp_multi_device_global_semaphore,
     const std::optional<ttnn::Tensor>& persistent_weight_buffer,
     std::optional<ttnn::ccl::Topology> fsdp_topology,
-    bool fuse_swiglu) {
+    bool fuse_swiglu,
+    const std::vector<uint32_t>& chunk_sizes) {
     return ttnn::prim::all_gather_minimal_matmul_async(
         input_tensor,
         weight_tensor,
@@ -67,7 +68,8 @@ std::vector<ttnn::Tensor> all_gather_minimal_matmul_async(
         fsdp_multi_device_global_semaphore,
         persistent_weight_buffer,
         fsdp_topology,
-        fuse_swiglu);
+        fuse_swiglu,
+        chunk_sizes);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async.hpp
@@ -42,6 +42,7 @@ std::vector<ttnn::Tensor> all_gather_minimal_matmul_async(
     const std::vector<GlobalSemaphore>& fsdp_multi_device_global_semaphore = {},
     const std::optional<ttnn::Tensor>& persistent_weight_buffer = std::nullopt,
     std::optional<ttnn::ccl::Topology> fsdp_topology = std::nullopt,
-    bool fuse_swiglu = false);
+    bool fuse_swiglu = false,
+    const std::vector<uint32_t>& chunk_sizes = {});
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/all_gather_minimal_matmul_async_nanobind.cpp
@@ -139,8 +139,13 @@ void bind_all_gather_minimal_matmul_async(nb::module_& mod) {
             used.
 
         force_transpose : Optional[bool], default: true
-            Minimal matmul has better performance in transpose when M > N.  However, to alleviate noc congestion,
-            we want transpose to always be true.
+            Minimal matmul has better performance in transpose when M > N, so the core grid is normally
+            oriented by that heuristic. Leaving this true forces transpose regardless of shape, which
+            alleviates NOC congestion and satisfies grid-divisibility constraints (e.g. a full 12-wide
+            core grid) at the cost of the wrong orientation for M <= N shapes.
+            Set it to false to let the (M > N) heuristic pick the orientation -- worth measuring on
+            M <= N shapes. Note the non-transposed grid moves the in0 mux cores from the bottom row to
+            the right column, so the caller's matmul core grid must leave that column free instead.
 
         num_workers_per_link : Optional[int], default: 1
             The number of worker cores per link to use for the all gather portion of the operation.  More than 1 typically
@@ -240,7 +245,8 @@ void bind_all_gather_minimal_matmul_async(nb::module_& mod) {
             nb::arg("fsdp_multi_device_global_semaphore") = std::vector<GlobalSemaphore>{},
             nb::arg("persistent_weight_buffer") = nb::none(),
             nb::arg("fsdp_topology") = nb::none(),
-            nb::arg("fuse_swiglu") = false});
+            nb::arg("fuse_swiglu") = false,
+            nb::arg("chunk_sizes") = std::vector<uint32_t>{}});
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation.cpp
@@ -178,11 +178,31 @@ void AllGatherMinimalMatmulAsyncOp::validate_on_program_cache_miss(
     TT_FATAL(chunks >= 1, "minimal_matmul requires chunks >= 1, got chunks={}", chunks);
     TT_FATAL(dim == -1, "minimal_matmul currently only supports dim=-1, got dim={}", dim);
 
-    if (chunks > 1) {
-        // Validate N is divisible by chunks
+    const auto& explicit_chunk_sizes = attributes.chunk_sizes;
+    if (!explicit_chunk_sizes.empty()) {
+        // Variable-width chunks: `chunks` widths (elements) that may differ, summing to N.
+        TT_FATAL(
+            static_cast<int32_t>(explicit_chunk_sizes.size()) == chunks,
+            "chunk_sizes must have exactly chunks={} entries, got {}",
+            chunks,
+            explicit_chunk_sizes.size());
+        uint32_t chunk_sizes_sum = 0;
+        for (size_t i = 0; i < explicit_chunk_sizes.size(); ++i) {
+            const uint32_t width = explicit_chunk_sizes[i];
+            TT_FATAL(width > 0, "chunk_sizes[{}] must be > 0", i);
+            TT_FATAL(
+                width % tt::constants::TILE_WIDTH == 0,
+                "chunk_sizes[{}]={} must be a multiple of TILE_WIDTH={}",
+                i,
+                width,
+                tt::constants::TILE_WIDTH);
+            chunk_sizes_sum += width;
+        }
+        TT_FATAL(chunk_sizes_sum == N, "chunk_sizes must sum to the output width N={}, got {}", N, chunk_sizes_sum);
+    } else if (chunks > 1) {
+        // Uniform split (the default): N must divide evenly and each chunk must be tile-aligned.
         TT_FATAL(N % chunks == 0, "Output width N={} must be divisible by chunks={}", N, chunks);
 
-        // Validate each chunk is tile-aligned
         const uint32_t N_per_chunk = N / chunks;
         TT_FATAL(
             N_per_chunk % tt::constants::TILE_WIDTH == 0,
@@ -364,10 +384,11 @@ AllGatherMinimalMatmulAsyncOp::spec_return_value_t AllGatherMinimalMatmulAsyncOp
             TensorLayout(in1_input_tensor.dtype(), PageConfig(Layout::TILE), in1_input_tensor.memory_config())));
     }
 
-    const uint32_t N_per_chunk = N / chunks;
-    for (int32_t i = 0; i < chunks; ++i) {
+    // Per-chunk widths: explicit when given, else the uniform N/chunks split.
+    const auto chunk_sizes = resolve_chunk_sizes(attributes, N);
+    for (const uint32_t chunk_width : chunk_sizes) {
         ttnn::Shape output_shape(in0_input_tensor_shape);
-        output_shape[-1] = N_per_chunk;
+        output_shape[-1] = chunk_width;
         output_specs.push_back(
             tt::tt_metal::TensorSpec(output_shape, TensorLayout(dtype, PageConfig(Layout::TILE), memory_config)));
     }
@@ -440,7 +461,8 @@ std::vector<ttnn::Tensor> all_gather_minimal_matmul_async(
     const std::vector<GlobalSemaphore>& fsdp_multi_device_global_semaphore,
     const std::optional<ttnn::Tensor>& persistent_weight_buffer,
     std::optional<ttnn::ccl::Topology> fsdp_topology,
-    bool fuse_swiglu) {
+    bool fuse_swiglu,
+    const std::vector<uint32_t>& chunk_sizes) {
     using OperationType = ttnn::experimental::prim::AllGatherMinimalMatmulAsyncOp;
 
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -487,7 +509,8 @@ std::vector<ttnn::Tensor> all_gather_minimal_matmul_async(
         fsdp_multi_device_global_semaphore,
         using_persistent_weight_buffer,
         fsdp_topology_,
-        fuse_swiglu};
+        fuse_swiglu,
+        chunk_sizes};
     auto tensor_args = OperationType::tensor_args_t{
         input_tensor,
         weight_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation.hpp
@@ -69,6 +69,7 @@ std::vector<ttnn::Tensor> all_gather_minimal_matmul_async(
     const std::vector<GlobalSemaphore>& fsdp_multi_device_global_semaphore = {},
     const std::optional<ttnn::Tensor>& persistent_weight_buffer = std::nullopt,
     std::optional<ttnn::ccl::Topology> fsdp_topology = std::nullopt,
-    bool fuse_swiglu = false);
+    bool fuse_swiglu = false,
+    const std::vector<uint32_t>& chunk_sizes = {});
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp
@@ -34,8 +34,7 @@ struct AllGatherMinimalMatmulAsyncParams {
     int32_t chunks = 1;  // Number of output tensors to split into (default 1 for backward compat)
     int32_t dim = -1;    // Dimension to split along (default -1)
 
-    // Per-chunk output widths along `dim`, in ELEMENTS; empty => uniform N/chunks. When set, must
-    // have `chunks` entries summing to N, each a multiple of TILE_WIDTH. Part of the cache key.
+    // Per-chunk output widths along `dim`, in ELEMENTS
     std::vector<uint32_t> chunk_sizes;
 
     // FSDP fusion: when set, the weight tensor is sharded along its K dim across

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp
@@ -34,6 +34,10 @@ struct AllGatherMinimalMatmulAsyncParams {
     int32_t chunks = 1;  // Number of output tensors to split into (default 1 for backward compat)
     int32_t dim = -1;    // Dimension to split along (default -1)
 
+    // Per-chunk output widths along `dim`, in ELEMENTS; empty => uniform N/chunks. When set, must
+    // have `chunks` entries summing to N, each a multiple of TILE_WIDTH. Part of the cache key.
+    std::vector<uint32_t> chunk_sizes;
+
     // FSDP fusion: when set, the weight tensor is sharded along its K dim across
     // `fsdp_cluster_axis` with size `fsdp_ring_size`, and the op all-gathers it
     // into `persistent_weight_buffer` before/concurrently-with the matmul.
@@ -72,7 +76,8 @@ struct AllGatherMinimalMatmulAsyncParams {
         std::vector<GlobalSemaphore> fsdp_semaphore,
         bool using_persistent_weight_buffer,
         ttnn::ccl::Topology fsdp_topology,
-        bool fuse_swiglu = false) :
+        bool fuse_swiglu = false,
+        std::vector<uint32_t> chunk_sizes = {}) :
         config(config),
         fused_activation(fused_activation),
         output_mem_config(output_mem_config),
@@ -91,6 +96,7 @@ struct AllGatherMinimalMatmulAsyncParams {
         fused_ternary_scalar(fused_ternary_scalar),
         chunks(chunks),
         dim(dim),
+        chunk_sizes(std::move(chunk_sizes)),
         fsdp_cluster_axis(fsdp_cluster_axis),
         fsdp_ring_size(fsdp_ring_size),
         fsdp_semaphore(std::move(fsdp_semaphore)),
@@ -111,6 +117,7 @@ struct AllGatherMinimalMatmulAsyncParams {
         "config",
         "chunks",
         "dim",
+        "chunk_sizes",
         "fsdp_cluster_axis",
         "fsdp_ring_size",
         "using_persistent_weight_buffer",
@@ -129,12 +136,22 @@ struct AllGatherMinimalMatmulAsyncParams {
             this->config,
             this->chunks,
             this->dim,
+            this->chunk_sizes,
             this->fsdp_cluster_axis,
             this->fsdp_ring_size,
             this->using_persistent_weight_buffer,
             this->fuse_swiglu);
     }
 };
+
+// Per-chunk widths (elements): explicit `chunk_sizes`, else the uniform N/chunks split.
+inline std::vector<uint32_t> resolve_chunk_sizes(const AllGatherMinimalMatmulAsyncParams& params, uint32_t N) {
+    if (!params.chunk_sizes.empty()) {
+        return params.chunk_sizes;
+    }
+    const auto chunks = static_cast<uint32_t>(params.chunks);
+    return std::vector<uint32_t>(chunks, N / chunks);
+}
 
 struct AllGatherMinimalMatmulAsyncInputs {
     Tensor input_tensor;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
@@ -194,6 +194,7 @@ all_gather_minimal_matmul_async_factory_helper(
     const uint32_t num_workers_per_link,
     const uint32_t num_buffers_per_channel,
     uint32_t N_chunks,
+    const std::vector<uint32_t>& chunk_sizes,
     std::optional<float> fused_ternary_scalar,
     const std::optional<const ttnn::Tensor>& fused_ternary_input_a,
     const std::optional<const ttnn::Tensor>& fused_ternary_input_b,
@@ -499,9 +500,6 @@ all_gather_minimal_matmul_async_factory_helper(
             num_workers_per_link);
     }
     uint32_t num_mux_cores = num_links * 2;  // 2 being the number of directions
-    TT_FATAL(
-        (transpose_core_grid ? full_grid_size.y : full_grid_size.x) >= num_mux_cores,
-        "The are not enough cores for the number of mux cores requested");
 
     // In-column fsdp mux row for a given (group, dir): dir SWAPPED (flip) AND the result shifted up by
     // one cyclically within the 2*num_links packed rows. The flip swaps which direction owns the
@@ -534,15 +532,42 @@ all_gather_minimal_matmul_async_factory_helper(
         "Scheme-4 single-row mux interleave assumes num_workers_per_link==2 (got {})",
         num_workers_per_link);
     const uint32_t single_mux_row = full_grid_size.y - 1;
+
+    // A mux must sit at the far end of the in0 forwarding chains it serves, adjacent to that chain's
+    // two fabric-sender cores, and its index must run along the axis perpendicular to the chain:
+    //
+    //   transposed     -> in0 chains are vertical COLUMNS spanning y (initial_endpoint = top_core),
+    //                     so the far end is the bottom row and the link index runs along x.
+    //   non-transposed -> in0 chains are horizontal ROWS spanning x (initial_endpoint = left_core),
+    //                     so the far end is the right column and the link index runs along y.
+    //
+    // Keeping every mux on the bottom row in the non-transposed case would leave all but one row's
+    // senders up to full_grid_size.y - 1 hops from their mux and funnel all of those fabric writes
+    // onto a single row. The single-row interleave scheme below is x-indexed in both orientations
+    // by construction (it packs all muxes onto one row on purpose).
+    //
+    // Mirrors fsdp_mux_in_column above: the column layout is only available when the matmul grid
+    // leaves the last column free. On a full-width grid that column holds workers, so fall back to
+    // the bottom-row layout -- still correct, just farther from the senders.
+    const bool in0_mux_in_column = !single_row_muxes && !transpose_core_grid && (grid_size.x < full_grid_size.x);
+    const bool mux_index_on_x = !in0_mux_in_column;
+    TT_FATAL(
+        (mux_index_on_x ? full_grid_size.x : full_grid_size.y) >= num_mux_cores,
+        "There are not enough cores along the mux axis ({}) for the number of mux cores requested ({})",
+        mux_index_on_x ? full_grid_size.x : full_grid_size.y,
+        num_mux_cores);
+
     const auto in0_mux_logical = [&](uint32_t link, uint32_t dir) -> tt::tt_metal::CoreCoord {
         if (single_row_muxes) {
             return tt::tt_metal::CoreCoord(num_workers_per_link * link + 1, single_mux_row);  // odd col 2g+1 (NOC_0 +x-aligned)
         }
-        uint32_t x = (num_workers_per_link * (link + 1)) - (1 - dir);
-        if (x >= full_grid_size.x) {
-            x -= full_grid_size.x;
+        uint32_t idx = (num_workers_per_link * (link + 1)) - (1 - dir);
+        const uint32_t wrap = in0_mux_in_column ? full_grid_size.y : full_grid_size.x;
+        if (idx >= wrap) {
+            idx -= wrap;
         }
-        return tt::tt_metal::CoreCoord(x, full_grid_size.y - 1);
+        return in0_mux_in_column ? tt::tt_metal::CoreCoord(full_grid_size.x - 1, idx)
+                                 : tt::tt_metal::CoreCoord(idx, full_grid_size.y - 1);
     };
     const auto fsdp_mux_logical = [&](uint32_t link, uint32_t dir) -> tt::tt_metal::CoreCoord {
         if (single_row_muxes) {
@@ -662,6 +687,30 @@ all_gather_minimal_matmul_async_factory_helper(
             defines["TERNARY_B_IS_FLOAT32"] = "1";
         }
     }
+    // Per-chunk tile widths + prefix-sum offsets, as defines (not CTAs, which would shift the
+    // kernels' fixed TensorAccessor arg offsets). Always emitted; uniform chunks are the equal case.
+    {
+        std::vector<uint32_t> chunk_tile_widths;
+        chunk_tile_widths.reserve(N_chunks);
+        if (chunk_sizes.empty()) {
+            chunk_tile_widths.assign(N_chunks, N_tiles / N_chunks);
+        } else {
+            for (const uint32_t width_elements : chunk_sizes) {
+                chunk_tile_widths.push_back(width_elements / tt::constants::TILE_WIDTH);
+            }
+        }
+        std::string widths_csv;
+        std::string offsets_csv = "0";
+        uint32_t running_offset = 0;
+        for (size_t i = 0; i < chunk_tile_widths.size(); ++i) {
+            widths_csv += (i == 0 ? "" : ",") + std::to_string(chunk_tile_widths[i]);
+            running_offset += chunk_tile_widths[i];
+            offsets_csv += "," + std::to_string(running_offset);
+        }
+        defines["CHUNK_TILE_WIDTHS"] = widths_csv;
+        defines["CHUNK_TILE_OFFSETS"] = offsets_csv;
+    }
+
     in0_defines = defines;
     in0_defines["READ_FROM_LOCAL_INPUT"] = "1";
     in0_defines["IS_IN0"] = "1";
@@ -1222,6 +1271,20 @@ all_gather_minimal_matmul_async_factory_helper(
         auto in1_prev_core = clamped_prev(in1_core_order, in1_core_order_index);
         auto in1_next_core = clamped_next(in1_core_order, in1_core_order_index);
 
+        // Fabric senders sit beside the mux at the in0 chain's far (high-coordinate) end. The chain
+        // direction follows in0_noc: increasing on NOC_0 (transposed), decreasing on NOC_1
+        // (non-transposed). With an increasing chain the far end is the tail, so the senders are at
+        // size-1 / size-2. With a decreasing chain build_core_order_for_axis emits
+        // [endpoint, L-1, L-2, ...], so the far end is reached immediately and the senders are at
+        // indices 1 / 2. Derive both from the same predicate that sets the direction so host
+        // dispatch, mux wiring and the kernel's own role test all agree on the same two cores.
+        const bool in0_increasing = (in0_noc == tt::tt_metal::NOC::NOC_0);
+        const uint32_t in0_fwd_idx = in0_increasing ? static_cast<uint32_t>(in0_core_order.size() - 1) : 1u;
+        const uint32_t in0_bwd_idx = in0_increasing ? static_cast<uint32_t>(in0_core_order.size() - 2) : 2u;
+        const bool in0_is_fabric_core = (in0_core_order_index == in0_fwd_idx) || (in0_core_order_index == in0_bwd_idx);
+        const auto in0_fwd_core = in0_core_order.at(in0_fwd_idx);
+        const auto in0_bwd_core = in0_core_order.at(in0_bwd_idx);
+
         auto in0_prev_core_physical = device->worker_core_from_logical_core(in0_prev_core);
         auto in0_next_core_physical = device->worker_core_from_logical_core(in0_next_core);
         auto in1_prev_core_physical = device->worker_core_from_logical_core(in1_prev_core);
@@ -1267,10 +1330,11 @@ all_gather_minimal_matmul_async_factory_helper(
             in0_injector_virtual_core.x,
             in0_injector_virtual_core.y,
             in0_core_order_index,
-            in0_core_order.size()};
-        if (in0_core_order_index > (in0_core_order.size() - 3)) {
+            in0_core_order.size(),
+            in0_fwd_idx,
+            in0_bwd_idx};
+        if (in0_is_fabric_core) {
             uint32_t worker_idx = in0_idx % num_workers_per_link;
-            auto last_in0_core = in0_core_order.back();
 
             // Actual client count on this core's mux: the senders share a mux per group of
             // num_workers_per_link along the in0 sender axis. The last group is short when the
@@ -1283,13 +1347,16 @@ all_gather_minimal_matmul_async_factory_helper(
             // direction it actually sends in. (Previously both directions were registered, with
             // the unused one returning nullptr from build_and_connect — wasting 5 semaphores per
             // core for nothing.)
-            // Core at size-2 → backward fabric sender → backward mux only.
-            // Core at size-1 → forward  fabric sender → forward  mux only.
-            const bool is_in0_backward_sender = (in0_core_order_index == (in0_core_order.size() - 2));
+            // Core at in0_bwd_idx → backward fabric sender → backward mux only.
+            // Core at in0_fwd_idx → forward  fabric sender → forward  mux only.
+            // The termination master is worker 0 of this core's link group, on the same chain-axis
+            // coordinate as the sender itself -- derive it from the actual sender core rather than
+            // from the chain tail, which is only the far end when the chain runs increasing.
+            const bool is_in0_backward_sender = (in0_core_order_index == in0_bwd_idx);
             if (is_in0_backward_sender) {
                 auto termination_master_logical_core_backward =
-                    transpose_core_grid ? tt::tt_metal::CoreCoord(in0_idx - worker_idx, last_in0_core.y - 1)
-                                        : tt::tt_metal::CoreCoord(last_in0_core.x - 1, in0_idx - worker_idx);
+                    transpose_core_grid ? tt::tt_metal::CoreCoord(in0_idx - worker_idx, in0_bwd_core.y)
+                                        : tt::tt_metal::CoreCoord(in0_bwd_core.x, in0_idx - worker_idx);
                 tt::tt_metal::CoreCoord termination_master_virtual_core_backward =
                     device->worker_core_from_logical_core(termination_master_logical_core_backward);
 
@@ -1309,10 +1376,10 @@ all_gather_minimal_matmul_async_factory_helper(
                     in0_term_sync_id,
                     in0_args);
             } else {
-                // Forward fabric sender (in0_core_order_index == size - 1).
-                auto termination_master_logical_core_forward = transpose_core_grid
-                                                                   ? tt::tt_metal::CoreCoord(in0_idx - worker_idx, last_in0_core.y)
-                                                                   : tt::tt_metal::CoreCoord(last_in0_core.x, in0_idx - worker_idx);
+                // Forward fabric sender (in0_core_order_index == in0_fwd_idx).
+                auto termination_master_logical_core_forward =
+                    transpose_core_grid ? tt::tt_metal::CoreCoord(in0_idx - worker_idx, in0_fwd_core.y)
+                                        : tt::tt_metal::CoreCoord(in0_fwd_core.x, in0_idx - worker_idx);
                 tt::tt_metal::CoreCoord termination_master_virtual_core_forward =
                     device->worker_core_from_logical_core(termination_master_logical_core_forward);
 
@@ -1336,7 +1403,7 @@ all_gather_minimal_matmul_async_factory_helper(
         if (in0_core_order_index == 0) {
             // in0 sender
             SetRuntimeArgs(program, in0_sender_kernels_id, core, in0_args);
-        } else if (in0_core_order_index > (in0_core_order.size() - 3)) {
+        } else if (in0_is_fabric_core) {
             // in0 receiver fabric
             SetRuntimeArgs(program, in0_receiver_fabric_kernels_id, core, in0_args);
         } else {
@@ -1671,6 +1738,7 @@ all_gather_minimal_matmul_async_factory(
     const uint32_t num_workers_per_link,
     const uint32_t num_buffers_per_channel,
     uint32_t N_chunks,
+    const std::vector<uint32_t>& chunk_sizes,
     std::optional<float> fused_ternary_scalar,
     const std::optional<const Tensor>& fused_ternary_input_a,
     const std::optional<const Tensor>& fused_ternary_input_b,
@@ -1710,6 +1778,7 @@ all_gather_minimal_matmul_async_factory(
             num_workers_per_link,
             num_buffers_per_channel,
             N_chunks,
+            chunk_sizes,
             fused_ternary_scalar,
             fused_ternary_input_a,
             fused_ternary_input_b,
@@ -1787,6 +1856,7 @@ AllGatherMinimalMatmulAsyncProgramFactory::create_at(
         attributes.num_workers_per_link,
         attributes.num_buffers_per_channel,
         attributes.chunks,
+        attributes.chunk_sizes,
         attributes.fused_ternary_scalar,
         tensor_args.fused_ternary_input_a,
         tensor_args.fused_ternary_input_b,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
@@ -533,22 +533,7 @@ all_gather_minimal_matmul_async_factory_helper(
         num_workers_per_link);
     const uint32_t single_mux_row = full_grid_size.y - 1;
 
-    // A mux must sit at the far end of the in0 forwarding chains it serves, adjacent to that chain's
-    // two fabric-sender cores, and its index must run along the axis perpendicular to the chain:
-    //
-    //   transposed     -> in0 chains are vertical COLUMNS spanning y (initial_endpoint = top_core),
-    //                     so the far end is the bottom row and the link index runs along x.
-    //   non-transposed -> in0 chains are horizontal ROWS spanning x (initial_endpoint = left_core),
-    //                     so the far end is the right column and the link index runs along y.
-    //
-    // Keeping every mux on the bottom row in the non-transposed case would leave all but one row's
-    // senders up to full_grid_size.y - 1 hops from their mux and funnel all of those fabric writes
-    // onto a single row. The single-row interleave scheme below is x-indexed in both orientations
-    // by construction (it packs all muxes onto one row on purpose).
-    //
-    // Mirrors fsdp_mux_in_column above: the column layout is only available when the matmul grid
-    // leaves the last column free. On a full-width grid that column holds workers, so fall back to
-    // the bottom-row layout -- still correct, just farther from the senders.
+    // A mux must sit at the far end of the in0 forwarding chains it serves
     const bool in0_mux_in_column = !single_row_muxes && !transpose_core_grid && (grid_size.x < full_grid_size.x);
     const bool mux_index_on_x = !in0_mux_in_column;
     TT_FATAL(
@@ -687,8 +672,7 @@ all_gather_minimal_matmul_async_factory_helper(
             defines["TERNARY_B_IS_FLOAT32"] = "1";
         }
     }
-    // Per-chunk tile widths + prefix-sum offsets, as defines (not CTAs, which would shift the
-    // kernels' fixed TensorAccessor arg offsets). Always emitted; uniform chunks are the equal case.
+    // Per-chunk tile widths + prefix-sum offsets, as defines
     {
         std::vector<uint32_t> chunk_tile_widths;
         chunk_tile_widths.reserve(N_chunks);
@@ -1271,13 +1255,7 @@ all_gather_minimal_matmul_async_factory_helper(
         auto in1_prev_core = clamped_prev(in1_core_order, in1_core_order_index);
         auto in1_next_core = clamped_next(in1_core_order, in1_core_order_index);
 
-        // Fabric senders sit beside the mux at the in0 chain's far (high-coordinate) end. The chain
-        // direction follows in0_noc: increasing on NOC_0 (transposed), decreasing on NOC_1
-        // (non-transposed). With an increasing chain the far end is the tail, so the senders are at
-        // size-1 / size-2. With a decreasing chain build_core_order_for_axis emits
-        // [endpoint, L-1, L-2, ...], so the far end is reached immediately and the senders are at
-        // indices 1 / 2. Derive both from the same predicate that sets the direction so host
-        // dispatch, mux wiring and the kernel's own role test all agree on the same two cores.
+        // Fabric senders sit beside the mux at the in0 chain's far (high-coordinate) end
         const bool in0_increasing = (in0_noc == tt::tt_metal::NOC::NOC_0);
         const uint32_t in0_fwd_idx = in0_increasing ? static_cast<uint32_t>(in0_core_order.size() - 1) : 1u;
         const uint32_t in0_bwd_idx = in0_increasing ? static_cast<uint32_t>(in0_core_order.size() - 2) : 2u;
@@ -1347,11 +1325,7 @@ all_gather_minimal_matmul_async_factory_helper(
             // direction it actually sends in. (Previously both directions were registered, with
             // the unused one returning nullptr from build_and_connect — wasting 5 semaphores per
             // core for nothing.)
-            // Core at in0_bwd_idx → backward fabric sender → backward mux only.
-            // Core at in0_fwd_idx → forward  fabric sender → forward  mux only.
-            // The termination master is worker 0 of this core's link group, on the same chain-axis
-            // coordinate as the sender itself -- derive it from the actual sender core rather than
-            // from the chain tail, which is only the far end when the chain runs increasing.
+            // Core at in0_bwd_idx → backward fabric sender → backward mux
             const bool is_in0_backward_sender = (in0_core_order_index == in0_bwd_idx);
             if (is_in0_backward_sender) {
                 auto termination_master_logical_core_backward =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
@@ -47,6 +47,9 @@ constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(22)
 constexpr bool is_linear = (topology == Topology::Linear);
 constexpr uint32_t N_chunks = get_compile_time_arg_val(23);
 constexpr uint32_t N_tiles_per_chunk = get_compile_time_arg_val(24);
+// Per-chunk tile widths + prefix-sum offsets (from CHUNK_TILE_WIDTHS/CHUNK_TILE_OFFSETS defines).
+constexpr uint32_t chunk_tile_widths[N_chunks] = {CHUNK_TILE_WIDTHS};
+constexpr uint32_t chunk_tile_offsets[N_chunks + 1] = {CHUNK_TILE_OFFSETS};
 constexpr uint32_t K_tiles_per_device = get_compile_time_arg_val(25);
 constexpr uint32_t K_block_tail_tiles = get_compile_time_arg_val(26);
 
@@ -141,7 +144,13 @@ void kernel_main() {
     const uint8_t out_ready_sem_injector_noc0_x = get_arg_val<uint32_t>(argidx++);
     const uint8_t out_ready_sem_injector_noc0_y = get_arg_val<uint32_t>(argidx++);
     const uint32_t in0_core_order_index = get_arg_val<uint32_t>(argidx++);
-    const uint32_t in0_core_order_size = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const uint32_t in0_core_order_size = get_arg_val<uint32_t>(argidx++);
+    // Fabric-sender chain indices, supplied by the host (order: forward then backward). Read
+    // unconditionally so argidx stays aligned across every kernel variant. The in0 chain runs
+    // decreasing on NOC_1 (non-transposed core grid), so these are NOT necessarily the chain tail --
+    // never re-derive them from in0_core_order_size.
+    const uint32_t forward_in0_core_order_index = get_arg_val<uint32_t>(argidx++);
+    const uint32_t backward_in0_core_order_index = get_arg_val<uint32_t>(argidx++);
 
     // Tensor accessor for input tensor
     constexpr auto in0_args = TensorAccessorArgs<ct_arg_count>();
@@ -154,9 +163,6 @@ void kernel_main() {
         make_tensor_accessor_tuple_uniform_page_size_common(outputs_args, out_addr_common_arg_start, out_tile_size);
 
 #ifdef USE_MUX
-    uint32_t backward_in0_core_order_index = in0_core_order_size - 2;
-    uint32_t forward_in0_core_order_index = in0_core_order_size - 1;
-
     // Each fabric-sender core only parses + connects the SINGLE direction it actually uses.
     // The program factory pushes RT args for exactly one direction per core, so argidx alignment
     // stays correct. The unused-direction mux/handle is default-initialized (connection_valid=false)
@@ -350,10 +356,12 @@ void kernel_main() {
                                 defer_write_n_tile,
                                 defer_write_n_tile_end);
                         } else {
-                            write_block_sync_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                            write_block_sync_split<M_block_tiles, N_block_tiles, N_chunks>(
                                 noc_obj,
                                 outputs_tuple,
                                 out0_shape,
+                                chunk_tile_widths,
+                                chunk_tile_offsets,
                                 out_read_ptr,
                                 out_tile_size,
                                 defer_write_m_tile,
@@ -492,8 +500,7 @@ void kernel_main() {
                         if constexpr (num_targets_backward_direction == 0) {
                             // Dev 0 (chain head): long send via mux_backward + pkt_hdrs_forward
                             if constexpr (num_targets_forward_direction > 0) {
-                                if (in0_core_order_index >= backward_in0_core_order_index &&
-                                    in0_core_order_index < forward_in0_core_order_index &&
+                                if (in0_core_order_index == backward_in0_core_order_index &&
                                     k_block_iter < (K_num_blocks - K_blocks_per_device)) {
                                     forward_half_block_to_fabric_neighbor(
                                         noc_obj,
@@ -517,7 +524,7 @@ void kernel_main() {
                             }
                         } else {
                             // Dev k > 0: short send via mux_forward + pkt_hdrs_backward
-                            if (in0_core_order_index >= forward_in0_core_order_index &&
+                            if (in0_core_order_index == forward_in0_core_order_index &&
                                 k_block_iter < (K_num_blocks - K_blocks_per_device)) {
                                 forward_half_block_to_fabric_neighbor(
                                     noc_obj,
@@ -545,7 +552,7 @@ void kernel_main() {
                         // all devices via wrap-around relay.
                         if (k_block_iter < (K_num_blocks - (K_num_blocks / num_devices))) {
                             if constexpr (num_targets_backward_direction > 0) {
-                                if (in0_core_order_index >= forward_in0_core_order_index) {
+                                if (in0_core_order_index == forward_in0_core_order_index) {
                                     forward_half_block_to_fabric_neighbor(
                                         noc_obj,
                                         m_tile,
@@ -567,8 +574,7 @@ void kernel_main() {
                                 }
                             }
                             if constexpr (num_targets_forward_direction > 0) {
-                                if (in0_core_order_index >= backward_in0_core_order_index &&
-                                    in0_core_order_index < forward_in0_core_order_index) {
+                                if (in0_core_order_index == backward_in0_core_order_index) {
                                     forward_half_block_to_fabric_neighbor(
                                         noc_obj,
                                         m_tile,
@@ -682,10 +688,12 @@ void kernel_main() {
                             n_tile,
                             n_tile_end);
                     } else {
-                        write_block_sync_granular_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                        write_block_sync_granular_split<M_block_tiles, N_block_tiles, N_chunks>(
                             noc_obj,
                             outputs_tuple,
                             out0_shape,
+                            chunk_tile_widths,
+                            chunk_tile_offsets,
                             cb_out,
                             out_tile_size,
                             m_tile,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
@@ -145,10 +145,7 @@ void kernel_main() {
     const uint8_t out_ready_sem_injector_noc0_y = get_arg_val<uint32_t>(argidx++);
     const uint32_t in0_core_order_index = get_arg_val<uint32_t>(argidx++);
     [[maybe_unused]] const uint32_t in0_core_order_size = get_arg_val<uint32_t>(argidx++);
-    // Fabric-sender chain indices, supplied by the host (order: forward then backward). Read
-    // unconditionally so argidx stays aligned across every kernel variant. The in0 chain runs
-    // decreasing on NOC_1 (non-transposed core grid), so these are NOT necessarily the chain tail --
-    // never re-derive them from in0_core_order_size.
+    // Fabric-sender chain indices, supplied by the host (order: forward then backward)
     const uint32_t forward_in0_core_order_index = get_arg_val<uint32_t>(argidx++);
     const uint32_t backward_in0_core_order_index = get_arg_val<uint32_t>(argidx++);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
@@ -40,6 +40,9 @@ void kernel_main() {
     constexpr uint32_t my_rank = get_compile_time_arg_val(17);
     constexpr uint32_t N_chunks = get_compile_time_arg_val(18);
     constexpr uint32_t N_tiles_per_chunk = get_compile_time_arg_val(19);
+    // Per-chunk tile widths + prefix-sum offsets (from CHUNK_TILE_WIDTHS/CHUNK_TILE_OFFSETS defines).
+    constexpr uint32_t chunk_tile_widths[N_chunks] = {CHUNK_TILE_WIDTHS};
+    constexpr uint32_t chunk_tile_offsets[N_chunks + 1] = {CHUNK_TILE_OFFSETS};
     constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(20));
     constexpr bool is_linear = (topology == Topology::Linear);
     constexpr uint32_t K_tiles_per_device = get_compile_time_arg_val(21);
@@ -344,10 +347,12 @@ void kernel_main() {
                                 defer_write_n_tile,
                                 defer_write_n_tile_end);
                         } else {
-                            write_block_sync_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                            write_block_sync_split<M_block_tiles, N_block_tiles, N_chunks>(
                                 noc_obj,
                                 outputs_tuple,
                                 out0_shape,
+                                chunk_tile_widths,
+                                chunk_tile_offsets,
                                 out_read_ptr,
                                 out_tile_size,
                                 defer_write_m_tile,
@@ -687,10 +692,12 @@ void kernel_main() {
                             n_tile,
                             n_tile_end);
                     } else {
-                        write_block_sync_granular_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                        write_block_sync_granular_split<M_block_tiles, N_block_tiles, N_chunks>(
                             noc_obj,
                             outputs_tuple,
                             out0_shape,
+                            chunk_tile_widths,
+                            chunk_tile_offsets,
                             cb_out,
                             out_tile_size,
                             m_tile,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/matmul_dataflow_common.hpp
@@ -769,16 +769,13 @@ FORCE_INLINE void write_tile_to_chunk(
  *
  * Note: Unlike write_block_sync, this function takes a tuple of accessors, rather than a single accessor.
  */
-template <
-    uint32_t M_block_tiles,
-    uint32_t N_block_tiles,
-    uint32_t N_chunks,
-    uint32_t N_tiles_per_chunk,
-    typename... Accessors>
+template <uint32_t M_block_tiles, uint32_t N_block_tiles, uint32_t N_chunks, typename... Accessors>
 void write_block_sync_split(
     Noc noc,
     const std::tuple<Accessors...>& accessors,
     const TensorShape2D& chunk_shape,
+    const uint32_t (&chunk_tile_widths)[N_chunks],
+    const uint32_t (&chunk_tile_offsets)[N_chunks + 1],
     uint32_t read_ptr,
     uint32_t tile_size_bytes,
     uint32_t d0_start,
@@ -788,11 +785,14 @@ void write_block_sync_split(
     ASSERT(d0_end > d0_start);
     ASSERT(d1_end > d1_start);
 
-    const uint32_t chunk_idx_start = d1_start / N_tiles_per_chunk;
-    const uint32_t tile_idx_in_chunk_start = d1_start % N_tiles_per_chunk;
+    // Scan the prefix-sum table for the chunk holding d1_start (widths may differ; N_chunks is 2-8).
+    uint32_t chunk_idx_start = 0;
+    while (chunk_idx_start + 1 < N_chunks && d1_start >= chunk_tile_offsets[chunk_idx_start + 1]) {
+        chunk_idx_start++;
+    }
+    const uint32_t tile_idx_in_chunk_start = d1_start - chunk_tile_offsets[chunk_idx_start];
 
     for (uint32_t i = d0_start; i < d0_end; i++) {
-        // Assumes that all chunks have same number of tiles on the M-axis
         if (i >= chunk_shape.logical_d0) {
             break;
         }
@@ -802,7 +802,7 @@ void write_block_sync_split(
 
         for (uint32_t j = d1_start; j < d1_end; j++, tile_idx_in_chunk++) {
             // If we've reached the end of the current chunk, move to the next one
-            if (tile_idx_in_chunk >= chunk_shape.logical_d1) {
+            if (chunk_idx < N_chunks && tile_idx_in_chunk >= chunk_tile_widths[chunk_idx]) {
                 tile_idx_in_chunk = 0;
                 chunk_idx++;  // Move to next chunk; if chunk is past last one then next branch will skip padding
             }
@@ -813,7 +813,8 @@ void write_block_sync_split(
                 continue;
             }
 
-            uint32_t tile_id_in_chunk = i * chunk_shape.logical_d1 + tile_idx_in_chunk;
+            // Row stride is this chunk's own width (a shared width would scatter later chunks).
+            uint32_t tile_id_in_chunk = i * chunk_tile_widths[chunk_idx] + tile_idx_in_chunk;
 
             // Compile-time dispatch preserving concrete types
             write_tile_to_chunk(
@@ -836,24 +837,25 @@ void write_block_sync_split(
  * Variadic write method for split operation with N output tensors.
  * Takes the tuple directly, preserving concrete TensorAccessor<DSpec> types for noc.async_write.
  */
-template <
-    uint32_t M_block_tiles,
-    uint32_t N_block_tiles,
-    uint32_t N_chunks,
-    uint32_t N_tiles_per_chunk,
-    typename... Accessors>
+template <uint32_t M_block_tiles, uint32_t N_block_tiles, uint32_t N_chunks, typename... Accessors>
 void write_block_sync_granular_split(
     Noc noc,
     const std::tuple<Accessors...>& accessors,
     const TensorShape2D& chunk_shape,
+    const uint32_t (&chunk_tile_widths)[N_chunks],
+    const uint32_t (&chunk_tile_offsets)[N_chunks + 1],
     CircularBuffer cb_out,
     uint32_t tile_size_bytes,
     uint32_t d0_start,
     uint32_t d0_end,
     uint32_t d1_start,
     uint32_t d1_end) {
-    const uint32_t chunk_idx_start = d1_start / N_tiles_per_chunk;
-    const uint32_t tile_idx_in_chunk_start = d1_start % N_tiles_per_chunk;
+    // Scan the prefix-sum table for the chunk containing d1_start (widths may differ per chunk).
+    uint32_t chunk_idx_start = 0;
+    while (chunk_idx_start + 1 < N_chunks && d1_start >= chunk_tile_offsets[chunk_idx_start + 1]) {
+        chunk_idx_start++;
+    }
+    const uint32_t tile_idx_in_chunk_start = d1_start - chunk_tile_offsets[chunk_idx_start];
 
     for (uint32_t m_id = 0; m_id < M_block_tiles; m_id++) {
         cb_out.wait_front(N_block_tiles);
@@ -866,7 +868,7 @@ void write_block_sync_granular_split(
 
             for (uint32_t n_tile_id = d1_start; n_tile_id < d1_end; n_tile_id++, tile_idx_in_chunk++) {
                 // If we've reached the end of the current chunk, move to the next one
-                if (tile_idx_in_chunk >= chunk_shape.logical_d1) {
+                if (chunk_idx < N_chunks && tile_idx_in_chunk >= chunk_tile_widths[chunk_idx]) {
                     tile_idx_in_chunk = 0;
                     chunk_idx++;  // Move to next chunk; if chunk is past last one then next branch will skip padding
                 }
@@ -875,7 +877,7 @@ void write_block_sync_granular_split(
                     break;
                 }
 
-                uint32_t tile_id = m_tile * chunk_shape.logical_d1 + tile_idx_in_chunk;
+                uint32_t tile_id = m_tile * chunk_tile_widths[chunk_idx] + tile_idx_in_chunk;
                 // Compile-time dispatch preserving concrete types
                 write_tile_to_chunk(
                     noc,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ccl_experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ccl_experimental_nanobind.cpp
@@ -29,6 +29,7 @@
 #include "ttnn/operations/experimental/ccl/send_recv_async/recv_async_h2d/recv_async_h2d_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/send_recv_async/send_async_d2h/send_async_d2h_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/neighbor_pad_async/neighbor_pad_async_nanobind.hpp"
+#include "ttnn/operations/experimental/ccl/neighbor_pad_halo/neighbor_pad_halo_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/slice_reshard_async/slice_reshard_async_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/strided_all_gather_async/strided_all_gather_async_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/strided_reduce_scatter_async/strided_reduce_scatter_async_nanobind.hpp"
@@ -65,6 +66,8 @@ void py_module(nb::module_& mod) {
     ccl::bind_recv_async_h2d(mod);
     ccl::bind_send_async_d2h(mod);
     ccl::bind_neighbor_pad_async(mod);
+    ccl::bind_neighbor_pad_halo(mod);
+    ccl::bind_halo_scatter(mod);
     ccl::bind_slice_reshard_async(mod);
     ccl::bind_deepseek_moe_reduce_scatter(mod);
     ccl::bind_all_to_all_dispatch_metadata(mod);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_device_operation_types.hpp
@@ -89,6 +89,13 @@ struct MinimalMatmulStridedReduceScatterAsyncInputs {
     /* Fused addcmul inputs: output = addcmul_a + scalar * mm_output * addcmul_b */
     const std::optional<const Tensor> addcmul_input_tensor1 = std::nullopt;  // residual/base
     const std::optional<const Tensor> addcmul_input_tensor2 = std::nullopt;  // gate/multiplier
+
+    /* Caller-owned scratch for the per-MM-core progress counters the MM uses to signal the RS
+       (one uint32 slot per MM core, one row per core, height-sharded in L1 so the row sits at the
+       same local address everywhere). Supplying it lets one device-lifetime allocation serve every
+       MMRS program; when omitted the RS factory allocates a private array per program, which
+       permanently lowers the device's L1 floor and starves later ops of circular-buffer space. */
+    const std::optional<const Tensor> mm_progress_counters = std::nullopt;
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.cpp
@@ -251,7 +251,8 @@ std::vector<Tensor> minimal_matmul_strided_reduce_scatter_async(
     const std::optional<float> fused_ternary_scalar,
     const std::optional<const Tensor>& addcmul_input_tensor1,
     const std::optional<const Tensor>& addcmul_input_tensor2,
-    std::optional<tt::tt_metal::DataType> dtype) {
+    std::optional<tt::tt_metal::DataType> dtype,
+    const std::optional<const Tensor>& mm_progress_counters) {
     using OperationType = ttnn::experimental::prim::MinimalMatmulStridedReduceScatterAsync;
 
     uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
@@ -296,7 +297,8 @@ std::vector<Tensor> minimal_matmul_strided_reduce_scatter_async(
         optional_rs_output_tensor,
         bias,
         addcmul_input_tensor1,
-        addcmul_input_tensor2};
+        addcmul_input_tensor2,
+        mm_progress_counters};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.cpp
@@ -172,6 +172,29 @@ MinimalMatmulStridedReduceScatterAsync::compute_output_specs(
         tt::tt_metal::TensorLayout(
             mm_output_spec.data_type(), mm_output_spec.page_config(), attributes.rs_output_mem_config));
 
+    // --- L1 handoff (step 1): block-shard the MM output across the matmul core grid so the RS
+    // reader's TensorAccessor reads it directly from the matmul cores' L1 instead of round-tripping
+    // through DRAM (kills the ~M*N write + read that was causing the DRAM/NoC contention). The fused
+    // matmul disables core-grid transpose, so M is parallelized on grid.y and N on grid.x. Done last
+    // so the RS intermediate/output specs above keep their original (DRAM) memory config.
+    if (attributes.matmul_struct.config.has_value() &&
+        attributes.matmul_struct.config->compute_with_storage_grid_size.x > 0) {
+        const auto grid = attributes.matmul_struct.config->compute_with_storage_grid_size;
+        const uint32_t gx = grid.x;
+        const uint32_t gy = grid.y;
+        const uint32_t Mt = mm_output_shape[-2] / tt::constants::TILE_HEIGHT;
+        const uint32_t Nt = mm_output_shape[-1] / tt::constants::TILE_WIDTH;
+        const uint32_t Mt_per_core = (Mt + gy - 1) / gy;
+        const uint32_t Nt_per_core = (Nt + gx - 1) / gx;
+        const auto mm_shard_spec = tt::tt_metal::ShardSpec(
+            CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(gx - 1, gy - 1))),
+            {Mt_per_core * tt::constants::TILE_HEIGHT, Nt_per_core * tt::constants::TILE_WIDTH});
+        const auto mm_l1_sharded = MemoryConfig{TensorMemoryLayout::BLOCK_SHARDED, BufferType::L1, mm_shard_spec};
+        mm_output_spec = tt::tt_metal::TensorSpec(
+            mm_output_shape,
+            tt::tt_metal::TensorLayout(mm_output_spec.data_type(), mm_output_spec.page_config(), mm_l1_sharded));
+    }
+
     return {mm_output_spec, rs_intermediate_spec, rs_output_spec};
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.cpp
@@ -172,11 +172,7 @@ MinimalMatmulStridedReduceScatterAsync::compute_output_specs(
         tt::tt_metal::TensorLayout(
             mm_output_spec.data_type(), mm_output_spec.page_config(), attributes.rs_output_mem_config));
 
-    // --- L1 handoff (step 1): block-shard the MM output across the matmul core grid so the RS
-    // reader's TensorAccessor reads it directly from the matmul cores' L1 instead of round-tripping
-    // through DRAM (kills the ~M*N write + read that was causing the DRAM/NoC contention). The fused
-    // matmul disables core-grid transpose, so M is parallelized on grid.y and N on grid.x. Done last
-    // so the RS intermediate/output specs above keep their original (DRAM) memory config.
+    // --- L1 handoff (step 1): block-shard the MM output across the matmul core grid so the RS reader's
     if (attributes.matmul_struct.config.has_value() &&
         attributes.matmul_struct.config->compute_with_storage_grid_size.x > 0) {
         const auto grid = attributes.matmul_struct.config->compute_with_storage_grid_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_op.hpp
@@ -76,6 +76,8 @@ std::vector<Tensor> minimal_matmul_strided_reduce_scatter_async(
     std::optional<float> fused_ternary_scalar = std::nullopt,
     const std::optional<const Tensor>& addcmul_input_tensor1 = std::nullopt,
     const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt,
-    std::optional<tt::tt_metal::DataType> dtype = std::nullopt);
+    std::optional<tt::tt_metal::DataType> dtype = std::nullopt,
+    // Shared per-MM-core progress counter scratch; see MinimalMatmulStridedReduceScatterAsyncInputs.
+    const std::optional<const Tensor>& mm_progress_counters = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_program.cpp
@@ -108,9 +108,7 @@ void MinimalMatmulStridedReduceScatterAsyncProgramFactory::override_runtime_argu
     for (auto& [range, program] : cached_workload.workload.get_programs()) {
         auto& shared_variables = cached_workload.shared_variables.at(range);
 
-        // The progress-counter address is baked into the reader + MM runtime args at build time and
-        // is not re-pointed here, so a caller-supplied array must stay put for the cached program's
-        // life; otherwise the kernels would signal/poll whatever now occupies that L1 address.
+        // The progress-counter address is baked into the reader + MM runtime args at build time
         if (tensor_args.mm_progress_counters.has_value()) {
             TT_FATAL(
                 static_cast<uint32_t>(tensor_args.mm_progress_counters->buffer()->address()) ==

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/device/minimal_matmul_strided_reduce_scatter_async_program.cpp
@@ -59,7 +59,8 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
     std::optional<uint32_t> chunk_width_in_mm_blocks,
     std::optional<float> fused_ternary_scalar = std::nullopt,
     const std::optional<const Tensor>& addcmul_input_tensor1 = std::nullopt,
-    const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt);
+    const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt,
+    const std::optional<const Tensor>& mm_progress_counters = std::nullopt);
 
 void ring_strided_reduce_scatter_async_helper_override_runtime_arguments(
     tt::tt_metal::Program& program,
@@ -106,6 +107,19 @@ void MinimalMatmulStridedReduceScatterAsyncProgramFactory::override_runtime_argu
     std::vector<Tensor>& output_tensor) {
     for (auto& [range, program] : cached_workload.workload.get_programs()) {
         auto& shared_variables = cached_workload.shared_variables.at(range);
+
+        // The progress-counter address is baked into the reader + MM runtime args at build time and
+        // is not re-pointed here, so a caller-supplied array must stay put for the cached program's
+        // life; otherwise the kernels would signal/poll whatever now occupies that L1 address.
+        if (tensor_args.mm_progress_counters.has_value()) {
+            TT_FATAL(
+                static_cast<uint32_t>(tensor_args.mm_progress_counters->buffer()->address()) ==
+                    shared_variables.rs_shared_variables.mm_progress_counters_addr,
+                "mm_progress_counters moved from L1 address {} to {} since this program was compiled; the "
+                "array must be allocated once and kept alive for every call that reuses the program",
+                shared_variables.rs_shared_variables.mm_progress_counters_addr,
+                tensor_args.mm_progress_counters->buffer()->address());
+        }
 
         // Override RS runtime arguments
         // output_tensor[0] = MM output = RS input
@@ -183,7 +197,10 @@ minimal_matmul_strided_reduce_scatter_async_program(
     /* Fused addcmul params */
     const std::optional<float> fused_ternary_scalar = std::nullopt,
     const std::optional<const Tensor>& addcmul_input_tensor1 = std::nullopt,
-    const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt) {
+    const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt,
+
+    /* Caller-owned per-MM-core progress counter scratch shared across MMRS programs. */
+    const std::optional<const Tensor>& mm_progress_counters = std::nullopt) {
     tt::tt_metal::Program program{};
 
     // Derive matmul geometry parameters for the RS factory.
@@ -242,7 +259,8 @@ minimal_matmul_strided_reduce_scatter_async_program(
         // Phase 2: fuse addcmul at the RS final write step (not in MM kernel)
         fused_ternary_scalar,
         addcmul_input_tensor1,
-        addcmul_input_tensor2);
+        addcmul_input_tensor2,
+        mm_progress_counters);
 
     // =========================================================================
     // STEP 2: Create the Matmul program SECOND
@@ -325,7 +343,10 @@ MinimalMatmulStridedReduceScatterAsyncProgramFactory::create_at(
         /* Fused addcmul params */
         attributes.fused_ternary_scalar,
         tensor_args.addcmul_input_tensor1,
-        tensor_args.addcmul_input_tensor2);
+        tensor_args.addcmul_input_tensor2,
+
+        /* Shared MM->RS progress counter scratch */
+        tensor_args.mm_progress_counters);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.cpp
@@ -33,7 +33,8 @@ std::vector<ttnn::Tensor> minimal_matmul_strided_reduce_scatter_async(
     std::optional<float> fused_ternary_scalar,
     const std::optional<const Tensor>& addcmul_input_tensor1,
     const std::optional<const Tensor>& addcmul_input_tensor2,
-    std::optional<tt::tt_metal::DataType> dtype) {
+    std::optional<tt::tt_metal::DataType> dtype,
+    const std::optional<const Tensor>& mm_progress_counters) {
     auto all_outputs = ttnn::prim::minimal_matmul_strided_reduce_scatter_async(
         input_tensor,
         weight_tensor,
@@ -61,7 +62,8 @@ std::vector<ttnn::Tensor> minimal_matmul_strided_reduce_scatter_async(
         fused_ternary_scalar,
         addcmul_input_tensor1,
         addcmul_input_tensor2,
-        dtype);
+        dtype,
+        mm_progress_counters);
 
     return {std::move(all_outputs[0]), std::move(all_outputs[2])};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async.hpp
@@ -38,6 +38,7 @@ std::vector<ttnn::Tensor> minimal_matmul_strided_reduce_scatter_async(
     std::optional<float> fused_ternary_scalar = std::nullopt,
     const std::optional<const Tensor>& addcmul_input_tensor1 = std::nullopt,
     const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt,
-    std::optional<tt::tt_metal::DataType> dtype = std::nullopt);
+    std::optional<tt::tt_metal::DataType> dtype = std::nullopt,
+    const std::optional<const Tensor>& mm_progress_counters = std::nullopt);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_nanobind.cpp
@@ -63,6 +63,12 @@ void bind_minimal_matmul_strided_reduce_scatter_async(nb::module_& mod) {
             * :attr:`fused_ternary_scalar` (Optional[float]): Scalar value for fused addcmul operation.
             * :attr:`addcmul_input_tensor1` (Optional[ttnn.Tensor]): First additional input tensor for fused addcmul (residual/base).
             * :attr:`addcmul_input_tensor2` (Optional[ttnn.Tensor]): Second additional input tensor for fused addcmul (gate/multiplier).
+            * :attr:`mm_progress_counters` (Optional[ttnn.Tensor]): Caller-owned scratch for the MM->RS
+              per-core progress counters: a uint32 ROW_MAJOR tensor of shape [num_cores, slots], L1
+              HEIGHT_SHARDED with shard [1, slots] over a core grid covering the RS worker cores, where
+              slots >= the device compute grid area. Share one such tensor across every MMRS call (see
+              CCLManager.get_mm_progress_counters_buffer); otherwise each compiled program allocates its
+              own and permanently lowers the device's L1 floor.
 
         )doc",
         &ttnn::experimental::minimal_matmul_strided_reduce_scatter_async,
@@ -92,7 +98,8 @@ void bind_minimal_matmul_strided_reduce_scatter_async(nb::module_& mod) {
         nb::arg("fused_ternary_scalar") = nb::none(),
         nb::arg("addcmul_input_tensor1") = nb::none(),
         nb::arg("addcmul_input_tensor2") = nb::none(),
-        nb::arg("dtype") = nb::none());
+        nb::arg("dtype") = nb::none(),
+        nb::arg("mm_progress_counters") = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_common/kernels/np_reorder.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_common/kernels/np_reorder.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <stdint.h>
+
+// W global two-pass reorder: within a slice of nf frames × h_total rows, emit all interior rows first
+// (nf*input_H_dev) then all corner rows (nf*2*padding_h), so the W exchange does its H-independent
+// interior work while H is still producing and only reaches the H→W corner gate once H's per-batch
+// corner commit is done (no stall). Returns (frame, h_padded). The W reader and W writer call this in
+// lock-step to address the halo buffer identically — keep it shared so the two can never drift.
+inline void np_reorder_batch(
+    uint32_t k, uint32_t nf, uint32_t input_H_dev, uint32_t padding_h, uint32_t& frame, uint32_t& h_padded) {
+    const uint32_t interior = nf * input_H_dev;
+    if (k < interior) {
+        frame = k / input_H_dev;
+        h_padded = padding_h + (k % input_H_dev);
+    } else {
+        const uint32_t kc = k - interior;
+        const uint32_t cpf = 2 * padding_h;  // corners per frame (top + bottom)
+        frame = kc / cpf;
+        const uint32_t c = kc % cpf;
+        h_padded = (c < padding_h) ? c : (padding_h + input_H_dev + (c - padding_h));
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_common/kernels/np_reorder.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_common/kernels/np_reorder.hpp
@@ -4,11 +4,7 @@
 
 #include <stdint.h>
 
-// W global two-pass reorder: within a slice of nf frames × h_total rows, emit all interior rows first
-// (nf*input_H_dev) then all corner rows (nf*2*padding_h), so the W exchange does its H-independent
-// interior work while H is still producing and only reaches the H→W corner gate once H's per-batch
-// corner commit is done (no stall). Returns (frame, h_padded). The W reader and W writer call this in
-// lock-step to address the halo buffer identically — keep it shared so the two can never drift.
+// W global two-pass reorder: within a slice of nf frames × h_total rows
 inline void np_reorder_batch(
     uint32_t k, uint32_t nf, uint32_t input_H_dev, uint32_t padding_h, uint32_t& frame, uint32_t& h_padded) {
     const uint32_t interior = nf * input_H_dev;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_common/kernels/np_zero_pad.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_common/kernels/np_zero_pad.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <stdint.h>
+
+// Fill one CB stick with zeros by reading from the device's MEM_ZEROS scratch region. Used for the
+// zero-pad rows of the NP halo exchange. Shared by np_h_reader and np_phase2_w_reader.
+template <uint32_t stick_size_bytes>
+inline void zeroPadCb(uint32_t cb_id) {
+    constexpr uint32_t num_full_reads = stick_size_bytes / MEM_ZEROS_SIZE;
+    constexpr uint32_t partial_read_size = stick_size_bytes % MEM_ZEROS_SIZE;
+    const uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+    uint32_t cb_write_addr = get_write_ptr(cb_id);
+
+    for (uint32_t i = 0; i < num_full_reads; ++i) {
+        noc_async_read(zeros_noc_addr, cb_write_addr, MEM_ZEROS_SIZE);
+        cb_write_addr += MEM_ZEROS_SIZE;
+    }
+    if (partial_read_size > 0) {
+        noc_async_read(zeros_noc_addr, cb_write_addr, partial_read_size);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_common/kernels/np_zero_pad.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_common/kernels/np_zero_pad.hpp
@@ -4,8 +4,7 @@
 
 #include <stdint.h>
 
-// Fill one CB stick with zeros by reading from the device's MEM_ZEROS scratch region. Used for the
-// zero-pad rows of the NP halo exchange. Shared by np_h_reader and np_phase2_w_reader.
+// Fill one CB stick with zeros by reading from the device's MEM_ZEROS scratch region
 template <uint32_t stick_size_bytes>
 inline void zeroPadCb(uint32_t cb_id) {
     constexpr uint32_t num_full_reads = stick_size_bytes / MEM_ZEROS_SIZE;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/CMakeLists.txt
@@ -1,0 +1,43 @@
+add_library(ttnn_op_experimental_neighbor_pad_halo ${LIB_TYPE})
+add_library(TTNN::Ops::Experimental::NeighborPadHalo ALIAS ttnn_op_experimental_neighbor_pad_halo)
+
+tt_reuse_precompile_headers(ttnn_op_experimental_neighbor_pad_halo TTNN::PCHFull)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_neighbor_pad_halo)
+
+file(GLOB_RECURSE kernels device/kernels/*)
+
+target_sources(
+    ttnn_op_experimental_neighbor_pad_halo
+    PUBLIC
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${kernels}
+    PRIVATE
+        neighbor_pad_halo.cpp
+        device/neighbor_pad_halo_device_operation.cpp
+        device/neighbor_pad_halo_program_factory.cpp
+        halo_scatter.cpp
+        device/halo_scatter_device_operation.cpp
+        device/halo_scatter_program_factory.cpp
+)
+
+target_include_directories(ttnn_op_experimental_neighbor_pad_halo PRIVATE ${FixmeOpIncDirs})
+target_link_libraries(
+    ttnn_op_experimental_neighbor_pad_halo
+    PRIVATE
+        TT::Metalium
+        TTNN::Core
+        TTNN::Ops::Experimental::CCL
+)
+
+install(
+    TARGETS
+        ttnn_op_experimental_neighbor_pad_halo
+    FILE_SET
+    kernels
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo
+        COMPONENT ttnn-runtime
+)
+
+install(TARGETS ttnn_op_experimental_neighbor_pad_halo LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_device_operation.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "halo_scatter_device_operation.hpp"
+#include "halo_scatter_device_operation_types.hpp"
+#include "halo_scatter_program_factory.hpp"
+
+#include <tt-metalium/tt_metal.hpp>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::experimental::prim {
+
+void NpHaloScatterDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& compact = tensor_args.compact_buffer;
+    const auto& x = tensor_args.interior_src;
+
+    TT_FATAL(compact.layout() == Layout::ROW_MAJOR, "HaloScatter: compact_buffer must be row-major.");
+    TT_FATAL(x.layout() == Layout::ROW_MAJOR, "HaloScatter: interior_src must be row-major.");
+    TT_FATAL(
+        compact.dtype() == x.dtype(),
+        "HaloScatter: compact ({}) and interior_src ({}) dtype must match.",
+        compact.dtype(),
+        x.dtype());
+    TT_FATAL(
+        compact.dtype() == DataType::BFLOAT16 || compact.dtype() == DataType::FLOAT32,
+        "HaloScatter: dtype must be bfloat16 or float32. got {}",
+        compact.dtype());
+    TT_FATAL(
+        x.logical_shape().size() == 5,
+        "HaloScatter: interior_src must be rank 5 [B,T,H,W,C]. got {}",
+        x.logical_shape().size());
+    TT_FATAL(args.np_padding_h > 0, "HaloScatter: np_padding_h must be > 0.");
+}
+
+TensorSpec NpHaloScatterDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // border_only: interior_src is ALREADY the padded buffer; output IS it (in place). repack: grow H,W.
+    if (args.border_only) {
+        return tensor_args.interior_src.tensor_spec();
+    }
+    const auto& s = tensor_args.interior_src.logical_shape();
+    ttnn::Shape output_shape(
+        {s[0], s[1], s[2] + 2 * args.np_padding_h, s[3] + 2 * args.np_padding_w, s[4]});
+    return TensorSpec(
+        output_shape,
+        tt::tt_metal::TensorLayout(
+            tensor_args.interior_src.dtype(),
+            tt::tt_metal::PageConfig(Layout::ROW_MAJOR),
+            args.output_mem_config));
+}
+
+Tensor NpHaloScatterDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (args.border_only) {
+        return tensor_args.interior_src;  // write border in place, interior preserved
+    }
+    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.interior_src.device());
+}
+
+ttsl::hash::hash_t NpHaloScatterDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& x = tensor_args.interior_src;
+    return operation::hash_operation<NpHaloScatterDeviceOperation>(
+        args, x.dtype(), x.memory_config(), x.logical_shape());
+}
+
+}  // namespace ttnn::experimental::prim
+
+namespace ttnn::prim {
+
+Tensor halo_scatter(
+    const Tensor& compact_buffer,
+    const Tensor& interior_src,
+    const ttnn::experimental::prim::NpHaloScatterParams& params) {
+    using OperationType = ttnn::experimental::prim::NpHaloScatterDeviceOperation;
+    auto tensor_args =
+        OperationType::tensor_args_t{.compact_buffer = compact_buffer, .interior_src = interior_src};
+    return ttnn::device_operation::launch<OperationType>(params, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_device_operation.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <variant>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "halo_scatter_device_operation_types.hpp"
+#include "halo_scatter_program_factory.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct NpHaloScatterDeviceOperation {
+    using operation_attributes_t = NpHaloScatterParams;
+    using tensor_args_t = NpHaloScatterInputs;
+    using spec_return_value_t = tt::tt_metal::TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<NpHaloScatterMeshWorkloadFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::experimental::prim
+
+namespace ttnn::prim {
+
+// Primitive entry point: repack into a newly-allocated padded buffer (interior from interior_src,
+// border from the compact halo buffer) and return it.
+Tensor halo_scatter(
+    const Tensor& compact_buffer,
+    const Tensor& interior_src,
+    const ttnn::experimental::prim::NpHaloScatterParams& params);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_device_operation.hpp
@@ -27,8 +27,7 @@ struct NpHaloScatterDeviceOperation {
 
 namespace ttnn::prim {
 
-// Primitive entry point: repack into a newly-allocated padded buffer (interior from interior_src,
-// border from the compact halo buffer) and return it.
+// Primitive entry point: repack into a newly-allocated padded buffer
 Tensor halo_scatter(
     const Tensor& compact_buffer,
     const Tensor& interior_src,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_device_operation_types.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+#include <tuple>
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::experimental::prim {
+
+// Local (no-fabric) repack into a padded buffer [outer, H+2pH, W+2pW, C]: fill the INTERIOR from the
+// unpadded activation `x` and the BORDER from the compact halo buffer [H-top | H-bot | W-left |
+// W-right] produced by neighbor_pad_halo, in a single pass that writes every padded page once. This
+// folds the old ttnn.pad (interior copy) + border scatter into one op; the next conv then reads the
+// padded buffer as a plain coalesced conv (pad=0). The mapping is the inverse of
+// compact_halo_reference() for the border, a plain strided placement for the interior — pure
+// DRAM->DRAM stick copies, no arithmetic. The op ALLOCATES its padded output (uninitialized; every
+// page is written), so no separate pad/zero pass is needed.
+struct NpHaloScatterParams {
+    uint32_t np_padding_h;  // H halo rows per side (pH)
+    uint32_t np_padding_w;  // W halo cols per side (pW)
+    tt::tt_metal::MemoryConfig output_mem_config;
+    // border_only: copy-free mode. interior_src is ALREADY the padded [.,H+2pH,W+2pW,C] buffer (interior
+    // written by the previous conv's padded-output); write ONLY the border from compact, in place. When
+    // false (default): repack mode — interior_src is unpadded, allocate padded, fill interior + border.
+    bool border_only = false;
+
+    static constexpr auto attribute_names = std::make_tuple("np_padding_h", "np_padding_w", "border_only");
+    auto attribute_values() const { return std::forward_as_tuple(np_padding_h, np_padding_w, border_only); }
+};
+
+struct NpHaloScatterInputs {
+    Tensor compact_buffer;  // [total_sticks, C] compact halo buffer (border source, from neighbor_pad_halo)
+    Tensor interior_src;    // repack: unpadded [.,H,W,C] interior source. border_only: the padded buffer (in place).
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_device_operation_types.hpp
@@ -9,21 +9,12 @@
 
 namespace ttnn::experimental::prim {
 
-// Local (no-fabric) repack into a padded buffer [outer, H+2pH, W+2pW, C]: fill the INTERIOR from the
-// unpadded activation `x` and the BORDER from the compact halo buffer [H-top | H-bot | W-left |
-// W-right] produced by neighbor_pad_halo, in a single pass that writes every padded page once. This
-// folds the old ttnn.pad (interior copy) + border scatter into one op; the next conv then reads the
-// padded buffer as a plain coalesced conv (pad=0). The mapping is the inverse of
-// compact_halo_reference() for the border, a plain strided placement for the interior — pure
-// DRAM->DRAM stick copies, no arithmetic. The op ALLOCATES its padded output (uninitialized; every
-// page is written), so no separate pad/zero pass is needed.
+// Local (no-fabric) repack into a padded buffer [outer, H+2pH, W+2pW
 struct NpHaloScatterParams {
     uint32_t np_padding_h;  // H halo rows per side (pH)
     uint32_t np_padding_w;  // W halo cols per side (pW)
     tt::tt_metal::MemoryConfig output_mem_config;
-    // border_only: copy-free mode. interior_src is ALREADY the padded [.,H+2pH,W+2pW,C] buffer (interior
-    // written by the previous conv's padded-output); write ONLY the border from compact, in place. When
-    // false (default): repack mode — interior_src is unpadded, allocate padded, fill interior + border.
+    // border_only: copy-free mode
     bool border_only = false;
 
     static constexpr auto attribute_names = std::make_tuple("np_padding_h", "np_padding_w", "border_only");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_program_factory.cpp
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "halo_scatter_program_factory.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <algorithm>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::experimental::prim {
+
+// ============================================================================
+// create_mesh_workload — the scatter is local + identical on every device, so
+// each mesh coordinate gets the same single-core program.
+// ============================================================================
+NpHaloScatterMeshWorkloadFactory::cached_mesh_workload_t NpHaloScatterMeshWorkloadFactory::create_mesh_workload(
+    const NpHaloScatterParams& operation_attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const NpHaloScatterInputs& tensor_args,
+    Tensor& tensor_return_value) {
+    tt::tt_metal::distributed::MeshWorkload mesh_workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+
+    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
+        for (const auto& mesh_coord : mesh_coord_range) {
+            const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
+            auto cached_program = create_at(operation_attributes, mesh_coord, tensor_args, tensor_return_value);
+            shared_variables[single_coord_range] = cached_program.shared_variables;
+            mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
+        }
+    }
+
+    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+}
+
+// ============================================================================
+// create_at — one writer kernel on a single core that copies each compact halo
+// stick to its fixed padded-buffer border page (in place; interior untouched).
+// ============================================================================
+NpHaloScatterMeshWorkloadFactory::cached_program_t NpHaloScatterMeshWorkloadFactory::create_at(
+    const NpHaloScatterParams& op,
+    const ttnn::MeshCoordinate& /*mesh_coordinate*/,
+    const NpHaloScatterInputs& tensor_args,
+    Tensor& tensor_return_value) {
+    Program program{};
+
+    Buffer* compact = tensor_args.compact_buffer.buffer();  // [total_sticks, C] (border source)
+    Buffer* dst = tensor_return_value.buffer();          // padded output (allocated) or in-place (border_only)
+    // border_only: no interior reads; x_src unused (point it at dst, harmless). repack: unpadded interior.
+    Buffer* x_src = op.border_only ? dst : tensor_args.interior_src.buffer();
+
+    const auto& xshape = tensor_args.interior_src.logical_shape();
+    const uint32_t rank = xshape.size();
+    const uint32_t pH = op.np_padding_h;
+    const uint32_t pW = op.np_padding_w;
+    // border_only: interior_src is padded, so subtract to get interior dims. repack: it's unpadded already.
+    const uint32_t Wd = op.border_only ? xshape[rank - 2] - 2 * pW : xshape[rank - 2];
+    const uint32_t Hd = op.border_only ? xshape[rank - 3] - 2 * pH : xshape[rank - 3];
+    uint32_t outer = 1;  // product of all dims before H (B*T)
+    for (uint32_t d = 0; d + 3 < rank; d++) {
+        outer *= xshape[d];
+    }
+    const uint32_t Hp = Hd + 2 * pH;
+    const uint32_t Wp = Wd + 2 * pW;
+
+    const uint32_t page_size = compact->aligned_page_size();
+    tt::DataFormat df = datatype_to_dataformat_converter(tensor_args.compact_buffer.dtype());
+
+    // Every padded page is written once: interior (Hd*Wd) from x + border (2 H-sections pH*Wd + 2
+    // W-sections Hp*pW) from compact, per frame.
+    const uint32_t interior_sticks = outer * Hd * Wd;
+    const uint32_t border_sticks = outer * (2 * pH * Wd + 2 * pW * Hp);
+    const uint32_t total_sticks = interior_sticks + border_sticks;
+    // border_only: process only the border sticks [interior_sticks, total_sticks); the kernel's global
+    // index maps >= interior_sticks to border sections, so the interior is never touched.
+    const uint32_t work_start = op.border_only ? interior_sticks : 0u;
+    const uint32_t work_count = total_sticks - work_start;
+
+    // Spread across the full compute grid: each core copies a contiguous global-stick range.
+    const CoreCoord grid = tensor_return_value.device()->compute_with_storage_grid_size();
+    const uint32_t num_cores = std::min<uint32_t>(grid.x * grid.y, std::max<uint32_t>(work_count, 1u));
+    const CoreRangeSet all_cores = num_cores_to_corerangeset(num_cores, grid, /*row_wise=*/true);
+    const uint32_t per_core = (work_count + num_cores - 1) / num_cores;  // ceil
+
+    constexpr uint32_t cb_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_pages = 8;  // sticks per barrier batch (in-flight reads/writes)
+    CircularBufferConfig cb_cfg =
+        CircularBufferConfig(cb_pages * page_size, {{cb_id, df}}).set_page_size(cb_id, page_size);
+    CreateCircularBuffer(program, all_cores, cb_cfg);
+
+    auto writer_cfg = WriterDataMovementConfig{};
+    writer_cfg.compile_args = {page_size, outer, Hp, Wp, Hd, Wd, pH, pW, cb_id, cb_pages};
+    TensorAccessorArgs(*x_src).append_to(writer_cfg.compile_args);
+    TensorAccessorArgs(*compact).append_to(writer_cfg.compile_args);
+    TensorAccessorArgs(*dst).append_to(writer_cfg.compile_args);
+
+    KernelHandle writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/halo_scatter_writer.cpp",
+        all_cores,
+        writer_cfg);
+
+    // Per-core [x_addr, compact_addr, dst_addr, stick_start, stick_count]; contiguous ranges row-wise
+    // over [work_start, total_sticks).
+    uint32_t assigned = work_start;
+    for (const auto& cr : all_cores.ranges()) {
+        for (const auto& c : cr) {
+            const uint32_t start = assigned;
+            const uint32_t count = (start >= total_sticks) ? 0u : std::min(per_core, total_sticks - start);
+            SetRuntimeArgs(
+                program,
+                writer_kernel_id,
+                c,
+                {x_src->address(), compact->address(), dst->address(), start, count});
+            assigned += count;
+        }
+    }
+
+    return cached_program_t{std::move(program), {NpHaloScatterArtifacts{writer_kernel_id, all_cores}}};
+}
+
+// ============================================================================
+// override_runtime_arguments — refresh the (x, compact, padded) DRAM addresses.
+// ============================================================================
+void NpHaloScatterMeshWorkloadFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const NpHaloScatterParams& /*op*/,
+    const NpHaloScatterInputs& tensor_args,
+    Tensor& tensor_return_value) {
+    const uint32_t x_addr = tensor_args.interior_src.buffer()->address();
+    const uint32_t compact_addr = tensor_args.compact_buffer.buffer()->address();
+    const uint32_t dst_addr = tensor_return_value.buffer()->address();
+
+    for (auto& [coordinate_range, shared_vars] : cached_workload.shared_variables) {
+        auto& program = cached_workload.workload.get_programs().at(coordinate_range);
+        auto& args_by_core = GetRuntimeArgs(program, shared_vars.artifacts.writer_kernel_id);
+        for (const auto& cr : shared_vars.artifacts.cores.ranges()) {
+            for (const auto& c : cr) {
+                auto& args = args_by_core[c.x][c.y];
+                args[0] = x_addr;
+                args[1] = compact_addr;
+                args[2] = dst_addr;
+            }
+        }
+    }
+}
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_program_factory.cpp
@@ -15,10 +15,7 @@ using namespace tt::tt_metal;
 
 namespace ttnn::experimental::prim {
 
-// ============================================================================
-// create_mesh_workload — the scatter is local + identical on every device, so
-// each mesh coordinate gets the same single-core program.
-// ============================================================================
+// ============================================================================ create_mesh_workload
 NpHaloScatterMeshWorkloadFactory::cached_mesh_workload_t NpHaloScatterMeshWorkloadFactory::create_mesh_workload(
     const NpHaloScatterParams& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
@@ -39,10 +36,7 @@ NpHaloScatterMeshWorkloadFactory::cached_mesh_workload_t NpHaloScatterMeshWorklo
     return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
 }
 
-// ============================================================================
-// create_at — one writer kernel on a single core that copies each compact halo
-// stick to its fixed padded-buffer border page (in place; interior untouched).
-// ============================================================================
+// ============================================================================ create_at
 NpHaloScatterMeshWorkloadFactory::cached_program_t NpHaloScatterMeshWorkloadFactory::create_at(
     const NpHaloScatterParams& op,
     const ttnn::MeshCoordinate& /*mesh_coordinate*/,
@@ -72,13 +66,11 @@ NpHaloScatterMeshWorkloadFactory::cached_program_t NpHaloScatterMeshWorkloadFact
     const uint32_t page_size = compact->aligned_page_size();
     tt::DataFormat df = datatype_to_dataformat_converter(tensor_args.compact_buffer.dtype());
 
-    // Every padded page is written once: interior (Hd*Wd) from x + border (2 H-sections pH*Wd + 2
-    // W-sections Hp*pW) from compact, per frame.
+    // Every padded page is written once: interior (Hd*Wd) from x + border
     const uint32_t interior_sticks = outer * Hd * Wd;
     const uint32_t border_sticks = outer * (2 * pH * Wd + 2 * pW * Hp);
     const uint32_t total_sticks = interior_sticks + border_sticks;
-    // border_only: process only the border sticks [interior_sticks, total_sticks); the kernel's global
-    // index maps >= interior_sticks to border sections, so the interior is never touched.
+    // border_only: process only the border sticks [interior_sticks, total_sticks)
     const uint32_t work_start = op.border_only ? interior_sticks : 0u;
     const uint32_t work_count = total_sticks - work_start;
 
@@ -106,8 +98,7 @@ NpHaloScatterMeshWorkloadFactory::cached_program_t NpHaloScatterMeshWorkloadFact
         all_cores,
         writer_cfg);
 
-    // Per-core [x_addr, compact_addr, dst_addr, stick_start, stick_count]; contiguous ranges row-wise
-    // over [work_start, total_sticks).
+    // Per-core [x_addr, compact_addr, dst_addr, stick_start, stick_count]
     uint32_t assigned = work_start;
     for (const auto& cr : all_cores.ranges()) {
         for (const auto& c : cr) {
@@ -125,9 +116,7 @@ NpHaloScatterMeshWorkloadFactory::cached_program_t NpHaloScatterMeshWorkloadFact
     return cached_program_t{std::move(program), {NpHaloScatterArtifacts{writer_kernel_id, all_cores}}};
 }
 
-// ============================================================================
-// override_runtime_arguments — refresh the (x, compact, padded) DRAM addresses.
-// ============================================================================
+// ============================================================================ override_runtime_arguments
 void NpHaloScatterMeshWorkloadFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const NpHaloScatterParams& /*op*/,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/halo_scatter_program_factory.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "halo_scatter_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
+
+#include <tt-metalium/host_api.hpp>
+
+namespace ttnn::experimental::prim {
+
+struct NpHaloScatterArtifacts {
+    tt::tt_metal::KernelHandle writer_kernel_id = 0;
+    tt::tt_metal::CoreRangeSet cores;
+};
+
+struct NpHaloScatterSharedVariables {
+    NpHaloScatterArtifacts artifacts;
+};
+
+struct NpHaloScatterMeshWorkloadFactory {
+    using shared_variables_t = NpHaloScatterSharedVariables;
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+    static cached_mesh_workload_t create_mesh_workload(
+        const NpHaloScatterParams& operation_attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const NpHaloScatterInputs& tensor_args,
+        Tensor& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_workload,
+        const NpHaloScatterParams& operation_attributes,
+        const NpHaloScatterInputs& tensor_args,
+        Tensor& tensor_return_value);
+
+private:
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create_at(
+        const NpHaloScatterParams& operation_attributes,
+        const ttnn::MeshCoordinate& mesh_coordinate,
+        const NpHaloScatterInputs& tensor_args,
+        Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/halo_scatter_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/halo_scatter_writer.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+// Repack into a persistent padded buffer [outer, Hp, Wp, C]: fill the INTERIOR from the unpadded
+// activation `x` and the BORDER from the compact halo buffer [H-top | H-bot | W-left | W-right], in a
+// single pass that writes every padded page exactly once (folds the old ttnn.pad + border-scatter).
+//   interior stick (t, h, w)  -> padded[t, h+pH,       w+pW]         (src: x page t*Hd*Wd + h*Wd + w)
+//   H-top  stick (t, pr, w)   -> padded[t, pr,          pW+w]        (src: compact)
+//   H-bot  stick (t, pr, w)   -> padded[t, pH+Hd+pr,    pW+w]
+//   W-left stick (t, hp, wc)  -> padded[t, hp,          wc]          (full height, incl corners)
+//   W-right stick(t, hp, wc)  -> padded[t, hp,          pW+Wd+wc]
+// Compact section order + (t,row,col) t-major matches compact_halo_reference(). Parallelized by a
+// single global stick index: [0, N_int) are interior sticks (from x), [N_int, ...) are compact border
+// sticks; each core owns a contiguous [start, start+count) range. Pages of interleaved DRAM are
+// bank-distributed (no contiguous multi-page read), so throughput comes from BATCHING the async
+// reads/writes (one barrier per batch of cb_pages) rather than a per-stick read+write+barrier.
+void kernel_main() {
+    const uint32_t x_addr = get_arg_val<uint32_t>(0);        // interior source (unpadded activation)
+    const uint32_t compact_addr = get_arg_val<uint32_t>(1);  // border source (compact halo buffer)
+    const uint32_t dst_addr = get_arg_val<uint32_t>(2);      // padded output
+    const uint32_t stick_start = get_arg_val<uint32_t>(3);
+    const uint32_t stick_count = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t page_size = get_compile_time_arg_val(0);
+    constexpr uint32_t outer = get_compile_time_arg_val(1);  // B*T frames
+    constexpr uint32_t Hp = get_compile_time_arg_val(2);     // padded H = Hd + 2*pH
+    constexpr uint32_t Wp = get_compile_time_arg_val(3);     // padded W = Wd + 2*pW
+    constexpr uint32_t Hd = get_compile_time_arg_val(4);
+    constexpr uint32_t Wd = get_compile_time_arg_val(5);
+    constexpr uint32_t pH = get_compile_time_arg_val(6);
+    constexpr uint32_t pW = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_id = get_compile_time_arg_val(8);
+    constexpr uint32_t batch = get_compile_time_arg_val(9);  // sticks per barrier batch (= cb pages)
+
+    constexpr auto x_args = TensorAccessorArgs<10>();
+    constexpr auto compact_args = TensorAccessorArgs<x_args.next_compile_time_args_offset()>();
+    constexpr auto dst_args = TensorAccessorArgs<compact_args.next_compile_time_args_offset()>();
+    const auto x_src = TensorAccessor(x_args, x_addr, page_size);
+    const auto compact = TensorAccessor(compact_args, compact_addr, page_size);
+    const auto dst = TensorAccessor(dst_args, dst_addr, page_size);
+
+    constexpr uint32_t frame_stride = Hp * Wp;
+    constexpr uint32_t n_int = outer * Hd * Wd;  // interior sticks
+    constexpr uint32_t h_sec = outer * pH * Wd;  // H-top == H-bot (compact)
+    constexpr uint32_t w_sec = outer * Hp * pW;  // W-left == W-right (compact)
+    constexpr uint32_t bb1 = n_int + h_sec;      // end of H-top (global index)
+    constexpr uint32_t bb2 = bb1 + h_sec;        // end of H-bot
+    constexpr uint32_t bb3 = bb2 + w_sec;        // end of W-left
+
+    const uint32_t l1_base = get_write_ptr(cb_id);
+    const uint32_t end = stick_start + stick_count;
+
+    // Map a global stick index to (src noc addr, dst page).
+    auto src_noc = [&](uint32_t gi) -> uint64_t {
+        if (gi < n_int) {
+            return get_noc_addr(gi, x_src);
+        } else if (gi < bb1) {
+            return get_noc_addr(gi - n_int, compact);
+        } else if (gi < bb2) {
+            return get_noc_addr(h_sec + (gi - bb1), compact);
+        } else if (gi < bb3) {
+            return get_noc_addr(2 * h_sec + (gi - bb2), compact);
+        } else {
+            return get_noc_addr(2 * h_sec + w_sec + (gi - bb3), compact);
+        }
+    };
+    auto dst_page = [&](uint32_t gi) -> uint32_t {
+        if (gi < n_int) {
+            const uint32_t t = gi / (Hd * Wd);
+            const uint32_t rem = gi - t * (Hd * Wd);
+            const uint32_t h = rem / Wd;
+            const uint32_t w = rem - h * Wd;
+            return t * frame_stride + (h + pH) * Wp + (pW + w);
+        } else if (gi < bb1) {
+            const uint32_t j = gi - n_int;
+            const uint32_t t = j / (pH * Wd);
+            const uint32_t rem = j - t * (pH * Wd);
+            const uint32_t pr = rem / Wd;
+            const uint32_t w = rem - pr * Wd;
+            return t * frame_stride + pr * Wp + (pW + w);
+        } else if (gi < bb2) {
+            const uint32_t j = gi - bb1;
+            const uint32_t t = j / (pH * Wd);
+            const uint32_t rem = j - t * (pH * Wd);
+            const uint32_t pr = rem / Wd;
+            const uint32_t w = rem - pr * Wd;
+            return t * frame_stride + (pH + Hd + pr) * Wp + (pW + w);
+        } else if (gi < bb3) {
+            const uint32_t j = gi - bb2;
+            const uint32_t t = j / (Hp * pW);
+            const uint32_t rem = j - t * (Hp * pW);
+            const uint32_t hp = rem / pW;
+            const uint32_t wc = rem - hp * pW;
+            return t * frame_stride + hp * Wp + wc;
+        } else {
+            const uint32_t j = gi - bb3;
+            const uint32_t t = j / (Hp * pW);
+            const uint32_t rem = j - t * (Hp * pW);
+            const uint32_t hp = rem / pW;
+            const uint32_t wc = rem - hp * pW;
+            return t * frame_stride + hp * Wp + (pW + Wd + wc);
+        }
+    };
+
+    for (uint32_t gi = stick_start; gi < end; gi += batch) {
+        const uint32_t n = (end - gi < batch) ? (end - gi) : batch;
+        // Batch of reads: src -> L1 ring slots, one barrier.
+        for (uint32_t k = 0; k < n; k++) {
+            noc_async_read(src_noc(gi + k), l1_base + k * page_size, page_size);
+        }
+        noc_async_read_barrier();
+        // Batch of writes: L1 ring slots -> padded pages, one barrier.
+        for (uint32_t k = 0; k < n; k++) {
+            noc_async_write(l1_base + k * page_size, get_noc_addr(dst_page(gi + k), dst), page_size);
+        }
+        noc_async_write_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/halo_scatter_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/halo_scatter_writer.cpp
@@ -4,19 +4,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 
-// Repack into a persistent padded buffer [outer, Hp, Wp, C]: fill the INTERIOR from the unpadded
-// activation `x` and the BORDER from the compact halo buffer [H-top | H-bot | W-left | W-right], in a
-// single pass that writes every padded page exactly once (folds the old ttnn.pad + border-scatter).
-//   interior stick (t, h, w)  -> padded[t, h+pH,       w+pW]         (src: x page t*Hd*Wd + h*Wd + w)
-//   H-top  stick (t, pr, w)   -> padded[t, pr,          pW+w]        (src: compact)
-//   H-bot  stick (t, pr, w)   -> padded[t, pH+Hd+pr,    pW+w]
-//   W-left stick (t, hp, wc)  -> padded[t, hp,          wc]          (full height, incl corners)
-//   W-right stick(t, hp, wc)  -> padded[t, hp,          pW+Wd+wc]
-// Compact section order + (t,row,col) t-major matches compact_halo_reference(). Parallelized by a
-// single global stick index: [0, N_int) are interior sticks (from x), [N_int, ...) are compact border
-// sticks; each core owns a contiguous [start, start+count) range. Pages of interleaved DRAM are
-// bank-distributed (no contiguous multi-page read), so throughput comes from BATCHING the async
-// reads/writes (one barrier per batch of cb_pages) rather than a per-stick read+write+barrier.
+// Repack into a persistent padded buffer [outer, Hp, Wp, C]: fill the INTERIOR from the unpadded activation `x`
 void kernel_main() {
     const uint32_t x_addr = get_arg_val<uint32_t>(0);        // interior source (unpadded activation)
     const uint32_t compact_addr = get_arg_val<uint32_t>(1);  // border source (compact halo buffer)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_fused_scatter_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_fused_scatter_writer.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+// Fused scatter phase for neighbor_pad_halo padded-output mode. Runs on cores DISJOINT from the fabric
+// exchange (columns x>=1), concurrently with the exchange. Writes the padded output [outer, Hp, Wp, C]:
+//   INTERIOR (t,h,w) -> padded[t, h+pH, w+pW]   from interior_src (input); NO dependency on the exchange
+//     -> processed first, overlapping the fabric exchange.
+//   BORDER  -> from the compact halo buffer [H-top|H-bot|W-left|W-right]; depends on the exchange, so
+//     before its first border stick a core waits exchange_done >= num_readers (all fabric halo landed).
+// Same stick mapping as halo_scatter_writer (interior + 4 border sections, t-major). border_only: interior
+// already present in padded_output, work starts at the border (interior skipped, no overlap).
+void kernel_main() {
+    const uint32_t x_addr = get_arg_val<uint32_t>(0);        // interior source (input)
+    const uint32_t compact_addr = get_arg_val<uint32_t>(1);  // border source (compact halo buffer)
+    const uint32_t dst_addr = get_arg_val<uint32_t>(2);      // padded output
+    const uint32_t stick_start = get_arg_val<uint32_t>(3);
+    const uint32_t stick_count = get_arg_val<uint32_t>(4);
+    const uint32_t exchange_done_addr = get_arg_val<uint32_t>(5);  // GlobalSemaphore L1 address
+    const uint32_t num_readers = get_arg_val<uint32_t>(6);         // exchange_done target count
+
+    constexpr uint32_t page_size = get_compile_time_arg_val(0);
+    constexpr uint32_t outer = get_compile_time_arg_val(1);
+    constexpr uint32_t Hp = get_compile_time_arg_val(2);
+    constexpr uint32_t Wp = get_compile_time_arg_val(3);
+    constexpr uint32_t Hd = get_compile_time_arg_val(4);
+    constexpr uint32_t Wd = get_compile_time_arg_val(5);
+    constexpr uint32_t pH = get_compile_time_arg_val(6);
+    constexpr uint32_t pW = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_id = get_compile_time_arg_val(8);
+    constexpr uint32_t batch = get_compile_time_arg_val(9);
+    constexpr uint32_t border_only = get_compile_time_arg_val(10);
+
+    constexpr auto x_args = TensorAccessorArgs<11>();
+    constexpr auto compact_args = TensorAccessorArgs<x_args.next_compile_time_args_offset()>();
+    constexpr auto dst_args = TensorAccessorArgs<compact_args.next_compile_time_args_offset()>();
+    const auto x_src = TensorAccessor(x_args, x_addr, page_size);
+    const auto compact = TensorAccessor(compact_args, compact_addr, page_size);
+    const auto dst = TensorAccessor(dst_args, dst_addr, page_size);
+
+    constexpr uint32_t frame_stride = Hp * Wp;
+    constexpr uint32_t n_int = outer * Hd * Wd;
+    constexpr uint32_t h_sec = outer * pH * Wd;
+    constexpr uint32_t w_sec = outer * Hp * pW;
+    constexpr uint32_t bb1 = n_int + h_sec;
+    constexpr uint32_t bb2 = bb1 + h_sec;
+    constexpr uint32_t bb3 = bb2 + w_sec;
+
+    const uint32_t l1_base = get_write_ptr(cb_id);
+    const uint32_t end = stick_start + stick_count;
+
+    auto src_noc = [&](uint32_t gi) -> uint64_t {
+        if (gi < n_int) {
+            return get_noc_addr(gi, x_src);
+        } else if (gi < bb1) {
+            return get_noc_addr(gi - n_int, compact);
+        } else if (gi < bb2) {
+            return get_noc_addr(h_sec + (gi - bb1), compact);
+        } else if (gi < bb3) {
+            return get_noc_addr(2 * h_sec + (gi - bb2), compact);
+        } else {
+            return get_noc_addr(2 * h_sec + w_sec + (gi - bb3), compact);
+        }
+    };
+    auto dst_page = [&](uint32_t gi) -> uint32_t {
+        if (gi < n_int) {
+            const uint32_t t = gi / (Hd * Wd);
+            const uint32_t rem = gi - t * (Hd * Wd);
+            const uint32_t h = rem / Wd;
+            const uint32_t w = rem - h * Wd;
+            return t * frame_stride + (h + pH) * Wp + (pW + w);
+        } else if (gi < bb1) {
+            const uint32_t j = gi - n_int;
+            const uint32_t t = j / (pH * Wd);
+            const uint32_t rem = j - t * (pH * Wd);
+            const uint32_t pr = rem / Wd;
+            const uint32_t w = rem - pr * Wd;
+            return t * frame_stride + pr * Wp + (pW + w);
+        } else if (gi < bb2) {
+            const uint32_t j = gi - bb1;
+            const uint32_t t = j / (pH * Wd);
+            const uint32_t rem = j - t * (pH * Wd);
+            const uint32_t pr = rem / Wd;
+            const uint32_t w = rem - pr * Wd;
+            return t * frame_stride + (pH + Hd + pr) * Wp + (pW + w);
+        } else if (gi < bb3) {
+            const uint32_t j = gi - bb2;
+            const uint32_t t = j / (Hp * pW);
+            const uint32_t rem = j - t * (Hp * pW);
+            const uint32_t hp = rem / pW;
+            const uint32_t wc = rem - hp * pW;
+            return t * frame_stride + hp * Wp + wc;
+        } else {
+            const uint32_t j = gi - bb3;
+            const uint32_t t = j / (Hp * pW);
+            const uint32_t rem = j - t * (Hp * pW);
+            const uint32_t hp = rem / pW;
+            const uint32_t wc = rem - hp * pW;
+            return t * frame_stride + hp * Wp + (pW + Wd + wc);
+        }
+    };
+
+    // Border sticks (gi >= n_int) depend on the fabric exchange. Wait exactly once, before the first
+    // border stick this core touches; interior sticks (gi < n_int) run first with no wait (overlap).
+    volatile tt_l1_ptr uint32_t* exch = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(exchange_done_addr);
+    bool waited = false;
+    if (border_only) {
+        noc_semaphore_wait_min(exch, num_readers);
+        waited = true;
+    }
+
+    for (uint32_t gi = stick_start; gi < end; gi += batch) {
+        const uint32_t n = (end - gi < batch) ? (end - gi) : batch;
+        if (!waited && (gi + n) > n_int) {
+            noc_semaphore_wait_min(exch, num_readers);
+            waited = true;
+        }
+        for (uint32_t k = 0; k < n; k++) {
+            noc_async_read(src_noc(gi + k), l1_base + k * page_size, page_size);
+        }
+        noc_async_read_barrier();
+        for (uint32_t k = 0; k < n; k++) {
+            noc_async_write(l1_base + k * page_size, get_noc_addr(dst_page(gi + k), dst), page_size);
+        }
+        noc_async_write_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_fused_scatter_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_fused_scatter_writer.cpp
@@ -4,14 +4,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 
-// Fused scatter phase for neighbor_pad_halo padded-output mode. Runs on cores DISJOINT from the fabric
-// exchange (columns x>=1), concurrently with the exchange. Writes the padded output [outer, Hp, Wp, C]:
-//   INTERIOR (t,h,w) -> padded[t, h+pH, w+pW]   from interior_src (input); NO dependency on the exchange
-//     -> processed first, overlapping the fabric exchange.
-//   BORDER  -> from the compact halo buffer [H-top|H-bot|W-left|W-right]; depends on the exchange, so
-//     before its first border stick a core waits exchange_done >= num_readers (all fabric halo landed).
-// Same stick mapping as halo_scatter_writer (interior + 4 border sections, t-major). border_only: interior
-// already present in padded_output, work starts at the border (interior skipped, no overlap).
+// Fused scatter phase for neighbor_pad_halo padded-output mode
 void kernel_main() {
     const uint32_t x_addr = get_arg_val<uint32_t>(0);        // interior source (input)
     const uint32_t compact_addr = get_arg_val<uint32_t>(1);  // border source (compact halo buffer)
@@ -102,8 +95,7 @@ void kernel_main() {
         }
     };
 
-    // Border sticks (gi >= n_int) depend on the fabric exchange. Wait exactly once, before the first
-    // border stick this core touches; interior sticks (gi < n_int) run first with no wait (overlap).
+    // Border sticks (gi >= n_int) depend on the fabric exchange
     volatile tt_l1_ptr uint32_t* exch = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(exchange_done_addr);
     bool waited = false;
     if (border_only) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_h_mux_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_h_mux_writer.cpp
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fabric-MUX H writer for neighbor_pad_halo. Mirrors np_w_mux_writer for the H exchange: N workers per
+// (link,direction) feed the H-axis eth link through a mux core to reach link bandwidth, instead of the
+// single-worker H send. Uses the same stateful linear API + mux lifecycle as all_gather.
+//
+// H send pattern (vs W): the paired np_h_reader gathers a full H-halo row (num_sticks_to_read = W_dev
+// sticks) into send_cb in dst-bank-major order per row; this writer ships each bank's sticks as
+// W_COALESCE-sized 4KB packets, once per padding row, per frame this worker owns. Straight-to-DRAM
+// (use_l1=0); the neighbor's np_h_reader waits on h_neighbor_sem.
+
+#include "api/dataflow/dataflow_api.h"
+#include <tt-metalium/buffer_types.hpp>
+#include "tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp"
+#include "tt_metal/fabric/hw/inc/noc_addr.h"
+#include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+#include "tt_metal/fabric/hw/inc/linear/api.h"
+#include <cstdint>
+
+using address_t = uint32_t;
+using namespace tt::tt_fabric::linear::experimental;
+
+// ---- Compile-time args ----
+constexpr bool is_padding_zeros = get_compile_time_arg_val(0);
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(1);  // c_in0: reader's is_first local-pad output
+constexpr uint32_t send_cb_id = get_compile_time_arg_val(2);    // hsend: coalesced fabric-send ring
+constexpr uint32_t stick_size = get_compile_time_arg_val(3);
+constexpr auto dst_ct_args = TensorAccessorArgs<4>();
+constexpr uint32_t ct_after_dst = dst_ct_args.next_compile_time_args_offset();
+constexpr uint32_t H_COALESCE = get_compile_time_arg_val(ct_after_dst);
+constexpr uint32_t NP_NUM_DRAM_BANKS = 8;
+// Mux connection CT args (lockstep with FabricMuxConfig on the host).
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(ct_after_dst + 1);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(ct_after_dst + 2);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(ct_after_dst + 3);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(ct_after_dst + 4);
+constexpr uint32_t num_mux_clients = get_compile_time_arg_val(ct_after_dst + 5);
+
+void kernel_main() {
+    // ---- Common runtime args ---- (index 2 = h_neighbor_sem, index 3 = barrier_sem; matches np_writer CRTA)
+    const address_t output_tensor_address = get_common_arg_val<address_t>(1);
+    const size_t neighbor_sem = get_common_arg_val<uint32_t>(2);
+    const size_t barrier_sem = get_common_arg_val<uint32_t>(3);
+
+    // ---- Per-core runtime args ----
+    uint32_t arg_idx = 0;
+    // Compact-buffer H-section base for this worker's first frame (h_top or h_bot section base +
+    // outer_dim_start*padding*num_sticks_per_halo_dim). The compact buffer stores H-top and H-bot as
+    // SEPARATE sections (stride padding, not output_halo_dim_size) — see np_writer's fabric_only override.
+    const uint32_t h_base = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t outer_dim_count = get_arg_val<uint32_t>(arg_idx++);   // frames this worker owns
+    const uint32_t padding = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_sticks_to_read = get_arg_val<uint32_t>(arg_idx++);       // W_dev
+    const uint32_t num_sticks_per_halo_dim = get_arg_val<uint32_t>(arg_idx++);  // W_dev (row stride)
+    const uint8_t neighbor_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t neighbor_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_first_chip = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_last_chip = get_arg_val<uint32_t>(arg_idx++);
+    const bool direction = get_arg_val<uint32_t>(arg_idx++);
+    auto unicast_route_info = ccl_routing_utils::line_unicast_route_info_t{
+        .dst_mesh_id = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++)),
+        .dst_chip_id = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++))};
+
+    // Mux connection RT args — EXACT layout of ccl::fabric_mux_connection_rt_args (positions 0..16).
+    const bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const bool is_termination_master = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const uint8_t fabric_mux_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t fabric_mux_y = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_channel_base_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_connection_info_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_connection_handshake_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t local_buffer_index_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint8_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
+
+    // The H->W barrier is signaled by np_h_reader after its recv drains (recv-authority), not here — the
+    // W corner reads need this device's incoming H to have LANDED, which the writer's send-done can't
+    // guarantee for >2 H-axes or small shapes. Only the startup-barrier opp coords are read here.
+    // Opposite-direction H-worker coords on the neighbor device, for the pairwise startup barrier (so the
+    // non-sending edge worker on the neighbor also gets incremented). NOC coords are device-independent.
+    const uint8_t opp_bar_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t opp_bar_y = get_arg_val<uint32_t>(arg_idx++);
+
+    const auto dst_accessor = TensorAccessor(dst_ct_args, output_tensor_address, stick_size);
+    // is_first_chip/is_last_chip are direction-adjusted by the factory (match np_h_reader + np_writer):
+    // a worker sends iff !is_last_chip; it fills its own outward padding locally iff is_first_chip.
+    const bool has_neighbor = !is_last_chip;
+
+    tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel> mux_connection;
+    if (mux_connection_valid) {
+        mux_connection = tt::tt_fabric::build_connection_to_fabric_endpoint<fabric_mux_num_buffers_per_channel>(
+            fabric_mux_x, fabric_mux_y, fabric_mux_channel_id, fabric_mux_num_buffers_per_channel,
+            fabric_mux_channel_buffer_size_bytes, fabric_mux_channel_base_address,
+            fabric_mux_connection_info_address, fabric_mux_connection_handshake_address,
+            fabric_mux_flow_control_address, fabric_mux_buffer_index_address, local_flow_control_address,
+            local_teardown_address, local_buffer_index_address);
+        tt::tt_fabric::wait_for_fabric_endpoint_ready(
+            fabric_mux_x, fabric_mux_y, fabric_mux_status_address, local_fabric_mux_status_address);
+        tt::tt_fabric::fabric_client_connect(mux_connection);
+    }
+
+    const uint8_t num_hops = static_cast<uint8_t>(unicast_route_info.dst_chip_id);
+    auto pkt_hdr = PacketHeaderPool::allocate_header();
+    fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::PayloadSize>(
+        pkt_hdr, num_hops, nullptr, static_cast<uint16_t>(H_COALESCE * stick_size));
+    auto pkt_hdr_sem = PacketHeaderPool::allocate_header();
+    fabric_unicast_noc_unicast_atomic_inc_set_state<
+        UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
+        pkt_hdr_sem, num_hops, tt::tt_fabric::NocUnicastAtomicIncCommandHeader{0, outer_dim_count});
+
+    // No startup barrier: it was a cross-device start-of-op sync needed when the writer signaled the H->W
+    // barrier on H-SEND (to make send~=recv). np_h_reader now signals that barrier AFTER its recv drains,
+    // so W corners already wait for real H-recv and the startup barrier is redundant.
+    (void)opp_bar_x;
+    (void)opp_bar_y;
+
+    // Compact H-section layout: rows are [frame][pad_id][W], stride padding rows per frame. h_base already
+    // includes this worker's outer_dim_start offset + the h_top/h_bot section base. Per frame the reader
+    // produces (in order): the is_first local-pad row into c_in0 (edge devices only), then the coalesced
+    // send rows into hsend. Drain in the same order.
+    for (uint32_t od = 0; od < outer_dim_count; od++) {
+        if (is_first_chip) {
+            // Local outward padding for this device's edge H-halo (no fabric): write c_in0 to the compact
+            // H-section. Replicate: reader pushed one stick per W col -> broadcast each to all padding rows.
+            // Zeros: reader pushed one stick -> broadcast to all padding rows x W cols.
+            const uint32_t frame_base = h_base + od * padding * num_sticks_per_halo_dim;
+            if (!is_padding_zeros) {
+                for (uint32_t col = 0; col < num_sticks_to_read; col++) {
+                    cb_wait_front(cb_output_id, 1);
+                    const uint32_t l1 = get_read_ptr(cb_output_id);
+                    for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
+                        noc_async_write(
+                            l1, get_noc_addr(frame_base + pad_id * num_sticks_per_halo_dim + col, dst_accessor),
+                            stick_size);
+                    }
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_output_id, 1);
+                }
+            } else {
+                cb_wait_front(cb_output_id, 1);
+                const uint32_t l1 = get_read_ptr(cb_output_id);
+                for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
+                    for (uint32_t col = 0; col < num_sticks_to_read; col++) {
+                        noc_async_write(
+                            l1, get_noc_addr(frame_base + pad_id * num_sticks_per_halo_dim + col, dst_accessor),
+                            stick_size);
+                    }
+                }
+                noc_async_write_barrier();
+                cb_pop_front(cb_output_id, 1);
+            }
+        }
+        if (has_neighbor && mux_connection_valid) {
+            for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
+                const uint32_t base_row = h_base + (od * padding + pad_id) * num_sticks_per_halo_dim;
+                cb_wait_front(send_cb_id, num_sticks_to_read);
+                const uint32_t row_l1 = get_read_ptr(send_cb_id);
+                uint32_t m = 0;
+                for (uint32_t j = 0; j < NP_NUM_DRAM_BANKS; j++) {
+                    for (uint32_t w = j; w < num_sticks_to_read;) {
+                        uint32_t g = 0;
+                        for (uint32_t ww = w; g < H_COALESCE && ww < num_sticks_to_read; ww += NP_NUM_DRAM_BANKS) {
+                            g++;
+                        }
+                        fabric_unicast_noc_unicast_write_with_state<
+                            UnicastWriteUpdateMask::DstAddr | UnicastWriteUpdateMask::PayloadSize>(
+                            &mux_connection,
+                            pkt_hdr,
+                            row_l1 + m * stick_size,
+                            tt::tt_fabric::NocUnicastCommandHeader{get_noc_addr(base_row + w, dst_accessor)},
+                            static_cast<uint16_t>(g * stick_size));
+                        // The payload copy (send_cb -> mux slot) is non-blocking and pkt_hdr is reused for
+                        // the next packet; flush per packet so neither the source row nor the header is
+                        // touched while the mux is still reading it (a dropped-packet race, worse at large
+                        // page where the copy takes longer). Measured free: the writes have drained by the
+                        // next loop iteration, so the poll returns immediately.
+                        noc_async_writes_flushed();
+                        m += g;
+                        w += g * NP_NUM_DRAM_BANKS;
+                    }
+                }
+                cb_pop_front(send_cb_id, num_sticks_to_read);
+            }
+        }
+    }
+    if (has_neighbor && mux_connection_valid) {
+        // Single deferred recv-sem inc of the full frame count (set_state configured Val=outer_dim_count).
+        uint64_t nb_recv = safe_get_noc_addr(neighbor_sem_noc0_x, neighbor_sem_noc0_y, neighbor_sem, 0);
+        fabric_unicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+            &mux_connection, pkt_hdr_sem, tt::tt_fabric::NocUnicastAtomicIncCommandHeader{nb_recv, 0});
+    }
+
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
+
+    // H->W barrier is signaled by np_h_reader after recv (see its H_SIGNAL_W_RECV block), not here.
+
+    if (mux_connection_valid) {
+        tt::tt_fabric::fabric_client_disconnect(mux_connection);
+        if (is_termination_master) {
+            auto* term_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
+            noc_semaphore_wait(term_ptr, num_mux_clients - 1);
+            tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
+        } else {
+            uint64_t dest =
+                safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
+            noc_semaphore_inc(dest, 1);
+            noc_async_atomic_barrier();
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_h_mux_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_h_mux_writer.cpp
@@ -47,9 +47,7 @@ void kernel_main() {
 
     // ---- Per-core runtime args ----
     uint32_t arg_idx = 0;
-    // Compact-buffer H-section base for this worker's first frame (h_top or h_bot section base +
-    // outer_dim_start*padding*num_sticks_per_halo_dim). The compact buffer stores H-top and H-bot as
-    // SEPARATE sections (stride padding, not output_halo_dim_size) — see np_writer's fabric_only override.
+    // Compact-buffer H-section base for this worker's first frame
     const uint32_t h_base = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t outer_dim_count = get_arg_val<uint32_t>(arg_idx++);   // frames this worker owns
     const uint32_t padding = get_arg_val<uint32_t>(arg_idx++);
@@ -83,17 +81,12 @@ void kernel_main() {
     const uint8_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
 
-    // The H->W barrier is signaled by np_h_reader after its recv drains (recv-authority), not here — the
-    // W corner reads need this device's incoming H to have LANDED, which the writer's send-done can't
-    // guarantee for >2 H-axes or small shapes. Only the startup-barrier opp coords are read here.
-    // Opposite-direction H-worker coords on the neighbor device, for the pairwise startup barrier (so the
-    // non-sending edge worker on the neighbor also gets incremented). NOC coords are device-independent.
+    // The H->W barrier is signaled by np_h_reader after its recv drains (recv-authority), not here
     const uint8_t opp_bar_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t opp_bar_y = get_arg_val<uint32_t>(arg_idx++);
 
     const auto dst_accessor = TensorAccessor(dst_ct_args, output_tensor_address, stick_size);
-    // is_first_chip/is_last_chip are direction-adjusted by the factory (match np_h_reader + np_writer):
-    // a worker sends iff !is_last_chip; it fills its own outward padding locally iff is_first_chip.
+    // is_first_chip/is_last_chip are direction-adjusted by the factory
     const bool has_neighbor = !is_last_chip;
 
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel> mux_connection;
@@ -118,21 +111,14 @@ void kernel_main() {
         UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
         pkt_hdr_sem, num_hops, tt::tt_fabric::NocUnicastAtomicIncCommandHeader{0, outer_dim_count});
 
-    // No startup barrier: it was a cross-device start-of-op sync needed when the writer signaled the H->W
-    // barrier on H-SEND (to make send~=recv). np_h_reader now signals that barrier AFTER its recv drains,
-    // so W corners already wait for real H-recv and the startup barrier is redundant.
+    // No startup barrier: it was a cross-device start-of-op sync needed when the writer signaled the H->W barrier
     (void)opp_bar_x;
     (void)opp_bar_y;
 
-    // Compact H-section layout: rows are [frame][pad_id][W], stride padding rows per frame. h_base already
-    // includes this worker's outer_dim_start offset + the h_top/h_bot section base. Per frame the reader
-    // produces (in order): the is_first local-pad row into c_in0 (edge devices only), then the coalesced
-    // send rows into hsend. Drain in the same order.
+    // Compact H-section layout: rows are [frame][pad_id][W], stride padding rows per frame
     for (uint32_t od = 0; od < outer_dim_count; od++) {
         if (is_first_chip) {
-            // Local outward padding for this device's edge H-halo (no fabric): write c_in0 to the compact
-            // H-section. Replicate: reader pushed one stick per W col -> broadcast each to all padding rows.
-            // Zeros: reader pushed one stick -> broadcast to all padding rows x W cols.
+            // Local outward padding for this device's edge H-halo (no fabric): write c_in0 to the compact H-section
             const uint32_t frame_base = h_base + od * padding * num_sticks_per_halo_dim;
             if (!is_padding_zeros) {
                 for (uint32_t col = 0; col < num_sticks_to_read; col++) {
@@ -179,11 +165,7 @@ void kernel_main() {
                             row_l1 + m * stick_size,
                             tt::tt_fabric::NocUnicastCommandHeader{get_noc_addr(base_row + w, dst_accessor)},
                             static_cast<uint16_t>(g * stick_size));
-                        // The payload copy (send_cb -> mux slot) is non-blocking and pkt_hdr is reused for
-                        // the next packet; flush per packet so neither the source row nor the header is
-                        // touched while the mux is still reading it (a dropped-packet race, worse at large
-                        // page where the copy takes longer). Measured free: the writes have drained by the
-                        // next loop iteration, so the poll returns immediately.
+                        // The payload copy (send_cb -> mux slot) is non-blocking and pkt_hdr is reused for the next
                         noc_async_writes_flushed();
                         m += g;
                         w += g * NP_NUM_DRAM_BANKS;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_h_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_h_reader.cpp
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt_metal/fabric/hw/inc/noc_addr.h"
+#include "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_common/kernels/np_zero_pad.hpp"
+#include <cstdint>
+
+using address_t = uint32_t;
+
+// Compile-time args (uniform across all H fabric reader cores)
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(0);
+constexpr bool is_padding_zeros = get_compile_time_arg_val(1);
+constexpr uint32_t stick_size = get_compile_time_arg_val(2);
+// Input TensorAccessorArgs at index 3 (variable length)
+constexpr auto src_ct_args = TensorAccessorArgs<3>();
+constexpr uint32_t ct_after_src = src_ct_args.next_compile_time_args_offset();
+// L1 intermediate config
+constexpr bool use_l1_intermediate = get_compile_time_arg_val(ct_after_src);
+constexpr uint32_t recv_cb_id = get_compile_time_arg_val(ct_after_src + 1);
+// Dedicated send CB for the batched H-halo send (separate ring from cb_output_id so the
+// per-stick recv/is_first pushes don't desync the row reserves).
+constexpr uint32_t send_cb_id = get_compile_time_arg_val(ct_after_src + 2);
+// H-send bank-major coalesce factor (0 = row-contiguous). When > 0, gather the H-halo row into send_cb
+// in dst-bank-major order (w=0,8,..; 1,9,..) so the writer ships same-bank sticks as one 4KB packet.
+constexpr uint32_t H_COALESCE = get_compile_time_arg_val(ct_after_src + 3);
+// When set (H-mux path), this reader owns the H->W barrier: it signals the W-reader cores only AFTER its
+// incoming H has landed, so the W corner reads (which read this device's H-section) can't race the H
+// exchange. On the direct path (0) np_writer signals the barrier instead.
+constexpr uint32_t H_SIGNAL_W_RECV = get_compile_time_arg_val(ct_after_src + 4);
+constexpr uint32_t NP_NUM_DRAM_BANKS = 8;
+constexpr uint32_t MAX_W_BAR_TARGETS = 16;
+
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+    // Common runtime args (uniform across all cores, updated between dispatches). Index 1 (output addr)
+    // is part of the shared CRTA layout but unused by this reader.
+    const address_t input_tensor_address = get_common_arg_val<address_t>(0);
+    const size_t h_neighbor_sem = get_common_arg_val<uint32_t>(2);
+
+    // Per-core runtime args
+    uint32_t arg_idx = 0;
+    const uint32_t outer_dim_offset_start_id = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t stick_start_id = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t input_halo_dim_size = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t outer_dim_size = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t padding = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_sticks_to_read = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_sticks_per_halo_dim = get_arg_val<uint32_t>(arg_idx++);
+    // Number of corner sticks per pad row in L1 recv buffer (= pad2_left + pad2_right for 2D corners-only)
+    const uint32_t num_l1_recv_sticks_per_row = get_arg_val<uint32_t>(arg_idx++);
+    // Rows per input frame for the per-frame stride (num_sticks_per_halo_dim * input_frame_rows). Equals
+    // input_halo_dim_size for a contiguous input; equals the PADDED H for a padded-input (strided) read,
+    // so the frame advance skips the padded border rows while the edge formula still uses the interior H.
+    const uint32_t input_frame_rows = get_arg_val<uint32_t>(arg_idx++);
+    // Per-core direction args (moved from compile-time for kernel consolidation)
+    const bool is_first_chip = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_last_chip = get_arg_val<uint32_t>(arg_idx++);
+    const bool direction = get_arg_val<uint32_t>(arg_idx++);
+    // H->W barrier targets (H-mux path only): W-reader cores this reader signals once its recv is done.
+    uint32_t num_w_bar = 0;
+    uint8_t w_bar_x[MAX_W_BAR_TARGETS];
+    uint8_t w_bar_y[MAX_W_BAR_TARGETS];
+    if constexpr (H_SIGNAL_W_RECV) {
+        num_w_bar = get_arg_val<uint32_t>(arg_idx++);
+        for (uint32_t t = 0; t < MAX_W_BAR_TARGETS; t++) {
+            w_bar_x[t] = get_arg_val<uint32_t>(arg_idx++);
+            w_bar_y[t] = get_arg_val<uint32_t>(arg_idx++);
+        }
+    }
+
+    uint32_t read_size = stick_size;
+    const auto src_accessor = TensorAccessor(src_ct_args, input_tensor_address);
+
+    uint32_t outer_dim_offset = outer_dim_offset_start_id;
+    uint32_t recv_buf_addr = 0;
+    uint32_t buf_offset = 0;  // recv: accumulates across all outer_dims (no L1 reuse)
+    if constexpr (use_l1_intermediate) {
+        if (!is_first_chip) {
+            recv_buf_addr = get_write_ptr(recv_cb_id);
+        }
+    }
+    for (uint32_t outer_dim = 0; outer_dim < outer_dim_size; outer_dim++) {
+        if (is_first_chip) {
+            if (!is_padding_zeros) {
+                // Replicate a slice of 1 from input to output
+                uint32_t src_stick_id = 0;
+                if (direction) {
+                    src_stick_id = num_sticks_per_halo_dim * (input_halo_dim_size - 1) + stick_start_id;
+                } else {
+                    src_stick_id = stick_start_id;
+                }
+                src_stick_id += outer_dim_offset;
+                for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
+                    cb_reserve_back(cb_output_id, 1);
+                    uint32_t src_buffer_l1_addr = get_write_ptr(cb_output_id);
+
+                    uint64_t src_noc_addr = get_noc_addr(src_stick_id, src_accessor);
+                    noc_async_read(src_noc_addr, src_buffer_l1_addr, read_size);
+
+                    src_stick_id++;
+
+                    noc_async_read_barrier();
+                    cb_push_back(cb_output_id, 1);
+                }
+            } else {
+                cb_reserve_back(cb_output_id, 1);
+                zeroPadCb<stick_size>(cb_output_id);
+                noc_async_read_barrier();
+                cb_push_back(cb_output_id, 1);
+            }
+        }
+
+        if (!is_last_chip) {
+            // Read the "end" of each slice into the dedicated send CB. Batch the whole row: one
+            // cb_reserve + one barrier for all num_sticks_to_read sticks instead of per stick. The
+            // per-stick path issued ~18k read+barrier pairs and was latency-bound; coalescing the
+            // row makes it bandwidth-bound. send_cb_id holds exactly 2 rows so a row reserve never
+            // wraps mid-batch, and the paired writer drains it one stick at a time.
+            for (uint32_t pad_id = padding; pad_id > 0; pad_id--) {
+                uint32_t src_stick_id = 0;
+                if (direction) {
+                    src_stick_id = (padding - pad_id) * num_sticks_per_halo_dim + stick_start_id;
+                } else {
+                    src_stick_id = (input_halo_dim_size - pad_id) * num_sticks_per_halo_dim + stick_start_id;
+                }
+                src_stick_id += outer_dim_offset;
+                cb_reserve_back(send_cb_id, num_sticks_to_read);
+                uint32_t row_base_l1_addr = get_write_ptr(send_cb_id);
+                if constexpr (H_COALESCE > 0) {
+                    // Bank-major gather: send_cb[m] = column w in dst-bank order (0,8,..; 1,9,..) so the
+                    // writer coalesces same-bank sticks. src is scattered; the batch shares one barrier.
+                    uint32_t m = 0;
+                    for (uint32_t j = 0; j < NP_NUM_DRAM_BANKS; j++) {
+                        for (uint32_t w = j; w < num_sticks_to_read; w += NP_NUM_DRAM_BANKS) {
+                            noc_async_read(
+                                get_noc_addr(src_stick_id + w, src_accessor),
+                                row_base_l1_addr + m * stick_size,
+                                read_size);
+                            m++;
+                        }
+                    }
+                } else {
+                    for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
+                        uint64_t src_noc_addr = get_noc_addr(src_stick_id + iter, src_accessor);
+                        noc_async_read(src_noc_addr, row_base_l1_addr + iter * stick_size, read_size);
+                    }
+                }
+                noc_async_read_barrier();
+                cb_push_back(send_cb_id, num_sticks_to_read);
+            }
+        }
+
+        // No local interior copy in this kernel. Dedicated local-copy kernels handle that work.
+
+        outer_dim_offset += (num_sticks_per_halo_dim * input_frame_rows);
+
+        // Per-batch H-commit: pull this od's incoming H-halo from the L1 recv buffer into the CB as
+        // soon as its sender link delivers it (per-core cumulative count, 1 inc/outer_dim), so the
+        // paired writer commits + signals HT/HB this batch rather than after the whole send pass.
+        if constexpr (use_l1_intermediate) {
+            if (!is_first_chip) {
+                noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), outer_dim + 1);
+                for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
+                    // num_l1_recv_sticks_per_row (corners-only) not num_sticks_to_read (full row).
+                    for (uint32_t iter = 0; iter < num_l1_recv_sticks_per_row; iter++) {
+                        cb_reserve_back(cb_output_id, 1);
+                        uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
+                        noc_async_read(get_noc_addr(recv_buf_addr + buf_offset), dst_l1_addr, stick_size);
+                        noc_async_read_barrier();
+                        cb_push_back(cb_output_id, 1);
+                        buf_offset += stick_size;
+                    }
+                }
+            }
+        }
+    }
+
+    // Drain the per-core fabric-arrival sem. 2D recvs were interleaved above; 1D wrote straight to
+    // DRAM so just wait for all outer_dims here, then reset.
+    if (!is_first_chip) {
+        if constexpr (use_l1_intermediate) {
+            noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), 0);
+        } else {
+            noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), outer_dim_size);
+            noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), 0);
+        }
+    }
+
+    // H-mux path: the incoming H has now landed (recv drained above). Signal the H->W barrier on each
+    // W-reader core so the W corner reads (which read this device's H-section) see complete H data. Done
+    // here (recv-authority) not in the writer (send-done) so it holds for >2 H-axes and small shapes.
+    if constexpr (H_SIGNAL_W_RECV) {
+        const uint32_t barrier_sem = get_common_arg_val<uint32_t>(3);
+        for (uint32_t t = 0; t < num_w_bar; t++) {
+            noc_semaphore_inc(safe_get_noc_addr(w_bar_x[t], w_bar_y[t], barrier_sem, 0), 1);
+        }
+        noc_async_atomic_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_h_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_h_reader.cpp
@@ -19,25 +19,17 @@ constexpr uint32_t ct_after_src = src_ct_args.next_compile_time_args_offset();
 // L1 intermediate config
 constexpr bool use_l1_intermediate = get_compile_time_arg_val(ct_after_src);
 constexpr uint32_t recv_cb_id = get_compile_time_arg_val(ct_after_src + 1);
-// Dedicated send CB for the batched H-halo send (separate ring from cb_output_id so the
-// per-stick recv/is_first pushes don't desync the row reserves).
+// Dedicated send CB for the batched H-halo send
 constexpr uint32_t send_cb_id = get_compile_time_arg_val(ct_after_src + 2);
-// H-send bank-major coalesce factor (0 = row-contiguous). When > 0, gather the H-halo row into send_cb
-// in dst-bank-major order (w=0,8,..; 1,9,..) so the writer ships same-bank sticks as one 4KB packet.
+// H-send bank-major coalesce factor (0 = row-contiguous)
 constexpr uint32_t H_COALESCE = get_compile_time_arg_val(ct_after_src + 3);
-// When set (H-mux path), this reader owns the H->W barrier: it signals the W-reader cores only AFTER its
-// incoming H has landed, so the W corner reads (which read this device's H-section) can't race the H
-// exchange. On the direct path (0) np_writer signals the barrier instead.
+// When set (H-mux path), this reader owns the H->W barrier: it signals the W-reader cores only AFTER its incoming H
 constexpr uint32_t H_SIGNAL_W_RECV = get_compile_time_arg_val(ct_after_src + 4);
 constexpr uint32_t NP_NUM_DRAM_BANKS = 8;
 constexpr uint32_t MAX_W_BAR_TARGETS = 16;
 
 void kernel_main() {
-    ///////////////////////////////////////////////////
-    // ARGS
-    ///////////////////////////////////////////////////
-    // Common runtime args (uniform across all cores, updated between dispatches). Index 1 (output addr)
-    // is part of the shared CRTA layout but unused by this reader.
+    // ///////////////////////////////////////////////// ARGS /////////////////////////////////////////////////
     const address_t input_tensor_address = get_common_arg_val<address_t>(0);
     const size_t h_neighbor_sem = get_common_arg_val<uint32_t>(2);
 
@@ -52,9 +44,7 @@ void kernel_main() {
     const uint32_t num_sticks_per_halo_dim = get_arg_val<uint32_t>(arg_idx++);
     // Number of corner sticks per pad row in L1 recv buffer (= pad2_left + pad2_right for 2D corners-only)
     const uint32_t num_l1_recv_sticks_per_row = get_arg_val<uint32_t>(arg_idx++);
-    // Rows per input frame for the per-frame stride (num_sticks_per_halo_dim * input_frame_rows). Equals
-    // input_halo_dim_size for a contiguous input; equals the PADDED H for a padded-input (strided) read,
-    // so the frame advance skips the padded border rows while the edge formula still uses the interior H.
+    // Rows per input frame for the per-frame stride (num_sticks_per_halo_dim * input_frame_rows)
     const uint32_t input_frame_rows = get_arg_val<uint32_t>(arg_idx++);
     // Per-core direction args (moved from compile-time for kernel consolidation)
     const bool is_first_chip = get_arg_val<uint32_t>(arg_idx++);
@@ -115,11 +105,7 @@ void kernel_main() {
         }
 
         if (!is_last_chip) {
-            // Read the "end" of each slice into the dedicated send CB. Batch the whole row: one
-            // cb_reserve + one barrier for all num_sticks_to_read sticks instead of per stick. The
-            // per-stick path issued ~18k read+barrier pairs and was latency-bound; coalescing the
-            // row makes it bandwidth-bound. send_cb_id holds exactly 2 rows so a row reserve never
-            // wraps mid-batch, and the paired writer drains it one stick at a time.
+            // Read the "end" of each slice into the dedicated send CB
             for (uint32_t pad_id = padding; pad_id > 0; pad_id--) {
                 uint32_t src_stick_id = 0;
                 if (direction) {
@@ -131,8 +117,7 @@ void kernel_main() {
                 cb_reserve_back(send_cb_id, num_sticks_to_read);
                 uint32_t row_base_l1_addr = get_write_ptr(send_cb_id);
                 if constexpr (H_COALESCE > 0) {
-                    // Bank-major gather: send_cb[m] = column w in dst-bank order (0,8,..; 1,9,..) so the
-                    // writer coalesces same-bank sticks. src is scattered; the batch shares one barrier.
+                    // Bank-major gather: send_cb[m] = column w in dst-bank order
                     uint32_t m = 0;
                     for (uint32_t j = 0; j < NP_NUM_DRAM_BANKS; j++) {
                         for (uint32_t w = j; w < num_sticks_to_read; w += NP_NUM_DRAM_BANKS) {
@@ -158,9 +143,7 @@ void kernel_main() {
 
         outer_dim_offset += (num_sticks_per_halo_dim * input_frame_rows);
 
-        // Per-batch H-commit: pull this od's incoming H-halo from the L1 recv buffer into the CB as
-        // soon as its sender link delivers it (per-core cumulative count, 1 inc/outer_dim), so the
-        // paired writer commits + signals HT/HB this batch rather than after the whole send pass.
+        // Per-batch H-commit: pull this od's incoming H-halo from the L1 recv buffer into the CB as soon
         if constexpr (use_l1_intermediate) {
             if (!is_first_chip) {
                 noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), outer_dim + 1);
@@ -179,8 +162,7 @@ void kernel_main() {
         }
     }
 
-    // Drain the per-core fabric-arrival sem. 2D recvs were interleaved above; 1D wrote straight to
-    // DRAM so just wait for all outer_dims here, then reset.
+    // Drain the per-core fabric-arrival sem
     if (!is_first_chip) {
         if constexpr (use_l1_intermediate) {
             noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), 0);
@@ -190,9 +172,7 @@ void kernel_main() {
         }
     }
 
-    // H-mux path: the incoming H has now landed (recv drained above). Signal the H->W barrier on each
-    // W-reader core so the W corner reads (which read this device's H-section) see complete H data. Done
-    // here (recv-authority) not in the writer (send-done) so it holds for >2 H-axes and small shapes.
+    // H-mux path: the incoming H has now landed (recv drained above)
     if constexpr (H_SIGNAL_W_RECV) {
         const uint32_t barrier_sem = get_common_arg_val<uint32_t>(3);
         for (uint32_t t = 0; t < num_w_bar; t++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_phase2_w_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_phase2_w_reader.cpp
@@ -1,0 +1,393 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Phase 2 W fabric reader for the fused neighbor_pad + conv3d op.
+//
+// Reads W-boundary sticks from the input tensor (interior rows) and the compact halo
+// buffer (H-padded rows) into a CB that the paired writer ships over the W fabric.
+// Per-T-batch, the receiver-side reader increments a progress semaphore on every
+// conv3d reader core so conv3d compute can start processing early T-blocks while
+// later ones are still in flight.
+
+#include "api/dataflow/dataflow_api.h"
+#include <tt-metalium/buffer_types.hpp>
+#include "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_common/kernels/np_reorder.hpp"
+#include "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_common/kernels/np_zero_pad.hpp"
+#include <cstdint>
+
+using address_t = uint32_t;
+
+// Compile-time args (uniform across all W fabric reader cores)
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(0);
+constexpr bool is_padding_zeros = get_compile_time_arg_val(1);
+constexpr uint32_t stick_size = get_compile_time_arg_val(2);
+// Halo buffer TensorAccessorArgs start at index 3 (variable length)
+constexpr auto dst_args = TensorAccessorArgs<3>();
+constexpr uint32_t ct_after_dst = dst_args.next_compile_time_args_offset();
+// Input tensor TensorAccessorArgs follow the halo buffer args
+constexpr auto src_args = TensorAccessorArgs<ct_after_dst>();
+constexpr uint32_t ct_after_src = src_args.next_compile_time_args_offset();
+// Granularity (in T-input frames) for per-batch progress-sem signals. Must match the
+// conv3d reader's progress_t_batch_size compile-time arg.
+constexpr uint32_t progress_t_batch_size = get_compile_time_arg_val(ct_after_src);
+
+// Global two-pass gate, set per-shape by the program factory (lockstep with np_writer via the same
+// factory value). ON: defer all corners past H's finish (NP-bound win, regresses conv-bound).
+// Follows progress_t_batch_size (ct_after_src) in the W-reader arg layout.
+constexpr bool W_TWO_PASS = get_compile_time_arg_val(ct_after_src + 1);
+
+// W-send bank-major coalesce factor (0 = per-stick). When > 0 (halo-only, pw==1, 8-aligned bases), a
+// middle device gathers same-dst-bank sticks (rel, rel+8, ...) into the CB so the writer ships N of them
+// as one N*page fabric packet. BH has 8 interleaved DRAM banks.
+constexpr uint32_t W_COALESCE = get_compile_time_arg_val(ct_after_src + 2);
+// Uniform-mux mode: all W devices (incl. edges) use the coalesce path so the recv-sem targeting is
+// consistent across the whole W chain. Edge devices skip the send-gather for their no-neighbor direction.
+constexpr uint32_t W_MUX_MODE = get_compile_time_arg_val(ct_after_src + 3);
+constexpr uint32_t NP_NUM_DRAM_BANKS = 8;
+
+void kernel_main() {
+    // Common runtime args (uniform across all cores, updated between dispatches)
+    const address_t output_tensor_address = get_common_arg_val<address_t>(0);
+    const uint32_t barrier_sem_addr = get_common_arg_val<uint32_t>(1);
+    const uint32_t w_neighbor_sem_addr = get_common_arg_val<uint32_t>(2);
+    // [3] num_reader_cores: number of conv3d reader cores to signal.
+    // [4+]: NOC coords of conv3d reader cores.
+    const uint32_t num_reader_cores = get_common_arg_val<uint32_t>(3);
+
+    // Per-core runtime args
+    uint32_t arg_idx = 0;
+    const uint32_t outer_dim_size = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t outer_dim_start = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t padding = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t barrier_count = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t output_row_width = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t pad2_left = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_interior_sticks = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_first_chip = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_last_chip = get_arg_val<uint32_t>(arg_idx++);
+    const bool direction = get_arg_val<uint32_t>(arg_idx++);
+    const address_t input_tensor_address = get_arg_val<address_t>(arg_idx++);
+    const uint32_t input_H_dev = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t padding_h = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t h_halo_hbot_base = get_arg_val<uint32_t>(arg_idx++);
+    // Padded-input mode (0 = contiguous). When >0 the input is [.,H+2*input_pad_h,W+2*input_pad_w,C] and
+    // the W-edge input reads target its INTERIOR (row stride = padded W, frame stride = padded H*W).
+    const uint32_t input_pad_h = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t input_pad_w = get_arg_val<uint32_t>(arg_idx++);
+    // Input page for interior (t, h_in, w_col); honors padded-input strides (identity when pad==0).
+    const uint32_t in_Wp = num_interior_sticks + 2 * input_pad_w;
+    auto in_page = [&](uint32_t t, uint32_t h_in, uint32_t w_col) -> uint32_t {
+        return t * (input_H_dev + 2 * input_pad_h) * in_Wp + (h_in + input_pad_h) * in_Wp + (w_col + input_pad_w);
+    };
+    // Per-batch region progress sem for this (W-direction, link). W-edge/corner conv3d tiles wait on
+    // just this link's count, race-free across links (one producer per (region,link) -> monotonic).
+    const uint32_t w_region_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t h_total = input_H_dev + 2 * padding_h;
+
+    // Per-batch corner H-gate: each corner W-stick read waits only the H-batch it needs (no upfront
+    // H->W barrier). H-region sems for all H-links live in CRTA after the reader coords: HT[0..3],
+    // HB[0..3], h_batches_per_link, num_h_links, h_total_batches.
+    uint32_t htop_sem[4] = {0, 0, 0, 0};
+    uint32_t hbot_sem[4] = {0, 0, 0, 0};
+    uint32_t h_batches_per_link = 0, num_h_links = 0, h_total_batches = 0;
+    if constexpr (progress_t_batch_size > 0) {
+        const uint32_t h_base = 4 + 2 * num_reader_cores;
+        for (uint32_t l = 0; l < 4; l++) {
+            htop_sem[l] = get_common_arg_val<uint32_t>(h_base + l);
+            hbot_sem[l] = get_common_arg_val<uint32_t>(h_base + 4 + l);
+        }
+        h_batches_per_link = get_common_arg_val<uint32_t>(h_base + 8);
+        num_h_links = get_common_arg_val<uint32_t>(h_base + 9);
+        h_total_batches = get_common_arg_val<uint32_t>(h_base + 10);
+    }
+
+    const auto input_accessor = TensorAccessor(src_args, input_tensor_address, stick_size);
+    const auto dst_accessor = TensorAccessor(dst_args, output_tensor_address, stick_size);
+
+    // output_row_width and pad2_left are unused in the fabric-only path; keep the RTA layout stable
+    // so the factory can share code with the standalone NP op.
+    (void)output_row_width;
+    (void)pad2_left;
+
+    if constexpr (progress_t_batch_size > 0) {
+        (void)barrier_sem_addr;
+        (void)barrier_count;
+    }
+
+    volatile tt_l1_ptr uint32_t* w_neighbor_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(w_neighbor_sem_addr);
+
+    // outer_dim runs over T_in * h_total; one progress-sem batch = progress_t_batch_size * h_total sticks.
+    const uint32_t sticks_per_batch = progress_t_batch_size * h_total;
+    // Frames in this core's slice (link-local; the partial last batch lives here when T % N != 0).
+    const uint32_t slice_frames = (h_total > 0) ? (outer_dim_size / h_total) : 0;
+    // Interior-first layout: rows [0, interior_rows) are H-independent (read from INPUT), then corner
+    // rows [interior_rows, ...) (read from the halo H-section). Signal / barrier at the transition.
+    const uint32_t interior_rows = slice_frames * input_H_dev;
+    const uint32_t corner_rows_per_batch = progress_t_batch_size * 2 * padding_h;
+
+    // H->W ordering (progress==0, halo-only, no conv):
+    //   Fast path (interior_first_p0): frames align to this core's slice, so np_reorder_batch below emits
+    //   ALL interior rows first (overlapping the H exchange), then ALL corners. The H->W barrier is then
+    //   taken ONCE at the interior->corner transition (outer_dim == interior_rows) below.
+    //   Fallback (partial last frame): reorder can't cover a partial frame safely, so read linearly and
+    //   take the H->W barrier upfront here.
+    // (progress>0 fused path gates corners per-batch on HT/HB and ignores this barrier.)
+    // Coalescing (middle device) uses the upfront barrier (bank-major mixes interior+corner), so it
+    // opts out of interior-first.
+    // Coalesce for middle devices always; in uniform-mux mode, edge devices coalesce too.
+    const bool w_coalesce_active = (W_COALESCE > 0) && (W_MUX_MODE || (!is_first_chip && !is_last_chip));
+    // Send-side neighbor for THIS direction (writer sends only when it exists). Per-core args are
+    // direction-swapped by the factory, so the send condition is uniformly !is_last_chip. Edge devices
+    // skip the gather for their no-neighbor direction (paired mux writer also skips) so the CB isn't left full.
+    const bool has_send_neighbor = !is_last_chip;
+    const bool interior_first_p0 = (progress_t_batch_size == 0) && (barrier_count > 0) &&
+                                   (outer_dim_size == slice_frames * h_total) && !w_coalesce_active;
+    if constexpr (progress_t_batch_size == 0) {
+        if (!interior_first_p0 && barrier_count > 0) {
+            noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem_addr), barrier_count);
+            noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem_addr), 0);
+        }
+    }
+
+    // Coalesced bank-major gather (middle device): read the W-edge stick for rows in dst-bank order
+    // (rel, rel+8, ...) into the CB in groups of up to W_COALESCE, so the paired writer ships each group
+    // as one contiguous fabric packet. Corners (H-padded rows) are safe here — the upfront barrier above
+    // guaranteed the H exchange is complete.
+    if constexpr (W_COALESCE > 0) {
+        if (w_coalesce_active) {
+            const uint32_t w_col = direction ? 0u : (num_interior_sticks - 1u);
+            for (uint32_t j = 0; has_send_neighbor && j < NP_NUM_DRAM_BANKS; j++) {
+                uint32_t r = j;
+                while (r < outer_dim_size) {
+                    uint32_t g = 0;
+                    for (uint32_t rr = r; g < W_COALESCE && rr < outer_dim_size; rr += NP_NUM_DRAM_BANKS) {
+                        g++;
+                    }
+                    cb_reserve_back(cb_output_id, g);
+                    const uint32_t base_l1 = get_write_ptr(cb_output_id);
+                    for (uint32_t m = 0; m < g; m++) {
+                        const uint32_t rel = r + m * NP_NUM_DRAM_BANKS;
+                        const uint32_t global_idx = outer_dim_start + rel;
+                        const uint32_t t_idx = global_idx / h_total;
+                        const uint32_t hp = global_idx % h_total;
+                        const uint32_t l1_addr = base_l1 + m * stick_size;
+                        if (hp >= padding_h && hp < padding_h + input_H_dev) {
+                            const uint32_t page = in_page(t_idx, hp - padding_h, w_col);
+                            noc_async_read(get_noc_addr(page, input_accessor), l1_addr, stick_size);
+                        } else {
+                            uint32_t halo_page;
+                            if (hp < padding_h) {
+                                halo_page = t_idx * padding_h * num_interior_sticks + hp * num_interior_sticks + w_col;
+                            } else {
+                                const uint32_t pad_row = hp - padding_h - input_H_dev;
+                                halo_page = h_halo_hbot_base + t_idx * padding_h * num_interior_sticks +
+                                            pad_row * num_interior_sticks + w_col;
+                            }
+                            noc_async_read(get_noc_addr(halo_page, dst_accessor), l1_addr, stick_size);
+                        }
+                    }
+                    noc_async_read_barrier();
+                    cb_push_back(cb_output_id, g);
+                    r += g * NP_NUM_DRAM_BANKS;  // next group start on this bank
+                }
+            }
+            // Receive-completion: wait for all incoming W-halo rows to land before the op returns.
+            if (!is_first_chip) {
+                noc_semaphore_wait_min(w_neighbor_sem_ptr, outer_dim_size);
+                noc_semaphore_set(w_neighbor_sem_ptr, 0);
+            }
+            return;
+        }
+    }
+
+    // Main loop: read W-boundary sticks → CB for the paired writer.
+    for (uint32_t outer_dim = 0; outer_dim < outer_dim_size; outer_dim++) {
+        // outer_dim maps to (t, h_padded). Per-batch two-pass reorder (interior rows of a batch before
+        // its corners) for FULL batches; linear for the partial last batch (and when not batching).
+        uint32_t t_idx;
+        uint32_t h_padded;
+        bool use_reorder;
+        if constexpr (progress_t_batch_size > 0) {
+            use_reorder = W_TWO_PASS;
+        } else {
+            use_reorder = interior_first_p0;
+        }
+        if (use_reorder) {
+            // Interior rows first (H-independent), corners last. W does interior work while H produces.
+            uint32_t frame_in_slice;
+            np_reorder_batch(outer_dim, slice_frames, input_H_dev, padding_h, frame_in_slice, h_padded);
+            t_idx = (outer_dim_start / h_total) + frame_in_slice;
+        } else {
+            const uint32_t global_idx = outer_dim_start + outer_dim;
+            t_idx = global_idx / h_total;
+            h_padded = global_idx % h_total;
+        }
+        const bool h_interior = (h_padded >= padding_h && h_padded < padding_h + input_H_dev);
+
+        // progress==0 fast path: take the H->W barrier ONCE at the first corner row (all interior done).
+        if constexpr (progress_t_batch_size == 0) {
+            if (interior_first_p0 && outer_dim == interior_rows) {
+                noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem_addr), barrier_count);
+                noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem_addr), 0);
+            }
+        }
+
+        // A non-interior row is a corner stick built from H-halo. Before reading it, wait this
+        // frame's H batch committed across ALL H-links (the W-reader's frames span the H partition).
+        // Top-pad → HT, bot-pad → HB. addr 0 = no H neighbor on that side → skip (zero-pad).
+        if constexpr (progress_t_batch_size > 0) {
+            if (!h_interior && h_batches_per_link > 0) {
+                uint32_t need = t_idx / progress_t_batch_size + 1;
+                if (need > h_total_batches) {
+                    need = h_total_batches;
+                }
+                uint32_t hlink = (need - 1) / h_batches_per_link;
+                if (hlink >= num_h_links) {
+                    hlink = num_h_links - 1;
+                }
+                const uint32_t* hsem = (h_padded < padding_h) ? htop_sem : hbot_sem;
+                for (uint32_t l = 0; l <= hlink; l++) {
+                    if (hsem[l] == 0) {
+                        continue;
+                    }
+                    const uint32_t end_b = (l + 1) * h_batches_per_link;
+                    const uint32_t thr = (need < end_b ? need : end_b) - l * h_batches_per_link;
+                    noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(hsem[l]), thr);
+                }
+            }
+        }
+
+        if (is_first_chip) {
+            if (!is_padding_zeros) {
+                cb_reserve_back(cb_output_id, 1);
+                uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
+                uint32_t w_col = direction ? (num_interior_sticks - 1) : 0;
+                if (h_interior) {
+                    uint32_t h_in = h_padded - padding_h;
+                    uint32_t page = in_page(t_idx, h_in, w_col);
+                    noc_async_read(get_noc_addr(page, input_accessor), dst_l1_addr, stick_size);
+                } else {
+                    uint32_t halo_page;
+                    if (h_padded < padding_h) {
+                        uint32_t pad_row = h_padded;
+                        halo_page = t_idx * padding_h * num_interior_sticks + pad_row * num_interior_sticks + w_col;
+                    } else {
+                        uint32_t pad_row = h_padded - padding_h - input_H_dev;
+                        halo_page = h_halo_hbot_base + t_idx * padding_h * num_interior_sticks +
+                                    pad_row * num_interior_sticks + w_col;
+                    }
+                    noc_async_read(get_noc_addr(halo_page, dst_accessor), dst_l1_addr, stick_size);
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_output_id, 1);
+            } else {
+                cb_reserve_back(cb_output_id, 1);
+                zeroPadCb<stick_size>(cb_output_id);
+                noc_async_read_barrier();
+                cb_push_back(cb_output_id, 1);
+            }
+        }
+
+        if (!is_last_chip) {
+            for (uint32_t pad_id = padding; pad_id > 0; pad_id--) {
+                cb_reserve_back(cb_output_id, 1);
+                uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
+                uint32_t w_col;
+                if (direction) {
+                    w_col = padding - pad_id;
+                } else {
+                    w_col = num_interior_sticks - pad_id;
+                }
+                if (h_interior) {
+                    uint32_t h_in = h_padded - padding_h;
+                    uint32_t page = in_page(t_idx, h_in, w_col);
+                    noc_async_read(get_noc_addr(page, input_accessor), dst_l1_addr, stick_size);
+                } else {
+                    uint32_t halo_page;
+                    if (h_padded < padding_h) {
+                        uint32_t pad_row = h_padded;
+                        halo_page = t_idx * padding_h * num_interior_sticks + pad_row * num_interior_sticks + w_col;
+                    } else {
+                        uint32_t pad_row = h_padded - padding_h - input_H_dev;
+                        halo_page = h_halo_hbot_base + t_idx * padding_h * num_interior_sticks +
+                                    pad_row * num_interior_sticks + w_col;
+                    }
+                    noc_async_read(get_noc_addr(halo_page, dst_accessor), dst_l1_addr, stick_size);
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_output_id, 1);
+            }
+        }
+
+        // Per-batch conv-signalling — fused (progress>0) path only. Receiver signals a conv W-edge tile's
+        // region sem after wait_min(w_neighbor_sem, outer_dim+1) confirms this batch's remote fabric write
+        // landed. The halo-only op (progress==0) has no conv consumer, so it skips all of this and does a
+        // single receive-completion wait at the end (see tail below) — the "no signalling" standalone path.
+        if constexpr (progress_t_batch_size > 0) {
+            bool do_signal;
+            if constexpr (W_TWO_PASS) {
+                do_signal = (outer_dim >= interior_rows) && (corner_rows_per_batch > 0) &&
+                            ((outer_dim + 1 - interior_rows) % corner_rows_per_batch == 0);
+            } else {
+                do_signal = ((outer_dim + 1) % sticks_per_batch == 0);
+            }
+            if (!is_first_chip && do_signal) {
+                noc_semaphore_wait_min(w_neighbor_sem_ptr, outer_dim + 1);
+                noc_async_write_barrier();
+                for (uint32_t i = 0; i < num_reader_cores; i++) {
+                    const uint32_t rx = get_common_arg_val<uint32_t>(4 + i * 2);
+                    const uint32_t ry = get_common_arg_val<uint32_t>(4 + i * 2 + 1);
+                    noc_semaphore_inc(get_noc_addr(rx, ry, w_region_sem_addr), 1);
+                }
+                noc_async_atomic_barrier();
+            }
+        }
+    }
+
+    if constexpr (progress_t_batch_size > 0) {
+        // Fused path: tail conv-signal for the partial last batch (receiver side only).
+        bool tail_signal;
+        if constexpr (W_TWO_PASS) {
+            tail_signal =
+                (corner_rows_per_batch > 0) && ((outer_dim_size - interior_rows) % corner_rows_per_batch != 0);
+        } else {
+            tail_signal = (outer_dim_size % sticks_per_batch != 0);
+        }
+        if (!is_first_chip && tail_signal) {
+            noc_semaphore_wait_min(w_neighbor_sem_ptr, outer_dim_size);
+            noc_async_write_barrier();
+            for (uint32_t i = 0; i < num_reader_cores; i++) {
+                const uint32_t rx = get_common_arg_val<uint32_t>(4 + i * 2);
+                const uint32_t ry = get_common_arg_val<uint32_t>(4 + i * 2 + 1);
+                noc_semaphore_inc(get_noc_addr(rx, ry, w_region_sem_addr), 1);
+            }
+            noc_async_atomic_barrier();
+        }
+    } else {
+        // Halo-only op: no conv consumer. The op's output IS the halo buffer, so the receiver must wait
+        // for ALL incoming W-halo rows to land in DRAM before the kernel exits — otherwise the host reads
+        // an in-flight buffer. One receive-completion wait replaces the per-batch conv signalling.
+        if (!is_first_chip) {
+            noc_semaphore_wait_min(w_neighbor_sem_ptr, outer_dim_size);
+        }
+    }
+    // Single end-of-kernel reset; sem was monotonically increasing across the loop.
+    if (!is_first_chip) {
+        noc_semaphore_set(w_neighbor_sem_ptr, 0);
+    }
+    // Trace-safe self-reset of the H-region sems this core consumed in the corner gate above: the H
+    // producer increments HT/HB on the W-reader cores too, and the per-batch corner waits guarantee
+    // those increments have landed, so zero them for the next dispatch without a host-side reset.
+    if constexpr (progress_t_batch_size > 0) {
+        for (uint32_t l = 0; l < num_h_links && l < 4; l++) {
+            if (htop_sem[l] != 0) {
+                noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(htop_sem[l]), 0);
+            }
+            if (hbot_sem[l] != 0) {
+                noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(hbot_sem[l]), 0);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_phase2_w_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_phase2_w_reader.cpp
@@ -2,13 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Phase 2 W fabric reader for the fused neighbor_pad + conv3d op.
-//
-// Reads W-boundary sticks from the input tensor (interior rows) and the compact halo
-// buffer (H-padded rows) into a CB that the paired writer ships over the W fabric.
-// Per-T-batch, the receiver-side reader increments a progress semaphore on every
-// conv3d reader core so conv3d compute can start processing early T-blocks while
-// later ones are still in flight.
+// Phase 2 W fabric reader for the fused neighbor_pad + conv3d op
 
 #include "api/dataflow/dataflow_api.h"
 #include <tt-metalium/buffer_types.hpp>
@@ -28,21 +22,15 @@ constexpr uint32_t ct_after_dst = dst_args.next_compile_time_args_offset();
 // Input tensor TensorAccessorArgs follow the halo buffer args
 constexpr auto src_args = TensorAccessorArgs<ct_after_dst>();
 constexpr uint32_t ct_after_src = src_args.next_compile_time_args_offset();
-// Granularity (in T-input frames) for per-batch progress-sem signals. Must match the
-// conv3d reader's progress_t_batch_size compile-time arg.
+// Granularity (in T-input frames) for per-batch progress-sem signals
 constexpr uint32_t progress_t_batch_size = get_compile_time_arg_val(ct_after_src);
 
-// Global two-pass gate, set per-shape by the program factory (lockstep with np_writer via the same
-// factory value). ON: defer all corners past H's finish (NP-bound win, regresses conv-bound).
-// Follows progress_t_batch_size (ct_after_src) in the W-reader arg layout.
+// Global two-pass gate, set per-shape by the program factory (lockstep with np_writer via the same factory value)
 constexpr bool W_TWO_PASS = get_compile_time_arg_val(ct_after_src + 1);
 
-// W-send bank-major coalesce factor (0 = per-stick). When > 0 (halo-only, pw==1, 8-aligned bases), a
-// middle device gathers same-dst-bank sticks (rel, rel+8, ...) into the CB so the writer ships N of them
-// as one N*page fabric packet. BH has 8 interleaved DRAM banks.
+// W-send bank-major coalesce factor (0 = per-stick)
 constexpr uint32_t W_COALESCE = get_compile_time_arg_val(ct_after_src + 2);
-// Uniform-mux mode: all W devices (incl. edges) use the coalesce path so the recv-sem targeting is
-// consistent across the whole W chain. Edge devices skip the send-gather for their no-neighbor direction.
+// Uniform-mux mode: all W devices
 constexpr uint32_t W_MUX_MODE = get_compile_time_arg_val(ct_after_src + 3);
 constexpr uint32_t NP_NUM_DRAM_BANKS = 8;
 
@@ -51,8 +39,7 @@ void kernel_main() {
     const address_t output_tensor_address = get_common_arg_val<address_t>(0);
     const uint32_t barrier_sem_addr = get_common_arg_val<uint32_t>(1);
     const uint32_t w_neighbor_sem_addr = get_common_arg_val<uint32_t>(2);
-    // [3] num_reader_cores: number of conv3d reader cores to signal.
-    // [4+]: NOC coords of conv3d reader cores.
+    // [3] num_reader_cores: number of conv3d reader cores to signal
     const uint32_t num_reader_cores = get_common_arg_val<uint32_t>(3);
 
     // Per-core runtime args
@@ -71,8 +58,7 @@ void kernel_main() {
     const uint32_t input_H_dev = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t padding_h = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t h_halo_hbot_base = get_arg_val<uint32_t>(arg_idx++);
-    // Padded-input mode (0 = contiguous). When >0 the input is [.,H+2*input_pad_h,W+2*input_pad_w,C] and
-    // the W-edge input reads target its INTERIOR (row stride = padded W, frame stride = padded H*W).
+    // Padded-input mode (0 = contiguous)
     const uint32_t input_pad_h = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t input_pad_w = get_arg_val<uint32_t>(arg_idx++);
     // Input page for interior (t, h_in, w_col); honors padded-input strides (identity when pad==0).
@@ -80,14 +66,11 @@ void kernel_main() {
     auto in_page = [&](uint32_t t, uint32_t h_in, uint32_t w_col) -> uint32_t {
         return t * (input_H_dev + 2 * input_pad_h) * in_Wp + (h_in + input_pad_h) * in_Wp + (w_col + input_pad_w);
     };
-    // Per-batch region progress sem for this (W-direction, link). W-edge/corner conv3d tiles wait on
-    // just this link's count, race-free across links (one producer per (region,link) -> monotonic).
+    // Per-batch region progress sem for this (W-direction, link)
     const uint32_t w_region_sem_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t h_total = input_H_dev + 2 * padding_h;
 
-    // Per-batch corner H-gate: each corner W-stick read waits only the H-batch it needs (no upfront
-    // H->W barrier). H-region sems for all H-links live in CRTA after the reader coords: HT[0..3],
-    // HB[0..3], h_batches_per_link, num_h_links, h_total_batches.
+    // Per-batch corner H-gate: each corner W-stick read waits only the H-batch it needs (no upfront H->W barrier)
     uint32_t htop_sem[4] = {0, 0, 0, 0};
     uint32_t hbot_sem[4] = {0, 0, 0, 0};
     uint32_t h_batches_per_link = 0, num_h_links = 0, h_total_batches = 0;
@@ -105,8 +88,7 @@ void kernel_main() {
     const auto input_accessor = TensorAccessor(src_args, input_tensor_address, stick_size);
     const auto dst_accessor = TensorAccessor(dst_args, output_tensor_address, stick_size);
 
-    // output_row_width and pad2_left are unused in the fabric-only path; keep the RTA layout stable
-    // so the factory can share code with the standalone NP op.
+    // output_row_width and pad2_left are unused in the fabric-only path
     (void)output_row_width;
     (void)pad2_left;
 
@@ -122,25 +104,13 @@ void kernel_main() {
     const uint32_t sticks_per_batch = progress_t_batch_size * h_total;
     // Frames in this core's slice (link-local; the partial last batch lives here when T % N != 0).
     const uint32_t slice_frames = (h_total > 0) ? (outer_dim_size / h_total) : 0;
-    // Interior-first layout: rows [0, interior_rows) are H-independent (read from INPUT), then corner
-    // rows [interior_rows, ...) (read from the halo H-section). Signal / barrier at the transition.
+    // Interior-first layout: rows [0, interior_rows) are H-independent (read from INPUT)
     const uint32_t interior_rows = slice_frames * input_H_dev;
     const uint32_t corner_rows_per_batch = progress_t_batch_size * 2 * padding_h;
 
-    // H->W ordering (progress==0, halo-only, no conv):
-    //   Fast path (interior_first_p0): frames align to this core's slice, so np_reorder_batch below emits
-    //   ALL interior rows first (overlapping the H exchange), then ALL corners. The H->W barrier is then
-    //   taken ONCE at the interior->corner transition (outer_dim == interior_rows) below.
-    //   Fallback (partial last frame): reorder can't cover a partial frame safely, so read linearly and
-    //   take the H->W barrier upfront here.
-    // (progress>0 fused path gates corners per-batch on HT/HB and ignores this barrier.)
-    // Coalescing (middle device) uses the upfront barrier (bank-major mixes interior+corner), so it
-    // opts out of interior-first.
-    // Coalesce for middle devices always; in uniform-mux mode, edge devices coalesce too.
+    // H->W ordering (progress==0, halo-only, no conv): Fast path
     const bool w_coalesce_active = (W_COALESCE > 0) && (W_MUX_MODE || (!is_first_chip && !is_last_chip));
-    // Send-side neighbor for THIS direction (writer sends only when it exists). Per-core args are
-    // direction-swapped by the factory, so the send condition is uniformly !is_last_chip. Edge devices
-    // skip the gather for their no-neighbor direction (paired mux writer also skips) so the CB isn't left full.
+    // Send-side neighbor for THIS direction (writer sends only when it exists)
     const bool has_send_neighbor = !is_last_chip;
     const bool interior_first_p0 = (progress_t_batch_size == 0) && (barrier_count > 0) &&
                                    (outer_dim_size == slice_frames * h_total) && !w_coalesce_active;
@@ -152,9 +122,6 @@ void kernel_main() {
     }
 
     // Coalesced bank-major gather (middle device): read the W-edge stick for rows in dst-bank order
-    // (rel, rel+8, ...) into the CB in groups of up to W_COALESCE, so the paired writer ships each group
-    // as one contiguous fabric packet. Corners (H-padded rows) are safe here — the upfront barrier above
-    // guaranteed the H exchange is complete.
     if constexpr (W_COALESCE > 0) {
         if (w_coalesce_active) {
             const uint32_t w_col = direction ? 0u : (num_interior_sticks - 1u);
@@ -204,8 +171,7 @@ void kernel_main() {
 
     // Main loop: read W-boundary sticks → CB for the paired writer.
     for (uint32_t outer_dim = 0; outer_dim < outer_dim_size; outer_dim++) {
-        // outer_dim maps to (t, h_padded). Per-batch two-pass reorder (interior rows of a batch before
-        // its corners) for FULL batches; linear for the partial last batch (and when not batching).
+        // outer_dim maps to (t, h_padded)
         uint32_t t_idx;
         uint32_t h_padded;
         bool use_reorder;
@@ -234,9 +200,7 @@ void kernel_main() {
             }
         }
 
-        // A non-interior row is a corner stick built from H-halo. Before reading it, wait this
-        // frame's H batch committed across ALL H-links (the W-reader's frames span the H partition).
-        // Top-pad → HT, bot-pad → HB. addr 0 = no H neighbor on that side → skip (zero-pad).
+        // A non-interior row is a corner stick built from H-halo
         if constexpr (progress_t_batch_size > 0) {
             if (!h_interior && h_batches_per_link > 0) {
                 uint32_t need = t_idx / progress_t_batch_size + 1;
@@ -321,10 +285,7 @@ void kernel_main() {
             }
         }
 
-        // Per-batch conv-signalling — fused (progress>0) path only. Receiver signals a conv W-edge tile's
-        // region sem after wait_min(w_neighbor_sem, outer_dim+1) confirms this batch's remote fabric write
-        // landed. The halo-only op (progress==0) has no conv consumer, so it skips all of this and does a
-        // single receive-completion wait at the end (see tail below) — the "no signalling" standalone path.
+        // Per-batch conv-signalling — fused (progress>0) path
         if constexpr (progress_t_batch_size > 0) {
             bool do_signal;
             if constexpr (W_TWO_PASS) {
@@ -366,9 +327,7 @@ void kernel_main() {
             noc_async_atomic_barrier();
         }
     } else {
-        // Halo-only op: no conv consumer. The op's output IS the halo buffer, so the receiver must wait
-        // for ALL incoming W-halo rows to land in DRAM before the kernel exits — otherwise the host reads
-        // an in-flight buffer. One receive-completion wait replaces the per-batch conv signalling.
+        // Halo-only op: no conv consumer
         if (!is_first_chip) {
             noc_semaphore_wait_min(w_neighbor_sem_ptr, outer_dim_size);
         }
@@ -377,9 +336,7 @@ void kernel_main() {
     if (!is_first_chip) {
         noc_semaphore_set(w_neighbor_sem_ptr, 0);
     }
-    // Trace-safe self-reset of the H-region sems this core consumed in the corner gate above: the H
-    // producer increments HT/HB on the W-reader cores too, and the per-batch corner waits guarantee
-    // those increments have landed, so zero them for the next dispatch without a host-side reset.
+    // Trace-safe self-reset of the H-region sems this core consumed in the corner gate above: the H producer
     if constexpr (progress_t_batch_size > 0) {
         for (uint32_t l = 0; l < num_h_links && l < 4; l++) {
             if (htop_sem[l] != 0) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_w_mux_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_w_mux_writer.cpp
@@ -84,9 +84,7 @@ void kernel_main() {
 
     const auto dst_accessor = TensorAccessor(dst_ct_args, output_tensor_address, stick_size);
 
-    // Nothing to send from an outward-facing edge worker (no neighbor this direction). The WRITER's
-    // is_first/is_last args are NOT direction-swapped (unlike the reader's), so the send condition is
-    // direction-dependent: forward sends iff !is_last_chip, backward sends iff !is_first_chip.
+    // Nothing to send from an outward-facing edge worker (no neighbor this direction)
     const bool has_neighbor = direction ? !is_first_chip : !is_last_chip;
 
     // ---- Build + connect the mux endpoint ----
@@ -111,9 +109,7 @@ void kernel_main() {
         tt::tt_fabric::fabric_client_connect(mux_connection);
     }
 
-    // Stateful send headers (matches all_gather's mux usage): configure once with set_state, then update
-    // only the dst addr + payload size per packet with with_state. num_hops = unicast distance to the
-    // immediate W neighbor (dst_chip_id carries the hop count for the 1D line).
+    // Stateful send headers (matches all_gather's mux usage): configure once with set_state
     const uint8_t num_hops = static_cast<uint8_t>(unicast_route_info.dst_chip_id);
     auto pkt_hdr = PacketHeaderPool::allocate_header();
     fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::PayloadSize>(
@@ -123,9 +119,7 @@ void kernel_main() {
         UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
         pkt_hdr_sem, num_hops, tt::tt_fabric::NocUnicastAtomicIncCommandHeader{0, outer_dim_size});
 
-    // NOTE (bring-up): no separate W startup barrier here. barrier_sem is shared with the reader's H->W
-    // barrier (same core), so a writer inc/reset would clobber the reader's count. H->W ordering is
-    // provided by the reader's barrier wait; buffers are fresh in a single standalone dispatch.
+    // NOTE (bring-up): no separate W startup barrier here
     (void)barrier_sem;
     (void)barrier_sem_noc0_x;
     (void)barrier_sem_noc0_y;
@@ -151,8 +145,7 @@ void kernel_main() {
                     l1_read_addr,
                     tt::tt_fabric::NocUnicastCommandHeader{dst_noc_addr},
                     static_cast<uint16_t>(g * stick_size));
-                // Flush the non-blocking mux write before releasing the group: the mux reads the payload
-                // out of send_cb asynchronously, so popping first lets the reader overwrite it mid-read.
+                // Flush the non-blocking mux write before releasing the group: the mux reads the payload out
                 noc_async_writes_flushed();
                 cb_pop_front(send_cb_id, g);
                 r += g * NP_NUM_DRAM_BANKS;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_w_mux_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_w_mux_writer.cpp
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fabric-MUX W writer for neighbor_pad_halo (reach fabric link BW).
+//
+// Purpose: the single-worker-per-link W send caps at ~1.4 GB/s/link because the EDM exposes only one
+// direct local-worker sender channel per link (fabric.cpp:226). To saturate the eth link (~12.5 GB/s
+// Linear) multiple workers must feed it through a MUX core. This kernel is one such worker: it connects
+// to a fabric-mux endpoint and routes ALL fabric ops (startup barrier atomic-inc, coalesced W-halo data,
+// and the W recv-sem atomic-inc) through the mux connection, mirroring the all_gather worker-mux pattern
+// (ttnn/.../all_gather_async/device/kernels/minimal_default_writer.cpp, USE_WORKER_MUX path).
+//
+// Scope (v1, middle W devices, coalesced path): each (link,direction) is served by N workers + 1 mux
+// core; each worker owns a contiguous sub-range of this direction's W rows (split host-side). Bank-major
+// coalescing is identical to np_writer's W-coalesce send (base+r, base+r+8, ... contiguous on one bank).
+// Edge-device per-stick + corner handling is TODO before this replaces np_writer for all W cores.
+
+#include "api/dataflow/dataflow_api.h"
+#include <tt-metalium/buffer_types.hpp>
+#include "tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp"
+#include "tt_metal/fabric/hw/inc/noc_addr.h"
+#include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+#include "tt_metal/fabric/hw/inc/linear/api.h"
+#include <cstdint>
+
+using address_t = uint32_t;
+using namespace tt::tt_fabric::linear::experimental;
+
+// ---- Compile-time args ----
+constexpr uint32_t send_cb_id = get_compile_time_arg_val(0);
+constexpr uint32_t stick_size = get_compile_time_arg_val(1);
+constexpr auto dst_ct_args = TensorAccessorArgs<2>();
+constexpr uint32_t ct_after_dst = dst_ct_args.next_compile_time_args_offset();
+constexpr uint32_t W_COALESCE = get_compile_time_arg_val(ct_after_dst);
+constexpr uint32_t NP_NUM_DRAM_BANKS = 8;
+// Mux connection CT args (lockstep with FabricMuxConfig on the host).
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(ct_after_dst + 1);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(ct_after_dst + 2);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(ct_after_dst + 3);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(ct_after_dst + 4);
+constexpr uint32_t num_mux_clients = get_compile_time_arg_val(ct_after_dst + 5);
+
+void kernel_main() {
+    // ---- Common runtime args ----
+    const address_t output_tensor_address = get_common_arg_val<address_t>(1);
+    const size_t neighbor_sem = get_common_arg_val<uint32_t>(2);
+    const size_t barrier_sem = get_common_arg_val<uint32_t>(3);
+
+    // ---- Per-core runtime args ----
+    uint32_t arg_idx = 0;
+    const uint32_t base = get_arg_val<uint32_t>(arg_idx++);            // compact-buffer W-section base for this worker
+    const uint32_t outer_dim_size = get_arg_val<uint32_t>(arg_idx++);  // this worker's row count
+    const uint8_t neighbor_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t neighbor_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_first_chip = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_last_chip = get_arg_val<uint32_t>(arg_idx++);
+    const bool direction = get_arg_val<uint32_t>(arg_idx++);
+    auto unicast_route_info = ccl_routing_utils::line_unicast_route_info_t{
+        .dst_mesh_id = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++)),
+        .dst_chip_id = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++))};
+
+    // Mux connection RT args — EXACT layout of ccl::fabric_mux_connection_rt_args (positions 0..16).
+    const bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;                       // 0
+    const bool is_termination_master = get_arg_val<uint32_t>(arg_idx++) == 1;                      // 1
+    const uint8_t fabric_mux_x = get_arg_val<uint32_t>(arg_idx++);                                 // 2
+    const uint8_t fabric_mux_y = get_arg_val<uint32_t>(arg_idx++);                                 // 3
+    const size_t fabric_mux_channel_base_address = get_arg_val<uint32_t>(arg_idx++);               // 4
+    const size_t fabric_mux_connection_info_address = get_arg_val<uint32_t>(arg_idx++);            // 5
+    const size_t fabric_mux_connection_handshake_address = get_arg_val<uint32_t>(arg_idx++);       // 6
+    const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);               // 7
+    const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);               // 8
+    const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);                        // 9
+    const uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));     // 10
+    const uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));  // 11
+    const uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));   // 12
+    const uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));       // 13
+    const uint32_t local_buffer_index_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));   // 14
+    const uint8_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);                     // 15
+    const uint8_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);                     // 16
+
+    const auto dst_accessor = TensorAccessor(dst_ct_args, output_tensor_address, stick_size);
+
+    // Nothing to send from an outward-facing edge worker (no neighbor this direction). The WRITER's
+    // is_first/is_last args are NOT direction-swapped (unlike the reader's), so the send condition is
+    // direction-dependent: forward sends iff !is_last_chip, backward sends iff !is_first_chip.
+    const bool has_neighbor = direction ? !is_first_chip : !is_last_chip;
+
+    // ---- Build + connect the mux endpoint ----
+    tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel> mux_connection;
+    if (mux_connection_valid) {
+        mux_connection = tt::tt_fabric::build_connection_to_fabric_endpoint<fabric_mux_num_buffers_per_channel>(
+            fabric_mux_x,
+            fabric_mux_y,
+            fabric_mux_channel_id,
+            fabric_mux_num_buffers_per_channel,
+            fabric_mux_channel_buffer_size_bytes,
+            fabric_mux_channel_base_address,
+            fabric_mux_connection_info_address,
+            fabric_mux_connection_handshake_address,
+            fabric_mux_flow_control_address,
+            fabric_mux_buffer_index_address,
+            local_flow_control_address,
+            local_teardown_address,
+            local_buffer_index_address);
+        tt::tt_fabric::wait_for_fabric_endpoint_ready(
+            fabric_mux_x, fabric_mux_y, fabric_mux_status_address, local_fabric_mux_status_address);
+        tt::tt_fabric::fabric_client_connect(mux_connection);
+    }
+
+    // Stateful send headers (matches all_gather's mux usage): configure once with set_state, then update
+    // only the dst addr + payload size per packet with with_state. num_hops = unicast distance to the
+    // immediate W neighbor (dst_chip_id carries the hop count for the 1D line).
+    const uint8_t num_hops = static_cast<uint8_t>(unicast_route_info.dst_chip_id);
+    auto pkt_hdr = PacketHeaderPool::allocate_header();
+    fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::PayloadSize>(
+        pkt_hdr, num_hops, nullptr, static_cast<uint16_t>(W_COALESCE * stick_size));
+    auto pkt_hdr_sem = PacketHeaderPool::allocate_header();
+    fabric_unicast_noc_unicast_atomic_inc_set_state<
+        UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
+        pkt_hdr_sem, num_hops, tt::tt_fabric::NocUnicastAtomicIncCommandHeader{0, outer_dim_size});
+
+    // NOTE (bring-up): no separate W startup barrier here. barrier_sem is shared with the reader's H->W
+    // barrier (same core), so a writer inc/reset would clobber the reader's count. H->W ordering is
+    // provided by the reader's barrier wait; buffers are fresh in a single standalone dispatch.
+    (void)barrier_sem;
+    (void)barrier_sem_noc0_x;
+    (void)barrier_sem_noc0_y;
+    (void)is_first_chip;
+
+    // ---- Coalesced W send through the mux (bank-major; lockstep with np_phase2_w_reader) ----
+    if (has_neighbor && mux_connection_valid) {
+        for (uint32_t j = 0; j < NP_NUM_DRAM_BANKS; j++) {
+            uint32_t r = j;
+            while (r < outer_dim_size) {
+                uint32_t g = 0;
+                for (uint32_t rr = r; g < W_COALESCE && rr < outer_dim_size; rr += NP_NUM_DRAM_BANKS) {
+                    g++;
+                }
+                cb_wait_front(send_cb_id, g);
+                const uint32_t l1_read_addr = get_read_ptr(send_cb_id);
+                const uint64_t dst_noc_addr = get_noc_addr(base + r, dst_accessor);
+                // Tail groups on a bank are shorter than W_COALESCE, so update PayloadSize too.
+                fabric_unicast_noc_unicast_write_with_state<
+                    UnicastWriteUpdateMask::DstAddr | UnicastWriteUpdateMask::PayloadSize>(
+                    &mux_connection,
+                    pkt_hdr,
+                    l1_read_addr,
+                    tt::tt_fabric::NocUnicastCommandHeader{dst_noc_addr},
+                    static_cast<uint16_t>(g * stick_size));
+                // Flush the non-blocking mux write before releasing the group: the mux reads the payload
+                // out of send_cb asynchronously, so popping first lets the reader overwrite it mid-read.
+                noc_async_writes_flushed();
+                cb_pop_front(send_cb_id, g);
+                r += g * NP_NUM_DRAM_BANKS;
+            }
+        }
+        // ---- Raise the neighbor's W recv sem (deferred single inc of the full row count) ----
+        uint64_t nb_recv = safe_get_noc_addr(neighbor_sem_noc0_x, neighbor_sem_noc0_y, neighbor_sem, 0);
+        fabric_unicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+            &mux_connection, pkt_hdr_sem, tt::tt_fabric::NocUnicastAtomicIncCommandHeader{nb_recv, 0});
+    }
+
+    // ---- Disconnect + termination handshake (avoid mux-kernel hang) ----
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
+    if (mux_connection_valid) {
+        tt::tt_fabric::fabric_client_disconnect(mux_connection);
+        if (is_termination_master) {
+            auto* term_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
+            noc_semaphore_wait(term_ptr, num_mux_clients - 1);
+            tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
+        } else {
+            uint64_t dest =
+                safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
+            noc_semaphore_inc(dest, 1);
+            noc_async_atomic_barrier();
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_writer.cpp
@@ -21,8 +21,7 @@
 using address_t = uint32_t;
 using namespace tt::tt_fabric::linear::experimental;
 
-// Runtime-arg versions of route info readers, local to this kernel.
-// Used because consolidated kernels have per-core routing via runtime args.
+// Runtime-arg versions of route info readers, local to this kernel
 inline ccl_routing_utils::line_unicast_route_info_t get_line_unicast_route_info_from_rt_args(uint32_t& arg_idx) {
     return {
         .dst_mesh_id = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++)),
@@ -56,32 +55,22 @@ constexpr uint32_t progress_t_batch_size = get_compile_time_arg_val(ct_after_dst
 // CB the fabric-send loop drains. H writer: dedicated batched send ring (c_in2). W writer: c_in0.
 constexpr uint32_t send_cb_id = get_compile_time_arg_val(ct_after_dst + 6);
 
-// Global two-pass gate, set per-shape by the program factory (lockstep with np_phase2_w_reader via
-// the same factory value). Follows send_cb_id (ct_after_dst + 6) in the W-writer/H-writer arg layout.
+// Global two-pass gate, set per-shape by the program factory
 constexpr bool W_TWO_PASS = get_compile_time_arg_val(ct_after_dst + 7);
 
-// H-writer corner-first send (H-writer path only): raise the recv sem after the corner sticks, before
-// the bulk middle, so the neighbor's recv-wait clears after ~pad2 sticks instead of the whole row. Set
-// per-shape by the program factory; unused on the W writer. Follows W_TWO_PASS in the arg layout.
+// H-writer corner-first send (H-writer path only): raise the recv sem after the corner sticks
 constexpr bool H_CORNER_FIRST = get_compile_time_arg_val(ct_after_dst + 8);
 
-// W-send bank-major coalesce factor (0 = per-stick). Lockstep with np_phase2_w_reader: a middle W
-// device ships N same-dst-bank sticks (base+r, base+r+8, ...) as one N*page fabric write to the
-// neighbor's interleaved DRAM. Follows H_CORNER_FIRST in the arg layout. BH: 8 DRAM banks.
+// W-send bank-major coalesce factor (0 = per-stick)
 constexpr uint32_t W_COALESCE = get_compile_time_arg_val(ct_after_dst + 9);
 constexpr uint32_t NP_NUM_DRAM_BANKS = 8;
 
 void kernel_main() {
-    ///////////////////////////////////////////////////
-    // ARGS
-    ///////////////////////////////////////////////////
-    // Common runtime args (uniform across all cores, updated between dispatches). Index 0 (input addr)
-    // is part of the shared CRTA layout but unused by the writer (it reads/writes the output buffer).
+    // ///////////////////////////////////////////////// ARGS /////////////////////////////////////////////////
     const address_t output_tensor_address = get_common_arg_val<address_t>(1);
     const size_t neighbor_sem = get_common_arg_val<uint32_t>(2);
     const size_t barrier_sem = get_common_arg_val<uint32_t>(3);
-    // Number of conv3d reader cores to signal and their NOC (x,y) coordinates.
-    // Packed as: [num_reader_cores, x0, y0, x1, y1, ...]
+    // Number of conv3d reader cores to signal and their NOC (x,y) coordinates
     const uint32_t num_reader_cores = get_common_arg_val<uint32_t>(4);
     // Reader core NOC coords start at CRTA index 5: x0=5, y0=6, x1=7, y1=8, ...
 
@@ -102,8 +91,7 @@ void kernel_main() {
     const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
 
-    // Phase 2 barrier signal targets (0 for 1D, >0 for 2D)
-    // Max targets = pad2_num_links * 2 directions (up to 8 W fabric cores)
+    // Phase 2 barrier signal targets (0 for 1D, >0 for 2D) Max targets = pad2_num_links * 2 directions
     constexpr uint32_t MAX_PHASE2_SIGNAL_TARGETS = 8;
     const uint32_t num_phase2_signal_targets = get_arg_val<uint32_t>(arg_idx++);
     uint8_t signal_noc_x[MAX_PHASE2_SIGNAL_TARGETS];
@@ -124,8 +112,7 @@ void kernel_main() {
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
 
     const uint32_t outer_dim_offset_start_t = get_arg_val<uint32_t>(static_cast<uint32_t>(arg_for_fab));
-    // This (direction,link)'s H-region sem (H-top/H-bot), signalled per-batch from
-    // handle_incoming_writes so the W-reader corner gate + conv3d H-edge tiles ramp without a barrier.
+    // This (direction,link)'s H-region sem (H-top/H-bot), signalled per-batch from handle_incoming_writes
     uint32_t h_region_sem_addr = 0;
     if constexpr (progress_t_batch_size > 0) {
         h_region_sem_addr = get_arg_val<uint32_t>(static_cast<uint32_t>(arg_for_fab) + 1);
@@ -168,20 +155,14 @@ void kernel_main() {
         noc_async_writes_flushed();
     };
 
-    // H writers: always open fabric at start (for data transfer in main loop).
-    // W writers: open at start only when startup barrier is enabled (defer data transfer until CB ready).
+    // H writers: always open fabric at start (for data transfer in main loop)
     bool fabric_opened = false;
     if (!is_w_fabric_writer || use_barrier_sem) {
         fabric_connection.open();
         fabric_opened = true;
     }
 
-    // Startup barrier: sync across all devices before sending new fabric data.
-    // H writers: multicast to all H-axis devices (same column, consistent harvesting).
-    // W writers: 1-hop unicast to immediate W neighbor only.
-    //   W-axis devices span different UBBs with potentially different core harvesting,
-    //   so multicast (which targets fixed NOC x,y) would hit wrong cores on remote devices.
-    //   H all-to-all multicast + W 1-hop unicast transitively synchronizes the full mesh.
+    // Startup barrier: sync across all devices before sending new fabric data
     if (use_barrier_sem) {
         if constexpr (!is_w_fabric_writer) {
             // H barrier: multicast to all H-axis devices (same column)
@@ -232,10 +213,7 @@ void kernel_main() {
                 noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
             }
         } else {
-            // W barrier: 1-hop unicast to immediate W neighbor only.
-            // neighbor_sem_noc0_x/y and barrier_sem_noc0_x/y are NOC coords of the local
-            // device's worker cores. Since NOC coords are not chip-dependent, these are
-            // valid targets on the neighbor device as well.
+            // W barrier: 1-hop unicast to immediate W neighbor
             if (!is_last_chip) {
                 auto pkt_hdr_barrier_sem_inc = PacketHeaderPool::allocate_header();
 
@@ -280,22 +258,11 @@ void kernel_main() {
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 
-    // Corners-only optimization for 2D H writers:
-    // Only W-boundary sticks (corners) go to neighbor L1; non-corner sticks go directly to DRAM.
-    // Phase 2 W reader only needs corners, so this is safe.
-    // Derivation: the output row is [pad2_left | W interior sticks | pad2_right].
-    // The factory sets stick_start_id = pad2_left (the W offset where interior data begins),
-    // num_sticks_per_halo_dim = W + pad2_left + pad2_right (full output row width),
-    // and num_sticks_to_read = W (interior width). So:
-    //   pad2_left_sticks  = stick_start_id = pad2_left
-    //   pad2_right_sticks = (W + pad2_left + pad2_right) - W - pad2_left = pad2_right
-    // These can be different (asymmetric W padding is supported).
+    // Corners-only optimization for 2D H writers: Only W-boundary sticks (corners) go to neighbor L1
     uint32_t pad2_left_sticks = 0;
     uint32_t pad2_right_sticks = 0;
     if constexpr (use_l1_intermediate && !is_w_fabric_writer) {
-        // Use padding_left for corner count (not stick_start_id) so it works when stick_start_id=0
-        // (fabric_only mode). In fabric_only: stick_start_id=0 but padding_left=W/2=104,
-        // giving pad2_left_sticks=104, pad2_right_sticks=104 → overlap case → all sticks are corners.
+        // Use padding_left for corner count (not stick_start_id) so it works when stick_start_id=0 (fabric_only mode)
         pad2_left_sticks = (padding_left > 0) ? padding_left : stick_start_id;
         uint32_t w_overhead = num_sticks_per_halo_dim - num_sticks_to_read;
         pad2_right_sticks = (w_overhead >= pad2_left_sticks) ? (w_overhead - pad2_left_sticks) : pad2_left_sticks;
@@ -305,8 +272,7 @@ void kernel_main() {
         return iter < pad2_right_sticks || iter >= (num_sticks_to_read - pad2_left_sticks);
     };
 
-    // W-path interior-first reorder dims (common args [4],[5], W-writer only). Parsed for every W-writer
-    // (the factory always sets [4],[5]); used by W_TWO_PASS (progress>0) and the progress==0 halo path.
+    // W-path interior-first reorder dims
     uint32_t w_input_H = 0, w_pad_h = 0, w_h_total = 1, w_row_stride = 0, w_slice_frames = 0;
     bool w_interior_first_p0 = false;
     if constexpr (is_w_fabric_writer) {
@@ -319,10 +285,7 @@ void kernel_main() {
         w_interior_first_p0 = (progress_t_batch_size == 0) && (outer_dim_size == w_slice_frames * w_h_total);
     }
 
-    // Coalesced W-send (middle device): ship g (<= W_COALESCE) same-dst-bank sticks as one g*page fabric
-    // write, lockstep with np_phase2_w_reader's bank-major gather. base = outer_dim_offset_start_id =
-    // section_base + w_link_start (compact W base, 8-aligned by factory eligibility), so dst sticks
-    // base+r, base+r+8, ..., base+r+8*(g-1) are contiguous on bank (base+r)%8 in interleaved DRAM.
+    // Coalesced W-send (middle device): ship g (<= W_COALESCE) same-dst-bank sticks as one g*page fabric write
     if constexpr (is_w_fabric_writer && W_COALESCE > 0) {
         if (!is_first_chip && !is_last_chip) {
             if (!fabric_opened) {
@@ -447,13 +410,7 @@ void kernel_main() {
 
         if (!is_last_chip) {
             bool did_corner_first = false;
-            // H writer, corners-only, padding==1: the neighbor's H reader recv-commit pulls only the
-            // corner sticks; the bulk middle sticks go straight to its output DRAM for conv (gated far
-            // later by w_region_sem). So send the few corners first and raise the recv sem BEFORE the
-            // middle bulk — the neighbor clears its recv-wait after ~pad2 sticks instead of the whole
-            // row, taking the full-row send off the H-recv critical path. The single send_cb row holds
-            // both passes, so no extra read. padding!=1 needs all pad rows resident before the sem inc
-            // (the 2-row send_cb can't guarantee that), so it keeps the in-order path below.
+            // H writer, corners-only, padding==1: the neighbor's H reader recv-commit pulls only the corner sticks
             if constexpr (use_l1_intermediate && !is_w_fabric_writer) {
                 if (H_CORNER_FIRST && padding == 1) {
                     uint32_t dst_stick_id =
@@ -474,8 +431,7 @@ void kernel_main() {
                     }
                     noc_async_write_barrier();
 
-                    // Corners delivered: raise the recv sem before the middle bulk so the neighbor's
-                    // recv-commit clears now instead of after the whole row.
+                    // Corners delivered: raise the recv sem before the middle bulk so the neighbor's recv-commit
                     raise_neighbor_sem();
 
                     // Pass 2: bulk middle sticks -> neighbor DRAM (off the H-recv critical path).
@@ -502,10 +458,7 @@ void kernel_main() {
                         dst_stick_id = pad_id * num_sticks_per_halo_dim + stick_start_id;
                     }
                     dst_stick_id += eff_offset;
-                    // H-writer bank-major coalesced send (use_l1=0). np_h_reader gathered the row into
-                    // send_cb in bank-major order (w=0,8,..; 1,9,..); ship each bank's sticks as
-                    // W_COALESCE-sized packets to base_row+w (contiguous on bank (base_row+w)%8, 8-aligned
-                    // base_row). W_COALESCE here holds h_coalesce_n (the H writer's factory arg slot).
+                    // H-writer bank-major coalesced send (use_l1=0)
                     if constexpr (!is_w_fabric_writer && W_COALESCE > 0) {
                         const uint32_t base_row = dst_stick_id;
                         cb_wait_front(send_cb_id, num_sticks_to_read);
@@ -570,9 +523,7 @@ void kernel_main() {
 
                         dst_stick_id++;
 
-                        // fabric_send_stick already flushed the local writes (source read done), so the
-                        // CB slot is safe to reuse. The receiver only reads after the post-loop
-                        // raise_neighbor_sem, so no per-stick remote-completion barrier is needed here.
+                        // fabric_send_stick already flushed the local writes (source read done)
                         cb_pop_front(send_cb_id, 1);
                     }
                 }
@@ -585,10 +536,7 @@ void kernel_main() {
 
         outer_dim_offset += (num_sticks_per_halo_dim * output_halo_dim_size);
 
-        // Per-batch H-commit: commit this od's incoming H-halo (pushed by the paired reader from the
-        // L1 recv buffer as soon as the sender link delivered it), then signal HT/HB per batch — so
-        // the W-reader corner gate + conv3d H-edge tiles ramp this batch rather than after the whole
-        // send pass.  One producer per (region,link) -> monotonic.
+        // Per-batch H-commit: commit this od's incoming H-halo
         if constexpr (handle_incoming_writes) {
             if (!is_first_chip) {
                 for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
@@ -667,10 +615,7 @@ void kernel_main() {
     // Ensure all DRAM writes from main loop are complete.
     noc_async_write_barrier();
 
-    // Partial-last-batch tail: the partial last batch never hit a (od+1)%pb boundary in the loop
-    // above, so its HT/HB sem was never bumped — fire it once here, else consumers waiting
-    // ceil(link_dims/pb) deadlock on the missing count. Recv+commit of incoming H-halo is interleaved
-    // per-od into the send loop above, so this only handles the trailing partial batch.
+    // Partial-last-batch tail: the partial last batch never hit a (od+1)%pb boundary in the loop above
     if constexpr (handle_incoming_writes) {
         if (!is_first_chip) {
             if constexpr (progress_t_batch_size > 0) {
@@ -696,9 +641,7 @@ void kernel_main() {
         fabric_connection.close();
     }
 
-    // Signal Phase 2 W-cores AFTER handle_incoming_writes and fabric close.
-    // This guarantees L1-routed corners are committed to DRAM before W-readers start.
-    // In 1D mode num_phase2_signal_targets == 0, so this is a no-op.
+    // Signal Phase 2 W-cores AFTER handle_incoming_writes and fabric close
     noc_async_write_barrier();
     for (uint32_t st = 0; st < num_phase2_signal_targets; st++) {
         uint64_t sem_noc_addr = get_noc_addr(signal_noc_x[st], signal_noc_y[st], barrier_sem);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/np_writer.cpp
@@ -1,0 +1,708 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include <tt-metalium/buffer_types.hpp>
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
+#include "tt_metal/fabric/hw/inc/noc_addr.h"
+#include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
+#include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
+#include "cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+#include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
+#include "tt_metal/fabric/hw/inc/linear/api.h"
+#include "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_common/kernels/np_reorder.hpp"
+#include <cstdint>
+#include <utility>
+
+using address_t = uint32_t;
+using namespace tt::tt_fabric::linear::experimental;
+
+// Runtime-arg versions of route info readers, local to this kernel.
+// Used because consolidated kernels have per-core routing via runtime args.
+inline ccl_routing_utils::line_unicast_route_info_t get_line_unicast_route_info_from_rt_args(uint32_t& arg_idx) {
+    return {
+        .dst_mesh_id = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++)),
+        .dst_chip_id = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++))};
+}
+
+inline ccl_routing_utils::line_multicast_route_info_t get_line_multicast_route_info_from_rt_args(uint32_t& arg_idx) {
+    return {
+        .dst_mesh_id = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++)),
+        .dst_chip_id = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++)),
+        .e_num_hops = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++)),
+        .w_num_hops = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++)),
+        .n_num_hops = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++)),
+        .s_num_hops = static_cast<uint16_t>(get_arg_val<uint32_t>(arg_idx++))};
+}
+
+// Compile-time args (uniform across all cores sharing this kernel)
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(0);
+constexpr bool is_padding_zeros = get_compile_time_arg_val(1);
+constexpr uint32_t stick_size = get_compile_time_arg_val(2);
+// Output TensorAccessorArgs start at index 3 (variable length)
+constexpr auto dst_ct_args = TensorAccessorArgs<3>();
+constexpr uint32_t ct_after_dst = dst_ct_args.next_compile_time_args_offset();
+constexpr bool use_l1_intermediate = get_compile_time_arg_val(ct_after_dst);
+constexpr uint32_t recv_cb_id = get_compile_time_arg_val(ct_after_dst + 1);
+constexpr bool handle_incoming_writes = get_compile_time_arg_val(ct_after_dst + 2);
+constexpr bool is_w_fabric_writer = get_compile_time_arg_val(ct_after_dst + 3);
+constexpr uint32_t ring_size = get_compile_time_arg_val(ct_after_dst + 4);
+// Per-batch progress-sem signalling granularity (in T-input frames).
+constexpr uint32_t progress_t_batch_size = get_compile_time_arg_val(ct_after_dst + 5);
+// CB the fabric-send loop drains. H writer: dedicated batched send ring (c_in2). W writer: c_in0.
+constexpr uint32_t send_cb_id = get_compile_time_arg_val(ct_after_dst + 6);
+
+// Global two-pass gate, set per-shape by the program factory (lockstep with np_phase2_w_reader via
+// the same factory value). Follows send_cb_id (ct_after_dst + 6) in the W-writer/H-writer arg layout.
+constexpr bool W_TWO_PASS = get_compile_time_arg_val(ct_after_dst + 7);
+
+// H-writer corner-first send (H-writer path only): raise the recv sem after the corner sticks, before
+// the bulk middle, so the neighbor's recv-wait clears after ~pad2 sticks instead of the whole row. Set
+// per-shape by the program factory; unused on the W writer. Follows W_TWO_PASS in the arg layout.
+constexpr bool H_CORNER_FIRST = get_compile_time_arg_val(ct_after_dst + 8);
+
+// W-send bank-major coalesce factor (0 = per-stick). Lockstep with np_phase2_w_reader: a middle W
+// device ships N same-dst-bank sticks (base+r, base+r+8, ...) as one N*page fabric write to the
+// neighbor's interleaved DRAM. Follows H_CORNER_FIRST in the arg layout. BH: 8 DRAM banks.
+constexpr uint32_t W_COALESCE = get_compile_time_arg_val(ct_after_dst + 9);
+constexpr uint32_t NP_NUM_DRAM_BANKS = 8;
+
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+    // Common runtime args (uniform across all cores, updated between dispatches). Index 0 (input addr)
+    // is part of the shared CRTA layout but unused by the writer (it reads/writes the output buffer).
+    const address_t output_tensor_address = get_common_arg_val<address_t>(1);
+    const size_t neighbor_sem = get_common_arg_val<uint32_t>(2);
+    const size_t barrier_sem = get_common_arg_val<uint32_t>(3);
+    // Number of conv3d reader cores to signal and their NOC (x,y) coordinates.
+    // Packed as: [num_reader_cores, x0, y0, x1, y1, ...]
+    const uint32_t num_reader_cores = get_common_arg_val<uint32_t>(4);
+    // Reader core NOC coords start at CRTA index 5: x0=5, y0=6, x1=7, y1=8, ...
+
+    // Per-core runtime args
+    uint32_t arg_idx = 0;
+    const uint32_t outer_dim_offset_start_id = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t stick_start_id = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t input_halo_dim_size = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t output_halo_dim_size = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t outer_dim_size = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t padding = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t padding_left = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_sticks_to_read = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_sticks_per_halo_dim = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t neighbor_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t neighbor_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+
+    // Phase 2 barrier signal targets (0 for 1D, >0 for 2D)
+    // Max targets = pad2_num_links * 2 directions (up to 8 W fabric cores)
+    constexpr uint32_t MAX_PHASE2_SIGNAL_TARGETS = 8;
+    const uint32_t num_phase2_signal_targets = get_arg_val<uint32_t>(arg_idx++);
+    uint8_t signal_noc_x[MAX_PHASE2_SIGNAL_TARGETS];
+    uint8_t signal_noc_y[MAX_PHASE2_SIGNAL_TARGETS];
+    for (uint32_t st = 0; st < MAX_PHASE2_SIGNAL_TARGETS; st++) {
+        signal_noc_x[st] = get_arg_val<uint32_t>(arg_idx++);
+        signal_noc_y[st] = get_arg_val<uint32_t>(arg_idx++);
+    }
+
+    // Per-core direction and routing args (moved from compile-time for kernel consolidation)
+    const bool is_first_chip = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_last_chip = get_arg_val<uint32_t>(arg_idx++);
+    const bool direction = get_arg_val<uint32_t>(arg_idx++);
+    auto unicast_route_info = get_line_unicast_route_info_from_rt_args(arg_idx);
+    auto barrier_multicast_route_info = get_line_multicast_route_info_from_rt_args(arg_idx);
+
+    size_t arg_for_fab = arg_idx;
+    auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
+
+    const uint32_t outer_dim_offset_start_t = get_arg_val<uint32_t>(static_cast<uint32_t>(arg_for_fab));
+    // This (direction,link)'s H-region sem (H-top/H-bot), signalled per-batch from
+    // handle_incoming_writes so the W-reader corner gate + conv3d H-edge tiles ramp without a barrier.
+    uint32_t h_region_sem_addr = 0;
+    if constexpr (progress_t_batch_size > 0) {
+        h_region_sem_addr = get_arg_val<uint32_t>(static_cast<uint32_t>(arg_for_fab) + 1);
+    }
+
+    const auto dst_accessor = TensorAccessor(dst_ct_args, output_tensor_address, stick_size);
+
+    // L1 intermediate: discover the recv CB base address (same on neighbor device due to identical program)
+    uint32_t recv_buf_base = 0;
+    if constexpr (use_l1_intermediate) {
+        recv_buf_base = get_write_ptr(recv_cb_id);
+    }
+
+    // pre-populate packet headers with proper routing
+    auto pkt_hdr = PacketHeaderPool::allocate_header();
+    ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr, unicast_route_info);
+    auto pkt_hdr_sem_inc = PacketHeaderPool::allocate_header();
+
+    // Send one payload stick to dst_noc_addr over the fabric; pkt_hdr is reused per stick.
+    auto fabric_send_stick = [&](uint32_t l1_read_addr, uint64_t dst_noc_addr) {
+        pkt_hdr->to_noc_unicast_write(tt::tt_fabric::NocUnicastCommandHeader{dst_noc_addr}, stick_size);
+        auto& conn =
+            direction ? fabric_connection.get_backward_connection() : fabric_connection.get_forward_connection();
+        conn.wait_for_empty_write_slot();
+        conn.send_payload_without_header_non_blocking_from_address(l1_read_addr, stick_size);
+        conn.send_payload_flush_non_blocking_from_address((uint32_t)pkt_hdr, sizeof(PACKET_HEADER_TYPE));
+        noc_async_writes_flushed();
+    };
+
+    // Atomic-inc the neighbor's output-ready semaphore over the fabric.
+    auto raise_neighbor_sem = [&]() {
+        uint64_t sem_noc_addr = safe_get_noc_addr(neighbor_sem_noc0_x, neighbor_sem_noc0_y, neighbor_sem, 0);
+        pkt_hdr_sem_inc->to_noc_unicast_atomic_inc(
+            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{sem_noc_addr, static_cast<uint32_t>(1)});
+        ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_sem_inc, unicast_route_info);
+        auto& conn =
+            direction ? fabric_connection.get_backward_connection() : fabric_connection.get_forward_connection();
+        conn.wait_for_empty_write_slot();
+        conn.send_payload_flush_blocking_from_address((uint32_t)pkt_hdr_sem_inc, sizeof(PACKET_HEADER_TYPE));
+        noc_async_writes_flushed();
+    };
+
+    // H writers: always open fabric at start (for data transfer in main loop).
+    // W writers: open at start only when startup barrier is enabled (defer data transfer until CB ready).
+    bool fabric_opened = false;
+    if (!is_w_fabric_writer || use_barrier_sem) {
+        fabric_connection.open();
+        fabric_opened = true;
+    }
+
+    // Startup barrier: sync across all devices before sending new fabric data.
+    // H writers: multicast to all H-axis devices (same column, consistent harvesting).
+    // W writers: 1-hop unicast to immediate W neighbor only.
+    //   W-axis devices span different UBBs with potentially different core harvesting,
+    //   so multicast (which targets fixed NOC x,y) would hit wrong cores on remote devices.
+    //   H all-to-all multicast + W 1-hop unicast transitively synchronizes the full mesh.
+    if (use_barrier_sem) {
+        if constexpr (!is_w_fabric_writer) {
+            // H barrier: multicast to all H-axis devices (same column)
+            auto pkt_hdr_barrier_sem_inc = PacketHeaderPool::allocate_header();
+
+            if (!is_last_chip) {
+                // Set up multicast routing and atomic inc state
+                ccl_routing_utils::fabric_set_line_multicast_route(
+                    pkt_hdr_barrier_sem_inc, barrier_multicast_route_info);
+                fabric_multicast_noc_unicast_atomic_inc_set_state<
+                    UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
+                    pkt_hdr_barrier_sem_inc,
+                    static_cast<uint8_t>(barrier_multicast_route_info.start_distance_in_hops),
+                    static_cast<uint8_t>(barrier_multicast_route_info.range_hops),
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{0, static_cast<uint32_t>(1)});
+
+                // Multicast to same-direction cores on all reachable devices
+                uint64_t same_dir_noc_addr =
+                    safe_get_noc_addr(neighbor_sem_noc0_x, neighbor_sem_noc0_y, barrier_sem, 0);
+                if (direction) {
+                    fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+                        &fabric_connection.get_backward_connection(),
+                        pkt_hdr_barrier_sem_inc,
+                        tt::tt_fabric::NocUnicastAtomicIncCommandHeader{same_dir_noc_addr, 0});
+                } else {
+                    fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+                        &fabric_connection.get_forward_connection(),
+                        pkt_hdr_barrier_sem_inc,
+                        tt::tt_fabric::NocUnicastAtomicIncCommandHeader{same_dir_noc_addr, 0});
+                }
+
+                // Multicast to opposite-direction cores on all reachable devices
+                uint64_t opp_dir_noc_addr = safe_get_noc_addr(barrier_sem_noc0_x, barrier_sem_noc0_y, barrier_sem, 0);
+                if (direction) {
+                    fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+                        &fabric_connection.get_backward_connection(),
+                        pkt_hdr_barrier_sem_inc,
+                        tt::tt_fabric::NocUnicastAtomicIncCommandHeader{opp_dir_noc_addr, 0});
+                } else {
+                    fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+                        &fabric_connection.get_forward_connection(),
+                        pkt_hdr_barrier_sem_inc,
+                        tt::tt_fabric::NocUnicastAtomicIncCommandHeader{opp_dir_noc_addr, 0});
+                }
+            }
+
+            if constexpr (ring_size > 1) {
+                noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
+            }
+        } else {
+            // W barrier: 1-hop unicast to immediate W neighbor only.
+            // neighbor_sem_noc0_x/y and barrier_sem_noc0_x/y are NOC coords of the local
+            // device's worker cores. Since NOC coords are not chip-dependent, these are
+            // valid targets on the neighbor device as well.
+            if (!is_last_chip) {
+                auto pkt_hdr_barrier_sem_inc = PacketHeaderPool::allocate_header();
+
+                // Unicast barrier inc to same-direction W core on immediate neighbor
+                uint64_t same_dir_noc_addr =
+                    safe_get_noc_addr(neighbor_sem_noc0_x, neighbor_sem_noc0_y, barrier_sem, 0);
+                pkt_hdr_barrier_sem_inc->to_noc_unicast_atomic_inc(
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{same_dir_noc_addr, 1u});
+                ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_barrier_sem_inc, unicast_route_info);
+                if (direction) {
+                    fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+                    fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
+                        (uint32_t)pkt_hdr_barrier_sem_inc, sizeof(PACKET_HEADER_TYPE));
+                } else {
+                    fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+                    fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+                        (uint32_t)pkt_hdr_barrier_sem_inc, sizeof(PACKET_HEADER_TYPE));
+                }
+
+                // Unicast barrier inc to opposite-direction W core on immediate neighbor
+                uint64_t opp_dir_noc_addr = safe_get_noc_addr(barrier_sem_noc0_x, barrier_sem_noc0_y, barrier_sem, 0);
+                pkt_hdr_barrier_sem_inc->to_noc_unicast_atomic_inc(
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{opp_dir_noc_addr, 1u});
+                ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_barrier_sem_inc, unicast_route_info);
+                if (direction) {
+                    fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+                    fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
+                        (uint32_t)pkt_hdr_barrier_sem_inc, sizeof(PACKET_HEADER_TYPE));
+                } else {
+                    fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+                    fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+                        (uint32_t)pkt_hdr_barrier_sem_inc, sizeof(PACKET_HEADER_TYPE));
+                }
+            }
+
+            // Wait for 1 barrier inc from each adjacent W device (if it exists)
+            uint32_t w_barrier_wait = (is_first_chip ? 0u : 1u) + (is_last_chip ? 0u : 1u);
+            if (w_barrier_wait > 0) {
+                noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), w_barrier_wait);
+            }
+        }
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
+    }
+
+    // Corners-only optimization for 2D H writers:
+    // Only W-boundary sticks (corners) go to neighbor L1; non-corner sticks go directly to DRAM.
+    // Phase 2 W reader only needs corners, so this is safe.
+    // Derivation: the output row is [pad2_left | W interior sticks | pad2_right].
+    // The factory sets stick_start_id = pad2_left (the W offset where interior data begins),
+    // num_sticks_per_halo_dim = W + pad2_left + pad2_right (full output row width),
+    // and num_sticks_to_read = W (interior width). So:
+    //   pad2_left_sticks  = stick_start_id = pad2_left
+    //   pad2_right_sticks = (W + pad2_left + pad2_right) - W - pad2_left = pad2_right
+    // These can be different (asymmetric W padding is supported).
+    uint32_t pad2_left_sticks = 0;
+    uint32_t pad2_right_sticks = 0;
+    if constexpr (use_l1_intermediate && !is_w_fabric_writer) {
+        // Use padding_left for corner count (not stick_start_id) so it works when stick_start_id=0
+        // (fabric_only mode). In fabric_only: stick_start_id=0 but padding_left=W/2=104,
+        // giving pad2_left_sticks=104, pad2_right_sticks=104 → overlap case → all sticks are corners.
+        pad2_left_sticks = (padding_left > 0) ? padding_left : stick_start_id;
+        uint32_t w_overhead = num_sticks_per_halo_dim - num_sticks_to_read;
+        pad2_right_sticks = (w_overhead >= pad2_left_sticks) ? (w_overhead - pad2_left_sticks) : pad2_left_sticks;
+    }
+    // A W-boundary (corner) stick is one of the pad2 columns at either row end; the rest are interior.
+    auto is_corner_stick = [&](uint32_t iter) {
+        return iter < pad2_right_sticks || iter >= (num_sticks_to_read - pad2_left_sticks);
+    };
+
+    // W-path interior-first reorder dims (common args [4],[5], W-writer only). Parsed for every W-writer
+    // (the factory always sets [4],[5]); used by W_TWO_PASS (progress>0) and the progress==0 halo path.
+    uint32_t w_input_H = 0, w_pad_h = 0, w_h_total = 1, w_row_stride = 0, w_slice_frames = 0;
+    bool w_interior_first_p0 = false;
+    if constexpr (is_w_fabric_writer) {
+        w_input_H = get_common_arg_val<uint32_t>(4);
+        w_pad_h = get_common_arg_val<uint32_t>(5);
+        w_h_total = w_input_H + 2 * w_pad_h;
+        w_row_stride = num_sticks_per_halo_dim * output_halo_dim_size;
+        w_slice_frames = (w_h_total > 0) ? (outer_dim_size / w_h_total) : 0;
+        // Lockstep with np_phase2_w_reader: progress==0 reorders interior-first when frames align.
+        w_interior_first_p0 = (progress_t_batch_size == 0) && (outer_dim_size == w_slice_frames * w_h_total);
+    }
+
+    // Coalesced W-send (middle device): ship g (<= W_COALESCE) same-dst-bank sticks as one g*page fabric
+    // write, lockstep with np_phase2_w_reader's bank-major gather. base = outer_dim_offset_start_id =
+    // section_base + w_link_start (compact W base, 8-aligned by factory eligibility), so dst sticks
+    // base+r, base+r+8, ..., base+r+8*(g-1) are contiguous on bank (base+r)%8 in interleaved DRAM.
+    if constexpr (is_w_fabric_writer && W_COALESCE > 0) {
+        if (!is_first_chip && !is_last_chip) {
+            if (!fabric_opened) {
+                fabric_connection.open();
+                fabric_opened = true;
+            }
+            const uint32_t base = outer_dim_offset_start_id;
+            auto& conn =
+                direction ? fabric_connection.get_backward_connection() : fabric_connection.get_forward_connection();
+            for (uint32_t j = 0; j < NP_NUM_DRAM_BANKS; j++) {
+                uint32_t r = j;
+                while (r < outer_dim_size) {
+                    uint32_t g = 0;
+                    for (uint32_t rr = r; g < W_COALESCE && rr < outer_dim_size; rr += NP_NUM_DRAM_BANKS) {
+                        g++;
+                    }
+                    cb_wait_front(send_cb_id, g);
+                    const uint32_t l1_read_addr = get_read_ptr(send_cb_id);
+                    const uint64_t dst_noc_addr = get_noc_addr(base + r, dst_accessor);
+                    pkt_hdr->to_noc_unicast_write(tt::tt_fabric::NocUnicastCommandHeader{dst_noc_addr}, g * stick_size);
+                    conn.wait_for_empty_write_slot();
+                    conn.send_payload_without_header_non_blocking_from_address(l1_read_addr, g * stick_size);
+                    conn.send_payload_flush_non_blocking_from_address((uint32_t)pkt_hdr, sizeof(PACKET_HEADER_TYPE));
+                    noc_async_writes_flushed();
+                    cb_pop_front(send_cb_id, g);
+                    r += g * NP_NUM_DRAM_BANKS;
+                }
+            }
+            // Raise the neighbor's W recv sem by the full row count (receiver waits >= outer_dim_size).
+            {
+                uint64_t sem_noc_addr = safe_get_noc_addr(neighbor_sem_noc0_x, neighbor_sem_noc0_y, neighbor_sem, 0);
+                pkt_hdr_sem_inc->to_noc_unicast_atomic_inc(
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{sem_noc_addr, outer_dim_size});
+                ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_sem_inc, unicast_route_info);
+                conn.wait_for_empty_write_slot();
+                conn.send_payload_flush_blocking_from_address((uint32_t)pkt_hdr_sem_inc, sizeof(PACKET_HEADER_TYPE));
+                noc_async_writes_flushed();
+            }
+            noc_async_write_barrier();
+            fabric_connection.close();
+            return;
+        }
+    }
+
+    uint32_t outer_dim_offset = outer_dim_offset_start_id;
+    uint32_t l1_buf_offset = 0;                       // L1 intermediate: accumulates across all outer_dims (no reuse)
+    uint32_t inc_offset = outer_dim_offset_start_id;  // recv-commit cursor, advances per committed od
+    for (uint32_t outer_dim = 0; outer_dim < outer_dim_size; outer_dim++) {
+        // Interior-first reorder: ALL interior rows then ALL corners (lockstep with the W reader).
+        uint32_t eff_offset = outer_dim_offset;
+        bool w_use_reorder = false;
+        if constexpr (is_w_fabric_writer && progress_t_batch_size > 0) {
+            w_use_reorder = W_TWO_PASS;
+        } else if constexpr (is_w_fabric_writer) {
+            w_use_reorder = w_interior_first_p0;
+        }
+        if (w_use_reorder) {
+            uint32_t frame_in_slice, hp;
+            np_reorder_batch(outer_dim, w_slice_frames, w_input_H, w_pad_h, frame_in_slice, hp);
+            const uint32_t reordered = frame_in_slice * w_h_total + hp;
+            eff_offset = outer_dim_offset_start_id + reordered * w_row_stride;
+        }
+        if (is_first_chip) {
+            if (!is_padding_zeros) {
+                // Replicate a slice of 1 from input to output
+                uint32_t dst_stick_id = 0;
+                if (direction) {
+                    dst_stick_id = (output_halo_dim_size - padding) * num_sticks_per_halo_dim + stick_start_id;
+                } else {
+                    dst_stick_id = stick_start_id;
+                }
+                dst_stick_id += eff_offset;
+                for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
+                    cb_wait_front(cb_output_id, 1);
+                    if constexpr (is_w_fabric_writer) {
+                        if (!fabric_opened) {
+                            fabric_connection.open();
+                            fabric_opened = true;
+                        }
+                    }
+                    uint32_t l1_read_addr = get_read_ptr(cb_output_id);
+
+                    for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
+                        uint64_t dst_noc_addr =
+                            get_noc_addr(dst_stick_id + pad_id * num_sticks_per_halo_dim, dst_accessor);
+                        noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+                    }
+                    dst_stick_id++;
+
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_output_id, 1);
+                }
+            } else {
+                uint32_t dst_stick_id = 0;
+                if (direction) {
+                    dst_stick_id = (output_halo_dim_size - padding) * num_sticks_per_halo_dim + stick_start_id;
+                } else {
+                    dst_stick_id = stick_start_id;
+                }
+                dst_stick_id += eff_offset;
+                cb_wait_front(cb_output_id, 1);
+                if constexpr (is_w_fabric_writer) {
+                    if (!fabric_opened) {
+                        fabric_connection.open();
+                        fabric_opened = true;
+                    }
+                }
+                uint32_t l1_read_addr = get_read_ptr(cb_output_id);
+                for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
+                    for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
+                        uint64_t dst_noc_addr =
+                            get_noc_addr(dst_stick_id + pad_id * num_sticks_per_halo_dim, dst_accessor);
+                        noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+                    }
+                    dst_stick_id++;
+
+                    noc_async_write_barrier();
+                }
+                cb_pop_front(cb_output_id, 1);
+            }
+        }
+
+        if (!is_last_chip) {
+            bool did_corner_first = false;
+            // H writer, corners-only, padding==1: the neighbor's H reader recv-commit pulls only the
+            // corner sticks; the bulk middle sticks go straight to its output DRAM for conv (gated far
+            // later by w_region_sem). So send the few corners first and raise the recv sem BEFORE the
+            // middle bulk — the neighbor clears its recv-wait after ~pad2 sticks instead of the whole
+            // row, taking the full-row send off the H-recv critical path. The single send_cb row holds
+            // both passes, so no extra read. padding!=1 needs all pad rows resident before the sem inc
+            // (the 2-row send_cb can't guarantee that), so it keeps the in-order path below.
+            if constexpr (use_l1_intermediate && !is_w_fabric_writer) {
+                if (H_CORNER_FIRST && padding == 1) {
+                    uint32_t dst_stick_id =
+                        (direction ? (output_halo_dim_size - 1) * num_sticks_per_halo_dim + stick_start_id
+                                   : stick_start_id) +
+                        eff_offset;
+                    cb_wait_front(send_cb_id, num_sticks_to_read);
+                    const uint32_t row_base = get_read_ptr(send_cb_id);
+                    // Pass 1: corner sticks -> neighbor L1.
+                    for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
+                        if (!is_corner_stick(iter)) {
+                            continue;
+                        }
+                        uint64_t dst_noc_addr = safe_get_noc_addr(
+                            neighbor_sem_noc0_x, neighbor_sem_noc0_y, recv_buf_base + l1_buf_offset, 0);
+                        l1_buf_offset += stick_size;
+                        fabric_send_stick(row_base + iter * stick_size, dst_noc_addr);
+                    }
+                    noc_async_write_barrier();
+
+                    // Corners delivered: raise the recv sem before the middle bulk so the neighbor's
+                    // recv-commit clears now instead of after the whole row.
+                    raise_neighbor_sem();
+
+                    // Pass 2: bulk middle sticks -> neighbor DRAM (off the H-recv critical path).
+                    for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
+                        if (!is_corner_stick(iter)) {
+                            fabric_send_stick(
+                                row_base + iter * stick_size, get_noc_addr(dst_stick_id, dst_accessor, 0, 0));
+                        }
+                        dst_stick_id++;
+                    }
+                    noc_async_write_barrier();
+                    cb_pop_front(send_cb_id, num_sticks_to_read);
+                    did_corner_first = true;
+                }
+            }
+            if (!did_corner_first) {
+                // Read the "end" of each slice into the CB to write to the neighbor
+                for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
+                    uint32_t dst_stick_id = 0;
+                    if (direction) {
+                        dst_stick_id =
+                            (output_halo_dim_size - (padding - pad_id)) * num_sticks_per_halo_dim + stick_start_id;
+                    } else {
+                        dst_stick_id = pad_id * num_sticks_per_halo_dim + stick_start_id;
+                    }
+                    dst_stick_id += eff_offset;
+                    // H-writer bank-major coalesced send (use_l1=0). np_h_reader gathered the row into
+                    // send_cb in bank-major order (w=0,8,..; 1,9,..); ship each bank's sticks as
+                    // W_COALESCE-sized packets to base_row+w (contiguous on bank (base_row+w)%8, 8-aligned
+                    // base_row). W_COALESCE here holds h_coalesce_n (the H writer's factory arg slot).
+                    if constexpr (!is_w_fabric_writer && W_COALESCE > 0) {
+                        const uint32_t base_row = dst_stick_id;
+                        cb_wait_front(send_cb_id, num_sticks_to_read);
+                        const uint32_t row_l1 = get_read_ptr(send_cb_id);
+                        auto& conn = direction ? fabric_connection.get_backward_connection()
+                                               : fabric_connection.get_forward_connection();
+                        uint32_t m = 0;
+                        for (uint32_t j = 0; j < NP_NUM_DRAM_BANKS; j++) {
+                            for (uint32_t w = j; w < num_sticks_to_read;) {
+                                uint32_t g = 0;
+                                for (uint32_t ww = w; g < W_COALESCE && ww < num_sticks_to_read;
+                                     ww += NP_NUM_DRAM_BANKS) {
+                                    g++;
+                                }
+                                const uint64_t dst_noc = get_noc_addr(base_row + w, dst_accessor);
+                                pkt_hdr->to_noc_unicast_write(
+                                    tt::tt_fabric::NocUnicastCommandHeader{dst_noc}, g * stick_size);
+                                conn.wait_for_empty_write_slot();
+                                conn.send_payload_without_header_non_blocking_from_address(
+                                    row_l1 + m * stick_size, g * stick_size);
+                                conn.send_payload_flush_non_blocking_from_address(
+                                    (uint32_t)pkt_hdr, sizeof(PACKET_HEADER_TYPE));
+                                noc_async_writes_flushed();
+                                m += g;
+                                w += g * NP_NUM_DRAM_BANKS;
+                            }
+                        }
+                        cb_pop_front(send_cb_id, num_sticks_to_read);
+                        continue;  // next pad_id; skip the per-stick loop
+                    }
+                    for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
+                        cb_wait_front(send_cb_id, 1);
+                        if constexpr (is_w_fabric_writer) {
+                            if (!fabric_opened) {
+                                fabric_connection.open();
+                                fabric_opened = true;
+                            }
+                        }
+                        uint32_t l1_read_addr = get_read_ptr(send_cb_id);
+
+                        uint64_t dst_noc_addr;
+                        if constexpr (use_l1_intermediate && !is_w_fabric_writer) {
+                            // Corners-only: W-boundary sticks go to L1, rest to DRAM
+                            if (is_corner_stick(iter)) {
+                                dst_noc_addr = safe_get_noc_addr(
+                                    neighbor_sem_noc0_x, neighbor_sem_noc0_y, recv_buf_base + l1_buf_offset, 0);
+                                l1_buf_offset += stick_size;
+                            } else {
+                                // Non-corner: send directly to neighbor's output DRAM
+                                dst_noc_addr = get_noc_addr(dst_stick_id, dst_accessor, 0, 0);
+                            }
+                        } else if constexpr (use_l1_intermediate) {
+                            // W writer: all sticks to L1
+                            dst_noc_addr = safe_get_noc_addr(
+                                neighbor_sem_noc0_x, neighbor_sem_noc0_y, recv_buf_base + l1_buf_offset, 0);
+                            l1_buf_offset += stick_size;
+                        } else {
+                            dst_noc_addr = get_noc_addr(dst_stick_id, dst_accessor, 0, 0);
+                        }
+
+                        fabric_send_stick(l1_read_addr, dst_noc_addr);
+
+                        dst_stick_id++;
+
+                        // fabric_send_stick already flushed the local writes (source read done), so the
+                        // CB slot is safe to reuse. The receiver only reads after the post-loop
+                        // raise_neighbor_sem, so no per-stick remote-completion barrier is needed here.
+                        cb_pop_front(send_cb_id, 1);
+                    }
+                }
+
+                raise_neighbor_sem();
+            }
+        }
+
+        // No local interior copy in this kernel. Dedicated local-copy kernels handle that work.
+
+        outer_dim_offset += (num_sticks_per_halo_dim * output_halo_dim_size);
+
+        // Per-batch H-commit: commit this od's incoming H-halo (pushed by the paired reader from the
+        // L1 recv buffer as soon as the sender link delivered it), then signal HT/HB per batch — so
+        // the W-reader corner gate + conv3d H-edge tiles ramp this batch rather than after the whole
+        // send pass.  One producer per (region,link) -> monotonic.
+        if constexpr (handle_incoming_writes) {
+            if (!is_first_chip) {
+                for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
+                    uint32_t row_offset;
+                    if (direction) {
+                        row_offset = (output_halo_dim_size - padding + pad_id) * num_sticks_per_halo_dim;
+                    } else {
+                        row_offset = pad_id * num_sticks_per_halo_dim;
+                    }
+                    uint32_t base_dst = inc_offset + row_offset + stick_start_id;
+
+                    if constexpr (use_l1_intermediate && !is_w_fabric_writer) {
+                        if (pad2_right_sticks + pad2_left_sticks >= num_sticks_to_read) {
+                            // Overlap: all sticks are corners, pop exactly num_sticks_to_read
+                            for (uint32_t c = 0; c < num_sticks_to_read; c++) {
+                                cb_wait_front(cb_output_id, 1);
+                                uint32_t l1_read_addr = get_read_ptr(cb_output_id);
+                                uint64_t dst_noc_addr = get_noc_addr(base_dst + c, dst_accessor);
+                                noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+                                noc_async_write_barrier();
+                                cb_pop_front(cb_output_id, 1);
+                            }
+                        } else {
+                            // Corners-only: pop left corners then right corners from CB
+                            for (uint32_t c = 0; c < pad2_right_sticks; c++) {
+                                cb_wait_front(cb_output_id, 1);
+                                uint32_t l1_read_addr = get_read_ptr(cb_output_id);
+                                uint64_t dst_noc_addr = get_noc_addr(base_dst + c, dst_accessor);
+                                noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+                                noc_async_write_barrier();
+                                cb_pop_front(cb_output_id, 1);
+                            }
+                            uint32_t right_start = base_dst + (num_sticks_to_read - pad2_left_sticks);
+                            for (uint32_t c = 0; c < pad2_left_sticks; c++) {
+                                cb_wait_front(cb_output_id, 1);
+                                uint32_t l1_read_addr = get_read_ptr(cb_output_id);
+                                uint64_t dst_noc_addr = get_noc_addr(right_start + c, dst_accessor);
+                                noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+                                noc_async_write_barrier();
+                                cb_pop_front(cb_output_id, 1);
+                            }
+                        }
+                    } else {
+                        uint32_t dst_stick_id = base_dst;
+                        for (uint32_t iter = 0; iter < num_sticks_to_read; iter++) {
+                            cb_wait_front(cb_output_id, 1);
+                            uint32_t l1_read_addr = get_read_ptr(cb_output_id);
+                            uint64_t dst_noc_addr = get_noc_addr(dst_stick_id, dst_accessor);
+                            noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+                            noc_async_write_barrier();
+                            cb_pop_front(cb_output_id, 1);
+                            dst_stick_id++;
+                        }
+                    }
+                }
+                inc_offset += num_sticks_per_halo_dim * output_halo_dim_size;
+
+                if constexpr (progress_t_batch_size > 0) {
+                    if ((outer_dim_offset_start_t + outer_dim + 1) % progress_t_batch_size == 0) {
+                        noc_async_write_barrier();
+                        for (uint32_t i = 0; i < num_reader_cores; i++) {
+                            const uint32_t rx = get_common_arg_val<uint32_t>(5 + i * 2);
+                            const uint32_t ry = get_common_arg_val<uint32_t>(5 + i * 2 + 1);
+                            noc_semaphore_inc(get_noc_addr(rx, ry, h_region_sem_addr), 1);
+                        }
+                        for (uint32_t st = 0; st < num_phase2_signal_targets; st++) {
+                            noc_semaphore_inc(get_noc_addr(signal_noc_x[st], signal_noc_y[st], h_region_sem_addr), 1);
+                        }
+                        noc_async_atomic_barrier();
+                    }
+                }
+            }
+        }
+    }
+
+    // Ensure all DRAM writes from main loop are complete.
+    noc_async_write_barrier();
+
+    // Partial-last-batch tail: the partial last batch never hit a (od+1)%pb boundary in the loop
+    // above, so its HT/HB sem was never bumped — fire it once here, else consumers waiting
+    // ceil(link_dims/pb) deadlock on the missing count. Recv+commit of incoming H-halo is interleaved
+    // per-od into the send loop above, so this only handles the trailing partial batch.
+    if constexpr (handle_incoming_writes) {
+        if (!is_first_chip) {
+            if constexpr (progress_t_batch_size > 0) {
+                if ((outer_dim_offset_start_t + outer_dim_size) % progress_t_batch_size != 0) {
+                    noc_async_write_barrier();
+                    for (uint32_t i = 0; i < num_reader_cores; i++) {
+                        const uint32_t rx = get_common_arg_val<uint32_t>(5 + i * 2);
+                        const uint32_t ry = get_common_arg_val<uint32_t>(5 + i * 2 + 1);
+                        noc_semaphore_inc(get_noc_addr(rx, ry, h_region_sem_addr), 1);
+                    }
+                    for (uint32_t st = 0; st < num_phase2_signal_targets; st++) {
+                        noc_semaphore_inc(get_noc_addr(signal_noc_x[st], signal_noc_y[st], h_region_sem_addr), 1);
+                    }
+                    noc_async_atomic_barrier();
+                }
+            }
+        }
+    }
+
+    // Close fabric connection.
+    if (fabric_opened) {
+        noc_async_write_barrier();
+        fabric_connection.close();
+    }
+
+    // Signal Phase 2 W-cores AFTER handle_incoming_writes and fabric close.
+    // This guarantees L1-routed corners are committed to DRAM before W-readers start.
+    // In 1D mode num_phase2_signal_targets == 0, so this is a no-op.
+    noc_async_write_barrier();
+    for (uint32_t st = 0; st < num_phase2_signal_targets; st++) {
+        uint64_t sem_noc_addr = get_noc_addr(signal_noc_x[st], signal_noc_y[st], barrier_sem);
+        noc_semaphore_inc(sem_noc_addr, 1);
+    }
+    noc_async_atomic_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_device_operation.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "neighbor_pad_halo_device_operation.hpp"
+#include "neighbor_pad_halo_device_operation_types.hpp"
+#include "neighbor_pad_halo_program_factory.hpp"
+
+#include <array>
+#include <cstdint>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::experimental::prim {
+
+void NpHaloDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto& input_shape = input_tensor.logical_shape();
+
+    TT_FATAL(
+        input_shape.size() == 5,
+        "NpHalo: Activation tensor must have 5 dimensions (BTHWC). got {}",
+        input_shape.size());
+    TT_FATAL(input_tensor.layout() == Layout::ROW_MAJOR, "NpHalo: Activation tensor must be row-major.");
+    TT_FATAL(
+        input_tensor.dtype() == DataType::BFLOAT16 || input_tensor.dtype() == DataType::FLOAT32,
+        "NpHalo: Activation tensor must be bfloat16 or float32. got {}",
+        input_tensor.dtype());
+
+    TT_FATAL(
+        args.padding_mode == "zeros" || args.padding_mode == "replicate",
+        "NpHalo: Padding mode must be zeros or replicate. got {}",
+        args.padding_mode);
+
+    TT_FATAL(args.np_padding_h > 0, "NpHalo: np_padding_h must be > 0 (H-halo must be needed).");
+
+    // Only the 2D (H+W) compact-buffer path is implemented (the deployed VAE always pads both H and W).
+    TT_FATAL(args.np_pad_dim2.has_value(), "NpHalo: requires 2D padding (H+W); np_pad_dim2 must be set.");
+
+    // The halo_buffer is pre-allocated by the caller and written in place; it must be a DRAM tensor
+    // with the same dtype as the input (the exchange is a raw stick copy, no arithmetic).
+    const auto& halo_buffer = tensor_args.halo_buffer;
+    TT_FATAL(
+        halo_buffer.dtype() == input_tensor.dtype(),
+        "NpHalo: halo_buffer dtype ({}) must match input dtype ({}).",
+        halo_buffer.dtype(),
+        input_tensor.dtype());
+}
+
+TensorSpec NpHaloDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // Fused padded-output mode returns the padded buffer; compact mode returns the compact halo buffer.
+    if (args.output_padded) {
+        return tensor_args.padded_output.value().tensor_spec();
+    }
+    return tensor_args.halo_buffer.tensor_spec();
+}
+
+Tensor NpHaloDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (args.output_padded) {
+        return tensor_args.padded_output.value();
+    }
+    return tensor_args.halo_buffer;
+}
+
+ttsl::hash::hash_t NpHaloDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    operation::Hash hash = operation::hash_operation<NpHaloDeviceOperation>(
+        args, input_tensor.dtype(), input_tensor.memory_config(), input_tensor.logical_shape());
+    return hash;
+}
+
+}  // namespace ttnn::experimental::prim
+
+namespace ttnn::prim {
+
+Tensor neighbor_pad_halo(
+    const Tensor& input,
+    const Tensor& halo_buffer,
+    const ttnn::experimental::prim::NpHaloParams& params,
+    const std::optional<Tensor>& padded_output) {
+    using OperationType = ttnn::experimental::prim::NpHaloDeviceOperation;
+
+    auto tensor_args =
+        OperationType::tensor_args_t{.input_tensor = input, .halo_buffer = halo_buffer, .padded_output = padded_output};
+
+    return ttnn::device_operation::launch<OperationType>(params, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_device_operation.cpp
@@ -44,8 +44,7 @@ void NpHaloDeviceOperation::validate_on_program_cache_miss(
     // Only the 2D (H+W) compact-buffer path is implemented (the deployed VAE always pads both H and W).
     TT_FATAL(args.np_pad_dim2.has_value(), "NpHalo: requires 2D padding (H+W); np_pad_dim2 must be set.");
 
-    // The halo_buffer is pre-allocated by the caller and written in place; it must be a DRAM tensor
-    // with the same dtype as the input (the exchange is a raw stick copy, no arithmetic).
+    // The halo_buffer is pre-allocated by the caller and written in place
     const auto& halo_buffer = tensor_args.halo_buffer;
     TT_FATAL(
         halo_buffer.dtype() == input_tensor.dtype(),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_device_operation.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <vector>
+#include <variant>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "neighbor_pad_halo_device_operation_types.hpp"
+#include "neighbor_pad_halo_program_factory.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct NpHaloDeviceOperation {
+    using operation_attributes_t = NpHaloParams;
+    using tensor_args_t = NpHaloInputs;
+    using spec_return_value_t = tt::tt_metal::TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<NpHaloMeshWorkloadFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::experimental::prim
+
+namespace ttnn::prim {
+
+// Primitive entry point: runs the standalone halo-only fabric exchange (no conv, no interior copy).
+// halo_buffer must be a pre-allocated compact DRAM buffer sized for
+//   [H-top | H-bot | W-left | W-right] sticks; it is written in place and returned as the output.
+Tensor neighbor_pad_halo(
+    const Tensor& input,
+    const Tensor& halo_buffer,
+    const ttnn::experimental::prim::NpHaloParams& params,
+    const std::optional<Tensor>& padded_output = std::nullopt);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_device_operation.hpp
@@ -31,9 +31,7 @@ struct NpHaloDeviceOperation {
 
 namespace ttnn::prim {
 
-// Primitive entry point: runs the standalone halo-only fabric exchange (no conv, no interior copy).
-// halo_buffer must be a pre-allocated compact DRAM buffer sized for
-//   [H-top | H-bot | W-left | W-right] sticks; it is written in place and returned as the output.
+// Primitive entry point: runs the standalone halo-only fabric exchange (no conv, no interior copy)
 Tensor neighbor_pad_halo(
     const Tensor& input,
     const Tensor& halo_buffer,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_device_operation_types.hpp
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/global_semaphore.hpp"
+
+namespace ttnn::experimental::prim {
+
+// Standalone halo-only neighbor-pad: the fabric H+W halo exchange
+struct NpHaloParams {
+    // NP topology: H-fabric and W-fabric halo exchange
+    uint32_t np_padding_h;     // H padding per side (1 for k333)
+    uint32_t np_padding_w;     // W padding per side
+    uint32_t np_cluster_axis;  // mesh axis for H parallelism
+    uint32_t np_ring_size;     // number of H-parallel devices
+    ttnn::ccl::Topology np_topology;
+    GlobalSemaphore h_neighbor_semaphore;
+    GlobalSemaphore barrier_semaphore;
+    GlobalSemaphore w_neighbor_semaphore;
+    std::optional<uint32_t> np_pad_dim2;  // W-axis dim index (required for the 2D compact layout)
+    uint32_t np_pad2_left = 0;
+    uint32_t np_pad2_right = 0;
+    std::optional<uint32_t> np_pad2_cluster_axis;
+    size_t np_num_links = 2;
+    size_t np_pad2_num_links = 2;
+    tt::tt_metal::MemoryConfig np_output_mem_config;
+    std::string padding_mode;
+    // Padded-input mode (opt-in, default 0 = contiguous input)
+    uint32_t input_pad_h = 0;
+    uint32_t input_pad_w = 0;
+
+    // Padded-output (fused) mode (opt-in, default false): additionally scatter the exchanged compact halo + interior
+    bool output_padded = false;
+    bool border_only = false;
+
+    // GlobalSemaphore is not default constructible, so an explicit constructor is required.
+    NpHaloParams(
+        uint32_t np_padding_h_,
+        uint32_t np_padding_w_,
+        uint32_t np_cluster_axis_,
+        uint32_t np_ring_size_,
+        ttnn::ccl::Topology np_topology_,
+        const GlobalSemaphore& h_neighbor_semaphore_,
+        const GlobalSemaphore& barrier_semaphore_,
+        const GlobalSemaphore& w_neighbor_semaphore_,
+        std::optional<uint32_t> np_pad_dim2_,
+        uint32_t np_pad2_left_,
+        uint32_t np_pad2_right_,
+        std::optional<uint32_t> np_pad2_cluster_axis_,
+        size_t np_num_links_,
+        size_t np_pad2_num_links_,
+        tt::tt_metal::MemoryConfig np_output_mem_config_,
+        const std::string& padding_mode_) :
+        np_padding_h(np_padding_h_),
+        np_padding_w(np_padding_w_),
+        np_cluster_axis(np_cluster_axis_),
+        np_ring_size(np_ring_size_),
+        np_topology(np_topology_),
+        h_neighbor_semaphore(h_neighbor_semaphore_),
+        barrier_semaphore(barrier_semaphore_),
+        w_neighbor_semaphore(w_neighbor_semaphore_),
+        np_pad_dim2(np_pad_dim2_),
+        np_pad2_left(np_pad2_left_),
+        np_pad2_right(np_pad2_right_),
+        np_pad2_cluster_axis(np_pad2_cluster_axis_),
+        np_num_links(np_num_links_),
+        np_pad2_num_links(np_pad2_num_links_),
+        np_output_mem_config(std::move(np_output_mem_config_)),
+        padding_mode(padding_mode_) {}
+
+    // Hash: NP topology + padding geometry (semaphores are per-call addresses, excluded).
+    static constexpr auto attribute_names = std::make_tuple(
+        "np_padding_h",
+        "np_padding_w",
+        "np_cluster_axis",
+        "np_ring_size",
+        "np_topology",
+        "np_pad2_left",
+        "np_pad2_right",
+        "np_num_links",
+        "np_pad2_num_links",
+        "padding_mode",
+        "input_pad_h",
+        "input_pad_w",
+        "output_padded",
+        "border_only");
+
+    auto attribute_values() const {
+        return std::forward_as_tuple(
+            np_padding_h,
+            np_padding_w,
+            np_cluster_axis,
+            np_ring_size,
+            np_topology,
+            np_pad2_left,
+            np_pad2_right,
+            np_num_links,
+            np_pad2_num_links,
+            padding_mode,
+            input_pad_h,
+            input_pad_w,
+            output_padded,
+            border_only);
+    }
+};
+
+struct NpHaloInputs {
+    Tensor input_tensor;
+    Tensor halo_buffer;  // compact halo buffer in DRAM (pre-allocated); the op's output in compact mode
+    // Padded-output (fused) mode: the padded buffer the fused scatter writes and the op returns
+    std::optional<Tensor> padded_output;
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_program_factory.cpp
@@ -37,9 +37,7 @@ using namespace tt::tt_metal;
 
 namespace ttnn::experimental::prim {
 
-// ============================================================================
-// create_mesh_workload — iterate over mesh coords and call create_at()
-// ============================================================================
+// ============================================================================ create_mesh_workload
 NpHaloMeshWorkloadFactory::cached_mesh_workload_t NpHaloMeshWorkloadFactory::create_mesh_workload(
     const NpHaloParams& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
@@ -66,10 +64,7 @@ NpHaloMeshWorkloadFactory::cached_mesh_workload_t NpHaloMeshWorkloadFactory::cre
     return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
 }
 
-// ============================================================================
-// create_at — the heart of the fusion: NP fabric kernels + conv3d kernels in
-//             one program, sharing a progress semaphore for pipelining.
-// ============================================================================
+// ============================================================================ create_at
 NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at(
     const NpHaloParams& op,
     const ttnn::MeshCoordinate& mesh_coordinate,
@@ -80,13 +75,10 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
 
     Program program{};
 
-    // Padded-output fused mode: mux worker/mux core ranges (defined in the mux branches below, in cols>=1)
-    // that the concurrent interior-copy scatter must avoid. Empty in non-mux paths (subtract is a no-op).
+    // Padded-output fused mode: mux worker/mux core ranges
     CoreRangeSet occ_hw_workers, occ_hmux, occ_w_workers, occ_wmux;
 
-    // =========================================================================
-    // PART 1: NP FABRIC KERNELS (fabric_only H-dim path, dim=1 for BTHWC)
-    // =========================================================================
+    // ========================================================================= PART 1: NP FABRIC KERNELS
 
     // Use MeshCoordinates to find forward and backward devices along H axis
     uint32_t device_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
@@ -114,10 +106,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
     }
     uint32_t input_halo_dim_size = input_tensor_shape[np_dim];  // H_dev
 
-    // Padded-input mode: the input tensor is [.., H+2pH, W+2pW, C], so the values derived from its shape
-    // above are the PADDED W/H. Keep them as the reader's input row-stride / frame-rows (for the strided
-    // interior read), but reduce the halo-geometry dims to the INTERIOR (H_dev, W_dev) — the compact
-    // buffer, writer, and W-section sizing are all about the interior halo, unchanged from contiguous input.
+    // Padded-input mode: the input tensor is [.., H+2pH, W+2pW, C]
     const bool padded_input = op.input_pad_h > 0 || op.input_pad_w > 0;
     const uint32_t reader_row_stride = num_sticks_per_halo_dim;  // padded W (input tensor W)
     const uint32_t reader_frame_rows = input_halo_dim_size;      // padded H (input tensor H)
@@ -138,28 +127,18 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
     bool is_first_device = !backward_coord.has_value();
     bool is_last_device = !forward_coord.has_value();
     bool is_padding_zeros = op.padding_mode == "zeros";
-    // The fused op is always 2D (H+W padding) — validate() enforces np_pad_dim2.has_value(). The
-    // H-only (1D) path is removed; is_2d is kept as a named constant for readability where the W-phase
-    // setup is gated.
+    // The fused op is always 2D (H+W padding) — validate() enforces np_pad_dim2.has_value()
     TT_FATAL(op.np_pad_dim2.has_value(), "NpConv3d: fused op requires 2D padding (H+W).");
     const bool is_2d = true;
 
-    // Fabric-mux buffers per channel. 4 is the measured sweet spot on BH-LB 2x4 (+~3pp vs 1; 8 regresses
-    // on L1 pressure). PCC-invariant (channel buffering doesn't touch data).
+    // Fabric-mux buffers per channel
     const uint8_t np_num_buffers = 4;
 
-    // H corner-first (PCC-neutral): the H-writer sends the W-boundary corner sticks to the neighbor's L1
-    // recv buffer + raises the recv sem BEFORE the bulk middle row, so the neighbor's H recv-wait clears
-    // after ~2 sticks instead of the full row. Requires padding==1 (the kernel's corner-first path).
-    // W two-pass is the progress>0 conv gate; the halo op uses its own interior-first reorder (below)
-    // instead, so keep this OFF here.
+    // H corner-first (PCC-neutral): the H-writer sends the W-boundary corner sticks to the neighbor's L1 recv buffer
     const uint32_t use_corner_first = (op.np_padding_h == 1) ? 1u : 0u;
     const uint32_t use_w_two_pass = 0u;
 
-    // For the compact halo buffer, H-section rows are exactly W_dev wide.
-    // W-padding is handled in a separate W-section, so no extra columns in H rows.
-    // (The standalone NP factory widens rows to W+pad for padded-tensor output,
-    //  but the compact buffer layout keeps H and W sections independent.)
+    // For the compact halo buffer, H-section rows are exactly W_dev wide
     uint32_t output_num_sticks_per_halo_dim = num_sticks_per_halo_dim;
     uint32_t writer_stick_start_id = 0;
     uint32_t writer_num_sticks_to_read = num_sticks_per_halo_dim;
@@ -168,24 +147,13 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
     uint32_t num_links = static_cast<uint32_t>(op.np_num_links);
     uint32_t pad2_num_links = static_cast<uint32_t>(op.np_pad2_num_links);
 
-    // Halo-only op: no conv, so no per-batch progress signalling. progress_t_batch_size == 0 compiles
-    // out every per-batch region-sem path in the NP kernels; H->W ordering is instead an upfront barrier
-    // (the W-reader waits the H-writers' Phase-2 barrier signal — see np_phase2_w_reader).
+    // Halo-only op: no conv, so no per-batch progress signalling
     const uint32_t progress_t_batch_size = 0;
 
-    // H-send bank-major coalescing. The halo-only op's upfront H->W barrier makes the corner-first L1
-    // path unnecessary, so an eligible H exchange uses the simpler straight-to-DRAM path
-    // (use_l1_intermediate=0, whole H-halo row -> neighbor H-section DRAM; corners land in DRAM where the
-    // W-reader reads them) AND ships each row bank-major coalesced (h_coalesce_n same-bank sticks per 4KB
-    // packet). Eligible when padding_h==1: the row's w=j,j+8,... land same-bank/next-offset at
-    // base_row+j (valid for any base_row / W_dev, reader gathers in the same order). BH: 8 DRAM banks.
-    // Coalesce a bank's sticks into one fabric packet up to the fabric's actual max payload (not a fixed
-    // 4KB): default BH is 4352 B, and an 8K FabricRouterConfig raises it so each packet carries 2x the
-    // sticks. Cap the stick count so the send CBs stay bounded.
+    // H-send bank-major coalescing
     const uint32_t fabric_max_payload = static_cast<uint32_t>(tt::tt_fabric::get_tt_fabric_max_payload_size_bytes());
     const uint32_t max_coalesce_sticks = std::max(1u, std::min(64u, fabric_max_payload / page_size));
-    // Zeros only: the bank-major coalesced path handles the interior + zero fill, not replicate's
-    // edge-outward slice replication, so replicate stays on the per-stick direct path.
+    // Zeros only: the bank-major coalesced path handles the interior + zero fill
     uint32_t h_coalesce_n = 0;
     if (op.np_padding_h == 1 && is_padding_zeros) {
         h_coalesce_n = max_coalesce_sticks;
@@ -217,13 +185,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
         pad2_num_links,
         MAX_PAD2_NUM_LINKS);
 
-    // Fabric-mux worker count, auto-selected by W data-moved per (link,direction) like all_gather's
-    // default_workers: one worker caps at ~1.4 GB/s/link; multiple workers feeding the eth link through
-    // the mux reach the ~12.5 GB/s Linear ceiling. all_gather uses >256KB=>4, 4KB..256KB=>2, else 1.
-    // Capped at 2 here: the mux + 8-aligned split is validated at 2 workers (12.8 GB/s, PCC-exact);
-    // 4-worker mux is not yet validated. Zeros-only: the replicate-mode edge-outward mux path is unfixed,
-    // so replicate stays on the direct single-worker path. TT_NP_W_WORKERS overrides (matches all_gather's
-    // optional num_workers_per_direction).
+    // Fabric-mux worker count, auto-selected by W data-moved
     uint32_t num_w_workers = 1;
     {
         const uint32_t w_h_total_est = input_halo_dim_size + 2 * op.np_padding_h;
@@ -236,13 +198,11 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
         } else if (w_bytes_per_link_dir > 4u * 1024u) {
             heuristic = 2;
         }
-        // Auto-engage the W mux from the per-link byte heuristic, zeros only: the mux path does not do
-        // replicate's edge-outward slice replication, so replicate stays on the direct per-stick path.
+        // Auto-engage the W mux from the per-link byte heuristic
         if (is_padding_zeros) {
             num_w_workers = heuristic;
         }
-        // Clamp to available 8-row bank-units per link so no worker gets 0 rows (the 8-aligned split
-        // gives worker0 zero rows when rows_per_link < 8*num_w_workers -> degenerate/incorrect).
+        // Clamp to available 8-row bank-units per link so no worker gets 0 rows
         const uint32_t w_units_per_link = (pad2_num_links > 0) ? (w_rows_est / pad2_num_links / 8u) : 0u;
         num_w_workers = std::max(1u, std::min<uint32_t>(num_w_workers, std::max(1u, w_units_per_link)));
         log_debug(
@@ -253,9 +213,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
             num_w_workers);
     }
 
-    // H fabric cores occupy column 0, rows [0, num_h_fabric_cores). W fabric cores
-    // follow in the same column. This gives conv3d a clean rectangular grid
-    // (cols [1, grid.x)) instead of the L-shape produced by a first-row layout.
+    // H fabric cores occupy column 0, rows [0, num_h_fabric_cores)
     CoreCoord np_core_grid(1, num_h_fabric_cores);
     auto
         [num_np_cores,
@@ -265,8 +223,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
          np_dims_per_core_group_1,
          np_dims_per_core_group_2] = split_work_to_cores(np_core_grid, outer_dim_size * 2);
 
-    // Inc B: batch-align H partition so each (direction, link) owns whole T-batches (per-(HT/HB,link)
-    // sems need it). Link l owns frames [l*h_dims_per_link, min((l+1)*h_dims_per_link, outer_dim_size)).
+    // Inc B: batch-align H partition so each (direction, link) owns whole T-batches
     const uint32_t h_pb = progress_t_batch_size;
     const uint32_t h_total_batches = (h_pb > 0) ? ((outer_dim_size + h_pb - 1) / h_pb) : 0;
     const uint32_t h_batches_per_link = (h_total_batches > 0) ? ((h_total_batches + num_links - 1) / num_links) : 0;
@@ -284,12 +241,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
             .set_page_size(sender_cb_index, l1_scratch_cb_page_size_bytes);
     CreateCircularBuffer(program, np_worker_core_ranges, cb_sender_config);
 
-    // Dedicated H-send CB: the H-reader batches a full halo row (num_sticks_per_halo_dim sticks) per
-    // cb_reserve so the row reads coalesce into one barrier (the per-stick path was latency-bound,
-    // ~18k read+barrier pairs). Sized exactly 2 rows so a row reserve never wraps mid-batch (double
-    // buffered: reader fills row N+1 while the H-writer drains row N per stick). Kept separate from
-    // the sender CB because the per-stick recv/is_first pushes there would desync the row ring.
-    // H cores only; W keeps the per-stick c_in0 path.
+    // Dedicated H-send CB: the H-reader batches a full halo row
     uint32_t hsend_cb_index = tt::CB::c_in2;
     uint32_t hsend_cb_num_pages = 2 * num_sticks_per_halo_dim;
     CircularBufferConfig cb_hsend_config =
@@ -297,12 +249,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
             .set_page_size(hsend_cb_index, l1_scratch_cb_page_size_bytes);
     CreateCircularBuffer(program, np_worker_core_ranges, cb_hsend_config);
 
-    // L1 receive buffer for 2D padding: fabric-delivered H halo corner sticks arrive here.
-    // Corners-only optimization: only W-boundary sticks (pad2_left + pad2_right per row) go
-    // to L1; non-corner sticks go directly to neighbor DRAM via fabric.
-    // Buffer must hold ALL outer_dims' corner sticks (no per-outer_dim reuse) because the
-    // fabric pipeline can deliver data for outer_dim N+1 before the reader finishes
-    // copying outer_dim N.
+    // L1 receive buffer for 2D padding: fabric-delivered H halo corner sticks arrive here
     uint32_t recv_cb_index = tt::CB::c_in1;
     uint32_t corner_sticks_per_row = std::min(op.np_pad2_left + op.np_pad2_right, num_sticks_per_halo_dim);
     if (is_2d) {
@@ -361,8 +308,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
         uint32_t h_total = input_halo_dim_size + 2 * op.np_padding_h;
         w_outer_dim_size = outer_dim_size * h_total;
 
-        // W-section base offsets in the compact halo buffer:
-        // Layout: [H-top | H-bot | W-left | W-right]
+        // W-section base offsets in the compact halo buffer: Layout: [H-top | H-bot | W-left | W-right]
         uint32_t h_section_sticks = outer_dim_size * 2 * op.np_padding_h * num_sticks_per_halo_dim;
         w_section_wleft_base = h_section_sticks;
         w_section_wright_base = w_section_wleft_base + outer_dim_size * op.np_pad2_left * h_total;
@@ -370,13 +316,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
         w_rows_per_link = w_outer_dim_size / pad2_num_links;
         w_extra_rows = w_outer_dim_size % pad2_num_links;
 
-        // W-send bank-major coalescing (BH: 8 interleaved DRAM banks). Sticks base+r, base+r+8, ...,
-        // base+r+8*(N-1) land on bank (base+r)%8 at consecutive page offsets, so N ship as ONE N*page
-        // fabric write to get_noc_addr(base+r) — valid for ANY base (the N sticks differ by 8, hence same
-        // bank / next offset), and the reader gathers rel=r,r+8,... in the same order the writer sends. So
-        // only pw==1 + halo-only (progress==0) are required; base/row-count alignment is NOT needed.
-        // Zeros only: the coalesced reader/writer don't do replicate's edge-outward slice replication, so
-        // replicate stays on the per-stick direct path (matches h_coalesce_n).
+        // W-send bank-major coalescing (BH: 8 interleaved DRAM banks)
         const bool w_coalesce_ok =
             (progress_t_batch_size == 0) && (op.np_pad2_left == 1) && (op.np_pad2_right == 1) && is_padding_zeros;
         if (w_coalesce_ok) {
@@ -393,11 +333,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
         CreateCircularBuffer(program, w_fabric_core_range, cb_w_sender_config);
     }
 
-    // Mux gating + W worker/mux core coords, computed HERE (before the H-writer setup) so the H->W
-    // barrier signal can target the relocated mux W-reader cores.
-    // Uniform mux across ALL W devices (edges too) so the recv-sem targeting is consistent along the whole
-    // W chain (mixed mux/standard breaks edge<->middle recv). Edge devices' no-send direction is handled
-    // by has_neighbor/has_send_neighbor gating in the kernels + no mux kernel for that (link,dir).
+    // Mux gating + W worker/mux core coords, computed HERE (before the H-writer setup) so the H->W barrier signal
     const bool use_w_mux = is_2d && (num_w_workers > 1) && (w_coalesce_n > 0);
     std::vector<CoreCoord> mux_worker_logical, mux_worker_virtual, mux_core_logical;
     if (use_w_mux) {
@@ -423,26 +359,15 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
 
     uint32_t num_directions = 2;
 
-    // -------------------------------------------------------------------------
-    // PART 2: no conv consumer. There are no progress-sem signal targets, so reader_noc_coords stays
-    // empty (the H/W writers loop over 0 targets → no per-batch signalling).
-    // -------------------------------------------------------------------------
+    // ------------------------------------------------------------------------- PART 2: no conv consumer
     std::vector<std::pair<uint32_t, uint32_t>> reader_noc_coords;
 
-    // H-mux: mirror the W-mux (N workers per (link,dir) feed the H-axis eth link through a mux). H cores
-    // are placed in columns after the W-mux block. Auto-engage like W-mux: 2 H workers for zeros+coalesce
-    // (validated 8/8 PCC). Replicate stays on the direct path (pre-existing W-mux edge-outward bug).
-    // H bytes per (link,dir): 2 workers only when large enough to be bandwidth-bound (mirrors W's 4KB
-    // gate) and each worker gets >=1 frame — tiny shapes stay on the correct direct path.
+    // H-mux: mirror the W-mux (N workers per (link,dir) feed the H-axis eth link through a mux)
     const uint64_t h_bytes_per_link = (num_links > 0) ? (static_cast<uint64_t>(outer_dim_size) * op.np_padding_h *
                                                          num_sticks_per_halo_dim * page_size / num_links)
                                                       : 0;
     const uint32_t h_frames_per_link = (num_links > 0) ? (outer_dim_size / num_links) : 0;
-    // Auto-engage H workers by per-(link,dir) bytes, mirroring the W heuristic: 4 for the large,
-    // bandwidth-bound shapes (>256KB/link) — measured to cut the s4-class wall (H exchange is on the op's
-    // critical path, e.g. s4 469us at H4 vs 560us at H2) — and 2 for the >4KB mid band; tiny shapes stay on
-    // the direct path. Requires >=1 frame/worker. Zeros only (replicate uses the direct path, like W).
-    // W4+H4 is PCC byte-exact on all 2x4 prod shapes.
+    // Auto-engage H workers by per-(link,dir) bytes, mirroring the W heuristic: 4 for the large
     uint32_t num_h_workers = 1;
     if (is_padding_zeros && (h_frames_per_link >= 2u)) {
         if (h_bytes_per_link > 256u * 1024u) {
@@ -468,73 +393,69 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
     KernelHandle h_writer_kernel_id = 0;
 
     if (!use_h_mux) {
-    // -------------------------------------------------------------------------
-    // NP H-fabric reader kernel
-    // -------------------------------------------------------------------------
-    auto h_reader_kernel_config = ReaderDataMovementConfig{};
-    h_reader_kernel_config.compile_args = {
-        sender_cb_index,   // cb_output_id
-        is_padding_zeros,  // is_padding_zeros
-        page_size};        // stick_size
-    TensorAccessorArgs(*input_buffer).append_to(h_reader_kernel_config.compile_args);
-    h_reader_kernel_config.compile_args.push_back(h_use_l1);        // use_l1_intermediate (0 when H-coalescing)
-    h_reader_kernel_config.compile_args.push_back(recv_cb_index);   // recv_cb_id
-    h_reader_kernel_config.compile_args.push_back(hsend_cb_index);  // send_cb_id (batched H send)
-    h_reader_kernel_config.compile_args.push_back(h_coalesce_n);    // H-send bank-major coalesce factor (0=off)
-    h_reader_kernel_config.compile_args.push_back(0);               // H_SIGNAL_W_RECV: direct path, np_writer signals
-    h_reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/"
-        "np_h_reader.cpp",
-        np_worker_core_ranges,
-        h_reader_kernel_config);
-    SetCommonRuntimeArgs(
-        program,
-        h_reader_kernel_id,
-        {input_buffer->address(), halo_buffer->address(), op.h_neighbor_semaphore.address()});
+        // ------------------------------------------------------------------------- NP H-fabric reader kernel
+        auto h_reader_kernel_config = ReaderDataMovementConfig{};
+        h_reader_kernel_config.compile_args = {
+            sender_cb_index,   // cb_output_id
+            is_padding_zeros,  // is_padding_zeros
+            page_size};        // stick_size
+        TensorAccessorArgs(*input_buffer).append_to(h_reader_kernel_config.compile_args);
+        h_reader_kernel_config.compile_args.push_back(h_use_l1);        // use_l1_intermediate (0 when H-coalescing)
+        h_reader_kernel_config.compile_args.push_back(recv_cb_index);   // recv_cb_id
+        h_reader_kernel_config.compile_args.push_back(hsend_cb_index);  // send_cb_id (batched H send)
+        h_reader_kernel_config.compile_args.push_back(h_coalesce_n);    // H-send bank-major coalesce factor (0=off)
+        h_reader_kernel_config.compile_args.push_back(0);  // H_SIGNAL_W_RECV: direct path, np_writer signals
+        h_reader_kernel_id = CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/"
+            "np_h_reader.cpp",
+            np_worker_core_ranges,
+            h_reader_kernel_config);
+        SetCommonRuntimeArgs(
+            program,
+            h_reader_kernel_id,
+            {input_buffer->address(), halo_buffer->address(), op.h_neighbor_semaphore.address()});
 
-    // -------------------------------------------------------------------------
-    // NP H-fabric writer kernel
-    // -------------------------------------------------------------------------
-    auto h_writer_kernel_config = WriterDataMovementConfig{};
-    h_writer_kernel_config.compile_args = {
-        sender_cb_index,   // cb_output_id
-        is_padding_zeros,  // is_padding_zeros
-        page_size};        // stick_size
-    TensorAccessorArgs(*halo_buffer).append_to(h_writer_kernel_config.compile_args);
-    h_writer_kernel_config.compile_args.push_back(h_use_l1);         // use_l1_intermediate (0 when H-coalescing)
-    h_writer_kernel_config.compile_args.push_back(recv_cb_index);    // recv_cb_id
-    h_writer_kernel_config.compile_args.push_back(h_use_l1);         // handle_incoming_writes (0 when H-coalescing)
-    h_writer_kernel_config.compile_args.push_back(0);                // is_w_fabric_writer (false for H)
-    h_writer_kernel_config.compile_args.push_back(op.np_ring_size);  // ring_size
-    // Per-batch progress-sem granularity is always passed; 0 disables the per-batch path.
-    h_writer_kernel_config.compile_args.push_back(progress_t_batch_size);
-    h_writer_kernel_config.compile_args.push_back(hsend_cb_index);    // send_cb_id (batched H send)
-    h_writer_kernel_config.compile_args.push_back(use_w_two_pass);    // unused on H writer; keeps arg layout aligned
-    h_writer_kernel_config.compile_args.push_back(use_corner_first);  // H-writer corner-first gate
-    h_writer_kernel_config.compile_args.push_back(h_coalesce_n);      // coalesce factor (H-writer uses the H branch)
-    h_writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/"
-        "np_writer.cpp",
-        np_worker_core_ranges,
-        h_writer_kernel_config);
-    {
-        std::vector<uint32_t> h_writer_crta = {
-            input_buffer->address(),
-            halo_buffer->address(),
-            op.h_neighbor_semaphore.address(),
-            op.barrier_semaphore.address(),
-            // CRTA[4]: number of conv3d reader cores to signal
-            static_cast<uint32_t>(reader_noc_coords.size()),
-            // CRTA[5+]: interleaved (x, y) NOC coords for each reader core
-        };
-        for (const auto& [x, y] : reader_noc_coords) {
-            h_writer_crta.push_back(x);
-            h_writer_crta.push_back(y);
+        // ------------------------------------------------------------------------- NP H-fabric writer kernel
+        auto h_writer_kernel_config = WriterDataMovementConfig{};
+        h_writer_kernel_config.compile_args = {
+            sender_cb_index,   // cb_output_id
+            is_padding_zeros,  // is_padding_zeros
+            page_size};        // stick_size
+        TensorAccessorArgs(*halo_buffer).append_to(h_writer_kernel_config.compile_args);
+        h_writer_kernel_config.compile_args.push_back(h_use_l1);         // use_l1_intermediate (0 when H-coalescing)
+        h_writer_kernel_config.compile_args.push_back(recv_cb_index);    // recv_cb_id
+        h_writer_kernel_config.compile_args.push_back(h_use_l1);         // handle_incoming_writes (0 when H-coalescing)
+        h_writer_kernel_config.compile_args.push_back(0);                // is_w_fabric_writer (false for H)
+        h_writer_kernel_config.compile_args.push_back(op.np_ring_size);  // ring_size
+        // Per-batch progress-sem granularity is always passed; 0 disables the per-batch path.
+        h_writer_kernel_config.compile_args.push_back(progress_t_batch_size);
+        h_writer_kernel_config.compile_args.push_back(hsend_cb_index);  // send_cb_id (batched H send)
+        h_writer_kernel_config.compile_args.push_back(use_w_two_pass);  // unused on H writer; keeps arg layout aligned
+        h_writer_kernel_config.compile_args.push_back(use_corner_first);  // H-writer corner-first gate
+        h_writer_kernel_config.compile_args.push_back(h_coalesce_n);  // coalesce factor (H-writer uses the H branch)
+        h_writer_kernel_id = CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/"
+            "np_writer.cpp",
+            np_worker_core_ranges,
+            h_writer_kernel_config);
+        {
+            std::vector<uint32_t> h_writer_crta = {
+                input_buffer->address(),
+                halo_buffer->address(),
+                op.h_neighbor_semaphore.address(),
+                op.barrier_semaphore.address(),
+                // CRTA[4]: number of conv3d reader cores to signal
+                static_cast<uint32_t>(reader_noc_coords.size()),
+                // CRTA[5+]: interleaved (x, y) NOC coords for each reader core
+            };
+            for (const auto& [x, y] : reader_noc_coords) {
+                h_writer_crta.push_back(x);
+                h_writer_crta.push_back(y);
+            }
+            SetCommonRuntimeArgs(program, h_writer_kernel_id, h_writer_crta);
         }
-        SetCommonRuntimeArgs(program, h_writer_kernel_id, h_writer_crta);
-    }
 
     // Set per-core runtime args for H fabric cores
     uint32_t link_offset_start_id = 0;
@@ -558,9 +479,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
                 link_dims_to_read = (b_end > b_start) ? (b_end - b_start) : 0u;
             }
 
-            // Reader runtime args. Padded input: frame base/stride use padded dims (reader_frame_rows *
-            // reader_row_stride), stick_start skips the pH/pW border, row stride is padded W, but the
-            // edge-row count and sticks-to-read stay interior (input_halo_dim_size / num_sticks_per_halo_dim).
+            // Reader runtime args
             const uint32_t rd_frame_base =
                 padded_input ? (link_offset_start_id / num_sticks_per_halo_dim) * reader_frame_rows * reader_row_stride
                              : link_offset_start_id * input_halo_dim_size;
@@ -599,8 +518,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
                 true,                                                // use_barrier_semaphore
                 virtual_opposite_core.x,                             // barrier_sem_noc0_x
                 virtual_opposite_core.y};                            // barrier_sem_noc0_y
-            // Phase 2 signal targets (W fabric reader cores). Mux path: signal the relocated mux
-            // worker-reader cores (each waits the H->W barrier) instead of the standard column-0 W cores.
+            // Phase 2 signal targets (W fabric reader cores)
             constexpr uint32_t MAX_PHASE2_SIGNAL_TARGETS = 8;
             const std::vector<CoreCoord>& w_sig_cores = use_w_mux ? mux_worker_virtual : w_fabric_virtual_cores;
             const uint32_t n_w_sig = static_cast<uint32_t>(w_sig_cores.size());
@@ -684,9 +602,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
         occ_hw_workers = hw_crset;
         occ_hmux = hm_crset;
 
-        // Send CB (hsend) + sender CB (c_in0) on the H worker cores. hsend MUST be a whole multiple of the
-        // row size (num_sticks_per_halo_dim): the H reader reserves a full row at once and the writer reads
-        // it via get_read_ptr + m*stick, so a row must never straddle the CB wrap. 4 rows for pipelining.
+        // Send CB (hsend) + sender CB (c_in0) on the H worker cores
         {
             CircularBufferConfig cb_hs(
                 4u * num_sticks_per_halo_dim * l1_scratch_cb_page_size_bytes, {{hsend_cb_index, df}});
@@ -806,8 +722,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
                     ttnn::ccl::fabric_mux_connection_rt_args(
                         sends, /*is_termination_master=*/wk == 0, FabricMuxChannelType::FULL_SIZE_CHANNEL, mux_vc, wk,
                         wc, hmux_cfg, program, term_master_vc, w_rt, std::nullopt);
-                    // (H->W barrier targets moved to the H reader, which signals after recv.)
-                    // Opp-direction H-worker coords on the neighbor (for the pairwise startup barrier).
+                    // (H->W barrier targets moved to the H reader, which signals after recv.) Opp-direction H-worker
                     CoreCoord opp_vc = hmux_worker_virtual[(link * num_directions + (1 - dir)) * num_h_workers + wk];
                     w_rt.push_back(opp_vc.x);
                     w_rt.push_back(opp_vc.y);
@@ -817,9 +732,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
         }
     }
 
-    // -------------------------------------------------------------------------
-    // W fabric kernels for 2D padding (Phase 2)
-    // -------------------------------------------------------------------------
+    // ------------------------------------------------------------------------- W fabric kernels for 2D padding
     KernelHandle w_reader_kernel_id = 0;
     KernelHandle w_writer_kernel_id = 0;
     if (is_2d) {
@@ -837,19 +750,13 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
             w_num_targets_backward,
             mesh_device);
 
-        // ---------------------------------------------------------------------
-        // FABRIC-MUX W path (middle W devices, coalesced): N workers per (link,dir) feed a mux core so
-        // the eth link is saturated (reach ~12.5 GB/s/link vs ~1.4 single-worker). Gated on num_w_workers
-        // > 1 + middle device + coalesce-eligible; else falls through to the standard 1-worker path.
-        // Uses the shipping tt_fabric_mux kernel + ccl::fabric_mux_connection_{ct,rt}_args helpers.
-        // use_w_mux + mux core coords are computed above (before the H-writer barrier signal setup).
+        // --------------------------------------------------------------------- FABRIC-MUX W path
         if (use_w_mux) {
             using tt::tt_fabric::FabricMuxChannelType;
             const uint32_t l1_base =
                 mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
             const size_t mux_buf_size = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
-            // num_buffers per channel: 4 (np_num_buffers) is the measured 2x4 sweet spot (+~3pp); the mux
-            // still fits its full-size channels in L1 at 4. PCC-invariant.
+            // num_buffers per channel: 4 (np_num_buffers) is the measured 2x4 sweet spot (+~3pp)
             auto mux_cfg = tt::tt_fabric::FabricMuxConfig(
                 /*num_full_size_channels=*/static_cast<uint8_t>(num_w_workers),
                 /*num_header_only_channels=*/0,
@@ -858,8 +765,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
                 mux_buf_size,
                 l1_base);
 
-            // Core layout (halo-only op: cols>=1 are free). Per (link,dir): 1 mux core (col 1) + N worker
-            // cores (cols 2+). link/dir index = w_link*2 + w_dir.
+            // Core layout (halo-only op: cols>=1 are free)
 
             // W reader + mux writer kernels on the worker cores.
             std::vector<uint32_t> mux_reader_ct = {sender_cb_index, is_padding_zeros, page_size};
@@ -887,9 +793,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
             const std::vector<CoreCoord>& mux_mux_cores = mux_core_logical;
             std::set<CoreRange> worker_crs, mux_crs;
             for (const auto& c : mux_worker_cores) worker_crs.insert(CoreRange(c));
-            // Only create a mux kernel for (link,dir) that actually SEND (have a send-neighbor); the mux
-            // kernel blocks until its worker connects + signals terminate, so an unused mux would hang.
-            // dir=0 (forward) sends iff !is_last_w_device; dir=1 (backward) sends iff !is_first_w_device.
+            // Only create a mux kernel for (link,dir) that actually SEND (have a send-neighbor)
             for (uint32_t s = 0; s < mux_mux_cores.size(); s++) {
                 const uint32_t w_dir_s = s % 2;
                 const bool sends = w_dir_s == 0 ? !is_last_w_device : !is_first_w_device;
@@ -902,9 +806,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
             occ_w_workers = worker_crset;
             occ_wmux = mux_crset;
 
-            // Send CB (c_in0) on the mux WORKER cores — the base cb_w_sender_config was created only on
-            // the standard column-0 W cores, so the relocated workers had no CB (reader/writer would
-            // block on cb_reserve/cb_wait_front). Sized to hold coalesce groups deep for pipelining.
+            // Send CB (c_in0) on the mux WORKER cores — the base cb_w_sender_config was created only on the standard
             {
                 const uint32_t w_mux_cb_pages = 16 * w_coalesce_n;
                 CircularBufferConfig cb_mux_w(
@@ -915,8 +817,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
 
             w_reader_kernel_id = CreateKernel(program, kdir + "np_phase2_w_reader.cpp", worker_crset, mux_reader_cfg);
             w_writer_kernel_id = CreateKernel(program, kdir + "np_w_mux_writer.cpp", worker_crset, mux_writer_cfg);
-            // Reader common args (CRTA[0]=halo addr, [1]=barrier_sem, [2]=w_neighbor_sem) — MUST be set on
-            // the mux reader too, else barrier_sem_addr is unset and the H->W barrier wait never completes.
+            // Reader common args (CRTA[0]=halo addr, [1]=barrier_sem, [2]=w_neighbor_sem)
             SetCommonRuntimeArgs(
                 program,
                 w_reader_kernel_id,
@@ -957,18 +858,13 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
                     // Split this (link,dir)'s W rows across workers.
                     const uint32_t rows_this_link = w_rows_per_link + (w_link < w_extra_rows ? 1 : 0);
                     const uint32_t base_link_start = (w_link * w_rows_per_link) + std::min(w_link, w_extra_rows);
-                    // 8-aligned per-worker split: each worker's start is a whole number of 8-row (bank)
-                    // units so its coalesce base stays bank-consistent with the receiver's read; the LAST
-                    // worker absorbs the non-8 remainder (its coalesce handles the partial tail group).
-                    // Even (non-8) splits corrupt the W-section at ~0.996 PCC on non-aligned shapes.
+                    // 8-aligned per-worker split: each worker's start is a whole number of 8-row
                     constexpr uint32_t BANKS = 8;
                     const uint32_t units = rows_this_link / BANKS;
                     const uint32_t units_per_wk = units / num_w_workers;
                     const uint32_t pw = w_dir ? op.np_pad2_right : op.np_pad2_left;
                     const uint32_t section_base = w_dir ? w_section_wright_base : w_section_wleft_base;
-                    // recv-sem target = the SAME-direction worker core (matches the standard W writer,
-                    // which sets neighbor_sem_noc0 = w_virtual_core[w_link*2+w_dir]). The receiving reader
-                    // on the neighbor waits at the same (device-independent) core coords.
+                    // recv-sem target = the SAME-direction worker core
                     for (uint32_t wk = 0; wk < num_w_workers; wk++) {
                         CoreCoord wc = mux_worker_cores[s * num_w_workers + wk];
                         CoreCoord wc_vc = mux_worker_virtual[s * num_w_workers + wk];
@@ -976,8 +872,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
                         const bool last_wk = (wk == num_w_workers - 1);
                         const uint32_t wk_count =
                             last_wk ? (rows_this_link - wk * units_per_wk * BANKS) : (units_per_wk * BANKS);
-                        // Reader RT args (same layout as the standard W reader). barrier_count = number of
-                        // H workers that signal the H->W barrier (H-mux: links*dirs*workers; else H cores).
+                        // Reader RT args (same layout as the standard W reader)
                         const uint32_t h_signal_count =
                             use_h_mux ? (num_links * num_directions * num_h_workers) : num_h_fabric_cores;
                         std::vector<uint32_t> r_rt = {
@@ -989,9 +884,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
                             outer_dim_size * op.np_padding_h * num_sticks_per_halo_dim,
                             op.input_pad_h, op.input_pad_w, 0u};
                         SetRuntimeArgs(program, w_reader_kernel_id, {wc}, r_rt);
-                        // Writer RT args: per-core (base,rows,sem xy,dir,route) then mux conn (0..16).
-                        // sem targets = the neighbor's reader worker core (NOC coords are device-independent),
-                        // NOT the mux core: the recv-sem + startup-barrier incs land on the reader that waits them.
+                        // Writer RT args: per-core (base,rows,sem xy,dir,route) then mux conn (0..16)
                         std::vector<uint32_t> w_rt = {
                             section_base + wk_start * pw, wk_count,
                             wc_vc.x, wc_vc.y, wc_vc.x, wc_vc.y,
@@ -1007,33 +900,31 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
             }
             w_fabric_core_range = worker_crset;
         } else {
-        // W reader kernel — fused-owned copy: always fabric-only, always per-batch
-        // progress-sem signalling.
-        auto w_reader_kernel_config = ReaderDataMovementConfig{};
-        w_reader_kernel_config.compile_args = {sender_cb_index, is_padding_zeros, page_size};
-        TensorAccessorArgs(*halo_buffer).append_to(w_reader_kernel_config.compile_args);
-        TensorAccessorArgs(*input_buffer).append_to(w_reader_kernel_config.compile_args);
-        // Per-batch signal granularity (matches conv3d reader's progress_t_batch_size CT arg).
-        w_reader_kernel_config.compile_args.push_back(progress_t_batch_size);
-        w_reader_kernel_config.compile_args.push_back(use_w_two_pass);  // global two-pass gate (lockstep w/ writer)
-        w_reader_kernel_config.compile_args.push_back(w_coalesce_n);    // W-send bank-major coalesce factor (0=off)
-        w_reader_kernel_config.compile_args.push_back(0);              // W_MUX_MODE off (standard 1-worker path)
-        w_reader_kernel_id = CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/"
-            "np_phase2_w_reader.cpp",
-            w_fabric_core_range,
-            w_reader_kernel_config);
-        {
-            std::vector<uint32_t> w_reader_crta = {
-                halo_buffer->address(),
-                op.barrier_semaphore.address(),
-                op.w_neighbor_semaphore.address(),
-            };
-            // No per-batch H-region sems (progress_t_batch_size == 0). H->W ordering is the upfront
-            // barrier the W-reader waits on (op.barrier_semaphore, CRTA[1]).
-            SetCommonRuntimeArgs(program, w_reader_kernel_id, w_reader_crta);
-        }
+            // W reader kernel — fused-owned copy: always fabric-only, always per-batch progress-sem signalling
+            auto w_reader_kernel_config = ReaderDataMovementConfig{};
+            w_reader_kernel_config.compile_args = {sender_cb_index, is_padding_zeros, page_size};
+            TensorAccessorArgs(*halo_buffer).append_to(w_reader_kernel_config.compile_args);
+            TensorAccessorArgs(*input_buffer).append_to(w_reader_kernel_config.compile_args);
+            // Per-batch signal granularity (matches conv3d reader's progress_t_batch_size CT arg).
+            w_reader_kernel_config.compile_args.push_back(progress_t_batch_size);
+            w_reader_kernel_config.compile_args.push_back(use_w_two_pass);  // global two-pass gate (lockstep w/ writer)
+            w_reader_kernel_config.compile_args.push_back(w_coalesce_n);    // W-send bank-major coalesce factor (0=off)
+            w_reader_kernel_config.compile_args.push_back(0);               // W_MUX_MODE off (standard 1-worker path)
+            w_reader_kernel_id = CreateKernel(
+                program,
+                "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/"
+                "np_phase2_w_reader.cpp",
+                w_fabric_core_range,
+                w_reader_kernel_config);
+            {
+                std::vector<uint32_t> w_reader_crta = {
+                    halo_buffer->address(),
+                    op.barrier_semaphore.address(),
+                    op.w_neighbor_semaphore.address(),
+                };
+                // No per-batch H-region sems (progress_t_batch_size == 0)
+                SetCommonRuntimeArgs(program, w_reader_kernel_id, w_reader_crta);
+            }
 
         // W writer kernel
         auto w_writer_kernel_config = WriterDataMovementConfig{};
@@ -1044,9 +935,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
         w_writer_kernel_config.compile_args.push_back(0);            // handle_incoming_writes
         w_writer_kernel_config.compile_args.push_back(1);            // is_w_fabric_writer
         w_writer_kernel_config.compile_args.push_back(w_ring_size);  // ring_size
-        // progress_t_batch_size: W-writer doesn't per-batch-signal in 2D (gated by
-        // num_phase2_signal_targets > 0 at runtime), but the CT arg must be present to
-        // match np_writer.cpp's arg layout.
+        // progress_t_batch_size: W-writer doesn't per-batch-signal in 2D
         w_writer_kernel_config.compile_args.push_back(progress_t_batch_size);
         w_writer_kernel_config.compile_args.push_back(sender_cb_index);  // send_cb_id: W keeps the c_in0 per-stick path
         w_writer_kernel_config.compile_args.push_back(use_w_two_pass);   // global two-pass gate (lockstep w/ reader)
@@ -1069,10 +958,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
              input_halo_dim_size,
              static_cast<uint32_t>(op.np_padding_h)});  // [4],[5]: W-writer per-batch two-pass reorder dims
 
-        // Per-core W fabric runtime args.
-        // When pipelining (progress_t_batch_size>0), align each link to whole T-batches so the
-        // per-(region,link) progress sem counts batches 1:1 and the conv3d reader can map a batch to
-        // its owning link by integer division (no per-link boundary table).
+        // Per-core W fabric runtime args
         const uint32_t w_h_total = input_halo_dim_size + 2 * op.np_padding_h;
         const uint32_t w_sticks_per_batch = progress_t_batch_size * w_h_total;
         const uint32_t total_w_batches =
@@ -1096,8 +982,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
                 CoreCoord w_core = w_fabric_logical_cores[w_core_idx];
                 CoreCoord w_virtual_core = w_fabric_virtual_cores[w_core_idx];
 
-                // barrier_count = number of H workers that signal the H->W barrier (H-mux:
-                // links*dirs*workers; else H fabric cores).
+                // barrier_count = number of H workers that signal the H->W barrier
                 uint32_t barrier_count =
                     use_h_mux ? (num_links * num_directions * num_h_workers) : num_h_fabric_cores;
 
@@ -1122,14 +1007,11 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
                 // Padded-input strides for the W-edge interior reads (0 = contiguous).
                 w_reader_rt_args.push_back(op.input_pad_h);
                 w_reader_rt_args.push_back(op.input_pad_w);
-                // No conv W-edge consumer: push 0 for the (unused) per-batch region progress sem addr
-                // to keep the W-reader's per-core arg layout stable.
+                // No conv W-edge consumer: push 0 for the (unused) per-batch region progress sem addr to keep
                 w_reader_rt_args.push_back(0u);
                 SetRuntimeArgs(program, w_reader_kernel_id, {w_core}, w_reader_rt_args);
 
-                // W writer runtime args — addresses the W-section of the compact buffer.
-                // Direction 0 (forward): writes W-left on receiver.
-                // Direction 1 (backward): writes W-right on receiver.
+                // W writer runtime args — addresses the W-section of the compact buffer
                 uint32_t w_pad = w_direction ? op.np_pad2_right : op.np_pad2_left;
                 uint32_t w_base = w_direction ? w_section_wright_base : w_section_wleft_base;
                 std::vector<uint32_t> w_writer_rt_args = {
@@ -1202,13 +1084,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
         }  // end else (standard 1-worker W path)
     }
 
-    // ------------------------------------------------------------------------
-    // Padded-output fused mode: copy the INTERIOR (input -> padded output) on the free cores (columns
-    // x>=1; fabric uses column 0) CONCURRENTLY with the fabric exchange. The interior has no dependency
-    // on the exchange, so no barrier is needed — it just overlaps the fabric transport instead of being
-    // serialized after it (the old two-op flow). The caller fills the border afterward via
-    // halo_scatter(border_only), which reads the compact buffer this op wrote (op-level dependency).
-    // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------ Padded-output fused mode: copy
     tt::tt_metal::KernelHandle scatter_kernel_id = 0;
     CoreRangeSet scatter_core_range;
     bool has_scatter = false;
@@ -1219,8 +1095,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
         const uint32_t Hp_i = Hd_i + 2 * op.np_padding_h;
         const uint32_t Wp_i = Wd_i + 2 * op.np_padding_w;
         const uint32_t n_int = outer_dim_size * Hd_i * Wd_i;
-        // Free cores = cols [1, grid.x) minus the NP sender workers (col 0 is fabric). The interior copy
-        // runs here, concurrent with the exchange (which uses col 0 + the worker cores).
+        // Free cores = cols [1, grid.x) minus the NP sender workers (col 0 is fabric)
         const CoreRangeSet cols_ge1(CoreRange({1, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
         const CoreRangeSet scatter_cores = cols_ge1.subtract(np_worker_core_ranges)
                                                .subtract(occ_hw_workers)
@@ -1302,9 +1177,7 @@ NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at
                 scatter_core_range}}};
 }
 
-// ============================================================================
-// override_runtime_arguments — refresh per-dispatch addresses for the NP kernels
-// ============================================================================
+// ============================================================================ override_runtime_arguments
 void NpHaloMeshWorkloadFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const NpHaloParams& op,
@@ -1320,22 +1193,17 @@ void NpHaloMeshWorkloadFactory::override_runtime_arguments(
     for (auto& [coordinate_range, shared_vars] : cached_workload.shared_variables) {
         auto& program = cached_workload.workload.get_programs().at(coordinate_range);
 
-        // --- NP H-fabric reader CRTA ---
-        // CRTA[0] = input_addr, CRTA[1] = halo_buffer_addr, CRTA[2] = h_sem_addr
+        // --- NP H-fabric reader CRTA --- CRTA[0] = input_addr, CRTA[1] = halo_buffer_addr, CRTA[2] = h_sem_addr
         auto& hr = GetCommonRuntimeArgs(program, shared_vars.np_artifacts.h_reader_kernel_id);
         hr[0] = input_addr;
         hr[1] = halo_buffer_addr;
         hr[2] = h_sem_addr;
-        // Mux path (H_SIGNAL_W_RECV): np_h_reader signals the H->W barrier from CRTA[3]. It ping-pongs
-        // per dispatch, so refresh it or a cache hit signals the prior barrier while the W-reader waits
-        // on the current one -> deadlock. Direct path has only 3 CRTA (np_writer owns the barrier).
+        // Mux path (H_SIGNAL_W_RECV): np_h_reader signals the H->W barrier from CRTA[3]
         if (hr.size() > 3) {
             hr[3] = barrier_sem_addr;
         }
 
-        // --- NP H-fabric writer CRTA ---
-        // CRTA[0] = input_addr, CRTA[1] = halo_buffer_addr, CRTA[2] = h_sem_addr,
-        // CRTA[3] = barrier_sem_addr, CRTA[4] = num_reader_cores (static), CRTA[5+] = NOC coords (static)
+        // --- NP H-fabric writer CRTA --- CRTA[0] = input_addr, CRTA[1] = halo_buffer_addr, CRTA[2] = h_sem_addr
         auto& hw = GetCommonRuntimeArgs(program, shared_vars.np_artifacts.h_writer_kernel_id);
         hw[0] = input_addr;
         hw[1] = halo_buffer_addr;
@@ -1351,11 +1219,7 @@ void NpHaloMeshWorkloadFactory::override_runtime_arguments(
             wr[2] = w_sem_addr;
             // wr[3+] = num_reader_cores and NOC coords — static, set once in create_at()
 
-            // Per-core RTA[10] of the W-reader holds input_buffer->address() (set in
-            // create_at from the first dispatch's input). On subsequent dispatches the
-            // input tensor may be at a different DRAM address, so refresh RTA[10] here
-            // or the W-reader will pull halo sticks from a stale/garbage DRAM region
-            // and fabric-write garbage into the neighbor's halo buffer.
+            // Per-core RTA[10] of the W-reader holds input_buffer->address()
             auto& w_reader_args_by_core = GetRuntimeArgs(program, shared_vars.np_artifacts.w_reader_kernel_id);
             for (const auto& core_range : shared_vars.np_artifacts.fabric_core_range.ranges()) {
                 for (uint32_t x = core_range.start_coord.x; x <= core_range.end_coord.x; ++x) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_program_factory.cpp
@@ -1,0 +1,1398 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "neighbor_pad_halo_program_factory.hpp"
+
+// NP fabric includes
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
+#include "ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp"
+#include "ttnn/operations/ccl/common/uops/command_lowering.hpp"
+#include "ttnn/operations/ccl/common/host/ccl_worker_builder.hpp"
+#include "ttnn/operations/ccl/common/host/command_backend_runtime_args_overrider.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/experimental/fabric/fabric.hpp>  // FabricMuxConfig, get_tt_fabric_channel_buffer_size_bytes
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/constants.hpp>
+#include "ttnn/operations/cb_utils.hpp"
+#include <algorithm>
+#include <map>
+#include <string>
+#include <tt-metalium/hal.hpp>
+
+#include <optional>
+#include <ranges>
+#include <sstream>
+#include <type_traits>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::experimental::prim {
+
+// ============================================================================
+// create_mesh_workload — iterate over mesh coords and call create_at()
+// ============================================================================
+NpHaloMeshWorkloadFactory::cached_mesh_workload_t NpHaloMeshWorkloadFactory::create_mesh_workload(
+    const NpHaloParams& operation_attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const NpHaloInputs& tensor_args,
+    Tensor& tensor_return_value) {
+    tt::tt_metal::distributed::MeshWorkload mesh_workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+
+    // Synchronize before dispatching programs.
+    auto* mesh_device = tensor_args.input_tensor.device();
+    {
+        tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
+    }
+
+    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
+        for (const auto& mesh_coord : mesh_coord_range) {
+            const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
+            auto cached_program = create_at(operation_attributes, mesh_coord, tensor_args, tensor_return_value);
+            shared_variables[single_coord_range] = cached_program.shared_variables;
+            mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
+        }
+    }
+
+    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+}
+
+// ============================================================================
+// create_at — the heart of the fusion: NP fabric kernels + conv3d kernels in
+//             one program, sharing a progress semaphore for pipelining.
+// ============================================================================
+NpHaloMeshWorkloadFactory::cached_program_t NpHaloMeshWorkloadFactory::create_at(
+    const NpHaloParams& op,
+    const ttnn::MeshCoordinate& mesh_coordinate,
+    const NpHaloInputs& tensor_args,
+    Tensor& tensor_return_value) {
+    (void)tensor_return_value;  // output IS the pre-allocated tensor_args.halo_buffer
+    auto* mesh_device = tensor_args.input_tensor.device();
+
+    Program program{};
+
+    // Padded-output fused mode: mux worker/mux core ranges (defined in the mux branches below, in cols>=1)
+    // that the concurrent interior-copy scatter must avoid. Empty in non-mux paths (subtract is a no-op).
+    CoreRangeSet occ_hw_workers, occ_hmux, occ_w_workers, occ_wmux;
+
+    // =========================================================================
+    // PART 1: NP FABRIC KERNELS (fabric_only H-dim path, dim=1 for BTHWC)
+    // =========================================================================
+
+    // Use MeshCoordinates to find forward and backward devices along H axis
+    uint32_t device_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
+        tensor_args.input_tensor, mesh_coordinate, op.np_cluster_axis);
+
+    std::optional<MeshCoordinate> forward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+        tensor_args.input_tensor, mesh_coordinate, 1, ttnn::ccl::Topology::Linear, op.np_cluster_axis);
+
+    std::optional<MeshCoordinate> backward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+        tensor_args.input_tensor, mesh_coordinate, -1, ttnn::ccl::Topology::Linear, op.np_cluster_axis);
+
+    // Tensor info
+    const auto& input_tensor_shape = tensor_args.input_tensor.padded_shape();
+    Buffer* input_buffer = tensor_args.input_tensor.buffer();
+    Buffer* halo_buffer = tensor_args.halo_buffer.buffer();
+
+    // H-dim is index 2 in BTHWC layout (B=0, T=1, H=2, W=3, C=4)
+    constexpr uint32_t np_dim = 2;
+    uint32_t page_size = input_buffer->aligned_page_size();
+
+    // num_sticks_per_halo_dim = W_dev (product of dims between H and C)
+    uint32_t num_sticks_per_halo_dim = 1;
+    for (size_t d = np_dim + 1; d < input_tensor_shape.size() - 1; d++) {
+        num_sticks_per_halo_dim *= input_tensor_shape[d];
+    }
+    uint32_t input_halo_dim_size = input_tensor_shape[np_dim];  // H_dev
+
+    // Padded-input mode: the input tensor is [.., H+2pH, W+2pW, C], so the values derived from its shape
+    // above are the PADDED W/H. Keep them as the reader's input row-stride / frame-rows (for the strided
+    // interior read), but reduce the halo-geometry dims to the INTERIOR (H_dev, W_dev) — the compact
+    // buffer, writer, and W-section sizing are all about the interior halo, unchanged from contiguous input.
+    const bool padded_input = op.input_pad_h > 0 || op.input_pad_w > 0;
+    const uint32_t reader_row_stride = num_sticks_per_halo_dim;  // padded W (input tensor W)
+    const uint32_t reader_frame_rows = input_halo_dim_size;      // padded H (input tensor H)
+    if (padded_input) {
+        num_sticks_per_halo_dim -= 2 * op.input_pad_w;  // -> interior W_dev
+        input_halo_dim_size -= 2 * op.input_pad_h;      // -> interior H_dev
+    }
+
+    // In fabric_only mode output is a compact halo buffer
+    uint32_t output_halo_dim_size = op.np_padding_h + op.np_padding_h;  // padding_left + padding_right
+
+    // outer_dim_size = B * T (all dims before H)
+    uint32_t outer_dim_size = 1;
+    for (size_t d = 0; d < np_dim; d++) {
+        outer_dim_size *= input_tensor_shape[d];
+    }
+
+    bool is_first_device = !backward_coord.has_value();
+    bool is_last_device = !forward_coord.has_value();
+    bool is_padding_zeros = op.padding_mode == "zeros";
+    // The fused op is always 2D (H+W padding) — validate() enforces np_pad_dim2.has_value(). The
+    // H-only (1D) path is removed; is_2d is kept as a named constant for readability where the W-phase
+    // setup is gated.
+    TT_FATAL(op.np_pad_dim2.has_value(), "NpConv3d: fused op requires 2D padding (H+W).");
+    const bool is_2d = true;
+
+    // Fabric-mux buffers per channel. 4 is the measured sweet spot on BH-LB 2x4 (+~3pp vs 1; 8 regresses
+    // on L1 pressure). PCC-invariant (channel buffering doesn't touch data).
+    const uint8_t np_num_buffers = 4;
+
+    // H corner-first (PCC-neutral): the H-writer sends the W-boundary corner sticks to the neighbor's L1
+    // recv buffer + raises the recv sem BEFORE the bulk middle row, so the neighbor's H recv-wait clears
+    // after ~2 sticks instead of the full row. Requires padding==1 (the kernel's corner-first path).
+    // W two-pass is the progress>0 conv gate; the halo op uses its own interior-first reorder (below)
+    // instead, so keep this OFF here.
+    const uint32_t use_corner_first = (op.np_padding_h == 1) ? 1u : 0u;
+    const uint32_t use_w_two_pass = 0u;
+
+    // For the compact halo buffer, H-section rows are exactly W_dev wide.
+    // W-padding is handled in a separate W-section, so no extra columns in H rows.
+    // (The standalone NP factory widens rows to W+pad for padded-tensor output,
+    //  but the compact buffer layout keeps H and W sections independent.)
+    uint32_t output_num_sticks_per_halo_dim = num_sticks_per_halo_dim;
+    uint32_t writer_stick_start_id = 0;
+    uint32_t writer_num_sticks_to_read = num_sticks_per_halo_dim;
+
+    auto compute_grid_size = mesh_device->compute_with_storage_grid_size();
+    uint32_t num_links = static_cast<uint32_t>(op.np_num_links);
+    uint32_t pad2_num_links = static_cast<uint32_t>(op.np_pad2_num_links);
+
+    // Halo-only op: no conv, so no per-batch progress signalling. progress_t_batch_size == 0 compiles
+    // out every per-batch region-sem path in the NP kernels; H->W ordering is instead an upfront barrier
+    // (the W-reader waits the H-writers' Phase-2 barrier signal — see np_phase2_w_reader).
+    const uint32_t progress_t_batch_size = 0;
+
+    // H-send bank-major coalescing. The halo-only op's upfront H->W barrier makes the corner-first L1
+    // path unnecessary, so an eligible H exchange uses the simpler straight-to-DRAM path
+    // (use_l1_intermediate=0, whole H-halo row -> neighbor H-section DRAM; corners land in DRAM where the
+    // W-reader reads them) AND ships each row bank-major coalesced (h_coalesce_n same-bank sticks per 4KB
+    // packet). Eligible when padding_h==1: the row's w=j,j+8,... land same-bank/next-offset at
+    // base_row+j (valid for any base_row / W_dev, reader gathers in the same order). BH: 8 DRAM banks.
+    // Coalesce a bank's sticks into one fabric packet up to the fabric's actual max payload (not a fixed
+    // 4KB): default BH is 4352 B, and an 8K FabricRouterConfig raises it so each packet carries 2x the
+    // sticks. Cap the stick count so the send CBs stay bounded.
+    const uint32_t fabric_max_payload = static_cast<uint32_t>(tt::tt_fabric::get_tt_fabric_max_payload_size_bytes());
+    const uint32_t max_coalesce_sticks = std::max(1u, std::min(64u, fabric_max_payload / page_size));
+    // Zeros only: the bank-major coalesced path handles the interior + zero fill, not replicate's
+    // edge-outward slice replication, so replicate stays on the per-stick direct path.
+    uint32_t h_coalesce_n = 0;
+    if (op.np_padding_h == 1 && is_padding_zeros) {
+        h_coalesce_n = max_coalesce_sticks;
+        if (h_coalesce_n < 2) {
+            h_coalesce_n = 0;
+        }
+    }
+    const uint32_t h_use_l1 = (h_coalesce_n > 0) ? 0u : 1u;  // straight-to-DRAM when coalescing
+
+    constexpr uint32_t MAX_PAD2_NUM_LINKS = 4;
+    uint32_t total_fabric_cores = (num_links * 2) + (pad2_num_links * 2);
+    // Fabric cores live in the first column (y-axis), so bound against compute_grid_size.y.
+    if (total_fabric_cores > compute_grid_size.y) {
+        uint32_t max_total = compute_grid_size.y;
+        uint32_t h_cores = num_links * 2;
+        uint32_t available_for_w = (max_total > h_cores) ? (max_total - h_cores) : 0;
+        pad2_num_links = available_for_w / 2;
+        if (pad2_num_links == 0) {
+            pad2_num_links = 1;
+            num_links = (max_total - 2) / 2;
+        }
+    }
+
+    uint32_t num_h_fabric_cores = num_links * 2;
+    uint32_t num_w_fabric_cores = pad2_num_links * 2;
+    TT_FATAL(
+        pad2_num_links <= MAX_PAD2_NUM_LINKS,
+        "pad2_num_links ({}) exceeds maximum supported ({})",
+        pad2_num_links,
+        MAX_PAD2_NUM_LINKS);
+
+    // Fabric-mux worker count, auto-selected by W data-moved per (link,direction) like all_gather's
+    // default_workers: one worker caps at ~1.4 GB/s/link; multiple workers feeding the eth link through
+    // the mux reach the ~12.5 GB/s Linear ceiling. all_gather uses >256KB=>4, 4KB..256KB=>2, else 1.
+    // Capped at 2 here: the mux + 8-aligned split is validated at 2 workers (12.8 GB/s, PCC-exact);
+    // 4-worker mux is not yet validated. Zeros-only: the replicate-mode edge-outward mux path is unfixed,
+    // so replicate stays on the direct single-worker path. TT_NP_W_WORKERS overrides (matches all_gather's
+    // optional num_workers_per_direction).
+    uint32_t num_w_workers = 1;
+    {
+        const uint32_t w_h_total_est = input_halo_dim_size + 2 * op.np_padding_h;
+        const uint64_t w_rows_est = static_cast<uint64_t>(outer_dim_size) * w_h_total_est;  // W interior rows/dir
+        const uint64_t w_bytes_per_link_dir =
+            (pad2_num_links > 0) ? (w_rows_est * op.np_pad2_left * page_size / pad2_num_links) : 0;
+        uint32_t heuristic = 1;
+        if (w_bytes_per_link_dir > 256u * 1024u) {
+            heuristic = 4;
+        } else if (w_bytes_per_link_dir > 4u * 1024u) {
+            heuristic = 2;
+        }
+        // Auto-engage the W mux from the per-link byte heuristic, zeros only: the mux path does not do
+        // replicate's edge-outward slice replication, so replicate stays on the direct per-stick path.
+        if (is_padding_zeros) {
+            num_w_workers = heuristic;
+        }
+        // Clamp to available 8-row bank-units per link so no worker gets 0 rows (the 8-aligned split
+        // gives worker0 zero rows when rows_per_link < 8*num_w_workers -> degenerate/incorrect).
+        const uint32_t w_units_per_link = (pad2_num_links > 0) ? (w_rows_est / pad2_num_links / 8u) : 0u;
+        num_w_workers = std::max(1u, std::min<uint32_t>(num_w_workers, std::max(1u, w_units_per_link)));
+        log_debug(
+            tt::LogOp,
+            "np_halo mux: W bytes/(link,dir)={}, heuristic={}, num_w_workers={}",
+            w_bytes_per_link_dir,
+            heuristic,
+            num_w_workers);
+    }
+
+    // H fabric cores occupy column 0, rows [0, num_h_fabric_cores). W fabric cores
+    // follow in the same column. This gives conv3d a clean rectangular grid
+    // (cols [1, grid.x)) instead of the L-shape produced by a first-row layout.
+    CoreCoord np_core_grid(1, num_h_fabric_cores);
+    auto
+        [num_np_cores,
+         np_worker_core_ranges,
+         np_core_group_1,
+         np_core_group_2,
+         np_dims_per_core_group_1,
+         np_dims_per_core_group_2] = split_work_to_cores(np_core_grid, outer_dim_size * 2);
+
+    // Inc B: batch-align H partition so each (direction, link) owns whole T-batches (per-(HT/HB,link)
+    // sems need it). Link l owns frames [l*h_dims_per_link, min((l+1)*h_dims_per_link, outer_dim_size)).
+    const uint32_t h_pb = progress_t_batch_size;
+    const uint32_t h_total_batches = (h_pb > 0) ? ((outer_dim_size + h_pb - 1) / h_pb) : 0;
+    const uint32_t h_batches_per_link = (h_total_batches > 0) ? ((h_total_batches + num_links - 1) / num_links) : 0;
+    const uint32_t h_dims_per_link = h_batches_per_link * h_pb;
+
+    // L1 scratch CB for NP fabric transfer
+    uint32_t l1_scratch_cb_page_size_bytes = page_size;
+    uint32_t num_sticks_to_write_per_packet = 1;
+    uint32_t np_cb_num_pages = 2 * num_sticks_to_write_per_packet;
+    tt::DataFormat df = datatype_to_dataformat_converter(tensor_args.input_tensor.dtype());
+
+    uint32_t sender_cb_index = tt::CB::c_in0;
+    CircularBufferConfig cb_sender_config =
+        CircularBufferConfig(np_cb_num_pages * l1_scratch_cb_page_size_bytes, {{sender_cb_index, df}})
+            .set_page_size(sender_cb_index, l1_scratch_cb_page_size_bytes);
+    CreateCircularBuffer(program, np_worker_core_ranges, cb_sender_config);
+
+    // Dedicated H-send CB: the H-reader batches a full halo row (num_sticks_per_halo_dim sticks) per
+    // cb_reserve so the row reads coalesce into one barrier (the per-stick path was latency-bound,
+    // ~18k read+barrier pairs). Sized exactly 2 rows so a row reserve never wraps mid-batch (double
+    // buffered: reader fills row N+1 while the H-writer drains row N per stick). Kept separate from
+    // the sender CB because the per-stick recv/is_first pushes there would desync the row ring.
+    // H cores only; W keeps the per-stick c_in0 path.
+    uint32_t hsend_cb_index = tt::CB::c_in2;
+    uint32_t hsend_cb_num_pages = 2 * num_sticks_per_halo_dim;
+    CircularBufferConfig cb_hsend_config =
+        CircularBufferConfig(hsend_cb_num_pages * l1_scratch_cb_page_size_bytes, {{hsend_cb_index, df}})
+            .set_page_size(hsend_cb_index, l1_scratch_cb_page_size_bytes);
+    CreateCircularBuffer(program, np_worker_core_ranges, cb_hsend_config);
+
+    // L1 receive buffer for 2D padding: fabric-delivered H halo corner sticks arrive here.
+    // Corners-only optimization: only W-boundary sticks (pad2_left + pad2_right per row) go
+    // to L1; non-corner sticks go directly to neighbor DRAM via fabric.
+    // Buffer must hold ALL outer_dims' corner sticks (no per-outer_dim reuse) because the
+    // fabric pipeline can deliver data for outer_dim N+1 before the reader finishes
+    // copying outer_dim N.
+    uint32_t recv_cb_index = tt::CB::c_in1;
+    uint32_t corner_sticks_per_row = std::min(op.np_pad2_left + op.np_pad2_right, num_sticks_per_halo_dim);
+    if (is_2d) {
+        uint32_t max_padding = op.np_padding_h;  // symmetric H padding; matches main's max(left,right)
+        uint32_t max_outer_dims_per_core = std::max(np_dims_per_core_group_1, h_dims_per_link);
+        uint32_t recv_total_sticks = max_outer_dims_per_core * max_padding * corner_sticks_per_row;
+        uint32_t recv_buf_size = recv_total_sticks * page_size;
+        if (recv_buf_size > 0) {
+            CircularBufferConfig recv_cb_config =
+                CircularBufferConfig(recv_buf_size, {{recv_cb_index, df}}).set_page_size(recv_cb_index, page_size);
+            CreateCircularBuffer(program, np_worker_core_ranges, recv_cb_config);
+        }
+    }
+
+    // Phase 2 W-axis setup (for 2D padding)
+    std::vector<CoreCoord> w_fabric_logical_cores;
+    std::vector<CoreCoord> w_fabric_virtual_cores;
+    CoreRangeSet w_fabric_core_range;
+    bool is_first_w_device = true;
+    bool is_last_w_device = true;
+    uint32_t w_forward_device_offset = 0;
+    uint32_t w_backward_device_offset = 0;
+    std::optional<MeshCoordinate> w_forward_coord;
+    std::optional<MeshCoordinate> w_backward_coord;
+    uint32_t w_outer_dim_size = 0;
+    uint32_t w_rows_per_link = 0;
+    uint32_t w_extra_rows = 0;
+    uint32_t w_section_wleft_base = 0;
+    uint32_t w_section_wright_base = 0;
+    uint32_t w_coalesce_n = 0;  // W-send bank-major coalesce factor (0 = per-stick); set in the is_2d block
+
+    if (is_2d) {
+        w_forward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            tensor_args.input_tensor, mesh_coordinate, 1, ttnn::ccl::Topology::Linear, op.np_pad2_cluster_axis);
+        w_backward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            tensor_args.input_tensor, mesh_coordinate, -1, ttnn::ccl::Topology::Linear, op.np_pad2_cluster_axis);
+
+        is_first_w_device = !w_backward_coord.has_value();
+        is_last_w_device = !w_forward_coord.has_value();
+        if (w_forward_coord.has_value()) {
+            w_forward_device_offset = 1;
+        }
+        if (w_backward_coord.has_value()) {
+            w_backward_device_offset = 1;
+        }
+
+        for (uint32_t i = 0; i < num_w_fabric_cores; i++) {
+            CoreCoord wc = {0, num_h_fabric_cores + i};
+            w_fabric_logical_cores.push_back(wc);
+            w_fabric_virtual_cores.push_back(mesh_device->worker_core_from_logical_core(wc));
+        }
+        w_fabric_core_range =
+            CoreRangeSet(CoreRange({0, num_h_fabric_cores}, {0, num_h_fabric_cores + num_w_fabric_cores - 1}));
+
+        // fabric_only: W exchange covers all H_dev + 2*ph rows per T
+        uint32_t h_total = input_halo_dim_size + 2 * op.np_padding_h;
+        w_outer_dim_size = outer_dim_size * h_total;
+
+        // W-section base offsets in the compact halo buffer:
+        // Layout: [H-top | H-bot | W-left | W-right]
+        uint32_t h_section_sticks = outer_dim_size * 2 * op.np_padding_h * num_sticks_per_halo_dim;
+        w_section_wleft_base = h_section_sticks;
+        w_section_wright_base = w_section_wleft_base + outer_dim_size * op.np_pad2_left * h_total;
+
+        w_rows_per_link = w_outer_dim_size / pad2_num_links;
+        w_extra_rows = w_outer_dim_size % pad2_num_links;
+
+        // W-send bank-major coalescing (BH: 8 interleaved DRAM banks). Sticks base+r, base+r+8, ...,
+        // base+r+8*(N-1) land on bank (base+r)%8 at consecutive page offsets, so N ship as ONE N*page
+        // fabric write to get_noc_addr(base+r) — valid for ANY base (the N sticks differ by 8, hence same
+        // bank / next offset), and the reader gathers rel=r,r+8,... in the same order the writer sends. So
+        // only pw==1 + halo-only (progress==0) are required; base/row-count alignment is NOT needed.
+        // Zeros only: the coalesced reader/writer don't do replicate's edge-outward slice replication, so
+        // replicate stays on the per-stick direct path (matches h_coalesce_n).
+        const bool w_coalesce_ok =
+            (progress_t_batch_size == 0) && (op.np_pad2_left == 1) && (op.np_pad2_right == 1) && is_padding_zeros;
+        if (w_coalesce_ok) {
+            w_coalesce_n = max_coalesce_sticks;  // sticks per fabric-max-payload packet
+            if (w_coalesce_n < 2) {
+                w_coalesce_n = 0;
+            }
+        }
+        // W send CB (c_in0 on W cores): deep enough to double-buffer a coalesce group (per-stick uses 2).
+        uint32_t w_cb_num_pages = (w_coalesce_n > 0) ? (2 * w_coalesce_n) : np_cb_num_pages;
+        CircularBufferConfig cb_w_sender_config =
+            CircularBufferConfig(w_cb_num_pages * l1_scratch_cb_page_size_bytes, {{sender_cb_index, df}})
+                .set_page_size(sender_cb_index, l1_scratch_cb_page_size_bytes);
+        CreateCircularBuffer(program, w_fabric_core_range, cb_w_sender_config);
+    }
+
+    // Mux gating + W worker/mux core coords, computed HERE (before the H-writer setup) so the H->W
+    // barrier signal can target the relocated mux W-reader cores.
+    // Uniform mux across ALL W devices (edges too) so the recv-sem targeting is consistent along the whole
+    // W chain (mixed mux/standard breaks edge<->middle recv). Edge devices' no-send direction is handled
+    // by has_neighbor/has_send_neighbor gating in the kernels + no mux kernel for that (link,dir).
+    const bool use_w_mux = is_2d && (num_w_workers > 1) && (w_coalesce_n > 0);
+    std::vector<CoreCoord> mux_worker_logical, mux_worker_virtual, mux_core_logical;
+    if (use_w_mux) {
+        for (uint32_t s = 0; s < pad2_num_links * 2; s++) {
+            mux_core_logical.push_back(CoreCoord{1, s});
+            for (uint32_t wk = 0; wk < num_w_workers; wk++) {
+                CoreCoord wc{2 + wk, s};
+                mux_worker_logical.push_back(wc);
+                mux_worker_virtual.push_back(mesh_device->worker_core_from_logical_core(wc));
+            }
+        }
+    }
+
+    // Compute H fabric unicast and multicast route configurations
+    auto [h_unicast_forward_args, h_unicast_backward_args] =
+        ::ttnn::ccl::get_forward_backward_line_unicast_configuration(
+            mesh_coordinate, forward_coord, backward_coord, mesh_device);
+
+    auto [num_targets_forward, num_targets_backward] =
+        ::ttnn::ccl::get_forward_backward_line_mcast_distance(op.np_ring_size, device_index, op.np_topology, false);
+    auto [h_mcast_forward_args, h_mcast_backward_args] = ::ttnn::ccl::get_forward_backward_line_mcast_configuration(
+        mesh_coordinate, forward_coord, backward_coord, num_targets_forward, num_targets_backward, mesh_device);
+
+    uint32_t num_directions = 2;
+
+    // -------------------------------------------------------------------------
+    // PART 2: no conv consumer. There are no progress-sem signal targets, so reader_noc_coords stays
+    // empty (the H/W writers loop over 0 targets → no per-batch signalling).
+    // -------------------------------------------------------------------------
+    std::vector<std::pair<uint32_t, uint32_t>> reader_noc_coords;
+
+    // H-mux: mirror the W-mux (N workers per (link,dir) feed the H-axis eth link through a mux). H cores
+    // are placed in columns after the W-mux block. Auto-engage like W-mux: 2 H workers for zeros+coalesce
+    // (validated 8/8 PCC). Replicate stays on the direct path (pre-existing W-mux edge-outward bug).
+    // H bytes per (link,dir): 2 workers only when large enough to be bandwidth-bound (mirrors W's 4KB
+    // gate) and each worker gets >=1 frame — tiny shapes stay on the correct direct path.
+    const uint64_t h_bytes_per_link = (num_links > 0) ? (static_cast<uint64_t>(outer_dim_size) * op.np_padding_h *
+                                                         num_sticks_per_halo_dim * page_size / num_links)
+                                                      : 0;
+    const uint32_t h_frames_per_link = (num_links > 0) ? (outer_dim_size / num_links) : 0;
+    // Auto-engage H workers by per-(link,dir) bytes, mirroring the W heuristic: 4 for the large,
+    // bandwidth-bound shapes (>256KB/link) — measured to cut the s4-class wall (H exchange is on the op's
+    // critical path, e.g. s4 469us at H4 vs 560us at H2) — and 2 for the >4KB mid band; tiny shapes stay on
+    // the direct path. Requires >=1 frame/worker. Zeros only (replicate uses the direct path, like W).
+    // W4+H4 is PCC byte-exact on all 2x4 prod shapes.
+    uint32_t num_h_workers = 1;
+    if (is_padding_zeros && (h_frames_per_link >= 2u)) {
+        if (h_bytes_per_link > 256u * 1024u) {
+            num_h_workers = 4;
+        } else if (h_bytes_per_link > 4u * 1024u) {
+            num_h_workers = 2;
+        }
+    }
+    const bool use_h_mux = is_2d && (h_coalesce_n > 0) && (num_h_workers > 1);
+    std::vector<CoreCoord> hmux_worker_logical, hmux_worker_virtual, hmux_core_logical;
+    if (use_h_mux) {
+        const uint32_t h_mux_col = use_w_mux ? (2u + num_w_workers) : 1u;
+        for (uint32_t s = 0; s < num_links * num_directions; s++) {
+            hmux_core_logical.push_back(CoreCoord{h_mux_col, s});
+            for (uint32_t wk = 0; wk < num_h_workers; wk++) {
+                CoreCoord wc{h_mux_col + 1 + wk, s};
+                hmux_worker_logical.push_back(wc);
+                hmux_worker_virtual.push_back(mesh_device->worker_core_from_logical_core(wc));
+            }
+        }
+    }
+    KernelHandle h_reader_kernel_id = 0;
+    KernelHandle h_writer_kernel_id = 0;
+
+    if (!use_h_mux) {
+    // -------------------------------------------------------------------------
+    // NP H-fabric reader kernel
+    // -------------------------------------------------------------------------
+    auto h_reader_kernel_config = ReaderDataMovementConfig{};
+    h_reader_kernel_config.compile_args = {
+        sender_cb_index,   // cb_output_id
+        is_padding_zeros,  // is_padding_zeros
+        page_size};        // stick_size
+    TensorAccessorArgs(*input_buffer).append_to(h_reader_kernel_config.compile_args);
+    h_reader_kernel_config.compile_args.push_back(h_use_l1);        // use_l1_intermediate (0 when H-coalescing)
+    h_reader_kernel_config.compile_args.push_back(recv_cb_index);   // recv_cb_id
+    h_reader_kernel_config.compile_args.push_back(hsend_cb_index);  // send_cb_id (batched H send)
+    h_reader_kernel_config.compile_args.push_back(h_coalesce_n);    // H-send bank-major coalesce factor (0=off)
+    h_reader_kernel_config.compile_args.push_back(0);               // H_SIGNAL_W_RECV: direct path, np_writer signals
+    h_reader_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/"
+        "np_h_reader.cpp",
+        np_worker_core_ranges,
+        h_reader_kernel_config);
+    SetCommonRuntimeArgs(
+        program,
+        h_reader_kernel_id,
+        {input_buffer->address(), halo_buffer->address(), op.h_neighbor_semaphore.address()});
+
+    // -------------------------------------------------------------------------
+    // NP H-fabric writer kernel
+    // -------------------------------------------------------------------------
+    auto h_writer_kernel_config = WriterDataMovementConfig{};
+    h_writer_kernel_config.compile_args = {
+        sender_cb_index,   // cb_output_id
+        is_padding_zeros,  // is_padding_zeros
+        page_size};        // stick_size
+    TensorAccessorArgs(*halo_buffer).append_to(h_writer_kernel_config.compile_args);
+    h_writer_kernel_config.compile_args.push_back(h_use_l1);         // use_l1_intermediate (0 when H-coalescing)
+    h_writer_kernel_config.compile_args.push_back(recv_cb_index);    // recv_cb_id
+    h_writer_kernel_config.compile_args.push_back(h_use_l1);         // handle_incoming_writes (0 when H-coalescing)
+    h_writer_kernel_config.compile_args.push_back(0);                // is_w_fabric_writer (false for H)
+    h_writer_kernel_config.compile_args.push_back(op.np_ring_size);  // ring_size
+    // Per-batch progress-sem granularity is always passed; 0 disables the per-batch path.
+    h_writer_kernel_config.compile_args.push_back(progress_t_batch_size);
+    h_writer_kernel_config.compile_args.push_back(hsend_cb_index);    // send_cb_id (batched H send)
+    h_writer_kernel_config.compile_args.push_back(use_w_two_pass);    // unused on H writer; keeps arg layout aligned
+    h_writer_kernel_config.compile_args.push_back(use_corner_first);  // H-writer corner-first gate
+    h_writer_kernel_config.compile_args.push_back(h_coalesce_n);      // coalesce factor (H-writer uses the H branch)
+    h_writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/"
+        "np_writer.cpp",
+        np_worker_core_ranges,
+        h_writer_kernel_config);
+    {
+        std::vector<uint32_t> h_writer_crta = {
+            input_buffer->address(),
+            halo_buffer->address(),
+            op.h_neighbor_semaphore.address(),
+            op.barrier_semaphore.address(),
+            // CRTA[4]: number of conv3d reader cores to signal
+            static_cast<uint32_t>(reader_noc_coords.size()),
+            // CRTA[5+]: interleaved (x, y) NOC coords for each reader core
+        };
+        for (const auto& [x, y] : reader_noc_coords) {
+            h_writer_crta.push_back(x);
+            h_writer_crta.push_back(y);
+        }
+        SetCommonRuntimeArgs(program, h_writer_kernel_id, h_writer_crta);
+    }
+
+    // Set per-core runtime args for H fabric cores
+    uint32_t link_offset_start_id = 0;
+    uint32_t writer_link_offset_start_id = 0;
+    for (uint32_t link = 0; link < num_links; link++) {
+        uint32_t link_dims_to_read = 0;
+
+        for (uint32_t direction = 0; direction < num_directions; direction++) {
+            CoreCoord core = {0, link * num_directions + direction};
+            CoreCoord opposite_core = {0, (link * num_directions) + (1 - direction)};
+            CoreCoord virtual_core = mesh_device->worker_core_from_logical_core(core);
+            CoreCoord virtual_opposite_core = mesh_device->worker_core_from_logical_core(opposite_core);
+            if (np_core_group_1.contains(core)) {
+                link_dims_to_read = np_dims_per_core_group_1;
+            } else {
+                link_dims_to_read = np_dims_per_core_group_2;
+            }
+            if (h_pb > 0) {
+                const uint32_t b_start = link * h_dims_per_link;
+                const uint32_t b_end = std::min((link + 1) * h_dims_per_link, outer_dim_size);
+                link_dims_to_read = (b_end > b_start) ? (b_end - b_start) : 0u;
+            }
+
+            // Reader runtime args. Padded input: frame base/stride use padded dims (reader_frame_rows *
+            // reader_row_stride), stick_start skips the pH/pW border, row stride is padded W, but the
+            // edge-row count and sticks-to-read stay interior (input_halo_dim_size / num_sticks_per_halo_dim).
+            const uint32_t rd_frame_base =
+                padded_input ? (link_offset_start_id / num_sticks_per_halo_dim) * reader_frame_rows * reader_row_stride
+                             : link_offset_start_id * input_halo_dim_size;
+            std::vector<uint32_t> reader_rt_args = {
+                rd_frame_base,                                                       // outer_dim_offset_start_id
+                padded_input ? (op.input_pad_h * reader_row_stride + op.input_pad_w) : 0u,  // stick_start_id
+                input_halo_dim_size,                                                 // input_halo_dim_size (interior)
+                link_dims_to_read,                                                   // outer_dim_size
+                op.np_padding_h,                                                     // padding (symmetric)
+                num_sticks_per_halo_dim,                                             // num_sticks_to_read (interior)
+                padded_input ? reader_row_stride : num_sticks_per_halo_dim,          // num_sticks_per_halo_dim (stride)
+                corner_sticks_per_row,                                               // num_l1_recv_sticks_per_row
+                padded_input ? reader_frame_rows : input_halo_dim_size};            // input_frame_rows (frame stride)
+            reader_rt_args.push_back(direction ? is_last_device : is_first_device);  // is_first_chip
+            reader_rt_args.push_back(direction ? is_first_device : is_last_device);  // is_last_chip
+            reader_rt_args.push_back(direction);                                     // direction
+            SetRuntimeArgs(program, h_reader_kernel_id, {core}, reader_rt_args);
+
+            // Writer runtime args
+            uint32_t h_writer_num_sticks_per_halo_dim = output_num_sticks_per_halo_dim;
+            uint32_t h_writer_stick_start = writer_stick_start_id;
+            uint32_t h_writer_num_sticks_to_read = writer_num_sticks_to_read;
+
+            std::vector<uint32_t> writer_rt_args = {
+                writer_link_offset_start_id * output_halo_dim_size,  // outer_dim_offset_start_id
+                h_writer_stick_start,                                // stick_start_id
+                input_halo_dim_size,                                 // input_halo_dim_size
+                output_halo_dim_size,                                // output_halo_dim_size
+                link_dims_to_read,                                   // outer_dim_size
+                op.np_padding_h,                                     // padding (symmetric)
+                op.np_pad2_left,                                     // padding_left (W-axis, for L1 corner detection)
+                h_writer_num_sticks_to_read,                         // num_sticks_to_read
+                h_writer_num_sticks_per_halo_dim,                    // num_sticks_per_halo_dim
+                virtual_core.x,                                      // neighbor_sem_noc0_x
+                virtual_core.y,                                      // neighbor_sem_noc0_y
+                true,                                                // use_barrier_semaphore
+                virtual_opposite_core.x,                             // barrier_sem_noc0_x
+                virtual_opposite_core.y};                            // barrier_sem_noc0_y
+            // Phase 2 signal targets (W fabric reader cores). Mux path: signal the relocated mux
+            // worker-reader cores (each waits the H->W barrier) instead of the standard column-0 W cores.
+            constexpr uint32_t MAX_PHASE2_SIGNAL_TARGETS = 8;
+            const std::vector<CoreCoord>& w_sig_cores = use_w_mux ? mux_worker_virtual : w_fabric_virtual_cores;
+            const uint32_t n_w_sig = static_cast<uint32_t>(w_sig_cores.size());
+            writer_rt_args.push_back(n_w_sig);
+            for (uint32_t s = 0; s < MAX_PHASE2_SIGNAL_TARGETS; s++) {
+                if (s < n_w_sig) {
+                    writer_rt_args.push_back(w_sig_cores[s].x);
+                    writer_rt_args.push_back(w_sig_cores[s].y);
+                } else {
+                    writer_rt_args.push_back(0);
+                    writer_rt_args.push_back(0);
+                }
+            }
+            writer_rt_args.push_back(direction ? is_last_device : is_first_device);  // is_first_chip
+            writer_rt_args.push_back(direction ? is_first_device : is_last_device);  // is_last_chip
+            writer_rt_args.push_back(direction);                                     // direction
+            // Unicast route args
+            const auto& h_unicast_args = direction ? h_unicast_backward_args : h_unicast_forward_args;
+            writer_rt_args.insert(writer_rt_args.end(), h_unicast_args.begin(), h_unicast_args.end());
+            // Barrier multicast route info
+            const auto& h_mcast_args = direction ? h_mcast_backward_args : h_mcast_forward_args;
+            writer_rt_args.insert(writer_rt_args.end(), h_mcast_args.begin(), h_mcast_args.end());
+            // Fabric connection args
+            if (direction) {
+                writer_rt_args.push_back(false);
+                writer_rt_args.push_back(backward_coord.has_value());
+                if (backward_coord.has_value()) {
+                    const auto src_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
+                    const auto dst_fabric_node_id = mesh_device->get_fabric_node_id(backward_coord.value());
+                    tt::tt_fabric::append_fabric_connection_rt_args(
+                        src_fabric_node_id, dst_fabric_node_id, link, program, {core}, writer_rt_args);
+                }
+            } else {
+                writer_rt_args.push_back(forward_coord.has_value());
+                if (forward_coord.has_value()) {
+                    const auto src_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
+                    const auto dst_fabric_node_id = mesh_device->get_fabric_node_id(forward_coord.value());
+                    tt::tt_fabric::append_fabric_connection_rt_args(
+                        src_fabric_node_id, dst_fabric_node_id, link, program, {core}, writer_rt_args);
+                }
+                writer_rt_args.push_back(false);
+            }
+            // fabric_only mode: override writer rt_args to index into the compact halo buffer
+            {
+                uint32_t link_t_start = (output_num_sticks_per_halo_dim > 0)
+                                            ? (writer_link_offset_start_id / output_num_sticks_per_halo_dim)
+                                            : 0u;
+                uint32_t top_halo_total = outer_dim_size * op.np_padding_h * num_sticks_per_halo_dim;
+                uint32_t h_top_link_start = link_t_start * op.np_padding_h * num_sticks_per_halo_dim;
+                uint32_t h_bot_link_start = top_halo_total + link_t_start * op.np_padding_h * num_sticks_per_halo_dim;
+                writer_rt_args[0] = direction ? h_bot_link_start : h_top_link_start;  // per-link offset
+                writer_rt_args[1] = 0;                        // stick_start_id (no W-offset in compact)
+                writer_rt_args[3] = op.np_padding_h;          // output_halo_dim_size (compact)
+                writer_rt_args[8] = num_sticks_per_halo_dim;  // stride = W_dev, not padded W
+            }
+            // No per-batch progress args (progress_t_batch_size == 0, no conv consumer).
+            SetRuntimeArgs(program, h_writer_kernel_id, {core}, writer_rt_args);
+        }
+        link_offset_start_id += (link_dims_to_read * num_sticks_per_halo_dim);
+        writer_link_offset_start_id += (link_dims_to_read * output_num_sticks_per_halo_dim);
+    }
+    }  // end if(!use_h_mux)
+
+    if (use_h_mux) {
+        using tt::tt_fabric::FabricMuxChannelType;
+        const uint32_t l1_base = mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+        const size_t mux_buf_size = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
+        auto hmux_cfg = tt::tt_fabric::FabricMuxConfig(
+            static_cast<uint8_t>(num_h_workers), 0, np_num_buffers, 0, mux_buf_size, l1_base);
+
+        const std::string kdir = "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/";
+        std::set<CoreRange> hw_crs, hm_crs;
+        for (const auto& c : hmux_worker_logical) hw_crs.insert(CoreRange(c));
+        // Mux kernel only for (link,dir) that send (edge outward dirs don't).
+        for (uint32_t s = 0; s < hmux_core_logical.size(); s++) {
+            const bool sends = (s % num_directions == 0) ? !is_last_device : !is_first_device;
+            if (sends) hm_crs.insert(CoreRange(hmux_core_logical[s]));
+        }
+        CoreRangeSet hw_crset(hw_crs);
+        CoreRangeSet hm_crset(hm_crs.empty() ? std::set<CoreRange>{CoreRange({0, 0})} : hm_crs);
+        occ_hw_workers = hw_crset;
+        occ_hmux = hm_crset;
+
+        // Send CB (hsend) + sender CB (c_in0) on the H worker cores. hsend MUST be a whole multiple of the
+        // row size (num_sticks_per_halo_dim): the H reader reserves a full row at once and the writer reads
+        // it via get_read_ptr + m*stick, so a row must never straddle the CB wrap. 4 rows for pipelining.
+        {
+            CircularBufferConfig cb_hs(
+                4u * num_sticks_per_halo_dim * l1_scratch_cb_page_size_bytes, {{hsend_cb_index, df}});
+            cb_hs.set_page_size(hsend_cb_index, l1_scratch_cb_page_size_bytes);
+            CreateCircularBuffer(program, hw_crset, cb_hs);
+            CircularBufferConfig cb_s0(np_cb_num_pages * l1_scratch_cb_page_size_bytes, {{sender_cb_index, df}});
+            cb_s0.set_page_size(sender_cb_index, l1_scratch_cb_page_size_bytes);
+            CreateCircularBuffer(program, hw_crset, cb_s0);
+        }
+
+        // H reader on worker cores (same CT layout as the standard H reader).
+        std::vector<uint32_t> hr_ct = {sender_cb_index, is_padding_zeros, page_size};
+        TensorAccessorArgs(*input_buffer).append_to(hr_ct);
+        hr_ct.push_back(h_use_l1);
+        hr_ct.push_back(recv_cb_index);
+        hr_ct.push_back(hsend_cb_index);
+        hr_ct.push_back(h_coalesce_n);
+        hr_ct.push_back(1);  // H_SIGNAL_W_RECV: this reader signals the H->W barrier after its recv drains
+        auto hr_cfg = ReaderDataMovementConfig{};
+        hr_cfg.compile_args = hr_ct;
+        h_reader_kernel_id = CreateKernel(program, kdir + "np_h_reader.cpp", hw_crset, hr_cfg);
+        SetCommonRuntimeArgs(
+            program,
+            h_reader_kernel_id,
+            {input_buffer->address(),
+             halo_buffer->address(),
+             op.h_neighbor_semaphore.address(),
+             op.barrier_semaphore.address()});
+
+        // H-mux writer on worker cores. CT: is_padding_zeros, c_in0 (is_first local pad), hsend, stick.
+        std::vector<uint32_t> hw_ct = {is_padding_zeros, sender_cb_index, hsend_cb_index, page_size};
+        TensorAccessorArgs(*halo_buffer).append_to(hw_ct);
+        hw_ct.push_back(h_coalesce_n);
+        ttnn::ccl::fabric_mux_connection_ct_args(num_h_workers, FabricMuxChannelType::FULL_SIZE_CHANNEL, hmux_cfg, hw_ct);
+        auto hw_cfg = WriterDataMovementConfig{};
+        hw_cfg.compile_args = hw_ct;
+        h_writer_kernel_id = CreateKernel(program, kdir + "np_h_mux_writer.cpp", hw_crset, hw_cfg);
+        SetCommonRuntimeArgs(
+            program, h_writer_kernel_id,
+            {input_buffer->address(), halo_buffer->address(), op.h_neighbor_semaphore.address(),
+             op.barrier_semaphore.address()});
+
+        auto hmux_kernel_id = CreateKernel(
+            program, "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp", hm_crset,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt::tt_metal::NOC::RISCV_0_default,
+                .compile_args = hmux_cfg.get_fabric_mux_compile_time_args(),
+                .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
+
+        // W-reader barrier targets (H workers signal these so the W reader clears its H->W wait).
+        const std::vector<CoreCoord>& w_sig = use_w_mux ? mux_worker_virtual : w_fabric_virtual_cores;
+        const uint32_t top_halo_total = outer_dim_size * op.np_padding_h * num_sticks_per_halo_dim;
+        const uint32_t frames_per_link = outer_dim_size / num_links;
+        const uint32_t frames_extra = outer_dim_size % num_links;
+
+        for (uint32_t link = 0; link < num_links; link++) {
+            const uint32_t link_f0 = link * frames_per_link + std::min(link, frames_extra);
+            const uint32_t link_fc = frames_per_link + (link < frames_extra ? 1u : 0u);
+            const uint32_t per_wk = link_fc / num_h_workers;
+            const uint32_t extra_wk = link_fc % num_h_workers;
+            for (uint32_t dir = 0; dir < num_directions; dir++) {
+                const uint32_t s = link * num_directions + dir;
+                CoreCoord mux_lc = hmux_core_logical[s];
+                CoreCoord mux_vc = mesh_device->worker_core_from_logical_core(mux_lc);
+                const bool sends = (dir == 0) ? !is_last_device : !is_first_device;
+                if (sends) {
+                    const auto src_id = mesh_device->get_fabric_node_id(mesh_coordinate);
+                    const auto dst_id = mesh_device->get_fabric_node_id(dir ? backward_coord.value() : forward_coord.value());
+                    auto mux_rt = hmux_cfg.get_fabric_mux_run_time_args(src_id, dst_id, link, program, {mux_lc});
+                    SetRuntimeArgs(program, hmux_kernel_id, {mux_lc}, mux_rt);
+                }
+                CoreCoord term_master_vc =
+                    mesh_device->worker_core_from_logical_core(hmux_worker_logical[s * num_h_workers + 0]);
+                const uint32_t h_section_base = dir ? top_halo_total : 0u;
+                const uint32_t h_dev_off = (dir ? backward_coord.has_value() : forward_coord.has_value()) ? 1u : 0u;
+                for (uint32_t wk = 0; wk < num_h_workers; wk++) {
+                    CoreCoord wc = hmux_worker_logical[s * num_h_workers + wk];
+                    CoreCoord wc_vc = hmux_worker_virtual[s * num_h_workers + wk];
+                    const uint32_t wk_f0 = link_f0 + wk * per_wk + std::min(wk, extra_wk);
+                    const uint32_t wk_fc = per_wk + (wk < extra_wk ? 1u : 0u);
+                    // Reader RT args (same layout as the standard H reader). wk_f0 is in FRAME units here.
+                    std::vector<uint32_t> r_rt = {
+                        padded_input ? wk_f0 * reader_frame_rows * reader_row_stride
+                                     : wk_f0 * num_sticks_per_halo_dim * input_halo_dim_size,  // outer_dim_offset_start_id
+                        padded_input ? (op.input_pad_h * reader_row_stride + op.input_pad_w) : 0u,  // stick_start_id
+                        input_halo_dim_size,
+                        wk_fc,  // outer_dim_size (frames this worker owns)
+                        op.np_padding_h,
+                        num_sticks_per_halo_dim,
+                        padded_input ? reader_row_stride : num_sticks_per_halo_dim,
+                        corner_sticks_per_row,
+                        padded_input ? reader_frame_rows : input_halo_dim_size};  // input_frame_rows
+                    r_rt.push_back(dir ? is_last_device : is_first_device);
+                    r_rt.push_back(dir ? is_first_device : is_last_device);
+                    r_rt.push_back(dir);
+                    // H->W barrier targets: this reader signals these W-reader cores after its recv drains.
+                    constexpr uint32_t MAX_W_BARRIER_TARGETS = 16;
+                    r_rt.push_back(static_cast<uint32_t>(w_sig.size()));
+                    for (uint32_t t = 0; t < MAX_W_BARRIER_TARGETS; t++) {
+                        r_rt.push_back(t < w_sig.size() ? w_sig[t].x : 0u);
+                        r_rt.push_back(t < w_sig.size() ? w_sig[t].y : 0u);
+                    }
+                    SetRuntimeArgs(program, h_reader_kernel_id, {wc}, r_rt);
+                    // Writer RT args (np_h_mux_writer layout).
+                    std::vector<uint32_t> w_rt = {
+                        h_section_base + wk_f0 * op.np_padding_h * num_sticks_per_halo_dim,  // h_base
+                        wk_fc,                                                               // outer_dim_count
+                        op.np_padding_h,
+                        num_sticks_per_halo_dim,  // num_sticks_to_read (W_dev)
+                        num_sticks_per_halo_dim,  // num_sticks_per_halo_dim
+                        wc_vc.x, wc_vc.y,         // recv-sem target = same-dir worker
+                        // is_first/is_last direction-adjusted (match np_h_reader + np_writer).
+                        static_cast<uint32_t>(dir ? is_last_device : is_first_device),
+                        static_cast<uint32_t>(dir ? is_first_device : is_last_device), dir,
+                        0u, h_dev_off};  // route mesh, distance-in-hops
+                    ttnn::ccl::fabric_mux_connection_rt_args(
+                        sends, /*is_termination_master=*/wk == 0, FabricMuxChannelType::FULL_SIZE_CHANNEL, mux_vc, wk,
+                        wc, hmux_cfg, program, term_master_vc, w_rt, std::nullopt);
+                    // (H->W barrier targets moved to the H reader, which signals after recv.)
+                    // Opp-direction H-worker coords on the neighbor (for the pairwise startup barrier).
+                    CoreCoord opp_vc = hmux_worker_virtual[(link * num_directions + (1 - dir)) * num_h_workers + wk];
+                    w_rt.push_back(opp_vc.x);
+                    w_rt.push_back(opp_vc.y);
+                    SetRuntimeArgs(program, h_writer_kernel_id, {wc}, w_rt);
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // W fabric kernels for 2D padding (Phase 2)
+    // -------------------------------------------------------------------------
+    KernelHandle w_reader_kernel_id = 0;
+    KernelHandle w_writer_kernel_id = 0;
+    if (is_2d) {
+        const auto& mesh_view_w = mesh_device->get_view();
+        uint32_t w_ring_size = (op.np_pad2_cluster_axis.value() == 0) ? mesh_view_w.num_rows() : mesh_view_w.num_cols();
+        uint32_t w_device_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
+            tensor_args.input_tensor, mesh_coordinate, op.np_pad2_cluster_axis);
+        auto [w_num_targets_forward, w_num_targets_backward] =
+            ::ttnn::ccl::get_forward_backward_line_mcast_distance(w_ring_size, w_device_index, op.np_topology, false);
+        auto [w_mcast_forward_args, w_mcast_backward_args] = ::ttnn::ccl::get_forward_backward_line_mcast_configuration(
+            mesh_coordinate,
+            w_forward_coord,
+            w_backward_coord,
+            w_num_targets_forward,
+            w_num_targets_backward,
+            mesh_device);
+
+        // ---------------------------------------------------------------------
+        // FABRIC-MUX W path (middle W devices, coalesced): N workers per (link,dir) feed a mux core so
+        // the eth link is saturated (reach ~12.5 GB/s/link vs ~1.4 single-worker). Gated on num_w_workers
+        // > 1 + middle device + coalesce-eligible; else falls through to the standard 1-worker path.
+        // Uses the shipping tt_fabric_mux kernel + ccl::fabric_mux_connection_{ct,rt}_args helpers.
+        // use_w_mux + mux core coords are computed above (before the H-writer barrier signal setup).
+        if (use_w_mux) {
+            using tt::tt_fabric::FabricMuxChannelType;
+            const uint32_t l1_base =
+                mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+            const size_t mux_buf_size = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
+            // num_buffers per channel: 4 (np_num_buffers) is the measured 2x4 sweet spot (+~3pp); the mux
+            // still fits its full-size channels in L1 at 4. PCC-invariant.
+            auto mux_cfg = tt::tt_fabric::FabricMuxConfig(
+                /*num_full_size_channels=*/static_cast<uint8_t>(num_w_workers),
+                /*num_header_only_channels=*/0,
+                /*num_buffers_full_size_channel=*/np_num_buffers,
+                /*num_buffers_header_only_channel=*/0,
+                mux_buf_size,
+                l1_base);
+
+            // Core layout (halo-only op: cols>=1 are free). Per (link,dir): 1 mux core (col 1) + N worker
+            // cores (cols 2+). link/dir index = w_link*2 + w_dir.
+
+            // W reader + mux writer kernels on the worker cores.
+            std::vector<uint32_t> mux_reader_ct = {sender_cb_index, is_padding_zeros, page_size};
+            TensorAccessorArgs(*halo_buffer).append_to(mux_reader_ct);
+            TensorAccessorArgs(*input_buffer).append_to(mux_reader_ct);
+            mux_reader_ct.push_back(progress_t_batch_size);
+            mux_reader_ct.push_back(use_w_two_pass);
+            mux_reader_ct.push_back(w_coalesce_n);
+            mux_reader_ct.push_back(1);  // W_MUX_MODE: coalesce for edge devices too
+            auto mux_reader_cfg = ReaderDataMovementConfig{};
+            mux_reader_cfg.compile_args = mux_reader_ct;
+
+            std::vector<uint32_t> mux_writer_ct = {sender_cb_index, page_size};
+            TensorAccessorArgs(*halo_buffer).append_to(mux_writer_ct);
+            mux_writer_ct.push_back(w_coalesce_n);
+            ttnn::ccl::fabric_mux_connection_ct_args(
+                num_w_workers, FabricMuxChannelType::FULL_SIZE_CHANNEL, mux_cfg, mux_writer_ct);
+            auto mux_writer_cfg = WriterDataMovementConfig{};
+            mux_writer_cfg.compile_args = mux_writer_ct;
+
+            const std::string kdir =
+                "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/";
+            // Reuse the hoisted core lists (flat: [link*2+dir][worker] for workers, [link*2+dir] for mux).
+            const std::vector<CoreCoord>& mux_worker_cores = mux_worker_logical;
+            const std::vector<CoreCoord>& mux_mux_cores = mux_core_logical;
+            std::set<CoreRange> worker_crs, mux_crs;
+            for (const auto& c : mux_worker_cores) worker_crs.insert(CoreRange(c));
+            // Only create a mux kernel for (link,dir) that actually SEND (have a send-neighbor); the mux
+            // kernel blocks until its worker connects + signals terminate, so an unused mux would hang.
+            // dir=0 (forward) sends iff !is_last_w_device; dir=1 (backward) sends iff !is_first_w_device.
+            for (uint32_t s = 0; s < mux_mux_cores.size(); s++) {
+                const uint32_t w_dir_s = s % 2;
+                const bool sends = w_dir_s == 0 ? !is_last_w_device : !is_first_w_device;
+                if (sends) {
+                    mux_crs.insert(CoreRange(mux_mux_cores[s]));
+                }
+            }
+            CoreRangeSet worker_crset(worker_crs);
+            CoreRangeSet mux_crset(mux_crs.empty() ? std::set<CoreRange>{CoreRange({0, 0})} : mux_crs);
+            occ_w_workers = worker_crset;
+            occ_wmux = mux_crset;
+
+            // Send CB (c_in0) on the mux WORKER cores — the base cb_w_sender_config was created only on
+            // the standard column-0 W cores, so the relocated workers had no CB (reader/writer would
+            // block on cb_reserve/cb_wait_front). Sized to hold coalesce groups deep for pipelining.
+            {
+                const uint32_t w_mux_cb_pages = 16 * w_coalesce_n;
+                CircularBufferConfig cb_mux_w(
+                    w_mux_cb_pages * l1_scratch_cb_page_size_bytes, {{sender_cb_index, df}});
+                cb_mux_w.set_page_size(sender_cb_index, l1_scratch_cb_page_size_bytes);
+                CreateCircularBuffer(program, worker_crset, cb_mux_w);
+            }
+
+            w_reader_kernel_id = CreateKernel(program, kdir + "np_phase2_w_reader.cpp", worker_crset, mux_reader_cfg);
+            w_writer_kernel_id = CreateKernel(program, kdir + "np_w_mux_writer.cpp", worker_crset, mux_writer_cfg);
+            // Reader common args (CRTA[0]=halo addr, [1]=barrier_sem, [2]=w_neighbor_sem) — MUST be set on
+            // the mux reader too, else barrier_sem_addr is unset and the H->W barrier wait never completes.
+            SetCommonRuntimeArgs(
+                program,
+                w_reader_kernel_id,
+                {halo_buffer->address(), op.barrier_semaphore.address(), op.w_neighbor_semaphore.address()});
+            SetCommonRuntimeArgs(
+                program,
+                w_writer_kernel_id,
+                {halo_buffer->address(), halo_buffer->address(), op.w_neighbor_semaphore.address(),
+                 op.barrier_semaphore.address(), input_halo_dim_size, static_cast<uint32_t>(op.np_padding_h)});
+
+            auto mux_kernel_id = CreateKernel(
+                program,
+                "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
+                mux_crset,
+                tt::tt_metal::DataMovementConfig{
+                    .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt::tt_metal::NOC::RISCV_0_default,
+                    .compile_args = mux_cfg.get_fabric_mux_compile_time_args(),
+                    .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
+
+            for (uint32_t w_link = 0; w_link < pad2_num_links; w_link++) {
+                for (uint32_t w_dir = 0; w_dir < 2; w_dir++) {
+                    const uint32_t s = w_link * 2 + w_dir;
+                    const bool dir_has_neighbor = w_dir ? w_backward_coord.has_value() : w_forward_coord.has_value();
+                    // Mux kernel RT args (one mux core per (link,dir)); only meaningful if the dir has a neighbor.
+                    CoreCoord mux_lc = mux_mux_cores[s];
+                    CoreCoord mux_vc = mesh_device->worker_core_from_logical_core(mux_lc);
+                    if (dir_has_neighbor) {
+                        const auto src_id = mesh_device->get_fabric_node_id(mesh_coordinate);
+                        const auto dst_id = mesh_device->get_fabric_node_id(
+                            w_dir ? w_backward_coord.value() : w_forward_coord.value());
+                        auto mux_rt = mux_cfg.get_fabric_mux_run_time_args(src_id, dst_id, w_link, program, {mux_lc});
+                        SetRuntimeArgs(program, mux_kernel_id, {mux_lc}, mux_rt);
+                    }
+                    // Termination master = worker 0 of this (link,dir) group.
+                    CoreCoord term_master_lc = mux_worker_cores[s * num_w_workers + 0];
+                    CoreCoord term_master_vc = mesh_device->worker_core_from_logical_core(term_master_lc);
+                    // Split this (link,dir)'s W rows across workers.
+                    const uint32_t rows_this_link = w_rows_per_link + (w_link < w_extra_rows ? 1 : 0);
+                    const uint32_t base_link_start = (w_link * w_rows_per_link) + std::min(w_link, w_extra_rows);
+                    // 8-aligned per-worker split: each worker's start is a whole number of 8-row (bank)
+                    // units so its coalesce base stays bank-consistent with the receiver's read; the LAST
+                    // worker absorbs the non-8 remainder (its coalesce handles the partial tail group).
+                    // Even (non-8) splits corrupt the W-section at ~0.996 PCC on non-aligned shapes.
+                    constexpr uint32_t BANKS = 8;
+                    const uint32_t units = rows_this_link / BANKS;
+                    const uint32_t units_per_wk = units / num_w_workers;
+                    const uint32_t pw = w_dir ? op.np_pad2_right : op.np_pad2_left;
+                    const uint32_t section_base = w_dir ? w_section_wright_base : w_section_wleft_base;
+                    // recv-sem target = the SAME-direction worker core (matches the standard W writer,
+                    // which sets neighbor_sem_noc0 = w_virtual_core[w_link*2+w_dir]). The receiving reader
+                    // on the neighbor waits at the same (device-independent) core coords.
+                    for (uint32_t wk = 0; wk < num_w_workers; wk++) {
+                        CoreCoord wc = mux_worker_cores[s * num_w_workers + wk];
+                        CoreCoord wc_vc = mux_worker_virtual[s * num_w_workers + wk];
+                        const uint32_t wk_start = base_link_start + wk * units_per_wk * BANKS;
+                        const bool last_wk = (wk == num_w_workers - 1);
+                        const uint32_t wk_count =
+                            last_wk ? (rows_this_link - wk * units_per_wk * BANKS) : (units_per_wk * BANKS);
+                        // Reader RT args (same layout as the standard W reader). barrier_count = number of
+                        // H workers that signal the H->W barrier (H-mux: links*dirs*workers; else H cores).
+                        const uint32_t h_signal_count =
+                            use_h_mux ? (num_links * num_directions * num_h_workers) : num_h_fabric_cores;
+                        std::vector<uint32_t> r_rt = {
+                            wk_count, wk_start, pw, h_signal_count, output_num_sticks_per_halo_dim,
+                            op.np_pad2_left, num_sticks_per_halo_dim,
+                            static_cast<uint32_t>(w_dir ? is_last_w_device : is_first_w_device),
+                            static_cast<uint32_t>(w_dir ? is_first_w_device : is_last_w_device),
+                            w_dir, input_buffer->address(), input_halo_dim_size, op.np_padding_h,
+                            outer_dim_size * op.np_padding_h * num_sticks_per_halo_dim,
+                            op.input_pad_h, op.input_pad_w, 0u};
+                        SetRuntimeArgs(program, w_reader_kernel_id, {wc}, r_rt);
+                        // Writer RT args: per-core (base,rows,sem xy,dir,route) then mux conn (0..16).
+                        // sem targets = the neighbor's reader worker core (NOC coords are device-independent),
+                        // NOT the mux core: the recv-sem + startup-barrier incs land on the reader that waits them.
+                        std::vector<uint32_t> w_rt = {
+                            section_base + wk_start * pw, wk_count,
+                            wc_vc.x, wc_vc.y, wc_vc.x, wc_vc.y,
+                            static_cast<uint32_t>(is_first_w_device), static_cast<uint32_t>(is_last_w_device), w_dir,
+                            0u, static_cast<uint32_t>(w_dir ? w_backward_device_offset : w_forward_device_offset)};
+                        ttnn::ccl::fabric_mux_connection_rt_args(
+                            dir_has_neighbor, /*is_termination_master=*/wk == 0,
+                            FabricMuxChannelType::FULL_SIZE_CHANNEL, mux_vc, wk, wc, mux_cfg, program,
+                            term_master_vc, w_rt, std::nullopt);
+                        SetRuntimeArgs(program, w_writer_kernel_id, {wc}, w_rt);
+                    }
+                }
+            }
+            w_fabric_core_range = worker_crset;
+        } else {
+        // W reader kernel — fused-owned copy: always fabric-only, always per-batch
+        // progress-sem signalling.
+        auto w_reader_kernel_config = ReaderDataMovementConfig{};
+        w_reader_kernel_config.compile_args = {sender_cb_index, is_padding_zeros, page_size};
+        TensorAccessorArgs(*halo_buffer).append_to(w_reader_kernel_config.compile_args);
+        TensorAccessorArgs(*input_buffer).append_to(w_reader_kernel_config.compile_args);
+        // Per-batch signal granularity (matches conv3d reader's progress_t_batch_size CT arg).
+        w_reader_kernel_config.compile_args.push_back(progress_t_batch_size);
+        w_reader_kernel_config.compile_args.push_back(use_w_two_pass);  // global two-pass gate (lockstep w/ writer)
+        w_reader_kernel_config.compile_args.push_back(w_coalesce_n);    // W-send bank-major coalesce factor (0=off)
+        w_reader_kernel_config.compile_args.push_back(0);              // W_MUX_MODE off (standard 1-worker path)
+        w_reader_kernel_id = CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/"
+            "np_phase2_w_reader.cpp",
+            w_fabric_core_range,
+            w_reader_kernel_config);
+        {
+            std::vector<uint32_t> w_reader_crta = {
+                halo_buffer->address(),
+                op.barrier_semaphore.address(),
+                op.w_neighbor_semaphore.address(),
+            };
+            // No per-batch H-region sems (progress_t_batch_size == 0). H->W ordering is the upfront
+            // barrier the W-reader waits on (op.barrier_semaphore, CRTA[1]).
+            SetCommonRuntimeArgs(program, w_reader_kernel_id, w_reader_crta);
+        }
+
+        // W writer kernel
+        auto w_writer_kernel_config = WriterDataMovementConfig{};
+        w_writer_kernel_config.compile_args = {sender_cb_index, is_padding_zeros, page_size};
+        TensorAccessorArgs(*halo_buffer).append_to(w_writer_kernel_config.compile_args);
+        w_writer_kernel_config.compile_args.push_back(0);            // use_l1_intermediate
+        w_writer_kernel_config.compile_args.push_back(0);            // recv_cb_id
+        w_writer_kernel_config.compile_args.push_back(0);            // handle_incoming_writes
+        w_writer_kernel_config.compile_args.push_back(1);            // is_w_fabric_writer
+        w_writer_kernel_config.compile_args.push_back(w_ring_size);  // ring_size
+        // progress_t_batch_size: W-writer doesn't per-batch-signal in 2D (gated by
+        // num_phase2_signal_targets > 0 at runtime), but the CT arg must be present to
+        // match np_writer.cpp's arg layout.
+        w_writer_kernel_config.compile_args.push_back(progress_t_batch_size);
+        w_writer_kernel_config.compile_args.push_back(sender_cb_index);  // send_cb_id: W keeps the c_in0 per-stick path
+        w_writer_kernel_config.compile_args.push_back(use_w_two_pass);   // global two-pass gate (lockstep w/ reader)
+        w_writer_kernel_config.compile_args.push_back(
+            use_corner_first);  // unused on W writer; keeps arg layout aligned
+        w_writer_kernel_config.compile_args.push_back(w_coalesce_n);  // W-send bank-major coalesce factor (0=off)
+        w_writer_kernel_id = CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/"
+            "np_writer.cpp",
+            w_fabric_core_range,
+            w_writer_kernel_config);
+        SetCommonRuntimeArgs(
+            program,
+            w_writer_kernel_id,
+            {halo_buffer->address(),
+             halo_buffer->address(),
+             op.w_neighbor_semaphore.address(),
+             op.h_neighbor_semaphore.address(),
+             input_halo_dim_size,
+             static_cast<uint32_t>(op.np_padding_h)});  // [4],[5]: W-writer per-batch two-pass reorder dims
+
+        // Per-core W fabric runtime args.
+        // When pipelining (progress_t_batch_size>0), align each link to whole T-batches so the
+        // per-(region,link) progress sem counts batches 1:1 and the conv3d reader can map a batch to
+        // its owning link by integer division (no per-link boundary table).
+        const uint32_t w_h_total = input_halo_dim_size + 2 * op.np_padding_h;
+        const uint32_t w_sticks_per_batch = progress_t_batch_size * w_h_total;
+        const uint32_t total_w_batches =
+            w_sticks_per_batch > 0 ? ((w_outer_dim_size + w_sticks_per_batch - 1) / w_sticks_per_batch) : 0;
+        const uint32_t w_batches_per_link =
+            (total_w_batches > 0) ? ((total_w_batches + pad2_num_links - 1) / pad2_num_links) : 0;
+        for (uint32_t w_link = 0; w_link < pad2_num_links; w_link++) {
+            uint32_t w_link_start, w_link_count;
+            if (progress_t_batch_size > 0) {
+                const uint32_t b_start = w_link * w_batches_per_link;
+                const uint32_t b_end = std::min((w_link + 1) * w_batches_per_link, total_w_batches);
+                w_link_start = std::min(b_start * w_sticks_per_batch, w_outer_dim_size);
+                w_link_count = std::min(b_end * w_sticks_per_batch, w_outer_dim_size) - w_link_start;
+            } else {
+                w_link_start = (w_link * w_rows_per_link) + std::min(w_link, w_extra_rows);
+                w_link_count = w_rows_per_link + (w_link < w_extra_rows ? 1 : 0);
+            }
+
+            for (uint32_t w_direction = 0; w_direction < 2; w_direction++) {
+                uint32_t w_core_idx = (w_link * 2) + w_direction;
+                CoreCoord w_core = w_fabric_logical_cores[w_core_idx];
+                CoreCoord w_virtual_core = w_fabric_virtual_cores[w_core_idx];
+
+                // barrier_count = number of H workers that signal the H->W barrier (H-mux:
+                // links*dirs*workers; else H fabric cores).
+                uint32_t barrier_count =
+                    use_h_mux ? (num_links * num_directions * num_h_workers) : num_h_fabric_cores;
+
+                // W reader runtime args
+                std::vector<uint32_t> w_reader_rt_args = {
+                    w_link_count,
+                    w_link_start,
+                    w_direction ? op.np_pad2_right : op.np_pad2_left,
+                    barrier_count,
+                    output_num_sticks_per_halo_dim,
+                    op.np_pad2_left,
+                    num_sticks_per_halo_dim};
+                w_reader_rt_args.push_back(w_direction ? is_last_w_device : is_first_w_device);
+                w_reader_rt_args.push_back(w_direction ? is_first_w_device : is_last_w_device);
+                w_reader_rt_args.push_back(w_direction);
+                // fabric_only: pass input buffer address for interior row reads
+                w_reader_rt_args.push_back(input_buffer->address());
+                w_reader_rt_args.push_back(input_halo_dim_size);
+                w_reader_rt_args.push_back(op.np_padding_h);
+                // h_halo_hbot_base
+                w_reader_rt_args.push_back(outer_dim_size * op.np_padding_h * num_sticks_per_halo_dim);
+                // Padded-input strides for the W-edge interior reads (0 = contiguous).
+                w_reader_rt_args.push_back(op.input_pad_h);
+                w_reader_rt_args.push_back(op.input_pad_w);
+                // No conv W-edge consumer: push 0 for the (unused) per-batch region progress sem addr
+                // to keep the W-reader's per-core arg layout stable.
+                w_reader_rt_args.push_back(0u);
+                SetRuntimeArgs(program, w_reader_kernel_id, {w_core}, w_reader_rt_args);
+
+                // W writer runtime args — addresses the W-section of the compact buffer.
+                // Direction 0 (forward): writes W-left on receiver.
+                // Direction 1 (backward): writes W-right on receiver.
+                uint32_t w_pad = w_direction ? op.np_pad2_right : op.np_pad2_left;
+                uint32_t w_base = w_direction ? w_section_wright_base : w_section_wleft_base;
+                std::vector<uint32_t> w_writer_rt_args = {
+                    w_base + w_link_start * w_pad,
+                    0,
+                    num_sticks_per_halo_dim,
+                    w_pad,
+                    w_link_count,
+                    w_pad,
+                    0,
+                    1,
+                    1,
+                    w_virtual_core.x,
+                    w_virtual_core.y,
+                    true,
+                    w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)].x,
+                    w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)].y};
+                // No Phase 2 signal targets
+                constexpr uint32_t MAX_PHASE2_SIGNAL_TARGETS = 8;
+                w_writer_rt_args.push_back(0);
+                for (uint32_t s = 0; s < MAX_PHASE2_SIGNAL_TARGETS * 2; s++) {
+                    w_writer_rt_args.push_back(0);
+                }
+                w_writer_rt_args.push_back(w_direction ? is_last_w_device : is_first_w_device);
+                w_writer_rt_args.push_back(w_direction ? is_first_w_device : is_last_w_device);
+                w_writer_rt_args.push_back(w_direction);
+                // W unicast route args
+                uint32_t w_device_offset = w_direction ? w_backward_device_offset : w_forward_device_offset;
+                w_writer_rt_args.push_back(0);                // dst_mesh_id (unused for 1D)
+                w_writer_rt_args.push_back(w_device_offset);  // distance_in_hops
+                // W barrier multicast route info
+                const auto& w_mcast_args = w_direction ? w_mcast_backward_args : w_mcast_forward_args;
+                w_writer_rt_args.insert(w_writer_rt_args.end(), w_mcast_args.begin(), w_mcast_args.end());
+                // Fabric connection args
+                if (w_direction) {
+                    w_writer_rt_args.push_back(false);
+                    w_writer_rt_args.push_back(w_backward_coord.has_value());
+                    if (w_backward_coord.has_value()) {
+                        const auto src_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
+                        const auto dst_fabric_node_id = mesh_device->get_fabric_node_id(w_backward_coord.value());
+                        tt::tt_fabric::append_fabric_connection_rt_args(
+                            src_fabric_node_id, dst_fabric_node_id, w_link, program, {w_core}, w_writer_rt_args);
+                    }
+                } else {
+                    w_writer_rt_args.push_back(w_forward_coord.has_value());
+                    if (w_forward_coord.has_value()) {
+                        const auto src_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
+                        const auto dst_fabric_node_id = mesh_device->get_fabric_node_id(w_forward_coord.value());
+                        tt::tt_fabric::append_fabric_connection_rt_args(
+                            src_fabric_node_id, dst_fabric_node_id, w_link, program, {w_core}, w_writer_rt_args);
+                    }
+                    w_writer_rt_args.push_back(false);
+                }
+                // fabric_only: override W writer rt_args to index into compact halo buffer W section
+                {
+                    const uint32_t h_total = input_halo_dim_size + 2 * op.np_padding_h;
+                    const uint32_t wleft_base = outer_dim_size * 2u * op.np_padding_h * num_sticks_per_halo_dim;
+                    const uint32_t wright_base = wleft_base + outer_dim_size * op.np_pad2_left * h_total;
+                    const uint32_t pw_this_dir = w_direction ? op.np_pad2_right : op.np_pad2_left;
+                    const uint32_t section_base = w_direction ? wright_base : wleft_base;
+                    w_writer_rt_args[0] = section_base + w_link_start * pw_this_dir;
+                    w_writer_rt_args[3] = pw_this_dir;
+                    w_writer_rt_args[6] = 0;
+                    w_writer_rt_args[7] = 1;
+                    w_writer_rt_args[8] = 1;
+                }
+                SetRuntimeArgs(program, w_writer_kernel_id, {w_core}, w_writer_rt_args);
+            }
+        }
+        }  // end else (standard 1-worker W path)
+    }
+
+    // ------------------------------------------------------------------------
+    // Padded-output fused mode: copy the INTERIOR (input -> padded output) on the free cores (columns
+    // x>=1; fabric uses column 0) CONCURRENTLY with the fabric exchange. The interior has no dependency
+    // on the exchange, so no barrier is needed — it just overlaps the fabric transport instead of being
+    // serialized after it (the old two-op flow). The caller fills the border afterward via
+    // halo_scatter(border_only), which reads the compact buffer this op wrote (op-level dependency).
+    // ------------------------------------------------------------------------
+    tt::tt_metal::KernelHandle scatter_kernel_id = 0;
+    CoreRangeSet scatter_core_range;
+    bool has_scatter = false;
+    if (op.output_padded && tensor_args.padded_output.has_value() && compute_grid_size.x > 1) {
+        Buffer* padded_buf = tensor_args.padded_output.value().buffer();
+        const uint32_t Hd_i = input_halo_dim_size;      // interior H (input is unpadded in repack mode)
+        const uint32_t Wd_i = num_sticks_per_halo_dim;  // interior W
+        const uint32_t Hp_i = Hd_i + 2 * op.np_padding_h;
+        const uint32_t Wp_i = Wd_i + 2 * op.np_padding_w;
+        const uint32_t n_int = outer_dim_size * Hd_i * Wd_i;
+        // Free cores = cols [1, grid.x) minus the NP sender workers (col 0 is fabric). The interior copy
+        // runs here, concurrent with the exchange (which uses col 0 + the worker cores).
+        const CoreRangeSet cols_ge1(CoreRange({1, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
+        const CoreRangeSet scatter_cores = cols_ge1.subtract(np_worker_core_ranges)
+                                               .subtract(occ_hw_workers)
+                                               .subtract(occ_hmux)
+                                               .subtract(occ_w_workers)
+                                               .subtract(occ_wmux);
+        const uint32_t num_scatter = scatter_cores.num_cores();
+        if (n_int > 0 && num_scatter > 0) {
+            const uint32_t per_core = (n_int + num_scatter - 1) / num_scatter;
+
+            constexpr uint32_t sc_cb_id = tt::CBIndex::c_0;
+            constexpr uint32_t sc_pages = 8;
+            tt::DataFormat sc_df = datatype_to_dataformat_converter(tensor_args.input_tensor.dtype());
+            CircularBufferConfig sc_cb_cfg =
+                CircularBufferConfig(sc_pages * page_size, {{sc_cb_id, sc_df}}).set_page_size(sc_cb_id, page_size);
+            CreateCircularBuffer(program, scatter_cores, sc_cb_cfg);
+
+            std::vector<uint32_t> sc_ct = {
+                page_size,
+                outer_dim_size,
+                Hp_i,
+                Wp_i,
+                Hd_i,
+                Wd_i,
+                op.np_padding_h,
+                op.np_padding_w,
+                sc_cb_id,
+                sc_pages,
+                /*border_only=*/0u};
+            TensorAccessorArgs(*input_buffer).append_to(sc_ct);
+            TensorAccessorArgs(*halo_buffer).append_to(sc_ct);
+            TensorAccessorArgs(*padded_buf).append_to(sc_ct);
+            auto sc_cfg = WriterDataMovementConfig{};
+            sc_cfg.compile_args = sc_ct;
+            scatter_kernel_id = CreateKernel(
+                program,
+                "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/kernels/"
+                "np_fused_scatter_writer.cpp",
+                scatter_cores,
+                sc_cfg);
+            scatter_core_range = scatter_cores;
+            has_scatter = true;
+
+            uint32_t assigned = 0;
+            for (const auto& cr : scatter_cores.ranges()) {
+                for (const auto& c : cr) {
+                    const uint32_t start = assigned;
+                    const uint32_t count = (start >= n_int) ? 0u : std::min(per_core, n_int - start);
+                    // Interior-only range [0,n_int): the kernel's exchange_done wait never triggers.
+                    SetRuntimeArgs(
+                        program,
+                        scatter_kernel_id,
+                        c,
+                        {input_buffer->address(),
+                         halo_buffer->address(),
+                         padded_buf->address(),
+                         start,
+                         count,
+                         /*exchange_done=*/0u,
+                         /*num_readers=*/0u});
+                    assigned += count;
+                }
+            }
+        }
+    }
+
+    return cached_program_t{
+        std::move(program),
+        NpHaloSharedVariables{
+            .np_artifacts = NpHaloArtifacts{
+                h_reader_kernel_id,
+                h_writer_kernel_id,
+                w_reader_kernel_id,
+                w_writer_kernel_id,
+                /*has_w_fabric=*/true,
+                w_fabric_core_range,
+                has_scatter,
+                scatter_kernel_id,
+                scatter_core_range}}};
+}
+
+// ============================================================================
+// override_runtime_arguments — refresh per-dispatch addresses for the NP kernels
+// ============================================================================
+void NpHaloMeshWorkloadFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const NpHaloParams& op,
+    const NpHaloInputs& tensor_args,
+    Tensor& tensor_return_value) {
+    const uint32_t input_addr = tensor_args.input_tensor.buffer()->address();
+    const uint32_t halo_buffer_addr = tensor_args.halo_buffer.buffer()->address();
+    (void)tensor_return_value;  // output IS the halo_buffer
+    const uint32_t h_sem_addr = op.h_neighbor_semaphore.address();
+    const uint32_t barrier_sem_addr = op.barrier_semaphore.address();
+    const uint32_t w_sem_addr = op.w_neighbor_semaphore.address();
+
+    for (auto& [coordinate_range, shared_vars] : cached_workload.shared_variables) {
+        auto& program = cached_workload.workload.get_programs().at(coordinate_range);
+
+        // --- NP H-fabric reader CRTA ---
+        // CRTA[0] = input_addr, CRTA[1] = halo_buffer_addr, CRTA[2] = h_sem_addr
+        auto& hr = GetCommonRuntimeArgs(program, shared_vars.np_artifacts.h_reader_kernel_id);
+        hr[0] = input_addr;
+        hr[1] = halo_buffer_addr;
+        hr[2] = h_sem_addr;
+        // Mux path (H_SIGNAL_W_RECV): np_h_reader signals the H->W barrier from CRTA[3]. It ping-pongs
+        // per dispatch, so refresh it or a cache hit signals the prior barrier while the W-reader waits
+        // on the current one -> deadlock. Direct path has only 3 CRTA (np_writer owns the barrier).
+        if (hr.size() > 3) {
+            hr[3] = barrier_sem_addr;
+        }
+
+        // --- NP H-fabric writer CRTA ---
+        // CRTA[0] = input_addr, CRTA[1] = halo_buffer_addr, CRTA[2] = h_sem_addr,
+        // CRTA[3] = barrier_sem_addr, CRTA[4] = num_reader_cores (static), CRTA[5+] = NOC coords (static)
+        auto& hw = GetCommonRuntimeArgs(program, shared_vars.np_artifacts.h_writer_kernel_id);
+        hw[0] = input_addr;
+        hw[1] = halo_buffer_addr;
+        hw[2] = h_sem_addr;
+        hw[3] = barrier_sem_addr;
+        // hw[4+] = num_reader_cores and NOC coords — static, set once in create_at()
+
+        // --- NP W-fabric kernels (only when 2D) ---
+        if (shared_vars.np_artifacts.has_w_fabric) {
+            auto& wr = GetCommonRuntimeArgs(program, shared_vars.np_artifacts.w_reader_kernel_id);
+            wr[0] = halo_buffer_addr;
+            wr[1] = barrier_sem_addr;
+            wr[2] = w_sem_addr;
+            // wr[3+] = num_reader_cores and NOC coords — static, set once in create_at()
+
+            // Per-core RTA[10] of the W-reader holds input_buffer->address() (set in
+            // create_at from the first dispatch's input). On subsequent dispatches the
+            // input tensor may be at a different DRAM address, so refresh RTA[10] here
+            // or the W-reader will pull halo sticks from a stale/garbage DRAM region
+            // and fabric-write garbage into the neighbor's halo buffer.
+            auto& w_reader_args_by_core = GetRuntimeArgs(program, shared_vars.np_artifacts.w_reader_kernel_id);
+            for (const auto& core_range : shared_vars.np_artifacts.fabric_core_range.ranges()) {
+                for (uint32_t x = core_range.start_coord.x; x <= core_range.end_coord.x; ++x) {
+                    for (uint32_t y = core_range.start_coord.y; y <= core_range.end_coord.y; ++y) {
+                        auto& w_reader_args = w_reader_args_by_core[x][y];
+                        if (w_reader_args.size() > 10) {
+                            w_reader_args[10] = input_addr;
+                        }
+                    }
+                }
+            }
+
+            auto& ww = GetCommonRuntimeArgs(program, shared_vars.np_artifacts.w_writer_kernel_id);
+            ww[0] = halo_buffer_addr;
+            ww[1] = halo_buffer_addr;
+            ww[2] = w_sem_addr;
+            ww[3] = h_sem_addr;
+        }
+
+        // --- Padded-output fused interior-copy scatter kernel: refresh per-core [input, compact, padded]. ---
+        if (shared_vars.np_artifacts.has_scatter && tensor_args.padded_output.has_value()) {
+            const uint32_t padded_addr = tensor_args.padded_output.value().buffer()->address();
+            auto& sc_args_by_core = GetRuntimeArgs(program, shared_vars.np_artifacts.scatter_kernel_id);
+            for (const auto& cr : shared_vars.np_artifacts.scatter_core_range.ranges()) {
+                for (uint32_t x = cr.start_coord.x; x <= cr.end_coord.x; ++x) {
+                    for (uint32_t y = cr.start_coord.y; y <= cr.end_coord.y; ++y) {
+                        auto& a = sc_args_by_core[x][y];
+                        if (a.size() >= 3) {
+                            a[0] = input_addr;
+                            a[1] = halo_buffer_addr;
+                            a[2] = padded_addr;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_program_factory.hpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "neighbor_pad_halo_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
+
+#include <tt-metalium/host_api.hpp>
+
+namespace ttnn::experimental::prim {
+
+// Kernel handles + core set for the NP fabric kernels the halo-only program factory builds.
+// Retained in the cached program so override_runtime_arguments can refresh per-dispatch args.
+struct NpHaloArtifacts {
+    tt::tt_metal::KernelHandle h_reader_kernel_id = 0;
+    tt::tt_metal::KernelHandle h_writer_kernel_id = 0;
+    tt::tt_metal::KernelHandle w_reader_kernel_id = 0;
+    tt::tt_metal::KernelHandle w_writer_kernel_id = 0;
+    bool has_w_fabric = false;
+    tt::tt_metal::CoreRangeSet fabric_core_range;  // all NP fabric cores (H + W)
+    // Padded-output fused mode: the concurrent interior-copy scatter kernel (0 if not padded mode).
+    bool has_scatter = false;
+    tt::tt_metal::KernelHandle scatter_kernel_id = 0;
+    tt::tt_metal::CoreRangeSet scatter_core_range;
+};
+
+struct NpHaloSharedVariables {
+    NpHaloArtifacts np_artifacts;
+};
+
+struct NpHaloMeshWorkloadFactory {
+    using shared_variables_t = NpHaloSharedVariables;
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+    static cached_mesh_workload_t create_mesh_workload(
+        const NpHaloParams& operation_attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const NpHaloInputs& tensor_args,
+        Tensor& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_workload,
+        const NpHaloParams& operation_attributes,
+        const NpHaloInputs& tensor_args,
+        Tensor& tensor_return_value);
+
+private:
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create_at(
+        const NpHaloParams& operation_attributes,
+        const ttnn::MeshCoordinate& mesh_coordinate,
+        const NpHaloInputs& tensor_args,
+        Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_program_factory.hpp
@@ -10,8 +10,7 @@
 
 namespace ttnn::experimental::prim {
 
-// Kernel handles + core set for the NP fabric kernels the halo-only program factory builds.
-// Retained in the cached program so override_runtime_arguments can refresh per-dispatch args.
+// Kernel handles + core set for the NP fabric kernels the halo-only program factory builds
 struct NpHaloArtifacts {
     tt::tt_metal::KernelHandle h_reader_kernel_id = 0;
     tt::tt_metal::KernelHandle h_writer_kernel_id = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/halo_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/halo_scatter.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "halo_scatter.hpp"
+#include "device/halo_scatter_device_operation.hpp"
+
+#include <tt_stl/assert.hpp>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::experimental {
+
+ttnn::Tensor halo_scatter(
+    const ttnn::Tensor& compact_buffer,
+    const ttnn::Tensor& interior_src,
+    uint32_t np_padding_h,
+    uint32_t np_padding_w,
+    const std::optional<MemoryConfig>& memory_config,
+    bool border_only) {
+    TT_FATAL(np_padding_h > 0, "halo_scatter: np_padding_h must be > 0");
+
+    MemoryConfig output_mem_config = memory_config.value_or(interior_src.memory_config());
+
+    ttnn::experimental::prim::NpHaloScatterParams params{
+        .np_padding_h = np_padding_h,
+        .np_padding_w = np_padding_w,
+        .output_mem_config = output_mem_config,
+        .border_only = border_only,
+    };
+
+    return ttnn::prim::halo_scatter(compact_buffer, interior_src, params);
+}
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/halo_scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/halo_scatter.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::experimental {
+
+// Local (no-fabric) repack for the persistent-padded activation pipeline. Allocates a padded buffer
+// [B,T,H+2pH,W+2pW,C] and fills it in one pass: INTERIOR from `interior_src` (the unpadded
+// activation) and BORDER from the compact halo buffer [H-top | H-bot | W-left | W-right] produced by
+// neighbor_pad_halo. Folds the old ttnn.pad (interior copy) + border scatter into one op; the next
+// conv reads the result as a plain coalesced conv (pad=0).
+//
+// Args:
+//   compact_buffer : the compact halo buffer returned by neighbor_pad_halo (border source)
+//   interior_src   : the unpadded activation [B,T,H,W,C] (interior source)
+//   np_padding_h/w : halo rows/cols per side (must match the neighbor_pad_halo call)
+//
+// Returns: a newly-allocated padded buffer with interior + border filled.
+ttnn::Tensor halo_scatter(
+    const ttnn::Tensor& compact_buffer,
+    const ttnn::Tensor& interior_src,
+    uint32_t np_padding_h,
+    uint32_t np_padding_w,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    bool border_only = false);
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/halo_scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/halo_scatter.hpp
@@ -10,18 +10,7 @@
 
 namespace ttnn::experimental {
 
-// Local (no-fabric) repack for the persistent-padded activation pipeline. Allocates a padded buffer
-// [B,T,H+2pH,W+2pW,C] and fills it in one pass: INTERIOR from `interior_src` (the unpadded
-// activation) and BORDER from the compact halo buffer [H-top | H-bot | W-left | W-right] produced by
-// neighbor_pad_halo. Folds the old ttnn.pad (interior copy) + border scatter into one op; the next
-// conv reads the result as a plain coalesced conv (pad=0).
-//
-// Args:
-//   compact_buffer : the compact halo buffer returned by neighbor_pad_halo (border source)
-//   interior_src   : the unpadded activation [B,T,H,W,C] (interior source)
-//   np_padding_h/w : halo rows/cols per side (must match the neighbor_pad_halo call)
-//
-// Returns: a newly-allocated padded buffer with interior + border filled.
+// Local (no-fabric) repack for the persistent-padded activation pipeline
 ttnn::Tensor halo_scatter(
     const ttnn::Tensor& compact_buffer,
     const ttnn::Tensor& interior_src,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/neighbor_pad_halo.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/neighbor_pad_halo.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "neighbor_pad_halo.hpp"
+#include "device/neighbor_pad_halo_device_operation.hpp"
+
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include <tt-metalium/math.hpp>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::experimental {
+
+ttnn::Tensor neighbor_pad_halo(
+    const ttnn::Tensor& input,
+    const ttnn::Tensor& halo_buffer,
+    uint32_t np_padding_h,
+    uint32_t np_padding_w,
+    uint32_t np_cluster_axis,
+    size_t np_num_links,
+    ttnn::ccl::Topology np_topology,
+    const GlobalSemaphore& h_neighbor_semaphore,
+    const GlobalSemaphore& barrier_semaphore,
+    const GlobalSemaphore& w_neighbor_semaphore,
+    uint32_t np_pad_dim2,
+    uint32_t np_pad2_left,
+    uint32_t np_pad2_right,
+    uint32_t np_pad2_cluster_axis,
+    size_t np_pad2_num_links,
+    const std::string& padding_mode,
+    const std::optional<MemoryConfig>& memory_config,
+    uint32_t input_pad_h,
+    uint32_t input_pad_w,
+    const std::optional<ttnn::Tensor>& padded_output,
+    bool border_only) {
+    TT_FATAL(np_padding_h > 0, "neighbor_pad_halo: np_padding_h must be > 0");
+    TT_FATAL(np_pad_dim2 > 0, "neighbor_pad_halo: 2D padding required (np_pad_dim2 must be > 0)");
+
+    // Derive ring size from mesh view along the cluster axis
+    auto* mesh_device = input.device();
+    const auto& mesh_view = mesh_device->get_view();
+    uint32_t np_ring_size = (np_cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
+    TT_FATAL(
+        np_ring_size > 1,
+        "neighbor_pad_halo: requires num_devices > 1 along cluster axis {}, got {}",
+        np_cluster_axis,
+        np_ring_size);
+
+    tt::tt_fabric::Topology resolved_topology =
+        ::ttnn::ccl::get_usable_topology(input, std::make_optional(np_topology), np_cluster_axis);
+
+    MemoryConfig output_mem_config = memory_config.value_or(halo_buffer.memory_config());
+
+    ttnn::experimental::prim::NpHaloParams params(
+        np_padding_h,
+        np_padding_w,
+        np_cluster_axis,
+        np_ring_size,
+        resolved_topology,
+        h_neighbor_semaphore,
+        barrier_semaphore,
+        w_neighbor_semaphore,
+        std::make_optional(np_pad_dim2),
+        np_pad2_left,
+        np_pad2_right,
+        std::make_optional(np_pad2_cluster_axis),
+        np_num_links,
+        np_pad2_num_links,
+        output_mem_config,
+        padding_mode);
+    params.input_pad_h = input_pad_h;
+    params.input_pad_w = input_pad_w;
+    params.output_padded = padded_output.has_value();
+    params.border_only = border_only;
+
+    return ttnn::prim::neighbor_pad_halo(input, halo_buffer, params, padded_output);
+}
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/neighbor_pad_halo.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/neighbor_pad_halo.hpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/global_semaphore.hpp"
+#include "ttnn/operations/experimental/ccl/neighbor_pad_halo/device/neighbor_pad_halo_device_operation_types.hpp"
+#include <tt-metalium/sub_device_types.hpp>
+
+namespace ttnn::experimental {
+
+// Standalone halo-only neighbor-pad (no conv, no interior copy).
+//
+// Launches the fabric NP writer/reader kernels on boundary cores to exchange halo rows into
+// `halo_buffer` (compact DRAM, pre-allocated by the caller), and returns that buffer. This is the
+// fabric H+W halo exchange from neighbor_pad_conv3d with the conv3d stage stripped — pure transport,
+// benchmarked toward DRAM read + fabric bandwidth.
+//
+// Args:
+//   input        : unpadded input tensor [B, T, H, W, C] row-major bfloat16/float32
+//   halo_buffer  : pre-allocated compact DRAM halo buffer [H-top | H-bot | W-left | W-right]
+//   np_padding_h : halo rows per side in the H dimension (typically 1 for k=3)
+//   np_padding_w : halo columns per side in the W dimension
+//   np_cluster_axis : mesh axis for H-parallel devices
+//   np_num_links    : number of fabric links for the H exchange
+//   np_topology     : fabric topology (Linear or Ring)
+//   h_neighbor_semaphore / barrier_semaphore / w_neighbor_semaphore : NP handshake semaphores
+//   np_pad_dim2          : secondary (W-axis) padding dim index (must be > 0 — 2D required)
+//   np_pad2_left/right   : padding amounts for the secondary dim
+//   np_pad2_cluster_axis : cluster axis for the secondary dim
+//   np_pad2_num_links    : links for the secondary dim
+//   padding_mode         : "zeros" or "replicate"
+//   memory_config        : optional output memory config (defaults to the halo_buffer's)
+//
+// Returns: the compact halo buffer (written in place).
+ttnn::Tensor neighbor_pad_halo(
+    const ttnn::Tensor& input,
+    const ttnn::Tensor& halo_buffer,
+    uint32_t np_padding_h,
+    uint32_t np_padding_w,
+    uint32_t np_cluster_axis,
+    size_t np_num_links,
+    ttnn::ccl::Topology np_topology,
+    const GlobalSemaphore& h_neighbor_semaphore,
+    const GlobalSemaphore& barrier_semaphore,
+    const GlobalSemaphore& w_neighbor_semaphore,
+    uint32_t np_pad_dim2,
+    uint32_t np_pad2_left,
+    uint32_t np_pad2_right,
+    uint32_t np_pad2_cluster_axis,
+    size_t np_pad2_num_links,
+    const std::string& padding_mode = "zeros",
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    uint32_t input_pad_h = 0,
+    uint32_t input_pad_w = 0,
+    const std::optional<ttnn::Tensor>& padded_output = std::nullopt,
+    bool border_only = false);
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/neighbor_pad_halo.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/neighbor_pad_halo.hpp
@@ -15,30 +15,7 @@
 
 namespace ttnn::experimental {
 
-// Standalone halo-only neighbor-pad (no conv, no interior copy).
-//
-// Launches the fabric NP writer/reader kernels on boundary cores to exchange halo rows into
-// `halo_buffer` (compact DRAM, pre-allocated by the caller), and returns that buffer. This is the
-// fabric H+W halo exchange from neighbor_pad_conv3d with the conv3d stage stripped — pure transport,
-// benchmarked toward DRAM read + fabric bandwidth.
-//
-// Args:
-//   input        : unpadded input tensor [B, T, H, W, C] row-major bfloat16/float32
-//   halo_buffer  : pre-allocated compact DRAM halo buffer [H-top | H-bot | W-left | W-right]
-//   np_padding_h : halo rows per side in the H dimension (typically 1 for k=3)
-//   np_padding_w : halo columns per side in the W dimension
-//   np_cluster_axis : mesh axis for H-parallel devices
-//   np_num_links    : number of fabric links for the H exchange
-//   np_topology     : fabric topology (Linear or Ring)
-//   h_neighbor_semaphore / barrier_semaphore / w_neighbor_semaphore : NP handshake semaphores
-//   np_pad_dim2          : secondary (W-axis) padding dim index (must be > 0 — 2D required)
-//   np_pad2_left/right   : padding amounts for the secondary dim
-//   np_pad2_cluster_axis : cluster axis for the secondary dim
-//   np_pad2_num_links    : links for the secondary dim
-//   padding_mode         : "zeros" or "replicate"
-//   memory_config        : optional output memory config (defaults to the halo_buffer's)
-//
-// Returns: the compact halo buffer (written in place).
+// Standalone halo-only neighbor-pad (no conv, no interior copy)
 ttnn::Tensor neighbor_pad_halo(
     const ttnn::Tensor& input,
     const ttnn::Tensor& halo_buffer,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/neighbor_pad_halo_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/neighbor_pad_halo_nanobind.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "neighbor_pad_halo_nanobind.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "ttnn/operations/experimental/ccl/neighbor_pad_halo/neighbor_pad_halo.hpp"
+#include "ttnn/operations/experimental/ccl/neighbor_pad_halo/halo_scatter.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/global_semaphore.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+void bind_neighbor_pad_halo(nb::module_& mod) {
+    ttnn::bind_function<"neighbor_pad_halo", "ttnn.experimental.">(
+        mod,
+        R"doc(
+        Standalone halo-only neighbor-pad (no conv, no interior copy).
+
+        Exchanges halo rows between neighboring devices via fabric into a compact
+        pre-allocated DRAM halo buffer [H-top | H-bot | W-left | W-right], and returns
+        that buffer. This is the fabric H+W halo exchange with the
+        conv3d stage removed — pure transport, benchmarked toward DRAM + fabric bandwidth.
+        The caller must pre-allocate `halo_buffer` with the correct size (see NP design docs).
+
+        Args:
+            input (ttnn.Tensor): Unpadded activation tensor [B, T, H, W, C] row-major.
+            halo_buffer (ttnn.Tensor): Pre-allocated compact DRAM halo buffer (also the output).
+            np_padding_h (int): H-halo rows per side (typically 1 for k=3).
+            np_padding_w (int): W-halo columns per side.
+            np_cluster_axis (int): Mesh axis for H-parallel devices.
+            np_num_links (int): Number of fabric links for the H exchange.
+            np_topology (ttnn.Topology): Fabric topology (Linear or Ring).
+            h_neighbor_semaphore (ttnn.GlobalSemaphore): H-neighbor handshake semaphore.
+            barrier_semaphore (ttnn.GlobalSemaphore): NP barrier semaphore.
+            w_neighbor_semaphore (ttnn.GlobalSemaphore): W-neighbor handshake semaphore.
+            np_pad_dim2 (int): Secondary (W-axis) padding dimension index (must be > 0).
+            np_pad2_left (int): Padding amount left for the secondary dim.
+            np_pad2_right (int): Padding amount right for the secondary dim.
+            np_pad2_cluster_axis (int): Cluster axis for the secondary dim.
+            np_pad2_num_links (int): Links for the secondary dim.
+
+        Keyword Args:
+            padding_mode (str): "zeros" or "replicate". Defaults to "zeros".
+            memory_config (ttnn.MemoryConfig, optional): Output memory config.
+
+        Returns:
+            ttnn.Tensor: The compact halo buffer (written in place).
+        )doc",
+        &ttnn::experimental::neighbor_pad_halo,
+        nb::arg("input"),
+        nb::arg("halo_buffer"),
+        nb::arg("np_padding_h"),
+        nb::arg("np_padding_w"),
+        nb::arg("np_cluster_axis"),
+        nb::arg("np_num_links"),
+        nb::arg("np_topology"),
+        nb::arg("h_neighbor_semaphore"),
+        nb::arg("barrier_semaphore"),
+        nb::arg("w_neighbor_semaphore"),
+        nb::arg("np_pad_dim2"),
+        nb::arg("np_pad2_left"),
+        nb::arg("np_pad2_right"),
+        nb::arg("np_pad2_cluster_axis"),
+        nb::arg("np_pad2_num_links"),
+        nb::kw_only(),
+        nb::arg("padding_mode") = "zeros",
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("input_pad_h") = 0,
+        nb::arg("input_pad_w") = 0,
+        nb::arg("padded_output") = nb::none(),
+        nb::arg("border_only") = false);
+}
+
+void bind_halo_scatter(nb::module_& mod) {
+    ttnn::bind_function<"halo_scatter", "ttnn.experimental.">(
+        mod,
+        R"doc(
+        Local (no-fabric) repack for the persistent-padded activation pipeline.
+
+        Allocates a padded buffer [B,T,H+2pH,W+2pW,C] and fills it in one pass: interior from
+        interior_src (the unpadded activation) and border from the compact halo buffer
+        [H-top | H-bot | W-left | W-right] produced by neighbor_pad_halo. Folds the old ttnn.pad
+        (interior copy) + border scatter into one op; the next conv reads the result as a plain
+        coalesced conv (pad=0).
+
+        Args:
+            compact_buffer (ttnn.Tensor): Compact halo buffer returned by neighbor_pad_halo (border source).
+            interior_src (ttnn.Tensor): Unpadded activation [B,T,H,W,C] (interior source).
+            np_padding_h (int): H-halo rows per side (must match the neighbor_pad_halo call).
+            np_padding_w (int): W-halo columns per side.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): Output memory config.
+
+        Returns:
+            ttnn.Tensor: A newly-allocated padded buffer with interior + border filled.
+        )doc",
+        &ttnn::experimental::halo_scatter,
+        nb::arg("compact_buffer"),
+        nb::arg("interior_src"),
+        nb::arg("np_padding_h"),
+        nb::arg("np_padding_w"),
+        nb::kw_only(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("border_only") = false);
+}
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/neighbor_pad_halo_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_halo/neighbor_pad_halo_nanobind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+namespace nb = nanobind;
+void bind_neighbor_pad_halo(nb::module_& mod);
+void bind_halo_scatter(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -185,6 +185,17 @@ void kernel_main() {
         }
     }
 
+    // Mirror the writer's split-forwarding (see ring_attention_all_gather_writer.cpp): on an even ring
+    // the diametric slice is relayed in halves across both links. Direction 1 receives one extra slice
+    // (its own diametric shard's second half, signaled but never relayed) and relays one extra (the
+    // second half of its downstream neighbor's diametric shard). Gated on ring geometry only so the
+    // writer and the SDPA op receiver make the identical decision.
+    const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    if (split_forwarding_enabled && direction == 1) {
+        slices_expected++;
+        writes_expected++;
+    }
+
     while (slices_received < slices_expected) {
         // Do i expect more from the backward direction?
         // In the linear case, I expect num_targets_backward_direction slices from the left
@@ -224,16 +235,34 @@ void kernel_main() {
         // In the ring case, if I have received on the right less than my targets on the left, forward
         if ((topology == Topology::Linear && writes_expected > 0) ||
             (topology == Topology::Ring && (slices_received < (writes_expected + 1)))) {
+            // The last slice we relay is the diametric shard of our downstream neighbor; relay only
+            // this link's half so the paired writer pops a matching cb_output count.
+            const bool is_split_forwarded_slice = split_forwarding_enabled && (slices_received == writes_expected);
             for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-                uint32_t tiles_read = input_tile_id_start[input_idx];
-                uint32_t tiles_to_read = input_tile_id_end[input_idx];
-
-                uint32_t output_tile_id_start = 0;
-                uint32_t pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
-                uint32_t row_offset =
-                    (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
                 uint32_t slice_Wt = input_tensor_Wt[input_idx];
                 uint32_t stride_Wt = output_tensor_Wt[input_idx];
+
+                // Packet-aligned midpoint of this input's per-batch-head page range (matches the
+                // writer). Direction 0 relays [start, mid); direction 1 relays [mid, end).
+                const uint32_t total_pages = input_tile_id_end[input_idx] - input_tile_id_start[input_idx];
+                const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
+                const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;
+                const bool split_this_input = is_split_forwarded_slice;
+                uint32_t relay_start = input_tile_id_start[input_idx];
+                uint32_t relay_end = input_tile_id_end[input_idx];
+                if (split_this_input) {
+                    if (direction == 0) {
+                        relay_end = input_tile_id_start[input_idx] + first_half_pages;
+                    } else {
+                        relay_start = input_tile_id_start[input_idx] + first_half_pages;
+                    }
+                }
+
+                uint32_t tiles_read = relay_start;
+                uint32_t tiles_to_read = relay_end;
+                uint32_t output_tile_id_start = 0;
+                uint32_t pages_read_in_row = relay_start % slice_Wt;
+                uint32_t row_offset = (relay_start / slice_Wt) * stride_Wt;
                 if (gather_dim == 3) {
                     output_tile_id_start = actual_sender_chip_id * input_tensor_Wt[input_idx];
                 } else {
@@ -262,11 +291,10 @@ void kernel_main() {
                             }
                             return pid;
                         });
-                    pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
-                    row_offset =
-                        (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
-                    tiles_read = input_tile_id_start[input_idx];
-                    tiles_to_read = input_tile_id_end[input_idx];
+                    pages_read_in_row = relay_start % slice_Wt;
+                    row_offset = (relay_start / slice_Wt) * stride_Wt;
+                    tiles_read = relay_start;
+                    tiles_to_read = relay_end;
                     output_tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -185,11 +185,7 @@ void kernel_main() {
         }
     }
 
-    // Mirror the writer's split-forwarding (see ring_attention_all_gather_writer.cpp): on an even ring
-    // the diametric slice is relayed in halves across both links. Direction 1 receives one extra slice
-    // (its own diametric shard's second half, signaled but never relayed) and relays one extra (the
-    // second half of its downstream neighbor's diametric shard). Gated on ring geometry only so the
-    // writer and the SDPA op receiver make the identical decision.
+    // Mirror the writer's split-forwarding (see ring_attention_all_gather_writer.cpp): on an even ring the diametric
     const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
     if (split_forwarding_enabled && direction == 1) {
         slices_expected++;
@@ -235,15 +231,13 @@ void kernel_main() {
         // In the ring case, if I have received on the right less than my targets on the left, forward
         if ((topology == Topology::Linear && writes_expected > 0) ||
             (topology == Topology::Ring && (slices_received < (writes_expected + 1)))) {
-            // The last slice we relay is the diametric shard of our downstream neighbor; relay only
-            // this link's half so the paired writer pops a matching cb_output count.
+            // The last slice we relay is the diametric shard of our downstream neighbor
             const bool is_split_forwarded_slice = split_forwarding_enabled && (slices_received == writes_expected);
             for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
                 uint32_t slice_Wt = input_tensor_Wt[input_idx];
                 uint32_t stride_Wt = output_tensor_Wt[input_idx];
 
-                // Packet-aligned midpoint of this input's per-batch-head page range (matches the
-                // writer). Direction 0 relays [start, mid); direction 1 relays [mid, end).
+                // Packet-aligned midpoint of this input's per-batch-head page range (matches the writer)
                 const uint32_t total_pages = input_tile_id_end[input_idx] - input_tile_id_start[input_idx];
                 const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
                 const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -294,12 +294,7 @@ void kernel_main() {
         }
     }
 
-    // On an even ring the terminal relayed slice (its receiver's diametric shard, N/2 hops away on
-    // both links) would otherwise traverse its final hop on one link while the other idles. Relay its
-    // first half on direction 0 and its second half on direction 1 so both links share that hop;
-    // direction 1 gains one relay to carry the second half. Gated on ring geometry only so the paired
-    // reader and the SDPA op receiver make the identical decision without shape info; a single-packet
-    // range degenerates to first_half_pages == 0 (direction 0 relays nothing).
+    // On an even ring the terminal relayed slice
     const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
     if (split_forwarding_enabled && direction == 1) {
         writes_expected++;
@@ -343,9 +338,7 @@ void kernel_main() {
                 tile_id_start = actual_slice_chip_id * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
             }
 
-            // Packet-aligned midpoint of this input's per-batch-head page range. On the split slice
-            // direction 0 relays [start, mid) and direction 1 relays [mid, end); the skipped half's
-            // cursor still advances so cb_output pops match the pages the paired reader pushed.
+            // Packet-aligned midpoint of this input's per-batch-head page range
             const uint32_t total_pages = tiles_to_read - input_tile_id_start[input_idx];
             const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
             const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -294,6 +294,17 @@ void kernel_main() {
         }
     }
 
+    // On an even ring the terminal relayed slice (its receiver's diametric shard, N/2 hops away on
+    // both links) would otherwise traverse its final hop on one link while the other idles. Relay its
+    // first half on direction 0 and its second half on direction 1 so both links share that hop;
+    // direction 1 gains one relay to carry the second half. Gated on ring geometry only so the paired
+    // reader and the SDPA op receiver make the identical decision without shape info; a single-packet
+    // range degenerates to first_half_pages == 0 (direction 0 relays nothing).
+    const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    if (split_forwarding_enabled && direction == 1) {
+        writes_expected++;
+    }
+
     while (slice_writes < writes_expected) {
         // Direction == backward
         // Did I get something from my left to send to my right?
@@ -315,6 +326,7 @@ void kernel_main() {
             slice_chip_id = my_chip_id - slice_writes - 1;
             actual_slice_chip_id = (slice_chip_id < 0) ? ring_size + slice_chip_id : slice_chip_id;
         }
+        const bool is_split_forwarded_slice = split_forwarding_enabled && (slice_writes == writes_expected - 1);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             uint32_t tiles_read = input_tile_id_start[input_idx];
             uint32_t tiles_to_read = input_tile_id_end[input_idx];
@@ -330,47 +342,65 @@ void kernel_main() {
             } else {
                 tile_id_start = actual_slice_chip_id * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
             }
+
+            // Packet-aligned midpoint of this input's per-batch-head page range. On the split slice
+            // direction 0 relays [start, mid) and direction 1 relays [mid, end); the skipped half's
+            // cursor still advances so cb_output pops match the pages the paired reader pushed.
+            const uint32_t total_pages = tiles_to_read - input_tile_id_start[input_idx];
+            const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
+            const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;
+            const bool split_this_input = is_split_forwarded_slice;
+
             for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
                 while (tiles_read < tiles_to_read) {
                     uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
-                    cb_output.wait_front(packet_size_in_pages);
-                    size_t l1_read_addr = cb_output.get_read_ptr();
+                    uint32_t page_in_bh = tiles_read - input_tile_id_start[input_idx];
+                    bool relay_this_packet =
+                        !split_this_input ||
+                        (direction == 0 ? (page_in_bh < first_half_pages) : (page_in_bh >= first_half_pages));
+
                     uint32_t first_tile_id = tile_id_start + row_offset + pages_read_in_row;
                     pages_read_in_row++;
                     if (pages_read_in_row >= slice_Wt) {
                         row_offset += stride_Wt;
                         pages_read_in_row = 0;
                     }
-
+                    uint32_t second_tile_id = 0;
                     if (num_pages_to_read == 2) {
-                        uint32_t second_tile_id = tile_id_start + row_offset + pages_read_in_row;
+                        second_tile_id = tile_id_start + row_offset + pages_read_in_row;
                         pages_read_in_row++;
                         if (pages_read_in_row >= slice_Wt) {
                             row_offset += stride_Wt;
                             pages_read_in_row = 0;
                         }
+                    }
 
-                        scatter_fabric_write_unidir(
-                            first_tile_id,
-                            second_tile_id,
-                            output_addrgens[input_idx],
-                            pkt_hdr,
-                            *fabric_direction_connection,
-                            l1_read_addr,
-                            output_page_size);
-                    } else {
-                        ASSERT(num_pages_to_read == 1);
-                        fabric_write_unidir(
-                            first_tile_id,
-                            output_addrgens[input_idx],
-                            pkt_hdr,
-                            *fabric_direction_connection,
-                            l1_read_addr,
-                            output_page_size);
+                    if (relay_this_packet) {
+                        cb_output.wait_front(packet_size_in_pages);
+                        size_t l1_read_addr = cb_output.get_read_ptr();
+                        if (num_pages_to_read == 2) {
+                            scatter_fabric_write_unidir(
+                                first_tile_id,
+                                second_tile_id,
+                                output_addrgens[input_idx],
+                                pkt_hdr,
+                                *fabric_direction_connection,
+                                l1_read_addr,
+                                output_page_size);
+                        } else {
+                            ASSERT(num_pages_to_read == 1);
+                            fabric_write_unidir(
+                                first_tile_id,
+                                output_addrgens[input_idx],
+                                pkt_hdr,
+                                *fabric_direction_connection,
+                                l1_read_addr,
+                                output_page_size);
+                        }
+                        cb_output.pop_front(packet_size_in_pages);
                     }
 
                     tiles_read += num_pages_to_read;
-                    cb_output.pop_front(packet_size_in_pages);
                 }
                 tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
                 tiles_read = input_tile_id_start[input_idx];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/sources.cmake
@@ -145,6 +145,7 @@ set(TTNN_OP_EXPERIMENTAL_CCL_NANOBIND_SRCS
     send_recv_async/recv_async_h2d/recv_async_h2d_nanobind.cpp
     send_recv_async/send_async_d2h/send_async_d2h_nanobind.cpp
     neighbor_pad_async/neighbor_pad_async_nanobind.cpp
+    neighbor_pad_halo/neighbor_pad_halo_nanobind.cpp
     slice_reshard_async/slice_reshard_async_nanobind.cpp
     deepseek_moe_reduce_scatter/deepseek_moe_reduce_scatter_nanobind.cpp
     all_to_all_dispatch_metadata/all_to_all_dispatch_metadata_nanobind.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp
@@ -60,8 +60,18 @@ struct MinimalMatmulOpReceiver {
     uint32_t num_k_blocks = 0;
     uint32_t local_k_start = 0;
     uint32_t local_k_end = 0;
-    std::array<volatile tt_l1_ptr uint32_t*, 3> signal_op_semaphore_addr_ptrs = {};  // backward, forward, self
-    std::array<uint32_t, 3> sem_targets = {};
+    // Per-worker signaling: each of the N all-gather workers in a remote direction increments its own
+    // semaphore, so a k-block is ready only once all N have signaled. self is a single semaphore
+    // (aggregated by the writer-side worker barrier). N==1 reproduces the legacy [backward,forward,self].
+    uint32_t num_ag_workers = 1;
+    uint32_t* backward_sem_addrs = nullptr;  // [num_ag_workers] L1 semaphore addresses
+    uint32_t* forward_sem_addrs = nullptr;   // [num_ag_workers] L1 semaphore addresses
+    volatile tt_l1_ptr uint32_t* self_sem_ptr = nullptr;
+    std::array<uint32_t, 3> sem_targets = {};  // indexed by direction: [backward, forward, self]
+    // Direction the most recent compute_actual_k_block_iter awaited, so a caller doing per-band reads
+    // can wait_for_dir() the same direction for bands 1..N. dir 2 (self/local) is not aggregator-
+    // signaled, so the caller must read it whole rather than band-by-band.
+    uint8_t streamed_dir = 2;
     ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring;
     bool read_local_slice_from_input;
 
@@ -78,6 +88,19 @@ struct MinimalMatmulOpReceiver {
     uint8_t next_forward = 0;
     int8_t next_backward = 0;
 
+    // Interleaved-middle schedule state. Two independent direction cursors let the middle
+    // forward/backward region be consumed one-backward-one-forward instead of drained as
+    // whole-device groups. Each cursor keeps its own within-direction order (so the monotonic
+    // per-direction semaphores stay valid); only the interleaving between directions changes.
+    uint8_t il_phase = 0;     // 0 = self, 1 = fwd/bwd (middle + folded diametric halves)
+    uint8_t il_bwd_dist = 1;  // backward cursor device = my - il_bwd_dist
+    uint32_t il_bwd_chunk = 0;
+    uint8_t il_fwd_dist = 1;  // forward cursor device = my + il_fwd_dist
+    uint32_t il_fwd_chunk = 0;
+    bool il_emit_backward = false;  // next slot prefers forward, so each pair is forward-then-backward
+    bool has_straddle = false;      // any k-block owned by two devices (expected==2)
+    bool use_interleaved = false;
+
     MinimalMatmulOpReceiver() {}
 
     MinimalMatmulOpReceiver(
@@ -87,8 +110,12 @@ struct MinimalMatmulOpReceiver {
         uint8_t* k_block_device_received,
         uint32_t* device_k_block_counts,
         uint32_t* device_k_block_start_ids,
-        uint32_t* forward_k_block_schedule) :
+        uint32_t* forward_k_block_schedule,
+        uint32_t* backward_sem_addrs,
+        uint32_t* forward_sem_addrs) :
         wait_for_op_signal(wait_for_op_signal),
+        backward_sem_addrs(backward_sem_addrs),
+        forward_sem_addrs(forward_sem_addrs),
         k_block_device_expected(k_block_device_expected),
         k_block_device_received(k_block_device_received),
         device_k_block_counts(device_k_block_counts),
@@ -108,13 +135,17 @@ struct MinimalMatmulOpReceiver {
         read_local_slice_from_input = (bool)get_arg_val<uint32_t>(rt_args_idx++);
         local_k_start = get_arg_val<uint32_t>(rt_args_idx++);
         local_k_end = get_arg_val<uint32_t>(rt_args_idx++);
+        num_ag_workers = get_arg_val<uint32_t>(rt_args_idx++);
 
         if (this->wait_for_op_signal) {
-            this->signal_op_semaphore_addr_ptrs[0] =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(rt_args_idx++)));
-            this->signal_op_semaphore_addr_ptrs[1] =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(rt_args_idx++)));
-            this->signal_op_semaphore_addr_ptrs[2] =
+            // Semaphore ids arrive as [backward_0..N-1, forward_0..N-1, self].
+            for (uint32_t w = 0; w < num_ag_workers; w++) {
+                this->backward_sem_addrs[w] = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
+            }
+            for (uint32_t w = 0; w < num_ag_workers; w++) {
+                this->forward_sem_addrs[w] = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
+            }
+            this->self_sem_ptr =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(rt_args_idx++)));
         }
 
@@ -127,6 +158,20 @@ struct MinimalMatmulOpReceiver {
             k_block_device_expected,
             device_k_block_counts,
             device_k_block_start_ids);
+
+        // A straddling k-block (expected==2) is co-completed by two devices sitting on
+        // different direction passes; interleaving would reorder those pair-completions, so
+        // the interleaved path is only enabled when no k-block straddles a device boundary.
+        for (uint32_t k = 0; k < num_k_blocks; k++) {
+            if (k_block_device_expected[k] == 2) {
+                has_straddle = true;
+                break;
+            }
+        }
+#if defined(AG_ALTERNATE_MIDDLE) && AG_ALTERNATE_MIDDLE
+        use_interleaved =
+            (topology == ttnn::ccl::Topology::Ring) && (num_devices % 2 == 0) && (num_devices > 2) && !has_straddle;
+#endif
     }
 
     void reset() {
@@ -136,6 +181,13 @@ struct MinimalMatmulOpReceiver {
         devices_received = 0;
         next_forward = 0;
         next_backward = 0;
+
+        il_phase = 0;
+        il_bwd_dist = 1;
+        il_bwd_chunk = 0;
+        il_fwd_dist = 1;
+        il_fwd_chunk = 0;
+        il_emit_backward = false;
 
         for (uint32_t k = 0; k < num_k_blocks; k++) {
             k_block_device_received[k] = 0;
@@ -209,23 +261,136 @@ struct MinimalMatmulOpReceiver {
         }
     }
 
+    // Block on the current direction's signal(s) exactly as the grouped path does: self is a
+    // single aggregated semaphore; a remote direction is ready only once all N workers signal.
+    void wait_for_dir(uint8_t dir) {
+        if (wait_for_op_signal && !(read_local_slice_from_input && (dir == 2))) {
+            uint32_t sem_target = sem_targets[dir];
+            if (dir == 2) {
+                noc_semaphore_wait_min(self_sem_ptr, sem_target + 1);
+            } else {
+                uint32_t* addrs = (dir == 0) ? backward_sem_addrs : forward_sem_addrs;
+                for (uint32_t w = 0; w < num_ag_workers; w++) {
+                    noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addrs[w]), sem_target + 1);
+                }
+            }
+            sem_targets[dir]++;
+        }
+    }
+
+    // Emit the next (direction, device, chunk) of the interleaved schedule: all self chunks,
+    // then the two remote directions alternating at chunk granularity, each kept in distance
+    // order 1..half. The diametric device (distance half) is not a separate step: its backward
+    // and forward halves ride the respective cursors, so it interleaves like any other block.
+    void next_interleaved_slot(uint8_t& out_dir, uint8_t& out_dev, uint32_t& out_chunk) {
+        const uint32_t half = num_devices / 2;
+        while (true) {
+            if (il_phase == 0) {  // self
+                if (device_chunk_id < device_k_block_counts[my_chip_id]) {
+                    out_dir = 2;
+                    out_dev = my_chip_id;
+                    out_chunk = device_chunk_id++;
+                    return;
+                }
+                il_phase = 1;
+                continue;
+            }
+            // fwd/bwd region, distances 1..half. The diametric device sits at distance half and
+            // is split-forwarded: the backward link carries its first half, the forward link its
+            // second half, so each cursor folds its diametric half in as a normal last step.
+            bool bwd_avail = il_bwd_dist <= half;
+            bool fwd_avail = il_fwd_dist <= half;
+            if (!bwd_avail && !fwd_avail) {
+                return;  // all k-blocks emitted; caller only steps num_k_blocks times
+            }
+            // Prefer the toggled side; if it is drained, take the other.
+            bool pick_backward = il_emit_backward ? bwd_avail : !fwd_avail;
+            il_emit_backward = !il_emit_backward;
+            if (pick_backward) {
+                out_dir = 0;
+                out_dev = (my_chip_id + num_devices - il_bwd_dist) % num_devices;
+                uint32_t navail =
+                    (il_bwd_dist < half) ? device_k_block_counts[out_dev] : device_k_block_counts[out_dev] / 2;
+                out_chunk = il_bwd_chunk++;
+                if (il_bwd_chunk >= navail) {
+                    il_bwd_chunk = 0;
+                    il_bwd_dist++;
+                }
+            } else {
+                out_dir = 1;
+                out_dev = (my_chip_id + il_fwd_dist) % num_devices;
+                uint32_t base = (il_fwd_dist < half) ? 0 : device_k_block_counts[out_dev] / 2;
+                uint32_t navail = device_k_block_counts[out_dev] - base;
+                out_chunk = base + il_fwd_chunk++;
+                if (il_fwd_chunk >= navail) {
+                    il_fwd_chunk = 0;
+                    il_fwd_dist++;
+                }
+            }
+            return;
+        }
+    }
+
+    uint32_t build_interleaved_k_block(uint32_t k_block_iter) {
+        uint8_t dir;
+        uint8_t dev;
+        uint32_t chunk;
+        next_interleaved_slot(dir, dev, chunk);
+        // Record for a banded caller: it wait_for_dir()s this same direction for bands 1..N.
+        streamed_dir = dir;
+        wait_for_dir(dir);
+        uint32_t k_block = device_k_block_start_ids[dev] + chunk;
+        k_block_device_received[k_block]++;  // expected==1 on this path; preserve the received count
+        forward_k_block_schedule[k_block_iter] = k_block;
+        return k_block;
+    }
+
     uint32_t compute_actual_k_block_iter(bool is_first_n_block_iter, uint32_t k_block_iter, bool is_forward) {
         uint32_t k_block_received = 0;
 
         if (is_first_n_block_iter) {
-            while (true) {
-                if (wait_for_op_signal && !(read_local_slice_from_input && (curr_k_block_dir == 2))) {
-                    volatile tt_l1_ptr uint32_t* semaphore = signal_op_semaphore_addr_ptrs[curr_k_block_dir];
-                    uint32_t sem_target = sem_targets[curr_k_block_dir];
-                    noc_semaphore_wait_min(semaphore, sem_target + 1);
-                    sem_targets[curr_k_block_dir]++;
-                }
-                int32_t k_block = process_chunk(
-                    device_id, device_chunk_id, curr_k_block_dir, devices_received, next_forward, next_backward);
-                if (k_block >= 0) {
-                    k_block_received = (uint32_t)k_block;
-                    forward_k_block_schedule[k_block_iter] = k_block_received;
-                    break;
+#if defined(AG_ALTERNATE_MIDDLE) && AG_ALTERNATE_MIDDLE
+            if (use_interleaved) {
+                k_block_received = build_interleaved_k_block(k_block_iter);
+            } else
+#endif
+            {
+                while (true) {
+                    // On an even ring the diametric device's slice is split-forwarded: its second half
+                    // is relayed on the forward link, so await that half on the forward signal semaphore.
+                    if (topology == ttnn::ccl::Topology::Ring && num_devices % 2 == 0 && num_devices > 2) {
+                        uint32_t diametric_device = (my_chip_id + num_devices / 2) % num_devices;
+                        if (device_id == diametric_device && device_k_block_counts[device_id] >= 2 &&
+                            device_chunk_id >= device_k_block_counts[device_id] / 2) {
+                            curr_k_block_dir = 1;  // forward
+                        }
+                    }
+                    if (wait_for_op_signal && !(read_local_slice_from_input && (curr_k_block_dir == 2))) {
+                        uint32_t sem_target = sem_targets[curr_k_block_dir];
+                        if (curr_k_block_dir == 2) {
+                            // self: single semaphore (writer-side worker barrier already aggregated all workers)
+                            noc_semaphore_wait_min(self_sem_ptr, sem_target + 1);
+                        } else {
+                            // remote direction: a k-block is ready only once all N workers have signaled their
+                            // own semaphore (per-worker counters are drift-safe across independent fabric links)
+                            uint32_t* addrs = (curr_k_block_dir == 0) ? backward_sem_addrs : forward_sem_addrs;
+                            for (uint32_t w = 0; w < num_ag_workers; w++) {
+                                noc_semaphore_wait_min(
+                                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addrs[w]), sem_target + 1);
+                            }
+                        }
+                        sem_targets[curr_k_block_dir]++;
+                    }
+                    // Record before process_chunk advances curr_k_block_dir, so a banded caller waits
+                    // the same direction's aggregator signal for this k-block's later bands.
+                    streamed_dir = curr_k_block_dir;
+                    int32_t k_block = process_chunk(
+                        device_id, device_chunk_id, curr_k_block_dir, devices_received, next_forward, next_backward);
+                    if (k_block >= 0) {
+                        k_block_received = (uint32_t)k_block;
+                        forward_k_block_schedule[k_block_iter] = k_block_received;
+                        break;
+                    }
                 }
             }
         } else {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp
@@ -60,17 +60,13 @@ struct MinimalMatmulOpReceiver {
     uint32_t num_k_blocks = 0;
     uint32_t local_k_start = 0;
     uint32_t local_k_end = 0;
-    // Per-worker signaling: each of the N all-gather workers in a remote direction increments its own
-    // semaphore, so a k-block is ready only once all N have signaled. self is a single semaphore
-    // (aggregated by the writer-side worker barrier). N==1 reproduces the legacy [backward,forward,self].
+    // Per-worker signaling: each of the N all-gather workers in a remote direction increments its own semaphore
     uint32_t num_ag_workers = 1;
     uint32_t* backward_sem_addrs = nullptr;  // [num_ag_workers] L1 semaphore addresses
     uint32_t* forward_sem_addrs = nullptr;   // [num_ag_workers] L1 semaphore addresses
     volatile tt_l1_ptr uint32_t* self_sem_ptr = nullptr;
     std::array<uint32_t, 3> sem_targets = {};  // indexed by direction: [backward, forward, self]
-    // Direction the most recent compute_actual_k_block_iter awaited, so a caller doing per-band reads
-    // can wait_for_dir() the same direction for bands 1..N. dir 2 (self/local) is not aggregator-
-    // signaled, so the caller must read it whole rather than band-by-band.
+    // Direction the most recent compute_actual_k_block_iter awaited
     uint8_t streamed_dir = 2;
     ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring;
     bool read_local_slice_from_input;
@@ -88,10 +84,7 @@ struct MinimalMatmulOpReceiver {
     uint8_t next_forward = 0;
     int8_t next_backward = 0;
 
-    // Interleaved-middle schedule state. Two independent direction cursors let the middle
-    // forward/backward region be consumed one-backward-one-forward instead of drained as
-    // whole-device groups. Each cursor keeps its own within-direction order (so the monotonic
-    // per-direction semaphores stay valid); only the interleaving between directions changes.
+    // Interleaved-middle schedule state
     uint8_t il_phase = 0;     // 0 = self, 1 = fwd/bwd (middle + folded diametric halves)
     uint8_t il_bwd_dist = 1;  // backward cursor device = my - il_bwd_dist
     uint32_t il_bwd_chunk = 0;
@@ -159,9 +152,7 @@ struct MinimalMatmulOpReceiver {
             device_k_block_counts,
             device_k_block_start_ids);
 
-        // A straddling k-block (expected==2) is co-completed by two devices sitting on
-        // different direction passes; interleaving would reorder those pair-completions, so
-        // the interleaved path is only enabled when no k-block straddles a device boundary.
+        // A straddling k-block (expected==2) is co-completed by two devices sitting on different direction passes
         for (uint32_t k = 0; k < num_k_blocks; k++) {
             if (k_block_device_expected[k] == 2) {
                 has_straddle = true;
@@ -261,8 +252,7 @@ struct MinimalMatmulOpReceiver {
         }
     }
 
-    // Block on the current direction's signal(s) exactly as the grouped path does: self is a
-    // single aggregated semaphore; a remote direction is ready only once all N workers signal.
+    // Block on the current direction's signal(s) exactly as the grouped path does: self is a single aggregated
     void wait_for_dir(uint8_t dir) {
         if (wait_for_op_signal && !(read_local_slice_from_input && (dir == 2))) {
             uint32_t sem_target = sem_targets[dir];
@@ -278,10 +268,7 @@ struct MinimalMatmulOpReceiver {
         }
     }
 
-    // Emit the next (direction, device, chunk) of the interleaved schedule: all self chunks,
-    // then the two remote directions alternating at chunk granularity, each kept in distance
-    // order 1..half. The diametric device (distance half) is not a separate step: its backward
-    // and forward halves ride the respective cursors, so it interleaves like any other block.
+    // Emit the next (direction, device, chunk) of the interleaved schedule: all self chunks
     void next_interleaved_slot(uint8_t& out_dir, uint8_t& out_dev, uint32_t& out_chunk) {
         const uint32_t half = num_devices / 2;
         while (true) {
@@ -295,9 +282,7 @@ struct MinimalMatmulOpReceiver {
                 il_phase = 1;
                 continue;
             }
-            // fwd/bwd region, distances 1..half. The diametric device sits at distance half and
-            // is split-forwarded: the backward link carries its first half, the forward link its
-            // second half, so each cursor folds its diametric half in as a normal last step.
+            // fwd/bwd region, distances 1..half
             bool bwd_avail = il_bwd_dist <= half;
             bool fwd_avail = il_fwd_dist <= half;
             if (!bwd_avail && !fwd_avail) {
@@ -356,8 +341,7 @@ struct MinimalMatmulOpReceiver {
 #endif
             {
                 while (true) {
-                    // On an even ring the diametric device's slice is split-forwarded: its second half
-                    // is relayed on the forward link, so await that half on the forward signal semaphore.
+                    // On an even ring the diametric device's slice is split-forwarded: its second half is relayed
                     if (topology == ttnn::ccl::Topology::Ring && num_devices % 2 == 0 && num_devices > 2) {
                         uint32_t diametric_device = (my_chip_id + num_devices / 2) % num_devices;
                         if (device_id == diametric_device && device_k_block_counts[device_id] >= 2 &&
@@ -371,8 +355,7 @@ struct MinimalMatmulOpReceiver {
                             // self: single semaphore (writer-side worker barrier already aggregated all workers)
                             noc_semaphore_wait_min(self_sem_ptr, sem_target + 1);
                         } else {
-                            // remote direction: a k-block is ready only once all N workers have signaled their
-                            // own semaphore (per-worker counters are drift-safe across independent fabric links)
+                            // remote direction: a k-block is ready only once all N workers have signaled their own
                             uint32_t* addrs = (curr_k_block_dir == 0) ? backward_sem_addrs : forward_sem_addrs;
                             for (uint32_t w = 0; w < num_ag_workers; w++) {
                                 noc_semaphore_wait_min(
@@ -381,8 +364,7 @@ struct MinimalMatmulOpReceiver {
                         }
                         sem_targets[curr_k_block_dir]++;
                     }
-                    // Record before process_chunk advances curr_k_block_dir, so a banded caller waits
-                    // the same direction's aggregator signal for this k-block's later bands.
+                    // Record before process_chunk advances curr_k_block_dir
                     streamed_dir = curr_k_block_dir;
                     int32_t k_block = process_chunk(
                         device_id, device_chunk_id, curr_k_block_dir, devices_received, next_forward, next_backward);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_mm_signal_aggregator.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_mm_signal_aggregator.cpp
@@ -2,17 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Matmul-signal aggregation kernel for the writer-signals-matmul path (Option W).
-//
-// One aggregator runs per all-gather direction on the receiving device. Each of the N AG writer
-// workers in that direction fabric-increments its own per-worker semaphore on this core as soon as
-// its portion of a k-block lands (ordered after the data on that worker's fabric connection). This
-// aggregator waits for all N per-worker semaphores to advance, which means the whole k-block has
-// landed, then increments the matmul cores' single direction semaphore exactly once - decoupling the
-// matmul from the AG reader's forwarding pace while keeping the matmul cores at just 3 semaphores.
-//
-// The iteration cadence mirrors the reader's remote-receive loop so that the number and order of
-// matmul signals matches exactly what the (reader-signaled) legacy path produced.
+// Matmul-signal aggregation kernel for the writer-signals-matmul path (Option W)
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
@@ -21,16 +11,12 @@
 
 using ttnn::ccl::Topology;
 
-// Each AG writer worker fires this many per-worker incs per chunk (one per row-band). The aggregator
-// waits for all of them (event_target advances by IN0_SUB_CHUNKS per chunk) before signaling the
-// matmul once per chunk. Default 1 = single inc per chunk (legacy). Must match the writer.
+// Each AG writer worker fires this many per-worker incs per chunk (one per row-band)
 #ifndef IN0_SUB_CHUNKS
 #define IN0_SUB_CHUNKS 1
 #endif
 
-///////////////////////////////////////////////////
-// COMPILE TIME ARGS
-///////////////////////////////////////////////////
+// ///////////////////////////////////////////////// COMPILE TIME ARGS
 constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
 constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(1);
 constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(2);
@@ -53,8 +39,7 @@ void kernel_main() {
         device_k_block_counts[d] = get_arg_val<uint32_t>(arg_idx++);
     }
 
-    // Per-worker semaphore addresses (this core's L1) that the AG writer workers increment.
-    // GlobalSemaphore L1 addresses (already resolved host-side); do NOT get_semaphore() them.
+    // Per-worker semaphore addresses (this core's L1) that the AG writer workers increment
     volatile tt_l1_ptr uint32_t* per_worker_sem_ptrs[num_ag_workers];
     for (uint32_t w = 0; w < num_ag_workers; w++) {
         per_worker_sem_ptrs[w] = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
@@ -74,9 +59,7 @@ void kernel_main() {
         slices_expected = direction == 1 ? num_targets_backward_direction : num_targets_forward_direction;
     }
 
-    // Split-forwarding: on an even ring the diametric slice arrives split across both links, so the
-    // upstream writer fabric-increments this direction's per-worker sems only for its half. Mirror
-    // the reader's receive accounting exactly so event_target tracks what the writer actually sends.
+    // Split-forwarding: on an even ring the diametric slice arrives split across both links
     bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
     if (split_forwarding_enabled && direction == 1) {
         slices_expected++;
@@ -93,8 +76,7 @@ void kernel_main() {
             while (slices_received < slices_expected) {
                 uint32_t actual_sender_chip_id = get_sender_id(direction, my_chip_id, slices_received, ring_size);
                 uint32_t num_chunks = device_k_block_counts[actual_sender_chip_id];
-                // The diametric slice (last one received) lands split across both links; wait on only
-                // this direction's half (direction 0 = first half, direction 1 = second half).
+                // The diametric slice (last one received) lands split across both links
                 bool is_split_received_slice =
                     split_forwarding_enabled && (slices_received == slices_expected - 1) && (num_chunks >= 2);
                 uint32_t first_half_chunks = num_chunks / 2;
@@ -105,9 +87,7 @@ void kernel_main() {
                     if (!receive_this_chunk) {
                         continue;
                     }
-                    // Writer fires IN0_SUB_CHUNKS per-worker incs per chunk (one per row-band). Signal
-                    // the matmul once per band as it lands, so the injector can read band s while band
-                    // s+1 is still on the fabric.
+                    // Writer fires IN0_SUB_CHUNKS per-worker incs per chunk (one per row-band)
                     for (uint32_t sub = 0; sub < IN0_SUB_CHUNKS; sub++) {
                         event_target++;
                         // Wait for all N workers' portion of this band to land.
@@ -125,19 +105,12 @@ void kernel_main() {
             }
         }
     }
-    // event_target counts up monotonically and each wait gates on it, so the per-worker sems must
-    // start every invocation at 0. Zero them here (all increments for this run have been observed by
-    // the final wait_min) so a trace replay begins clean instead of inheriting the prior run's value.
+    // event_target counts up monotonically and each wait gates
     for (uint32_t w = 0; w < num_ag_workers; w++) {
         noc_semaphore_set(per_worker_sem_ptrs[w], 0);
     }
 
-    // Drain the non-posted atomic increments issued to the matmul semaphores above. Without this the
-    // final noc_semaphore_inc's ack can still be in flight when this core is released; the next op
-    // reusing this core inherits the outstanding atomic on the NIU and its terminal
-    // noc_async_atomic_barrier() (which checks cumulative issued==acked) hangs off-by-one. This
-    // surfaces under NOC contention (8k fabric payload) as an intermittent, device-random,
-    // aggregator-core-fixed mesh deadlock. Mirrors the writer kernel's teardown barriers.
+    // Drain the non-posted atomic increments issued to the matmul semaphores above
     noc_async_write_barrier();
     noc_async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_mm_signal_aggregator.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_mm_signal_aggregator.cpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Matmul-signal aggregation kernel for the writer-signals-matmul path (Option W).
+//
+// One aggregator runs per all-gather direction on the receiving device. Each of the N AG writer
+// workers in that direction fabric-increments its own per-worker semaphore on this core as soon as
+// its portion of a k-block lands (ordered after the data on that worker's fabric connection). This
+// aggregator waits for all N per-worker semaphores to advance, which means the whole k-block has
+// landed, then increments the matmul cores' single direction semaphore exactly once - decoupling the
+// matmul from the AG reader's forwarding pace while keeping the matmul cores at just 3 semaphores.
+//
+// The iteration cadence mirrors the reader's remote-receive loop so that the number and order of
+// matmul signals matches exactly what the (reader-signaled) legacy path produced.
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/ccl/ccl_host_types.hpp"
+#include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp"
+#include <cstdint>
+
+using ttnn::ccl::Topology;
+
+// Each AG writer worker fires this many per-worker incs per chunk (one per row-band). The aggregator
+// waits for all of them (event_target advances by IN0_SUB_CHUNKS per chunk) before signaling the
+// matmul once per chunk. Default 1 = single inc per chunk (legacy). Must match the writer.
+#ifndef IN0_SUB_CHUNKS
+#define IN0_SUB_CHUNKS 1
+#endif
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(1);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(2);
+constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(3));
+constexpr bool direction = get_compile_time_arg_val(4);  // 1 is forward, 0 is backward
+constexpr uint32_t num_ag_workers = get_compile_time_arg_val(5);
+constexpr uint32_t num_mm_cores = get_compile_time_arg_val(6);
+
+void kernel_main() {
+    uint32_t arg_idx = 0;
+    uint32_t ring_size = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_batches = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t input_tensor_Ht = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t mm_cores_y = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t mm_block_ht = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t mm_signal_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+
+    uint32_t device_k_block_counts[ring_size];
+    for (uint32_t d = 0; d < ring_size; d++) {
+        device_k_block_counts[d] = get_arg_val<uint32_t>(arg_idx++);
+    }
+
+    // Per-worker semaphore addresses (this core's L1) that the AG writer workers increment.
+    // GlobalSemaphore L1 addresses (already resolved host-side); do NOT get_semaphore() them.
+    volatile tt_l1_ptr uint32_t* per_worker_sem_ptrs[num_ag_workers];
+    for (uint32_t w = 0; w < num_ag_workers; w++) {
+        per_worker_sem_ptrs[w] = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
+    }
+
+    // Matmul receiver core NOC coords (this device) to signal, [x0, y0, x1, y1, ...].
+    uint32_t mm_core_noc_coords[num_mm_cores * 2];
+    for (uint32_t i = 0; i < num_mm_cores * 2; i++) {
+        mm_core_noc_coords[i] = get_arg_val<uint32_t>(arg_idx++);
+    }
+
+    // Number of remote slices this direction receives (mirrors the reader).
+    uint32_t slices_expected = 0;
+    if (topology == Topology::Linear) {
+        slices_expected = direction == 1 ? num_targets_forward_direction : num_targets_backward_direction;
+    } else {  // Ring
+        slices_expected = direction == 1 ? num_targets_backward_direction : num_targets_forward_direction;
+    }
+
+    // Split-forwarding: on an even ring the diametric slice arrives split across both links, so the
+    // upstream writer fabric-increments this direction's per-worker sems only for its half. Mirror
+    // the reader's receive accounting exactly so event_target tracks what the writer actually sends.
+    bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    if (split_forwarding_enabled && direction == 1) {
+        slices_expected++;
+    }
+
+    uint32_t padded_M_tiles = round_up(input_tensor_Ht, mm_cores_y);
+    uint32_t M_tiles_per_core = padded_M_tiles / mm_cores_y;
+    uint32_t M_blocks_per_core = div_up(M_tiles_per_core, mm_block_ht);
+
+    uint32_t event_target = 0;
+    for (uint32_t b_idx = 0; b_idx < num_batches; b_idx++) {
+        for (uint32_t m_block_iter = 0; m_block_iter < M_blocks_per_core; m_block_iter++) {
+            uint32_t slices_received = 0;
+            while (slices_received < slices_expected) {
+                uint32_t actual_sender_chip_id = get_sender_id(direction, my_chip_id, slices_received, ring_size);
+                uint32_t num_chunks = device_k_block_counts[actual_sender_chip_id];
+                // The diametric slice (last one received) lands split across both links; wait on only
+                // this direction's half (direction 0 = first half, direction 1 = second half).
+                bool is_split_received_slice =
+                    split_forwarding_enabled && (slices_received == slices_expected - 1) && (num_chunks >= 2);
+                uint32_t first_half_chunks = num_chunks / 2;
+                for (uint32_t chunk_idx = 0; chunk_idx < num_chunks; chunk_idx++) {
+                    bool receive_this_chunk =
+                        !is_split_received_slice ||
+                        (direction == 0 ? (chunk_idx < first_half_chunks) : (chunk_idx >= first_half_chunks));
+                    if (!receive_this_chunk) {
+                        continue;
+                    }
+                    // Writer fires IN0_SUB_CHUNKS per-worker incs per chunk (one per row-band). Signal
+                    // the matmul once per band as it lands, so the injector can read band s while band
+                    // s+1 is still on the fabric.
+                    for (uint32_t sub = 0; sub < IN0_SUB_CHUNKS; sub++) {
+                        event_target++;
+                        // Wait for all N workers' portion of this band to land.
+                        for (uint32_t w = 0; w < num_ag_workers; w++) {
+                            noc_semaphore_wait_min(per_worker_sem_ptrs[w], event_target);
+                        }
+                        for (uint32_t c = 0; c < num_mm_cores; c++) {
+                            uint64_t mm_sem_noc_addr = get_noc_addr(
+                                mm_core_noc_coords[c * 2], mm_core_noc_coords[c * 2 + 1], mm_signal_sem_addr);
+                            noc_semaphore_inc(mm_sem_noc_addr, 1);
+                        }
+                    }
+                }
+                slices_received++;
+            }
+        }
+    }
+    // event_target counts up monotonically and each wait gates on it, so the per-worker sems must
+    // start every invocation at 0. Zero them here (all increments for this run have been observed by
+    // the final wait_min) so a trace replay begins clean instead of inheriting the prior run's value.
+    for (uint32_t w = 0; w < num_ag_workers; w++) {
+        noc_semaphore_set(per_worker_sem_ptrs[w], 0);
+    }
+
+    // Drain the non-posted atomic increments issued to the matmul semaphores above. Without this the
+    // final noc_semaphore_inc's ack can still be in flight when this core is released; the next op
+    // reusing this core inherits the outstanding atomic on the NIU and its terminal
+    // noc_async_atomic_barrier() (which checks cumulative issued==acked) hangs off-by-one. This
+    // surfaces under NOC contention (8k fabric payload) as an intermittent, device-random,
+    // aggregator-core-fixed mesh deadlock. Mirrors the writer kernel's teardown barriers.
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -15,6 +15,12 @@
 using address_t = uint32_t;
 using ttnn::ccl::Topology;
 
+// Must match write_chunk / the aggregator: the CB producer (read_chunk) splits each chunk into this
+// many row-bands so its tile order matches the consumer (write_chunk). Default 1 = whole-chunk.
+#ifndef IN0_SUB_CHUNKS
+#define IN0_SUB_CHUNKS 1
+#endif
+
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////
@@ -72,8 +78,10 @@ void kernel_main() {
     const auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_tensor_address);
 
     OpSignaler op_signaler;
+    bool writer_signals_mm = false;
     if constexpr (fuse_op) {
         op_signaler = OpSignaler(arg_idx);
+        writer_signals_mm = get_arg_val<uint32_t>(arg_idx++) == 1;
     }
 
     uint32_t slices_expected = 0;
@@ -93,6 +101,15 @@ void kernel_main() {
             slices_expected = num_targets_forward_direction;
         }
         writes_expected = slices_expected - 1;
+    }
+
+    // Mirror the writer's split-forwarding: on an even ring the diametric slice arrives in halves
+    // from both links. Direction 1 receives one extra slice (the second half) and relays one extra
+    // (its inbound +1-hop slice's second half). Gated to the reader-signaled path; see writer.
+    bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    if (split_forwarding_enabled && direction == 1) {
+        slices_expected++;
+        writes_expected++;
     }
 
     uint32_t batch_input_tile_offset = input_worker_tile_offset;
@@ -131,53 +148,89 @@ void kernel_main() {
                     input_tensor_Ht,
                     output_tensor_Wt,
                     my_chip_id,
-                    false);
+                    false,
+                    mm_cores_y,
+                    IN0_SUB_CHUNKS);
             }
 
             // Receive remote chunks
             uint32_t slices_received = 0;
+            uint32_t slices_forwarded = 0;
             uint32_t last_input_chunk_start_tile = input_chunk_start_tile;
             while (slices_received < slices_expected) {
                 uint32_t actual_sender_chip_id = get_sender_id(direction, my_chip_id, slices_received, ring_size);
+                uint32_t num_chunks = device_k_block_counts[actual_sender_chip_id];
+
+                bool should_forward = (topology == Topology::Linear && writes_expected > 0) ||
+                                      (topology == Topology::Ring && ((slices_received + 1) < (writes_expected + 1)));
+                // The diametric slice (last one received) arrives split across both links.
+                bool is_split_received_slice =
+                    split_forwarding_enabled && (slices_received == slices_expected - 1) && (num_chunks >= 2);
+                // The last slice we relay is sent on in halves, one per link.
+                bool is_split_forwarded_slice = split_forwarding_enabled && should_forward &&
+                                                (slices_forwarded == writes_expected - 1) && (num_chunks >= 2);
+                uint32_t first_half_chunks = num_chunks / 2;
 
                 input_chunk_start_tile = global_tile_index;
-                for (uint32_t chunk_idx = 0; chunk_idx < device_k_block_counts[actual_sender_chip_id]; chunk_idx++) {
-                    // Receive the next chunk of data
-                    noc_semaphore_wait_min(
-                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
-                    sem_target++;
+                for (uint32_t chunk_idx = 0; chunk_idx < num_chunks; chunk_idx++) {
+                    // For a split diametric slice each link delivers only its half, so wait on only
+                    // that half's semaphores (direction 0 = first half, direction 1 = second).
+                    bool receive_this_chunk =
+                        !is_split_received_slice ||
+                        (direction == 0 ? (chunk_idx < first_half_chunks) : (chunk_idx >= first_half_chunks));
+                    if (receive_this_chunk) {
+                        noc_semaphore_wait_min(
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
+                        sem_target++;
+                    }
 
-                    if ((topology == Topology::Linear && writes_expected > 0) ||
-                        (topology == Topology::Ring && ((slices_received + 1) < (writes_expected + 1)))) {
+                    if (should_forward) {
                         uint32_t actual_chunk_w = device_chunk_widths[actual_sender_chip_id][chunk_idx];
                         uint32_t actual_chunk_h = next_mm_aligned_chunk_height(
                             input_chunk_start_tile, M_tiles_per_core, input_tensor_Wt, mm_block_ht);
-                        uint32_t tiles_in_current_chunk = actual_chunk_w * actual_chunk_h * mm_cores_y;
-                        read_chunk(
-                            input_chunk_start_tile,
-                            batch_input_tile_offset,
-                            cb_output_id,
-                            tiles_in_current_chunk,
-                            actual_chunk_w,
-                            actual_chunk_h,
-                            padded_M_tiles / mm_cores_y,
-                            max_tiles_per_packet,
-                            ag_worker_id,
-                            ag_worker_cores,
-                            input_tensor_addrgen,
-                            input_tensor_page_size,
-                            output_tensor_addrgen,
-                            input_tensor_Wt,
-                            input_tensor_Ht,
-                            output_tensor_Wt,
-                            actual_sender_chip_id,
-                            true);
+                        // A split-forwarded slice is received whole but relayed in halves; read only
+                        // the half this link relays so the writer pops a matching CB count.
+                        bool relay_this_chunk =
+                            !is_split_forwarded_slice ||
+                            (direction == 0 ? (chunk_idx < first_half_chunks) : (chunk_idx >= first_half_chunks));
+                        if (relay_this_chunk) {
+                            uint32_t tiles_in_current_chunk = actual_chunk_w * actual_chunk_h * mm_cores_y;
+                            read_chunk(
+                                input_chunk_start_tile,
+                                batch_input_tile_offset,
+                                cb_output_id,
+                                tiles_in_current_chunk,
+                                actual_chunk_w,
+                                actual_chunk_h,
+                                padded_M_tiles / mm_cores_y,
+                                max_tiles_per_packet,
+                                ag_worker_id,
+                                ag_worker_cores,
+                                input_tensor_addrgen,
+                                input_tensor_page_size,
+                                output_tensor_addrgen,
+                                input_tensor_Wt,
+                                input_tensor_Ht,
+                                output_tensor_Wt,
+                                actual_sender_chip_id,
+                                true,
+                                mm_cores_y,
+                                IN0_SUB_CHUNKS);
+                        } else {
+                            advance_chunk_start_tile(
+                                input_chunk_start_tile, actual_chunk_w, actual_chunk_h, input_tensor_Wt);
+                        }
                         last_input_chunk_start_tile = input_chunk_start_tile;
                     }
                     if constexpr (fuse_op) {
-                        // Signal matmul to go
-                        op_signaler.synchronize_workers_and_signal_op(actual_sender_chip_id);
+                        if (!writer_signals_mm && receive_this_chunk) {
+                            //  Signal matmul to go
+                            op_signaler.synchronize_workers_and_signal_op(actual_sender_chip_id);
+                        }
                     }
+                }
+                if (should_forward) {
+                    slices_forwarded++;
                 }
                 slices_received++;
             }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -15,8 +15,7 @@
 using address_t = uint32_t;
 using ttnn::ccl::Topology;
 
-// Must match write_chunk / the aggregator: the CB producer (read_chunk) splits each chunk into this
-// many row-bands so its tile order matches the consumer (write_chunk). Default 1 = whole-chunk.
+// Must match write_chunk / the aggregator: the CB producer (read_chunk) splits each chunk into this many row-bands
 #ifndef IN0_SUB_CHUNKS
 #define IN0_SUB_CHUNKS 1
 #endif
@@ -103,9 +102,7 @@ void kernel_main() {
         writes_expected = slices_expected - 1;
     }
 
-    // Mirror the writer's split-forwarding: on an even ring the diametric slice arrives in halves
-    // from both links. Direction 1 receives one extra slice (the second half) and relays one extra
-    // (its inbound +1-hop slice's second half). Gated to the reader-signaled path; see writer.
+    // Mirror the writer's split-forwarding: on an even ring the diametric slice arrives in halves from both links
     bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
     if (split_forwarding_enabled && direction == 1) {
         slices_expected++;
@@ -173,8 +170,7 @@ void kernel_main() {
 
                 input_chunk_start_tile = global_tile_index;
                 for (uint32_t chunk_idx = 0; chunk_idx < num_chunks; chunk_idx++) {
-                    // For a split diametric slice each link delivers only its half, so wait on only
-                    // that half's semaphores (direction 0 = first half, direction 1 = second).
+                    // For a split diametric slice each link delivers only its half
                     bool receive_this_chunk =
                         !is_split_received_slice ||
                         (direction == 0 ? (chunk_idx < first_half_chunks) : (chunk_idx >= first_half_chunks));
@@ -188,8 +184,7 @@ void kernel_main() {
                         uint32_t actual_chunk_w = device_chunk_widths[actual_sender_chip_id][chunk_idx];
                         uint32_t actual_chunk_h = next_mm_aligned_chunk_height(
                             input_chunk_start_tile, M_tiles_per_core, input_tensor_Wt, mm_block_ht);
-                        // A split-forwarded slice is received whole but relayed in halves; read only
-                        // the half this link relays so the writer pops a matching CB count.
+                        // A split-forwarded slice is received whole but relayed in halves
                         bool relay_this_chunk =
                             !is_split_forwarded_slice ||
                             (direction == 0 ? (chunk_idx < first_half_chunks) : (chunk_idx >= first_half_chunks));

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -61,16 +61,12 @@ constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
 
 inline constexpr uint32_t sharded_args_start_idx = 24 + ccl_routing_utils::num_line_unicast_args;
 
-// Streaming matmul signal: each chunk's M-rows are delivered as this many row-bands, with one
-// matmul-aggregator inc per band. Default 1 = single inc per chunk (legacy). Must match the value
-// the matmul in0 kernel and the aggregator are built with.
+// Streaming matmul signal: each chunk's M-rows are delivered as this many row-bands
 #ifndef IN0_SUB_CHUNKS
 #define IN0_SUB_CHUNKS 1
 #endif
 
-// Mirrors the out_ready_sem gate inside write_chunk(): this writer forwards a chunk over fabric to a
-// remote device only when its direction has a target. When true, the writer also owns signaling the
-// remote device's matmul (semaphores[dir]) for each chunk it delivers (see writer_signals_mm).
+// Mirrors the out_ready_sem gate inside write_chunk(): this writer forwards a chunk over fabric to a remote device
 inline constexpr bool has_remote_target =
     (direction == 1 && num_targets_backward_direction) || (direction == 0 && num_targets_forward_direction);
 
@@ -113,10 +109,7 @@ void kernel_main() {
 
     bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
 #if defined(USE_MUX_V2)
-    // V2 is fully runtime-arg driven; build_from_args consumes the 11 client-connection args the
-    // host appends via FabricMuxV2Config::append_client_connection_rt_args. No worker-side
-    // termination protocol: the mux self-drains once every client closes.
-    // build_from_args takes size_t&; bridge through a size_t since arg_idx is uint32_t here.
+    // V2 is fully runtime-arg driven
 #define EAGER_STAGING false
     size_t mux_arg_idx = arg_idx;
     auto mux_connection = tt::tt_fabric::FabricMuxV2Sender<EAGER_STAGING>::build_from_args(mux_arg_idx);
@@ -145,8 +138,7 @@ void kernel_main() {
     if constexpr (fuse_op) {
         op_signaler_sender = OpSignaler(arg_idx);
         writer_signals_mm = get_arg_val<uint32_t>(arg_idx++) == 1;
-        // Option W: this worker signals its own per-worker semaphore on the direction's aggregation
-        // core (a single remote core), which collects all N workers and signals the matmul once.
+        // Option W: this worker signals its own per-worker semaphore on the direction's aggregation core
         agg_core_noc_x = get_arg_val<uint32_t>(arg_idx++);
         agg_core_noc_y = get_arg_val<uint32_t>(arg_idx++);
         // GlobalSemaphore L1 address (already resolved host-side); do NOT get_semaphore() it.
@@ -198,8 +190,7 @@ void kernel_main() {
     }
 
     auto page_size = tt::tt_fabric::linear::addrgen_detail::get_page_size(output_addrgen);
-    // Template holds the max-arity payload/chunk layout; each write overrides DstAddrs plus the actual
-    // ChunkSizes/PayloadSize, since a packet may carry fewer tiles than max_tiles_per_packet (tail/holes).
+    // Template holds the max-arity payload/chunk layout
     uint64_t scatter_dummy_addrs[NOC_SCATTER_WRITE_MAX_CHUNKS] = {0, 0, 0, 0};
     uint16_t scatter_init_chunk_sizes[NOC_SCATTER_WRITE_MAX_CHUNKS - 1] = {
         static_cast<uint16_t>(page_size), static_cast<uint16_t>(page_size), static_cast<uint16_t>(page_size)};
@@ -225,8 +216,7 @@ void kernel_main() {
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_unicast_hdr, unicast_route_info);
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_sem_inc, unicast_route_info);
 
-    // Dedicated header for signaling the remote device's matmul directly (writer_signals_mm). Only
-    // allocated when enabled, to avoid consuming a packet-header pool slot on the default path.
+    // Dedicated header for signaling the remote device's matmul directly (writer_signals_mm)
     volatile tt_l1_ptr PACKET_HEADER_TYPE* pkt_hdr_mm_sem_inc = nullptr;
     if (fuse_op && writer_signals_mm && has_remote_target) {
         pkt_hdr_mm_sem_inc = PacketHeaderPool::allocate_header();
@@ -260,11 +250,7 @@ void kernel_main() {
 
     Noc noc_obj;
 
-    // On an even ring the diametric device's slice is the last one relayed and would otherwise
-    // traverse the full half-ring on one link while the other idles. Relay its first half on
-    // direction 0 and its second half on direction 1 so both links share the final hop; direction 1
-    // gains one relay to carry that second half. Gated to the reader-signaled path: the
-    // writer-signals aggregator expects whole per-sender slices per direction.
+    // On an even ring the diametric device's slice is the last one relayed and would otherwise traverse the full
     bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
     if (split_forwarding_enabled && direction == 1) {
         writes_expected++;
@@ -288,8 +274,7 @@ void kernel_main() {
                 uint32_t actual_chunk_h = next_mm_aligned_chunk_height(
                     input_chunk_start_tile, M_tiles_per_core, input_tensor_Wt, mm_block_ht);
                 uint32_t tiles_in_current_chunk = actual_chunk_w * actual_chunk_h * mm_cores_y;
-                // write_chunk fires the per-worker aggregator inc once per row-band (IN0_SUB_CHUNKS
-                // total per chunk), replacing the single post-chunk inc that used to live here.
+                // write_chunk fires the per-worker aggregator inc once per row-band
                 bool mm_sig_local = fuse_op && writer_signals_mm && has_remote_target;
                 uint64_t agg_sem_noc_addr_local =
                     mm_sig_local ? safe_get_noc_addr(
@@ -346,8 +331,7 @@ void kernel_main() {
                     uint32_t actual_chunk_h = next_mm_aligned_chunk_height(
                         input_chunk_start_tile, M_tiles_per_core, input_tensor_Wt, mm_block_ht);
 
-                    // Direction 0 relays the first half of a split slice, direction 1 the second;
-                    // each walks past the half it does not relay.
+                    // Direction 0 relays the first half of a split slice, direction 1 the second
                     bool relay_this_chunk =
                         !is_split_forwarded_slice ||
                         (direction == 0 ? (chunk_idx < first_half_chunks) : (chunk_idx >= first_half_chunks));
@@ -409,8 +393,7 @@ void kernel_main() {
 
     if (mux_connection_valid) {
 #if defined(USE_MUX_V2)
-        // close() requests teardown and blocks on the manager's ack. The mux self-terminates once
-        // all clients have closed, so there is no termination-master election on the worker side.
+        // close() requests teardown and blocks on the manager's ack
         mux_connection.close();
 #else
         tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -7,6 +7,9 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
+#if defined(USE_MUX_V2)
+#include "tt_metal/fabric/hw/inc/tt_fabric_mux_v2_sender.hpp"
+#endif
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
@@ -58,6 +61,19 @@ constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
 
 inline constexpr uint32_t sharded_args_start_idx = 24 + ccl_routing_utils::num_line_unicast_args;
 
+// Streaming matmul signal: each chunk's M-rows are delivered as this many row-bands, with one
+// matmul-aggregator inc per band. Default 1 = single inc per chunk (legacy). Must match the value
+// the matmul in0 kernel and the aggregator are built with.
+#ifndef IN0_SUB_CHUNKS
+#define IN0_SUB_CHUNKS 1
+#endif
+
+// Mirrors the out_ready_sem gate inside write_chunk(): this writer forwards a chunk over fabric to a
+// remote device only when its direction has a target. When true, the writer also owns signaling the
+// remote device's matmul (semaphores[dir]) for each chunk it delivers (see writer_signals_mm).
+inline constexpr bool has_remote_target =
+    (direction == 1 && num_targets_backward_direction) || (direction == 0 && num_targets_forward_direction);
+
 void kernel_main() {
     ///////////////////////////////////////////////////
     // ARGS
@@ -96,6 +112,16 @@ void kernel_main() {
     }
 
     bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
+#if defined(USE_MUX_V2)
+    // V2 is fully runtime-arg driven; build_from_args consumes the 11 client-connection args the
+    // host appends via FabricMuxV2Config::append_client_connection_rt_args. No worker-side
+    // termination protocol: the mux self-drains once every client closes.
+    // build_from_args takes size_t&; bridge through a size_t since arg_idx is uint32_t here.
+#define EAGER_STAGING false
+    size_t mux_arg_idx = arg_idx;
+    auto mux_connection = tt::tt_fabric::FabricMuxV2Sender<EAGER_STAGING>::build_from_args(mux_arg_idx);
+    arg_idx = static_cast<uint32_t>(mux_arg_idx);
+#else
     uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
     uint32_t termination_sync_address = get_semaphore(termination_sync_id);
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -105,16 +131,29 @@ void kernel_main() {
     uint32_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
+#endif
 
     constexpr auto output_tensor_args = TensorAccessorArgs<sharded_args_start_idx>();
     const auto output_addrgen = TensorAccessor(output_tensor_args, output_address);
 
     /* Args for overlapped all gather */
     OpSignaler op_signaler_sender;
+    bool writer_signals_mm = false;
+    uint32_t agg_core_noc_x = 0;
+    uint32_t agg_core_noc_y = 0;
+    uint32_t agg_per_worker_sem_addr = 0;
     if constexpr (fuse_op) {
         op_signaler_sender = OpSignaler(arg_idx);
+        writer_signals_mm = get_arg_val<uint32_t>(arg_idx++) == 1;
+        // Option W: this worker signals its own per-worker semaphore on the direction's aggregation
+        // core (a single remote core), which collects all N workers and signals the matmul once.
+        agg_core_noc_x = get_arg_val<uint32_t>(arg_idx++);
+        agg_core_noc_y = get_arg_val<uint32_t>(arg_idx++);
+        // GlobalSemaphore L1 address (already resolved host-side); do NOT get_semaphore() it.
+        agg_per_worker_sem_addr = get_arg_val<uint32_t>(arg_idx++);
     }
 
+#if !defined(USE_MUX_V2)
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel>* mux_connection_handle;
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel> mux_connection;
     if (mux_connection_valid) {
@@ -142,6 +181,7 @@ void kernel_main() {
         tt::tt_fabric::wait_for_fabric_endpoint_ready(
             fabric_mux_x, fabric_mux_y, fabric_mux_status_address, local_fabric_mux_status_address);
     }
+#endif
 
     // pre-populate packet headers
     auto pkt_scatter_hdr = PacketHeaderPool::allocate_header();
@@ -149,18 +189,26 @@ void kernel_main() {
     auto pkt_hdr_sem_inc = PacketHeaderPool::allocate_header();
 
     if (mux_connection_valid) {
+#if defined(USE_MUX_V2)
+        // open() gates on the mux reporting READY_FOR_TRAFFIC internally, then opens the connection.
+        mux_connection.open();
+#else
         tt::tt_fabric::fabric_client_connect(*mux_connection_handle);
+#endif
     }
 
     auto page_size = tt::tt_fabric::linear::addrgen_detail::get_page_size(output_addrgen);
+    // Template holds the max-arity payload/chunk layout; each write overrides DstAddrs plus the actual
+    // ChunkSizes/PayloadSize, since a packet may carry fewer tiles than max_tiles_per_packet (tail/holes).
+    uint64_t scatter_dummy_addrs[NOC_SCATTER_WRITE_MAX_CHUNKS] = {0, 0, 0, 0};
+    uint16_t scatter_init_chunk_sizes[NOC_SCATTER_WRITE_MAX_CHUNKS - 1] = {
+        static_cast<uint16_t>(page_size), static_cast<uint16_t>(page_size), static_cast<uint16_t>(page_size)};
     fabric_unicast_noc_scatter_write_set_state<
         UnicastScatterWriteUpdateMask::ChunkSizes | UnicastScatterWriteUpdateMask::PayloadSize>(
         pkt_scatter_hdr,
         static_cast<uint8_t>(unicast_route_info.distance_in_hops),
-        NocUnicastScatterCommandHeader(
-            {0, 0},  // ignore
-            {static_cast<uint16_t>(page_size)}),
-        page_size * 2);
+        NocUnicastScatterCommandHeader(scatter_dummy_addrs, scatter_init_chunk_sizes, max_tiles_per_packet),
+        page_size * max_tiles_per_packet);
 
     fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::PayloadSize>(
         pkt_unicast_hdr, static_cast<uint8_t>(unicast_route_info.distance_in_hops), nullptr, output_page_size);
@@ -176,6 +224,21 @@ void kernel_main() {
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_scatter_hdr, unicast_route_info);
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_unicast_hdr, unicast_route_info);
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_sem_inc, unicast_route_info);
+
+    // Dedicated header for signaling the remote device's matmul directly (writer_signals_mm). Only
+    // allocated when enabled, to avoid consuming a packet-header pool slot on the default path.
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* pkt_hdr_mm_sem_inc = nullptr;
+    if (fuse_op && writer_signals_mm && has_remote_target) {
+        pkt_hdr_mm_sem_inc = PacketHeaderPool::allocate_header();
+        fabric_unicast_noc_unicast_atomic_inc_set_state<
+            UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
+            pkt_hdr_mm_sem_inc,
+            static_cast<uint8_t>(unicast_route_info.distance_in_hops),
+            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+                0,                           // ignore (set per-core below)
+                static_cast<uint16_t>(1)});  // increment 1
+        ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_mm_sem_inc, unicast_route_info);
+    }
     // 2. unicast output ready semaphore
     uint64_t out_ready_sem_noc_addr_in_pkt =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem, 0);
@@ -197,6 +260,16 @@ void kernel_main() {
 
     Noc noc_obj;
 
+    // On an even ring the diametric device's slice is the last one relayed and would otherwise
+    // traverse the full half-ring on one link while the other idles. Relay its first half on
+    // direction 0 and its second half on direction 1 so both links share the final hop; direction 1
+    // gains one relay to carry that second half. Gated to the reader-signaled path: the
+    // writer-signals aggregator expects whole per-sender slices per direction.
+    bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    if (split_forwarding_enabled && direction == 1) {
+        writes_expected++;
+    }
+
     uint32_t batch_output_tile_offset = output_worker_tile_offset;
     uint32_t global_tile_index = 0;
     uint32_t output_tiles_per_batch = output_tensor_Wt * output_tensor_Ht;
@@ -215,6 +288,13 @@ void kernel_main() {
                 uint32_t actual_chunk_h = next_mm_aligned_chunk_height(
                     input_chunk_start_tile, M_tiles_per_core, input_tensor_Wt, mm_block_ht);
                 uint32_t tiles_in_current_chunk = actual_chunk_w * actual_chunk_h * mm_cores_y;
+                // write_chunk fires the per-worker aggregator inc once per row-band (IN0_SUB_CHUNKS
+                // total per chunk), replacing the single post-chunk inc that used to live here.
+                bool mm_sig_local = fuse_op && writer_signals_mm && has_remote_target;
+                uint64_t agg_sem_noc_addr_local =
+                    mm_sig_local ? safe_get_noc_addr(
+                                       (uint8_t)agg_core_noc_x, (uint8_t)agg_core_noc_y, agg_per_worker_sem_addr, 0)
+                                 : 0;
                 write_chunk(
                     input_chunk_start_tile,
                     batch_output_tile_offset,
@@ -240,7 +320,12 @@ void kernel_main() {
                     direction,
                     num_targets_forward_direction,
                     num_targets_backward_direction,
-                    true && !read_local_slice_from_input);
+                    true && !read_local_slice_from_input,
+                    mm_cores_y,
+                    IN0_SUB_CHUNKS,
+                    mm_sig_local,
+                    pkt_hdr_mm_sem_inc,
+                    agg_sem_noc_addr_local);
                 if (fuse_op && direction == 1 && !read_local_slice_from_input) {
                     // Synchronize and signal that the local tensor slice is available
                     op_signaler_sender.synchronize_workers_and_signal_op(my_chip_id);
@@ -251,13 +336,35 @@ void kernel_main() {
             uint32_t slice_writes = 0;
             while (slice_writes < writes_expected) {
                 uint32_t actual_sender_chip_id = get_sender_id(direction, my_chip_id, slice_writes, ring_size);
+                uint32_t num_chunks = device_k_block_counts[actual_sender_chip_id];
+                bool is_split_forwarded_slice =
+                    split_forwarding_enabled && (slice_writes == writes_expected - 1) && (num_chunks >= 2);
+                uint32_t first_half_chunks = num_chunks / 2;
                 input_chunk_start_tile = global_tile_index;
-                for (uint32_t chunk_idx = 0; chunk_idx < device_k_block_counts[actual_sender_chip_id]; chunk_idx++) {
+                for (uint32_t chunk_idx = 0; chunk_idx < num_chunks; chunk_idx++) {
                     uint32_t actual_chunk_w = device_chunk_widths[actual_sender_chip_id][chunk_idx];
                     uint32_t actual_chunk_h = next_mm_aligned_chunk_height(
                         input_chunk_start_tile, M_tiles_per_core, input_tensor_Wt, mm_block_ht);
+
+                    // Direction 0 relays the first half of a split slice, direction 1 the second;
+                    // each walks past the half it does not relay.
+                    bool relay_this_chunk =
+                        !is_split_forwarded_slice ||
+                        (direction == 0 ? (chunk_idx < first_half_chunks) : (chunk_idx >= first_half_chunks));
+                    if (!relay_this_chunk) {
+                        advance_chunk_start_tile(
+                            input_chunk_start_tile, actual_chunk_w, actual_chunk_h, input_tensor_Wt);
+                        continue;
+                    }
+
                     uint32_t tiles_in_current_chunk = actual_chunk_w * actual_chunk_h * mm_cores_y;
 
+                    // Same per-band aggregator inc as the local send, fired inside write_chunk.
+                    bool mm_sig_fwd = fuse_op && writer_signals_mm && has_remote_target;
+                    uint64_t agg_sem_noc_addr_fwd =
+                        mm_sig_fwd ? safe_get_noc_addr(
+                                         (uint8_t)agg_core_noc_x, (uint8_t)agg_core_noc_y, agg_per_worker_sem_addr, 0)
+                                   : 0;
                     write_chunk(
                         input_chunk_start_tile,
                         batch_output_tile_offset,
@@ -283,7 +390,12 @@ void kernel_main() {
                         direction,
                         num_targets_forward_direction,
                         num_targets_backward_direction,
-                        false);
+                        false,
+                        mm_cores_y,
+                        IN0_SUB_CHUNKS,
+                        mm_sig_fwd,
+                        pkt_hdr_mm_sem_inc,
+                        agg_sem_noc_addr_fwd);
                 }
                 slice_writes++;
             }
@@ -296,6 +408,11 @@ void kernel_main() {
     noc_obj.async_atomic_barrier();
 
     if (mux_connection_valid) {
+#if defined(USE_MUX_V2)
+        // close() requests teardown and blocks on the manager's ack. The mux self-terminates once
+        // all clients have closed, so there is no termination-master election on the worker side.
+        mux_connection.close();
+#else
         tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
         if constexpr (is_termination_master) {
@@ -308,6 +425,7 @@ void kernel_main() {
             noc_semaphore_inc(dest_addr, 1);
             noc_obj.async_atomic_barrier();
         }
+#endif
     }
     noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp
@@ -91,9 +91,7 @@ FORCE_INLINE uint32_t next_mm_aligned_chunk_height(
     }
 }
 
-// Advance chunk_start_tile past one chunk without moving data. Mirrors the
-// tile-advance tail of read_chunk/write_chunk so a direction that relays only
-// half of a split slice lands on the same M-block boundary a full traversal would.
+// Advance chunk_start_tile past one chunk without moving data
 FORCE_INLINE void advance_chunk_start_tile(
     uint32_t& chunk_start_tile, uint32_t chunk_width, uint32_t subchunk_height, uint32_t input_tensor_Wt) {
     uint32_t chunk_start_row = chunk_start_tile / input_tensor_Wt;
@@ -126,9 +124,7 @@ FORCE_INLINE uint32_t read_chunk(
     uint32_t output_tensor_Wt,
     uint32_t actual_sender_chip_id,
     bool read_output,
-    // Must mirror write_chunk's band decomposition exactly: this reader is the CB producer feeding
-    // write_chunk (the consumer) on the same core, so the per-band tile order must match or the relay
-    // maps source tiles to the wrong output addresses. mm_sub_chunks==1 => whole-chunk (baseline).
+    // Must mirror write_chunk's band decomposition exactly: this reader is the CB producer feeding write_chunk
     uint32_t mm_cores_y = 1,
     uint32_t mm_sub_chunks = 1) {
     // Chunk values (chunk spans all mm cores)
@@ -185,7 +181,6 @@ FORCE_INLINE uint32_t read_chunk(
                     input_tensor_Ht);
                 if (tile_id >= 0) {
                     // Device 2.0 migration: legacy primitive retained, precomposed uint64_t address
-                    // from get_noc_addr(tile_id, accessor).
                     uint64_t noc_read_addr =
                         get_noc_addr(tile_id, read_output ? output_tensor_addrgen : input_tensor_addrgen);
                     noc_async_read(noc_read_addr, l1_write_addr, input_tensor_page_size);
@@ -210,8 +205,7 @@ FORCE_INLINE uint32_t read_chunk(
     return 0;  // return value is unused by callers
 }
 
-// FabricSenderType is deduced from mux_connection so the same body serves any fabric sender that
-// satisfies the linear-API contract (WorkerToFabricMuxSender for Mux V1, FabricMuxV2Sender for V2).
+// FabricSenderType is deduced from mux_connection so the same body serves any fabric sender that satisfies
 template <typename AddrGenType, typename FabricSenderType>
 FORCE_INLINE uint32_t write_chunk(
     uint32_t& chunk_start_tile,
@@ -239,13 +233,7 @@ FORCE_INLINE uint32_t write_chunk(
     const uint32_t num_targets_forward_direction,
     const uint32_t num_targets_backward_direction,
     bool write_local,
-    // Streaming matmul signal (Option W, M sub-chunking). The chunk's subchunk_height M-rows are
-    // delivered as mm_sub_chunks row-bands: for each band the walk sweeps the band's rows of EVERY
-    // injector (injector-major, same as the whole-chunk walk but height-limited), then fires one
-    // matmul-aggregator inc. Because a band is a contiguous row-range of all injectors, "band s landed" is
-    // true for every injector at once -- the invariant the injector reader relies on. The out_ready
-    // sem and chunk_start advance stay per-chunk (the AG receiver counts one per chunk).
-    // mm_sub_chunks==1 => a single band spanning the whole chunk => byte-identical to no sub-chunking.
+    // Streaming matmul signal (Option W, M sub-chunking)
     uint32_t mm_cores_y = 1,
     uint32_t mm_sub_chunks = 1,
     bool mm_signal_enabled = false,
@@ -274,9 +262,7 @@ FORCE_INLINE uint32_t write_chunk(
         uint32_t packets_in_band = div_up(worker_tiles_in_band, num_tiles_per_packet);
         uint32_t band_tile_iter = 0;
 
-        // Subchunk tracker for this band: band_h rows of injector 0, starting band_lo rows into the
-        // chunk; advance_subchunk jumps subchunk_height_stride (== M_tiles_per_core) to the next
-        // injector's same band. Injector-major within the band.
+        // Subchunk tracker for this band: band_h rows of injector 0, starting band_lo rows into the chunk
         uint32_t band_start_row = chunk_start_row + band_lo;
         uint32_t subchunk_start_row = band_start_row;
         uint32_t subchunk_end_row = band_start_row + band_h - 1;
@@ -294,9 +280,7 @@ FORCE_INLINE uint32_t write_chunk(
             cb_output.wait_front(max_tiles_per_packet);
             size_t l1_read_addr = cb_output.get_read_ptr();
 
-            // Collect the packet's valid dest tiles. get_chunk_tile advances the row/col cursor each
-            // call and returns <0 for a padding hole; the reader front-packs the same valid tiles into
-            // the source CB in this order, so source tile k maps to noc_addrs[k].
+            // Collect the packet's valid dest tiles
             uint64_t noc_addrs[NOC_SCATTER_WRITE_MAX_CHUNKS] = {0, 0, 0, 0};
             uint64_t local_noc_addrs[NOC_SCATTER_WRITE_MAX_CHUNKS] = {0, 0, 0, 0};
             uint16_t chunk_sizes[NOC_SCATTER_WRITE_MAX_CHUNKS - 1] = {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp
@@ -19,6 +19,7 @@
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 #include "tt_metal/fabric/hw/inc/linear/api.h"
+#include "subchunk_bands.hpp"
 
 using namespace tt::tt_fabric::linear::experimental;
 
@@ -90,6 +91,21 @@ FORCE_INLINE uint32_t next_mm_aligned_chunk_height(
     }
 }
 
+// Advance chunk_start_tile past one chunk without moving data. Mirrors the
+// tile-advance tail of read_chunk/write_chunk so a direction that relays only
+// half of a split slice lands on the same M-block boundary a full traversal would.
+FORCE_INLINE void advance_chunk_start_tile(
+    uint32_t& chunk_start_tile, uint32_t chunk_width, uint32_t subchunk_height, uint32_t input_tensor_Wt) {
+    uint32_t chunk_start_row = chunk_start_tile / input_tensor_Wt;
+    uint32_t new_chunk_start_tile = chunk_start_tile + chunk_width;
+    uint32_t new_chunk_row = new_chunk_start_tile / input_tensor_Wt;
+    if (new_chunk_row != chunk_start_row) {
+        chunk_start_tile = (chunk_start_row + subchunk_height) * input_tensor_Wt;
+    } else {
+        chunk_start_tile = new_chunk_start_tile;
+    }
+}
+
 template <typename AddrGenType>
 FORCE_INLINE uint32_t read_chunk(
     uint32_t& chunk_start_tile,
@@ -109,70 +125,79 @@ FORCE_INLINE uint32_t read_chunk(
     uint32_t input_tensor_Ht,
     uint32_t output_tensor_Wt,
     uint32_t actual_sender_chip_id,
-    bool read_output) {
-    uint32_t worker_tiles_in_curr_chunk =
-        (tiles_in_chunk / ag_worker_cores) + ((ag_worker_core_id < (tiles_in_chunk % ag_worker_cores)) ? 1 : 0);
-    uint32_t num_tiles_per_packet = std::min(max_tiles_per_packet, worker_tiles_in_curr_chunk);
-    uint32_t packets_in_curr_chunk = div_up(worker_tiles_in_curr_chunk, num_tiles_per_packet);
-    uint32_t chunk_tile_iter = 0;
-
+    bool read_output,
+    // Must mirror write_chunk's band decomposition exactly: this reader is the CB producer feeding
+    // write_chunk (the consumer) on the same core, so the per-band tile order must match or the relay
+    // maps source tiles to the wrong output addresses. mm_sub_chunks==1 => whole-chunk (baseline).
+    uint32_t mm_cores_y = 1,
+    uint32_t mm_sub_chunks = 1) {
     // Chunk values (chunk spans all mm cores)
     // convert chunk start from linear index into row and col coord, still in input tensor space
     uint32_t chunk_start_row = chunk_start_tile / input_tensor_Wt;
-    uint32_t chunk_start_col = chunk_start_tile % input_tensor_Wt;
-
-    // Subchunk values (subchunk spans just 1 mm core)
-    uint32_t subchunk_start_row = chunk_start_row;  // initialize the subchunk tracker (start and end)
-    uint32_t subchunk_end_row = chunk_start_row + subchunk_height - 1;
-
-    // Worker chunk values
-    uint32_t worker_chunk_start_row_chunk_space = worker_tile_offset / chunk_width;
-    uint32_t worker_chunk_start_col_chunk_space = worker_tile_offset % chunk_width;
-    uint32_t worker_chunk_row = chunk_start_row + worker_chunk_start_row_chunk_space;
-    uint32_t worker_chunk_col = chunk_start_col + worker_chunk_start_col_chunk_space;
-    if (worker_chunk_row > subchunk_end_row) {
-        advance_subchunk(worker_chunk_row, subchunk_start_row, subchunk_end_row, subchunk_height_stride);
-    }
-    if (read_output) {
-        worker_chunk_col = worker_chunk_col + actual_sender_chip_id * input_tensor_Wt;
-        chunk_start_col = chunk_start_col + actual_sender_chip_id * input_tensor_Wt;
-    }
+    uint32_t chunk_start_col_base = chunk_start_tile % input_tensor_Wt;
+    uint32_t chunk_start_col =
+        read_output ? (chunk_start_col_base + actual_sender_chip_id * input_tensor_Wt) : chunk_start_col_base;
     uint32_t chunk_end_col = chunk_start_col + chunk_width - 1;
+
     Noc noc_obj;
     CircularBuffer cb_output(cb_output_id);
-    for (uint32_t packet_idx = 0; packet_idx < packets_in_curr_chunk; packet_idx++) {
-        uint32_t tiles_left_in_chunk = worker_tiles_in_curr_chunk - chunk_tile_iter;
-        uint32_t tiles_to_read_in_packet = std::min(tiles_left_in_chunk, num_tiles_per_packet);
 
-        cb_output.reserve_back(max_tiles_per_packet);
-        size_t l1_write_addr = cb_output.get_write_ptr();
-        for (uint32_t j = 0; j < tiles_to_read_in_packet; ++j) {
-            int32_t tile_id = get_chunk_tile(
-                worker_chunk_row,
-                worker_chunk_col,
-                ag_worker_cores,
-                subchunk_start_row,
-                subchunk_end_row,
-                subchunk_height_stride,
-                chunk_start_col,
-                chunk_end_col,
-                chunk_width,
-                read_output ? output_tensor_Wt : input_tensor_Wt,
-                input_tensor_Ht);
-            if (tile_id >= 0) {
-                // Device 2.0 migration: legacy primitive retained, precomposed uint64_t address
-                // from get_noc_addr(tile_id, accessor).
-                uint64_t noc_read_addr =
-                    get_noc_addr(tile_id, read_output ? output_tensor_addrgen : input_tensor_addrgen);
-                noc_async_read(noc_read_addr, l1_write_addr, input_tensor_page_size);
+    for (uint32_t band = 0; band < mm_sub_chunks; band++) {
+        uint32_t band_lo, band_h;
+        balanced_band(subchunk_height, mm_sub_chunks, band, band_lo, band_h);
+        if (band_h == 0) {
+            break;  // empty trailing band, only when mm_sub_chunks > subchunk_height
+        }
+        uint32_t tiles_in_band = chunk_width * band_h * mm_cores_y;
+        uint32_t worker_tiles_in_band =
+            (tiles_in_band / ag_worker_cores) + ((ag_worker_core_id < (tiles_in_band % ag_worker_cores)) ? 1 : 0);
+        uint32_t num_tiles_per_packet = std::min(max_tiles_per_packet, worker_tiles_in_band);
+        uint32_t packets_in_band = div_up(worker_tiles_in_band, num_tiles_per_packet);
+        uint32_t band_tile_iter = 0;
 
-                l1_write_addr += input_tensor_page_size;
-            }
-            chunk_tile_iter++;
+        uint32_t band_start_row = chunk_start_row + band_lo;
+        uint32_t subchunk_start_row = band_start_row;
+        uint32_t subchunk_end_row = band_start_row + band_h - 1;
+        uint32_t worker_chunk_row = band_start_row + (worker_tile_offset / chunk_width);
+        uint32_t worker_chunk_col = chunk_start_col + (worker_tile_offset % chunk_width);
+        if (worker_chunk_row > subchunk_end_row) {
+            advance_subchunk(worker_chunk_row, subchunk_start_row, subchunk_end_row, subchunk_height_stride);
         }
 
-        noc_obj.async_read_barrier();
-        cb_output.push_back(max_tiles_per_packet);
+        for (uint32_t packet_idx = 0; packet_idx < packets_in_band; packet_idx++) {
+            uint32_t tiles_left_in_band = worker_tiles_in_band - band_tile_iter;
+            uint32_t tiles_to_read_in_packet = std::min(tiles_left_in_band, num_tiles_per_packet);
+
+            cb_output.reserve_back(max_tiles_per_packet);
+            size_t l1_write_addr = cb_output.get_write_ptr();
+            for (uint32_t j = 0; j < tiles_to_read_in_packet; ++j) {
+                int32_t tile_id = get_chunk_tile(
+                    worker_chunk_row,
+                    worker_chunk_col,
+                    ag_worker_cores,
+                    subchunk_start_row,
+                    subchunk_end_row,
+                    subchunk_height_stride,
+                    chunk_start_col,
+                    chunk_end_col,
+                    chunk_width,
+                    read_output ? output_tensor_Wt : input_tensor_Wt,
+                    input_tensor_Ht);
+                if (tile_id >= 0) {
+                    // Device 2.0 migration: legacy primitive retained, precomposed uint64_t address
+                    // from get_noc_addr(tile_id, accessor).
+                    uint64_t noc_read_addr =
+                        get_noc_addr(tile_id, read_output ? output_tensor_addrgen : input_tensor_addrgen);
+                    noc_async_read(noc_read_addr, l1_write_addr, input_tensor_page_size);
+
+                    l1_write_addr += input_tensor_page_size;
+                }
+                band_tile_iter++;
+            }
+
+            noc_obj.async_read_barrier();
+            cb_output.push_back(max_tiles_per_packet);
+        }
     }
 
     uint32_t new_chunk_start_tile = chunk_start_tile + chunk_width;
@@ -182,10 +207,12 @@ FORCE_INLINE uint32_t read_chunk(
     } else {
         chunk_start_tile = new_chunk_start_tile;
     }
-    return chunk_tile_iter;
+    return 0;  // return value is unused by callers
 }
 
-template <typename AddrGenType, uint8_t FABRIC_MUX_CHANNEL_NUM_BUFFERS = 0>
+// FabricSenderType is deduced from mux_connection so the same body serves any fabric sender that
+// satisfies the linear-API contract (WorkerToFabricMuxSender for Mux V1, FabricMuxV2Sender for V2).
+template <typename AddrGenType, typename FabricSenderType>
 FORCE_INLINE uint32_t write_chunk(
     uint32_t& chunk_start_tile,
     uint32_t worker_tile_offset,
@@ -203,7 +230,7 @@ FORCE_INLINE uint32_t write_chunk(
     uint32_t input_tensor_Ht,
     uint32_t output_tensor_Wt,
     uint32_t actual_sender_chip_id,
-    tt::tt_fabric::WorkerToFabricMuxSender<FABRIC_MUX_CHANNEL_NUM_BUFFERS>& mux_connection,
+    FabricSenderType& mux_connection,
     volatile PACKET_HEADER_TYPE* pkt_scatter_hdr,
     volatile PACKET_HEADER_TYPE* pkt_unicast_hdr,
     volatile PACKET_HEADER_TYPE* pkt_hdr_sem_inc,
@@ -211,132 +238,135 @@ FORCE_INLINE uint32_t write_chunk(
     const bool direction,
     const uint32_t num_targets_forward_direction,
     const uint32_t num_targets_backward_direction,
-    bool write_local) {
-    uint32_t worker_tiles_in_curr_chunk =
-        (tiles_in_chunk / ag_worker_cores) + ((ag_worker_core_id < (tiles_in_chunk % ag_worker_cores)) ? 1 : 0);
-    uint32_t num_tiles_per_packet = std::min(max_tiles_per_packet, worker_tiles_in_curr_chunk);
-    uint32_t packets_in_curr_chunk = div_up(worker_tiles_in_curr_chunk, num_tiles_per_packet);
-    uint32_t chunk_tile_iter = 0;
-
+    bool write_local,
+    // Streaming matmul signal (Option W, M sub-chunking). The chunk's subchunk_height M-rows are
+    // delivered as mm_sub_chunks row-bands: for each band the walk sweeps the band's rows of EVERY
+    // injector (injector-major, same as the whole-chunk walk but height-limited), then fires one
+    // matmul-aggregator inc. Because a band is a contiguous row-range of all injectors, "band s landed" is
+    // true for every injector at once -- the invariant the injector reader relies on. The out_ready
+    // sem and chunk_start advance stay per-chunk (the AG receiver counts one per chunk).
+    // mm_sub_chunks==1 => a single band spanning the whole chunk => byte-identical to no sub-chunking.
+    uint32_t mm_cores_y = 1,
+    uint32_t mm_sub_chunks = 1,
+    bool mm_signal_enabled = false,
+    volatile PACKET_HEADER_TYPE* pkt_hdr_mm_sem_inc = nullptr,
+    uint64_t mm_agg_sem_noc_addr = 0) {
     // Chunk values (chunk spans all mm cores)
     // convert chunk start from linear index into row and col coord, still in input tensor space
     uint32_t chunk_start_row = chunk_start_tile / input_tensor_Wt;
-    uint32_t chunk_start_col = chunk_start_tile % input_tensor_Wt;
-
-    // Subchunk values (subchunk spans just 1 mm core)
-    uint32_t subchunk_start_row = chunk_start_row;  // initialize the subchunk tracker (start and end)
-    uint32_t subchunk_end_row = chunk_start_row + subchunk_height - 1;
-
-    // Worker chunk values
-    uint32_t worker_chunk_start_row_chunk_space = worker_tile_offset / chunk_width;
-    uint32_t worker_chunk_start_col_chunk_space = worker_tile_offset % chunk_width;
-    uint32_t worker_chunk_row = chunk_start_row + worker_chunk_start_row_chunk_space;
-    uint32_t worker_chunk_col = chunk_start_col + worker_chunk_start_col_chunk_space;
-    if (worker_chunk_row > subchunk_end_row) {
-        advance_subchunk(worker_chunk_row, subchunk_start_row, subchunk_end_row, subchunk_height_stride);
-    }
-    worker_chunk_col = worker_chunk_col + actual_sender_chip_id * input_tensor_Wt;
-    chunk_start_col = chunk_start_col + actual_sender_chip_id * input_tensor_Wt;
+    uint32_t chunk_start_col_base = chunk_start_tile % input_tensor_Wt;
+    uint32_t chunk_start_col = chunk_start_col_base + actual_sender_chip_id * input_tensor_Wt;
     uint32_t chunk_end_col = chunk_start_col + chunk_width - 1;
 
     Noc noc_obj;
     CircularBuffer cb_output(cb_output_id);
-    for (uint32_t packet_idx = 0; packet_idx < packets_in_curr_chunk; packet_idx++) {
-        uint32_t tiles_left_in_chunk = worker_tiles_in_curr_chunk - chunk_tile_iter;
-        uint32_t tiles_to_write_in_packet = std::min(tiles_left_in_chunk, num_tiles_per_packet);
 
-        cb_output.wait_front(max_tiles_per_packet);
-        size_t l1_read_addr = cb_output.get_read_ptr();
-
-        uint32_t padded_tiles = 0;
-        int32_t tile_one_id = get_chunk_tile(
-            worker_chunk_row,
-            worker_chunk_col,
-            ag_worker_cores,
-            subchunk_start_row,
-            subchunk_end_row,
-            subchunk_height_stride,
-            chunk_start_col,
-            chunk_end_col,
-            chunk_width,
-            output_tensor_Wt,
-            input_tensor_Ht);
-        if (tile_one_id < 0) {
-            padded_tiles++;
+    for (uint32_t band = 0; band < mm_sub_chunks; band++) {
+        uint32_t band_lo, band_h;
+        balanced_band(subchunk_height, mm_sub_chunks, band, band_lo, band_h);
+        if (band_h == 0) {
+            break;  // empty trailing band, only when mm_sub_chunks > subchunk_height
         }
-        chunk_tile_iter++;
-        int32_t tile_two_id = tile_one_id;
-        if (tiles_to_write_in_packet == 2) {
-            tile_two_id = get_chunk_tile(
-                worker_chunk_row,
-                worker_chunk_col,
-                ag_worker_cores,
-                subchunk_start_row,
-                subchunk_end_row,
-                subchunk_height_stride,
-                chunk_start_col,
-                chunk_end_col,
-                chunk_width,
-                output_tensor_Wt,
-                input_tensor_Ht);
-            if (tile_two_id < 0) {
-                padded_tiles++;
+        uint32_t tiles_in_band = chunk_width * band_h * mm_cores_y;
+        uint32_t worker_tiles_in_band =
+            (tiles_in_band / ag_worker_cores) + ((ag_worker_core_id < (tiles_in_band % ag_worker_cores)) ? 1 : 0);
+        uint32_t num_tiles_per_packet = std::min(max_tiles_per_packet, worker_tiles_in_band);
+        uint32_t packets_in_band = div_up(worker_tiles_in_band, num_tiles_per_packet);
+        uint32_t band_tile_iter = 0;
+
+        // Subchunk tracker for this band: band_h rows of injector 0, starting band_lo rows into the
+        // chunk; advance_subchunk jumps subchunk_height_stride (== M_tiles_per_core) to the next
+        // injector's same band. Injector-major within the band.
+        uint32_t band_start_row = chunk_start_row + band_lo;
+        uint32_t subchunk_start_row = band_start_row;
+        uint32_t subchunk_end_row = band_start_row + band_h - 1;
+
+        uint32_t worker_chunk_row = band_start_row + (worker_tile_offset / chunk_width);
+        uint32_t worker_chunk_col = chunk_start_col + (worker_tile_offset % chunk_width);
+        if (worker_chunk_row > subchunk_end_row) {
+            advance_subchunk(worker_chunk_row, subchunk_start_row, subchunk_end_row, subchunk_height_stride);
+        }
+
+        for (uint32_t packet_idx = 0; packet_idx < packets_in_band; packet_idx++) {
+            uint32_t tiles_left_in_band = worker_tiles_in_band - band_tile_iter;
+            uint32_t tiles_to_write_in_packet = std::min(tiles_left_in_band, num_tiles_per_packet);
+
+            cb_output.wait_front(max_tiles_per_packet);
+            size_t l1_read_addr = cb_output.get_read_ptr();
+
+            // Collect the packet's valid dest tiles. get_chunk_tile advances the row/col cursor each
+            // call and returns <0 for a padding hole; the reader front-packs the same valid tiles into
+            // the source CB in this order, so source tile k maps to noc_addrs[k].
+            uint64_t noc_addrs[NOC_SCATTER_WRITE_MAX_CHUNKS] = {0, 0, 0, 0};
+            uint64_t local_noc_addrs[NOC_SCATTER_WRITE_MAX_CHUNKS] = {0, 0, 0, 0};
+            uint16_t chunk_sizes[NOC_SCATTER_WRITE_MAX_CHUNKS - 1] = {
+                static_cast<uint16_t>(output_page_size),
+                static_cast<uint16_t>(output_page_size),
+                static_cast<uint16_t>(output_page_size)};
+            uint32_t valid_tiles = 0;
+            for (uint32_t j = 0; j < tiles_to_write_in_packet; ++j) {
+                int32_t tile_id = get_chunk_tile(
+                    worker_chunk_row,
+                    worker_chunk_col,
+                    ag_worker_cores,
+                    subchunk_start_row,
+                    subchunk_end_row,
+                    subchunk_height_stride,
+                    chunk_start_col,
+                    chunk_end_col,
+                    chunk_width,
+                    output_tensor_Wt,
+                    input_tensor_Ht);
+                if (tile_id >= 0) {
+                    noc_addrs[valid_tiles] =
+                        tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, tile_id, 0);
+                    local_noc_addrs[valid_tiles] = output_addrgen.get_noc_addr(tile_id);
+                    valid_tiles++;
+                }
+                band_tile_iter++;
             }
-            chunk_tile_iter++;
-        }
 
-        tiles_to_write_in_packet = tiles_to_write_in_packet - padded_tiles;
-        // Will have more cases once scatter-write supports more than 2 distinct addresses
-        switch (tiles_to_write_in_packet) {
-            case 2: {
-                auto noc_address0 =
-                    tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, tile_one_id, 0);
-                auto noc_address1 =
-                    tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, tile_two_id, 0);
-                if ((direction == 1 && num_targets_backward_direction) ||
-                    (direction == 0 && num_targets_forward_direction)) {
-                    fabric_unicast_noc_scatter_write_with_state<UnicastScatterWriteUpdateMask::DstAddrs>(
+            const bool send_remote =
+                (direction == 1 && num_targets_backward_direction) || (direction == 0 && num_targets_forward_direction);
+            if (valid_tiles > 1) {
+                if (send_remote) {
+                    fabric_unicast_noc_scatter_write_with_state<
+                        UnicastScatterWriteUpdateMask::DstAddrs | UnicastScatterWriteUpdateMask::ChunkSizes |
+                        UnicastScatterWriteUpdateMask::PayloadSize>(
                         &mux_connection,
                         pkt_scatter_hdr,
                         l1_read_addr,
-                        NocUnicastScatterCommandHeader({noc_address0, noc_address1}, {0}));
+                        NocUnicastScatterCommandHeader(noc_addrs, chunk_sizes, valid_tiles),
+                        output_page_size * valid_tiles);
                 }
                 if (direction == 1 && write_local) {
-                    uint64_t local_noc0_dest_noc_addr_tile_one = output_addrgen.get_noc_addr(tile_one_id);
-                    uint64_t local_noc0_dest_noc_addr_tile_two = output_addrgen.get_noc_addr(tile_two_id);
-
-                    // Legacy primitive retained: precomposed uint64_t dst addrs.
-                    noc_async_write(l1_read_addr, local_noc0_dest_noc_addr_tile_one, output_page_size);
-                    noc_async_write(
-                        l1_read_addr + output_page_size, local_noc0_dest_noc_addr_tile_two, output_page_size);
+                    size_t local_l1_read_addr = l1_read_addr;
+                    for (uint32_t k = 0; k < valid_tiles; ++k) {
+                        noc_async_write(local_l1_read_addr, local_noc_addrs[k], output_page_size);
+                        local_l1_read_addr += output_page_size;
+                    }
                     noc_obj.async_write_barrier();
                 }
-                break;
-            }
-            case 1: {
-                auto noc_address0 =
-                    tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, tile_one_id, 0);
-                if ((direction == 1 && num_targets_backward_direction) ||
-                    (direction == 0 && num_targets_forward_direction)) {
+            } else if (valid_tiles == 1) {
+                if (send_remote) {
                     fabric_unicast_noc_unicast_write_with_state<UnicastWriteUpdateMask::DstAddr>(
-                        &mux_connection, pkt_unicast_hdr, l1_read_addr, NocUnicastCommandHeader{noc_address0});
+                        &mux_connection, pkt_unicast_hdr, l1_read_addr, NocUnicastCommandHeader{noc_addrs[0]});
                 }
                 if (direction == 1 && write_local) {
-                    uint64_t local_noc0_dest_noc_addr = output_addrgen.get_noc_addr(tile_one_id);
-
-                    // Legacy primitive retained: precomposed uint64_t dst addr.
-                    noc_async_write(l1_read_addr, local_noc0_dest_noc_addr, output_page_size);
+                    noc_async_write(l1_read_addr, local_noc_addrs[0], output_page_size);
                     noc_obj.async_write_barrier();
                 }
-                break;
             }
-            case 0:
-            default: {
-                break;
-            }
+            noc_obj.async_writes_flushed();
+            cb_output.pop_front(max_tiles_per_packet);
         }
-        noc_obj.async_writes_flushed();
-        cb_output.pop_front(max_tiles_per_packet);
+        // One matmul-aggregator inc per band, ordered after this band's writes on the fabric.
+        if (mm_signal_enabled) {
+            fabric_unicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+                &mux_connection,
+                pkt_hdr_mm_sem_inc,
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{mm_agg_sem_noc_addr, 0, 0});
+        }
     }
     // Write the semaphore packet
     if ((direction == 1 && num_targets_backward_direction) || (direction == 0 && num_targets_forward_direction)) {
@@ -353,5 +383,5 @@ FORCE_INLINE uint32_t write_chunk(
     } else {
         chunk_start_tile = new_chunk_start_tile;
     }
-    return chunk_tile_iter;
+    return 0;  // return value is unused by callers
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/subchunk_bands.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/subchunk_bands.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// Balanced M-row band partition. Splits `total_rows` into `num_bands` contiguous bands
+// whose heights differ by at most one row, spreading the remainder across the leading
+// bands (13 rows / 4 -> 4,3,3,3, not the front-loaded 4,4,4,1). Even heights keep the
+// per-band NOC packets uniform, and for num_bands <= total_rows every band is non-empty,
+// so the AG writer fires exactly num_bands matmul-aggregator incs and never desyncs from
+// the receiver (which always expects num_bands).
+//
+// The AG writer/reader (strided_all_gather_common.hpp) and the fused matmul in0 reader
+// (dm_in0_sender.cpp) both call this so their band boundaries are guaranteed identical.
+inline void balanced_band(uint32_t total_rows, uint32_t num_bands, uint32_t band, uint32_t& band_lo, uint32_t& band_h) {
+    uint32_t base = total_rows / num_bands;
+    uint32_t rem = total_rows % num_bands;
+    band_lo = band * base + (band < rem ? band : rem);
+    band_h = base + (band < rem ? 1 : 0);
+}
+
+// Interleaved two-NoC output-write row ownership (SPLIT_OUTPUT_WRITE + AGMM_INTERLEAVED_OUTPUT_WRITE).
+// An output block's M-rows are split between the NOC_1 writer (dm_in1, out_cb_a / c_2) and the NOC_0 writer
+// (dm_in0, out_cb_b / c_8). A contiguous [0, split_rows) prefix starves the NOC_0 writer: compute packs
+// rows in ascending m, so c_8 stays empty until compute crosses the split boundary and the two writers run
+// back-to-back instead of overlapping. Interleaving ownership across the block feeds both writers from the
+// first rows so they overlap.
+//
+// Ratio-preserving Bresenham: row m belongs to NOC_1 iff floor((m+1)*pct/100) > floor(m*pct/100). Summed
+// over m in [0, M) the NOC_1 count telescopes to floor(M*pct/100) -- exactly the contiguous split_rows --
+// so every CB reserve/push/pop count is unchanged. At pct == 50 this is exact alternation (rows 1,3,5,...
+// -> NOC_1); pct == 100 sends every row to NOC_1 (single-writer case).
+//
+// Contract: compute (copy_block_split / add_bias_block_split) routes each packed row with this predicate,
+// and each DM writer iterates all M rows but drains/writes only the rows it owns, in ascending m order. FIFO
+// pop order therefore matches compute's push order and the DRAM row index is d0_start + m. All three kernels
+// take the same pct from AG_SPLIT_NOC1_PCT, so they never diverge.
+inline bool split_row_to_noc1(uint32_t m, uint32_t pct) { return ((m + 1) * pct) / 100 > (m * pct) / 100; }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/subchunk_bands.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/subchunk_bands.hpp
@@ -6,15 +6,7 @@
 
 #include <cstdint>
 
-// Balanced M-row band partition. Splits `total_rows` into `num_bands` contiguous bands
-// whose heights differ by at most one row, spreading the remainder across the leading
-// bands (13 rows / 4 -> 4,3,3,3, not the front-loaded 4,4,4,1). Even heights keep the
-// per-band NOC packets uniform, and for num_bands <= total_rows every band is non-empty,
-// so the AG writer fires exactly num_bands matmul-aggregator incs and never desyncs from
-// the receiver (which always expects num_bands).
-//
-// The AG writer/reader (strided_all_gather_common.hpp) and the fused matmul in0 reader
-// (dm_in0_sender.cpp) both call this so their band boundaries are guaranteed identical.
+// Balanced M-row band partition
 inline void balanced_band(uint32_t total_rows, uint32_t num_bands, uint32_t band, uint32_t& band_lo, uint32_t& band_h) {
     uint32_t base = total_rows / num_bands;
     uint32_t rem = total_rows % num_bands;
@@ -22,20 +14,5 @@ inline void balanced_band(uint32_t total_rows, uint32_t num_bands, uint32_t band
     band_h = base + (band < rem ? 1 : 0);
 }
 
-// Interleaved two-NoC output-write row ownership (SPLIT_OUTPUT_WRITE + AGMM_INTERLEAVED_OUTPUT_WRITE).
-// An output block's M-rows are split between the NOC_1 writer (dm_in1, out_cb_a / c_2) and the NOC_0 writer
-// (dm_in0, out_cb_b / c_8). A contiguous [0, split_rows) prefix starves the NOC_0 writer: compute packs
-// rows in ascending m, so c_8 stays empty until compute crosses the split boundary and the two writers run
-// back-to-back instead of overlapping. Interleaving ownership across the block feeds both writers from the
-// first rows so they overlap.
-//
-// Ratio-preserving Bresenham: row m belongs to NOC_1 iff floor((m+1)*pct/100) > floor(m*pct/100). Summed
-// over m in [0, M) the NOC_1 count telescopes to floor(M*pct/100) -- exactly the contiguous split_rows --
-// so every CB reserve/push/pop count is unchanged. At pct == 50 this is exact alternation (rows 1,3,5,...
-// -> NOC_1); pct == 100 sends every row to NOC_1 (single-writer case).
-//
-// Contract: compute (copy_block_split / add_bias_block_split) routes each packed row with this predicate,
-// and each DM writer iterates all M rows but drains/writes only the rows it owns, in ascending m order. FIFO
-// pop order therefore matches compute's push order and the DRAM row index is d0_start + m. All three kernels
-// take the same pct from AG_SPLIT_NOC1_PCT, so they never diverge.
+// Interleaved two-NoC output-write row ownership (SPLIT_OUTPUT_WRITE + AGMM_INTERLEAVED_OUTPUT_WRITE)
 inline bool split_row_to_noc1(uint32_t m, uint32_t pct) { return ((m + 1) * pct) / 100 > (m * pct) / 100; }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
@@ -296,13 +296,7 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     /* All gather fusion */
     bool fuse_op = fused_op_signaler.has_value();
 
-    // Experimental (env-gated): have the AG writer signal the *remote* device's matmul directly over
-    // fabric, right after the chunk's data + out_ready_sem land, instead of relying on the remote AG
-    // reader to relay the signal after its forwarding read. Decouples matmul start from the remote
-    // reader's pace. Multi-worker safe: each of the N = num_links * num_workers_per_direction workers
-    // signals its own per-worker matmul semaphore, and the matmul waits for all N per k-block (see
-    // MinimalMatmulOpReceiver). The matmul-side semaphore count must agree (see the fused program's
-    // MinimalMatmulFusedOpSignaler::num_ag_workers). Always enabled when fusing a matmul.
+    // Experimental (env-gated): have the AG writer signal the *remote* device's matmul directly over fabric
     const bool writer_signals_mm = fuse_op;
     const uint32_t num_ag_workers = num_links * num_workers_per_direction;
 
@@ -323,10 +317,7 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     auto [unicast_forward_args, unicast_backward_args] = ttnn::ccl::get_forward_backward_line_unicast_configuration(
         sender_device_coord, forward_coord, backward_coord, mesh_device);
 
-    // Option W: carve `num_directions_per_link` extra trailing cores as per-direction matmul-signal
-    // aggregators. choose_worker_cores(1, T) fills T cores row-major from the offset, so the first
-    // num_links*num_cores_per_link are the AG worker/mux cores (unchanged layout) and the last ones
-    // are the aggregators.
+    // Option W: carve `num_directions_per_link` extra trailing cores as per-direction matmul-signal aggregators
     const uint32_t num_agg_cores = writer_signals_mm ? num_directions_per_link : 0;
     const uint32_t total_worker_cores = num_links * num_cores_per_link + num_agg_cores;
     const auto [all_core_range, all_cores] =
@@ -368,14 +359,10 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     CoreRangeSet mux_forward_core_range_set = CoreRangeSet(mux_forward_core_ranges);
     CoreRangeSet mux_backward_core_range_set = CoreRangeSet(mux_backward_core_ranges);
 
-    // Option W: per-direction matmul-signal aggregator cores (the trailing cores from choose_worker_cores),
-    // each holding N per-worker semaphores that the AG writer workers of that direction increment.
-    // Indexed by direction (0 = backward, 1 = forward).
+    // Option W: per-direction matmul-signal aggregator cores (the trailing cores from choose_worker_cores)
     std::vector<CoreCoord> agg_core_logical(num_directions_per_link);
     std::vector<CoreCoord> agg_core_virtual(num_directions_per_link);
-    // Holds L1 ADDRESSES (not semaphore ids): these are cross-device fabric atomic-inc targets, so they
-    // must be GlobalSemaphores. They are supplied by the caller appended to `semaphore` after the
-    // num_directions_per_link out_ready sems, laid out [dir0_w0..dir0_wN-1, dir1_w0..dir1_wN-1].
+    // Holds L1 ADDRESSES (not semaphore ids): these are cross-device fabric atomic-inc targets
     std::vector<std::vector<uint32_t>> agg_per_worker_sem_ids(num_directions_per_link);
     if (writer_signals_mm) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
@@ -393,9 +380,7 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     const size_t packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
     uint32_t l1_scratch_cb_page_size_bytes = page_size;
 
-    // scatter-write packs this many tiles (distinct dest noc addresses) per fabric packet, up to the
-    // hardware max of 4. Capped below by the actual per-packet page capacity, so 4 degrades gracefully
-    // when the fabric payload cannot hold 4 tiles.
+    // scatter-write packs this many tiles (distinct dest noc addresses) per fabric packet
     uint32_t max_target_noc_addresses_per_packet = 4;
 
     // for bfloat8_b, tile_num_per_link=6, we would need to send 2 packages, but they can be of size 3 instead of 4
@@ -438,17 +423,14 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     std::map<std::string, std::string> writer_compute_defines;
     std::map<std::string, std::string> agg_defines;
 
-    // Streaming matmul signal: deliver each chunk's M-rows as IN0_SUB_CHUNKS row-bands, one
-    // aggregator inc per band. All three kernels must agree on the count. Default 1 = legacy (one
-    // inc per chunk). The reader is the CB producer, so it must band-split identically to the writer.
+    // Streaming matmul signal: deliver each chunk's M-rows as IN0_SUB_CHUNKS row-bands, one aggregator inc per band
     const char* in0_sub_chunks_env = std::getenv("IN0_SUB_CHUNKS");
     const std::string in0_sub_chunks_str = (in0_sub_chunks_env != nullptr) ? in0_sub_chunks_env : "1";
     reader_compute_defines["IN0_SUB_CHUNKS"] = in0_sub_chunks_str;
     writer_compute_defines["IN0_SUB_CHUNKS"] = in0_sub_chunks_str;
     agg_defines["IN0_SUB_CHUNKS"] = in0_sub_chunks_str;
 
-    // Route the worker->fabric path through Mux V2 (dual-RISC forwarder+manager) instead of Mux V1.
-    // Always enabled for strided all-gather (and the fused AGMM).
+    // Route the worker->fabric path through Mux V2 (dual-RISC forwarder+manager) instead of Mux V1
     const bool use_mux_v2 = true;
     writer_compute_defines["USE_MUX_V2"] = "1";
 
@@ -522,8 +504,7 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                 buffer_size_bytes_full_size_channel,
                 mux_base_l1_address);
 
-            // V2 places one logical channel per worker; the config also lays out the shared control
-            // regions the forwarder/manager pair use. Only constructed when opted in.
+            // V2 places one logical channel per worker
             std::optional<tt::tt_fabric::FabricMuxV2Config> mux_v2_config;
             if (use_mux_v2) {
                 mux_v2_config.emplace(
@@ -540,8 +521,7 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                 const auto dst_node_id =
                     mesh_device->get_fabric_node_id(dir ? backward_coord.value() : forward_coord.value());
                 if (use_mux_v2) {
-                    // Creates both the forwarder (RISCV_0) and manager (RISCV_1) kernels on the mux
-                    // core and wires the forwarder's downstream fabric connection runtime args.
+                    // Creates both the forwarder (RISCV_0) and manager
                     tt::tt_fabric::add_fabric_mux_v2_to_program(
                         program,
                         *mux_v2_config,
@@ -641,8 +621,7 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                             worker + (link * num_workers_per_direction),
                             0);
                     }
-                    // When the writer signals the matmul directly over fabric, the reader must not
-                    // also relay the signal (it would double-count the matmul semaphore).
+                    // When the writer signals the matmul directly over fabric
                     reader_rt_args.push_back(static_cast<uint32_t>(writer_signals_mm ? 1 : 0));
                 }
 
@@ -668,9 +647,7 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                     global_worker_id,
                 };
                 if (use_mux_v2) {
-                    // V2 is runtime-arg driven and needs no mux compile-time args. Emit the same
-                    // number of slots (is_termination_master + 12 fillers) the V1 helper pushes so the
-                    // trailing line-unicast route info keeps its fixed compile-time-arg index.
+                    // V2 is runtime-arg driven and needs no mux compile-time args
                     sender_writer_compile_args.push_back(worker == 0);
                     sender_writer_compile_args.insert(sender_writer_compile_args.end(), 12, 0);
                 } else {
@@ -726,8 +703,7 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                     }
                 }
                 if (use_mux_v2) {
-                    // Layout: [mux_connection_valid][11 client-connection args]. The writer's
-                    // FabricMuxV2Sender::build_from_args consumes the 11 args in this exact order.
+                    // Layout: [mux_connection_valid][11 client-connection args]
                     writer_rt_args.push_back(static_cast<uint32_t>(mux_connection_valid ? 1 : 0));
                     const uint32_t flow_control_sem_id = CreateSemaphore(program, {core}, 0);
                     const uint32_t teardown_sem_id = CreateSemaphore(program, {core}, 0);
@@ -746,9 +722,7 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                         writer_rt_args);
                 }
                 if (fuse_op) {
-                    // Local self-signal path (op_signaler_sender): targets the single 'self' semaphore,
-                    // which is the last entry in the matmul semaphore vector [backward_0..N-1,
-                    // forward_0..N-1, self].
+                    // Local self-signal path (op_signaler_sender): targets the single 'self' semaphore
                     const uint32_t self_sem_index =
                         fused_op_signaler_sender_workers->fused_op_receiver_signal_semaphores.size() - 1;
                     fused_op_signaler_sender_workers->push_all_gather_fused_op_rt_args(
@@ -757,7 +731,6 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                         worker + (link * num_workers_per_direction),
                         self_sem_index);
                     // Option W: this worker signals its own per-worker semaphore on the remote direction's
-                    // aggregation core (single core), which collects all N workers and signals the matmul.
                     writer_rt_args.push_back(static_cast<uint32_t>(writer_signals_mm ? 1 : 0));
                     writer_rt_args.push_back(static_cast<uint32_t>(writer_signals_mm ? agg_core_virtual[dir].x : 0));
                     writer_rt_args.push_back(static_cast<uint32_t>(writer_signals_mm ? agg_core_virtual[dir].y : 0));
@@ -769,9 +742,7 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
         }
     }
 
-    // Option W: create one matmul-signal aggregator kernel per direction. Each waits for all N AG
-    // writer workers of its direction to signal a k-block landed, then signals every matmul core's
-    // direction semaphore once - decoupling the matmul from the AG reader's forwarding pace.
+    // Option W: create one matmul-signal aggregator kernel per direction
     if (writer_signals_mm) {
         const uint32_t num_mm_cores = fused_op_signaler.value().num_fused_op_cores_to_signal;
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
@@ -31,6 +31,7 @@
 #include <type_traits>
 #include <ranges>
 #include <optional>
+#include <cstdlib>
 
 using namespace tt::constants;
 
@@ -295,6 +296,16 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     /* All gather fusion */
     bool fuse_op = fused_op_signaler.has_value();
 
+    // Experimental (env-gated): have the AG writer signal the *remote* device's matmul directly over
+    // fabric, right after the chunk's data + out_ready_sem land, instead of relying on the remote AG
+    // reader to relay the signal after its forwarding read. Decouples matmul start from the remote
+    // reader's pace. Multi-worker safe: each of the N = num_links * num_workers_per_direction workers
+    // signals its own per-worker matmul semaphore, and the matmul waits for all N per k-block (see
+    // MinimalMatmulOpReceiver). The matmul-side semaphore count must agree (see the fused program's
+    // MinimalMatmulFusedOpSignaler::num_ag_workers). Always enabled when fusing a matmul.
+    const bool writer_signals_mm = fuse_op;
+    const uint32_t num_ag_workers = num_links * num_workers_per_direction;
+
     // Need a separate signaler for the sender workers, to handle the first tensor slice that is locally available
     std::optional<ttnn::experimental::ccl::StridedAllGatherFusedOpSignaler> fused_op_signaler_sender_workers;
     std::optional<ttnn::experimental::ccl::StridedAllGatherFusedOpSignaler> fused_op_signaler_forward;
@@ -312,8 +323,14 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     auto [unicast_forward_args, unicast_backward_args] = ttnn::ccl::get_forward_backward_line_unicast_configuration(
         sender_device_coord, forward_coord, backward_coord, mesh_device);
 
+    // Option W: carve `num_directions_per_link` extra trailing cores as per-direction matmul-signal
+    // aggregators. choose_worker_cores(1, T) fills T cores row-major from the offset, so the first
+    // num_links*num_cores_per_link are the AG worker/mux cores (unchanged layout) and the last ones
+    // are the aggregators.
+    const uint32_t num_agg_cores = writer_signals_mm ? num_directions_per_link : 0;
+    const uint32_t total_worker_cores = num_links * num_cores_per_link + num_agg_cores;
     const auto [all_core_range, all_cores] =
-        ttnn::ccl::choose_worker_cores(num_links, num_cores_per_link, mesh_device, std::nullopt, core_grid_offset);
+        ttnn::ccl::choose_worker_cores(1, total_worker_cores, mesh_device, std::nullopt, core_grid_offset);
     std::set<CoreRange> sender_worker_core_ranges;
     std::set<CoreRange> sender_forward_core_ranges;
     std::set<CoreRange> sender_backward_core_ranges;
@@ -351,16 +368,45 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     CoreRangeSet mux_forward_core_range_set = CoreRangeSet(mux_forward_core_ranges);
     CoreRangeSet mux_backward_core_range_set = CoreRangeSet(mux_backward_core_ranges);
 
+    // Option W: per-direction matmul-signal aggregator cores (the trailing cores from choose_worker_cores),
+    // each holding N per-worker semaphores that the AG writer workers of that direction increment.
+    // Indexed by direction (0 = backward, 1 = forward).
+    std::vector<CoreCoord> agg_core_logical(num_directions_per_link);
+    std::vector<CoreCoord> agg_core_virtual(num_directions_per_link);
+    // Holds L1 ADDRESSES (not semaphore ids): these are cross-device fabric atomic-inc targets, so they
+    // must be GlobalSemaphores. They are supplied by the caller appended to `semaphore` after the
+    // num_directions_per_link out_ready sems, laid out [dir0_w0..dir0_wN-1, dir1_w0..dir1_wN-1].
+    std::vector<std::vector<uint32_t>> agg_per_worker_sem_ids(num_directions_per_link);
+    if (writer_signals_mm) {
+        for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
+            CoreCoord agg_logical = all_cores[(num_links * num_cores_per_link) + dir];
+            agg_core_logical[dir] = agg_logical;
+            agg_core_virtual[dir] = mesh_device->worker_core_from_logical_core(agg_logical);
+            for (uint32_t w = 0; w < num_ag_workers; w++) {
+                agg_per_worker_sem_ids[dir].push_back(
+                    static_cast<uint32_t>(semaphore.at(num_directions_per_link + dir * num_ag_workers + w).address()));
+            }
+        }
+    }
+
     // L1 Scratch CB Creation
     const size_t packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
     uint32_t l1_scratch_cb_page_size_bytes = page_size;
 
-    // scatter-write currently only supports 2 distinct noc addresses
-    uint32_t max_target_noc_addresses_per_packet = 2;
+    // scatter-write packs this many tiles (distinct dest noc addresses) per fabric packet, up to the
+    // hardware max of 4. Capped below by the actual per-packet page capacity, so 4 degrades gracefully
+    // when the fabric payload cannot hold 4 tiles.
+    uint32_t max_target_noc_addresses_per_packet = 4;
 
     // for bfloat8_b, tile_num_per_link=6, we would need to send 2 packages, but they can be of size 3 instead of 4
     uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;
     uint32_t num_tiles_to_write_per_packet = std::min(max_target_noc_addresses_per_packet, num_pages_per_packet);
+    log_info(
+        tt::LogOp,
+        "strided AG: num_tiles_to_write_per_packet={} (cap={}, pages_per_packet={})",
+        num_tiles_to_write_per_packet,
+        max_target_noc_addresses_per_packet,
+        num_pages_per_packet);
     uint32_t cb_num_pages = 3 * num_tiles_to_write_per_packet;  // triple buffering
     tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
 
@@ -390,6 +436,21 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
 
     std::map<std::string, std::string> reader_compute_defines;
     std::map<std::string, std::string> writer_compute_defines;
+    std::map<std::string, std::string> agg_defines;
+
+    // Streaming matmul signal: deliver each chunk's M-rows as IN0_SUB_CHUNKS row-bands, one
+    // aggregator inc per band. All three kernels must agree on the count. Default 1 = legacy (one
+    // inc per chunk). The reader is the CB producer, so it must band-split identically to the writer.
+    const char* in0_sub_chunks_env = std::getenv("IN0_SUB_CHUNKS");
+    const std::string in0_sub_chunks_str = (in0_sub_chunks_env != nullptr) ? in0_sub_chunks_env : "1";
+    reader_compute_defines["IN0_SUB_CHUNKS"] = in0_sub_chunks_str;
+    writer_compute_defines["IN0_SUB_CHUNKS"] = in0_sub_chunks_str;
+    agg_defines["IN0_SUB_CHUNKS"] = in0_sub_chunks_str;
+
+    // Route the worker->fabric path through Mux V2 (dual-RISC forwarder+manager) instead of Mux V1.
+    // Always enabled for strided all-gather (and the fused AGMM).
+    const bool use_mux_v2 = true;
+    writer_compute_defines["USE_MUX_V2"] = "1";
 
     // KERNEL CREATION
     /* All gather fusion */
@@ -461,30 +522,48 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                 buffer_size_bytes_full_size_channel,
                 mux_base_l1_address);
 
+            // V2 places one logical channel per worker; the config also lays out the shared control
+            // regions the forwarder/manager pair use. Only constructed when opted in.
+            std::optional<tt::tt_fabric::FabricMuxV2Config> mux_v2_config;
+            if (use_mux_v2) {
+                mux_v2_config.emplace(
+                    static_cast<uint8_t>(num_full_size_channels),
+                    static_cast<uint8_t>(num_buffers_full_size_channels),
+                    buffer_size_bytes_full_size_channel,
+                    mux_base_l1_address);
+            }
+
             const bool mux_connection_valid =
                 (dir && backward_coord.has_value()) || (!dir && forward_coord.has_value());
             if (mux_connection_valid) {
-                auto mux_kernel_id = tt::tt_metal::CreateKernel(
-                    program,
-                    "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
-                    {mux_logical_core},
-                    tt::tt_metal::DataMovementConfig{
-                        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-                        .noc = tt::tt_metal::NOC::RISCV_0_default,
-                        .compile_args = mux_kernel_config.get_fabric_mux_compile_time_args(),
-                        .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
-                std::vector<uint32_t> mux_rt_args = {};
                 const auto src_node_id = mesh_device->get_fabric_node_id(sender_device_coord);
-                if (dir) {  // forward
-                    const auto dst_node_id = mesh_device->get_fabric_node_id(backward_coord.value());
-                    mux_rt_args = mux_kernel_config.get_fabric_mux_run_time_args(
-                        src_node_id, dst_node_id, link, program, {mux_logical_core});
+                const auto dst_node_id =
+                    mesh_device->get_fabric_node_id(dir ? backward_coord.value() : forward_coord.value());
+                if (use_mux_v2) {
+                    // Creates both the forwarder (RISCV_0) and manager (RISCV_1) kernels on the mux
+                    // core and wires the forwarder's downstream fabric connection runtime args.
+                    tt::tt_fabric::add_fabric_mux_v2_to_program(
+                        program,
+                        *mux_v2_config,
+                        mux_logical_core,
+                        src_node_id,
+                        dst_node_id,
+                        link,
+                        tt::tt_metal::NOC::RISCV_0_default);
                 } else {
-                    const auto dst_node_id = mesh_device->get_fabric_node_id(forward_coord.value());
-                    mux_rt_args = mux_kernel_config.get_fabric_mux_run_time_args(
+                    auto mux_kernel_id = tt::tt_metal::CreateKernel(
+                        program,
+                        "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
+                        {mux_logical_core},
+                        tt::tt_metal::DataMovementConfig{
+                            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+                            .noc = tt::tt_metal::NOC::RISCV_0_default,
+                            .compile_args = mux_kernel_config.get_fabric_mux_compile_time_args(),
+                            .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
+                    std::vector<uint32_t> mux_rt_args = mux_kernel_config.get_fabric_mux_run_time_args(
                         src_node_id, dst_node_id, link, program, {mux_logical_core});
+                    tt::tt_metal::SetRuntimeArgs(program, mux_kernel_id, {mux_logical_core}, mux_rt_args);
                 }
-                tt::tt_metal::SetRuntimeArgs(program, mux_kernel_id, {mux_logical_core}, mux_rt_args);
             }
 
             for (uint32_t worker = 0; worker < num_workers_per_direction; worker++) {
@@ -562,6 +641,9 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                             worker + (link * num_workers_per_direction),
                             0);
                     }
+                    // When the writer signals the matmul directly over fabric, the reader must not
+                    // also relay the signal (it would double-count the matmul semaphore).
+                    reader_rt_args.push_back(static_cast<uint32_t>(writer_signals_mm ? 1 : 0));
                 }
 
                 tt::tt_metal::SetRuntimeArgs(program, worker_sender_reader_kernel_id, {core}, reader_rt_args);
@@ -585,13 +667,21 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                     global_worker_count,
                     global_worker_id,
                 };
-                detail::strided_fabric_mux_connection_ct_args(
-                    worker == 0,
-                    mux_virtual_core,
-                    tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
-                    worker,
-                    mux_kernel_config,
-                    sender_writer_compile_args);
+                if (use_mux_v2) {
+                    // V2 is runtime-arg driven and needs no mux compile-time args. Emit the same
+                    // number of slots (is_termination_master + 12 fillers) the V1 helper pushes so the
+                    // trailing line-unicast route info keeps its fixed compile-time-arg index.
+                    sender_writer_compile_args.push_back(worker == 0);
+                    sender_writer_compile_args.insert(sender_writer_compile_args.end(), 12, 0);
+                } else {
+                    detail::strided_fabric_mux_connection_ct_args(
+                        worker == 0,
+                        mux_virtual_core,
+                        tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
+                        worker,
+                        mux_kernel_config,
+                        sender_writer_compile_args);
+                }
                 if (dir) {
                     sender_writer_compile_args.insert(
                         sender_writer_compile_args.end(), unicast_backward_args.begin(), unicast_backward_args.end());
@@ -635,22 +725,95 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                         writer_rt_args.push_back(width);
                     }
                 }
-                detail::strided_fabric_mux_connection_rt_args(
-                    mux_connection_valid,
-                    core,
-                    program,
-                    termination_master_virtual_core,
-                    num_workers_per_direction,
-                    writer_rt_args);
+                if (use_mux_v2) {
+                    // Layout: [mux_connection_valid][11 client-connection args]. The writer's
+                    // FabricMuxV2Sender::build_from_args consumes the 11 args in this exact order.
+                    writer_rt_args.push_back(static_cast<uint32_t>(mux_connection_valid ? 1 : 0));
+                    const uint32_t flow_control_sem_id = CreateSemaphore(program, {core}, 0);
+                    const uint32_t teardown_sem_id = CreateSemaphore(program, {core}, 0);
+                    mux_v2_config->append_client_connection_rt_args(
+                        mux_virtual_core,
+                        static_cast<uint8_t>(worker),
+                        {flow_control_sem_id, teardown_sem_id},
+                        writer_rt_args);
+                } else {
+                    detail::strided_fabric_mux_connection_rt_args(
+                        mux_connection_valid,
+                        core,
+                        program,
+                        termination_master_virtual_core,
+                        num_workers_per_direction,
+                        writer_rt_args);
+                }
                 if (fuse_op) {
+                    // Local self-signal path (op_signaler_sender): targets the single 'self' semaphore,
+                    // which is the last entry in the matmul semaphore vector [backward_0..N-1,
+                    // forward_0..N-1, self].
+                    const uint32_t self_sem_index =
+                        fused_op_signaler_sender_workers->fused_op_receiver_signal_semaphores.size() - 1;
                     fused_op_signaler_sender_workers->push_all_gather_fused_op_rt_args(
                         writer_rt_args,
                         num_workers_per_direction * num_links,
                         worker + (link * num_workers_per_direction),
-                        2);
+                        self_sem_index);
+                    // Option W: this worker signals its own per-worker semaphore on the remote direction's
+                    // aggregation core (single core), which collects all N workers and signals the matmul.
+                    writer_rt_args.push_back(static_cast<uint32_t>(writer_signals_mm ? 1 : 0));
+                    writer_rt_args.push_back(static_cast<uint32_t>(writer_signals_mm ? agg_core_virtual[dir].x : 0));
+                    writer_rt_args.push_back(static_cast<uint32_t>(writer_signals_mm ? agg_core_virtual[dir].y : 0));
+                    writer_rt_args.push_back(
+                        static_cast<uint32_t>(writer_signals_mm ? agg_per_worker_sem_ids[dir][global_worker_id] : 0));
                 }
                 tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
             }
+        }
+    }
+
+    // Option W: create one matmul-signal aggregator kernel per direction. Each waits for all N AG
+    // writer workers of its direction to signal a k-block landed, then signals every matmul core's
+    // direction semaphore once - decoupling the matmul from the AG reader's forwarding pace.
+    if (writer_signals_mm) {
+        const uint32_t num_mm_cores = fused_op_signaler.value().num_fused_op_cores_to_signal;
+        for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
+            std::vector<uint32_t> agg_ct_args = {
+                ring_index,
+                num_targets_forward,
+                num_targets_backward,
+                static_cast<uint32_t>(topology),
+                dir,
+                num_ag_workers,
+                num_mm_cores,
+            };
+            auto agg_kernel_id = tt::tt_metal::CreateKernel(
+                program,
+                "ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/"
+                "minimal_default_mm_signal_aggregator.cpp",
+                {agg_core_logical[dir]},
+                tt::tt_metal::DataMovementConfig{
+                    .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt::tt_metal::NOC::RISCV_0_default,
+                    .compile_args = agg_ct_args,
+                    .defines = agg_defines});
+
+            std::vector<uint32_t> agg_rt_args = {
+                ring_size,
+                batch_head_size,
+                input_tensor_Ht,
+                mm_cores_y_val,
+                mm_block_ht_val,
+                fused_op_signaler.value().fused_op_receiver_signal_semaphores[dir],  // mm direction sem id
+            };
+            for (uint32_t d = 0; d < ring_size; d++) {
+                agg_rt_args.push_back(device_k_block_counts[d]);
+            }
+            for (uint32_t w = 0; w < num_ag_workers; w++) {
+                agg_rt_args.push_back(agg_per_worker_sem_ids[dir][w]);
+            }
+            for (const auto& mm_core : fused_op_signaler.value().fused_op_receiver_cores_noc) {
+                agg_rt_args.push_back(static_cast<uint32_t>(mm_core.x));
+                agg_rt_args.push_back(static_cast<uint32_t>(mm_core.y));
+            }
+            tt::tt_metal::SetRuntimeArgs(program, agg_kernel_id, {agg_core_logical[dir]}, agg_rt_args);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_device_operation_types.hpp
@@ -67,6 +67,11 @@ struct StridedAllGatherMinimalMatmulAsyncInputs {
     const Tensor weight_tensor;
     const std::optional<Tensor> persistent_output_buffer;
     const std::optional<const Tensor> bias = std::nullopt;
+
+    // Fused addcmul: matmul_output = ternary_a + fused_ternary_scalar * matmul_out * ternary_b.
+    // Presence of both a and b enables FUSE_TERNARY in the matmul factory; the scalar rides in matmul_struct.
+    const std::optional<const Tensor> fused_ternary_input_a = std::nullopt;
+    const std::optional<const Tensor> fused_ternary_input_b = std::nullopt;
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_device_operation_types.hpp
@@ -68,8 +68,7 @@ struct StridedAllGatherMinimalMatmulAsyncInputs {
     const std::optional<Tensor> persistent_output_buffer;
     const std::optional<const Tensor> bias = std::nullopt;
 
-    // Fused addcmul: matmul_output = ternary_a + fused_ternary_scalar * matmul_out * ternary_b.
-    // Presence of both a and b enables FUSE_TERNARY in the matmul factory; the scalar rides in matmul_struct.
+    // Fused addcmul: matmul_output = ternary_a + fused_ternary_scalar * matmul_out * ternary_b
     const std::optional<const Tensor> fused_ternary_input_a = std::nullopt;
     const std::optional<const Tensor> fused_ternary_input_b = std::nullopt;
 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.cpp
@@ -28,8 +28,7 @@ void StridedAllGatherMinimalMatmulAsync::validate_on_program_cache_miss(
             !attributes.matmul_struct.fused_activation.has_value(),
             "StridedAllGatherMinimalMatmulAsync cannot combine fused_activation with ternary (addcmul) inputs.");
 
-        // Matmul output is [.., M, N]; ternary_a must match [M, N], ternary_b is [1, N] (broadcast) or [M, N].
-        // Derive M/N the same way compute_output_specs does (standalone matmul on input + weight).
+        // Matmul output is [.., M, N]
         auto mm_specs = matmul_device_operation_t::compute_output_specs(
             attributes.matmul_struct, {tensor_args.input_tensor, tensor_args.weight_tensor});
         const auto& mm_logical = mm_specs[0].logical_shape();
@@ -67,8 +66,7 @@ StridedAllGatherMinimalMatmulAsync::spec_return_value_t StridedAllGatherMinimalM
     tt::tt_metal::TensorSpec strided_all_gather_output_shape = StridedAllGatherAsync::compute_output_specs(
         attributes.strided_all_gather_async_struct, StridedAllGatherAsyncInputs{tensor_args.input_tensor});
 
-    // Matmul specs: one per output chunk (chunks == 1 by default). Output layout is
-    // [all_gather_output, matmul_chunk_0, ..., matmul_chunk_{chunks-1}].
+    // Matmul specs: one per output chunk (chunks == 1 by default)
     auto minimal_matmul_output_specs_vec = matmul_device_operation_t::compute_output_specs(
         attributes.matmul_struct, {tensor_args.input_tensor, tensor_args.weight_tensor});
 
@@ -130,8 +128,7 @@ std::vector<Tensor> strided_all_gather_minimal_matmul_async(
     int32_t chunks) {
     using OperationType = ttnn::experimental::prim::StridedAllGatherMinimalMatmulAsync;
 
-    // addcmul uses value=1 (torch default) when ternary inputs are given without an explicit scalar; the
-    // matmul factory unconditionally reads the scalar RT arg once ternary tensors are present.
+    // addcmul uses value=1 (torch default) when ternary inputs are given without an explicit scalar
     if (fused_ternary_input_a.has_value() && !fused_ternary_scalar.has_value()) {
         fused_ternary_scalar = 1.0f;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.cpp
@@ -20,6 +20,45 @@ void StridedAllGatherMinimalMatmulAsync::validate_on_program_cache_miss(
     TT_FATAL(
         tensor_args.input_tensor.padded_shape()[0] == 1 && tensor_args.input_tensor.padded_shape()[1] == 1,
         "StridedAllGatherMinimalMatmulAsync requires input tensor to have batch size of 1.");
+    TT_FATAL(
+        tensor_args.fused_ternary_input_a.has_value() == tensor_args.fused_ternary_input_b.has_value(),
+        "StridedAllGatherMinimalMatmulAsync fused addcmul requires both ternary inputs (a and b) or neither.");
+    if (tensor_args.fused_ternary_input_a.has_value()) {
+        TT_FATAL(
+            !attributes.matmul_struct.fused_activation.has_value(),
+            "StridedAllGatherMinimalMatmulAsync cannot combine fused_activation with ternary (addcmul) inputs.");
+
+        // Matmul output is [.., M, N]; ternary_a must match [M, N], ternary_b is [1, N] (broadcast) or [M, N].
+        // Derive M/N the same way compute_output_specs does (standalone matmul on input + weight).
+        auto mm_specs = matmul_device_operation_t::compute_output_specs(
+            attributes.matmul_struct, {tensor_args.input_tensor, tensor_args.weight_tensor});
+        const auto& mm_logical = mm_specs[0].logical_shape();
+        const uint32_t M = mm_logical[-2];
+        const uint32_t N = mm_logical[-1];
+
+        const auto& ternary_a = tensor_args.fused_ternary_input_a.value();
+        const auto& ternary_b = tensor_args.fused_ternary_input_b.value();
+        TT_FATAL(
+            ternary_a.layout() == tt::tt_metal::Layout::TILE && ternary_b.layout() == tt::tt_metal::Layout::TILE,
+            "StridedAllGatherMinimalMatmulAsync ternary inputs must be TILE layout.");
+        const auto& a_logical = ternary_a.logical_shape();
+        const auto& b_logical = ternary_b.logical_shape();
+        TT_FATAL(
+            a_logical[-2] == M && a_logical[-1] == N,
+            "fused_ternary_input_a shape must match matmul output [M={}, N={}], got [{}, {}].",
+            M,
+            N,
+            a_logical[-2],
+            a_logical[-1]);
+        TT_FATAL(
+            (b_logical[-2] == 1 || b_logical[-2] == M) && b_logical[-1] == N,
+            "fused_ternary_input_b shape must be [1, N={}] (broadcast) or [M={}, N={}] (full), got [{}, {}].",
+            N,
+            M,
+            N,
+            b_logical[-2],
+            b_logical[-1]);
+    }
 }
 
 StridedAllGatherMinimalMatmulAsync::spec_return_value_t StridedAllGatherMinimalMatmulAsync::compute_output_specs(
@@ -28,13 +67,18 @@ StridedAllGatherMinimalMatmulAsync::spec_return_value_t StridedAllGatherMinimalM
     tt::tt_metal::TensorSpec strided_all_gather_output_shape = StridedAllGatherAsync::compute_output_specs(
         attributes.strided_all_gather_async_struct, StridedAllGatherAsyncInputs{tensor_args.input_tensor});
 
-    // Matmul shape - now returns a vector, extract the single output (chunks=1 by default)
+    // Matmul specs: one per output chunk (chunks == 1 by default). Output layout is
+    // [all_gather_output, matmul_chunk_0, ..., matmul_chunk_{chunks-1}].
     auto minimal_matmul_output_specs_vec = matmul_device_operation_t::compute_output_specs(
         attributes.matmul_struct, {tensor_args.input_tensor, tensor_args.weight_tensor});
-    TT_FATAL(minimal_matmul_output_specs_vec.size() == 1, "Expected single matmul output spec");
-    tt::tt_metal::TensorSpec minimal_matmul_output_specs = minimal_matmul_output_specs_vec[0];
 
-    return {strided_all_gather_output_shape, minimal_matmul_output_specs};
+    spec_return_value_t specs;
+    specs.reserve(1 + minimal_matmul_output_specs_vec.size());
+    specs.push_back(strided_all_gather_output_shape);
+    for (auto& spec : minimal_matmul_output_specs_vec) {
+        specs.push_back(spec);
+    }
+    return specs;
 }
 
 StridedAllGatherMinimalMatmulAsync::tensor_return_value_t StridedAllGatherMinimalMatmulAsync::create_output_tensors(
@@ -44,13 +88,17 @@ StridedAllGatherMinimalMatmulAsync::tensor_return_value_t StridedAllGatherMinima
         attributes.strided_all_gather_async_struct,
         StridedAllGatherAsyncInputs{tensor_args.input_tensor, tensor_args.persistent_output_buffer});
 
-    // Matmul output tensor - now returns a vector, extract the single output (chunks=1 by default)
+    // Matmul outputs: one per chunk (chunks == 1 by default), appended after the all-gather output.
     auto minimal_matmul_output_tensors_vec = matmul_device_operation_t::create_output_tensors(
         attributes.matmul_struct, {strided_all_gather_output_tensor, tensor_args.weight_tensor});
-    TT_FATAL(minimal_matmul_output_tensors_vec.size() == 1, "Expected single matmul output tensor");
-    ttnn::Tensor minimal_matmul_output_tensor = minimal_matmul_output_tensors_vec[0];
 
-    return {strided_all_gather_output_tensor, minimal_matmul_output_tensor};
+    tensor_return_value_t outputs;
+    outputs.reserve(1 + minimal_matmul_output_tensors_vec.size());
+    outputs.push_back(strided_all_gather_output_tensor);
+    for (auto& t : minimal_matmul_output_tensors_vec) {
+        outputs.push_back(t);
+    }
+    return outputs;
 }
 
 }  // namespace ttnn::experimental::prim
@@ -75,8 +123,18 @@ std::vector<Tensor> strided_all_gather_minimal_matmul_async(
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel,
-    std::optional<bool> read_local_slice_from_input) {
+    std::optional<bool> read_local_slice_from_input,
+    const std::optional<const Tensor>& fused_ternary_input_a,
+    const std::optional<const Tensor>& fused_ternary_input_b,
+    std::optional<float> fused_ternary_scalar,
+    int32_t chunks) {
     using OperationType = ttnn::experimental::prim::StridedAllGatherMinimalMatmulAsync;
+
+    // addcmul uses value=1 (torch default) when ternary inputs are given without an explicit scalar; the
+    // matmul factory unconditionally reads the scalar RT arg once ternary tensors are present.
+    if (fused_ternary_input_a.has_value() && !fused_ternary_scalar.has_value()) {
+        fused_ternary_scalar = 1.0f;
+    }
 
     std::vector<std::optional<const Tensor>> optional_input_tensors = {};
     std::vector<IDevice*> devices = ttnn::ccl::get_active_physical_devices(input_tensor);
@@ -109,7 +167,9 @@ std::vector<Tensor> strided_all_gather_minimal_matmul_async(
         .config = config,
         .fused_activation = std::move(fused_activation),
         .output_mem_config = memory_config_mm,
-        .compute_kernel_config = compute_kernel_config.value()};
+        .fused_ternary_scalar = fused_ternary_scalar,
+        .compute_kernel_config = compute_kernel_config.value(),
+        .chunks = chunks};
     ttnn::experimental::prim::StridedAllGatherAsync ag_op{};
 
     bool read_local_from_input = read_local_slice_from_input.value_or(false);
@@ -121,7 +181,8 @@ std::vector<Tensor> strided_all_gather_minimal_matmul_async(
         read_local_from_input,
         devices,
         ag_op};
-    auto tensor_args = OperationType::tensor_args_t{input_tensor, weight_tensor, persistent_output_buffer, bias};
+    auto tensor_args = OperationType::tensor_args_t{
+        input_tensor, weight_tensor, persistent_output_buffer, bias, fused_ternary_input_a, fused_ternary_input_b};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.hpp
@@ -66,6 +66,10 @@ std::vector<Tensor> strided_all_gather_minimal_matmul_async(
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel,
-    std::optional<bool> read_local_slice_from_input);
+    std::optional<bool> read_local_slice_from_input,
+    const std::optional<const Tensor>& fused_ternary_input_a,
+    const std::optional<const Tensor>& fused_ternary_input_b,
+    std::optional<float> fused_ternary_scalar,
+    int32_t chunks);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.cpp
@@ -119,10 +119,7 @@ strided_all_gather_minimal_matmul_async_program(
         read_local_slice_from_input,
         read_local_slice_from_input ? std::optional<const Tensor>(input_tensor) : std::nullopt);
 
-    // Option W (writer-signals-matmul): the matmul cores keep the legacy 3 semaphores (backward,
-    // forward, self) and wait +1 per k-block. When the flag is on, a dedicated per-direction
-    // aggregation core (see the AG program factory) collects the N per-worker landing signals and
-    // provides that single +1 - so the matmul semaphore count is unchanged here (num_ag_workers = 1).
+    // Option W (writer-signals-matmul): the matmul cores keep the legacy 3 semaphores
 
     // Matmul outputs: one tensor per chunk (chunks == 1 -> single output).
     std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> empty_srs_fused_op_signaler;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ///
 #include <algorithm>
+#include <cstdlib>
 
 #include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_op.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
@@ -18,7 +19,7 @@
 #include "ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.hpp"
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
 #include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.hpp"
-#include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp"
+#include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_fabric_bound_program_factory.hpp"
 
 using namespace tt::constants;
 
@@ -54,15 +55,21 @@ void StridedAllGatherMinimalMatmulAsyncProgramFactory::override_runtime_argument
             StridedAllGatherAsyncInputs(tensor_args.input_tensor),
             output_tensor.at(0));
 
-        auto cached_program_proxy = ttnn::experimental::prim::MinimalMatmulProgramFactory::cached_program_t::proxy(
-            program, shared_variables.mm_shared_variables);
+        auto cached_program_proxy =
+            ttnn::experimental::prim::MinimalMatmulFabricBoundProgramFactory::cached_program_t::proxy(
+                program, shared_variables.mm_shared_variables);
 
-        // Create a vector for the single output tensor
-        std::vector<Tensor> matmul_output_vec = {output_tensor.at(1)};
-        ttnn::experimental::prim::MinimalMatmulProgramFactory::override_runtime_arguments(
+        // Matmul outputs are all tensors after the all-gather output (one per chunk).
+        std::vector<Tensor> matmul_output_vec(output_tensor.begin() + 1, output_tensor.end());
+        ttnn::experimental::prim::MinimalMatmulFabricBoundProgramFactory::override_runtime_arguments(
             cached_program_proxy,
             attributes.matmul_struct,
-            {output_tensor.at(0), tensor_args.weight_tensor, tensor_args.bias, tensor_args.input_tensor},
+            {output_tensor.at(0),
+             tensor_args.weight_tensor,
+             tensor_args.bias,
+             tensor_args.input_tensor,
+             tensor_args.fused_ternary_input_a,
+             tensor_args.fused_ternary_input_b},
             matmul_output_vec);
     }
 }
@@ -72,7 +79,7 @@ strided_all_gather_minimal_matmul_async_program(
     const Tensor& input_tensor,
     Tensor& all_gather_output_tensor,
     const Tensor& weight_tensor,
-    Tensor& matmul_output_tensor,
+    std::vector<Tensor> matmul_output_tensors,
     bool read_local_slice_from_input,
 
     /* All Gather Params */
@@ -94,7 +101,10 @@ strided_all_gather_minimal_matmul_async_program(
     const std::optional<const Tensor>& bias,
     const std::optional<operations::unary::UnaryWithParam>& fused_activation,
     ttnn::experimental::prim::MinimalMatmulConfig config,
-    DeviceComputeKernelConfig compute_kernel_config) {
+    DeviceComputeKernelConfig compute_kernel_config,
+    std::optional<float> fused_ternary_scalar,
+    const std::optional<const Tensor>& fused_ternary_input_a,
+    const std::optional<const Tensor>& fused_ternary_input_b) {
     tt::tt_metal::Program program{};
 
     // Create a matmul signal info object that gets populated by the matmul kernel
@@ -109,10 +119,14 @@ strided_all_gather_minimal_matmul_async_program(
         read_local_slice_from_input,
         read_local_slice_from_input ? std::optional<const Tensor>(input_tensor) : std::nullopt);
 
-    // Matmul - wrap single output tensor in vector for unified interface
+    // Option W (writer-signals-matmul): the matmul cores keep the legacy 3 semaphores (backward,
+    // forward, self) and wait +1 per k-block. When the flag is on, a dedicated per-direction
+    // aggregation core (see the AG program factory) collects the N per-worker landing signals and
+    // provides that single +1 - so the matmul semaphore count is unchanged here (num_ag_workers = 1).
+
+    // Matmul outputs: one tensor per chunk (chunks == 1 -> single output).
     std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> empty_srs_fused_op_signaler;
-    std::vector<Tensor> matmul_output_tensors = {matmul_output_tensor};
-    auto mm_shared_variables = ttnn::experimental::prim::minimal_matmul_factory_helper_common(
+    auto mm_shared_variables = ttnn::experimental::prim::minimal_matmul_fabric_bound_factory_helper_common(
         program,
         all_gather_output_tensor,
         weight_tensor,
@@ -122,10 +136,10 @@ strided_all_gather_minimal_matmul_async_program(
         matmul_output_tensors,
         compute_kernel_config,
         matmul_fused_op_signaler,
-        1,  // N_chunks = 1 for single output
-        std::nullopt,
-        std::nullopt,
-        std::nullopt,
+        static_cast<uint32_t>(matmul_output_tensors.size()),  // N_chunks
+        fused_ternary_scalar,
+        fused_ternary_input_a,
+        fused_ternary_input_b,
         empty_srs_fused_op_signaler);
 
     // Create the all gather fused op signaler
@@ -189,12 +203,15 @@ StridedAllGatherMinimalMatmulAsyncProgramFactory::create_at(
         attributes.strided_all_gather_async_struct.topology,
         attributes.strided_all_gather_async_struct.cluster_axis);
 
+    // Matmul outputs are all tensors after the all-gather output (one per chunk).
+    std::vector<Tensor> matmul_output_tensors(output_tensor.begin() + 1, output_tensor.end());
+
     // Return the StridedAllGatherMinimalMatmulAsync program with callbacks
     return strided_all_gather_minimal_matmul_async_program(
         tensor_args.input_tensor,   // input_tensor
         output_tensor[0],           // all_gather_output_tensor
         tensor_args.weight_tensor,  // weight_tensor
-        output_tensor[1],           // matmul_output_tensor
+        matmul_output_tensors,      // matmul_output_tensors (one per chunk)
         attributes.read_local_slice_from_input,
 
         /* All Gather Params */
@@ -216,7 +233,10 @@ StridedAllGatherMinimalMatmulAsyncProgramFactory::create_at(
         tensor_args.bias,  // Bias
         attributes.matmul_struct.fused_activation,
         attributes.matmul_struct.config.value(),
-        attributes.matmul_struct.compute_kernel_config);
+        attributes.matmul_struct.compute_kernel_config,
+        attributes.matmul_struct.fused_ternary_scalar,
+        tensor_args.fused_ternary_input_a,
+        tensor_args.fused_ternary_input_b);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.hpp
@@ -6,14 +6,14 @@
 
 #include "strided_all_gather_minimal_matmul_async_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp"
+#include "ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_fabric_bound_program_factory.hpp"
 
 namespace ttnn::experimental::prim {
 
 struct StridedAllGatherMinimalMatmulAsyncProgramFactory {
     struct shared_variables_t {
         StridedAllGatherAsyncProgramFactory::shared_variables_t ag_shared_variables;
-        MinimalMatmulProgramFactory::shared_variables_t mm_shared_variables;
+        MinimalMatmulFabricBoundProgramFactory::shared_variables_t mm_shared_variables;
     };
 
     using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async.cpp
@@ -25,7 +25,11 @@ std::vector<ttnn::Tensor> strided_all_gather_minimal_matmul_async(
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel,
-    std::optional<bool> read_local_slice_from_input) {
+    std::optional<bool> read_local_slice_from_input,
+    const std::optional<const Tensor>& fused_ternary_input_a,
+    const std::optional<const Tensor>& fused_ternary_input_b,
+    std::optional<float> fused_ternary_scalar,
+    int32_t chunks) {
     return ttnn::prim::strided_all_gather_minimal_matmul_async(
         input_tensor,
         weight_tensor,
@@ -45,7 +49,11 @@ std::vector<ttnn::Tensor> strided_all_gather_minimal_matmul_async(
         num_workers_per_link.value_or(
             1),  // Conservatively 1 right now since the all gather core grid is hardcoded from the outside
         num_buffers_per_channel,
-        read_local_slice_from_input);
+        read_local_slice_from_input,
+        fused_ternary_input_a,
+        fused_ternary_input_b,
+        fused_ternary_scalar,
+        chunks);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async.hpp
@@ -30,6 +30,10 @@ std::vector<ttnn::Tensor> strided_all_gather_minimal_matmul_async(
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     std::optional<uint32_t> num_workers_per_link = std::nullopt,
     std::optional<uint32_t> num_buffers_per_channel = std::nullopt,
-    std::optional<bool> read_local_slice_from_input = std::nullopt);
+    std::optional<bool> read_local_slice_from_input = std::nullopt,
+    const std::optional<const Tensor>& fused_ternary_input_a = std::nullopt,
+    const std::optional<const Tensor>& fused_ternary_input_b = std::nullopt,
+    std::optional<float> fused_ternary_scalar = std::nullopt,
+    int32_t chunks = 1);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async_nanobind.cpp
@@ -47,6 +47,10 @@ void bind_strided_all_gather_minimal_matmul_async(nb::module_& mod) {
             * :attr:`program_config` (Optional[ttnn.MatmulProgramConfig])
             * :attr:`fused_activation` (Optional[str])
             * :attr:`compute_kernel_config` (Optional[DeviceComputeKernelConfig])
+            * :attr:`fused_ternary_input_a` (Optional[ttnn.Tensor]): addcmul residual/base tensor (added to the result).
+            * :attr:`fused_ternary_input_b` (Optional[ttnn.Tensor]): addcmul multiplier/gate tensor; a single tile-row broadcasts across M.
+            * :attr:`fused_ternary_scalar` (Optional[float]): addcmul scale; output = a + scalar * matmul_out * b. Requires both a and b.
+            * :attr:`chunks` (int): split the matmul output into this many tensors along N (default 1). Returns [all_gather_output, matmul_chunk_0, ..., matmul_chunk_{chunks-1}]. N must be divisible by chunks.
 
         Example:
 
@@ -74,7 +78,11 @@ void bind_strided_all_gather_minimal_matmul_async(nb::module_& mod) {
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("num_workers_per_link") = nb::none(),
         nb::arg("num_buffers_per_channel") = nb::none(),
-        nb::arg("read_local_slice_from_input") = nb::none());
+        nb::arg("read_local_slice_from_input") = nb::none(),
+        nb::arg("fused_ternary_input_a") = nb::none(),
+        nb::arg("fused_ternary_input_b") = nb::none(),
+        nb::arg("fused_ternary_scalar") = nb::none(),
+        nb::arg("chunks") = 1);
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_reduction.cpp
@@ -83,6 +83,9 @@ void kernel_main() {
                 const uint32_t effective_chunk_width_in_tiles =
                     get_effective_chunk_width_in_tiles(chunk_idx, chunk_width_in_tiles, mm_N_full_block_wt);
                 const uint32_t effective_subchunk_size = current_mm_block_ht * effective_chunk_width_in_tiles;
+                // Hoist the (run-invariant) divisions out of the tile advance.
+                const auto steps_worker = decompose_tile_advance(
+                    effective_worker_id, effective_subchunk_size, effective_chunk_width_in_tiles);
 
                 // Same slice_idx pattern as the reader, but starting at i=1 (skipping
                 // the read-only i=0 pass that the compute kernel does not participate in).
@@ -106,8 +109,7 @@ void kernel_main() {
                             tile_row_in_mm_M_unit_block,
                             chunk_col_in_tiles,
                             mm_core_idx,
-                            effective_worker_id,
-                            effective_subchunk_size,
+                            steps_worker,
                             effective_chunk_width_in_tiles,
                             current_mm_block_ht);
                         uint32_t tiles_to_read = how_many_tiles_to_read_formula(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
@@ -135,8 +135,24 @@ void kernel_main() {
     auto intermediate_tensor_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_tensor_address);
 #endif
 #ifdef FUSE_MM_OP_SIGNALER
-    Semaphore<> mm_op_ready_sem(get_arg_val<uint32_t>(arg_idx++));
+    // Per-core MM progress counters (replaces the old single aggregate semaphore). This is a flat
+    // L1 array of (mm_cores_x * mm_cores_y) uint32 counters, at the same L1 address on every RS
+    // worker core. Each MM core increments its OWN slot (indexed by its row-major core id) as it
+    // completes each output block, with no worker barrier. The reader waits per-tile on the slot of
+    // the specific MM core that produced that tile — so a fast MM core never stalls a slow peer.
+    const uint32_t mm_progress_counters = get_arg_val<uint32_t>(arg_idx++);  // L1 base addr
+    // mm_cores_x = number of MM cores along N. The MM output [M,N] is split into mm_N_full_block_wt-
+    // wide per-core N bands, so mm_cores_x = ceil(N_tiles / N_tiles_per_core).
+    const uint32_t mm_cores_x = (input_tensor_Wt + mm_N_full_block_wt - 1) / mm_N_full_block_wt;
     uint32_t mm_sem_target = 0;
+    {
+        // Zero the counters before any MM increment can arrive. Safe: both kernels launch together
+        // but the MM's first signal is a full output block (~100us) away, while this is a few ns.
+        volatile tt_l1_ptr uint32_t* c = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mm_progress_counters);
+        for (uint32_t i = 0; i < mm_cores_x * mm_cores_y; i++) {
+            c[i] = 0;
+        }
+    }
 #endif
 
 #ifdef FUSE_RS_ADDCMUL
@@ -195,6 +211,11 @@ void kernel_main() {
                 const uint32_t effective_chunk_width_in_tiles =
                     get_effective_chunk_width_in_tiles(chunk_idx, chunk_width_in_tiles, mm_N_full_block_wt);
                 const uint32_t effective_subchunk_size = current_mm_block_ht * effective_chunk_width_in_tiles;
+                // Hoist the (run-invariant) divisions out of the per-tile advance.
+                const auto steps_worker = decompose_tile_advance(
+                    effective_worker_id, effective_subchunk_size, effective_chunk_width_in_tiles);
+                const auto steps_advance = decompose_tile_advance(
+                    effective_advance_by_tiles, effective_subchunk_size, effective_chunk_width_in_tiles);
                 int32_t slice_idx = direction ? my_chip_id - 1 : my_chip_id + 1;
 
 #ifdef FUSE_MM_OP_SIGNALER
@@ -204,7 +225,10 @@ void kernel_main() {
                 // signals guarantees all N-full-blocks covering this chunk are ready.
                 const uint32_t sem_increment = (effective_chunk_width_in_tiles + mm_block_wt - 1) / mm_block_wt;
                 mm_sem_target += sem_increment;
-                mm_op_ready_sem.wait_min(mm_sem_target);
+                // The wait is now PER-TILE on the producing MM core's counter (see the input read
+                // site below), not a single aggregate wait here — so fast MM cores don't stall on
+                // slow peers. mm_sem_target is the block-count threshold; it is identical for every
+                // tile in this chunk, and the same threshold applies per-core.
 #endif
                 // Run a full bidirectional ring reduce-scatter for the current chunk.
                 // i=0: read input -> reader_output_cb (writer forwards to neighbor, no compute).
@@ -222,6 +246,13 @@ void kernel_main() {
 
                     const auto [mm_N_full_blocks_per_slice, cols_before_actual_slice] =
                         get_slice_N_block_info(actual_slice_idx, slice_Wt, mm_N_full_block_wt);
+#ifdef FUSE_MM_OP_SIGNALER
+                    // Producing MM core-x base for this ring slice. A tile's MM output column is
+                    // slice_N_begin + slice_col, with slice_N_begin = floor(actual_slice_idx*slice_Wt /
+                    // mm_N_full_block_wt)*mm_N_full_block_wt (MM-core aligned). slice_col's sub-block part is
+                    // always < mm_N_full_block_wt, so core-x = slice_N_begin/mm_N_full_block_wt + chunk_piece_idx.
+                    const uint32_t mm_core_x_base = (actual_slice_idx * slice_Wt) / mm_N_full_block_wt;
+#endif
                     // Wait for the neighboring device's writer to signal that it has finished
                     // writing this chunk's tiles into our intermediate buffer.
                     if (do_reduce) {
@@ -235,13 +266,17 @@ void kernel_main() {
                         uint32_t tile_row_in_mm_M_unit_block = 0;
                         uint32_t chunk_col_in_tiles = 0;
                         uint32_t mm_core_idx = 0;
+#ifdef FUSE_MM_OP_SIGNALER
+                        // core-x is constant across this chunk piece (one MM N-band); core-y = mm_core_idx varies per
+                        // tile.
+                        const uint32_t mm_core_x = mm_core_x_base + chunk_piece_idx;
+#endif
                         // Get the first tile coordinates for the current chunk piece
                         get_next_tile_coordinates(
                             tile_row_in_mm_M_unit_block,
                             chunk_col_in_tiles,
                             mm_core_idx,
-                            effective_worker_id,
-                            effective_subchunk_size,
+                            steps_worker,
                             effective_chunk_width_in_tiles,
                             current_mm_block_ht);
                         uint32_t tiles_to_read = how_many_tiles_to_read_formula(
@@ -294,6 +329,23 @@ void kernel_main() {
                                     const uint32_t global_tile_idx = slice_coordinates_to_global_tile_index(
                                         slice_row, col_in_slice, actual_slice_idx, slice_Wt, input_tensor_Wt);
                                     const uint32_t input_tile_id = global_tile_idx + batch_offset;
+#ifdef FUSE_MM_OP_SIGNALER
+                                    // Per-tile gate: block until the MM core (row-major id) that produced this
+                                    // tile has completed >= mm_sem_target blocks. The counters are written
+                                    // remotely by the MM and only ever INCREASE, so a plain (un-invalidated)
+                                    // read is a safe lower bound on the true value: if it already shows
+                                    // >= target the data is definitely ready and we skip the invalidate-heavy
+                                    // spin entirely. Only a short read falls through to noc_semaphore_wait_min
+                                    // (which flushes L1). This avoids an L1-cache flush on the common
+                                    // already-satisfied path — ~one per tile across the whole slice.
+                                    const uint32_t mm_core_id = mm_core_idx * mm_cores_x + mm_core_x;
+                                    volatile tt_l1_ptr uint32_t* mm_counter_ptr =
+                                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                                            mm_progress_counters + mm_core_id * sizeof(uint32_t));
+                                    if (*mm_counter_ptr < mm_sem_target) {
+                                        noc_semaphore_wait_min(mm_counter_ptr, mm_sem_target);
+                                    }
+#endif
                                     noc_obj.async_read(
                                         input_tensor_addrgen,
                                         CoreLocalMem<uint8_t>(l1_write_addr),
@@ -350,8 +402,7 @@ void kernel_main() {
                                     tile_row_in_mm_M_unit_block,
                                     chunk_col_in_tiles,
                                     mm_core_idx,
-                                    effective_advance_by_tiles,
-                                    effective_subchunk_size,
+                                    steps_advance,
                                     effective_chunk_width_in_tiles,
                                     current_mm_block_ht);
                             }
@@ -377,8 +428,11 @@ void kernel_main() {
         // (lost signal). Target grows across batches; reset once at kernel exit. See #50793.
 
 #ifdef FUSE_MM_OP_SIGNALER
-        mm_op_ready_sem.set(0);
-        mm_sem_target = 0;
+        // Per-core signaling: mm_sem_target and the per-core counters are MONOTONIC across batches
+        // (the MM increments each core's counter once per block for the whole run, never resetting),
+        // so there is deliberately no per-batch reset here — resetting would race with the MM still
+        // incrementing. NOTE: multi-batch (B>1) correctness requires the MM to keep its per-core
+        // counters monotonic across batches (it does — the barrier→per-core change preserves this).
 #endif
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
@@ -135,19 +135,13 @@ void kernel_main() {
     auto intermediate_tensor_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_tensor_address);
 #endif
 #ifdef FUSE_MM_OP_SIGNALER
-    // Per-core MM progress counters (replaces the old single aggregate semaphore). This is a flat
-    // L1 array of (mm_cores_x * mm_cores_y) uint32 counters, at the same L1 address on every RS
-    // worker core. Each MM core increments its OWN slot (indexed by its row-major core id) as it
-    // completes each output block, with no worker barrier. The reader waits per-tile on the slot of
-    // the specific MM core that produced that tile — so a fast MM core never stalls a slow peer.
+    // Per-core MM progress counters (replaces the old single aggregate semaphore)
     const uint32_t mm_progress_counters = get_arg_val<uint32_t>(arg_idx++);  // L1 base addr
-    // mm_cores_x = number of MM cores along N. The MM output [M,N] is split into mm_N_full_block_wt-
-    // wide per-core N bands, so mm_cores_x = ceil(N_tiles / N_tiles_per_core).
+    // mm_cores_x = number of MM cores along N
     const uint32_t mm_cores_x = (input_tensor_Wt + mm_N_full_block_wt - 1) / mm_N_full_block_wt;
     uint32_t mm_sem_target = 0;
     {
-        // Zero the counters before any MM increment can arrive. Safe: both kernels launch together
-        // but the MM's first signal is a full output block (~100us) away, while this is a few ns.
+        // Zero the counters before any MM increment can arrive
         volatile tt_l1_ptr uint32_t* c = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mm_progress_counters);
         for (uint32_t i = 0; i < mm_cores_x * mm_cores_y; i++) {
             c[i] = 0;
@@ -225,10 +219,7 @@ void kernel_main() {
                 // signals guarantees all N-full-blocks covering this chunk are ready.
                 const uint32_t sem_increment = (effective_chunk_width_in_tiles + mm_block_wt - 1) / mm_block_wt;
                 mm_sem_target += sem_increment;
-                // The wait is now PER-TILE on the producing MM core's counter (see the input read
-                // site below), not a single aggregate wait here — so fast MM cores don't stall on
-                // slow peers. mm_sem_target is the block-count threshold; it is identical for every
-                // tile in this chunk, and the same threshold applies per-core.
+                // The wait is now PER-TILE on the producing MM core's counter (see the input read site below)
 #endif
                 // Run a full bidirectional ring reduce-scatter for the current chunk.
                 // i=0: read input -> reader_output_cb (writer forwards to neighbor, no compute).
@@ -247,10 +238,7 @@ void kernel_main() {
                     const auto [mm_N_full_blocks_per_slice, cols_before_actual_slice] =
                         get_slice_N_block_info(actual_slice_idx, slice_Wt, mm_N_full_block_wt);
 #ifdef FUSE_MM_OP_SIGNALER
-                    // Producing MM core-x base for this ring slice. A tile's MM output column is
-                    // slice_N_begin + slice_col, with slice_N_begin = floor(actual_slice_idx*slice_Wt /
-                    // mm_N_full_block_wt)*mm_N_full_block_wt (MM-core aligned). slice_col's sub-block part is
-                    // always < mm_N_full_block_wt, so core-x = slice_N_begin/mm_N_full_block_wt + chunk_piece_idx.
+                    // Producing MM core-x base for this ring slice
                     const uint32_t mm_core_x_base = (actual_slice_idx * slice_Wt) / mm_N_full_block_wt;
 #endif
                     // Wait for the neighboring device's writer to signal that it has finished
@@ -267,8 +255,7 @@ void kernel_main() {
                         uint32_t chunk_col_in_tiles = 0;
                         uint32_t mm_core_idx = 0;
 #ifdef FUSE_MM_OP_SIGNALER
-                        // core-x is constant across this chunk piece (one MM N-band); core-y = mm_core_idx varies per
-                        // tile.
+                        // core-x is constant across this chunk piece (one MM N-band)
                         const uint32_t mm_core_x = mm_core_x_base + chunk_piece_idx;
 #endif
                         // Get the first tile coordinates for the current chunk piece
@@ -330,14 +317,7 @@ void kernel_main() {
                                         slice_row, col_in_slice, actual_slice_idx, slice_Wt, input_tensor_Wt);
                                     const uint32_t input_tile_id = global_tile_idx + batch_offset;
 #ifdef FUSE_MM_OP_SIGNALER
-                                    // Per-tile gate: block until the MM core (row-major id) that produced this
-                                    // tile has completed >= mm_sem_target blocks. The counters are written
-                                    // remotely by the MM and only ever INCREASE, so a plain (un-invalidated)
-                                    // read is a safe lower bound on the true value: if it already shows
-                                    // >= target the data is definitely ready and we skip the invalidate-heavy
-                                    // spin entirely. Only a short read falls through to noc_semaphore_wait_min
-                                    // (which flushes L1). This avoids an L1-cache flush on the common
-                                    // already-satisfied path — ~one per tile across the whole slice.
+                                    // Per-tile gate: block until the MM core (row-major id) that produced this tile
                                     const uint32_t mm_core_id = mm_core_idx * mm_cores_x + mm_core_x;
                                     volatile tt_l1_ptr uint32_t* mm_counter_ptr =
                                         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
@@ -429,10 +409,6 @@ void kernel_main() {
 
 #ifdef FUSE_MM_OP_SIGNALER
         // Per-core signaling: mm_sem_target and the per-core counters are MONOTONIC across batches
-        // (the MM increments each core's counter once per block for the whole run, never resetting),
-        // so there is deliberately no per-batch reset here — resetting would race with the MM still
-        // incrementing. NOTE: multi-batch (B>1) correctness requires the MM to keep its per-core
-        // counters monotonic across batches (it does — the barrier→per-core change preserves this).
 #endif
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_writer.cpp
@@ -280,6 +280,11 @@ void kernel_main() {
                     const uint32_t effective_chunk_width_in_tiles =
                         get_effective_chunk_width_in_tiles(chunk_idx, chunk_width_in_tiles, N_full_block_wt);
                     const uint32_t effective_subchunk_size = current_mm_block_ht * effective_chunk_width_in_tiles;
+                    // Hoist the (run-invariant) divisions out of the per-tile advance.
+                    const auto steps_worker = decompose_tile_advance(
+                        effective_worker_id, effective_subchunk_size, effective_chunk_width_in_tiles);
+                    const auto steps_advance = decompose_tile_advance(
+                        effective_advance_by_tiles, effective_subchunk_size, effective_chunk_width_in_tiles);
                     int32_t slice_idx = direction ? my_chip_id - 1 : my_chip_id + 1;
 
                     // Ring reduce-scatter loop for this chunk.
@@ -302,8 +307,7 @@ void kernel_main() {
                                 tile_row_in_mm_M_unit_block,
                                 chunk_col_in_tiles,
                                 mm_core_idx,
-                                effective_worker_id,
-                                effective_subchunk_size,
+                                steps_worker,
                                 effective_chunk_width_in_tiles,
                                 current_mm_block_ht);
                             uint32_t tiles_to_read = how_many_tiles_to_read_formula(
@@ -373,8 +377,7 @@ void kernel_main() {
                                             tile_row_in_mm_M_unit_block,
                                             chunk_col_in_tiles,
                                             mm_core_idx,
-                                            effective_advance_by_tiles,
-                                            effective_subchunk_size,
+                                            steps_advance,
                                             effective_chunk_width_in_tiles,
                                             current_mm_block_ht);
                                     }
@@ -419,6 +422,12 @@ void kernel_main() {
                                                     page_size * num_in_bounds_tiles);
                                             } else {
                                                 // Non-contiguous or single tile: individual unicast writes.
+                                                // All iterations reuse pkt_unicast_hdr, and the fabric
+                                                // sends the header NON-BLOCKING (send_payload_flush_non_blocking).
+                                                // Without a flush between writes, iteration t+1's
+                                                // populate_unicast_write_fields() overwrites the header while
+                                                // t's header send is still in flight -> the previous packet
+                                                // lands at the wrong destination (silent PCC corruption).
                                                 for (uint32_t t = 0; t < num_in_bounds_tiles; t++) {
                                                     fabric_unicast_noc_unicast_write_with_state<
                                                         UnicastWriteUpdateMask::DstAddr>(
@@ -426,6 +435,7 @@ void kernel_main() {
                                                         pkt_unicast_hdr,
                                                         valid_l1_addrs[t],
                                                         NocUnicastCommandHeader{noc_addrs[t]});
+                                                    noc_async_writes_flushed();
                                                 }
                                             }
                                         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_writer.cpp
@@ -422,12 +422,7 @@ void kernel_main() {
                                                     page_size * num_in_bounds_tiles);
                                             } else {
                                                 // Non-contiguous or single tile: individual unicast writes.
-                                                // All iterations reuse pkt_unicast_hdr, and the fabric
-                                                // sends the header NON-BLOCKING (send_payload_flush_non_blocking).
-                                                // Without a flush between writes, iteration t+1's
-                                                // populate_unicast_write_fields() overwrites the header while
-                                                // t's header send is still in flight -> the previous packet
-                                                // lands at the wrong destination (silent PCC corruption).
+                                                // All iterations reuse pkt_unicast_hdr
                                                 for (uint32_t t = 0; t < num_in_bounds_tiles; t++) {
                                                     fabric_unicast_noc_unicast_write_with_state<
                                                         UnicastWriteUpdateMask::DstAddr>(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/strided_ring_reduce_scatter_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/strided_ring_reduce_scatter_common.hpp
@@ -59,10 +59,7 @@ FORCE_INLINE uint32_t get_effective_chunk_width_in_tiles(
     return std::min(remaining_width, chunk_width_in_tiles);
 }
 
-// A tile advance decomposed into whole chunk-pieces / rows / columns. The two divisions that
-// produce it depend only on run-invariant quantities (advance_by_tiles, subchunk_size,
-// chunk_width_in_tiles), so it is computed ONCE per run with decompose_tile_advance() and the
-// per-tile get_next_tile_coordinates() below stays division-free (the Tensix RISC has no HW divide).
+// A tile advance decomposed into whole chunk-pieces / rows / columns
 struct TileAdvanceSteps {
     uint32_t pieces;  // whole chunk-pieces to advance (added to mm_core_idx)
     uint32_t rows;    // whole rows to advance within a chunk piece

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/strided_ring_reduce_scatter_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/strided_ring_reduce_scatter_common.hpp
@@ -59,40 +59,52 @@ FORCE_INLINE uint32_t get_effective_chunk_width_in_tiles(
     return std::min(remaining_width, chunk_width_in_tiles);
 }
 
+// A tile advance decomposed into whole chunk-pieces / rows / columns. The two divisions that
+// produce it depend only on run-invariant quantities (advance_by_tiles, subchunk_size,
+// chunk_width_in_tiles), so it is computed ONCE per run with decompose_tile_advance() and the
+// per-tile get_next_tile_coordinates() below stays division-free (the Tensix RISC has no HW divide).
+struct TileAdvanceSteps {
+    uint32_t pieces;  // whole chunk-pieces to advance (added to mm_core_idx)
+    uint32_t rows;    // whole rows to advance within a chunk piece
+    uint32_t cols;    // remaining columns to advance
+};
+
+FORCE_INLINE TileAdvanceSteps
+decompose_tile_advance(uint32_t advance_by_tiles, const uint32_t subchunk_size, const uint32_t chunk_width_in_tiles) {
+    /**
+     * Decompose 'advance_by_tiles' into whole chunk-pieces, whole rows, and residual columns.
+     * This carries the (only) two divisions; call once per run, not per tile.
+     * Note: subchunk_size == mm_block_unit_ht * chunk_width_in_tiles
+     */
+    uint32_t pieces = 0;
+    if (advance_by_tiles >= subchunk_size) [[unlikely]] {
+        pieces = advance_by_tiles / subchunk_size;
+        advance_by_tiles -= pieces * subchunk_size;
+    }
+    uint32_t rows = 0;
+    if (advance_by_tiles >= chunk_width_in_tiles) {
+        rows = advance_by_tiles / chunk_width_in_tiles;
+        advance_by_tiles -= rows * chunk_width_in_tiles;
+    }
+    return {pieces, rows, advance_by_tiles};
+}
+
 FORCE_INLINE void get_next_tile_coordinates(
     uint32_t& tile_row_in_mm_M_unit_block,
     uint32_t& chunk_col_in_tiles,
     uint32_t& mm_core_idx,
-    uint32_t advance_by_tiles,
-    const uint32_t subchunk_size,
+    const TileAdvanceSteps& steps,
     const uint32_t chunk_width_in_tiles,
     const uint32_t mm_block_unit_ht) {
     /**
-     * Update the within-chunk-piece coordinates of a tile
-     * (row and column within a chunk piece and the corresponding core index)
-     * when moving by 'advance_by_tiles' tiles.
-     *
-     * First, check if 'advance_by_tiles' is at least as large as a full chunk piece
-     * and update the core index accordingly.
-     * Then, check if remaining 'advance_by_tiles' is at least as large as a full row
-     * and update the row index and core index accordingly.
-     * Finally, move the column index by the remaining number of tiles, and
-     * update the other coordinates if needed.
-     *
-     * Optimized to avoid modulo operations.
-     * Note: subchunk_size == mm_block_unit_ht * chunk_width_in_tiles
+     * Update the within-chunk-piece coordinates of a tile by a precomputed advance
+     * (see decompose_tile_advance). Division-free: only adds, compares and subtracts.
+     * Equivalent to the original divide-per-call form; the two divisions have been hoisted out.
      */
-    if (advance_by_tiles >= subchunk_size) [[unlikely]] {
-        const uint32_t move_by_pieces = advance_by_tiles / subchunk_size;
-        advance_by_tiles -= move_by_pieces * subchunk_size;
-        mm_core_idx += move_by_pieces;
-    }
+    mm_core_idx += steps.pieces;
 
-    if (advance_by_tiles >= chunk_width_in_tiles) {
-        const uint32_t move_by_rows = advance_by_tiles / chunk_width_in_tiles;
-        const uint32_t new_row = tile_row_in_mm_M_unit_block + move_by_rows;
-        advance_by_tiles -= move_by_rows * chunk_width_in_tiles;
-
+    if (steps.rows != 0) {
+        const uint32_t new_row = tile_row_in_mm_M_unit_block + steps.rows;
         if (new_row >= mm_block_unit_ht) {
             mm_core_idx += 1;
             tile_row_in_mm_M_unit_block = new_row - mm_block_unit_ht;
@@ -101,7 +113,7 @@ FORCE_INLINE void get_next_tile_coordinates(
         }
     }
 
-    uint32_t new_col = chunk_col_in_tiles + advance_by_tiles;
+    uint32_t new_col = chunk_col_in_tiles + steps.cols;
     if (new_col >= chunk_width_in_tiles) {
         tile_row_in_mm_M_unit_block += 1;
         new_col -= chunk_width_in_tiles;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_op_device_operation_types.hpp
@@ -29,14 +29,9 @@ struct StridedReduceScatterProgramArtifacts {
     uint32_t num_cores_per_link;
     // Index into the reader RT args where addcmul_a_address lives (0 = not used).
     uint32_t reader_addcmul_rt_arg_offset = 0;
-    // Per-core MM signaling: privately allocated L1 backing for the per-MM-core progress counter
-    // array, used only when the caller does not supply a shared one. Held here so it stays allocated
-    // for the cached program's life (its L1 address is baked into the reader + MM runtime args) —
-    // which is why sharing one array across programs is preferred, see mm_progress_counters.
+    // Per-core MM signaling: privately allocated L1 backing for the per-MM-core progress counter array
     std::shared_ptr<tt::tt_metal::Buffer> mm_progress_counters_buffer;
-    // The counter-array L1 address baked into the reader + MM runtime args at build time. Kept so a
-    // cached-program reuse can check that a caller-supplied array still lives at the same address
-    // (0 = not fused). Nothing re-points it on reuse.
+    // The counter-array L1 address baked into the reader + MM runtime args at build time
     uint32_t mm_progress_counters_addr = 0;
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_op_device_operation_types.hpp
@@ -29,10 +29,15 @@ struct StridedReduceScatterProgramArtifacts {
     uint32_t num_cores_per_link;
     // Index into the reader RT args where addcmul_a_address lives (0 = not used).
     uint32_t reader_addcmul_rt_arg_offset = 0;
-    // Per-core MM signaling: backing L1 buffer for the per-MM-core progress counter array (one
-    // shard/row per RS worker core). Held here so it stays allocated for the cached program's life
-    // (its L1 address is baked into the reader + MM runtime args).
+    // Per-core MM signaling: privately allocated L1 backing for the per-MM-core progress counter
+    // array, used only when the caller does not supply a shared one. Held here so it stays allocated
+    // for the cached program's life (its L1 address is baked into the reader + MM runtime args) —
+    // which is why sharing one array across programs is preferred, see mm_progress_counters.
     std::shared_ptr<tt::tt_metal::Buffer> mm_progress_counters_buffer;
+    // The counter-array L1 address baked into the reader + MM runtime args at build time. Kept so a
+    // cached-program reuse can check that a caller-supplied array still lives at the same address
+    // (0 = not fused). Nothing re-points it on reuse.
+    uint32_t mm_progress_counters_addr = 0;
 };
 
 struct operation_attributes_t {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_op_device_operation_types.hpp
@@ -29,6 +29,10 @@ struct StridedReduceScatterProgramArtifacts {
     uint32_t num_cores_per_link;
     // Index into the reader RT args where addcmul_a_address lives (0 = not used).
     uint32_t reader_addcmul_rt_arg_offset = 0;
+    // Per-core MM signaling: backing L1 buffer for the per-MM-core progress counter array (one
+    // shard/row per RS worker core). Held here so it stays allocated for the cached program's life
+    // (its L1 address is baked into the reader + MM runtime args).
+    std::shared_ptr<tt::tt_metal::Buffer> mm_progress_counters_buffer;
 };
 
 struct operation_attributes_t {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
@@ -406,9 +406,7 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
     std::map<std::string, std::string> writer_compute_defines;
     std::map<std::string, std::string> reduce_compute_defines;
 
-    // The input (MM output) is always fed through TensorAccessorArgs (below), even when L1-sharded
-    // for the fused-MM handoff, so the reader's TensorAccessor path handles it. The reader's manual
-    // INPUT_IS_SHARDED read path is unimplemented, so do NOT define INPUT_IS_SHARDED.
+    // The input (MM output) is always fed through TensorAccessorArgs (below)
     if (intermediate_is_sharded) {
         reader_compute_defines["INTERMEDIATE_IS_SHARDED"] = "1";
         writer_compute_defines["INTERMEDIATE_IS_SHARDED"] = "1";
@@ -434,26 +432,20 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
         fused_op_signaler->init_reduce_scatter(program, mesh_device, sender_worker_core_range_set);
     }
     bool fuse_mm_op = mm_fused_op_signaler.has_value();
-    // Per-core MM signaling: L1 array of per-MM-core progress counters, one row per RS worker core.
-    // Only set on the fallback path where no shared array was supplied.
+    // Per-core MM signaling: L1 array of per-MM-core progress counters, one row per RS worker core
     std::shared_ptr<tt::tt_metal::Buffer> mm_progress_counters_buffer;
     uint32_t captured_mm_progress_counters_addr = 0;
     if (fuse_mm_op) {
         mm_fused_op_signaler->init_strided_reduce_scatter(program, mesh_device, sender_worker_core_range_set);
         reader_compute_defines["FUSE_MM_OP_SIGNALER"] = "1";
 
-        // The counter array: one shard (row) per RS worker core, sized to the full device
-        // compute grid (a safe upper bound on the MM core count). HEIGHT_SHARDED => every RS core's
-        // row sits at the SAME local L1 address, which we bake into the reader + MM runtime args.
-        // The MM increments slot (row-major core id) on every RS core; the reader waits per-tile.
+        // The counter array: one shard (row) per RS worker core, sized to the full device compute grid
         const auto mm_grid = mesh_device->compute_with_storage_grid_size();
         const uint32_t num_mm_core_slots = mm_grid.x * mm_grid.y;
         const uint32_t counters_row_bytes = num_mm_core_slots * sizeof(uint32_t);
 
         if (mm_progress_counters.has_value()) {
-            // Caller-owned array, shared across programs. Preferred over allocating below: a private
-            // array is retained for the cached program's life, and those small permanent L1 blocks
-            // pin the freed regions above them, starving later ops of circular-buffer space.
+            // Caller-owned array, shared across programs
             const auto& counters = mm_progress_counters.value();
             const auto& counters_shard_spec = counters.memory_config().shard_spec();
             TT_FATAL(
@@ -476,9 +468,6 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
             mm_fused_op_signaler->mm_progress_counters_addr = static_cast<uint32_t>(counters.buffer()->address());
         } else {
             // BUILD-VERIFY: this is the ONE tt-metal buffer-API call to confirm against your tree
-            // (MeshDevice CreateBuffer/ShardedBufferConfig vs MeshBuffer, and the exact ShardSpecBuffer
-            // ctor args). Only mm_progress_counters_buffer->address() is consumed downstream, so the
-            // rest of the change is agnostic to how this line is spelled.
             const uint32_t num_rs_cores = sender_worker_core_range_set.num_cores();
             const auto counter_shard_spec = tt::tt_metal::ShardSpecBuffer(
                 sender_worker_core_range_set,
@@ -553,8 +542,7 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
         slice_Ht,                           // [23] slice_Ht (total height in tiles across all MM cores)
     };
 
-    // Input (MM output): always TensorAccessorArgs (handles interleaved AND L1-sharded) so the
-    // reader's TensorAccessor path works for the fused-MM L1 handoff.
+    // Input (MM output): always TensorAccessorArgs (handles interleaved AND L1-sharded) so the reader's
     tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(sender_reader_compile_args);
     if (intermediate_is_sharded) {
         shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_reader_compile_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
@@ -208,7 +208,8 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
     std::optional<uint32_t> chunk_width_in_mm_blocks,
     std::optional<float> fused_ternary_scalar,
     const std::optional<const Tensor>& addcmul_input_tensor1,
-    const std::optional<const Tensor>& addcmul_input_tensor2) {
+    const std::optional<const Tensor>& addcmul_input_tensor2,
+    const std::optional<const Tensor>& mm_progress_counters) {
     auto* mesh_device = input_tensor.device();
     [[maybe_unused]] bool is_first_chip = ring_index == 0;
     [[maybe_unused]] bool is_last_chip = ring_index == ring_size - 1;
@@ -434,38 +435,68 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
     }
     bool fuse_mm_op = mm_fused_op_signaler.has_value();
     // Per-core MM signaling: L1 array of per-MM-core progress counters, one row per RS worker core.
+    // Only set on the fallback path where no shared array was supplied.
     std::shared_ptr<tt::tt_metal::Buffer> mm_progress_counters_buffer;
+    uint32_t captured_mm_progress_counters_addr = 0;
     if (fuse_mm_op) {
         mm_fused_op_signaler->init_strided_reduce_scatter(program, mesh_device, sender_worker_core_range_set);
         reader_compute_defines["FUSE_MM_OP_SIGNALER"] = "1";
 
-        // Allocate the counter array: one shard (row) per RS worker core, sized to the full device
+        // The counter array: one shard (row) per RS worker core, sized to the full device
         // compute grid (a safe upper bound on the MM core count). HEIGHT_SHARDED => every RS core's
         // row sits at the SAME local L1 address, which we bake into the reader + MM runtime args.
         // The MM increments slot (row-major core id) on every RS core; the reader waits per-tile.
-        //
-        // BUILD-VERIFY: this is the ONE tt-metal buffer-API call to confirm against your tree
-        // (MeshDevice CreateBuffer/ShardedBufferConfig vs MeshBuffer, and the exact ShardSpecBuffer
-        // ctor args). Only mm_progress_counters_buffer->address() is consumed downstream, so the
-        // rest of the change is agnostic to how this line is spelled.
         const auto mm_grid = mesh_device->compute_with_storage_grid_size();
         const uint32_t num_mm_core_slots = mm_grid.x * mm_grid.y;
         const uint32_t counters_row_bytes = num_mm_core_slots * sizeof(uint32_t);
-        const uint32_t num_rs_cores = sender_worker_core_range_set.num_cores();
-        const auto counter_shard_spec = tt::tt_metal::ShardSpecBuffer(
-            sender_worker_core_range_set,
-            {1, num_mm_core_slots},
-            tt::tt_metal::ShardOrientation::ROW_MAJOR,
-            {1, num_mm_core_slots},
-            {num_rs_cores, num_mm_core_slots});
-        mm_progress_counters_buffer = tt::tt_metal::CreateBuffer(tt::tt_metal::ShardedBufferConfig{
-            .device = mesh_device,
-            .size = num_rs_cores * counters_row_bytes,
-            .page_size = counters_row_bytes,
-            .buffer_type = tt::tt_metal::BufferType::L1,
-            .buffer_layout = tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
-            .shard_parameters = counter_shard_spec});
-        mm_fused_op_signaler->mm_progress_counters_addr = static_cast<uint32_t>(mm_progress_counters_buffer->address());
+
+        if (mm_progress_counters.has_value()) {
+            // Caller-owned array, shared across programs. Preferred over allocating below: a private
+            // array is retained for the cached program's life, and those small permanent L1 blocks
+            // pin the freed regions above them, starving later ops of circular-buffer space.
+            const auto& counters = mm_progress_counters.value();
+            const auto& counters_shard_spec = counters.memory_config().shard_spec();
+            TT_FATAL(
+                counters.memory_config().buffer_type() == tt::tt_metal::BufferType::L1 &&
+                    counters_shard_spec.has_value(),
+                "mm_progress_counters must be an L1 sharded tensor so that its row lands at the same "
+                "local address on every RS worker core");
+            TT_FATAL(
+                counters_shard_spec->grid.contains(sender_worker_core_range_set),
+                "mm_progress_counters is sharded over {} which does not cover the RS worker cores {}",
+                counters_shard_spec->grid.str(),
+                sender_worker_core_range_set.str());
+            const uint32_t provided_row_bytes = counters_shard_spec->shape[1] * counters.element_size();
+            TT_FATAL(
+                provided_row_bytes >= counters_row_bytes,
+                "mm_progress_counters provides {} B per core but the MM grid needs {} slots ({} B)",
+                provided_row_bytes,
+                num_mm_core_slots,
+                counters_row_bytes);
+            mm_fused_op_signaler->mm_progress_counters_addr = static_cast<uint32_t>(counters.buffer()->address());
+        } else {
+            // BUILD-VERIFY: this is the ONE tt-metal buffer-API call to confirm against your tree
+            // (MeshDevice CreateBuffer/ShardedBufferConfig vs MeshBuffer, and the exact ShardSpecBuffer
+            // ctor args). Only mm_progress_counters_buffer->address() is consumed downstream, so the
+            // rest of the change is agnostic to how this line is spelled.
+            const uint32_t num_rs_cores = sender_worker_core_range_set.num_cores();
+            const auto counter_shard_spec = tt::tt_metal::ShardSpecBuffer(
+                sender_worker_core_range_set,
+                {1, num_mm_core_slots},
+                tt::tt_metal::ShardOrientation::ROW_MAJOR,
+                {1, num_mm_core_slots},
+                {num_rs_cores, num_mm_core_slots});
+            mm_progress_counters_buffer = tt::tt_metal::CreateBuffer(tt::tt_metal::ShardedBufferConfig{
+                .device = mesh_device,
+                .size = num_rs_cores * counters_row_bytes,
+                .page_size = counters_row_bytes,
+                .buffer_type = tt::tt_metal::BufferType::L1,
+                .buffer_layout = tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+                .shard_parameters = counter_shard_spec});
+            mm_fused_op_signaler->mm_progress_counters_addr =
+                static_cast<uint32_t>(mm_progress_counters_buffer->address());
+        }
+        captured_mm_progress_counters_addr = mm_fused_op_signaler->mm_progress_counters_addr;
     }
 
     // Kernel Runtime Args
@@ -774,7 +805,8 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
         num_mux_cores_per_direction_per_link,
         num_cores_per_link,
         captured_reader_addcmul_rt_arg_offset,
-        mm_progress_counters_buffer};
+        mm_progress_counters_buffer,
+        captured_mm_progress_counters_addr};
 }
 
 void ring_strided_reduce_scatter_async_helper_override_runtime_arguments(
@@ -907,7 +939,8 @@ RingStridedReduceScatterMeshWorkloadFactory::create_at(
         operation_attributes.chunk_width_in_mm_blocks,
         std::nullopt,   // fused_ternary_scalar
         std::nullopt,   // addcmul_input_tensor1
-        std::nullopt);  // addcmul_input_tensor2
+        std::nullopt,   // addcmul_input_tensor2
+        std::nullopt);  // mm_progress_counters (fused MM->RS only)
 
     return {std::move(program), std::move(shared_vars)};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
@@ -397,7 +397,7 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
         CreateCircularBuffer(program, sender_worker_core_range_set, cb_addcmul_b_config);
     }
 
-    bool input_is_sharded = input_tensor.is_sharded();
+    [[maybe_unused]] bool input_is_sharded = input_tensor.is_sharded();  // input always via TensorAccessorArgs
     bool intermediate_is_sharded = intermediate_tensor.is_sharded();
     bool output_is_sharded = output_tensor.is_sharded();
 
@@ -405,9 +405,9 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
     std::map<std::string, std::string> writer_compute_defines;
     std::map<std::string, std::string> reduce_compute_defines;
 
-    if (input_is_sharded) {
-        reader_compute_defines["INPUT_IS_SHARDED"] = "1";
-    }
+    // The input (MM output) is always fed through TensorAccessorArgs (below), even when L1-sharded
+    // for the fused-MM handoff, so the reader's TensorAccessor path handles it. The reader's manual
+    // INPUT_IS_SHARDED read path is unimplemented, so do NOT define INPUT_IS_SHARDED.
     if (intermediate_is_sharded) {
         reader_compute_defines["INTERMEDIATE_IS_SHARDED"] = "1";
         writer_compute_defines["INTERMEDIATE_IS_SHARDED"] = "1";
@@ -433,9 +433,39 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
         fused_op_signaler->init_reduce_scatter(program, mesh_device, sender_worker_core_range_set);
     }
     bool fuse_mm_op = mm_fused_op_signaler.has_value();
+    // Per-core MM signaling: L1 array of per-MM-core progress counters, one row per RS worker core.
+    std::shared_ptr<tt::tt_metal::Buffer> mm_progress_counters_buffer;
     if (fuse_mm_op) {
         mm_fused_op_signaler->init_strided_reduce_scatter(program, mesh_device, sender_worker_core_range_set);
         reader_compute_defines["FUSE_MM_OP_SIGNALER"] = "1";
+
+        // Allocate the counter array: one shard (row) per RS worker core, sized to the full device
+        // compute grid (a safe upper bound on the MM core count). HEIGHT_SHARDED => every RS core's
+        // row sits at the SAME local L1 address, which we bake into the reader + MM runtime args.
+        // The MM increments slot (row-major core id) on every RS core; the reader waits per-tile.
+        //
+        // BUILD-VERIFY: this is the ONE tt-metal buffer-API call to confirm against your tree
+        // (MeshDevice CreateBuffer/ShardedBufferConfig vs MeshBuffer, and the exact ShardSpecBuffer
+        // ctor args). Only mm_progress_counters_buffer->address() is consumed downstream, so the
+        // rest of the change is agnostic to how this line is spelled.
+        const auto mm_grid = mesh_device->compute_with_storage_grid_size();
+        const uint32_t num_mm_core_slots = mm_grid.x * mm_grid.y;
+        const uint32_t counters_row_bytes = num_mm_core_slots * sizeof(uint32_t);
+        const uint32_t num_rs_cores = sender_worker_core_range_set.num_cores();
+        const auto counter_shard_spec = tt::tt_metal::ShardSpecBuffer(
+            sender_worker_core_range_set,
+            {1, num_mm_core_slots},
+            tt::tt_metal::ShardOrientation::ROW_MAJOR,
+            {1, num_mm_core_slots},
+            {num_rs_cores, num_mm_core_slots});
+        mm_progress_counters_buffer = tt::tt_metal::CreateBuffer(tt::tt_metal::ShardedBufferConfig{
+            .device = mesh_device,
+            .size = num_rs_cores * counters_row_bytes,
+            .page_size = counters_row_bytes,
+            .buffer_type = tt::tt_metal::BufferType::L1,
+            .buffer_layout = tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+            .shard_parameters = counter_shard_spec});
+        mm_fused_op_signaler->mm_progress_counters_addr = static_cast<uint32_t>(mm_progress_counters_buffer->address());
     }
 
     // Kernel Runtime Args
@@ -492,11 +522,9 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
         slice_Ht,                           // [23] slice_Ht (total height in tiles across all MM cores)
     };
 
-    if (input_is_sharded) {
-        shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_compile_args);
-    } else {
-        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(sender_reader_compile_args);
-    }
+    // Input (MM output): always TensorAccessorArgs (handles interleaved AND L1-sharded) so the
+    // reader's TensorAccessor path works for the fused-MM L1 handoff.
+    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(sender_reader_compile_args);
     if (intermediate_is_sharded) {
         shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_reader_compile_args);
     } else {
@@ -664,9 +692,7 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
                     worker_id,                                // worker_id
                     num_workers,                              // num_workers
                 };
-                if (input_is_sharded) {
-                    shard_builder::extend_sharding_run_time_args(input_tensor, reader_rt_args);
-                }
+                // Input uses TensorAccessorArgs (see above) — no shard-map RT args, just the address.
                 if (intermediate_is_sharded) {
                     shard_builder::extend_sharding_run_time_args(intermediate_tensor, reader_rt_args);
                 }
@@ -747,7 +773,8 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
         num_workers_per_direction,
         num_mux_cores_per_direction_per_link,
         num_cores_per_link,
-        captured_reader_addcmul_rt_arg_offset};
+        captured_reader_addcmul_rt_arg_offset,
+        mm_progress_counters_buffer};
 }
 
 void ring_strided_reduce_scatter_async_helper_override_runtime_arguments(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_ring_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_ring_program_factory.hpp
@@ -70,8 +70,13 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
     // Optional fused addcmul at the final RS write step.
     // output = addcmul_a + fused_ternary_scalar * rs_result * addcmul_b
     std::optional<float> fused_ternary_scalar = std::nullopt,
-    const std::optional<const Tensor>& addcmul_input_tensor1 = std::nullopt,   // residual a [M, D/tp]
-    const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt);  // gate b [1, D/tp]
+    const std::optional<const Tensor>& addcmul_input_tensor1 = std::nullopt,  // residual a [M, D/tp]
+    const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt,  // gate b [1, D/tp]
+    // Caller-owned scratch for the per-MM-core progress counters (fused MM->RS signaling only):
+    // uint32, L1 HEIGHT_SHARDED with one row per core over a grid covering the RS worker cores.
+    // Sharing one tensor across all MMRS programs keeps this off the device's permanent L1 floor;
+    // when omitted a private array is allocated per program and retained for the program's life.
+    const std::optional<const Tensor>& mm_progress_counters = std::nullopt);
 
 // Override runtime arguments helper for ring topology
 void ring_strided_reduce_scatter_async_helper_override_runtime_arguments(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_ring_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_ring_program_factory.hpp
@@ -72,10 +72,7 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
     std::optional<float> fused_ternary_scalar = std::nullopt,
     const std::optional<const Tensor>& addcmul_input_tensor1 = std::nullopt,  // residual a [M, D/tp]
     const std::optional<const Tensor>& addcmul_input_tensor2 = std::nullopt,  // gate b [1, D/tp]
-    // Caller-owned scratch for the per-MM-core progress counters (fused MM->RS signaling only):
-    // uint32, L1 HEIGHT_SHARDED with one row per core over a grid covering the RS worker cores.
-    // Sharing one tensor across all MMRS programs keeps this off the device's permanent L1 floor;
-    // when omitted a private array is allocated per program and retained for the program's life.
+    // Caller-owned scratch for the per-MM-core progress counters (fused MM->RS signaling only): uint32
     const std::optional<const Tensor>& mm_progress_counters = std::nullopt);
 
 // Override runtime arguments helper for ring topology

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
@@ -55,14 +55,18 @@ ttnn::Tensor conv3d(
     const std::string& padding_mode_,
     uint32_t groups_,
     const std::optional<MemoryConfig>& memory_config,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
-    // Default blocking: minimal spatial blocks, smallest valid C_in_block. The same
-    // default is used by prepare_conv3d_weights, so the prepared weight's K-row
-    // blocking always matches the conv compute -- no near-zero-PCC mismatch (#47316) --
-    // and the minimal block keeps large kernels within L1 (#42146). This holds for both
-    // a rank-5 (prepared here) and a rank-2 (pre-prepared with the same default) weight.
-    const uint32_t default_c_in_block = ttnn::operations::experimental::conv3d::default_c_in_block(
-        kernel_size_[0] * kernel_size_[1] * kernel_size_[2]);
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<ttnn::Tensor>& halo_buffer,
+    uint32_t logical_h_mask,
+    uint32_t logical_w_mask,
+    const std::optional<ttnn::Tensor>& pad_offset_tensor,
+    uint32_t output_pad_h,
+    uint32_t output_pad_w) {
+    // Shared with prepare_conv3d_weights so the prepared weight's K-row blocking always matches the
+    // conv compute -- a mismatch is near-zero PCC (#47316) -- and the minimal block keeps large
+    // kernels within L1 (#42146).
+    const uint32_t default_c_in_block =
+        ttnn::operations::experimental::conv3d::default_c_in_block(kernel_size_[0] * kernel_size_[1] * kernel_size_[2]);
 
     auto config = config_opt.value_or(ttnn::experimental::prim::Conv3dConfig(
         tt::tt_metal::DataType::BFLOAT16,                        // weights_dtype
@@ -77,10 +81,8 @@ ttnn::Tensor conv3d(
         input_tensor.device()->compute_with_storage_grid_size()  // use full device grid
         ));
 
-    // An explicitly-provided config may still carry C_in_block == 0 ("auto"). Resolve it to the
-    // same default so prepare_conv3d_weights and the conv compute use one identical, non-zero
-    // block -- otherwise the internal prepare and the device op disagree on the K-row blocking
-    // (near-zero PCC, #47316). This mirrors prepare_conv3d_weights' own 0 handling.
+    // An explicitly-provided config may still carry C_in_block == 0 ("auto"); resolve it here so
+    // prepare_conv3d_weights and the device op cannot disagree on the K-row blocking (#47316).
     if (config.C_in_block == 0) {
         config.C_in_block = default_c_in_block;
     }
@@ -100,7 +102,13 @@ ttnn::Tensor conv3d(
         padding_mode_,
         groups_,
         memory_config,
-        compute_kernel_config);
+        compute_kernel_config,
+        halo_buffer,
+        logical_h_mask,
+        logical_w_mask,
+        pad_offset_tensor,
+        output_pad_h,
+        output_pad_w);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.hpp
@@ -29,6 +29,12 @@ ttnn::Tensor conv3d(
     const std::string& padding_mode_ = "zeros",
     uint32_t groups_ = 1,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    const std::optional<ttnn::Tensor>& halo_buffer = std::nullopt,
+    uint32_t logical_h_mask = 0,
+    uint32_t logical_w_mask = 0,
+    const std::optional<ttnn::Tensor>& pad_offset_tensor = std::nullopt,
+    uint32_t output_pad_h = 0,
+    uint32_t output_pad_w = 0);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
@@ -62,7 +62,13 @@ void bind_conv3d(nb::module_& mod) {
         nb::arg("padding_mode") = "zeros",
         nb::arg("groups") = 1,
         nb::arg("memory_config") = nb::none(),
-        nb::arg("compute_kernel_config") = nb::none());
+        nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("halo_buffer") = nb::none(),
+        nb::arg("logical_h_mask") = 0u,
+        nb::arg("logical_w_mask") = 0u,
+        nb::arg("pad_offset_tensor") = nb::none(),
+        nb::arg("output_pad_h") = 0u,
+        nb::arg("output_pad_w") = 0u);
 
     // Register to ttnn.experimental namespace
     ttnn::bind_function<"prepare_conv3d_weights", "ttnn.experimental.">(
@@ -72,9 +78,6 @@ void bind_conv3d(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("weight_tensor"),
         nb::arg("groups") = 1u,
-        // 0 == use the default minimal valid block (default_c_in_block), the same value conv3d
-        // defaults to, so the prepared weight and the conv compute agree on K-row blocking and
-        // stay within L1. A mismatch silently reorders rows (issues #42146, #47316).
         nb::arg("C_in_block") = 0u,
         nb::arg("alignment") = 32u,
         nb::arg("device") = nb::none());

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -230,6 +230,10 @@ tt::tt_metal::TensorSpec Conv3dDeviceOperation::compute_output_specs(
     auto [T_out, H_out, W_out] =
         detail::compute_output_dims(T_in, H_in, W_in, args.padding, args.stride, args.kernel_size, args.dilation);
 
+    // Padded-output mode: allocate a spatially padded output; the writer fills only the interior.
+    H_out += 2 * args.output_pad_h;
+    W_out += 2 * args.output_pad_w;
+
     ttnn::Shape output_shape({N, T_out, H_out, W_out, C_out});
     ttnn::Shape padded_output_shape({N, T_out, H_out, W_out, padded_C_out});
 
@@ -245,6 +249,26 @@ tt::tt_metal::TensorSpec Conv3dDeviceOperation::compute_output_specs(
 Tensor Conv3dDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
+}
+
+ttsl::hash::hash_t Conv3dDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto& weight_tensor = tensor_args.weight_tensor;
+    const auto& bias_tensor = tensor_args.bias_tensor;
+    operation::Hash hash = operation::hash_operation<Conv3dDeviceOperation>(
+        args,
+        input_tensor.dtype(),
+        input_tensor.memory_config(),
+        input_tensor.logical_shape(),
+        weight_tensor.dtype(),
+        weight_tensor.memory_config(),
+        weight_tensor.logical_shape(),
+        bias_tensor.has_value(),
+        tensor_args.halo_buffer.has_value(),
+        tensor_args.pad_offset_tensor.has_value());
+
+    return hash;
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv3dDeviceOperation::create_op_performance_model(
@@ -283,6 +307,9 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv3dDeviceOperation
     if (tensor_args.bias_tensor.has_value()) {
         input_tensors.push_back(tensor_args.bias_tensor.value());
     }
+    if (tensor_args.halo_buffer.has_value()) {
+        input_tensors.push_back(tensor_args.halo_buffer.value());
+    }
     tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
         input_tensors, output_tensor, ideal_dev_clock_cycles);
 
@@ -307,7 +334,13 @@ ttnn::experimental::prim::Conv3dDeviceOperation::tensor_return_value_t conv3d(
     const std::string& padding_mode_,
     uint32_t groups_,
     const std::optional<MemoryConfig>& memory_config,
-    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
+    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<Tensor>& halo_buffer,
+    uint32_t logical_h_mask,
+    uint32_t logical_w_mask,
+    const std::optional<Tensor>& pad_offset_tensor,
+    uint32_t output_pad_h,
+    uint32_t output_pad_w) {
     using OperationType = ttnn::experimental::prim::Conv3dDeviceOperation;
 
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -327,7 +360,11 @@ ttnn::experimental::prim::Conv3dDeviceOperation::tensor_return_value_t conv3d(
         .dilation =
             (config.dilation != default_dilation && dilation_ == default_dilation) ? config.dilation : dilation_,
         .padding_mode = padding_mode_,
-        .groups = groups_};
+        .groups = groups_,
+        .logical_h_mask = logical_h_mask,
+        .logical_w_mask = logical_w_mask,
+        .output_pad_h = output_pad_h,
+        .output_pad_w = output_pad_w};
     TT_FATAL(
         config.dilation == default_dilation || dilation_ == default_dilation || config.dilation == dilation_,
         "dilation in Conv3dConfig and op args must match when both are set. config=({}, {}, {}), args=({}, {}, {})",
@@ -338,7 +375,11 @@ ttnn::experimental::prim::Conv3dDeviceOperation::tensor_return_value_t conv3d(
         dilation_[1],
         dilation_[2]);
     auto tensor_args = OperationType::tensor_args_t{
-        .input_tensor = input_tensor, .weight_tensor = weight_tensor, .bias_tensor = bias_tensor};
+        .input_tensor = input_tensor,
+        .weight_tensor = weight_tensor,
+        .bias_tensor = bias_tensor,
+        .halo_buffer = halo_buffer,
+        .pad_offset_tensor = pad_offset_tensor};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
@@ -28,6 +28,7 @@ struct Conv3dDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
 };
@@ -50,6 +51,12 @@ ttnn::experimental::prim::Conv3dDeviceOperation::tensor_return_value_t conv3d(
     const std::string& padding_mode_,
     uint32_t groups_,
     const std::optional<MemoryConfig>& memory_config,
-    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config);
+    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<Tensor>& halo_buffer = std::nullopt,
+    uint32_t logical_h_mask = 0,
+    uint32_t logical_w_mask = 0,
+    const std::optional<Tensor>& pad_offset_tensor = std::nullopt,
+    uint32_t output_pad_h = 0,
+    uint32_t output_pad_w = 0);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation_types.hpp
@@ -86,12 +86,29 @@ struct Conv3dParams {
     std::array<uint32_t, 3> dilation;
     std::string padding_mode;
     uint32_t groups;
+    // Logical-pad masking (opt-in, halo mode only): zero interior sticks whose global spatial index is
+    // >= logical_*_mask. 0 == disabled.
+    uint32_t logical_h_mask = 0;
+    uint32_t logical_w_mask = 0;
+    // Padded-output mode (opt-in): the writer places the [H_out,W_out] result into the interior of a
+    // spatially padded [H_out+2*output_pad_h, W_out+2*output_pad_w] output buffer, leaving a border gap
+    // for a later border-fill (persistent padded activations). 0 == compact output.
+    uint32_t output_pad_h = 0;
+    uint32_t output_pad_w = 0;
 };
 
 struct Conv3dInputs {
     Tensor input_tensor;
     Tensor weight_tensor;
     std::optional<const Tensor> bias_tensor;
+    // Halo-aware mode: when set, the reader reads spatial (H/W) boundary conv-window positions from this
+    // compact [H-top|H-bot|W-left|W-right] buffer (produced by neighbor_pad_halo) instead of zero-padding.
+    // Temporal (T) boundary positions still zero-pad. Section geometry is derived in the program factory
+    // from the input shape + padding. Only meaningful with padding_mode "zeros".
+    std::optional<const Tensor> halo_buffer;
+    // Per-device [h_start, w_start] global spatial offset (uint32, one page per device), read by the
+    // reader to evaluate the logical-pad mask when masking is enabled.
+    std::optional<const Tensor> pad_offset_tensor;
 };
 
 namespace detail {

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation_types.hpp
@@ -86,13 +86,10 @@ struct Conv3dParams {
     std::array<uint32_t, 3> dilation;
     std::string padding_mode;
     uint32_t groups;
-    // Logical-pad masking (opt-in, halo mode only): zero interior sticks whose global spatial index is
-    // >= logical_*_mask. 0 == disabled.
+    // Logical-pad masking (opt-in, halo mode only): zero interior sticks whose global spatial index is >=
     uint32_t logical_h_mask = 0;
     uint32_t logical_w_mask = 0;
-    // Padded-output mode (opt-in): the writer places the [H_out,W_out] result into the interior of a
-    // spatially padded [H_out+2*output_pad_h, W_out+2*output_pad_w] output buffer, leaving a border gap
-    // for a later border-fill (persistent padded activations). 0 == compact output.
+    // Padded-output mode (opt-in): the writer places the [H_out,W_out] result into the interior of a spatially
     uint32_t output_pad_h = 0;
     uint32_t output_pad_w = 0;
 };
@@ -101,13 +98,9 @@ struct Conv3dInputs {
     Tensor input_tensor;
     Tensor weight_tensor;
     std::optional<const Tensor> bias_tensor;
-    // Halo-aware mode: when set, the reader reads spatial (H/W) boundary conv-window positions from this
-    // compact [H-top|H-bot|W-left|W-right] buffer (produced by neighbor_pad_halo) instead of zero-padding.
-    // Temporal (T) boundary positions still zero-pad. Section geometry is derived in the program factory
-    // from the input shape + padding. Only meaningful with padding_mode "zeros".
+    // Halo-aware mode: when set, the reader reads spatial (H/W) boundary conv-window positions from this compact
     std::optional<const Tensor> halo_buffer;
-    // Per-device [h_start, w_start] global spatial offset (uint32, one page per device), read by the
-    // reader to evaluate the logical-pad mask when masking is enabled.
+    // Per-device [h_start, w_start] global spatial offset (uint32, one page per device)
     std::optional<const Tensor> pad_offset_tensor;
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -294,6 +294,16 @@ tt::tt_metal::ProgramDescriptor Conv3dProgramFactory::create_descriptor(
     log_debug(tt::LogOp, "CB matmul_result_rm: page_size={} bytes, num_pages={}", tile_size, matmul_M_t * matmul_N_t);
 
     bool is_padding_zeros = operation_attributes.padding_mode == "zeros";
+    // Halo-aware mode: spatial (H/W) boundary conv-window positions read from the compact halo buffer
+    // instead of zero-padding. Only for zeros mode (the halo carries the neighbor's real pixels).
+    const bool halo_mode = tensor_args.halo_buffer.has_value() && is_padding_zeros;
+    // Logical-pad masking: opt-in. Needs the per-device offset tensor and a nonzero logical dim;
+    // otherwise fully off (byte-identical to today for every other conv3d caller). Independent of
+    // halo_mode: the persistent-padded plain conv (no halo buffer) reads a padded input and masks its
+    // logical-pad positions in-kernel (caller passes logical+pad as the threshold), avoiding a
+    // separate full-tensor pre-mask mul.
+    const bool mask_mode = tensor_args.pad_offset_tensor.has_value() &&
+                           (operation_attributes.logical_h_mask != 0 || operation_attributes.logical_w_mask != 0);
 
     uint32_t in_row_size_bytes = input_tensor.buffer()->aligned_page_size();
     uint32_t out_row_size_bytes = output_tensor.buffer()->aligned_page_size();
@@ -326,6 +336,23 @@ tt::tt_metal::ProgramDescriptor Conv3dProgramFactory::create_descriptor(
                 .buffer_index = static_cast<uint8_t>(cb_dram_read_scratch_id),
                 .data_format = data_format,
                 .page_size = dram_read_scratch_page_bytes,
+            }}},
+        });
+    }
+
+    // Tiny landing CB for the per-device [h_start, w_start] offset page (mask mode only).
+    uint32_t cb_pad_offset_id = 32;  // Invalid; set below if masking is enabled
+    if (mask_mode) {
+        const uint32_t pad_offset_page_bytes =
+            tt::round_up(2u * static_cast<uint32_t>(sizeof(uint32_t)), dram_read_alignment);
+        cb_pad_offset_id = next_cb_index++;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = pad_offset_page_bytes,
+            .core_ranges = CoreRangeSet(core_grid),
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_pad_offset_id),
+                .data_format = tt::DataFormat::UInt32,
+                .page_size = pad_offset_page_bytes,
             }}},
         });
     }
@@ -732,8 +759,19 @@ tt::tt_metal::ProgramDescriptor Conv3dProgramFactory::create_descriptor(
         coalesced_scratch_rows,
         cb_dram_read_scratch_id,
         static_cast<uint32_t>(enable_dram_read_staging),
-        dram_read_alignment};
+        dram_read_alignment,
+        static_cast<uint32_t>(halo_mode),
+        static_cast<uint32_t>(mask_mode),
+        operation_attributes.logical_h_mask,
+        operation_attributes.logical_w_mask,
+        cb_pad_offset_id};
     tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
+    // Halo buffer accessor follows the input accessor (nullptr when not in halo mode, like bias).
+    tt::tt_metal::TensorAccessorArgs(halo_mode ? tensor_args.halo_buffer.value().buffer() : nullptr)
+        .append_to(reader_compile_time_args);
+    // Per-device offset accessor follows the halo accessor (nullptr when not masking).
+    tt::tt_metal::TensorAccessorArgs(mask_mode ? tensor_args.pad_offset_tensor.value().buffer() : nullptr)
+        .append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp";
@@ -835,7 +873,9 @@ tt::tt_metal::ProgramDescriptor Conv3dProgramFactory::create_descriptor(
         static_cast<uint32_t>(weight_share_mode),
         weights_mcast_sender_sem_id,
         weights_mcast_receiver_sem_id,
-        static_cast<uint32_t>(enable_streaming_output)};
+        static_cast<uint32_t>(enable_streaming_output),
+        operation_attributes.output_pad_h,
+        operation_attributes.output_pad_w};
     tt::tt_metal::TensorAccessorArgs(*output_tensor.buffer()).append_to(writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(*weight_tensor.buffer()).append_to(writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(bias_tensor.has_value() ? bias_tensor.value().buffer() : nullptr)
@@ -849,6 +889,9 @@ tt::tt_metal::ProgramDescriptor Conv3dProgramFactory::create_descriptor(
     writer_desc.config = WriterConfigDescriptor{};
 
     tt::tt_metal::Buffer* input_buffer = input_tensor.buffer();
+    tt::tt_metal::Buffer* halo_buffer_ptr = halo_mode ? tensor_args.halo_buffer.value().buffer() : nullptr;
+    tt::tt_metal::Buffer* pad_offset_buffer_ptr =
+        mask_mode ? tensor_args.pad_offset_tensor.value().buffer() : nullptr;
     tt::tt_metal::Buffer* out_buffer = output_tensor.buffer();
     tt::tt_metal::Buffer* weight_buffer = weight_tensor.buffer();
     tt::tt_metal::Buffer* bias_buffer = bias_tensor.has_value() ? bias_tensor.value().buffer() : nullptr;
@@ -1179,19 +1222,27 @@ tt::tt_metal::ProgramDescriptor Conv3dProgramFactory::create_descriptor(
         const uint32_t num_workers = cw.has_work ? (uint32_t)worker_core_ids[group_id].size() : 0u;
 
         // Reader pos[0] is the input buffer address (patched on cache hit via emplace_runtime_args).
-        reader_desc.emplace_runtime_args(
-            core,
-            {input_buffer,
-             cw.c_in_block_start,
-             cw.c_in_block_end,
-             cw.c_out_block_start,
-             cw.c_out_block_end,
-             cw.t_out_start,
-             cw.t_out_end,
-             cw.h_out_start,
-             cw.h_out_end,
-             cw.w_out_start,
-             cw.w_out_end});
+        // Trailing halo buffer address (halo mode only) is read by the reader when its halo_mode CT flag set.
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.reserve(12);
+        reader_args.push_back(input_buffer);
+        reader_args.push_back(cw.c_in_block_start);
+        reader_args.push_back(cw.c_in_block_end);
+        reader_args.push_back(cw.c_out_block_start);
+        reader_args.push_back(cw.c_out_block_end);
+        reader_args.push_back(cw.t_out_start);
+        reader_args.push_back(cw.t_out_end);
+        reader_args.push_back(cw.h_out_start);
+        reader_args.push_back(cw.h_out_end);
+        reader_args.push_back(cw.w_out_start);
+        reader_args.push_back(cw.w_out_end);
+        if (halo_mode) {
+            reader_args.push_back(halo_buffer_ptr);
+        }
+        if (mask_mode) {
+            reader_args.push_back(pad_offset_buffer_ptr);
+        }
+        reader_desc.emplace_runtime_args(core, reader_args);
 
         compute_desc.runtime_args.emplace_back(
             core,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -294,14 +294,9 @@ tt::tt_metal::ProgramDescriptor Conv3dProgramFactory::create_descriptor(
     log_debug(tt::LogOp, "CB matmul_result_rm: page_size={} bytes, num_pages={}", tile_size, matmul_M_t * matmul_N_t);
 
     bool is_padding_zeros = operation_attributes.padding_mode == "zeros";
-    // Halo-aware mode: spatial (H/W) boundary conv-window positions read from the compact halo buffer
-    // instead of zero-padding. Only for zeros mode (the halo carries the neighbor's real pixels).
+    // Halo-aware mode: spatial (H/W) boundary conv-window positions read from the compact halo buffer instead
     const bool halo_mode = tensor_args.halo_buffer.has_value() && is_padding_zeros;
-    // Logical-pad masking: opt-in. Needs the per-device offset tensor and a nonzero logical dim;
-    // otherwise fully off (byte-identical to today for every other conv3d caller). Independent of
-    // halo_mode: the persistent-padded plain conv (no halo buffer) reads a padded input and masks its
-    // logical-pad positions in-kernel (caller passes logical+pad as the threshold), avoiding a
-    // separate full-tensor pre-mask mul.
+    // Logical-pad masking: opt-in
     const bool mask_mode = tensor_args.pad_offset_tensor.has_value() &&
                            (operation_attributes.logical_h_mask != 0 || operation_attributes.logical_w_mask != 0);
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -8,6 +8,17 @@
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 #include <ttnn/operations/experimental/conv3d/device/kernels/conv3d_gather_tuning.hpp>
 
+// Logical-pad masking (opt-in, halo mode only): the gather's interior-read path zeros sticks whose
+// GLOBAL spatial index is a padding position (global >= logical). Set once in main() from the CT
+// logical dims + this device's per-device [h_start, w_start] offset; 0 == disabled (all other conv3d
+// callers), so the runtime guard short-circuits and output is unchanged.
+namespace {
+uint32_t g_mask_logical_h = 0;
+uint32_t g_mask_logical_w = 0;
+uint32_t g_mask_h_start = 0;
+uint32_t g_mask_w_start = 0;
+}  // namespace
+
 // Pre-zero CB pages so tile-alignment padding is zero.
 template <uint32_t padded_page_bytes, typename Dst>
 FORCE_INLINE void pre_zero_pages(Noc noc, const Dst& dst, uint32_t offset, uint32_t num_pages) {
@@ -327,10 +338,21 @@ template <
     uint32_t N_TRIDS,
     bool EnableDramReadStaging,
     uint32_t dram_read_alignment,
-    typename Reader>
+    bool halo_mode,
+    uint32_t halo_h_total,
+    uint32_t halo_padding_h,
+    uint32_t halo_padding_w,
+    uint32_t halo_htop_base,
+    uint32_t halo_hbot_base,
+    uint32_t halo_wleft_base,
+    uint32_t halo_wright_base,
+    typename Reader,
+    typename HaloReader>
 void gather_rows_to_shard(
     Noc noc,
     const Reader& in_reader,
+    const HaloReader& halo_reader,
+    uint32_t halo_frame_base,
     const experimental::CB& shard_cb,
     const experimental::CB& dram_read_scratch_cb,
     uint32_t batch_page_base,
@@ -393,10 +415,70 @@ void gather_rows_to_shard(
                     }
                 }
                 if constexpr (check_padding) {
+                    // Universal logical-pad mask (halo mode): any position whose GLOBAL coord is beyond the
+                    // logical extent reads zero. global = start_dev + in holds across the neighbor boundary,
+                    // so this also catches halo reads of a neighbor's pad region (the H-halo/W-tail corner)
+                    // — the halo buffer is built from unmasked input, unlike the full-pad pre-mask. Globals
+                    // are 0 for every non-halo conv3d caller, so this short-circuits.
+                    bool logical_masked = false;
+                    if (g_mask_logical_h != 0 &&
+                        static_cast<uint32_t>(static_cast<int32_t>(g_mask_h_start) + h_in) >= g_mask_logical_h) {
+                        logical_masked = true;
+                    } else if (g_mask_logical_w != 0 &&
+                               static_cast<uint32_t>(static_cast<int32_t>(g_mask_w_start) + w_in) >=
+                                   g_mask_logical_w) {
+                        logical_masked = true;
+                    }
+                    if (logical_masked) {
+                        zeroPad<C_in_block_bytes>(noc, shard_cb, shard_offset);
+                    } else {
                     const bool w_outside = (w_in < 0 || w_in >= static_cast<int32_t>(W_in));
                     const bool in_padding = t_outside || h_outside || w_outside;
                     if (in_padding) {
-                        if constexpr (is_padding_zeros) {
+                        if constexpr (halo_mode) {
+                            // Temporal boundary stays zero (T not halo-exchanged); spatial boundary reads
+                            // the neighbor's stick from the compact [Htop|Hbot|Wleft|Wright] halo buffer.
+                            // W sections are h_total tall (cover corners); H sections are W_in wide.
+                            if (t_outside) {
+                                zeroPad<C_in_block_bytes>(noc, shard_cb, shard_offset);
+                            } else {
+                                const uint32_t frame = halo_frame_base + static_cast<uint32_t>(t_in);
+                                uint32_t halo_page;
+                                if (w_outside) {
+                                    const uint32_t hrow =
+                                        static_cast<uint32_t>(h_in + static_cast<int32_t>(halo_padding_h));
+                                    if (w_in < 0) {
+                                        halo_page = halo_wleft_base + (frame * halo_h_total + hrow) * halo_padding_w +
+                                                    static_cast<uint32_t>(w_in + static_cast<int32_t>(halo_padding_w));
+                                    } else {
+                                        halo_page = halo_wright_base + (frame * halo_h_total + hrow) * halo_padding_w +
+                                                    static_cast<uint32_t>(w_in - static_cast<int32_t>(W_in));
+                                    }
+                                } else if (h_in < 0) {
+                                    halo_page = halo_htop_base +
+                                                (frame * halo_padding_h +
+                                                 static_cast<uint32_t>(h_in + static_cast<int32_t>(halo_padding_h))) *
+                                                    W_in +
+                                                static_cast<uint32_t>(w_in);
+                                } else {
+                                    halo_page = halo_hbot_base +
+                                                (frame * halo_padding_h +
+                                                 static_cast<uint32_t>(h_in - static_cast<int32_t>(H_in))) *
+                                                    W_in +
+                                                static_cast<uint32_t>(w_in);
+                                }
+                                read_input_row_maybe_staged<EnableDramReadStaging, dram_read_alignment>(
+                                    noc,
+                                    halo_reader,
+                                    halo_page,
+                                    c_in_offset_bytes,
+                                    in_row_size_bytes,
+                                    shard_cb,
+                                    shard_offset,
+                                    C_in_block_bytes,
+                                    dram_read_scratch_cb);
+                            }
+                        } else if constexpr (is_padding_zeros) {
                             zeroPad<C_in_block_bytes>(noc, shard_cb, shard_offset);
                         } else {
                             const int32_t w_clamped = clampIndex(w_in, 0, static_cast<int32_t>(W_in) - 1);
@@ -428,20 +510,37 @@ void gather_rows_to_shard(
                             C_in_block_bytes,
                             dram_read_scratch_cb);
                     }
+                    }  // end logical_masked else
                 } else {
-                    // Fast path: no padding checks
-                    const uint32_t page_idx = batch_page_base + static_cast<uint32_t>(t_in) * H_in_W_in +
-                                              static_cast<uint32_t>(h_in) * W_in + static_cast<uint32_t>(w_in);
-                    read_input_row_maybe_staged<EnableDramReadStaging, dram_read_alignment>(
-                        noc,
-                        in_reader,
-                        page_idx,
-                        c_in_offset_bytes,
-                        in_row_size_bytes,
-                        shard_cb,
-                        shard_offset,
-                        C_in_block_bytes,
-                        dram_read_scratch_cb);
+                    // Fast path: no conv-padding checks. Still honor the logical-pad mask when enabled
+                    // (persistent-padded plain conv reads a padded input; pass logical+pad as the
+                    // threshold): zero any read whose GLOBAL coord is beyond the logical extent. The
+                    // g_mask_logical==0 guard short-circuits for every non-masking caller.
+                    bool logical_masked = false;
+                    if (g_mask_logical_h != 0 &&
+                        static_cast<uint32_t>(static_cast<int32_t>(g_mask_h_start) + h_in) >= g_mask_logical_h) {
+                        logical_masked = true;
+                    } else if (
+                        g_mask_logical_w != 0 &&
+                        static_cast<uint32_t>(static_cast<int32_t>(g_mask_w_start) + w_in) >= g_mask_logical_w) {
+                        logical_masked = true;
+                    }
+                    if (logical_masked) {
+                        zeroPad<C_in_block_bytes>(noc, shard_cb, shard_offset);
+                    } else {
+                        const uint32_t page_idx = batch_page_base + static_cast<uint32_t>(t_in) * H_in_W_in +
+                                                  static_cast<uint32_t>(h_in) * W_in + static_cast<uint32_t>(w_in);
+                        read_input_row_maybe_staged<EnableDramReadStaging, dram_read_alignment>(
+                            noc,
+                            in_reader,
+                            page_idx,
+                            c_in_offset_bytes,
+                            in_row_size_bytes,
+                            shard_cb,
+                            shard_offset,
+                            C_in_block_bytes,
+                            dram_read_scratch_cb);
+                    }
                 }
                 if constexpr (N_TRIDS != 0) {
                     if (use_ring) {
@@ -592,10 +691,21 @@ template <
     bool EnableCoalescedShardReads,
     bool EnableDramReadStaging,
     uint32_t dram_read_alignment,
-    typename Reader>
+    bool halo_mode,
+    uint32_t halo_h_total,
+    uint32_t halo_padding_h,
+    uint32_t halo_padding_w,
+    uint32_t halo_htop_base,
+    uint32_t halo_hbot_base,
+    uint32_t halo_wleft_base,
+    uint32_t halo_wright_base,
+    typename Reader,
+    typename HaloReader>
 void gather_rows_to_shard_selected(
     Noc noc,
     const Reader& in_reader,
+    const HaloReader& halo_reader,
+    uint32_t halo_frame_base,
     const experimental::CB& shard_cb,
     const experimental::CB& dram_read_scratch_cb,
     [[maybe_unused]] uint32_t shard_l1_base,
@@ -661,9 +771,19 @@ void gather_rows_to_shard_selected(
             decltype(check_padding_v)::value,
             GatherTrids,
             EnableDramReadStaging,
-            dram_read_alignment>(
+            dram_read_alignment,
+            halo_mode,
+            halo_h_total,
+            halo_padding_h,
+            halo_padding_w,
+            halo_htop_base,
+            halo_hbot_base,
+            halo_wleft_base,
+            halo_wright_base>(
             noc,
             in_reader,
+            halo_reader,
+            halo_frame_base,
             shard_cb,
             dram_read_scratch_cb,
             batch_page_base,
@@ -731,6 +851,15 @@ void kernel_main() {
     constexpr uint32_t cb_dram_read_scratch = get_compile_time_arg_val(39);
     constexpr bool enable_dram_read_staging = get_compile_time_arg_val(40) == 1;
     constexpr uint32_t dram_read_alignment = get_compile_time_arg_val(41);
+    // Halo-aware mode: spatial (H/W) boundary conv-window positions read from a compact
+    // [H-top|H-bot|W-left|W-right] halo buffer (produced by neighbor_pad_halo) instead of zero-padding.
+    constexpr bool halo_mode = get_compile_time_arg_val(42) == 1;
+    // Logical-pad masking (opt-in, halo mode only). mask_mode==0 => all new code below is elided and
+    // the RT/CT layout past halo is unchanged for every other conv3d caller.
+    constexpr bool mask_mode = get_compile_time_arg_val(43) == 1;
+    constexpr uint32_t logical_h_mask = get_compile_time_arg_val(44);
+    constexpr uint32_t logical_w_mask = get_compile_time_arg_val(45);
+    constexpr uint32_t cb_pad_offset = get_compile_time_arg_val(46);
     constexpr uint32_t padded_page_bytes = kT * kH * kW * C_in_block_bytes + patch_pad_bytes;
 
     // Load input/output addresses and range parameters
@@ -746,10 +875,49 @@ void kernel_main() {
     const uint32_t h_out_end = get_arg_val<uint32_t>(argidx++);
     const uint32_t w_out_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t w_out_end = get_arg_val<uint32_t>(argidx++);
+    // Trailing halo buffer address (halo mode only), then the per-device offset addr (mask mode only).
+    const uint32_t halo_addr = halo_mode ? get_arg_val<uint32_t>(argidx++) : 0u;
+    const uint32_t pad_offset_addr = mask_mode ? get_arg_val<uint32_t>(argidx++) : 0u;
 
-    // Tensor accessor for input tensor
-    constexpr auto in_args = TensorAccessorArgs<42>();
+    // Tensor accessor for input tensor (CT args 42..46 are scalar flags; input accessor starts at 47).
+    constexpr auto in_args = TensorAccessorArgs<47>();
     const auto in_reader = TensorAccessor(in_args, in_addr);
+    // Halo buffer accessor follows the input accessor.
+    constexpr auto halo_args = TensorAccessorArgs<in_args.next_compile_time_args_offset()>();
+    const auto halo_reader = TensorAccessor(halo_args, halo_addr);
+    // Reset mask globals every invocation: the gather reads them unconditionally, and a non-mask
+    // conv3d can reuse this core's L1 after a mask kernel — never inherit stale mask state.
+    g_mask_logical_h = 0;
+    g_mask_logical_w = 0;
+    g_mask_h_start = 0;
+    g_mask_w_start = 0;
+    // Per-device [h_start, w_start] offset accessor follows the halo accessor; read page 0 into the
+    // mask globals used by the gather's interior-read path. Only when masking is enabled.
+    if constexpr (mask_mode) {
+        constexpr auto offset_args = TensorAccessorArgs<halo_args.next_compile_time_args_offset()>();
+        const auto offset_reader = TensorAccessor(offset_args, pad_offset_addr);
+        Noc off_noc;
+        experimental::CB pad_off_cb(cb_pad_offset);
+        pad_off_cb.reserve_back(1);
+        const uint32_t off_l1 = pad_off_cb.get_write_ptr();
+        off_noc.async_read(
+            offset_reader, pad_off_cb, 2u * sizeof(uint32_t), {.page_id = 0, .offset_bytes = 0}, {.offset_bytes = 0});
+        off_noc.async_read_barrier();
+        volatile tt_l1_ptr uint32_t* off_p = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(off_l1);
+        g_mask_h_start = off_p[0];
+        g_mask_w_start = off_p[1];
+        g_mask_logical_h = logical_h_mask;
+        g_mask_logical_w = logical_w_mask;
+    }
+
+    // Compact halo section bases (pages), layout [H-top | H-bot | W-left | W-right]. H sections are W_in
+    // wide (interior W), W sections are (H_in + 2*padding_h) tall (include the corner rows). outer = N*T_in.
+    constexpr uint32_t halo_outer = N * T_in;
+    constexpr uint32_t halo_h_total = H_in + 2 * padding_h;
+    constexpr uint32_t halo_htop_base = 0;
+    constexpr uint32_t halo_hbot_base = halo_outer * padding_h * W_in;
+    constexpr uint32_t halo_wleft_base = 2 * halo_outer * padding_h * W_in;
+    constexpr uint32_t halo_wright_base = halo_wleft_base + halo_outer * padding_w * halo_h_total;
 
     Noc noc;
 
@@ -815,9 +983,24 @@ void kernel_main() {
                                 const int32_t w_shard_start =
                                     static_cast<int32_t>(w_block * stride_w) - static_cast<int32_t>(padding_w);
                                 const uint32_t W_shard_cur = (w_block_end - 1 - w_block) * stride_w + kW;
+                                // Pad-block gate: a block whose largest GLOBAL input index exceeds the
+                                // logical extent holds propagated pad rows/cols (last H-row / last W-col
+                                // device only). Force it off the fast/coalesced path so the guarded
+                                // per-stick gather masks those positions (interior-read path in §gather).
+                                bool block_has_pad = false;
+                                if constexpr (mask_mode) {
+                                    const int32_t h_max_g = static_cast<int32_t>(g_mask_h_start) + h_shard_start +
+                                                            static_cast<int32_t>(H_shard_cur) - 1;
+                                    const int32_t w_max_g = static_cast<int32_t>(g_mask_w_start) + w_shard_start +
+                                                            static_cast<int32_t>(W_shard_cur) - 1;
+                                    block_has_pad =
+                                        (logical_h_mask != 0 && h_max_g >= static_cast<int32_t>(logical_h_mask)) ||
+                                        (logical_w_mask != 0 && w_max_g >= static_cast<int32_t>(logical_w_mask));
+                                }
                                 const bool shard_all_in_bounds = th_in_bounds && w_shard_start >= 0 &&
                                                                  (w_shard_start + static_cast<int32_t>(W_shard_cur) -
-                                                                  1) < static_cast<int32_t>(W_in);
+                                                                  1) < static_cast<int32_t>(W_in) &&
+                                                                 !block_has_pad;
                                 const bool coalesce_this_block =
                                     enable_coalesced_shard_reads && shard_all_in_bounds && W_shard_cur > NUM_DRAM_BANKS;
                                 constexpr uint32_t coalesced_scratch_offset =
@@ -861,9 +1044,19 @@ void kernel_main() {
                                         gather_trids,
                                         enable_coalesced_shard_reads,
                                         enable_dram_read_staging,
-                                        dram_read_alignment>(
+                                        dram_read_alignment,
+                                        halo_mode,
+                                        halo_h_total,
+                                        padding_h,
+                                        padding_w,
+                                        halo_htop_base,
+                                        halo_hbot_base,
+                                        halo_wleft_base,
+                                        halo_wright_base>(
                                         noc,
                                         in_reader,
+                                        halo_reader,
+                                        batch_idx * T_in,
                                         shard_cb,
                                         dram_read_scratch_cb,
                                         shard_l1_base,
@@ -907,9 +1100,19 @@ void kernel_main() {
                                                 gather_trids,
                                                 enable_coalesced_shard_reads,
                                                 enable_dram_read_staging,
-                                                dram_read_alignment>(
+                                                dram_read_alignment,
+                                                halo_mode,
+                                                halo_h_total,
+                                                padding_h,
+                                                padding_w,
+                                                halo_htop_base,
+                                                halo_hbot_base,
+                                                halo_wleft_base,
+                                                halo_wright_base>(
                                                 noc,
                                                 in_reader,
+                                                halo_reader,
+                                                batch_idx * T_in,
                                                 shard_cb,
                                                 dram_read_scratch_cb,
                                                 shard_l1_base,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -8,10 +8,7 @@
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 #include <ttnn/operations/experimental/conv3d/device/kernels/conv3d_gather_tuning.hpp>
 
-// Logical-pad masking (opt-in, halo mode only): the gather's interior-read path zeros sticks whose
-// GLOBAL spatial index is a padding position (global >= logical). Set once in main() from the CT
-// logical dims + this device's per-device [h_start, w_start] offset; 0 == disabled (all other conv3d
-// callers), so the runtime guard short-circuits and output is unchanged.
+// Logical-pad masking (opt-in, halo mode only): the gather's interior-read path zeros sticks whose GLOBAL spatial
 namespace {
 uint32_t g_mask_logical_h = 0;
 uint32_t g_mask_logical_w = 0;
@@ -415,11 +412,7 @@ void gather_rows_to_shard(
                     }
                 }
                 if constexpr (check_padding) {
-                    // Universal logical-pad mask (halo mode): any position whose GLOBAL coord is beyond the
-                    // logical extent reads zero. global = start_dev + in holds across the neighbor boundary,
-                    // so this also catches halo reads of a neighbor's pad region (the H-halo/W-tail corner)
-                    // — the halo buffer is built from unmasked input, unlike the full-pad pre-mask. Globals
-                    // are 0 for every non-halo conv3d caller, so this short-circuits.
+                    // Universal logical-pad mask (halo mode): any position whose GLOBAL coord is beyond the logical
                     bool logical_masked = false;
                     if (g_mask_logical_h != 0 &&
                         static_cast<uint32_t>(static_cast<int32_t>(g_mask_h_start) + h_in) >= g_mask_logical_h) {
@@ -436,9 +429,7 @@ void gather_rows_to_shard(
                     const bool in_padding = t_outside || h_outside || w_outside;
                     if (in_padding) {
                         if constexpr (halo_mode) {
-                            // Temporal boundary stays zero (T not halo-exchanged); spatial boundary reads
-                            // the neighbor's stick from the compact [Htop|Hbot|Wleft|Wright] halo buffer.
-                            // W sections are h_total tall (cover corners); H sections are W_in wide.
+                            // Temporal boundary stays zero (T not halo-exchanged)
                             if (t_outside) {
                                 zeroPad<C_in_block_bytes>(noc, shard_cb, shard_offset);
                             } else {
@@ -512,10 +503,7 @@ void gather_rows_to_shard(
                     }
                     }  // end logical_masked else
                 } else {
-                    // Fast path: no conv-padding checks. Still honor the logical-pad mask when enabled
-                    // (persistent-padded plain conv reads a padded input; pass logical+pad as the
-                    // threshold): zero any read whose GLOBAL coord is beyond the logical extent. The
-                    // g_mask_logical==0 guard short-circuits for every non-masking caller.
+                    // Fast path: no conv-padding checks
                     bool logical_masked = false;
                     if (g_mask_logical_h != 0 &&
                         static_cast<uint32_t>(static_cast<int32_t>(g_mask_h_start) + h_in) >= g_mask_logical_h) {
@@ -851,11 +839,9 @@ void kernel_main() {
     constexpr uint32_t cb_dram_read_scratch = get_compile_time_arg_val(39);
     constexpr bool enable_dram_read_staging = get_compile_time_arg_val(40) == 1;
     constexpr uint32_t dram_read_alignment = get_compile_time_arg_val(41);
-    // Halo-aware mode: spatial (H/W) boundary conv-window positions read from a compact
-    // [H-top|H-bot|W-left|W-right] halo buffer (produced by neighbor_pad_halo) instead of zero-padding.
+    // Halo-aware mode: spatial (H/W) boundary conv-window positions read from a compact [H-top|H-bot|W-left|W-right]
     constexpr bool halo_mode = get_compile_time_arg_val(42) == 1;
-    // Logical-pad masking (opt-in, halo mode only). mask_mode==0 => all new code below is elided and
-    // the RT/CT layout past halo is unchanged for every other conv3d caller.
+    // Logical-pad masking
     constexpr bool mask_mode = get_compile_time_arg_val(43) == 1;
     constexpr uint32_t logical_h_mask = get_compile_time_arg_val(44);
     constexpr uint32_t logical_w_mask = get_compile_time_arg_val(45);
@@ -885,14 +871,12 @@ void kernel_main() {
     // Halo buffer accessor follows the input accessor.
     constexpr auto halo_args = TensorAccessorArgs<in_args.next_compile_time_args_offset()>();
     const auto halo_reader = TensorAccessor(halo_args, halo_addr);
-    // Reset mask globals every invocation: the gather reads them unconditionally, and a non-mask
-    // conv3d can reuse this core's L1 after a mask kernel — never inherit stale mask state.
+    // Reset mask globals every invocation: the gather reads them unconditionally
     g_mask_logical_h = 0;
     g_mask_logical_w = 0;
     g_mask_h_start = 0;
     g_mask_w_start = 0;
-    // Per-device [h_start, w_start] offset accessor follows the halo accessor; read page 0 into the
-    // mask globals used by the gather's interior-read path. Only when masking is enabled.
+    // Per-device [h_start, w_start] offset accessor follows the halo accessor
     if constexpr (mask_mode) {
         constexpr auto offset_args = TensorAccessorArgs<halo_args.next_compile_time_args_offset()>();
         const auto offset_reader = TensorAccessor(offset_args, pad_offset_addr);
@@ -910,8 +894,7 @@ void kernel_main() {
         g_mask_logical_w = logical_w_mask;
     }
 
-    // Compact halo section bases (pages), layout [H-top | H-bot | W-left | W-right]. H sections are W_in
-    // wide (interior W), W sections are (H_in + 2*padding_h) tall (include the corner rows). outer = N*T_in.
+    // Compact halo section bases (pages), layout [H-top | H-bot | W-left | W-right]
     constexpr uint32_t halo_outer = N * T_in;
     constexpr uint32_t halo_h_total = H_in + 2 * padding_h;
     constexpr uint32_t halo_htop_base = 0;
@@ -983,10 +966,7 @@ void kernel_main() {
                                 const int32_t w_shard_start =
                                     static_cast<int32_t>(w_block * stride_w) - static_cast<int32_t>(padding_w);
                                 const uint32_t W_shard_cur = (w_block_end - 1 - w_block) * stride_w + kW;
-                                // Pad-block gate: a block whose largest GLOBAL input index exceeds the
-                                // logical extent holds propagated pad rows/cols (last H-row / last W-col
-                                // device only). Force it off the fast/coalesced path so the guarded
-                                // per-stick gather masks those positions (interior-read path in §gather).
+                                // Pad-block gate: a block whose largest GLOBAL input index exceeds the logical
                                 bool block_has_pad = false;
                                 if constexpr (mask_mode) {
                                     const int32_t h_max_g = static_cast<int32_t>(g_mask_h_start) + h_shard_start +

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
@@ -63,6 +63,10 @@ void kernel_main() {
     constexpr uint32_t weights_mcast_sender_sem_id = get_compile_time_arg_val(23);
     constexpr uint32_t weights_mcast_receiver_sem_id = get_compile_time_arg_val(24);
     constexpr bool enable_streaming_output = get_compile_time_arg_val(25) == 1;
+    // Padded-output mode: write the compact [H_out,W_out] result into the interior of a spatially
+    // padded [H_out+2*output_pad_h, W_out+2*output_pad_w] buffer. 0 == compact (page index unchanged).
+    constexpr uint32_t output_pad_h = get_compile_time_arg_val(26);
+    constexpr uint32_t output_pad_w = get_compile_time_arg_val(27);
 
     uint32_t argidx = 0;
     const uint32_t out_addr = get_arg_val<uint32_t>(argidx++);
@@ -119,7 +123,7 @@ void kernel_main() {
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_weight_tiled);
     constexpr uint32_t partials_tile_bytes = get_tile_size(cb_matmul_interm_tiled);
-    constexpr auto out_args = TensorAccessorArgs<26>();
+    constexpr auto out_args = TensorAccessorArgs<28>();
     constexpr auto weight_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto bias_args = TensorAccessorArgs<weight_args.next_compile_time_args_offset()>();
     const auto out_writer = TensorAccessor(out_args, out_addr);
@@ -129,7 +133,9 @@ void kernel_main() {
     constexpr uint32_t output_tiles = matmul_M_t * matmul_N_t;
     constexpr uint32_t weight_tiles = matmul_K_t * matmul_N_t;
     constexpr uint32_t C_out_t = C_out_num_blocks * matmul_N_t;
-    constexpr uint32_t T_out_H_out_W_out = T_out * H_out * W_out;
+    constexpr uint32_t H_out_p = H_out + 2 * output_pad_h;
+    constexpr uint32_t W_out_p = W_out + 2 * output_pad_w;
+    constexpr uint32_t T_out_H_out_W_out = T_out * H_out_p * W_out_p;
 
     // Mcast passive participant: this core sits inside the mcast bbox but has no work. It exists
     // only to satisfy the multicast handshake (sender's wait depends on every core in the bbox
@@ -347,8 +353,9 @@ void kernel_main() {
                                                     cb_out.wait_front(rows_waited * row_tiles);
                                                 }
                                             }
-                                            uint32_t out_page_idx =
-                                                batch_idx * T_out_H_out_W_out + t * H_out * W_out + h * W_out + w;
+                                            uint32_t out_page_idx = batch_idx * T_out_H_out_W_out +
+                                                                    t * H_out_p * W_out_p +
+                                                                    (h + output_pad_h) * W_out_p + (w + output_pad_w);
                                             noc.async_write(
                                                 cb_out,
                                                 out_writer,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
@@ -63,8 +63,7 @@ void kernel_main() {
     constexpr uint32_t weights_mcast_sender_sem_id = get_compile_time_arg_val(23);
     constexpr uint32_t weights_mcast_receiver_sem_id = get_compile_time_arg_val(24);
     constexpr bool enable_streaming_output = get_compile_time_arg_val(25) == 1;
-    // Padded-output mode: write the compact [H_out,W_out] result into the interior of a spatially
-    // padded [H_out+2*output_pad_h, W_out+2*output_pad_w] buffer. 0 == compact (page index unchanged).
+    // Padded-output mode: write the compact [H_out,W_out] result into the interior of a spatially padded
     constexpr uint32_t output_pad_h = get_compile_time_arg_val(26);
     constexpr uint32_t output_pad_w = get_compile_time_arg_val(27);
 

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/CMakeLists.txt
@@ -37,6 +37,7 @@ target_sources(
 # Disable unity build for program factory files to avoid symbol collisions
 set_source_files_properties(
     device/minimal_matmul_program_factory.cpp
+    device/minimal_matmul_fabric_bound_program_factory.cpp
     PROPERTIES
         SKIP_UNITY_BUILD_INCLUSION
             ON

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
@@ -84,13 +84,11 @@ void kernel_main() {
 #if defined(FUSE_AG) && defined(READ_FROM_LOCAL_INPUT)
 // If we have FUSE_AG with READ_FROM_LOCAL_INPUT, in3 is defined
 #ifdef FUSE_BIAS
-    // After in2, then in3, then ternary. TensorAccessorArgs counts are tensor-config dependent, so advance
-    // the accessor-aware way (never a fixed arg count): skip in2 + in3 starting from in2's offset.
+    // After in2, then in3, then ternary
     constexpr uint32_t ternary_a_args_cta_offset =
         tensor_accessor::detail::get_tensor_accessor_args_cta_offset<2, in2_args_cta_offset>();
 #else
-    // After outputs, then in3, then ternary. Treat in3 as one more accessor past the N_chunks outputs so its
-    // real (config-dependent) arg count is skipped.
+    // After outputs, then in3, then ternary
     constexpr uint32_t ternary_a_args_cta_offset =
         tensor_accessor::detail::get_tensor_accessor_args_cta_offset<N_chunks + 1, out_tensor_args_cta_offset>();
 #endif
@@ -195,8 +193,7 @@ void kernel_main() {
     uint32_t mm_progress_counters_base = 0;
     if constexpr (is_output_writer) {
         srs_fuse_signaler = OpSignaler(srs_fuse_signaler_rt_args_idx);
-        // Per-core signaling: base L1 address of the RS cores' per-core progress counter array,
-        // pushed as the next RT arg right after the OpSignaler args.
+        // Per-core signaling: base L1 address of the RS cores' per-core progress counter array
         mm_progress_counters_base = get_arg_val<uint32_t>(srs_fuse_signaler_rt_args_idx++);
     }
 #endif
@@ -421,10 +418,7 @@ void kernel_main() {
              * of the next output block.
              */
 #ifdef SRS_FUSE_OP_SIGNALER
-            // Fused RS path: write each block promptly (no core-y defer stagger — the L1-sharded output has
-            // no DRAM write banks to spread). This lets the per-core progress counter the RS reader polls
-            // tick at compute-completion instead of at the global max_defer_write_k_block barrier ~a block
-            // later, which was delaying the reader by a full block.
+            // Fused RS path: write each block promptly
             defer_write = false;
 #else
             defer_write = !is_last_block;
@@ -485,9 +479,7 @@ void kernel_main() {
                     }
 #endif  // FUSE_SWIGLU
 #ifdef SRS_FUSE_OP_SIGNALER
-                    // Signal this core's per-core progress counter right after its prompt block write, at
-                    // compute-completion (every block, not just is_last_block). The reader waits per core, so
-                    // no global "all cores done writing" barrier is needed.
+                    // Signal this core's per-core progress counter right after its prompt block write
                     noc.async_write_barrier();
                     srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
@@ -84,14 +84,15 @@ void kernel_main() {
 #if defined(FUSE_AG) && defined(READ_FROM_LOCAL_INPUT)
 // If we have FUSE_AG with READ_FROM_LOCAL_INPUT, in3 is defined
 #ifdef FUSE_BIAS
-    // After in2, then in3, then ternary
+    // After in2, then in3, then ternary. TensorAccessorArgs counts are tensor-config dependent, so advance
+    // the accessor-aware way (never a fixed arg count): skip in2 + in3 starting from in2's offset.
     constexpr uint32_t ternary_a_args_cta_offset =
-        in2_args_cta_offset + tensor_accessor::detail::NUM_TENSOR_ACCESSOR_ARGS() * 2;
+        tensor_accessor::detail::get_tensor_accessor_args_cta_offset<2, in2_args_cta_offset>();
 #else
-    // After outputs, then in3, then ternary
+    // After outputs, then in3, then ternary. Treat in3 as one more accessor past the N_chunks outputs so its
+    // real (config-dependent) arg count is skipped.
     constexpr uint32_t ternary_a_args_cta_offset =
-        tensor_accessor::detail::get_tensor_accessor_args_cta_offset<N_chunks, out_tensor_args_cta_offset>() +
-        tensor_accessor::detail::NUM_TENSOR_ACCESSOR_ARGS();
+        tensor_accessor::detail::get_tensor_accessor_args_cta_offset<N_chunks + 1, out_tensor_args_cta_offset>();
 #endif
 #else
 // No FUSE_AG, same as dm_in1_sender_out
@@ -173,8 +174,8 @@ void kernel_main() {
 
 #ifdef READ_FROM_LOCAL_INPUT
 #ifdef FUSE_BIAS
-    constexpr auto in3_args =
-        TensorAccessorArgs<in2_args_cta_offset + tensor_accessor::detail::NUM_TENSOR_ACCESSOR_ARGS>();
+    // in3 (local input) sits right after in2 (bias); advance by in2's real arg count, not a fixed constant.
+    constexpr auto in3_args = TensorAccessorArgs<in2_args.next_compile_time_args_offset()>();
 #else
     constexpr uint32_t in3_args_cta_offset =
         tensor_accessor::detail::get_tensor_accessor_args_cta_offset<N_chunks, out_tensor_args_cta_offset>();
@@ -191,8 +192,12 @@ void kernel_main() {
     srs_fuse_signaler_rt_args_idx += 12;  // Skip MinimalMatmulFusedOpSignaler::push_matmul_fused_op_rt_args (12 args)
 #endif
     OpSignaler srs_fuse_signaler;
+    uint32_t mm_progress_counters_base = 0;
     if constexpr (is_output_writer) {
         srs_fuse_signaler = OpSignaler(srs_fuse_signaler_rt_args_idx);
+        // Per-core signaling: base L1 address of the RS cores' per-core progress counter array,
+        // pushed as the next RT arg right after the OpSignaler args.
+        mm_progress_counters_base = get_arg_val<uint32_t>(srs_fuse_signaler_rt_args_idx++);
     }
 #endif
 
@@ -357,9 +362,10 @@ void kernel_main() {
                 }
 #ifdef SRS_FUSE_OP_SIGNALER
                 if constexpr (is_output_writer) {
-                    if (not_first_block && k_block_iter == max_defer_write_k_block) {
+                    // Deferred-write path only (guarded by defer_write, which is false on the fused RS path).
+                    if (defer_write && not_first_block && k_block_iter == max_defer_write_k_block) {
                         noc.async_write_barrier();
-                        srs_fuse_signaler.synchronize_workers_and_signal_op(0);
+                        srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
                     }
                 }
 #endif
@@ -414,8 +420,16 @@ void kernel_main() {
              * If this isn't the last output block, defer writing until the defer_k_write_block iteration
              * of the next output block.
              */
+#ifdef SRS_FUSE_OP_SIGNALER
+            // Fused RS path: write each block promptly (no core-y defer stagger — the L1-sharded output has
+            // no DRAM write banks to spread). This lets the per-core progress counter the RS reader polls
+            // tick at compute-completion instead of at the global max_defer_write_k_block barrier ~a block
+            // later, which was delaying the reader by a full block.
+            defer_write = false;
+#else
             defer_write = !is_last_block;
             defer_write = defer_write && !is_injector_core;
+#endif
 
             if (!defer_write) {
                 if constexpr (is_output_writer) {
@@ -471,10 +485,11 @@ void kernel_main() {
                     }
 #endif  // FUSE_SWIGLU
 #ifdef SRS_FUSE_OP_SIGNALER
-                    if (is_last_block) {
-                        noc.async_write_barrier();
-                        srs_fuse_signaler.synchronize_workers_and_signal_op(0);
-                    }
+                    // Signal this core's per-core progress counter right after its prompt block write, at
+                    // compute-completion (every block, not just is_last_block). The reader waits per core, so
+                    // no global "all cores done writing" barrier is needed.
+                    noc.async_write_barrier();
+                    srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
 #endif
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
@@ -164,8 +164,7 @@ void kernel_main() {
     uint32_t mm_progress_counters_base = 0;
     if constexpr (is_output_writer) {
         srs_fuse_signaler = OpSignaler(srs_fuse_signaler_rt_args_idx);
-        // Per-core signaling: base L1 address of the RS cores' per-core progress counter array,
-        // pushed as the next RT arg right after the OpSignaler args.
+        // Per-core signaling: base L1 address of the RS cores' per-core progress counter array
         mm_progress_counters_base = get_arg_val<uint32_t>(srs_fuse_signaler_rt_args_idx++);
     }
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
@@ -161,8 +161,12 @@ void kernel_main() {
     srs_fuse_signaler_rt_args_idx += 12;  // Skip MinimalMatmulFusedOpSignaler::push_matmul_fused_op_rt_args (12 args)
 #endif
     OpSignaler srs_fuse_signaler;
+    uint32_t mm_progress_counters_base = 0;
     if constexpr (is_output_writer) {
         srs_fuse_signaler = OpSignaler(srs_fuse_signaler_rt_args_idx);
+        // Per-core signaling: base L1 address of the RS cores' per-core progress counter array,
+        // pushed as the next RT arg right after the OpSignaler args.
+        mm_progress_counters_base = get_arg_val<uint32_t>(srs_fuse_signaler_rt_args_idx++);
     }
 #endif
 
@@ -318,7 +322,7 @@ void kernel_main() {
                     // at the moment all cores are expected to be done writing their corresponding blocks.
                     if (not_first_block && k_block_iter == max_defer_write_k_block) {
                         noc.async_write_barrier();
-                        srs_fuse_signaler.synchronize_workers_and_signal_op(0);
+                        srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
                     }
                 }
 #endif
@@ -431,7 +435,7 @@ void kernel_main() {
 #ifdef SRS_FUSE_OP_SIGNALER
                     if (is_last_block) {
                         noc.async_write_barrier();
-                        srs_fuse_signaler.synchronize_workers_and_signal_op(0);
+                        srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
                     }
 #endif
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_compute.cpp
@@ -1,0 +1,750 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/tilize.h"
+#include "api/compute/matmul.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/compute/bcast.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/dataflow/circular_buffer.h"
+
+#include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/subchunk_bands.hpp"
+
+#ifndef IN0_SUB_CHUNKS
+#define IN0_SUB_CHUNKS 1
+#endif
+
+void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+    CircularBuffer cb_out(out_cb);
+    copy_tile_to_dst_init_short(in_cb);
+    reconfig_data_format_srca(in_cb);
+    pack_reconfig_data_format(out_cb);
+    uint32_t fused_act_dst_id = 0;
+
+    uint32_t tile_id = 0;
+    for (uint32_t m = 0; m < M_block_tiles; m++) {
+        for (uint32_t n = 0; n < N_block_tiles; n++) {
+            tile_regs_acquire();
+            tile_regs_wait();
+            copy_tile(in_cb, tile_id, fused_act_dst_id /*dst*/);
+#ifdef SFPU_OP_INIT_ACTIVATION
+            SFPU_OP_FUNC_ACTIVATION
+#endif
+            pack_tile(fused_act_dst_id, out_cb);
+            tile_regs_commit();
+            tile_regs_release();
+            tile_id++;
+        }
+        cb_out.push_back(N_block_tiles);
+    }
+}
+
+#ifdef SPLIT_OUTPUT_WRITE
+// Percent of the block's M-rows routed to NOC_1 (dm_in1 / out_cb_a); the rest go to NOC_0 (dm_in0 /
+// out_cb_b). Must match dm_in0/dm_in1 so the c_2/c_8 counts stay in lockstep.
+#ifndef AG_SPLIT_NOC1_PCT
+#define AG_SPLIT_NOC1_PCT 50
+#endif
+// Two-NoC output-write split: pack the block's first split_rows M-rows into out_cb_a (drained by the NOC_1
+// writer dm_in1) and the rest into out_cb_b (drained by the NOC_0 writer dm_in0). Same per-row pack as
+// copy_block; only the destination CB switches at the row boundary. Both CBs share the output format.
+void copy_block_split(
+    uint32_t in_cb,
+    uint32_t out_cb_a,
+    uint32_t out_cb_b,
+    uint32_t M_block_tiles,
+    uint32_t N_block_tiles,
+    uint32_t split_rows) {
+    CircularBuffer cb_out_a(out_cb_a);
+    CircularBuffer cb_out_b(out_cb_b);
+    copy_tile_to_dst_init_short(in_cb);
+    reconfig_data_format_srca(in_cb);
+    pack_reconfig_data_format(out_cb_a);
+    uint32_t fused_act_dst_id = 0;
+
+#ifdef AGMM_INTERLEAVED_OUTPUT_WRITE
+    (void)split_rows;  // interleaved routing uses the Bresenham predicate, not the contiguous boundary
+#endif
+    uint32_t tile_id = 0;
+    for (uint32_t m = 0; m < M_block_tiles; m++) {
+#ifdef AGMM_INTERLEAVED_OUTPUT_WRITE
+        const bool to_noc1 = split_row_to_noc1(m, AG_SPLIT_NOC1_PCT);
+#else
+        const bool to_noc1 = (m < split_rows);
+#endif
+        const uint32_t out_cb = to_noc1 ? out_cb_a : out_cb_b;
+        for (uint32_t n = 0; n < N_block_tiles; n++) {
+            tile_regs_acquire();
+            tile_regs_wait();
+            copy_tile(in_cb, tile_id, fused_act_dst_id /*dst*/);
+#ifdef SFPU_OP_INIT_ACTIVATION
+            SFPU_OP_FUNC_ACTIVATION
+#endif
+            pack_tile(fused_act_dst_id, out_cb);
+            tile_regs_commit();
+            tile_regs_release();
+            tile_id++;
+        }
+        if (to_noc1) {
+            cb_out_a.push_back(N_block_tiles);
+        } else {
+            cb_out_b.push_back(N_block_tiles);
+        }
+    }
+}
+
+#ifdef FUSE_BIAS
+// Bias variant of copy_block_split: add the row-broadcast bias (and the fused activation, if any) per tile,
+// packing the block's first split_rows M-rows into out_cb_a (c_2) and the rest into out_cb_b (c_8). Same
+// two-NoC split as copy_block_split; the DM writers drain their halves unchanged.
+void add_bias_block_split(
+    uint32_t in_cb,
+    uint32_t bias_cb,
+    uint32_t out_cb_a,
+    uint32_t out_cb_b,
+    uint32_t M_block_tiles,
+    uint32_t N_block_tiles,
+    uint32_t split_rows) {
+    CircularBuffer cb_out_a(out_cb_a);
+    CircularBuffer cb_out_b(out_cb_b);
+    add_bcast_rows_init_short(in_cb, bias_cb);
+    reconfig_data_format(in_cb, bias_cb);
+    pack_reconfig_data_format(out_cb_a);
+    uint32_t fused_act_dst_id = 0;
+
+#ifdef AGMM_INTERLEAVED_OUTPUT_WRITE
+    (void)split_rows;  // interleaved routing uses the Bresenham predicate, not the contiguous boundary
+#endif
+    uint32_t tile_id = 0;
+    for (uint32_t m = 0; m < M_block_tiles; m++) {
+#ifdef AGMM_INTERLEAVED_OUTPUT_WRITE
+        const bool to_noc1 = split_row_to_noc1(m, AG_SPLIT_NOC1_PCT);
+#else
+        const bool to_noc1 = (m < split_rows);
+#endif
+        const uint32_t out_cb = to_noc1 ? out_cb_a : out_cb_b;
+        for (uint32_t n = 0; n < N_block_tiles; n++) {
+            tile_regs_acquire();
+            tile_regs_wait();
+            add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, tile_id, n, fused_act_dst_id /*dst*/);
+#ifdef SFPU_OP_INIT_ACTIVATION
+            SFPU_OP_FUNC_ACTIVATION
+#endif
+            pack_tile(fused_act_dst_id, out_cb);
+            tile_regs_commit();
+            tile_regs_release();
+            tile_id++;
+        }
+        if (to_noc1) {
+            cb_out_a.push_back(N_block_tiles);
+        } else {
+            cb_out_b.push_back(N_block_tiles);
+        }
+    }
+}
+#endif  // FUSE_BIAS
+#endif  // SPLIT_OUTPUT_WRITE
+
+#ifdef FUSE_SWIGLU
+// Fused SwiGLU output stage. The matmul produced an interleaved gate/up block in
+// `in_cb` (the intermediate accumulator): within each M row, column tile 2p is the
+// gate projection and 2p+1 is the up projection (the weight was tile-pair interleaved
+// on the host). For each pair we emit one output tile = silu(gate) * up, so the block
+// shrinks from N_block_tiles to N_block_tiles/2 along N. No extra CB / no extra DRAM
+// round-trip: silu runs on the gate DST reg and the multiply is an SFPU dst*dst op.
+//
+// With FUSE_BIAS: bias is interleaved identically (tile 2p = gate bias, 2p+1 = up bias)
+// and added via row-broadcast before silu/mul: out = silu(gate + bias_gate) * (up + bias_up).
+//
+// N_block_tiles must be even (enforced host-side).
+void swiglu_block(uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+#ifdef FUSE_BIAS
+    reconfig_data_format(in_cb, bias_cb);
+#else
+    reconfig_data_format_srca(in_cb);
+#endif
+    pack_reconfig_data_format(out_cb);
+
+    constexpr uint32_t GATE_DST = 0;
+    constexpr uint32_t UP_DST = 1;
+    const uint32_t out_N_block_tiles = N_block_tiles >> 1;
+
+    for (uint32_t m = 0; m < M_block_tiles; m++) {
+        const uint32_t row_base = m * N_block_tiles;
+        for (uint32_t p = 0; p < out_N_block_tiles; p++) {
+            const uint32_t gate_n = p << 1;
+            const uint32_t up_n = gate_n + 1;
+            const uint32_t gate_tile_id = row_base + gate_n;
+            const uint32_t up_tile_id = gate_tile_id + 1;
+
+            tile_regs_acquire();
+#ifdef FUSE_BIAS
+            add_bcast_rows_init_short(in_cb, bias_cb);
+            add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, gate_tile_id, gate_n, GATE_DST);
+            add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, up_tile_id, up_n, UP_DST);
+#else
+            copy_tile_to_dst_init_short(in_cb);
+            copy_tile(in_cb, gate_tile_id, GATE_DST);
+            copy_tile(in_cb, up_tile_id, UP_DST);
+#endif
+            silu_tile_init();
+            silu_tile(GATE_DST);
+            mul_binary_tile_init();
+            mul_binary_tile(GATE_DST, UP_DST, GATE_DST);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(GATE_DST, out_cb);
+            tile_regs_release();
+        }
+        cb_push_back(out_cb, out_N_block_tiles);
+    }
+}
+#endif  // FUSE_SWIGLU
+
+// For caller: if FUSE_TERNARY defined then out_cb == in_cb
+/**
+ * Add bias to input block
+ * Performs: output = input + bias (row broadcast)
+ *
+ * stream_output:
+ *   - true: Pushes tiles one row at a time (for intermediate output to next stage)
+ *   - false: Pushes all tiles at end (for final output)
+ */
+void add_bias_block(uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+    CircularBuffer cb_out(out_cb);
+    add_bcast_rows_init_short(in_cb, bias_cb);
+    reconfig_data_format(in_cb, bias_cb);
+    pack_reconfig_data_format(out_cb);
+    uint32_t fused_act_dst_id = 0;
+
+    uint32_t tile_id = 0;
+    for (uint32_t m = 0; m < M_block_tiles; m++) {
+        for (uint32_t n = 0; n < N_block_tiles; n++) {
+            tile_regs_acquire();
+            tile_regs_wait();
+            add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, tile_id, n, fused_act_dst_id /*dst*/);
+#ifdef SFPU_OP_INIT_ACTIVATION
+            SFPU_OP_FUNC_ACTIVATION
+#endif
+            pack_tile(fused_act_dst_id, out_cb);
+            tile_regs_commit();
+            tile_regs_release();
+            tile_id++;
+        }
+        cb_out.push_back(N_block_tiles);
+    }
+}
+
+void add_bias_and_addcmul_block(
+    uint32_t intermediate_cb,
+    uint32_t bias_cb,
+    uint32_t ternary_a_cb,
+    uint32_t ternary_b_cb,
+    uint32_t scalar_value,
+    uint32_t out_cb,
+    uint32_t M_block_tiles,
+    uint32_t N_block_tiles,
+    uint32_t broadcast_ternary_b) {
+    // Note: unary_bcast_tile does not work with fp32_acc_to_dest=True.
+    // As a workaround, we perform addcmul through multiple LLKs calls (mul_tiles, mul_unary_tile, add_tiles_bcast).
+
+    const uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
+
+    CircularBuffer cb_intermediate(intermediate_cb);
+    CircularBuffer cb_bias(bias_cb);
+    CircularBuffer cb_ternary_a(ternary_a_cb);
+    CircularBuffer cb_ternary_b(ternary_b_cb);
+    CircularBuffer cb_out(out_cb);
+
+    constexpr uint32_t DST_ID = 0;
+#ifdef FUSE_BIAS
+    // ============================================
+    // STEP 1: Add bias block
+    // Read from intermediate_cb and write back to intermediate_cb
+    // ============================================
+
+    add_bcast_rows_init_short(intermediate_cb, bias_cb);
+    reconfig_data_format(intermediate_cb, bias_cb);
+    pack_reconfig_data_format(intermediate_cb);
+
+    // Wait for ALL input data ONCE at the beginning
+    cb_bias.wait_front(N_block_tiles);
+
+    // Unpacker waits for intermediate_cb to be ready
+    cb_intermediate.wait_front(out_block_num_tiles);
+
+    for (uint32_t m = 0; m < M_block_tiles; m++) {
+        for (uint32_t n = 0; n < N_block_tiles; n++) {
+            uint32_t tile_id = m * N_block_tiles + n;
+
+            tile_regs_acquire();
+            add_tiles_bcast<BroadcastType::ROW>(intermediate_cb, bias_cb, tile_id, n, DST_ID);
+
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(DST_ID, intermediate_cb);
+            tile_regs_release();
+        }
+    }
+
+    // Pop input and push output ONCE at the end
+    // cb_wait_front(intermediate_cb, out_block_num_tiles); // Unpacker-Packer sync
+    // cb_pop_front(intermediate_cb, out_block_num_tiles);
+    cb_bias.pop_front(N_block_tiles);
+
+    cb_intermediate.pop_front(out_block_num_tiles);
+
+    // Restore intermediate_cb to ready (+ sync packer/unpacker)
+    cb_intermediate.reserve_back(out_block_num_tiles);
+    cb_intermediate.push_back(out_block_num_tiles);
+#endif  // FUSE_BIAS
+
+    // ============================================
+    // STEP 2: Multiply by ternary_b and scalar
+    // Read from intermediate_cb and write back to intermediate_cb
+    // broadcast_ternary_b: 1 = single row broadcast, 0 = row-by-row streaming
+    // ============================================
+
+    cb_intermediate.wait_front(out_block_num_tiles);
+
+    uint32_t tile_id = 0;
+
+    if (broadcast_ternary_b) {
+        // === BROADCAST: single row, wait/pop once ===
+        cb_ternary_b.wait_front(N_block_tiles);
+
+#ifndef TERNARY_B_IS_FLOAT32
+        mul_bcast_rows_init_short(intermediate_cb, ternary_b_cb);
+#else
+        unary_bcast_init<BroadcastType::ROW>(ternary_b_cb, intermediate_cb);
+#endif  // TERNARY_B_IS_FLOAT32
+
+        binop_with_scalar_tile_init();
+        reconfig_data_format(intermediate_cb, ternary_b_cb);
+        pack_reconfig_data_format(intermediate_cb);
+
+        tile_id = 0;
+        for (uint32_t m = 0; m < M_block_tiles; m++) {
+            for (uint32_t n = 0; n < N_block_tiles; n++) {
+                tile_regs_acquire();
+
+#ifndef TERNARY_B_IS_FLOAT32
+                mul_tiles_bcast<BroadcastType::ROW>(intermediate_cb, ternary_b_cb, tile_id, n, DST_ID);
+#else
+                constexpr uint32_t TERNARY_B_DST_ID = 1;
+                unary_bcast_init<BroadcastType::ROW>(ternary_b_cb, intermediate_cb);
+                unary_bcast<BroadcastType::ROW>(ternary_b_cb, n, TERNARY_B_DST_ID);
+
+                copy_tile_to_dst_init_short(intermediate_cb);
+                copy_tile(intermediate_cb, tile_id, DST_ID);
+
+                mul_binary_tile_init();
+                mul_binary_tile(DST_ID, TERNARY_B_DST_ID, DST_ID);
+#endif  // TERNARY_B_IS_FLOAT32
+
+                mul_unary_tile(DST_ID, scalar_value);
+
+                tile_regs_commit();
+                tile_regs_wait();
+                pack_tile(DST_ID, intermediate_cb);
+                tile_regs_release();
+                tile_id++;
+            }
+        }
+
+        cb_ternary_b.pop_front(N_block_tiles);
+    } else {
+        // === NO BROADCAST: row-by-row, wait/pop per M row ===
+#ifndef TERNARY_B_IS_FLOAT32
+        mul_tiles_init(intermediate_cb, ternary_b_cb);
+#endif
+        binop_with_scalar_tile_init();
+        reconfig_data_format(intermediate_cb, ternary_b_cb);
+        pack_reconfig_data_format(intermediate_cb);
+
+        tile_id = 0;
+        for (uint32_t m = 0; m < M_block_tiles; m++) {
+            cb_ternary_b.wait_front(N_block_tiles);
+            for (uint32_t n = 0; n < N_block_tiles; n++) {
+                tile_regs_acquire();
+
+#ifndef TERNARY_B_IS_FLOAT32
+                mul_tiles(intermediate_cb, ternary_b_cb, tile_id, n, DST_ID);
+#else
+                constexpr uint32_t TERNARY_B_DST_ID = 1;
+                copy_tile_to_dst_init_short(ternary_b_cb);
+                copy_tile(ternary_b_cb, n, TERNARY_B_DST_ID);
+
+                copy_tile_to_dst_init_short(intermediate_cb);
+                copy_tile(intermediate_cb, tile_id, DST_ID);
+
+                mul_binary_tile_init();
+                mul_binary_tile(DST_ID, TERNARY_B_DST_ID, DST_ID);
+#endif  // TERNARY_B_IS_FLOAT32
+
+                mul_unary_tile(DST_ID, scalar_value);
+
+                tile_regs_commit();
+                tile_regs_wait();
+                pack_tile(DST_ID, intermediate_cb);
+                tile_regs_release();
+                tile_id++;
+            }
+            cb_ternary_b.pop_front(N_block_tiles);
+        }
+    }
+
+    cb_intermediate.pop_front(out_block_num_tiles);
+
+    // 'refill' intermediate_cb (also synchronize packer/unpacker)
+    cb_intermediate.reserve_back(out_block_num_tiles);
+    cb_intermediate.push_back(out_block_num_tiles);
+
+    cb_intermediate.wait_front(out_block_num_tiles);
+
+    add_tiles_init(intermediate_cb, ternary_a_cb);
+    reconfig_data_format(intermediate_cb, ternary_a_cb);
+    pack_reconfig_data_format(out_cb);
+
+    tile_id = 0;
+    for (uint32_t m = 0; m < M_block_tiles; m++) {
+        // Wait for one row of ternary_a tiles
+        cb_ternary_a.wait_front(N_block_tiles);
+
+        for (uint32_t n = 0; n < N_block_tiles; n++) {
+            tile_regs_acquire();
+
+            // ternary_a_cb is pushed one row at a time, so use column index n
+            add_tiles(intermediate_cb, ternary_a_cb, tile_id, n, DST_ID);
+
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(DST_ID, out_cb);
+            tile_regs_release();
+            tile_id++;
+        }
+
+        cb_ternary_a.pop_front(N_block_tiles);
+        cb_out.push_back(N_block_tiles);
+    }
+
+    cb_intermediate.pop_front(out_block_num_tiles);
+}
+
+// Slightly modified from compute_common.hpp
+//
+// m_out_tile_offset shifts where this call's rows land in the (full) output block. When in0 is
+// delivered as M-row sub-chunk bands, each band's in0 CB slot is 0-based (M_block_tiles == band_h,
+// in0 indexing starts at 0) but the band's results must accumulate into rows [band_lo, band_lo+band_h)
+// of the intermediate block, so pass m_out_tile_offset = band_lo. Whole-block callers pass 0.
+void matmul_blocks(
+    const uint32_t in0_cb,
+    const uint32_t in1_cb,
+    const uint32_t out_cb,
+    const uint32_t M_block_tiles,
+    const uint32_t N_block_tiles,
+    const uint32_t full_N_block_tiles,
+    const uint32_t K_block_tiles,
+    const uint32_t subblock_h,
+    const uint32_t subblock_w,
+    const uint32_t m_out_tile_offset = 0) {
+    uint32_t in0_index_offset = 0;
+
+    for (uint32_t M_start = 0; M_start < M_block_tiles; M_start += subblock_h) {
+        // The in0 CB slot is padded to a uniform (M_block_tiles / nb) rows, so a ragged band whose
+        // height is not a multiple of subblock_h still has real tiles for a full subblock_h read -- the
+        // trailing rows are slack. Compute the full subblock (a smaller rt_dim would need an
+        // mm_block_init_short re-init that stalls the engine), then pack only the real rows so a ragged
+        // band never writes into the next band's output rows. subblock_h | (M_block_tiles/nb) (host
+        // guard) keeps the deep read inside the slot.
+        const uint32_t real_h = std::min(subblock_h, M_block_tiles - M_start);
+        uint32_t in1_index_offset = 0;
+        for (uint32_t N_start = 0; N_start < N_block_tiles; N_start += subblock_w) {
+            tile_regs_acquire();
+
+            uint32_t dst_index = 0;
+            uint32_t in0_index = in0_index_offset;
+            uint32_t in1_index = in1_index_offset;
+
+            for (uint32_t inner_dim = 0; inner_dim < K_block_tiles; inner_dim++) {
+                matmul_block(
+                    in0_cb,
+                    in1_cb,
+                    in0_index,
+                    in1_index,
+                    dst_index,
+                    false /*transpose*/,
+                    subblock_w,
+                    subblock_h,
+                    K_block_tiles);
+                in0_index++;
+                in1_index += full_N_block_tiles;
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            uint32_t write_dst_index = 0;
+            for (uint32_t h = 0; h < real_h; h++) {
+                uint32_t h_tile_id = M_start + h + m_out_tile_offset;
+                for (uint32_t w = 0; w < subblock_w; w++) {
+                    uint32_t w_tile_id = N_start + w;
+                    uint32_t out_tile_id = h_tile_id * full_N_block_tiles + w_tile_id;
+                    pack_tile<true>(write_dst_index, out_cb, out_tile_id);
+                    write_dst_index++;
+                }
+            }
+            tile_regs_release();
+
+            in1_index_offset += subblock_w;
+        }
+        in0_index_offset += subblock_h * K_block_tiles;
+    }
+}
+
+void kernel_main() {
+    constexpr uint32_t K_num_blocks = get_compile_time_arg_val(0);
+    constexpr uint32_t M_block_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t K_block_tiles = get_compile_time_arg_val(2);
+    constexpr uint32_t N_block_tiles = get_compile_time_arg_val(3);
+    constexpr uint32_t M_blocks_per_core = get_compile_time_arg_val(4);
+    constexpr uint32_t N_blocks_per_core = get_compile_time_arg_val(5);
+    constexpr uint32_t subblock_h = get_compile_time_arg_val(6);
+    constexpr uint32_t subblock_w = get_compile_time_arg_val(7);
+    // Number of leading (self/local) k-block positions this device owns. The AG schedule always drains
+    // the local slice first, so positions [0, num_local_k_blocks) are local (never sub-chunked) and the
+    // rest are remote (sub-chunked into IN0_SUB_CHUNKS M-row bands on the first N-block). Kept identical
+    // across the dm_in0/dm_in1 senders so per-band CB push/pop counts match.
+    [[maybe_unused]] constexpr uint32_t num_local_k_blocks = get_compile_time_arg_val(8);
+
+    uint32_t argidx = 0;
+    const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t M_end_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t N_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t N_end_tile = get_arg_val<uint32_t>(argidx++);
+
+#ifdef FUSE_TERNARY
+    const uint32_t fused_ternary_scalar_uint = get_arg_val<uint32_t>(argidx++);
+    const uint32_t broadcast_ternary_b = get_arg_val<uint32_t>(argidx++);
+#else
+    // Default value when ternary is not fused (not used, helps compiler optimize)
+    constexpr uint32_t fused_ternary_scalar_uint = 0;
+    constexpr uint32_t broadcast_ternary_b = 1;
+#endif
+
+    constexpr uint32_t in0_cb = tt::CBIndex::c_0;
+    constexpr uint32_t in1_cb = tt::CBIndex::c_1;
+    constexpr uint32_t out_cb = tt::CBIndex::c_2;
+    constexpr uint32_t intermediate_cb = tt::CBIndex::c_3;
+
+    constexpr uint32_t in2_cb = tt::CBIndex::c_4;
+    constexpr uint32_t ternary_a_cb = tt::CBIndex::c_5;
+    constexpr uint32_t ternary_b_cb = tt::CBIndex::c_6;
+
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
+    CircularBuffer cb_out(out_cb);
+#ifdef SPLIT_OUTPUT_WRITE
+    // Second output CB for the two-NoC write split; drained by dm_in0 on NOC_0.
+    constexpr uint32_t out_cb_b = OUT_CB_B;
+    CircularBuffer cb_out_b(out_cb_b);
+#endif
+    CircularBuffer cb_intermediate(intermediate_cb);
+    CircularBuffer cb_in2(in2_cb);
+
+    // compute_kernel_hw_startup must be the first compute API call (before SFPU/op inits).
+    compute_kernel_hw_startup<SrcOrder::Reverse>(in0_cb, in1_cb, intermediate_cb);
+
+#ifdef SFPU_OP_INIT_ACTIVATION
+    SFPU_OP_INIT_ACTIVATION
+#endif
+
+    matmul_init(in0_cb, in1_cb);
+
+    constexpr uint32_t in0_block_num_tiles = M_block_tiles * K_block_tiles;
+    constexpr uint32_t in1_block_num_tiles = K_block_tiles * N_block_tiles;
+    constexpr uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
+
+    constexpr uint32_t M_num_subblocks = M_block_tiles / subblock_h;
+    constexpr uint32_t N_num_subblocks = N_block_tiles / subblock_w;
+
+    uint32_t current_M_block_tiles = M_block_tiles;
+    uint32_t current_N_block_tiles = N_block_tiles;
+    uint32_t current_subblock_h = subblock_h;
+    uint32_t current_subblock_w = subblock_w;
+
+    for (uint32_t m_block_iter = 0; m_block_iter < M_blocks_per_core; m_block_iter++) {
+        uint32_t m_tile = M_start_tile + m_block_iter * M_block_tiles;
+        uint32_t m_tile_end = std::min(m_tile + M_block_tiles, M_end_tile);
+        current_M_block_tiles = m_tile_end - m_tile;
+        current_subblock_h = std::min(current_M_block_tiles, subblock_h);
+
+        for (uint32_t n_block_iter = 0; n_block_iter < N_blocks_per_core; n_block_iter++) {
+            uint32_t n_tile = N_start_tile + n_block_iter * N_block_tiles;
+            uint32_t n_tile_end = std::min(n_tile + N_block_tiles, N_end_tile);
+            current_N_block_tiles = n_tile_end - n_tile;
+            current_subblock_w = std::min(current_N_block_tiles, subblock_w);
+
+            matmul_block_init(
+                in0_cb,
+                in1_cb,
+                false /*transpose*/,
+                current_subblock_w /*ct_dim*/,
+                current_subblock_h /*rt_dim*/,
+                K_block_tiles /*kt_dim*/);
+            reconfig_data_format(in1_cb, in0_cb);
+            pack_reconfig_data_format(intermediate_cb);
+            // Accumulation buffer
+            cb_intermediate.reserve_back(out_block_num_tiles);
+            // Sub-chunked (banded) matmul. Remote k-blocks on the first N-block arrive as IN0_SUB_CHUNKS
+            // M-row bands; local k-blocks and every k-block on later N-blocks arrive whole (nb == 1). in1
+            // is re-presented once per band (read once, pushed nb times by the in1 sender), so in0 and in1
+            // advance in lockstep and the matmul fires per band. Each k-block position is delivered fresh
+            // (no N-stride in0 reuse). With IN0_SUB_CHUNKS == 1 this degenerates to one whole band per
+            // position.
+            for (uint32_t k_block = 0; k_block < K_num_blocks; k_block++) {
+                const uint32_t nb =
+                    (n_block_iter == 0 && k_block >= num_local_k_blocks) ? (uint32_t)IN0_SUB_CHUNKS : 1u;
+#ifdef AG_INTERLEAVE_BANDS
+                // Interleave a forward remote k-block with the following backward one at band granularity:
+                // A.b0, B.b0, A.b1, B.b1, ... Both members share band_lo and accumulate into the same
+                // output rows; both are past k-block 0 so L1 accumulation is already on, so the two partials
+                // sum correctly regardless of order. The position-based pairing matches dm_in0/dm_in1 so the
+                // per-band in0/in1 CB counts stay in lockstep.
+                if (n_block_iter == 0 && nb > 1 && k_block >= num_local_k_blocks && (k_block + 1) < K_num_blocks &&
+                    ((k_block - num_local_k_blocks) & 1u) == 0) {
+                    for (uint32_t band = 0; band < nb; band++) {
+                        uint32_t band_lo, band_h;
+                        balanced_band(current_M_block_tiles, nb, band, band_lo, band_h);
+                        if (band_h == 0) {
+                            break;
+                        }
+                        // Reserve a uniform slot of M_block_tiles/nb rows for every band (not the ragged
+                        // band_h) so each band tiles the in0 CB exactly and no reservation wraps
+                        // fifo_limit mid-block. matmul reads band_h rows and packs the real ones.
+                        const uint32_t band_slot_tiles = (M_block_tiles / nb) * K_block_tiles;
+                        for (uint32_t member = 0; member < 2; member++) {
+                            cb_in0.wait_front(band_slot_tiles);
+                            cb_in1.wait_front(in1_block_num_tiles);
+                            matmul_blocks(
+                                in0_cb,
+                                in1_cb,
+                                intermediate_cb,
+                                band_h,
+                                current_N_block_tiles,
+                                N_block_tiles,
+                                K_block_tiles,
+                                current_subblock_h,
+                                current_subblock_w,
+                                band_lo);
+                            cb_in0.pop_front(band_slot_tiles);
+                            cb_in1.pop_front(in1_block_num_tiles);
+                        }
+                    }
+                    k_block++;  // the backward member of the pair is consumed here too
+                    continue;
+                }
+#endif
+                for (uint32_t band = 0; band < nb; band++) {
+                    uint32_t band_lo, band_h;
+                    balanced_band(current_M_block_tiles, nb, band, band_lo, band_h);
+                    if (band_h == 0) {
+                        break;  // only when nb > current_M_block_tiles
+                    }
+                    // Reserve a uniform slot of M_block_tiles/nb rows for every band (not the ragged
+                    // band_h) so each band tiles the in0 CB exactly and no reservation wraps fifo_limit
+                    // mid-block. matmul reads band_h rows and packs the real ones.
+                    const uint32_t band_slot_tiles = (M_block_tiles / nb) * K_block_tiles;
+                    cb_in0.wait_front(band_slot_tiles);
+                    cb_in1.wait_front(in1_block_num_tiles);
+
+                    matmul_blocks(
+                        in0_cb,
+                        in1_cb,
+                        intermediate_cb,
+                        band_h,
+                        current_N_block_tiles,
+                        N_block_tiles,
+                        K_block_tiles,
+                        current_subblock_h,
+                        current_subblock_w,
+                        band_lo);
+
+                    cb_in0.pop_front(band_slot_tiles);
+                    cb_in1.pop_front(in1_block_num_tiles);
+                }
+                if (k_block == 0) {
+                    PACK((llk_pack_reconfig_l1_acc(1)));
+                }
+            }
+
+            cb_intermediate.push_back(out_block_num_tiles);
+            PACK((llk_pack_reconfig_l1_acc(0)));
+
+#ifdef FUSE_SWIGLU
+            // SwiGLU collapses the interleaved gate/up block to half its N width.
+            cb_out.reserve_back(out_block_num_tiles >> 1);
+            cb_intermediate.wait_front(out_block_num_tiles);
+#ifdef FUSE_BIAS
+            cb_in2.wait_front(N_block_tiles);
+#endif
+            swiglu_block(intermediate_cb, in2_cb, out_cb, M_block_tiles, N_block_tiles);
+#ifdef FUSE_BIAS
+            cb_in2.pop_front(N_block_tiles);
+#endif
+            cb_intermediate.pop_front(out_block_num_tiles);
+
+#elif !defined(FUSE_TERNARY)
+#ifdef SPLIT_OUTPUT_WRITE
+            // Two-NoC split: pack low rows -> c_2 (dm_in1/NOC_1), high rows -> c_8 (dm_in0/NOC_0).
+            constexpr uint32_t split_rows = (M_block_tiles * AG_SPLIT_NOC1_PCT) / 100;
+            if (split_rows) {
+                cb_out.reserve_back(split_rows * N_block_tiles);
+            }
+            if (split_rows < M_block_tiles) {
+                cb_out_b.reserve_back((M_block_tiles - split_rows) * N_block_tiles);
+            }
+            cb_intermediate.wait_front(out_block_num_tiles);
+#ifndef FUSE_BIAS
+            copy_block_split(intermediate_cb, out_cb, out_cb_b, M_block_tiles, N_block_tiles, split_rows);
+#else
+            cb_in2.wait_front(N_block_tiles);
+            add_bias_block_split(intermediate_cb, in2_cb, out_cb, out_cb_b, M_block_tiles, N_block_tiles, split_rows);
+            cb_in2.pop_front(N_block_tiles);
+#endif  // FUSE_BIAS
+            cb_intermediate.pop_front(out_block_num_tiles);
+#else
+            cb_out.reserve_back(out_block_num_tiles);
+            cb_intermediate.wait_front(out_block_num_tiles);
+#ifndef FUSE_BIAS
+            copy_block(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
+#else
+            cb_in2.wait_front(N_block_tiles);
+            add_bias_block(intermediate_cb, in2_cb, out_cb, M_block_tiles, N_block_tiles);
+            cb_in2.pop_front(N_block_tiles);
+#endif  // FUSE_BIAS
+            cb_intermediate.pop_front(out_block_num_tiles);
+#endif  // SPLIT_OUTPUT_WRITE
+
+#else   // FUSE_TERNARY is set
+            cb_out.reserve_back(out_block_num_tiles);
+            add_bias_and_addcmul_block(
+                intermediate_cb,
+                in2_cb,
+                ternary_a_cb,
+                ternary_b_cb,
+                fused_ternary_scalar_uint,
+                out_cb,
+                M_block_tiles,
+                N_block_tiles,
+                broadcast_ternary_b);
+#endif  // FUSE_TERNARY
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_compute.cpp
@@ -47,14 +47,11 @@ void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_
 }
 
 #ifdef SPLIT_OUTPUT_WRITE
-// Percent of the block's M-rows routed to NOC_1 (dm_in1 / out_cb_a); the rest go to NOC_0 (dm_in0 /
-// out_cb_b). Must match dm_in0/dm_in1 so the c_2/c_8 counts stay in lockstep.
+// Percent of the block's M-rows routed to NOC_1 (dm_in1 / out_cb_a)
 #ifndef AG_SPLIT_NOC1_PCT
 #define AG_SPLIT_NOC1_PCT 50
 #endif
-// Two-NoC output-write split: pack the block's first split_rows M-rows into out_cb_a (drained by the NOC_1
-// writer dm_in1) and the rest into out_cb_b (drained by the NOC_0 writer dm_in0). Same per-row pack as
-// copy_block; only the destination CB switches at the row boundary. Both CBs share the output format.
+// Two-NoC output-write split: pack the block's first split_rows M-rows into out_cb_a
 void copy_block_split(
     uint32_t in_cb,
     uint32_t out_cb_a,
@@ -101,9 +98,7 @@ void copy_block_split(
 }
 
 #ifdef FUSE_BIAS
-// Bias variant of copy_block_split: add the row-broadcast bias (and the fused activation, if any) per tile,
-// packing the block's first split_rows M-rows into out_cb_a (c_2) and the rest into out_cb_b (c_8). Same
-// two-NoC split as copy_block_split; the DM writers drain their halves unchanged.
+// Bias variant of copy_block_split: add the row-broadcast bias (and the fused activation, if any) per tile
 void add_bias_block_split(
     uint32_t in_cb,
     uint32_t bias_cb,
@@ -153,17 +148,7 @@ void add_bias_block_split(
 #endif  // SPLIT_OUTPUT_WRITE
 
 #ifdef FUSE_SWIGLU
-// Fused SwiGLU output stage. The matmul produced an interleaved gate/up block in
-// `in_cb` (the intermediate accumulator): within each M row, column tile 2p is the
-// gate projection and 2p+1 is the up projection (the weight was tile-pair interleaved
-// on the host). For each pair we emit one output tile = silu(gate) * up, so the block
-// shrinks from N_block_tiles to N_block_tiles/2 along N. No extra CB / no extra DRAM
-// round-trip: silu runs on the gate DST reg and the multiply is an SFPU dst*dst op.
-//
-// With FUSE_BIAS: bias is interleaved identically (tile 2p = gate bias, 2p+1 = up bias)
-// and added via row-broadcast before silu/mul: out = silu(gate + bias_gate) * (up + bias_up).
-//
-// N_block_tiles must be even (enforced host-side).
+// Fused SwiGLU output stage
 void swiglu_block(uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
 #ifdef FUSE_BIAS
     reconfig_data_format(in_cb, bias_cb);
@@ -253,8 +238,7 @@ void add_bias_and_addcmul_block(
     uint32_t M_block_tiles,
     uint32_t N_block_tiles,
     uint32_t broadcast_ternary_b) {
-    // Note: unary_bcast_tile does not work with fp32_acc_to_dest=True.
-    // As a workaround, we perform addcmul through multiple LLKs calls (mul_tiles, mul_unary_tile, add_tiles_bcast).
+    // Note: unary_bcast_tile does not work with fp32_acc_to_dest=True
 
     const uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
 
@@ -266,10 +250,7 @@ void add_bias_and_addcmul_block(
 
     constexpr uint32_t DST_ID = 0;
 #ifdef FUSE_BIAS
-    // ============================================
-    // STEP 1: Add bias block
-    // Read from intermediate_cb and write back to intermediate_cb
-    // ============================================
+    // ============================================ STEP 1: Add bias block Read from intermediate_cb and write back
 
     add_bcast_rows_init_short(intermediate_cb, bias_cb);
     reconfig_data_format(intermediate_cb, bias_cb);
@@ -295,9 +276,7 @@ void add_bias_and_addcmul_block(
         }
     }
 
-    // Pop input and push output ONCE at the end
-    // cb_wait_front(intermediate_cb, out_block_num_tiles); // Unpacker-Packer sync
-    // cb_pop_front(intermediate_cb, out_block_num_tiles);
+    // Pop input and push output ONCE at the end cb_wait_front(intermediate_cb, out_block_num_tiles)
     cb_bias.pop_front(N_block_tiles);
 
     cb_intermediate.pop_front(out_block_num_tiles);
@@ -307,11 +286,7 @@ void add_bias_and_addcmul_block(
     cb_intermediate.push_back(out_block_num_tiles);
 #endif  // FUSE_BIAS
 
-    // ============================================
-    // STEP 2: Multiply by ternary_b and scalar
-    // Read from intermediate_cb and write back to intermediate_cb
-    // broadcast_ternary_b: 1 = single row broadcast, 0 = row-by-row streaming
-    // ============================================
+    // ============================================ STEP 2: Multiply by ternary_b and scalar Read
 
     cb_intermediate.wait_front(out_block_num_tiles);
 
@@ -439,12 +414,7 @@ void add_bias_and_addcmul_block(
     cb_intermediate.pop_front(out_block_num_tiles);
 }
 
-// Slightly modified from compute_common.hpp
-//
-// m_out_tile_offset shifts where this call's rows land in the (full) output block. When in0 is
-// delivered as M-row sub-chunk bands, each band's in0 CB slot is 0-based (M_block_tiles == band_h,
-// in0 indexing starts at 0) but the band's results must accumulate into rows [band_lo, band_lo+band_h)
-// of the intermediate block, so pass m_out_tile_offset = band_lo. Whole-block callers pass 0.
+// Slightly modified from compute_common.hpp m_out_tile_offset shifts where this call's rows land
 void matmul_blocks(
     const uint32_t in0_cb,
     const uint32_t in1_cb,
@@ -459,12 +429,7 @@ void matmul_blocks(
     uint32_t in0_index_offset = 0;
 
     for (uint32_t M_start = 0; M_start < M_block_tiles; M_start += subblock_h) {
-        // The in0 CB slot is padded to a uniform (M_block_tiles / nb) rows, so a ragged band whose
-        // height is not a multiple of subblock_h still has real tiles for a full subblock_h read -- the
-        // trailing rows are slack. Compute the full subblock (a smaller rt_dim would need an
-        // mm_block_init_short re-init that stalls the engine), then pack only the real rows so a ragged
-        // band never writes into the next band's output rows. subblock_h | (M_block_tiles/nb) (host
-        // guard) keeps the deep read inside the slot.
+        // The in0 CB slot is padded to a uniform (M_block_tiles / nb) rows
         const uint32_t real_h = std::min(subblock_h, M_block_tiles - M_start);
         uint32_t in1_index_offset = 0;
         for (uint32_t N_start = 0; N_start < N_block_tiles; N_start += subblock_w) {
@@ -517,10 +482,7 @@ void kernel_main() {
     constexpr uint32_t N_blocks_per_core = get_compile_time_arg_val(5);
     constexpr uint32_t subblock_h = get_compile_time_arg_val(6);
     constexpr uint32_t subblock_w = get_compile_time_arg_val(7);
-    // Number of leading (self/local) k-block positions this device owns. The AG schedule always drains
-    // the local slice first, so positions [0, num_local_k_blocks) are local (never sub-chunked) and the
-    // rest are remote (sub-chunked into IN0_SUB_CHUNKS M-row bands on the first N-block). Kept identical
-    // across the dm_in0/dm_in1 senders so per-band CB push/pop counts match.
+    // Number of leading (self/local) k-block positions this device owns
     [[maybe_unused]] constexpr uint32_t num_local_k_blocks = get_compile_time_arg_val(8);
 
     uint32_t argidx = 0;
@@ -602,21 +564,12 @@ void kernel_main() {
             pack_reconfig_data_format(intermediate_cb);
             // Accumulation buffer
             cb_intermediate.reserve_back(out_block_num_tiles);
-            // Sub-chunked (banded) matmul. Remote k-blocks on the first N-block arrive as IN0_SUB_CHUNKS
-            // M-row bands; local k-blocks and every k-block on later N-blocks arrive whole (nb == 1). in1
-            // is re-presented once per band (read once, pushed nb times by the in1 sender), so in0 and in1
-            // advance in lockstep and the matmul fires per band. Each k-block position is delivered fresh
-            // (no N-stride in0 reuse). With IN0_SUB_CHUNKS == 1 this degenerates to one whole band per
-            // position.
+            // Sub-chunked (banded) matmul
             for (uint32_t k_block = 0; k_block < K_num_blocks; k_block++) {
                 const uint32_t nb =
                     (n_block_iter == 0 && k_block >= num_local_k_blocks) ? (uint32_t)IN0_SUB_CHUNKS : 1u;
 #ifdef AG_INTERLEAVE_BANDS
-                // Interleave a forward remote k-block with the following backward one at band granularity:
-                // A.b0, B.b0, A.b1, B.b1, ... Both members share band_lo and accumulate into the same
-                // output rows; both are past k-block 0 so L1 accumulation is already on, so the two partials
-                // sum correctly regardless of order. The position-based pairing matches dm_in0/dm_in1 so the
-                // per-band in0/in1 CB counts stay in lockstep.
+                // Interleave a forward remote k-block with the following backward one at band granularity: A.b0
                 if (n_block_iter == 0 && nb > 1 && k_block >= num_local_k_blocks && (k_block + 1) < K_num_blocks &&
                     ((k_block - num_local_k_blocks) & 1u) == 0) {
                     for (uint32_t band = 0; band < nb; band++) {
@@ -625,9 +578,7 @@ void kernel_main() {
                         if (band_h == 0) {
                             break;
                         }
-                        // Reserve a uniform slot of M_block_tiles/nb rows for every band (not the ragged
-                        // band_h) so each band tiles the in0 CB exactly and no reservation wraps
-                        // fifo_limit mid-block. matmul reads band_h rows and packs the real ones.
+                        // Reserve a uniform slot of M_block_tiles/nb rows for every band
                         const uint32_t band_slot_tiles = (M_block_tiles / nb) * K_block_tiles;
                         for (uint32_t member = 0; member < 2; member++) {
                             cb_in0.wait_front(band_slot_tiles);
@@ -657,9 +608,7 @@ void kernel_main() {
                     if (band_h == 0) {
                         break;  // only when nb > current_M_block_tiles
                     }
-                    // Reserve a uniform slot of M_block_tiles/nb rows for every band (not the ragged
-                    // band_h) so each band tiles the in0 CB exactly and no reservation wraps fifo_limit
-                    // mid-block. matmul reads band_h rows and packs the real ones.
+                    // Reserve a uniform slot of M_block_tiles/nb rows for every band
                     const uint32_t band_slot_tiles = (M_block_tiles / nb) * K_block_tiles;
                     cb_in0.wait_front(band_slot_tiles);
                     cb_in1.wait_front(in1_block_num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_dm_in0_sender.cpp
@@ -1,0 +1,791 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "fabric_bound_matmul_dataflow_common.hpp"
+#include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp"
+#include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/subchunk_bands.hpp"
+
+// Set by the host only when fusing AG; default to 1 (single whole band per k-block) otherwise.
+#ifndef IN0_SUB_CHUNKS
+#define IN0_SUB_CHUNKS 1
+#endif
+
+// Two-NoC output-write split: under SPLIT_OUTPUT_WRITE, dm_in0 becomes a co-writer draining the second
+// output CB (AG_OUT_WRITE_CB = c_8) and writing the block's high M-rows [split_rows, M) on NOC_0, while
+// dm_in1 writes [0, split_rows) on NOC_1. split_rows = M_block_tiles*AG_SPLIT_NOC1_PCT/100; must match
+// compute/dm_in1. Defaults: single out CB c_2, 50% (inactive unless SPLIT_OUTPUT_WRITE is set).
+#ifndef AG_OUT_WRITE_CB
+#define AG_OUT_WRITE_CB 2
+#endif
+#ifndef AG_SPLIT_NOC1_PCT
+#define AG_SPLIT_NOC1_PCT 50
+#endif
+
+void kernel_main() {
+    Noc noc;
+    constexpr uint32_t M_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t padded_M_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t K_tiles = get_compile_time_arg_val(2);
+    constexpr uint32_t padded_K_tiles = get_compile_time_arg_val(3);
+    constexpr uint32_t N_tiles = get_compile_time_arg_val(4);
+    constexpr uint32_t padded_N_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t M_block_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t K_block_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t N_block_tiles = get_compile_time_arg_val(8);
+    constexpr uint32_t M_blocks_per_core = get_compile_time_arg_val(9);
+    constexpr uint32_t N_blocks_per_core = get_compile_time_arg_val(10);
+    constexpr uint32_t in0_tile_size = get_compile_time_arg_val(11);
+    constexpr uint32_t out_tile_size = get_compile_time_arg_val(12);
+    constexpr uint32_t in2_tile_size = get_compile_time_arg_val(13);
+    uint32_t in0_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(14));
+    uint32_t in0_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(15));
+    uint32_t in0_valid_semaphore_addr = get_semaphore(get_compile_time_arg_val(16));
+    Semaphore<> in0_sender_sem(get_compile_time_arg_val(14));
+    Semaphore<> in0_receiver_sem(get_compile_time_arg_val(15));
+    Semaphore<> in0_valid_sem(get_compile_time_arg_val(16));
+    constexpr uint32_t is_output_writer = get_compile_time_arg_val(17);
+    constexpr uint32_t is_injector_core = get_compile_time_arg_val(18);
+    constexpr uint32_t N_chunks = get_compile_time_arg_val(19);
+    constexpr uint32_t N_tiles_per_chunk = get_compile_time_arg_val(20);
+
+    // Load input/output addresses and range parameters
+    uint32_t argidx = 0;
+    const uint32_t in0_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in2_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in3_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t is_sink_core = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in0_dest_noc_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in0_dest_noc_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in0_sender_noc_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in0_sender_noc_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t M_end_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t N_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t N_end_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t defer_write_k_block = get_arg_val<uint32_t>(argidx++);
+    const uint32_t max_defer_write_k_block = get_arg_val<uint32_t>(argidx++);
+    // Leading (self/local) k-block positions this device owns. Receivers don't run the AG scheduler,
+    // so they use this to compute the same per-position band count the injector derives from streamed_dir.
+    // (Read unconditionally to keep the arg layout fixed; only consumed by receivers / IN0_SUB_CHUNKS > 1.)
+    [[maybe_unused]] const uint32_t num_local_k_blocks = get_arg_val<uint32_t>(argidx++);
+
+#ifdef FUSE_TERNARY
+    // Fuse addcmul - read runtime addresses before setting out_addr_rt_arg_idx
+    const uint32_t ternary_a_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t ternary_b_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t broadcast_ternary_b = get_arg_val<uint32_t>(argidx++);
+#endif  // FUSE_TERNARY
+
+    const uint32_t out_addr_rt_arg_idx = argidx;  // Output addresses start here (after ternary if present)
+
+    // Tensor accessor for input tensor
+    constexpr auto in0_args = TensorAccessorArgs<22>();
+    const auto in0_reader = TensorAccessor(in0_args, in0_addr);
+
+    // Always create tuple of output accessors (size = N_chunks)
+    constexpr uint32_t out_tensor_args_cta_offset = in0_args.next_compile_time_args_offset();
+    constexpr auto outputs_args = make_tensor_accessor_args_tuple<N_chunks, out_tensor_args_cta_offset>();
+    auto outputs_tuple = make_tensor_accessor_tuple_uniform_page_size(outputs_args, out_addr_rt_arg_idx, out_tile_size);
+
+#ifdef FUSE_BIAS
+    constexpr uint32_t in2_args_cta_offset =
+        tensor_accessor::detail::get_tensor_accessor_args_cta_offset<N_chunks, out_tensor_args_cta_offset>();
+    constexpr auto in2_args = TensorAccessorArgs<in2_args_cta_offset>();
+    const auto in2_reader = TensorAccessor(in2_args, in2_addr);
+#endif
+
+#ifdef FUSE_TERNARY
+// Calculate offset for ternary_a_args - must account for FUSE_BIAS and potentially FUSE_AG
+#if defined(FUSE_AG) && defined(READ_FROM_LOCAL_INPUT)
+// If we have FUSE_AG with READ_FROM_LOCAL_INPUT, in3 is defined
+#ifdef FUSE_BIAS
+    // After in2, then in3, then ternary. TensorAccessorArgs counts are tensor-config dependent, so advance
+    // the accessor-aware way (never a fixed arg count): skip in2 + in3 starting from in2's offset.
+    constexpr uint32_t ternary_a_args_cta_offset =
+        tensor_accessor::detail::get_tensor_accessor_args_cta_offset<2, in2_args_cta_offset>();
+#else
+    // After outputs, then in3, then ternary. Treat in3 as one more accessor past the N_chunks outputs so its
+    // real (config-dependent) arg count is skipped.
+    constexpr uint32_t ternary_a_args_cta_offset =
+        tensor_accessor::detail::get_tensor_accessor_args_cta_offset<N_chunks + 1, out_tensor_args_cta_offset>();
+#endif
+#else
+// No FUSE_AG, same as dm_in1_sender_out
+#ifdef FUSE_BIAS
+    constexpr uint32_t ternary_a_args_cta_offset = in2_args.next_compile_time_args_offset();
+
+#else
+
+    constexpr uint32_t ternary_a_args_cta_offset =
+        tensor_accessor::detail::get_tensor_accessor_args_cta_offset<N_chunks, out_tensor_args_cta_offset>();
+#endif
+#endif
+    constexpr uint32_t cb_ternary_a_id = tt::CBIndex::c_5;
+    constexpr uint32_t cb_ternary_b_id = tt::CBIndex::c_6;
+
+    constexpr uint32_t ternary_a_tile_size = get_tile_size(cb_ternary_a_id);
+    constexpr uint32_t ternary_b_tile_size = get_tile_size(cb_ternary_b_id);
+
+    constexpr auto ternary_a_args = TensorAccessorArgs<ternary_a_args_cta_offset>();
+    constexpr auto ternary_b_args = TensorAccessorArgs<ternary_a_args.next_compile_time_args_offset()>();
+
+    const auto ternary_a_reader = TensorAccessor(ternary_a_args, ternary_a_addr);
+    const auto ternary_b_reader = TensorAccessor(ternary_b_args, ternary_b_addr);
+
+#endif  // FUSE_TERNARY
+
+    const TensorShape2D in0_shape(M_tiles, K_tiles, padded_M_tiles, padded_K_tiles);
+    const TensorShape2D out_shape(M_tiles, N_tiles, padded_M_tiles, padded_N_tiles);
+    const TensorShape2D out0_shape(M_tiles, N_tiles_per_chunk, padded_M_tiles, N_tiles_per_chunk);
+
+    constexpr uint32_t K_num_blocks = padded_K_tiles / K_block_tiles;
+    constexpr uint32_t in0_block_num_tiles = M_block_tiles * K_block_tiles;
+    constexpr uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
+
+#ifdef FUSE_SWIGLU
+    // SwiGLU emits one output tile per interleaved gate/up pair, so the output along N
+    // is half the matmul (weight) N. The weight-space n ranges are halved at each write.
+    constexpr uint32_t out_N_block_tiles = N_block_tiles / 2;
+    constexpr uint32_t out_block_num_tiles_swiglu = M_block_tiles * out_N_block_tiles;
+    const TensorShape2D out_shape_swiglu(M_tiles, N_tiles / 2, padded_M_tiles, padded_N_tiles / 2);
+    // Split (chunks>1): each output chunk is half the weight per-chunk width.
+    constexpr uint32_t out_N_tiles_per_chunk = N_tiles_per_chunk / 2;
+    const TensorShape2D out0_shape_swiglu(M_tiles, out_N_tiles_per_chunk, padded_M_tiles, out_N_tiles_per_chunk);
+#endif
+
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out_id = AG_OUT_WRITE_CB;
+#ifdef FUSE_BIAS
+    constexpr uint32_t cb_in2_id = tt::CBIndex::c_4;
+#endif
+
+    CircularBuffer cb_in0(cb_in0_id);
+    CircularBuffer cb_out(cb_out_id);
+#ifdef FUSE_BIAS
+    CircularBuffer cb_in2(cb_in2_id);
+#endif
+
+#ifdef FUSE_AG
+    // Receiver for ccl fusing
+    MinimalMatmulOpReceiver fused_op_receiver;
+    uint32_t fused_op_rt_args_idx = out_addr_rt_arg_idx + N_chunks;
+    uint32_t num_devices = get_arg_val<uint32_t>(fused_op_rt_args_idx);
+    uint32_t num_k_blocks = get_arg_val<uint32_t>(fused_op_rt_args_idx + 1);
+    uint32_t num_ag_workers = get_arg_val<uint32_t>(fused_op_rt_args_idx + 9);  // after the 9 scalar args
+    uint8_t k_block_device_expected[num_k_blocks]{};
+    uint8_t k_block_device_received[num_k_blocks]{};
+    uint32_t device_k_block_counts[num_devices]{};
+    uint32_t device_k_block_start_ids[num_devices]{};
+    uint32_t forward_k_block_schedule[num_k_blocks]{};
+    uint32_t backward_sem_addrs[num_ag_workers]{};
+    uint32_t forward_sem_addrs[num_ag_workers]{};
+    if constexpr (is_injector_core) {
+        fused_op_receiver = MinimalMatmulOpReceiver(
+            true,
+            fused_op_rt_args_idx,
+            k_block_device_expected,
+            k_block_device_received,
+            device_k_block_counts,
+            device_k_block_start_ids,
+            forward_k_block_schedule,
+            backward_sem_addrs,
+            forward_sem_addrs);
+    }
+
+#ifdef READ_FROM_LOCAL_INPUT
+#ifdef FUSE_BIAS
+    // in3 (local input) sits right after in2 (bias); advance by in2's real arg count, not a fixed constant.
+    constexpr auto in3_args = TensorAccessorArgs<in2_args.next_compile_time_args_offset()>();
+#else
+    constexpr uint32_t in3_args_cta_offset =
+        tensor_accessor::detail::get_tensor_accessor_args_cta_offset<N_chunks, out_tensor_args_cta_offset>();
+    constexpr auto in3_args = TensorAccessorArgs<in3_args_cta_offset>();
+#endif
+    const auto in3_reader = TensorAccessor(in3_args, in3_addr);
+#endif
+#endif
+
+#ifdef SRS_FUSE_OP_SIGNALER
+    // OpSignaler runtime args start after output addresses and optional FUSE_AG args
+    uint32_t srs_fuse_signaler_rt_args_idx = out_addr_rt_arg_idx + N_chunks;
+#ifdef FUSE_AG
+    // Skip MinimalMatmulFusedOpSignaler::push_matmul_fused_op_rt_args: 9 scalars + num_ag_workers + (2N+1) sems
+    srs_fuse_signaler_rt_args_idx += (11 + 2 * get_arg_val<uint32_t>(out_addr_rt_arg_idx + N_chunks + 9));
+#endif
+    OpSignaler srs_fuse_signaler;
+    uint32_t mm_progress_counters_base = 0;
+    if constexpr (is_output_writer) {
+        srs_fuse_signaler = OpSignaler(srs_fuse_signaler_rt_args_idx);
+        // Per-core signaling: base L1 address of the RS cores' per-core progress counter array,
+        // pushed as the next RT arg right after the OpSignaler args.
+        mm_progress_counters_base = get_arg_val<uint32_t>(srs_fuse_signaler_rt_args_idx++);
+    }
+#endif
+
+    in0_valid_sem.set(VALID);
+
+    const uint64_t in0_sender_semaphore_noc_addr =
+        get_noc_addr(in0_sender_noc_x, in0_sender_noc_y, in0_sender_semaphore_addr);
+
+    const uint64_t in0_receiver_semaphore_noc_addr =
+        get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_receiver_semaphore_addr);
+
+    /**
+     * This is a Row-Major output block ordering.
+     * It enables reuse of the last in0 block when striding the output block N dimension.
+     */
+
+    bool k_forward = true;
+
+    uint32_t defer_write_m_tile = 0;
+    uint32_t defer_write_m_tile_end = 0;
+    uint32_t defer_write_n_tile = 0;
+    uint32_t defer_write_n_tile_end = 0;
+    bool defer_write = false;
+
+    for (uint32_t m_block_iter = 0; m_block_iter < M_blocks_per_core; m_block_iter++) {
+        uint32_t m_tile = M_start_tile + m_block_iter * M_block_tiles;
+        uint32_t m_tile_end = std::min(m_tile + M_block_tiles, M_end_tile);
+        uint32_t current_M_block_tiles = m_tile_end - m_tile;
+#ifdef FUSE_AG
+        if constexpr (is_injector_core) {
+            fused_op_receiver.reset();
+        }
+#endif
+
+        k_forward = true;
+        for (uint32_t n_block_iter = 0; n_block_iter < N_blocks_per_core; n_block_iter++) {
+            uint32_t n_tile = N_start_tile + n_block_iter * N_block_tiles;
+            uint32_t n_tile_end = std::min(n_tile + N_block_tiles, N_end_tile);
+            bool is_last_block = (m_block_iter == M_blocks_per_core - 1) && (n_block_iter == (N_blocks_per_core - 1));
+            bool not_first_block = (n_block_iter > 0 || m_block_iter > 0);
+
+            for (uint32_t k_block_iter = 0; k_block_iter < K_num_blocks; k_block_iter++) {
+#if defined(FUSE_AG) && (IN0_SUB_CHUNKS > 1) && defined(AG_INTERLEAVE_BANDS)
+                if constexpr (is_injector_core) {
+                    // Interleave a forward remote k-block with the following backward one: read/push/mcast
+                    // A.b0, B.b0, A.b1, B.b1, ... Position-based pairing matches compute and dm_in1 so the
+                    // per-band in0 CB counts stay in lockstep. Injectors never defer_write, so the deferred
+                    // output flush below never applies on this path.
+                    if (n_block_iter == 0 && k_block_iter >= num_local_k_blocks && (k_block_iter + 1) < K_num_blocks &&
+                        ((k_block_iter - num_local_k_blocks) & 1u) == 0) {
+                        // Resolve both slots up front; each call advances the schedule and updates
+                        // streamed_dir, so capture the forward direction before resolving the backward slot.
+                        const uint32_t kb_a =
+                            fused_op_receiver.compute_actual_k_block_iter(true, k_block_iter, k_forward);
+                        const uint8_t dir_a = fused_op_receiver.streamed_dir;
+                        const uint32_t kb_b =
+                            fused_op_receiver.compute_actual_k_block_iter(true, k_block_iter + 1, k_forward);
+                        const uint32_t kb_pair2[2] = {kb_a, kb_b};
+                        const uint8_t dir_pair[2] = {dir_a, fused_op_receiver.streamed_dir};
+                        for (uint32_t band = 0; band < (uint32_t)IN0_SUB_CHUNKS; band++) {
+                            uint32_t band_lo, band_h;
+                            balanced_band(current_M_block_tiles, (uint32_t)IN0_SUB_CHUNKS, band, band_lo, band_h);
+                            if (band_h == 0) {
+                                break;
+                            }
+                            // Reserve a uniform M_block_tiles/IN0_SUB_CHUNKS-tile slot per band so each band
+                            // tiles the in0 CB exactly (no fifo wrap on a ragged M block), but forward only
+                            // the band_h real tiles. Receivers mirror this member-inner order (see the
+                            // !is_injector_core branch), so exact band_bytes stays in lockstep.
+                            const uint32_t band_slot_tiles = (M_block_tiles / (uint32_t)IN0_SUB_CHUNKS) * K_block_tiles;
+                            const uint32_t band_bytes = band_h * K_block_tiles * in0_tile_size;
+                            const uint32_t band_start = m_tile + band_lo;
+                            const uint32_t band_end = band_start + band_h;
+                            for (uint32_t member = 0; member < 2; member++) {
+                                cb_in0.reserve_back(band_slot_tiles);
+                                uint32_t in0_start_address = get_write_ptr(cb_in0_id);
+                                {
+                                    // band 0's signal was consumed by compute_actual_k_block_iter above; later
+                                    // bands wait this member's own per-direction aggregator signal.
+                                    if (band > 0) {
+                                        fused_op_receiver.wait_for_dir(dir_pair[member]);
+                                    }
+                                    read_in0_block_sync<M_block_tiles, K_block_tiles>(
+                                        in0_reader,
+                                        in0_shape,
+                                        cb_in0_id,
+                                        in0_tile_size,
+#ifdef READ_FROM_LOCAL_INPUT
+                                        in3_reader,
+                                        fused_op_receiver.local_k_start,
+                                        fused_op_receiver.local_k_end,
+                                        fused_op_receiver.input_tensor_Wt,
+#endif
+                                        band_start,
+                                        band_end,
+                                        kb_pair2[member] * K_block_tiles,
+                                        (kb_pair2[member] + 1) * K_block_tiles,
+                                        /*issue_barrier=*/true);
+                                }
+                                cb_in0.push_back(band_slot_tiles);
+                                if (!is_sink_core) {
+                                    in0_sender_sem.wait(1);
+                                    in0_sender_sem.set(0);
+                                    uint64_t in0_unicast_data_addr =
+                                        get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_start_address);
+                                    noc_async_write(in0_start_address, in0_unicast_data_addr, band_bytes);
+#ifdef ARCH_BLACKHOLE
+                                    noc.async_writes_flushed();
+#endif
+                                    noc_semaphore_set_remote(in0_valid_semaphore_addr, in0_receiver_semaphore_noc_addr);
+                                }
+                            }
+                        }
+#ifdef SRS_FUSE_OP_SIGNALER
+                        if constexpr (is_output_writer) {
+                            if (not_first_block && k_block_iter == max_defer_write_k_block) {
+                                noc.async_write_barrier();
+                                srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
+                            }
+                            if (not_first_block && (k_block_iter + 1) == max_defer_write_k_block) {
+                                noc.async_write_barrier();
+                                srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
+                            }
+                        }
+#endif
+                        k_block_iter++;  // the backward member of the pair is consumed here too
+                        continue;
+                    }
+                }
+#endif
+#if defined(FUSE_AG) && (IN0_SUB_CHUNKS > 1) && defined(AG_INTERLEAVE_BANDS)
+                if constexpr (!is_injector_core) {
+                    // Receiver mirror of the injector's paired interleave above. The injector mcasts bands
+                    // member-inner (A.b0, B.b0, A.b1, B.b1, ...); receivers must recv AND forward in that SAME
+                    // order. The sequential non-interleave loop below walks the two k-blocks separately, so it
+                    // would forward each slot with the wrong (sequential) band_h and drop the last tile of
+                    // band 0's backward member. Uniform per-band slot, exact band_bytes forward.
+                    if (n_block_iter == 0 && k_block_iter >= num_local_k_blocks && (k_block_iter + 1) < K_num_blocks &&
+                        ((k_block_iter - num_local_k_blocks) & 1u) == 0) {
+                        // Receivers can defer_write; this branch consumes both paired positions and continues
+                        // past the top-of-loop flush below, so honor a flush scheduled on either one here.
+                        if constexpr (is_output_writer) {
+                            if (defer_write &&
+                                (k_block_iter == defer_write_k_block || (k_block_iter + 1) == defer_write_k_block)) {
+#ifdef FUSE_SWIGLU
+                                cb_out.wait_front(out_block_num_tiles_swiglu);
+                                uint32_t out_read_ptr_swiglu = get_read_ptr(cb_out_id);
+                                if constexpr (N_chunks == 1) {
+                                    write_block_sync<M_block_tiles, out_N_block_tiles>(
+                                        std::get<0>(outputs_tuple),
+                                        out_shape_swiglu,
+                                        out_read_ptr_swiglu,
+                                        out_tile_size,
+                                        defer_write_m_tile,
+                                        defer_write_m_tile_end,
+                                        defer_write_n_tile / 2,
+                                        defer_write_n_tile_end / 2);
+                                } else {
+                                    write_block_sync_split<
+                                        M_block_tiles,
+                                        out_N_block_tiles,
+                                        N_chunks,
+                                        out_N_tiles_per_chunk>(
+                                        outputs_tuple,
+                                        out0_shape_swiglu,
+                                        out_read_ptr_swiglu,
+                                        out_tile_size,
+                                        defer_write_m_tile,
+                                        defer_write_m_tile_end,
+                                        defer_write_n_tile / 2,
+                                        defer_write_n_tile_end / 2);
+                                }
+                                cb_out.pop_front(out_block_num_tiles_swiglu);
+#else
+                                cb_out.wait_front(out_block_num_tiles);
+                                uint32_t out_read_ptr = get_read_ptr(cb_out_id);
+                                if constexpr (N_chunks == 1) {
+                                    write_block_sync<M_block_tiles, N_block_tiles>(
+                                        std::get<0>(outputs_tuple),
+                                        out_shape,
+                                        out_read_ptr,
+                                        out_tile_size,
+                                        defer_write_m_tile,
+                                        defer_write_m_tile_end,
+                                        defer_write_n_tile,
+                                        defer_write_n_tile_end);
+                                } else {
+                                    write_block_sync_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                                        outputs_tuple,
+                                        out0_shape,
+                                        out_read_ptr,
+                                        out_tile_size,
+                                        defer_write_m_tile,
+                                        defer_write_m_tile_end,
+                                        defer_write_n_tile,
+                                        defer_write_n_tile_end);
+                                }
+                                cb_out.pop_front(out_block_num_tiles);
+#endif  // FUSE_SWIGLU
+                            }
+                        }
+                        for (uint32_t band = 0; band < (uint32_t)IN0_SUB_CHUNKS; band++) {
+                            uint32_t band_lo, band_h;
+                            balanced_band(current_M_block_tiles, (uint32_t)IN0_SUB_CHUNKS, band, band_lo, band_h);
+                            if (band_h == 0) {
+                                break;
+                            }
+                            const uint32_t band_slot_tiles = (M_block_tiles / (uint32_t)IN0_SUB_CHUNKS) * K_block_tiles;
+                            const uint32_t band_bytes = band_h * K_block_tiles * in0_tile_size;
+                            for (uint32_t member = 0; member < 2; member++) {
+                                cb_in0.reserve_back(band_slot_tiles);
+                                uint32_t in0_start_address = get_write_ptr(cb_in0_id);
+                                {
+                                    in0_receiver_sem.set(INVALID);
+                                    noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
+                                    in0_receiver_sem.wait(VALID);
+                                }
+                                cb_in0.push_back(band_slot_tiles);
+                                if (!is_sink_core) {
+                                    in0_sender_sem.wait(1);
+                                    in0_sender_sem.set(0);
+                                    uint64_t in0_unicast_data_addr =
+                                        get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_start_address);
+                                    noc_async_write(in0_start_address, in0_unicast_data_addr, band_bytes);
+#ifdef ARCH_BLACKHOLE
+                                    noc.async_writes_flushed();
+#endif
+                                    noc_semaphore_set_remote(in0_valid_semaphore_addr, in0_receiver_semaphore_noc_addr);
+                                }
+                            }
+                        }
+#ifdef SRS_FUSE_OP_SIGNALER
+                        if constexpr (is_output_writer) {
+                            if (not_first_block && k_block_iter == max_defer_write_k_block) {
+                                noc.async_write_barrier();
+                                srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
+                            }
+                            if (not_first_block && (k_block_iter + 1) == max_defer_write_k_block) {
+                                noc.async_write_barrier();
+                                srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
+                            }
+                        }
+#endif
+                        k_block_iter++;  // the backward member of the pair is consumed here too
+                        continue;
+                    }
+                }
+#endif
+                if (defer_write && k_block_iter == defer_write_k_block) {
+                    if constexpr (is_output_writer) {
+#ifdef FUSE_SWIGLU
+                        cb_out.wait_front(out_block_num_tiles_swiglu);
+                        uint32_t out_read_ptr_swiglu = get_read_ptr(cb_out_id);
+                        if constexpr (N_chunks == 1) {
+                            write_block_sync<M_block_tiles, out_N_block_tiles>(
+                                std::get<0>(outputs_tuple),
+                                out_shape_swiglu,
+                                out_read_ptr_swiglu,
+                                out_tile_size,
+                                defer_write_m_tile,
+                                defer_write_m_tile_end,
+                                defer_write_n_tile / 2,
+                                defer_write_n_tile_end / 2);
+                        } else {
+                            write_block_sync_split<M_block_tiles, out_N_block_tiles, N_chunks, out_N_tiles_per_chunk>(
+                                outputs_tuple,
+                                out0_shape_swiglu,
+                                out_read_ptr_swiglu,
+                                out_tile_size,
+                                defer_write_m_tile,
+                                defer_write_m_tile_end,
+                                defer_write_n_tile / 2,
+                                defer_write_n_tile_end / 2);
+                        }
+                        cb_out.pop_front(out_block_num_tiles_swiglu);
+#else
+                        cb_out.wait_front(out_block_num_tiles);
+                        uint32_t out_read_ptr = get_read_ptr(cb_out_id);
+
+                        // write_block_sync_split is more generic (support multiple output tensors)
+                        // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync should be faster
+                        if constexpr (N_chunks == 1) {
+                            write_block_sync<M_block_tiles, N_block_tiles>(
+                                std::get<0>(outputs_tuple),
+                                out_shape,
+                                out_read_ptr,
+                                out_tile_size,
+                                defer_write_m_tile,
+                                defer_write_m_tile_end,
+                                defer_write_n_tile,
+                                defer_write_n_tile_end);
+                        } else {
+                            write_block_sync_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                                outputs_tuple,
+                                out0_shape,
+                                out_read_ptr,
+                                out_tile_size,
+                                defer_write_m_tile,
+                                defer_write_m_tile_end,
+                                defer_write_n_tile,
+                                defer_write_n_tile_end);
+                        }
+                        cb_out.pop_front(out_block_num_tiles);
+#endif  // FUSE_SWIGLU
+                    }
+                }
+
+                // ---- Sub-chunked (banded) delivery ----
+                // Each k-block position is delivered as `nb` M-row bands. Remote positions on the first
+                // N-block use IN0_SUB_CHUNKS bands (matching the AG's per-band signalling); local positions
+                // and every position on later N-blocks use a single whole-block band. Reserve/read (or
+                // recv)/push/forward happen per band so the matmul and the downstream forward pipeline at
+                // band granularity. N-stride in0 reuse is intentionally disabled here (every position is
+                // delivered fresh), so there is no reuse skip on this path.
+                [[maybe_unused]] uint32_t k_block = k_forward ? k_block_iter : (K_num_blocks - 1) - k_block_iter;
+#ifdef FUSE_AG
+                if constexpr (is_injector_core) {
+                    k_block = fused_op_receiver.compute_actual_k_block_iter(n_block_iter == 0, k_block_iter, k_forward);
+                }
+                // streamed_dir is only meaningful on the injector; receivers use num_local_k_blocks below.
+                [[maybe_unused]] const uint8_t k_dir = is_injector_core ? fused_op_receiver.streamed_dir : (uint8_t)2;
+#else
+                [[maybe_unused]] const uint8_t k_dir = 2;
+#endif
+                uint32_t nb;
+                if constexpr (is_injector_core) {
+                    nb = (n_block_iter == 0 && k_dir != 2) ? (uint32_t)IN0_SUB_CHUNKS : 1u;
+                } else {
+                    nb = (n_block_iter == 0 && k_block_iter >= num_local_k_blocks) ? (uint32_t)IN0_SUB_CHUNKS : 1u;
+                }
+                for (uint32_t band = 0; band < nb; band++) {
+                    uint32_t band_lo, band_h;
+                    balanced_band(current_M_block_tiles, nb, band, band_lo, band_h);
+                    if (band_h == 0) {
+                        break;  // only when nb > current_M_block_tiles
+                    }
+                    // Uniform per-band slot (see the interleave branches above); this path serves
+                    // single-k-block positions (local or unpaired remote), so band_h forwards match.
+                    const uint32_t band_slot_tiles = (M_block_tiles / nb) * K_block_tiles;
+                    const uint32_t band_bytes = band_h * K_block_tiles * in0_tile_size;
+                    cb_in0.reserve_back(band_slot_tiles);
+                    uint32_t in0_start_address = get_write_ptr(cb_in0_id);
+                    if constexpr (is_injector_core) {
+                        const uint32_t band_start = m_tile + band_lo;
+                        const uint32_t band_end = band_start + band_h;
+#ifdef FUSE_AG
+                        // band 0's signal was already awaited by compute_actual_k_block_iter above; each
+                        // later band waits its own aggregator signal.
+                        if (nb > 1 && band > 0) {
+                            fused_op_receiver.wait_for_dir(k_dir);
+                        }
+#endif
+                        read_in0_block_sync<M_block_tiles, K_block_tiles>(
+                            in0_reader,
+                            in0_shape,
+                            cb_in0_id,
+                            in0_tile_size,
+#ifdef READ_FROM_LOCAL_INPUT
+                            in3_reader,
+                            fused_op_receiver.local_k_start,
+                            fused_op_receiver.local_k_end,
+                            fused_op_receiver.input_tensor_Wt,
+#endif
+                            band_start,
+                            band_end,
+                            k_block * K_block_tiles,
+                            (k_block + 1) * K_block_tiles,
+                            /*issue_barrier=*/true);
+                    } else {
+                        in0_receiver_sem.set(INVALID);
+                        noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
+                        in0_receiver_sem.wait(VALID);
+                    }
+
+                    cb_in0.push_back(band_slot_tiles);
+
+                    if (!is_sink_core) {
+                        in0_sender_sem.wait(1);
+                        in0_sender_sem.set(0);
+                        uint64_t in0_unicast_data_addr =
+                            get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_start_address);
+                        noc_async_write(in0_start_address, in0_unicast_data_addr, band_bytes);
+#ifdef ARCH_BLACKHOLE
+                        noc.async_writes_flushed();
+#endif
+                        noc_semaphore_set_remote(in0_valid_semaphore_addr, in0_receiver_semaphore_noc_addr);
+                    }
+                }
+#ifdef SRS_FUSE_OP_SIGNALER
+                if constexpr (is_output_writer) {
+                    if (not_first_block && k_block_iter == max_defer_write_k_block) {
+                        noc.async_write_barrier();
+                        srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
+                    }
+                }
+#endif
+            }
+#ifdef FUSE_BIAS
+            if constexpr (!is_output_writer) {
+                cb_in2.reserve_back(N_block_tiles);
+
+                uint32_t l1_write_addr_in2 = get_write_ptr(cb_in2_id);
+                for (uint32_t n_tile_id = n_tile; n_tile_id < n_tile_end; n_tile_id++) {
+                    noc.async_read(
+                        in2_reader,
+                        CoreLocalMem<uint32_t>(l1_write_addr_in2),
+                        in2_tile_size,
+                        {.page_id = n_tile_id},
+                        {});
+                    l1_write_addr_in2 += in2_tile_size;
+                }
+                noc.async_read_barrier();
+
+                cb_in2.push_back(N_block_tiles);
+            }
+#endif
+
+#ifdef FUSE_TERNARY
+            if constexpr (!is_output_writer) {
+                read_ternary_blocks_sync<M_block_tiles, N_block_tiles>(
+                    ternary_a_reader,
+                    ternary_b_reader,
+                    out_shape,
+                    cb_ternary_a_id,
+                    cb_ternary_b_id,
+                    ternary_a_tile_size,
+                    ternary_b_tile_size,
+                    broadcast_ternary_b,
+                    m_tile,
+                    m_tile_end,
+                    n_tile,
+                    n_tile_end);
+            }
+#endif
+
+            k_forward = !k_forward;
+
+            defer_write_m_tile = m_tile;
+            defer_write_m_tile_end = m_tile_end;
+            defer_write_n_tile = n_tile;
+            defer_write_n_tile_end = n_tile_end;
+            /**
+             * If this isn't the last output block, defer writing until the defer_k_write_block iteration
+             * of the next output block.
+             */
+            defer_write = !is_last_block;
+            defer_write = defer_write && !is_injector_core;
+
+            if (!defer_write) {
+                if constexpr (is_output_writer) {
+#ifdef FUSE_SWIGLU
+                    if constexpr (N_chunks == 1) {
+                        write_block_sync_granular<M_block_tiles, out_N_block_tiles>(
+                            std::get<0>(outputs_tuple),
+                            out_shape_swiglu,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile / 2,
+                            n_tile_end / 2);
+                    } else {
+                        write_block_sync_granular_split<
+                            M_block_tiles,
+                            out_N_block_tiles,
+                            N_chunks,
+                            out_N_tiles_per_chunk>(
+                            outputs_tuple,
+                            out0_shape_swiglu,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile / 2,
+                            n_tile_end / 2);
+                    }
+#else
+                    // write_block_sync_granular_split is more generic (support multiple output tensors)
+                    // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync_granular should be faster
+                    if constexpr (N_chunks == 1) {
+#ifdef SPLIT_OUTPUT_WRITE
+#ifdef AGMM_INTERLEAVED_OUTPUT_WRITE
+                        // NOC_0 writer: drains the rows split_row_to_noc1() assigns to NOC_0 from c_8,
+                        // interleaved across the block so it overlaps the NOC_1 writer (dm_in1).
+                        write_block_sync_granular_interleaved<M_block_tiles, N_block_tiles>(
+                            std::get<0>(outputs_tuple),
+                            out_shape,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile,
+                            n_tile_end,
+                            AG_SPLIT_NOC1_PCT,
+                            /*own_noc1=*/false);
+#else
+                        // NOC_0 writer: high rows [split_rows, M) from c_8.
+                        constexpr uint32_t split_rows = (M_block_tiles * AG_SPLIT_NOC1_PCT) / 100;
+                        write_block_sync_granular<M_block_tiles, N_block_tiles>(
+                            std::get<0>(outputs_tuple),
+                            out_shape,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile,
+                            n_tile_end,
+                            split_rows,
+                            M_block_tiles);
+#endif  // AGMM_INTERLEAVED_OUTPUT_WRITE
+#else
+                        write_block_sync_granular<M_block_tiles, N_block_tiles>(
+                            std::get<0>(outputs_tuple),
+                            out_shape,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile,
+                            n_tile_end);
+#endif
+                    } else {
+#ifdef SPLIT_OUTPUT_WRITE
+                        // NOC_0 writer: high rows [split_rows, M) from c_8, demuxed into the chunk tensors.
+                        constexpr uint32_t split_rows = (M_block_tiles * AG_SPLIT_NOC1_PCT) / 100;
+                        write_block_sync_granular_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                            outputs_tuple,
+                            out0_shape,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile,
+                            n_tile_end,
+                            split_rows,
+                            M_block_tiles);
+#else
+                        write_block_sync_granular_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                            outputs_tuple,
+                            out0_shape,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile,
+                            n_tile_end);
+#endif
+                    }
+#endif  // FUSE_SWIGLU
+#ifdef SRS_FUSE_OP_SIGNALER
+                    if (is_last_block) {
+                        noc.async_write_barrier();
+                        srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
+                    }
+#endif
+                }
+            }
+        }
+    }
+    noc.async_write_barrier();
+    noc.async_atomic_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_dm_in0_sender.cpp
@@ -18,10 +18,7 @@
 #define IN0_SUB_CHUNKS 1
 #endif
 
-// Two-NoC output-write split: under SPLIT_OUTPUT_WRITE, dm_in0 becomes a co-writer draining the second
-// output CB (AG_OUT_WRITE_CB = c_8) and writing the block's high M-rows [split_rows, M) on NOC_0, while
-// dm_in1 writes [0, split_rows) on NOC_1. split_rows = M_block_tiles*AG_SPLIT_NOC1_PCT/100; must match
-// compute/dm_in1. Defaults: single out CB c_2, 50% (inactive unless SPLIT_OUTPUT_WRITE is set).
+// Two-NoC output-write split: under SPLIT_OUTPUT_WRITE, dm_in0 becomes a co-writer draining the second output CB
 #ifndef AG_OUT_WRITE_CB
 #define AG_OUT_WRITE_CB 2
 #endif
@@ -72,9 +69,7 @@ void kernel_main() {
     const uint32_t N_end_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t defer_write_k_block = get_arg_val<uint32_t>(argidx++);
     const uint32_t max_defer_write_k_block = get_arg_val<uint32_t>(argidx++);
-    // Leading (self/local) k-block positions this device owns. Receivers don't run the AG scheduler,
-    // so they use this to compute the same per-position band count the injector derives from streamed_dir.
-    // (Read unconditionally to keep the arg layout fixed; only consumed by receivers / IN0_SUB_CHUNKS > 1.)
+    // Leading (self/local) k-block positions this device owns
     [[maybe_unused]] const uint32_t num_local_k_blocks = get_arg_val<uint32_t>(argidx++);
 
 #ifdef FUSE_TERNARY
@@ -107,13 +102,11 @@ void kernel_main() {
 #if defined(FUSE_AG) && defined(READ_FROM_LOCAL_INPUT)
 // If we have FUSE_AG with READ_FROM_LOCAL_INPUT, in3 is defined
 #ifdef FUSE_BIAS
-    // After in2, then in3, then ternary. TensorAccessorArgs counts are tensor-config dependent, so advance
-    // the accessor-aware way (never a fixed arg count): skip in2 + in3 starting from in2's offset.
+    // After in2, then in3, then ternary
     constexpr uint32_t ternary_a_args_cta_offset =
         tensor_accessor::detail::get_tensor_accessor_args_cta_offset<2, in2_args_cta_offset>();
 #else
-    // After outputs, then in3, then ternary. Treat in3 as one more accessor past the N_chunks outputs so its
-    // real (config-dependent) arg count is skipped.
+    // After outputs, then in3, then ternary
     constexpr uint32_t ternary_a_args_cta_offset =
         tensor_accessor::detail::get_tensor_accessor_args_cta_offset<N_chunks + 1, out_tensor_args_cta_offset>();
 #endif
@@ -151,8 +144,7 @@ void kernel_main() {
     constexpr uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
 
 #ifdef FUSE_SWIGLU
-    // SwiGLU emits one output tile per interleaved gate/up pair, so the output along N
-    // is half the matmul (weight) N. The weight-space n ranges are halved at each write.
+    // SwiGLU emits one output tile per interleaved gate/up pair, so the output along N is half the matmul (weight) N
     constexpr uint32_t out_N_block_tiles = N_block_tiles / 2;
     constexpr uint32_t out_block_num_tiles_swiglu = M_block_tiles * out_N_block_tiles;
     const TensorShape2D out_shape_swiglu(M_tiles, N_tiles / 2, padded_M_tiles, padded_N_tiles / 2);
@@ -224,8 +216,7 @@ void kernel_main() {
     uint32_t mm_progress_counters_base = 0;
     if constexpr (is_output_writer) {
         srs_fuse_signaler = OpSignaler(srs_fuse_signaler_rt_args_idx);
-        // Per-core signaling: base L1 address of the RS cores' per-core progress counter array,
-        // pushed as the next RT arg right after the OpSignaler args.
+        // Per-core signaling: base L1 address of the RS cores' per-core progress counter array
         mm_progress_counters_base = get_arg_val<uint32_t>(srs_fuse_signaler_rt_args_idx++);
     }
 #endif
@@ -271,14 +262,10 @@ void kernel_main() {
             for (uint32_t k_block_iter = 0; k_block_iter < K_num_blocks; k_block_iter++) {
 #if defined(FUSE_AG) && (IN0_SUB_CHUNKS > 1) && defined(AG_INTERLEAVE_BANDS)
                 if constexpr (is_injector_core) {
-                    // Interleave a forward remote k-block with the following backward one: read/push/mcast
-                    // A.b0, B.b0, A.b1, B.b1, ... Position-based pairing matches compute and dm_in1 so the
-                    // per-band in0 CB counts stay in lockstep. Injectors never defer_write, so the deferred
-                    // output flush below never applies on this path.
+                    // Interleave a forward remote k-block with the following backward one: read/push/mcast A.b0
                     if (n_block_iter == 0 && k_block_iter >= num_local_k_blocks && (k_block_iter + 1) < K_num_blocks &&
                         ((k_block_iter - num_local_k_blocks) & 1u) == 0) {
-                        // Resolve both slots up front; each call advances the schedule and updates
-                        // streamed_dir, so capture the forward direction before resolving the backward slot.
+                        // Resolve both slots up front
                         const uint32_t kb_a =
                             fused_op_receiver.compute_actual_k_block_iter(true, k_block_iter, k_forward);
                         const uint8_t dir_a = fused_op_receiver.streamed_dir;
@@ -292,10 +279,7 @@ void kernel_main() {
                             if (band_h == 0) {
                                 break;
                             }
-                            // Reserve a uniform M_block_tiles/IN0_SUB_CHUNKS-tile slot per band so each band
-                            // tiles the in0 CB exactly (no fifo wrap on a ragged M block), but forward only
-                            // the band_h real tiles. Receivers mirror this member-inner order (see the
-                            // !is_injector_core branch), so exact band_bytes stays in lockstep.
+                            // Reserve a uniform M_block_tiles/IN0_SUB_CHUNKS-tile slot per band so each band tiles
                             const uint32_t band_slot_tiles = (M_block_tiles / (uint32_t)IN0_SUB_CHUNKS) * K_block_tiles;
                             const uint32_t band_bytes = band_h * K_block_tiles * in0_tile_size;
                             const uint32_t band_start = m_tile + band_lo;
@@ -304,8 +288,7 @@ void kernel_main() {
                                 cb_in0.reserve_back(band_slot_tiles);
                                 uint32_t in0_start_address = get_write_ptr(cb_in0_id);
                                 {
-                                    // band 0's signal was consumed by compute_actual_k_block_iter above; later
-                                    // bands wait this member's own per-direction aggregator signal.
+                                    // band 0's signal was consumed by compute_actual_k_block_iter above
                                     if (band > 0) {
                                         fused_op_receiver.wait_for_dir(dir_pair[member]);
                                     }
@@ -359,15 +342,10 @@ void kernel_main() {
 #endif
 #if defined(FUSE_AG) && (IN0_SUB_CHUNKS > 1) && defined(AG_INTERLEAVE_BANDS)
                 if constexpr (!is_injector_core) {
-                    // Receiver mirror of the injector's paired interleave above. The injector mcasts bands
-                    // member-inner (A.b0, B.b0, A.b1, B.b1, ...); receivers must recv AND forward in that SAME
-                    // order. The sequential non-interleave loop below walks the two k-blocks separately, so it
-                    // would forward each slot with the wrong (sequential) band_h and drop the last tile of
-                    // band 0's backward member. Uniform per-band slot, exact band_bytes forward.
+                    // Receiver mirror of the injector's paired interleave above
                     if (n_block_iter == 0 && k_block_iter >= num_local_k_blocks && (k_block_iter + 1) < K_num_blocks &&
                         ((k_block_iter - num_local_k_blocks) & 1u) == 0) {
-                        // Receivers can defer_write; this branch consumes both paired positions and continues
-                        // past the top-of-loop flush below, so honor a flush scheduled on either one here.
+                        // Receivers can defer_write
                         if constexpr (is_output_writer) {
                             if (defer_write &&
                                 (k_block_iter == defer_write_k_block || (k_block_iter + 1) == defer_write_k_block)) {
@@ -506,8 +484,7 @@ void kernel_main() {
                         cb_out.wait_front(out_block_num_tiles);
                         uint32_t out_read_ptr = get_read_ptr(cb_out_id);
 
-                        // write_block_sync_split is more generic (support multiple output tensors)
-                        // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync should be faster
+                        // write_block_sync_split is more generic (support multiple output tensors) But for N_chunks
                         if constexpr (N_chunks == 1) {
                             write_block_sync<M_block_tiles, N_block_tiles>(
                                 std::get<0>(outputs_tuple),
@@ -534,13 +511,7 @@ void kernel_main() {
                     }
                 }
 
-                // ---- Sub-chunked (banded) delivery ----
-                // Each k-block position is delivered as `nb` M-row bands. Remote positions on the first
-                // N-block use IN0_SUB_CHUNKS bands (matching the AG's per-band signalling); local positions
-                // and every position on later N-blocks use a single whole-block band. Reserve/read (or
-                // recv)/push/forward happen per band so the matmul and the downstream forward pipeline at
-                // band granularity. N-stride in0 reuse is intentionally disabled here (every position is
-                // delivered fresh), so there is no reuse skip on this path.
+                // ---- Sub-chunked (banded) delivery ---- Each k-block position is delivered as `nb` M-row bands
                 [[maybe_unused]] uint32_t k_block = k_forward ? k_block_iter : (K_num_blocks - 1) - k_block_iter;
 #ifdef FUSE_AG
                 if constexpr (is_injector_core) {
@@ -563,8 +534,7 @@ void kernel_main() {
                     if (band_h == 0) {
                         break;  // only when nb > current_M_block_tiles
                     }
-                    // Uniform per-band slot (see the interleave branches above); this path serves
-                    // single-k-block positions (local or unpaired remote), so band_h forwards match.
+                    // Uniform per-band slot (see the interleave branches above)
                     const uint32_t band_slot_tiles = (M_block_tiles / nb) * K_block_tiles;
                     const uint32_t band_bytes = band_h * K_block_tiles * in0_tile_size;
                     cb_in0.reserve_back(band_slot_tiles);
@@ -573,8 +543,7 @@ void kernel_main() {
                         const uint32_t band_start = m_tile + band_lo;
                         const uint32_t band_end = band_start + band_h;
 #ifdef FUSE_AG
-                        // band 0's signal was already awaited by compute_actual_k_block_iter above; each
-                        // later band waits its own aggregator signal.
+                        // band 0's signal was already awaited by compute_actual_k_block_iter above
                         if (nb > 1 && band > 0) {
                             fused_op_receiver.wait_for_dir(k_dir);
                         }
@@ -705,12 +674,10 @@ void kernel_main() {
                     }
 #else
                     // write_block_sync_granular_split is more generic (support multiple output tensors)
-                    // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync_granular should be faster
                     if constexpr (N_chunks == 1) {
 #ifdef SPLIT_OUTPUT_WRITE
 #ifdef AGMM_INTERLEAVED_OUTPUT_WRITE
-                        // NOC_0 writer: drains the rows split_row_to_noc1() assigns to NOC_0 from c_8,
-                        // interleaved across the block so it overlaps the NOC_1 writer (dm_in1).
+                        // NOC_0 writer: drains the rows split_row_to_noc1() assigns to NOC_0 from c_8
                         write_block_sync_granular_interleaved<M_block_tiles, N_block_tiles>(
                             std::get<0>(outputs_tuple),
                             out_shape,

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_dm_in1_sender_out.cpp
@@ -1,0 +1,632 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "fabric_bound_matmul_dataflow_common.hpp"
+#include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp"
+
+// Set by the host only when fusing AG; default to 1 (single whole band per k-block) otherwise.
+#ifndef IN0_SUB_CHUNKS
+#define IN0_SUB_CHUNKS 1
+#endif
+
+// Two-NoC output-write split: this writer (NOC_1) handles the block's low M-rows [0, split_rows) from c_2;
+// dm_in0 writes [split_rows, M) from c_8 on NOC_0. split_rows = M_block_tiles*AG_SPLIT_NOC1_PCT/100, and
+// must match compute/dm_in0. Default 50% (no effect unless SPLIT_OUTPUT_WRITE is set).
+#ifndef AG_SPLIT_NOC1_PCT
+#define AG_SPLIT_NOC1_PCT 50
+#endif
+
+void kernel_main() {
+    Noc noc;
+    constexpr uint32_t M_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t padded_M_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t K_tiles = get_compile_time_arg_val(2);
+    constexpr uint32_t padded_K_tiles = get_compile_time_arg_val(3);
+    constexpr uint32_t N_tiles = get_compile_time_arg_val(4);
+    constexpr uint32_t padded_N_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t M_block_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t K_block_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t N_block_tiles = get_compile_time_arg_val(8);
+    constexpr uint32_t M_blocks_per_core = get_compile_time_arg_val(9);
+    constexpr uint32_t N_blocks_per_core = get_compile_time_arg_val(10);
+    constexpr uint32_t in1_tile_size = get_compile_time_arg_val(11);
+    constexpr uint32_t out_tile_size = get_compile_time_arg_val(12);
+    constexpr uint32_t in2_tile_size = get_compile_time_arg_val(13);
+    uint32_t in1_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(14));
+    uint32_t in1_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(15));
+    uint32_t in1_valid_semaphore_addr = get_semaphore(get_compile_time_arg_val(16));
+    Semaphore<> in1_sender_sem(get_compile_time_arg_val(14));
+    Semaphore<> in1_receiver_sem(get_compile_time_arg_val(15));
+    Semaphore<> in1_valid_sem(get_compile_time_arg_val(16));
+    constexpr uint32_t is_output_writer = get_compile_time_arg_val(17);
+    constexpr uint32_t is_injector_core = get_compile_time_arg_val(18);
+    constexpr uint32_t N_chunks = get_compile_time_arg_val(19);
+    constexpr uint32_t N_tiles_per_chunk = get_compile_time_arg_val(20);
+
+    // Load input/output addresses and range parameters
+    uint32_t argidx = 0;
+    const uint32_t in1_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in2_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t is_sink_core = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in1_dest_noc_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in1_dest_noc_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in1_sender_noc_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in1_sender_noc_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t M_end_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t N_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t N_end_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t defer_write_k_block = get_arg_val<uint32_t>(argidx++);
+    const uint32_t max_defer_write_k_block = get_arg_val<uint32_t>(argidx++);
+    // Leading (self/local) k-block positions this device owns; used by receivers to derive the same
+    // per-position band count the injector gets from streamed_dir (see dm_in0_sender.cpp).
+    // (Read unconditionally to keep the arg layout fixed; only consumed by receivers / IN0_SUB_CHUNKS > 1.)
+    [[maybe_unused]] const uint32_t num_local_k_blocks = get_arg_val<uint32_t>(argidx++);
+
+#ifdef FUSE_TERNARY
+    // Fuse addcmul - read runtime addresses before setting out_addr_rt_arg_idx
+    const uint32_t ternary_a_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t ternary_b_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t broadcast_ternary_b = get_arg_val<uint32_t>(argidx++);
+#endif  // FUSE_TERNARY
+
+    const uint32_t out_addr_rt_arg_idx = argidx;  // Output addresses start here (after ternary if present)
+
+    // Tensor accessor for input tensor
+    constexpr auto in1_args = TensorAccessorArgs<21>();
+    const auto in1_reader = TensorAccessor(in1_args, in1_addr);
+
+    // Always create tuple of output accessors (size = N_chunks)
+    constexpr uint32_t out_tensor_args_cta_offset = in1_args.next_compile_time_args_offset();
+    constexpr auto outputs_args = make_tensor_accessor_args_tuple<N_chunks, out_tensor_args_cta_offset>();
+    auto outputs_tuple = make_tensor_accessor_tuple_uniform_page_size(outputs_args, out_addr_rt_arg_idx, out_tile_size);
+
+#ifdef FUSE_BIAS
+    constexpr uint32_t in2_args_cta_offset =
+        tensor_accessor::detail::get_tensor_accessor_args_cta_offset<N_chunks, out_tensor_args_cta_offset>();
+    constexpr auto in2_args = TensorAccessorArgs<in2_args_cta_offset>();
+    const auto in2_reader = TensorAccessor(in2_args, in2_addr);
+#endif
+
+#ifdef FUSE_TERNARY
+// Calculate offset for ternary_a_args
+#ifdef FUSE_BIAS
+    constexpr uint32_t ternary_a_args_cta_offset = in2_args.next_compile_time_args_offset();
+#else
+    constexpr uint32_t ternary_a_args_cta_offset =
+        tensor_accessor::detail::get_tensor_accessor_args_cta_offset<N_chunks, out_tensor_args_cta_offset>();
+#endif
+    constexpr uint32_t cb_ternary_a_id = tt::CBIndex::c_5;
+    constexpr uint32_t cb_ternary_b_id = tt::CBIndex::c_6;
+
+    constexpr uint32_t ternary_a_tile_size = get_tile_size(cb_ternary_a_id);
+    constexpr uint32_t ternary_b_tile_size = get_tile_size(cb_ternary_b_id);
+
+    constexpr auto ternary_a_args = TensorAccessorArgs<ternary_a_args_cta_offset>();
+    constexpr auto ternary_b_args = TensorAccessorArgs<ternary_a_args.next_compile_time_args_offset()>();
+    const auto ternary_a_reader = TensorAccessor(ternary_a_args, ternary_a_addr);
+    const auto ternary_b_reader = TensorAccessor(ternary_b_args, ternary_b_addr);
+
+#endif  // FUSE_TERNARY
+
+    const TensorShape2D in1_shape(K_tiles, N_tiles, padded_K_tiles, padded_N_tiles);
+    const TensorShape2D out_shape(M_tiles, N_tiles, padded_M_tiles, padded_N_tiles);
+    const TensorShape2D out0_shape(M_tiles, N_tiles_per_chunk, padded_M_tiles, N_tiles_per_chunk);
+
+    constexpr uint32_t K_num_blocks = padded_K_tiles / K_block_tiles;
+    constexpr uint32_t in1_block_num_tiles = K_block_tiles * N_block_tiles;
+    constexpr uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
+
+#ifdef FUSE_SWIGLU
+    // SwiGLU emits one output tile per interleaved gate/up pair, so the output along N
+    // is half the matmul (weight) N. Compute the halved output geometry once here; the
+    // weight-space n ranges (n_tile, N_tiles, ...) are halved at each write call site.
+    constexpr uint32_t out_N_block_tiles = N_block_tiles / 2;
+    constexpr uint32_t out_block_num_tiles_swiglu = M_block_tiles * out_N_block_tiles;
+    const TensorShape2D out_shape_swiglu(M_tiles, N_tiles / 2, padded_M_tiles, padded_N_tiles / 2);
+    // Split (chunks>1): each output chunk is half the weight per-chunk width.
+    constexpr uint32_t out_N_tiles_per_chunk = N_tiles_per_chunk / 2;
+    const TensorShape2D out0_shape_swiglu(M_tiles, out_N_tiles_per_chunk, padded_M_tiles, out_N_tiles_per_chunk);
+#endif
+
+    constexpr uint32_t cb_in1_id = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out_id = tt::CBIndex::c_2;
+    // Scratch that holds the whole K_block x N_block once per k-block position so the injector can
+    // re-present it to compute once per M-row band (read once from DRAM, pushed nb times) without
+    // re-reading DRAM. Only used on the sub-chunked injector path.
+    constexpr uint32_t cb_in1_scratch_id = tt::CBIndex::c_7;
+#ifdef FUSE_BIAS
+    constexpr uint32_t cb_in2_id = tt::CBIndex::c_4;
+#endif
+
+    CircularBuffer cb_in1(cb_in1_id);
+    CircularBuffer cb_out(cb_out_id);
+#ifdef FUSE_BIAS
+    CircularBuffer cb_in2(cb_in2_id);
+#endif
+
+#ifdef FUSE_AG
+    // Receiver for ccl fusing
+    MinimalMatmulOpReceiver fused_op_receiver;
+    uint32_t fused_op_rt_args_idx = out_addr_rt_arg_idx + N_chunks;
+    uint32_t num_devices = get_arg_val<uint32_t>(fused_op_rt_args_idx);
+    uint32_t num_k_blocks = get_arg_val<uint32_t>(fused_op_rt_args_idx + 1);
+    uint32_t num_ag_workers = get_arg_val<uint32_t>(fused_op_rt_args_idx + 9);  // after the 9 scalar args
+    uint8_t k_block_device_expected[num_k_blocks]{};
+    uint8_t k_block_device_received[num_k_blocks]{};
+    uint32_t device_k_block_counts[num_devices]{};
+    uint32_t device_k_block_start_ids[num_devices]{};
+    uint32_t forward_k_block_schedule[num_k_blocks]{};
+    uint32_t backward_sem_addrs[num_ag_workers]{};
+    uint32_t forward_sem_addrs[num_ag_workers]{};
+    if constexpr (is_injector_core) {
+        fused_op_receiver = MinimalMatmulOpReceiver(
+            false,
+            fused_op_rt_args_idx,
+            k_block_device_expected,
+            k_block_device_received,
+            device_k_block_counts,
+            device_k_block_start_ids,
+            forward_k_block_schedule,
+            backward_sem_addrs,
+            forward_sem_addrs);
+    }
+#endif
+
+#ifdef SRS_FUSE_OP_SIGNALER
+    // OpSignaler runtime args start after output addresses and optional FUSE_AG args
+    uint32_t srs_fuse_signaler_rt_args_idx = out_addr_rt_arg_idx + N_chunks;
+#ifdef FUSE_AG
+    // Skip MinimalMatmulFusedOpSignaler::push_matmul_fused_op_rt_args: 9 scalars + num_ag_workers + (2N+1) sems
+    srs_fuse_signaler_rt_args_idx += (11 + 2 * get_arg_val<uint32_t>(out_addr_rt_arg_idx + N_chunks + 9));
+#endif
+    OpSignaler srs_fuse_signaler;
+    uint32_t mm_progress_counters_base = 0;
+    if constexpr (is_output_writer) {
+        srs_fuse_signaler = OpSignaler(srs_fuse_signaler_rt_args_idx);
+        // Per-core signaling: base L1 address of the RS cores' per-core progress counter array,
+        // pushed as the next RT arg right after the OpSignaler args.
+        mm_progress_counters_base = get_arg_val<uint32_t>(srs_fuse_signaler_rt_args_idx++);
+    }
+#endif
+
+    in1_valid_sem.set(VALID);
+
+    const uint64_t in1_sender_semaphore_noc_addr =
+        get_noc_addr(in1_sender_noc_x, in1_sender_noc_y, in1_sender_semaphore_addr);
+
+    const uint64_t in1_receiver_semaphore_noc_addr =
+        get_noc_addr(in1_dest_noc_x, in1_dest_noc_y, in1_receiver_semaphore_addr);
+
+    const uint64_t in1_unicast_data_base_addr = get_noc_addr(in1_dest_noc_x, in1_dest_noc_y, 0);
+
+    constexpr uint32_t full_N_tiles_bytes = N_block_tiles * in1_tile_size;
+
+    bool k_forward = true;
+
+    uint32_t defer_write_m_tile = 0;
+    uint32_t defer_write_m_tile_end = 0;
+    uint32_t defer_write_n_tile = 0;
+    uint32_t defer_write_n_tile_end = 0;
+    bool defer_write = false;
+
+    for (uint32_t m_block_iter = 0; m_block_iter < M_blocks_per_core; m_block_iter++) {
+        uint32_t m_tile = M_start_tile + m_block_iter * M_block_tiles;
+        uint32_t m_tile_end = std::min(m_tile + M_block_tiles, M_end_tile);
+#ifdef FUSE_AG
+        if constexpr (is_injector_core) {
+            fused_op_receiver.reset();
+        }
+#endif
+
+        k_forward = true;
+
+        for (uint32_t n_block_iter = 0; n_block_iter < N_blocks_per_core; n_block_iter++) {
+            uint32_t n_tile = N_start_tile + n_block_iter * N_block_tiles;
+            uint32_t n_tile_end = std::min(n_tile + N_block_tiles, N_end_tile);
+            uint32_t current_N_block_tiles = n_tile_end - n_tile;
+            uint32_t current_N_tiles_bytes = current_N_block_tiles * in1_tile_size;
+            bool is_last_block = (m_block_iter == M_blocks_per_core - 1) && (n_block_iter == (N_blocks_per_core - 1));
+            bool not_first_block = (n_block_iter > 0 || m_block_iter > 0);
+            for (uint32_t k_block_iter = 0; k_block_iter < K_num_blocks; k_block_iter++) {
+#if defined(FUSE_AG) && (IN0_SUB_CHUNKS > 1) && defined(AG_INTERLEAVE_BANDS)
+                if constexpr (is_injector_core) {
+                    // Re-present a forward remote k-block and the following backward one interleaved per band
+                    // (A.b0, B.b0, ...), matching dm_in0/compute. Both blocks are read once into the two-slot
+                    // scratch; in1 has no M dimension so each band re-presents the whole block. Injectors
+                    // never defer_write, so the deferred output flush below never applies on this path.
+                    if (n_block_iter == 0 && k_block_iter >= num_local_k_blocks && (k_block_iter + 1) < K_num_blocks &&
+                        ((k_block_iter - num_local_k_blocks) & 1u) == 0) {
+                        const uint32_t kb_pair[2] = {
+                            fused_op_receiver.compute_actual_k_block_iter(true, k_block_iter, k_forward),
+                            fused_op_receiver.compute_actual_k_block_iter(true, k_block_iter + 1, k_forward)};
+                        const uint32_t in1_block_bytes = in1_block_num_tiles * in1_tile_size;
+                        const uint32_t scratch_addr = get_write_ptr(cb_in1_scratch_id);
+                        const uint32_t scratch_pair[2] = {scratch_addr, scratch_addr + in1_block_bytes};
+                        {
+                            for (uint32_t member = 0; member < 2; member++) {
+                                read_in1_block_sync<K_block_tiles, N_block_tiles>(
+                                    in1_reader,
+                                    in1_shape,
+                                    cb_in1_scratch_id,
+                                    in1_tile_size,
+                                    kb_pair[member] * K_block_tiles,
+                                    (kb_pair[member] + 1) * K_block_tiles,
+                                    n_tile,
+                                    n_tile_end,
+                                    /*write_ptr_offset=*/member * in1_block_bytes);
+                            }
+                        }
+                        const uint64_t scratch_noc[2] = {get_noc_addr(scratch_pair[0]), get_noc_addr(scratch_pair[1])};
+                        for (uint32_t band = 0; band < (uint32_t)IN0_SUB_CHUNKS; band++) {
+                            for (uint32_t member = 0; member < 2; member++) {
+                                cb_in1.reserve_back(in1_block_num_tiles);
+                                uint32_t in1_start_address = get_write_ptr(cb_in1_id);
+                                noc_async_read(scratch_noc[member], in1_start_address, in1_block_bytes);
+                                noc.async_read_barrier();
+                                cb_in1.push_back(in1_block_num_tiles);
+                                if (!is_sink_core) {
+                                    in1_sender_sem.wait(1);
+                                    in1_sender_sem.set(0);
+                                    uint32_t fwd_addr = in1_start_address;
+                                    for (uint32_t i = 0; i < K_block_tiles; i++) {
+                                        uint64_t in1_unicast_data_addr = in1_unicast_data_base_addr | fwd_addr;
+                                        noc_async_write(fwd_addr, in1_unicast_data_addr, current_N_tiles_bytes);
+                                        fwd_addr += full_N_tiles_bytes;
+                                    }
+#ifdef ARCH_BLACKHOLE
+                                    noc.async_writes_flushed();
+#endif
+                                    noc_semaphore_set_remote(in1_valid_semaphore_addr, in1_receiver_semaphore_noc_addr);
+                                }
+                            }
+                        }
+#ifdef SRS_FUSE_OP_SIGNALER
+                        if constexpr (is_output_writer) {
+                            if (not_first_block && k_block_iter == max_defer_write_k_block) {
+                                noc.async_write_barrier();
+                                srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
+                            }
+                            if (not_first_block && (k_block_iter + 1) == max_defer_write_k_block) {
+                                noc.async_write_barrier();
+                                srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
+                            }
+                        }
+#endif
+                        k_block_iter++;  // the backward member of the pair is consumed here too
+                        continue;
+                    }
+                }
+#endif
+                if (defer_write && k_block_iter == defer_write_k_block) {
+                    if constexpr (is_output_writer) {
+#ifdef FUSE_SWIGLU
+                        cb_out.wait_front(out_block_num_tiles_swiglu);
+                        uint32_t out_read_ptr = get_read_ptr(cb_out_id);
+                        if constexpr (N_chunks == 1) {
+                            write_block_sync<M_block_tiles, out_N_block_tiles>(
+                                std::get<0>(outputs_tuple),
+                                out_shape_swiglu,
+                                out_read_ptr,
+                                out_tile_size,
+                                defer_write_m_tile,
+                                defer_write_m_tile_end,
+                                defer_write_n_tile / 2,
+                                defer_write_n_tile_end / 2);
+                        } else {
+                            write_block_sync_split<M_block_tiles, out_N_block_tiles, N_chunks, out_N_tiles_per_chunk>(
+                                outputs_tuple,
+                                out0_shape_swiglu,
+                                out_read_ptr,
+                                out_tile_size,
+                                defer_write_m_tile,
+                                defer_write_m_tile_end,
+                                defer_write_n_tile / 2,
+                                defer_write_n_tile_end / 2);
+                        }
+                        cb_out.pop_front(out_block_num_tiles_swiglu);
+#else
+                        cb_out.wait_front(out_block_num_tiles);
+                        uint32_t out_read_ptr = get_read_ptr(cb_out_id);
+
+                        // write_block_sync_split is more generic (support multiple output tensors)
+                        // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync should be faster
+                        if constexpr (N_chunks == 1) {
+                            write_block_sync<M_block_tiles, N_block_tiles>(
+                                std::get<0>(outputs_tuple),
+                                out_shape,
+                                out_read_ptr,
+                                out_tile_size,
+                                defer_write_m_tile,
+                                defer_write_m_tile_end,
+                                defer_write_n_tile,
+                                defer_write_n_tile_end);
+                        } else {
+                            write_block_sync_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                                outputs_tuple,
+                                out0_shape,
+                                out_read_ptr,
+                                out_tile_size,
+                                defer_write_m_tile,
+                                defer_write_m_tile_end,
+                                defer_write_n_tile,
+                                defer_write_n_tile_end);
+                        }
+                        cb_out.pop_front(out_block_num_tiles);
+#endif  // FUSE_SWIGLU
+                    }
+                }
+
+                // ---- Read-once, re-present-per-band ----
+                // in1 has no M dimension, so an M-row band consumes the whole K_block x N_block. To stay
+                // in lockstep with the banded in0 (so the matmul fires per band), the injector reads the
+                // block once from DRAM into scratch and re-presents it to compute once per band (pushed nb
+                // times, no DRAM re-read); receivers receive/push/forward once per band. nb is computed
+                // exactly as in dm_in0_sender so per-band CB and semaphore counts never desync.
+                [[maybe_unused]] uint32_t k_block = k_forward ? k_block_iter : (K_num_blocks - 1) - k_block_iter;
+                uint32_t nb;
+                if constexpr (is_injector_core) {
+#ifdef FUSE_AG
+                    k_block = fused_op_receiver.compute_actual_k_block_iter(n_block_iter == 0, k_block_iter, k_forward);
+                    const uint8_t k_dir = fused_op_receiver.streamed_dir;
+                    nb = (n_block_iter == 0 && k_dir != 2) ? (uint32_t)IN0_SUB_CHUNKS : 1u;
+#else
+                    nb = 1u;
+#endif
+                    // Read the whole K_block x N_block once into scratch. The scratch CB is used as a
+                    // plain fixed L1 region (single slot, single-core produce+consume in this kernel), so
+                    // we take its write pointer directly without reserve/push/pop.
+                    uint32_t scratch_addr = get_write_ptr(cb_in1_scratch_id);
+                    {
+                        read_in1_block_sync<K_block_tiles, N_block_tiles>(
+                            in1_reader,
+                            in1_shape,
+                            cb_in1_scratch_id,
+                            in1_tile_size,
+                            k_block * K_block_tiles,
+                            (k_block + 1) * K_block_tiles,
+                            n_tile,
+                            n_tile_end);
+                    }
+                    const uint64_t scratch_noc_addr = get_noc_addr(scratch_addr);
+                    const uint32_t in1_block_bytes = in1_block_num_tiles * in1_tile_size;
+                    for (uint32_t band = 0; band < nb; band++) {
+                        cb_in1.reserve_back(in1_block_num_tiles);
+                        uint32_t in1_start_address = get_write_ptr(cb_in1_id);
+                        // Re-present from scratch (local L1 copy, no DRAM re-read).
+                        noc_async_read(scratch_noc_addr, in1_start_address, in1_block_bytes);
+                        noc.async_read_barrier();
+                        cb_in1.push_back(in1_block_num_tiles);
+                        if (!is_sink_core) {
+                            in1_sender_sem.wait(1);
+                            in1_sender_sem.set(0);
+                            uint32_t fwd_addr = in1_start_address;
+                            for (uint32_t i = 0; i < K_block_tiles; i++) {
+                                uint64_t in1_unicast_data_addr = in1_unicast_data_base_addr | fwd_addr;
+                                noc_async_write(fwd_addr, in1_unicast_data_addr, current_N_tiles_bytes);
+                                fwd_addr += full_N_tiles_bytes;
+                            }
+#ifdef ARCH_BLACKHOLE
+                            noc.async_writes_flushed();
+#endif
+                            noc_semaphore_set_remote(in1_valid_semaphore_addr, in1_receiver_semaphore_noc_addr);
+                        }
+                    }
+                } else {
+                    nb = (n_block_iter == 0 && k_block_iter >= num_local_k_blocks) ? (uint32_t)IN0_SUB_CHUNKS : 1u;
+                    for (uint32_t band = 0; band < nb; band++) {
+                        cb_in1.reserve_back(in1_block_num_tiles);
+                        uint32_t in1_start_address = get_write_ptr(cb_in1_id);
+                        {
+                            in1_receiver_sem.set(INVALID);
+                            noc_semaphore_inc(in1_sender_semaphore_noc_addr, 1);
+                            in1_receiver_sem.wait(VALID);
+                        }
+                        cb_in1.push_back(in1_block_num_tiles);
+                        if (!is_sink_core) {
+                            in1_sender_sem.wait(1);
+                            in1_sender_sem.set(0);
+                            uint32_t fwd_addr = in1_start_address;
+                            for (uint32_t i = 0; i < K_block_tiles; i++) {
+                                uint64_t in1_unicast_data_addr = in1_unicast_data_base_addr | fwd_addr;
+                                noc_async_write(fwd_addr, in1_unicast_data_addr, current_N_tiles_bytes);
+                                fwd_addr += full_N_tiles_bytes;
+                            }
+#ifdef ARCH_BLACKHOLE
+                            noc.async_writes_flushed();
+#endif
+                            noc_semaphore_set_remote(in1_valid_semaphore_addr, in1_receiver_semaphore_noc_addr);
+                        }
+                    }
+                }
+#ifdef SRS_FUSE_OP_SIGNALER
+                if constexpr (is_output_writer) {
+                    if (not_first_block && k_block_iter == max_defer_write_k_block) {
+                        noc.async_write_barrier();
+                        srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
+                    }
+                }
+#endif
+            }
+#ifdef FUSE_BIAS
+            // Under the two-NoC split both DMs are output writers, so the !is_output_writer read never fires
+            // on either and nobody would fill the bias CB. dm_in1 (NOC_1 writer) reads it here; dm_in0 keeps
+            // skipping it (its !is_output_writer is already false under split).
+#ifdef SPLIT_OUTPUT_WRITE
+            constexpr bool read_bias = true;
+#else
+            constexpr bool read_bias = !is_output_writer;
+#endif
+            if constexpr (read_bias) {
+                cb_in2.reserve_back(N_block_tiles);
+
+                uint32_t l1_write_addr_in2 = get_write_ptr(cb_in2_id);
+                for (uint32_t n_tile_id = n_tile; n_tile_id < n_tile_end; n_tile_id++) {
+                    noc.async_read(
+                        in2_reader,
+                        CoreLocalMem<uint32_t>(l1_write_addr_in2),
+                        in2_tile_size,
+                        {.page_id = n_tile_id},
+                        {});
+                    l1_write_addr_in2 += in2_tile_size;
+                }
+                noc.async_read_barrier();
+
+                cb_in2.push_back(N_block_tiles);
+            }
+#endif
+
+#ifdef FUSE_TERNARY
+            if constexpr (!is_output_writer) {
+                read_ternary_blocks_sync<M_block_tiles, N_block_tiles>(
+                    ternary_a_reader,
+                    ternary_b_reader,
+                    out_shape,
+                    cb_ternary_a_id,
+                    cb_ternary_b_id,
+                    ternary_a_tile_size,
+                    ternary_b_tile_size,
+                    broadcast_ternary_b,
+                    m_tile,
+                    m_tile_end,
+                    n_tile,
+                    n_tile_end);
+            }
+#endif  // FUSE_TERNARY
+
+            k_forward = !k_forward;
+            // We have an output block to write out
+
+            defer_write_m_tile = m_tile;
+            defer_write_m_tile_end = m_tile_end;
+            defer_write_n_tile = n_tile;
+            defer_write_n_tile_end = n_tile_end;
+            /**
+             * If this isn't the last output block, defer writing until the defer_k_write_block iteration
+             * of the next output block.
+             */
+            defer_write = !is_last_block;
+            defer_write = defer_write && !is_injector_core;
+
+            if (!defer_write) {
+                if constexpr (is_output_writer) {
+#ifdef FUSE_SWIGLU
+                    if constexpr (N_chunks == 1) {
+                        write_block_sync_granular<M_block_tiles, out_N_block_tiles>(
+                            std::get<0>(outputs_tuple),
+                            out_shape_swiglu,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile / 2,
+                            n_tile_end / 2);
+                    } else {
+                        write_block_sync_granular_split<
+                            M_block_tiles,
+                            out_N_block_tiles,
+                            N_chunks,
+                            out_N_tiles_per_chunk>(
+                            outputs_tuple,
+                            out0_shape_swiglu,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile / 2,
+                            n_tile_end / 2);
+                    }
+#else
+                    // write_block_sync_granular_split is more generic (support multiple output tensors)
+                    // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync_granular should be faster
+                    if constexpr (N_chunks == 1) {
+#ifdef SPLIT_OUTPUT_WRITE
+#ifdef AGMM_INTERLEAVED_OUTPUT_WRITE
+                        // NOC_1 writer: drains the rows split_row_to_noc1() assigns to NOC_1 from c_2,
+                        // interleaved across the block so it overlaps the NOC_0 writer (dm_in0).
+                        write_block_sync_granular_interleaved<M_block_tiles, N_block_tiles>(
+                            std::get<0>(outputs_tuple),
+                            out_shape,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile,
+                            n_tile_end,
+                            AG_SPLIT_NOC1_PCT,
+                            /*own_noc1=*/true);
+#else
+                        // NOC_1 writer: low rows [0, split_rows) from c_2.
+                        constexpr uint32_t split_rows = (M_block_tiles * AG_SPLIT_NOC1_PCT) / 100;
+                        write_block_sync_granular<M_block_tiles, N_block_tiles>(
+                            std::get<0>(outputs_tuple),
+                            out_shape,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile,
+                            n_tile_end,
+                            0,
+                            split_rows);
+#endif  // AGMM_INTERLEAVED_OUTPUT_WRITE
+#else
+                        write_block_sync_granular<M_block_tiles, N_block_tiles>(
+                            std::get<0>(outputs_tuple),
+                            out_shape,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile,
+                            n_tile_end);
+#endif
+                    } else {
+#ifdef SPLIT_OUTPUT_WRITE
+                        // NOC_1 writer: low rows [0, split_rows) from c_2, demuxed into the chunk tensors.
+                        constexpr uint32_t split_rows = (M_block_tiles * AG_SPLIT_NOC1_PCT) / 100;
+                        write_block_sync_granular_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                            outputs_tuple,
+                            out0_shape,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile,
+                            n_tile_end,
+                            0,
+                            split_rows);
+#else
+                        write_block_sync_granular_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                            outputs_tuple,
+                            out0_shape,
+                            cb_out_id,
+                            out_tile_size,
+                            m_tile,
+                            m_tile_end,
+                            n_tile,
+                            n_tile_end);
+#endif
+                    }
+#endif  // FUSE_SWIGLU
+#ifdef SRS_FUSE_OP_SIGNALER
+                    if (is_last_block) {
+                        noc.async_write_barrier();
+                        srs_fuse_signaler.signal_op_per_core(mm_progress_counters_base);
+                    }
+#endif
+                }
+            }
+        }
+    }
+    noc.async_write_barrier();
+    noc.async_atomic_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_dm_in1_sender_out.cpp
@@ -17,9 +17,7 @@
 #define IN0_SUB_CHUNKS 1
 #endif
 
-// Two-NoC output-write split: this writer (NOC_1) handles the block's low M-rows [0, split_rows) from c_2;
-// dm_in0 writes [split_rows, M) from c_8 on NOC_0. split_rows = M_block_tiles*AG_SPLIT_NOC1_PCT/100, and
-// must match compute/dm_in0. Default 50% (no effect unless SPLIT_OUTPUT_WRITE is set).
+// Two-NoC output-write split: this writer (NOC_1) handles the block's low M-rows [0, split_rows) from c_2
 #ifndef AG_SPLIT_NOC1_PCT
 #define AG_SPLIT_NOC1_PCT 50
 #endif
@@ -66,9 +64,7 @@ void kernel_main() {
     const uint32_t N_end_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t defer_write_k_block = get_arg_val<uint32_t>(argidx++);
     const uint32_t max_defer_write_k_block = get_arg_val<uint32_t>(argidx++);
-    // Leading (self/local) k-block positions this device owns; used by receivers to derive the same
-    // per-position band count the injector gets from streamed_dir (see dm_in0_sender.cpp).
-    // (Read unconditionally to keep the arg layout fixed; only consumed by receivers / IN0_SUB_CHUNKS > 1.)
+    // Leading (self/local) k-block positions this device owns
     [[maybe_unused]] const uint32_t num_local_k_blocks = get_arg_val<uint32_t>(argidx++);
 
 #ifdef FUSE_TERNARY
@@ -126,9 +122,7 @@ void kernel_main() {
     constexpr uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
 
 #ifdef FUSE_SWIGLU
-    // SwiGLU emits one output tile per interleaved gate/up pair, so the output along N
-    // is half the matmul (weight) N. Compute the halved output geometry once here; the
-    // weight-space n ranges (n_tile, N_tiles, ...) are halved at each write call site.
+    // SwiGLU emits one output tile per interleaved gate/up pair, so the output along N is half the matmul (weight) N
     constexpr uint32_t out_N_block_tiles = N_block_tiles / 2;
     constexpr uint32_t out_block_num_tiles_swiglu = M_block_tiles * out_N_block_tiles;
     const TensorShape2D out_shape_swiglu(M_tiles, N_tiles / 2, padded_M_tiles, padded_N_tiles / 2);
@@ -139,9 +133,7 @@ void kernel_main() {
 
     constexpr uint32_t cb_in1_id = tt::CBIndex::c_1;
     constexpr uint32_t cb_out_id = tt::CBIndex::c_2;
-    // Scratch that holds the whole K_block x N_block once per k-block position so the injector can
-    // re-present it to compute once per M-row band (read once from DRAM, pushed nb times) without
-    // re-reading DRAM. Only used on the sub-chunked injector path.
+    // Scratch that holds the whole K_block x N_block once per k-block position so the injector can re-present
     constexpr uint32_t cb_in1_scratch_id = tt::CBIndex::c_7;
 #ifdef FUSE_BIAS
     constexpr uint32_t cb_in2_id = tt::CBIndex::c_4;
@@ -192,8 +184,7 @@ void kernel_main() {
     uint32_t mm_progress_counters_base = 0;
     if constexpr (is_output_writer) {
         srs_fuse_signaler = OpSignaler(srs_fuse_signaler_rt_args_idx);
-        // Per-core signaling: base L1 address of the RS cores' per-core progress counter array,
-        // pushed as the next RT arg right after the OpSignaler args.
+        // Per-core signaling: base L1 address of the RS cores' per-core progress counter array
         mm_progress_counters_base = get_arg_val<uint32_t>(srs_fuse_signaler_rt_args_idx++);
     }
 #endif
@@ -240,9 +231,6 @@ void kernel_main() {
 #if defined(FUSE_AG) && (IN0_SUB_CHUNKS > 1) && defined(AG_INTERLEAVE_BANDS)
                 if constexpr (is_injector_core) {
                     // Re-present a forward remote k-block and the following backward one interleaved per band
-                    // (A.b0, B.b0, ...), matching dm_in0/compute. Both blocks are read once into the two-slot
-                    // scratch; in1 has no M dimension so each band re-presents the whole block. Injectors
-                    // never defer_write, so the deferred output flush below never applies on this path.
                     if (n_block_iter == 0 && k_block_iter >= num_local_k_blocks && (k_block_iter + 1) < K_num_blocks &&
                         ((k_block_iter - num_local_k_blocks) & 1u) == 0) {
                         const uint32_t kb_pair[2] = {
@@ -337,8 +325,7 @@ void kernel_main() {
                         cb_out.wait_front(out_block_num_tiles);
                         uint32_t out_read_ptr = get_read_ptr(cb_out_id);
 
-                        // write_block_sync_split is more generic (support multiple output tensors)
-                        // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync should be faster
+                        // write_block_sync_split is more generic (support multiple output tensors) But for N_chunks
                         if constexpr (N_chunks == 1) {
                             write_block_sync<M_block_tiles, N_block_tiles>(
                                 std::get<0>(outputs_tuple),
@@ -365,12 +352,7 @@ void kernel_main() {
                     }
                 }
 
-                // ---- Read-once, re-present-per-band ----
-                // in1 has no M dimension, so an M-row band consumes the whole K_block x N_block. To stay
-                // in lockstep with the banded in0 (so the matmul fires per band), the injector reads the
-                // block once from DRAM into scratch and re-presents it to compute once per band (pushed nb
-                // times, no DRAM re-read); receivers receive/push/forward once per band. nb is computed
-                // exactly as in dm_in0_sender so per-band CB and semaphore counts never desync.
+                // ---- Read-once, re-present-per-band ---- in1 has no M dimension
                 [[maybe_unused]] uint32_t k_block = k_forward ? k_block_iter : (K_num_blocks - 1) - k_block_iter;
                 uint32_t nb;
                 if constexpr (is_injector_core) {
@@ -381,9 +363,7 @@ void kernel_main() {
 #else
                     nb = 1u;
 #endif
-                    // Read the whole K_block x N_block once into scratch. The scratch CB is used as a
-                    // plain fixed L1 region (single slot, single-core produce+consume in this kernel), so
-                    // we take its write pointer directly without reserve/push/pop.
+                    // Read the whole K_block x N_block once into scratch
                     uint32_t scratch_addr = get_write_ptr(cb_in1_scratch_id);
                     {
                         read_in1_block_sync<K_block_tiles, N_block_tiles>(
@@ -458,8 +438,6 @@ void kernel_main() {
             }
 #ifdef FUSE_BIAS
             // Under the two-NoC split both DMs are output writers, so the !is_output_writer read never fires
-            // on either and nobody would fill the bias CB. dm_in1 (NOC_1 writer) reads it here; dm_in0 keeps
-            // skipping it (its !is_output_writer is already false under split).
 #ifdef SPLIT_OUTPUT_WRITE
             constexpr bool read_bias = true;
 #else
@@ -546,12 +524,10 @@ void kernel_main() {
                     }
 #else
                     // write_block_sync_granular_split is more generic (support multiple output tensors)
-                    // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync_granular should be faster
                     if constexpr (N_chunks == 1) {
 #ifdef SPLIT_OUTPUT_WRITE
 #ifdef AGMM_INTERLEAVED_OUTPUT_WRITE
-                        // NOC_1 writer: drains the rows split_row_to_noc1() assigns to NOC_1 from c_2,
-                        // interleaved across the block so it overlaps the NOC_0 writer (dm_in0).
+                        // NOC_1 writer: drains the rows split_row_to_noc1() assigns to NOC_1 from c_2
                         write_block_sync_granular_interleaved<M_block_tiles, N_block_tiles>(
                             std::get<0>(outputs_tuple),
                             out_shape,

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_matmul_dataflow_common.hpp
@@ -20,8 +20,7 @@ auto make_tensor_accessor_tuple_impl(
     uint32_t address_rt_arg_index_start,
     uint32_t page_size,
     std::integer_sequence<uint32_t, Indexes...>) {
-    // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
-    // program cache hits.
+    // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize
     return std::make_tuple(TensorAccessor(
         std::get<Indexes>(args_tuple), get_arg_val<uint32_t>(address_rt_arg_index_start + Indexes), page_size)...);
 }
@@ -85,12 +84,9 @@ void read_in0_block_sync(
     uint32_t d0_end,
     uint32_t d1_start,
     uint32_t d1_end,
-    // When false, issue the async reads but skip the completion barrier, so a caller reading the
-    // block in M-row bands can keep band s's reads in flight while it waits for band s+1's data and
-    // barrier once after the last band.
+    // When false, issue the async reads but skip the completion barrier
     bool issue_barrier = true,
-    // Byte offset from the CB base at which this (sub-)block's writes begin. A caller streaming the
-    // block in M-row bands passes each band's offset so bands land at their slots instead of the base.
+    // Byte offset from the CB base at which this (sub-)block's writes begin
     uint32_t write_ptr_offset = 0) {
     ASSERT(d0_end > d0_start);
     ASSERT(d1_end > d1_start);
@@ -146,8 +142,7 @@ void read_in1_block_sync(
     uint32_t d0_end,
     uint32_t d1_start,
     uint32_t d1_end,
-    // Byte offset from the CB base at which this block's writes begin. Lets a caller stage several
-    // blocks into distinct slots of one scratch CB (e.g. the fwd/bwd pair of AG_INTERLEAVE_BANDS).
+    // Byte offset from the CB base at which this block's writes begin
     uint32_t write_ptr_offset = 0) {
     ASSERT(d0_end > d0_start);
     ASSERT(d1_end > d1_start);
@@ -288,10 +283,7 @@ void read_ternary_blocks_sync(
         uint32_t ternary_a_write_ptr = get_write_ptr(ternary_a_cb);
         for (uint32_t j = d1_start; j < d1_end; j++) {
             if (j >= shape.logical_d1) {
-                // Do not move tile data into CB if tile is outside ternary/output tensor.
-                // This can happen when ternary/output tensor shape is not a multiple of block sizes:
-                // For instance, if tensor shape is (M_tiles=7, N_tiles=3), but block sizes are (M_block_tiles=4,
-                // N_block_tiles=4)
+                // Do not move tile data into CB if tile is outside ternary/output tensor
                 break;
             }
             if (i < shape.logical_d0) {
@@ -324,10 +316,7 @@ void write_block_sync_granular(
     uint32_t d0_end,
     uint32_t d1_start,
     uint32_t d1_end,
-    // Restrict the write to the block's M-row sub-range [m_id_start, m_id_end). Used by the two-NoC output
-    // split: each DM writer drains only its half of a separate out CB and writes only its rows. The per-row
-    // cb_wait_front/pop happen once per iterated row, so the pop count matches what compute pushed to that
-    // CB. Defaults span the whole block (single-writer baseline).
+    // Restrict the write to the block's M-row sub-range [m_id_start, m_id_end)
     uint32_t m_id_start = 0,
     uint32_t m_id_end = M_block_tiles) {
     for (uint32_t m_id = m_id_start; m_id < m_id_end; m_id++) {
@@ -400,8 +389,7 @@ void write_block_sync_granular_interleaved(
 template <typename Tuple, size_t... Is>
 FORCE_INLINE void write_tile_to_chunk(
     const Tuple& accessors, uint32_t chunk_idx, uint32_t tile_id, uint32_t read_ptr, std::index_sequence<Is...>) {
-    // Fold expression: expands to if/else chain at compile time
-    // Each branch calls noc_async_write_page with the concrete type
+    // Fold expression: expands to if/else chain at compile time Each branch calls noc_async_write_page
     ((chunk_idx == Is ? (noc_async_write_page(tile_id, std::get<Is>(accessors), read_ptr), void()) : void()), ...);
 }
 
@@ -486,9 +474,7 @@ void write_block_sync_granular_split(
     uint32_t d0_end,
     uint32_t d1_start,
     uint32_t d1_end,
-    // Restrict the write to the block's M-row sub-range [m_id_start, m_id_end). Used by the two-NoC output
-    // split with chunks: each writer drains only its half of its output CB (per-row cb_wait_front/pop, so the
-    // pop count matches what compute pushed to that CB) and demuxes each row's N columns into the chunks.
+    // Restrict the write to the block's M-row sub-range [m_id_start, m_id_end)
     uint32_t m_id_start = 0,
     uint32_t m_id_end = M_block_tiles) {
     const uint32_t chunk_idx_start = d1_start / N_tiles_per_chunk;

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_matmul_dataflow_common.hpp
@@ -1,0 +1,528 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <algorithm>
+#include <tuple>
+#include <utility>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+// split_row_to_noc1: shared row-ownership predicate for the interleaved two-NoC output write.
+#include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/subchunk_bands.hpp"
+
+namespace detail {
+template <typename... Args, uint32_t... Indexes>
+auto make_tensor_accessor_tuple_impl(
+    const std::tuple<Args...>& args_tuple,
+    uint32_t address_rt_arg_index_start,
+    uint32_t page_size,
+    std::integer_sequence<uint32_t, Indexes...>) {
+    // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
+    // program cache hits.
+    return std::make_tuple(TensorAccessor(
+        std::get<Indexes>(args_tuple), get_arg_val<uint32_t>(address_rt_arg_index_start + Indexes), page_size)...);
+}
+}  // namespace detail
+
+/**
+ * Create a tuple of TensorAccessors from a tuple of TensorAccessorArgs.
+ * Each tensor gets its address from consecutive RT args starting at address_rt_arg_index_start.
+ */
+template <typename... Args>
+auto make_tensor_accessor_tuple_uniform_page_size(
+    const std::tuple<Args...>& args_tuple, uint32_t address_rt_arg_index_start, uint32_t page_size) {
+    return detail::make_tensor_accessor_tuple_impl(
+        args_tuple, address_rt_arg_index_start, page_size, std::make_integer_sequence<uint32_t, sizeof...(Args)>());
+}
+inline void fill_zeros_async(const Noc& noc, const CircularBuffer& cb, uint32_t bytes, uint32_t offset_bytes = 0) {
+    noc.async_write_zeros(cb, bytes, {.offset_bytes = offset_bytes});
+}
+
+struct TensorShape2D {
+    uint32_t logical_d0;
+    uint32_t logical_d1;
+    uint32_t padded_d0;
+    uint32_t padded_d1;
+    // Constructor to initialize with 2D shape
+    TensorShape2D(uint32_t _d0, uint32_t _d1, uint32_t _padded_d0, uint32_t _padded_d1) :
+        logical_d0(_d0), logical_d1(_d1), padded_d0(_padded_d0), padded_d1(_padded_d1) {
+        ASSERT(_d0 > 0);
+        ASSERT(_d1 > 0);
+        ASSERT(_d0 <= _padded_d0);
+        ASSERT(_d1 <= _padded_d1);
+    }
+};
+
+/**
+ * Read a block of in0 from a potentially padded tensor.
+ * Since this is for matmul, no need to read when M >= logical_M
+ * Otherwise, if K >= logical_K, fill with zeros.
+ */
+template <
+    uint32_t M_block_tiles,
+    uint32_t K_block_tiles,
+    typename TensorAccessorType
+#ifdef READ_FROM_LOCAL_INPUT
+    ,
+    typename LocalTensorAccessorType
+#endif
+    >
+void read_in0_block_sync(
+    const TensorAccessorType& tensor_accessor,
+    const TensorShape2D& shape,
+    uint32_t cb_id,
+    uint32_t tile_size_bytes,
+#ifdef READ_FROM_LOCAL_INPUT
+    const LocalTensorAccessorType& in3_accessor,
+    uint32_t local_k_start,
+    uint32_t local_k_end,
+    uint32_t input_tensor_Wt,
+#endif
+    uint32_t d0_start,
+    uint32_t d0_end,
+    uint32_t d1_start,
+    uint32_t d1_end,
+    // When false, issue the async reads but skip the completion barrier, so a caller reading the
+    // block in M-row bands can keep band s's reads in flight while it waits for band s+1's data and
+    // barrier once after the last band.
+    bool issue_barrier = true,
+    // Byte offset from the CB base at which this (sub-)block's writes begin. A caller streaming the
+    // block in M-row bands passes each band's offset so bands land at their slots instead of the base.
+    uint32_t write_ptr_offset = 0) {
+    ASSERT(d0_end > d0_start);
+    ASSERT(d1_end > d1_start);
+
+    Noc noc;
+    CircularBuffer cb(cb_id);
+    const uint32_t cb_base_write_ptr = cb.get_write_ptr();
+    uint32_t write_ptr = cb_base_write_ptr + write_ptr_offset;
+    for (uint32_t i = d0_start; i < d0_end; i++) {
+        if (i >= shape.logical_d0) {
+            break;
+        }
+        for (uint32_t j = d1_start; j < d1_end; j++) {
+            if (j < shape.logical_d1) {
+#ifdef READ_FROM_LOCAL_INPUT
+                if (local_k_start <= j && j <= local_k_end) {
+                    // read from self_tensor_accessor
+                    uint32_t tile_id = i * input_tensor_Wt + (j - local_k_start);
+                    noc_async_read_page(tile_id, in3_accessor, write_ptr);
+                } else {
+#endif
+                    uint32_t tile_id = i * shape.logical_d1 + j;
+                    noc_async_read_page(tile_id, tensor_accessor, write_ptr);
+#ifdef READ_FROM_LOCAL_INPUT
+                }
+#endif
+            } else {
+                fill_zeros_async(noc, cb, tile_size_bytes, write_ptr - cb_base_write_ptr);
+            }
+            write_ptr += tile_size_bytes;
+        }
+        // finish up incrementing write_ptr if (d1_end - d1_start) < K_block_tiles
+        write_ptr += (K_block_tiles - (d1_end - d1_start)) * tile_size_bytes;
+    }
+    if (issue_barrier) {
+        noc_async_read_barrier();
+    }
+    noc.write_zeros_l1_barrier();
+}
+
+/**
+ * Read a block of in1 from a potentially padded tensor.
+ * Since this is for matmul, no need to read when N >= logical_N
+ * Otherwise, if K >= logical_K, fill with zeros.
+ */
+template <uint32_t K_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
+void read_in1_block_sync(
+    const TensorAccessorType& tensor_accessor,
+    const TensorShape2D& shape,
+    uint32_t cb_id,
+    uint32_t tile_size_bytes,
+    uint32_t d0_start,
+    uint32_t d0_end,
+    uint32_t d1_start,
+    uint32_t d1_end,
+    // Byte offset from the CB base at which this block's writes begin. Lets a caller stage several
+    // blocks into distinct slots of one scratch CB (e.g. the fwd/bwd pair of AG_INTERLEAVE_BANDS).
+    uint32_t write_ptr_offset = 0) {
+    ASSERT(d0_end > d0_start);
+    ASSERT(d1_end > d1_start);
+    Noc noc;
+    CircularBuffer cb(cb_id);
+    const uint32_t cb_base_write_ptr = cb.get_write_ptr();
+    uint32_t write_ptr = cb_base_write_ptr + write_ptr_offset;
+    for (uint32_t i = d0_start; i < d0_end; i++) {
+        for (uint32_t j = d1_start; j < d1_end; j++) {
+            if (j >= shape.logical_d1) {
+                write_ptr += tile_size_bytes;
+                continue;
+            }
+            if (i < shape.logical_d0) {
+                uint32_t tile_id = i * shape.logical_d1 + j;
+                noc_async_read_page(tile_id, tensor_accessor, write_ptr);
+            } else {
+                fill_zeros_async(noc, cb, tile_size_bytes, write_ptr - cb_base_write_ptr);
+            }
+            write_ptr += tile_size_bytes;
+        }
+        // finish up incrementing write_ptr if (d1_end - d1_start) < K_block_tiles
+        write_ptr += (N_block_tiles - (d1_end - d1_start)) * tile_size_bytes;
+    }
+    noc_async_read_barrier();
+    noc.write_zeros_l1_barrier();
+}
+
+/**
+ * Write a block of output to a potentially padded tensor.
+ * Skip writing when M >= logical_M or N >= logical_N
+ */
+template <uint32_t M_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
+void write_block_sync(
+    const TensorAccessorType& tensor_accessor,
+    const TensorShape2D& shape,
+    uint32_t read_ptr,
+    uint32_t tile_size_bytes,
+    uint32_t d0_start,
+    uint32_t d0_end,
+    uint32_t d1_start,
+    uint32_t d1_end) {
+    ASSERT(d0_end > d0_start);
+    ASSERT(d1_end > d1_start);
+
+    for (uint32_t i = d0_start; i < d0_end; i++) {
+        if (i >= shape.logical_d0) {
+            break;
+        }
+        for (uint32_t j = d1_start; j < d1_end; j++) {
+            if (j >= shape.logical_d1) {
+                read_ptr += tile_size_bytes;
+                continue;
+            }
+            uint32_t tile_id = i * shape.logical_d1 + j;
+            noc_async_write_page(tile_id, tensor_accessor, read_ptr);
+            read_ptr += tile_size_bytes;
+        }
+        // finish up incrementing read_ptr if (d1_end - d1_start) < N_block_tiles
+        read_ptr += (N_block_tiles - (d1_end - d1_start)) * tile_size_bytes;
+    }
+    noc_async_writes_flushed();
+}
+
+/**
+ * Read ternary inputs (ternary_a and ternary_b) and write data to CB
+ *
+ * For ternary_a: read M_block_tiles * N_block_tiles tiles (full block), pushed one row at a time.
+ * For ternary_b:
+ *   - broadcast_ternary_b=1: read 1 row of tiles (N_block_tiles), compute broadcasts across M rows.
+ *   - broadcast_ternary_b=0: read M rows of tiles, pushed one row at a time (matches ternary_a pattern).
+ * Performance optimization: Unlike read_in0_block_sync and read_in1_block_sync, pushes ternary_a
+ * tiles one row at a time. This allows the compute kernel to begin processing addcmul operations
+ * as soon as the first row is ready, rather than waiting for the entire block. This overlapping
+ * of data movement and compute improves overall throughput.
+ */
+template <uint32_t M_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
+void read_ternary_blocks_sync(
+    const TensorAccessorType& ternary_a_accessor,
+    const TensorAccessorType& ternary_b_accessor,
+    const TensorShape2D& shape,
+    uint32_t ternary_a_cb,
+    uint32_t ternary_b_cb,
+    uint32_t a_tile_size_bytes,
+    uint32_t b_tile_size_bytes,
+    uint32_t broadcast_ternary_b,
+    uint32_t d0_start,
+    uint32_t d0_end,
+    uint32_t d1_start,
+    uint32_t d1_end) {
+    ASSERT(d0_end > d0_start);
+    ASSERT(d1_end > d1_start);
+
+    if (broadcast_ternary_b) {
+        // Broadcast: read single row, push all at once
+        cb_reserve_back(ternary_b_cb, N_block_tiles);
+        uint32_t ternary_b_write_ptr = get_write_ptr(ternary_b_cb);
+        for (uint32_t n_tile_id = d1_start; n_tile_id < d1_end; n_tile_id++) {
+            if (n_tile_id >= shape.logical_d1) {
+                break;
+            }
+            noc_async_read_page(n_tile_id, ternary_b_accessor, ternary_b_write_ptr);
+            ternary_b_write_ptr += b_tile_size_bytes;
+        }
+        noc_async_read_barrier();
+        cb_push_back(ternary_b_cb, N_block_tiles);
+    } else {
+        // No broadcast: read row-by-row (matches ternary_a pattern)
+        uint32_t b_m_id = 0;
+        uint32_t b_i = d0_start;
+        for (; b_i < d0_end; b_i++, b_m_id++) {
+            cb_reserve_back(ternary_b_cb, N_block_tiles);
+            uint32_t ternary_b_write_ptr = get_write_ptr(ternary_b_cb);
+            for (uint32_t j = d1_start; j < d1_end; j++) {
+                if (j >= shape.logical_d1) {
+                    break;
+                }
+                if (b_i < shape.logical_d0) {
+                    uint32_t tile_id = b_i * shape.logical_d1 + j;
+                    noc_async_read_page(tile_id, ternary_b_accessor, ternary_b_write_ptr);
+                }
+                ternary_b_write_ptr += b_tile_size_bytes;
+            }
+            noc_async_read_barrier();
+            cb_push_back(ternary_b_cb, N_block_tiles);
+        }
+        for (; b_m_id < M_block_tiles; b_m_id++) {
+            cb_reserve_back(ternary_b_cb, N_block_tiles);
+            cb_push_back(ternary_b_cb, N_block_tiles);
+        }
+    }
+
+    uint32_t m_id = 0;
+    uint32_t i = d0_start;
+    for (; i < d0_end; i++, m_id++) {
+        cb_reserve_back(ternary_a_cb, N_block_tiles);
+
+        uint32_t ternary_a_write_ptr = get_write_ptr(ternary_a_cb);
+        for (uint32_t j = d1_start; j < d1_end; j++) {
+            if (j >= shape.logical_d1) {
+                // Do not move tile data into CB if tile is outside ternary/output tensor.
+                // This can happen when ternary/output tensor shape is not a multiple of block sizes:
+                // For instance, if tensor shape is (M_tiles=7, N_tiles=3), but block sizes are (M_block_tiles=4,
+                // N_block_tiles=4)
+                break;
+            }
+            if (i < shape.logical_d0) {
+                uint32_t tile_id = i * shape.logical_d1 + j;
+                noc_async_read_page(tile_id, ternary_a_accessor, ternary_a_write_ptr);
+            }
+            ternary_a_write_ptr += a_tile_size_bytes;
+        }
+        noc_async_read_barrier();
+
+        cb_push_back(ternary_a_cb, N_block_tiles);
+    }
+    for (; m_id < M_block_tiles; m_id++) {
+        cb_reserve_back(ternary_a_cb, N_block_tiles);
+        cb_push_back(ternary_a_cb, N_block_tiles);
+    }
+}
+
+/**
+ * This write method is more granular, waiting on a row of output tiles
+ * in the output CB before writing those out, rather than waiting on the entire block.
+ */
+template <uint32_t M_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
+void write_block_sync_granular(
+    const TensorAccessorType& tensor_accessor,
+    const TensorShape2D& shape,
+    uint32_t cb_id_out,
+    uint32_t tile_size_bytes,
+    uint32_t d0_start,
+    uint32_t d0_end,
+    uint32_t d1_start,
+    uint32_t d1_end,
+    // Restrict the write to the block's M-row sub-range [m_id_start, m_id_end). Used by the two-NoC output
+    // split: each DM writer drains only its half of a separate out CB and writes only its rows. The per-row
+    // cb_wait_front/pop happen once per iterated row, so the pop count matches what compute pushed to that
+    // CB. Defaults span the whole block (single-writer baseline).
+    uint32_t m_id_start = 0,
+    uint32_t m_id_end = M_block_tiles) {
+    for (uint32_t m_id = m_id_start; m_id < m_id_end; m_id++) {
+        cb_wait_front(cb_id_out, N_block_tiles);
+        uint32_t m_tile = d0_start + m_id;
+        if (m_tile < d0_end && m_tile < shape.logical_d0) {
+            uint32_t out_read_ptr = get_read_ptr(cb_id_out);
+            for (uint32_t n_tile_id = d1_start; n_tile_id < d1_end; n_tile_id++) {
+                if (n_tile_id >= shape.logical_d1) {
+                    break;
+                }
+                uint32_t tile_id = m_tile * shape.logical_d1 + n_tile_id;
+                noc_async_write_page(tile_id, tensor_accessor, out_read_ptr);
+                out_read_ptr += tile_size_bytes;
+            }
+        }
+        cb_pop_front(cb_id_out, N_block_tiles);
+    }
+    noc_async_writes_flushed();
+}
+
+/**
+ * Interleaved two-NoC output write (SPLIT_OUTPUT_WRITE + AGMM_INTERLEAVED_OUTPUT_WRITE). Both DM writers call
+ * this over the SAME full block [0, M_block_tiles); each drains/writes only the rows it owns per
+ * split_row_to_noc1(m, noc1_pct): dm_in1 passes own_noc1 = true (c_2), dm_in0 passes own_noc1 = false (c_8).
+ * Because both iterate m ascending and compute pushed each CB in that same order, the per-row
+ * cb_wait_front/pop is FIFO-matched and the DRAM row is d0_start + m -- no index reconstruction. Rows the
+ * writer does not own are skipped without touching the CB (the other writer drains them from its own CB).
+ * Ragged clamp (m_tile < d0_end && < logical_d0) is identical to write_block_sync_granular; out-of-range
+ * owned rows are still popped (compute packed the full block) but not written.
+ */
+template <uint32_t M_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
+void write_block_sync_granular_interleaved(
+    const TensorAccessorType& tensor_accessor,
+    const TensorShape2D& shape,
+    uint32_t cb_id_out,
+    uint32_t tile_size_bytes,
+    uint32_t d0_start,
+    uint32_t d0_end,
+    uint32_t d1_start,
+    uint32_t d1_end,
+    uint32_t noc1_pct,
+    bool own_noc1) {
+    for (uint32_t m_id = 0; m_id < M_block_tiles; m_id++) {
+        if (split_row_to_noc1(m_id, noc1_pct) != own_noc1) {
+            continue;  // owned by the other NoC's writer; it drains this row from its own CB.
+        }
+        cb_wait_front(cb_id_out, N_block_tiles);
+        uint32_t m_tile = d0_start + m_id;
+        if (m_tile < d0_end && m_tile < shape.logical_d0) {
+            uint32_t out_read_ptr = get_read_ptr(cb_id_out);
+            for (uint32_t n_tile_id = d1_start; n_tile_id < d1_end; n_tile_id++) {
+                if (n_tile_id >= shape.logical_d1) {
+                    break;
+                }
+                uint32_t tile_id = m_tile * shape.logical_d1 + n_tile_id;
+                noc_async_write_page(tile_id, tensor_accessor, out_read_ptr);
+                out_read_ptr += tile_size_bytes;
+            }
+        }
+        cb_pop_front(cb_id_out, N_block_tiles);
+    }
+    noc_async_writes_flushed();
+}
+
+/**
+ * Helper: dispatch to correct tuple element using fold expression.
+ * Each branch calls noc_async_write_page with the concrete TensorAccessor type.
+ */
+template <typename Tuple, size_t... Is>
+FORCE_INLINE void write_tile_to_chunk(
+    const Tuple& accessors, uint32_t chunk_idx, uint32_t tile_id, uint32_t read_ptr, std::index_sequence<Is...>) {
+    // Fold expression: expands to if/else chain at compile time
+    // Each branch calls noc_async_write_page with the concrete type
+    ((chunk_idx == Is ? (noc_async_write_page(tile_id, std::get<Is>(accessors), read_ptr), void()) : void()), ...);
+}
+
+/**
+ * Write a block of output to a potentially padded tensor.
+ * Skip writing when M >= logical_M or N >= logical_N
+ *
+ * Note: Unlike write_block_sync, this function takes a tuple of accessors, rather than a single accessor.
+ */
+template <
+    uint32_t M_block_tiles,
+    uint32_t N_block_tiles,
+    uint32_t N_chunks,
+    uint32_t N_tiles_per_chunk,
+    typename... Accessors>
+void write_block_sync_split(
+    const std::tuple<Accessors...>& accessors,
+    const TensorShape2D& chunk_shape,
+    uint32_t read_ptr,
+    uint32_t tile_size_bytes,
+    uint32_t d0_start,
+    uint32_t d0_end,
+    uint32_t d1_start,
+    uint32_t d1_end) {
+    ASSERT(d0_end > d0_start);
+    ASSERT(d1_end > d1_start);
+
+    const uint32_t chunk_idx_start = d1_start / N_tiles_per_chunk;
+    const uint32_t tile_idx_in_chunk_start = d1_start % N_tiles_per_chunk;
+
+    for (uint32_t i = d0_start; i < d0_end; i++) {
+        // Assumes that all chunks have same number of tiles on the M-axis
+        if (i >= chunk_shape.logical_d0) {
+            break;
+        }
+
+        uint32_t chunk_idx = chunk_idx_start;
+        uint32_t tile_idx_in_chunk = tile_idx_in_chunk_start;
+
+        for (uint32_t j = d1_start; j < d1_end; j++, tile_idx_in_chunk++) {
+            // If we've reached the end of the current chunk, move to the next one
+            if (tile_idx_in_chunk >= chunk_shape.logical_d1) {
+                tile_idx_in_chunk = 0;
+                chunk_idx++;  // Move to next chunk; if chunk is past last one then next branch will skip padding
+            }
+
+            // Skip padding
+            if (chunk_idx >= N_chunks) {
+                read_ptr += tile_size_bytes;
+                continue;
+            }
+
+            uint32_t tile_id_in_chunk = i * chunk_shape.logical_d1 + tile_idx_in_chunk;
+
+            // Compile-time dispatch preserving concrete types
+            write_tile_to_chunk(
+                accessors, chunk_idx, tile_id_in_chunk, read_ptr, std::index_sequence_for<Accessors...>{});
+            read_ptr += tile_size_bytes;
+        }
+        // finish up incrementing read_ptr if (d1_end - d1_start) < N_block_tiles
+        read_ptr += (N_block_tiles - (d1_end - d1_start)) * tile_size_bytes;
+    }
+    noc_async_writes_flushed();
+}
+
+/**
+ * Variadic write method for split operation with N output tensors.
+ * Takes the tuple directly, preserving concrete TensorAccessor<DSpec> types for noc_async_write_tile.
+ */
+template <
+    uint32_t M_block_tiles,
+    uint32_t N_block_tiles,
+    uint32_t N_chunks,
+    uint32_t N_tiles_per_chunk,
+    typename... Accessors>
+void write_block_sync_granular_split(
+    const std::tuple<Accessors...>& accessors,
+    const TensorShape2D& chunk_shape,
+    uint32_t cb_id_out,
+    uint32_t tile_size_bytes,
+    uint32_t d0_start,
+    uint32_t d0_end,
+    uint32_t d1_start,
+    uint32_t d1_end,
+    // Restrict the write to the block's M-row sub-range [m_id_start, m_id_end). Used by the two-NoC output
+    // split with chunks: each writer drains only its half of its output CB (per-row cb_wait_front/pop, so the
+    // pop count matches what compute pushed to that CB) and demuxes each row's N columns into the chunks.
+    uint32_t m_id_start = 0,
+    uint32_t m_id_end = M_block_tiles) {
+    const uint32_t chunk_idx_start = d1_start / N_tiles_per_chunk;
+    const uint32_t tile_idx_in_chunk_start = d1_start % N_tiles_per_chunk;
+
+    for (uint32_t m_id = m_id_start; m_id < m_id_end; m_id++) {
+        cb_wait_front(cb_id_out, N_block_tiles);
+        uint32_t m_tile = d0_start + m_id;
+        if (m_tile < d0_end && m_tile < chunk_shape.logical_d0) {
+            uint32_t out_read_ptr = get_read_ptr(cb_id_out);
+
+            uint32_t chunk_idx = chunk_idx_start;
+            uint32_t tile_idx_in_chunk = tile_idx_in_chunk_start;
+
+            for (uint32_t n_tile_id = d1_start; n_tile_id < d1_end; n_tile_id++, tile_idx_in_chunk++) {
+                // If we've reached the end of the current chunk, move to the next one
+                if (tile_idx_in_chunk >= chunk_shape.logical_d1) {
+                    tile_idx_in_chunk = 0;
+                    chunk_idx++;  // Move to next chunk; if chunk is past last one then next branch will skip padding
+                }
+
+                if (chunk_idx >= N_chunks) {
+                    break;
+                }
+
+                uint32_t tile_id = m_tile * chunk_shape.logical_d1 + tile_idx_in_chunk;
+                // Compile-time dispatch preserving concrete types
+                write_tile_to_chunk(
+                    accessors, chunk_idx, tile_id, out_read_ptr, std::index_sequence_for<Accessors...>{});
+
+                out_read_ptr += tile_size_bytes;
+            }
+        }
+        cb_pop_front(cb_id_out, N_block_tiles);
+    }
+    noc_async_writes_flushed();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_fabric_bound_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_fabric_bound_program_factory.cpp
@@ -1,0 +1,1253 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "minimal_matmul_fabric_bound_program_factory.hpp"
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/constants.hpp>
+#include "ttnn/operations/cb_utils.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+
+namespace ttnn::experimental::prim {
+
+namespace {
+
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t> determine_default_block_sizes(
+    uint32_t M, uint32_t K, uint32_t N, bool fp32_dest_acc_en) {
+    (void)K;  // K not used for determining defaults currently
+    uint32_t M_block_tiles = 8;
+    uint32_t K_block_tiles = 8;
+    uint32_t N_block_tiles = 8;
+
+    uint32_t subblock_h = 2;
+    uint32_t subblock_w = 2;
+    if (!fp32_dest_acc_en) {
+        if (N >= M) {
+            subblock_h = 2;
+            subblock_w = 4;
+        } else {
+            subblock_h = 4;
+            subblock_w = 2;
+        }
+    }
+
+    return {M_block_tiles, K_block_tiles, N_block_tiles, subblock_h, subblock_w};
+}
+
+// Build a linear order of cores along one axis for data movement, plus index of the current core
+std::pair<std::vector<CoreCoord>, uint32_t> build_core_order_for_axis(
+    const CoreCoord& core,
+    bool transpose_core_grid,
+    uint32_t axis_length,
+    tt::tt_metal::NOC noc,
+    bool axis_is_x_when_not_transposed,
+    const CoreCoord& initial_endpoint) {
+    std::vector<CoreCoord> order;
+    order.reserve(axis_length);
+    order.push_back(initial_endpoint);
+
+    // Determine which coordinate of the current core defines its position along this axis
+    const size_t current_axis_value = transpose_core_grid ? (axis_is_x_when_not_transposed ? core.y : core.x)
+                                                          : (axis_is_x_when_not_transposed ? core.x : core.y);
+
+    // Direction along the axis: increasing for NOC_0, decreasing for NOC_1
+    const bool increasing = (noc == tt::tt_metal::NOC::NOC_0);
+
+    uint32_t index_of_current = 0;  // default to 0 if axis_length == 1
+    for (uint32_t worker_idx = 1; worker_idx < axis_length; ++worker_idx) {
+        CoreCoord worker_core = core;
+        size_t& coord_to_modify = transpose_core_grid ? (axis_is_x_when_not_transposed ? worker_core.y : worker_core.x)
+                                                      : (axis_is_x_when_not_transposed ? worker_core.x : worker_core.y);
+
+        coord_to_modify = increasing ? worker_idx : (axis_length - worker_idx);
+        if (coord_to_modify == current_axis_value) {
+            index_of_current = worker_idx;
+        }
+        order.push_back(worker_core);
+    }
+    return {order, index_of_current};
+}
+
+CoreCoord clamped_prev(const std::vector<CoreCoord>& order, uint32_t index) {
+    return order.at(index == 0 ? 0 : index - 1);
+}
+
+CoreCoord clamped_next(const std::vector<CoreCoord>& order, uint32_t index) {
+    const uint32_t last = static_cast<uint32_t>(order.size() - 1);
+    return order.at(index >= last ? last : index + 1);
+}
+
+// Append tensor accessors in a consistent order
+void append_accessors(
+    std::vector<uint32_t>& args,
+    const Tensor& main_tensor,
+    const std::vector<Tensor>& output_tensors,
+    const std::optional<const Tensor>& bias_tensor,
+    const std::optional<const Tensor>& ag_input_tensor = std::nullopt,
+    const std::optional<const Tensor>& ternary_a_tensor = std::nullopt,
+    const std::optional<const Tensor>& ternary_b_tensor = std::nullopt) {
+    tt::tt_metal::TensorAccessorArgs(*main_tensor.buffer()).append_to(args);
+    for (const auto& output_tensor : output_tensors) {
+        tt::tt_metal::TensorAccessorArgs(*output_tensor.buffer()).append_to(args);
+    }
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor.value().buffer()).append_to(args);
+    }
+    // AG input must come before ternary to match kernel accessor order
+    if (ag_input_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*ag_input_tensor.value().buffer()).append_to(args);
+    }
+    if (ternary_a_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*ternary_a_tensor.value().buffer()).append_to(args);
+    }
+    if (ternary_b_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*ternary_b_tensor.value().buffer()).append_to(args);
+    }
+}
+
+}  // namespace
+
+// SHARED IMPLEMENTATION - works with vector of output tensors (exposed for minimal_matmul_split)
+MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric_bound_factory_helper_common(
+    tt::tt_metal::Program& program,
+    const Tensor& input_tensor,
+    const Tensor& weight_tensor,
+    const std::optional<const Tensor>& bias_tensor,
+    const std::optional<operations::unary::UnaryWithParam>& fused_activation,
+    const std::optional<const MinimalMatmulConfig>& config,
+    const std::vector<Tensor>& output_tensors,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    std::optional<ttnn::experimental::ccl::MinimalMatmulFusedOpSignaler>& fused_op_signaler,
+    uint32_t N_chunks,
+    std::optional<float> fused_ternary_scalar,
+    const std::optional<const Tensor>& fused_ternary_input_a,
+    const std::optional<const Tensor>& fused_ternary_input_b,
+    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> srs_fused_op_signaler,
+    bool fuse_swiglu) {
+    (void)fused_ternary_scalar;  // Scalar not needed in dataflow kernel, only in compute kernel
+    auto* device = input_tensor.device();
+
+    bool fuse_op = fused_op_signaler.has_value();
+
+    if (!config.has_value()) {
+        log_debug(tt::LogOp, "No config provided, using default block sizes and core grid");
+    }
+
+    auto grid_size =
+        config.has_value() ? config.value().compute_with_storage_grid_size : device->compute_with_storage_grid_size();
+    auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    auto num_cores = core_grid.size();
+
+    bool use_bias = bias_tensor.has_value();
+    bool use_fused_ternary = fused_ternary_input_a.has_value() && fused_ternary_input_b.has_value();
+
+    /**
+     * Determine dataformats, compute kernel config
+     */
+    auto in0_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    auto in0_tile_size = tt::tile_size(in0_data_format);
+    auto in1_data_format = tt::tt_metal::datatype_to_dataformat_converter(weight_tensor.dtype());
+    auto in1_tile_size = tt::tile_size(in1_data_format);
+    auto output_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_tensors[0].dtype());
+    auto out_tile_size = tt::tile_size(output_data_format);
+
+    auto in2_data_format =
+        use_bias ? tt::tt_metal::datatype_to_dataformat_converter(bias_tensor.value().dtype()) : in1_data_format;
+    auto in2_tile_size = tt::tile_size(in2_data_format);
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    // Intermediate CB dataformat is the same datatype as DST register.
+    auto intermediate_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    auto intermediate_tile_size = tt::tile_size(intermediate_data_format);
+
+    /**
+     * in0: M_tiles x K_tiles
+     * in0 is divided into blocks, which are M_block_tiles x K_block_tiles
+     *
+     * in1: K_tiles x N_tiles
+     * in1 is divided into blocks, which are K_block_tiles x N_block_tiles
+     *
+     * output: M_tiles x N_tiles
+     * output is divided into blocks, which are M_block_tiles x N_block_tiles
+     *
+     * Blocks are further subdivided into subblocks. The output block is subdivided into subblock_h x subblock_w
+     * subblocks. The in0 and in1 blocks are accordingly subdivided on M and N.
+     */
+
+    auto in0_tensor_shape = input_tensor.padded_shape();
+    auto in1_tensor_shape = weight_tensor.padded_shape();
+    // Fold activation (LHS) upper dimensions into rows: M_total = prod(upper dims) * M
+    uint32_t K = in0_tensor_shape[-1];
+    uint32_t M = input_tensor.physical_volume() / K;
+    uint32_t N = in1_tensor_shape[-1];
+
+    uint32_t M_tiles = M / tt::constants::TILE_HEIGHT;
+    uint32_t K_tiles = K / tt::constants::TILE_WIDTH;
+    uint32_t N_tiles = N / tt::constants::TILE_WIDTH;
+
+    // Compute N_tiles_per_chunk for splitting
+    const uint32_t N_tiles_per_chunk = N_tiles / N_chunks;
+
+    auto [default_M_block_tiles, default_K_block_tiles, default_N_block_tiles, default_subblock_h, default_subblock_w] =
+        determine_default_block_sizes(M, K, N, fp32_dest_acc_en);
+
+    /**
+     * TODO: Pick optimal subblock sizes. Currently a simple default is used.
+     */
+    uint32_t subblock_h = config.has_value() ? config.value().subblock_h : default_subblock_h;
+    uint32_t subblock_w = config.has_value() ? config.value().subblock_w : default_subblock_w;
+
+    uint32_t M_block_tiles = config.has_value() ? config.value().M_block_size : default_M_block_tiles;
+    uint32_t K_block_tiles = config.has_value() ? config.value().K_block_size : default_K_block_tiles;
+    uint32_t N_block_tiles = config.has_value() ? config.value().N_block_size : default_N_block_tiles;
+
+    /**
+     * We originally saw that for non-square outputs, N > M was significantly faster than M > N.
+     * This is because originally, the in0 DM kernel was responsible for reading in0 and writing output.
+     * When M > N, the in0 DM kernel has more data to read on top of its responsibility to write output.
+     *
+     * An optimization is to have the DM kernel with less data to read handle writes, and transpose the core_grid
+     * to keep NOC usage consistent. With this optimization, N > M performance is symmetric with M > N.
+     *
+     * The smaller input read and mcast is always across a row of cores (x, y): (0, core_y) -> (grid_size.x-1, core_y)
+     * The larger input read and mcast is always across a column of cores (x, y): (core_x, 0) -> (core_x. grid_size.y-1)
+     *
+     * Output is always written by DM reading the smaller input.
+     *
+     * Small input + output DM always runs on RISCV_1, NOC_1
+     * Large input DM always runs on RISCV_0, NOC_0
+     */
+
+    auto small_input_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    auto small_input_risc = tt::tt_metal::DataMovementProcessor::RISCV_1;
+    auto large_input_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    auto large_input_risc = tt::tt_metal::DataMovementProcessor::RISCV_0;
+
+    // Transpose core grid if the output is wide (M > N)
+    // If transpose core grid, we parallelize M on cores_x and N on cores_y and swap the NOCs and RISCVs
+    // When fusing with strided reduce scatter, transposing is disabled
+    // because it resulted in slightly lower performance on a case of interest.
+    // (This can be revisited if needed.)
+    const bool fuse_srs = srs_fused_op_signaler.has_value();
+    bool transpose_core_grid = M > N && !fuse_srs;
+
+    auto in0_noc = transpose_core_grid ? large_input_noc : small_input_noc;
+    auto in0_risc = transpose_core_grid ? large_input_risc : small_input_risc;
+    uint32_t in0_parallel_axis_cores = transpose_core_grid ? grid_size.x : grid_size.y;
+
+    auto in1_noc = transpose_core_grid ? small_input_noc : large_input_noc;
+    auto in1_risc = transpose_core_grid ? small_input_risc : large_input_risc;
+    uint32_t in1_parallel_axis_cores = transpose_core_grid ? grid_size.y : grid_size.x;
+
+    /**
+     * We pad the input dimensions to the nearest multiple of the parallelization factor.
+     *
+     * Each core is assigned a certain number of tiles in M and N to compute.
+     * Within a core, tiles are blocked by M_block_tiles and N_block_tiles.
+     * Most output blocks are the full block size, but the last block in M or N can be partial.
+     */
+    uint32_t padded_M_tiles = tt::round_up(M_tiles, in0_parallel_axis_cores);
+    uint32_t padded_K_tiles = tt::round_up(K_tiles, K_block_tiles);
+
+    uint32_t padded_N_tiles;
+    uint32_t N_tiles_per_core;
+    if (fuse_swiglu) {
+        // Partition on gate/up PAIRS (= output tiles), so every core's weight-tile range is
+        // 2 * (pairs per core): even, and never splitting a pair across cores.
+        uint32_t out_N_tiles = N_tiles / 2;
+        uint32_t padded_out_N_tiles = tt::round_up(out_N_tiles, in1_parallel_axis_cores);
+        padded_N_tiles = 2 * padded_out_N_tiles;
+        N_tiles_per_core = 2 * (padded_out_N_tiles / in1_parallel_axis_cores);
+    } else {
+        padded_N_tiles = tt::round_up(N_tiles, in1_parallel_axis_cores);
+        N_tiles_per_core = padded_N_tiles / in1_parallel_axis_cores;
+    }
+
+    uint32_t M_tiles_per_core = padded_M_tiles / in0_parallel_axis_cores;
+
+    uint32_t K_blocks = padded_K_tiles / K_block_tiles;
+
+    uint32_t M_blocks_per_core = tt::div_up(M_tiles_per_core, M_block_tiles);
+    uint32_t N_blocks_per_core = tt::div_up(N_tiles_per_core, N_block_tiles);
+
+    if (fuse_swiglu) {
+        // The gate/up tile pairs are interleaved along N (gate=2p, up=2p+1). Every core's
+        // N range and every N block must start on an even tile and span an even number of
+        // tiles so a pair is never split across cores or blocks.
+        TT_FATAL(
+            N_tiles % 2 == 0 && N_tiles_per_core % 2 == 0 && N_block_tiles % 2 == 0,
+            "minimal_matmul fuse_swiglu requires N_tiles ({}), N_tiles_per_core ({}) and N_block_tiles ({}) all even",
+            N_tiles,
+            N_tiles_per_core,
+            N_block_tiles);
+    }
+
+    log_debug(tt::LogOp, "M_tiles_per_core: {}", M_tiles_per_core);
+    log_debug(tt::LogOp, "N_tiles_per_core: {}", N_tiles_per_core);
+    log_debug(tt::LogOp, "M_blocks_per_core: {}", M_blocks_per_core);
+    log_debug(tt::LogOp, "N_blocks_per_core: {}", N_blocks_per_core);
+
+    uint32_t in0_block_num_tiles = M_block_tiles * K_block_tiles;
+    uint32_t in1_block_num_tiles = K_block_tiles * N_block_tiles;
+    uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
+    uint32_t in2_block_num_tiles = N_block_tiles;
+
+    // Sub-chunk (M-row band) count for the fused AG in0 delivery; only meaningful when fusing AG.
+    // Parsed here so the in1 scratch CB, the divisibility checks, and the per-kernel define all agree
+    // on one value.
+    uint32_t in0_sub_chunks = 1;
+    if (fuse_op) {
+        if (const char* e = std::getenv("IN0_SUB_CHUNKS")) {
+            long v = std::strtol(e, nullptr, 10);
+            if (v > 1) {
+                in0_sub_chunks = static_cast<uint32_t>(v);
+            }
+        }
+    }
+    // Band-interleave: process a forward remote k-block and the following backward one one-band-at-a-time
+    // (fwd.b0, bwd.b0, ...) instead of draining each whole. Needs two k-blocks resident in the in1 scratch
+    // at once, so it also drives the scratch CB size below. Always enabled on the banded path.
+    bool interleave_bands = fuse_op && in0_sub_chunks > 1;
+    // Number of leading (self/local) k-block positions this device owns (see kernels). Placeholder
+    // K_blocks when not fusing / not banding (value only consumed on the IN0_SUB_CHUNKS > 1 path).
+    uint32_t num_local_k_blocks = K_blocks;
+
+    const uint32_t double_buffer_factor = 2;
+    uint32_t in0_cb_num_tiles = in0_block_num_tiles * double_buffer_factor;
+    uint32_t in1_cb_num_tiles = in1_block_num_tiles * double_buffer_factor;
+    // SwiGLU emits half the N tiles per block (one per gate/up pair), so the output CB only
+    // needs to hold half a block. The intermediate CB still holds the full (2N) block.
+    uint32_t out_block_num_tiles_written = fuse_swiglu ? (out_block_num_tiles / 2) : out_block_num_tiles;
+    // out_cb_num_tiles is sized below, after split_output_write is known: the two-NoC split path only
+    // runs with a single output block per core, so it does not need the double buffer (see there).
+    uint32_t interm_cb_num_tiles = out_block_num_tiles;  // not double buffered
+    uint32_t in2_cb_num_tiles = in2_block_num_tiles;     // not double buffered
+
+    auto core_0_0 = CoreCoord{0, 0};
+    auto core_0_1 = CoreCoord{0, 1};
+    auto core_1_0 = CoreCoord{1, 0};
+    auto core_endx_0 = CoreCoord{grid_size.x - 1, 0};
+    auto core_0_endy = CoreCoord{0, grid_size.y - 1};
+    auto core_endx_endy = CoreCoord{grid_size.x - 1, grid_size.y - 1};
+
+    auto in0_sender_cores = CoreRange(core_0_0, transpose_core_grid ? core_endx_0 : core_0_endy);
+    auto in0_receiver_cores = CoreRange(transpose_core_grid ? core_0_1 : core_1_0, core_endx_endy);
+    auto in1_sender_cores = CoreRange(core_0_0, transpose_core_grid ? core_0_endy : core_endx_0);
+    auto in1_receiver_cores = CoreRange(transpose_core_grid ? core_1_0 : core_0_1, core_endx_endy);
+
+    auto in0_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, INVALID);
+    auto in0_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, INVALID);
+    auto in0_valid_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, VALID);
+    auto in1_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, INVALID);
+    auto in1_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, INVALID);
+    auto in1_valid_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, VALID);
+
+    uint32_t in0_cb_id = tt::CBIndex::c_0;
+    tt::tt_metal::create_cb(in0_cb_id, program, core_grid, in0_tile_size, in0_cb_num_tiles, in0_data_format);
+
+    uint32_t in1_cb_id = tt::CBIndex::c_1;
+    tt::tt_metal::create_cb(in1_cb_id, program, core_grid, in1_tile_size, in1_cb_num_tiles, in1_data_format);
+
+    {
+        // Scratch holds one K_block x N_block so the in1 injector can read it once and re-present it to
+        // compute per M-row band without re-reading DRAM (see dm_in1_sender_out.cpp). Single-buffered.
+        // Created unconditionally: the in1 dataflow always reads through it (nb == 1 when not banding).
+        // Band-interleave needs the forward and backward k-blocks of a pair resident at once, so it holds
+        // two blocks.
+        uint32_t in1_scratch_cb_id = tt::CBIndex::c_7;
+        tt::tt_metal::create_cb(
+            in1_scratch_cb_id,
+            program,
+            core_grid,
+            in1_tile_size,
+            in1_block_num_tiles * (interleave_bands ? 2u : 1u),
+            in1_data_format);
+    }
+
+    // Two-NoC output-write split: the whole-block post-loop write is split across M-rows so dm_in1 writes
+    // the low rows on NOC_1 and dm_in0 writes the high rows on NOC_0. Both DMs are idle at the write
+    // (reads/mcasts done), so no input contention and no dynamic-NoC needed. Only valid for the plain (copy)
+    // epilogue with a single output and one M-block per core (defer_write always false). split_noc1_pct
+    // (0..100) sets the percent of rows going to NOC_1 (dm_in1); the rest go to NOC_0.
+    const uint32_t split_noc1_pct = 50;
+    // Works with bias (compute uses add_bias_block_split; dm_in1 reads the bias since both DMs are writers)
+    // and with chunks (N_chunks > 1): compute still packs low/high M-rows into c_2/c_8 and each writer demuxes
+    // its M-row half's N columns into the chunk tensors. Not compatible with ternary/swiglu epilogues.
+    bool split_output_write = !use_fused_ternary && !fuse_swiglu && M_blocks_per_core == 1 && M_block_tiles > 1;
+    // Interleaved two-NoC output write: replace the contiguous [0, split_rows) / [split_rows, M) row split
+    // with an interleaved (ratio-preserving Bresenham) ownership so both NoC writers are fed from the first
+    // rows and overlap, instead of running back-to-back (see split_row_to_noc1 in subchunk_bands.hpp). Only
+    // the N_chunks == 1 write path is interleaved; the chunked (N_chunks > 1) path stays contiguous, so the
+    // define is gated on N_chunks == 1 below to keep compute and both DM writers consistent. Set to false to
+    // restore the contiguous split.
+    const bool interleaved_output_write = true;
+
+    // Output CB double-buffering only earns its L1 when there is a *next* M-block for compute to work on
+    // while the writer drains the current one. When M_blocks_per_core == 1 there is exactly one output block
+    // per core, so the second buffer overlaps nothing and is dead L1 -- single-buffer it. This is the real
+    // condition (not split_output_write): it also covers the fused-ternary/addcmul epilogue, where
+    // split_output_write is false but M_blocks_per_core is still 1, so that op reclaims the buffer too. It
+    // reclaims one full output block per core (out_block_num_tiles_written tiles) -- the L1 we want back for
+    // the fabric AG buffers on the banded (IN0_SUB_CHUNKS > 1) path rather than paying for it by cutting
+    // num_buffers_per_channel. (c_8, only created on the split path, is already single-buffered.)
+    uint32_t out_cb_num_tiles = out_block_num_tiles_written * (M_blocks_per_core == 1 ? 1u : double_buffer_factor);
+
+    uint32_t out_cb_id = tt::CBIndex::c_2;
+    tt::tt_metal::create_cb(out_cb_id, program, core_grid, out_tile_size, out_cb_num_tiles, output_data_format);
+    if (split_output_write) {
+        // Second output CB (c_8): the high-row half drained by dm_in0 on NOC_0. Full-block size upper-bounds
+        // the high half; total out-CB L1 stays modest.
+        uint32_t out_cb_b_id = tt::CBIndex::c_8;
+        tt::tt_metal::create_cb(
+            out_cb_b_id, program, core_grid, out_tile_size, out_block_num_tiles, output_data_format);
+    }
+
+    uint32_t intermediate_cb_id = tt::CBIndex::c_3;
+    tt::tt_metal::create_cb(
+        intermediate_cb_id, program, core_grid, intermediate_tile_size, interm_cb_num_tiles, intermediate_data_format);
+
+    if (use_bias) {
+        uint32_t in2_cb_id = tt::CBIndex::c_4;
+        tt::tt_metal::create_cb(in2_cb_id, program, core_grid, in2_tile_size, in2_cb_num_tiles, in2_data_format);
+    }
+
+    // Create circular buffers for fused ternary inputs
+    if (use_fused_ternary) {
+        uint32_t ternary_a_cb_id = tt::CBIndex::c_5;
+        uint32_t ternary_c_cb_id = tt::CBIndex::c_6;
+
+        // Fused ternary input A - circular buffer c_5
+        auto ternary_a_data_format =
+            tt::tt_metal::datatype_to_dataformat_converter(fused_ternary_input_a.value().dtype());
+        auto ternary_a_tile_size = tt::tile_size(ternary_a_data_format);
+
+        TT_FATAL(ternary_a_tile_size == in1_tile_size, "ternary_a_tile_size must be equal to in1_tile_size");
+        TT_FATAL(ternary_a_data_format == in1_data_format, "ternary_a_data_format must be equal to in1_data_format");
+        uint32_t ternary_a_cb_num_tiles = out_block_num_tiles;  // Same as output block, not double buffered
+
+        tt::tt_metal::create_cb(
+            ternary_a_cb_id, program, core_grid, ternary_a_tile_size, ternary_a_cb_num_tiles, ternary_a_data_format);
+
+        // Fused ternary input C - circular buffer c_6
+        auto ternary_c_data_format =
+            tt::tt_metal::datatype_to_dataformat_converter(fused_ternary_input_b.value().dtype());
+        auto ternary_c_tile_size = tt::tile_size(ternary_c_data_format);
+        uint32_t ternary_c_cb_num_tiles = N_block_tiles;  // Single row (like bias), broadcast across M
+
+        tt::tt_metal::create_cb(
+            ternary_c_cb_id, program, core_grid, ternary_c_tile_size, ternary_c_cb_num_tiles, ternary_c_data_format);
+
+        log_debug(tt::LogOp, "ternary_a_cb_id: {}", ternary_a_cb_id);
+        log_debug(tt::LogOp, "ternary_c_cb_id: {}", ternary_c_cb_id);
+    }
+
+    log_debug(tt::LogOp, "in0_cb_id: {}", in0_cb_id);
+    log_debug(tt::LogOp, "in1_cb_id: {}", in1_cb_id);
+    log_debug(tt::LogOp, "out_cb_id: {}", out_cb_id);
+    log_debug(tt::LogOp, "intermediate_cb_id: {}", intermediate_cb_id);
+    log_debug(tt::LogOp, "M_tiles: {}", M_tiles);
+    log_debug(tt::LogOp, "padded_M_tiles: {}", padded_M_tiles);
+    log_debug(tt::LogOp, "K_tiles: {}", K_tiles);
+    log_debug(tt::LogOp, "padded_K_tiles: {}", padded_K_tiles);
+    log_debug(tt::LogOp, "N_tiles: {}", N_tiles);
+    log_debug(tt::LogOp, "padded_N_tiles: {}", padded_N_tiles);
+    log_debug(tt::LogOp, "M_block_tiles: {}", M_block_tiles);
+    log_debug(tt::LogOp, "K_block_tiles: {}", K_block_tiles);
+    log_debug(tt::LogOp, "N_block_tiles: {}", N_block_tiles);
+    log_debug(tt::LogOp, "subblock_h: {}", subblock_h);
+    log_debug(tt::LogOp, "subblock_w: {}", subblock_w);
+    log_debug(tt::LogOp, "in0_tile_size: {}", in0_tile_size);
+    log_debug(tt::LogOp, "in1_tile_size: {}", in1_tile_size);
+    log_debug(tt::LogOp, "out_tile_size: {}", out_tile_size);
+    log_debug(tt::LogOp, "in2_tile_size: {}", in2_tile_size);
+    log_debug(tt::LogOp, "intermediate_tile_size: {}", intermediate_tile_size);
+    log_debug(tt::LogOp, "intermediate_data_format: {}", intermediate_data_format);
+    log_debug(tt::LogOp, "in0_cb_num_tiles: {}", in0_cb_num_tiles);
+    log_debug(tt::LogOp, "in1_cb_num_tiles: {}", in1_cb_num_tiles);
+    log_debug(tt::LogOp, "out_cb_num_tiles: {}", out_cb_num_tiles);
+    log_debug(tt::LogOp, "interm_cb_num_tiles: {}", interm_cb_num_tiles);
+
+    std::map<std::string, std::string> defines;
+    if (use_bias) {
+        defines["FUSE_BIAS"] = "1";
+    }
+
+    if (fuse_swiglu) {
+        defines["FUSE_SWIGLU"] = "1";
+    }
+
+    if (use_fused_ternary) {
+        defines["FUSE_TERNARY"] = "1";
+
+        // Workaround for LLK bug (https://github.com/tenstorrent/tt-llk/issues/1338)
+        // - If ternary_b / gate is float32 then use unary_bcast (row broadcast) + mul_binary_tile (accurate)
+        // - If ternary_b / gate is bfloat16 then use mul_tiles_bcast (row broadcast) (workaround)
+        if (fused_ternary_input_b.value().dtype() == DataType::FLOAT32) {
+            defines["TERNARY_B_IS_FLOAT32"] = "1";
+        }
+    }
+
+    if (fuse_op) {
+        // Create semaphores
+        fused_op_signaler->init_fused_op(program, device, in0_sender_cores);
+        defines["FUSE_AG"] = "1";
+        // Stream the in0 read in this many M-row bands (parsed above), matching the AG's per-band
+        // delivery/signal. On the IN0_SUB_CHUNKS > 1 path the matmul also matmuls + forwards per band
+        // (see compute.cpp / dm_in0_sender.cpp / dm_in1_sender_out.cpp). Must equal the AG program's
+        // IN0_SUB_CHUNKS so the per-band signal counts match.
+        defines["IN0_SUB_CHUNKS"] = std::to_string(in0_sub_chunks);
+        if (in0_sub_chunks > 1) {
+            // Every band occupies a uniform in0 CB slot of (M_block_tiles / in0_sub_chunks) rows, so a
+            // ragged band (height not a multiple of subblock_h, e.g. a partial final M-block) still
+            // reserves a slot that tiles the CB exactly -- no mid-block fifo wrap. matmul reads the full
+            // subblock_h into the slot's slack rows and packs only the real rows. Two divisibility
+            // invariants make that exact:
+            //   1. in0_sub_chunks | M_block_tiles           -- uniform slot is a whole number of rows
+            //   2. subblock_h | (M_block_tiles/in0_sub_chunks) -- the deep read never runs past the slot
+            // Plus every band must be non-empty: balanced_band yields a zero band only when a block has
+            // fewer rows than in0_sub_chunks, and the in1 sender / signal aggregator fire IN0_SUB_CHUNKS
+            // times unconditionally -- a zero band would desync them against the in0/compute early-exit
+            // and deadlock. The smallest block is the (possibly partial) last one.
+            uint32_t last_m_block_tiles = M_tiles_per_core - (M_blocks_per_core - 1) * M_block_tiles;
+            TT_FATAL(
+                last_m_block_tiles >= in0_sub_chunks,
+                "smallest M block ({} tiles) must be >= IN0_SUB_CHUNKS ({}) so every M-row band is "
+                "non-empty",
+                last_m_block_tiles,
+                in0_sub_chunks);
+            TT_FATAL(
+                (M_block_tiles % in0_sub_chunks) == 0,
+                "IN0_SUB_CHUNKS ({}) must divide M_block_tiles ({})",
+                in0_sub_chunks,
+                M_block_tiles);
+            TT_FATAL(
+                ((M_block_tiles / in0_sub_chunks) % subblock_h) == 0,
+                "subblock_h ({}) must divide the per-band slot M_block_tiles/IN0_SUB_CHUNKS ({}/{} = {})",
+                subblock_h,
+                M_block_tiles,
+                in0_sub_chunks,
+                M_block_tiles / in0_sub_chunks);
+            // Count this device's local (self) k-blocks = the leading schedule positions the AG delivers
+            // whole (never sub-chunked). Mirrors compute_device_chunk_stats for start_ring_index. v1
+            // requires K_block_tiles-aligned device boundaries: a straddling (co-owned) k-block would
+            // break the local-first band schedule, so assert none exist.
+            uint32_t my_chip = fused_op_signaler->start_ring_index;
+            uint32_t in_Wt = fused_op_signaler->input_tensor_Wt;
+            uint32_t curr_device = 0;
+            uint32_t curr_device_end = in_Wt - 1;
+            uint32_t my_count = 0;
+            for (uint32_t kb = 0; kb < K_blocks; kb++) {
+                uint32_t kb_end = (kb + 1) * K_block_tiles - 1;
+                if (kb_end < curr_device_end) {
+                    if (curr_device == my_chip) {
+                        my_count++;
+                    }
+                } else if (kb_end == curr_device_end) {
+                    if (curr_device == my_chip) {
+                        my_count++;
+                    }
+                    curr_device++;
+                    curr_device_end = (curr_device + 1) * in_Wt - 1;
+                } else {
+                    TT_FATAL(
+                        false,
+                        "IN0_SUB_CHUNKS > 1 requires K_block_tiles ({}) aligned device boundaries "
+                        "(input_tensor_Wt = {}); a straddling k-block is not supported",
+                        K_block_tiles,
+                        in_Wt);
+                }
+            }
+            num_local_k_blocks = my_count;
+        }
+        // Consume the middle forward/backward k-blocks 1-backward-1-forward instead of grouped
+        // (see fused_receiver_utils.hpp::compute_actual_k_block_iter).
+        defines["AG_ALTERNATE_MIDDLE"] = "1";
+        // Band-interleave a forward remote k-block with the following backward one (see dm_in0_sender.cpp).
+        // Assigned to the shared defines map so in0/in1 senders and compute all agree on the paired path.
+        if (interleave_bands) {
+            defines["AG_INTERLEAVE_BANDS"] = "1";
+        }
+    }
+
+    uint32_t srs_fuse_signaler_sync_semaphore_id = 0;
+    if (fuse_srs) {
+        defines["SRS_FUSE_OP_SIGNALER"] = "1";
+        srs_fuse_signaler_sync_semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, 0);
+    }
+
+    std::vector<CoreCoord> all_worker_cores_noc;
+    if (fuse_srs) {
+        all_worker_cores_noc.reserve(num_cores);
+        auto all_cores_tmp = corerange_to_cores(core_grid, num_cores, true);
+        for (const auto& c : all_cores_tmp) {
+            all_worker_cores_noc.push_back(device->worker_core_from_logical_core(c));
+        }
+    }
+
+    uint32_t in0_addr = input_tensor.buffer()->address();
+    uint32_t in1_addr = weight_tensor.buffer()->address();
+    uint32_t in2_addr = use_bias ? bias_tensor.value().buffer()->address() : 0;
+    // Note: Dataflow kernels can take a variable number of output tensors.
+    // They are appended as a variable-length array at the end of the runtime-args:
+    //   - for in0 output-writer cores the first output address is at index 13
+    //   - for in1 output-writer cores the first output address is at index 12
+    uint32_t in3_addr = (fuse_op && fused_op_signaler->read_local_slice_from_input)
+                            ? fused_op_signaler->ag_input.value().buffer()->address()
+                            : 0;
+    auto in3_data_format =
+        (fuse_op && fused_op_signaler->read_local_slice_from_input)
+            ? tt::tt_metal::datatype_to_dataformat_converter(fused_op_signaler->ag_input.value().dtype())
+            : in1_data_format;
+
+    auto in3_tile_size = tt::tile_size(in3_data_format);
+
+    /**
+     * Create kernels
+     */
+
+    // Under the two-NoC split both DMs write (dm_in1 the low rows on NOC_1, dm_in0 the high rows on NOC_0);
+    // otherwise exactly one writes.
+    bool in0_is_output_writer = split_output_write ? true : !transpose_core_grid;
+    bool in1_is_output_writer = split_output_write ? true : transpose_core_grid;
+
+    // Per-DM-family defines. Under the split: dm_in1 writes rows [0, split) from c_2; dm_in0 drains c_8 and
+    // writes [split, M). Both get the same split percent so their ranges line up with compute's copy.
+    auto in0_defines = defines;
+    auto in1_defines = defines;
+    if (split_output_write) {
+        in1_defines["SPLIT_OUTPUT_WRITE"] = "1";
+        in1_defines["AG_SPLIT_NOC1_PCT"] = std::to_string(split_noc1_pct);
+        in0_defines["SPLIT_OUTPUT_WRITE"] = "1";
+        in0_defines["AG_OUT_WRITE_CB"] = std::to_string(static_cast<uint32_t>(tt::CBIndex::c_8));
+        in0_defines["AG_SPLIT_NOC1_PCT"] = std::to_string(split_noc1_pct);
+        if (interleaved_output_write && N_chunks == 1) {
+            in1_defines["AGMM_INTERLEAVED_OUTPUT_WRITE"] = "1";
+            in0_defines["AGMM_INTERLEAVED_OUTPUT_WRITE"] = "1";
+        }
+    }
+    // dm_in0 injector (read-local) variant layers READ_FROM_LOCAL_INPUT on top of the in0 defines.
+    auto in0_injector_defines = in0_defines;
+    if (fuse_op && fused_op_signaler->read_local_slice_from_input) {
+        in0_injector_defines["READ_FROM_LOCAL_INPUT"] = "1";
+    }
+
+    std::vector<uint32_t> in0_sender_compile_time_args = {
+        M_tiles,
+        padded_M_tiles,
+        K_tiles,
+        padded_K_tiles,
+        N_tiles,
+        padded_N_tiles,
+        M_block_tiles,
+        K_block_tiles,
+        N_block_tiles,
+        M_blocks_per_core,
+        N_blocks_per_core,
+        in0_tile_size,
+        out_tile_size,
+        in2_tile_size,
+        in0_sender_semaphore_id,
+        in0_receiver_semaphore_id,
+        in0_valid_semaphore_id,
+        in0_is_output_writer,
+        true,               // is_injector_core
+        N_chunks,           // N_chunks
+        N_tiles_per_chunk,  // N_tiles_per_chunk
+        in3_tile_size,
+    };
+    append_accessors(
+        in0_sender_compile_time_args,
+        input_tensor,
+        output_tensors,
+        bias_tensor,
+        (fuse_op && fused_op_signaler->read_local_slice_from_input) ? fused_op_signaler->ag_input : std::nullopt,
+        fused_ternary_input_a,
+        fused_ternary_input_b);
+    auto in0_sender_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_dm_in0_sender.cpp",
+        in0_sender_cores,
+        tt::tt_metal::DataMovementConfig{
+            .processor = in0_risc,
+            .noc = in0_noc,
+            .compile_args = in0_sender_compile_time_args,
+            .defines = in0_injector_defines});
+
+    std::vector<uint32_t> in0_receiver_compile_time_args = {
+        M_tiles,
+        padded_M_tiles,
+        K_tiles,
+        padded_K_tiles,
+        N_tiles,
+        padded_N_tiles,
+        M_block_tiles,
+        K_block_tiles,
+        N_block_tiles,
+        M_blocks_per_core,
+        N_blocks_per_core,
+        in0_tile_size,
+        out_tile_size,
+        in2_tile_size,
+        in0_sender_semaphore_id,
+        in0_receiver_semaphore_id,
+        in0_valid_semaphore_id,
+        in0_is_output_writer,
+        false,              // is_injector_core
+        N_chunks,           // N_chunks
+        N_tiles_per_chunk,  // N_tiles_per_chunk
+        in3_tile_size,
+    };
+    append_accessors(
+        in0_receiver_compile_time_args,
+        input_tensor,
+        output_tensors,
+        bias_tensor,
+        std::nullopt,  // no ag_input for in0_receiver
+        fused_ternary_input_a,
+        fused_ternary_input_b);
+
+    auto in0_receiver_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_dm_in0_sender.cpp",
+        in0_receiver_cores,
+        tt::tt_metal::DataMovementConfig{
+            .processor = in0_risc,
+            .noc = in0_noc,
+            .compile_args = in0_receiver_compile_time_args,
+            .defines = in0_defines});
+
+    std::vector<uint32_t> in1_sender_compile_time_args = {
+        M_tiles,
+        padded_M_tiles,
+        K_tiles,
+        padded_K_tiles,
+        N_tiles,
+        padded_N_tiles,
+        M_block_tiles,
+        K_block_tiles,
+        N_block_tiles,
+        M_blocks_per_core,
+        N_blocks_per_core,
+        in1_tile_size,
+        out_tile_size,
+        in2_tile_size,
+        in1_sender_semaphore_id,
+        in1_receiver_semaphore_id,
+        in1_valid_semaphore_id,
+        in1_is_output_writer,
+        true,               // is_injector_core
+        N_chunks,           // N_chunks
+        N_tiles_per_chunk,  // N_tiles_per_chunk
+    };
+    append_accessors(
+        in1_sender_compile_time_args,
+        weight_tensor,
+        output_tensors,
+        bias_tensor,
+        std::nullopt,  // no ag_input for in1_sender
+        fused_ternary_input_a,
+        fused_ternary_input_b);
+
+    auto in1_sender_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_dm_in1_sender_out.cpp",
+        in1_sender_cores,
+        tt::tt_metal::DataMovementConfig{
+            .processor = in1_risc,
+            .noc = in1_noc,
+            .compile_args = in1_sender_compile_time_args,
+            .defines = in1_defines});
+
+    std::vector<uint32_t> in1_receiver_compile_time_args = {
+        M_tiles,
+        padded_M_tiles,
+        K_tiles,
+        padded_K_tiles,
+        N_tiles,
+        padded_N_tiles,
+        M_block_tiles,
+        K_block_tiles,
+        N_block_tiles,
+        M_blocks_per_core,
+        N_blocks_per_core,
+        in1_tile_size,
+        out_tile_size,
+        in2_tile_size,
+        in1_sender_semaphore_id,
+        in1_receiver_semaphore_id,
+        in1_valid_semaphore_id,
+        in1_is_output_writer,
+        false,              // is_injector_core
+        N_chunks,           // N_chunks
+        N_tiles_per_chunk,  // N_tiles_per_chunk
+    };
+    append_accessors(
+        in1_receiver_compile_time_args,
+        weight_tensor,
+        output_tensors,
+        bias_tensor,
+        std::nullopt,  // no ag_input for in1_receiver
+        fused_ternary_input_a,
+        fused_ternary_input_b);
+
+    auto in1_receiver_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_dm_in1_sender_out.cpp",
+        in1_receiver_cores,
+        tt::tt_metal::DataMovementConfig{
+            .processor = in1_risc,
+            .noc = in1_noc,
+            .compile_args = in1_receiver_compile_time_args,
+            .defines = in1_defines});
+
+    std::vector<uint32_t> compute_compile_time_args = {
+        K_blocks,
+        M_block_tiles,
+        K_block_tiles,
+        N_block_tiles,
+        M_blocks_per_core,
+        N_blocks_per_core,
+        subblock_h,
+        subblock_w,
+        num_local_k_blocks};
+
+    auto compute_defines = defines;
+    if (split_output_write) {
+        compute_defines["SPLIT_OUTPUT_WRITE"] = "1";
+        compute_defines["OUT_CB_B"] = std::to_string(static_cast<uint32_t>(tt::CBIndex::c_8));
+        compute_defines["AG_SPLIT_NOC1_PCT"] = std::to_string(split_noc1_pct);
+        if (interleaved_output_write && N_chunks == 1) {
+            compute_defines["AGMM_INTERLEAVED_OUTPUT_WRITE"] = "1";
+        }
+    }
+    std::map<std::string, std::string> compute_activation_defines;
+    if (fused_activation.has_value()) {
+        compute_activation_defines = ttnn::operations::unary::utils::get_defines(
+            fused_activation.value().op_type,
+            fused_activation.value().params,
+            "ACTIVATION",
+            "fused_act_dst_id",
+            output_tensors[0].dtype());
+    }
+    compute_defines.merge(compute_activation_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, compute_defines, ttnn::get_throttle_level(compute_kernel_config));
+    auto compute_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/fabric_bound_compute.cpp",
+        core_grid,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_compile_time_args,
+            .defines = compute_defines});
+
+    /**
+     * The receiver writer cores defer their writes in order to reduce NOC congestion.
+     * Further, the amount of K_blocks they defer by depends on their core coordinate.
+     * If we have core_grid.x cores, we'd want to evenly stride the K_blocks they defer by.
+     * For first pass, it's easy enough to use core_grid.x
+     */
+    uint32_t k_blocks_per_core =
+        tt::div_up(K_blocks, (transpose_core_grid ? in1_parallel_axis_cores : in0_parallel_axis_cores));
+
+    auto cores = corerange_to_cores(core_grid, num_cores, true);
+
+    uint32_t max_defer_write_k_block = 0;
+    for (const auto& c : cores) {
+        uint32_t dwk = std::min(static_cast<uint32_t>(c.y) * k_blocks_per_core, K_blocks - 1);
+        max_defer_write_k_block = std::max(max_defer_write_k_block, dwk);
+    }
+
+    // NOTE: Uniform per-core M/N ranges are required for DM forward handshakes to match across links.
+    // If neighboring cores along a forwarding chain iterate different (M,N) counts, the sender can wait
+    // for requests that the receiver will never issue, leading to deadlock. Keep the original uniform
+    // div_up-based ranges for M and N.
+
+    for (uint32_t core_id = 0; core_id < num_cores; ++core_id) {
+        CoreCoord core = cores.at(core_id);
+        uint32_t in0_idx = transpose_core_grid ? core.x : core.y;
+        uint32_t in1_idx = transpose_core_grid ? core.y : core.x;
+
+        CoreCoord left_core = {(std::size_t)0, (std::size_t)core.y};
+        CoreCoord top_core = {(std::size_t)core.x, (std::size_t)0};
+
+        auto [in0_core_order, in0_core_order_index] = build_core_order_for_axis(
+            core,
+            transpose_core_grid,
+            in1_parallel_axis_cores,
+            in0_noc,
+            /*axis_is_x_when_not_transposed=*/true,
+            /*initial_endpoint=*/(transpose_core_grid ? top_core : left_core));
+
+        auto [in1_core_order, in1_core_order_index] = build_core_order_for_axis(
+            core,
+            transpose_core_grid,
+            in0_parallel_axis_cores,
+            in1_noc,
+            /*axis_is_x_when_not_transposed=*/false,
+            /*initial_endpoint=*/(transpose_core_grid ? left_core : top_core));
+
+        auto in0_prev_core = clamped_prev(in0_core_order, in0_core_order_index);
+        auto in0_next_core = clamped_next(in0_core_order, in0_core_order_index);
+        auto in1_prev_core = clamped_prev(in1_core_order, in1_core_order_index);
+        auto in1_next_core = clamped_next(in1_core_order, in1_core_order_index);
+
+        auto in0_prev_core_physical = device->worker_core_from_logical_core(in0_prev_core);
+        auto in0_next_core_physical = device->worker_core_from_logical_core(in0_next_core);
+        auto in1_prev_core_physical = device->worker_core_from_logical_core(in1_prev_core);
+        auto in1_next_core_physical = device->worker_core_from_logical_core(in1_next_core);
+
+        /**
+         * NOTE: Some cores are doing unnecessary work, on blocks which are processed just to make
+         * the total number of blocks divisible by the number of cores.
+         * We can't yet get rid of these blocks, since the receiver cores must ack
+         * all blocks that sender cores are expected to send.
+         */
+        uint32_t M_start_tile = M_tiles_per_core * in0_idx;
+        uint32_t M_end_tile = M_tiles_per_core * (in0_idx + 1);
+        uint32_t N_start_tile = N_tiles_per_core * in1_idx;
+        uint32_t N_end_tile = N_tiles_per_core * (in1_idx + 1);
+
+        // Defer write to K block with same coordinate as core
+        // The writer receiver cores always have core.x > 0
+        uint32_t defer_write_k_block = std::min(static_cast<uint32_t>(core.y) * k_blocks_per_core, K_blocks - 1);
+
+        bool is_in0_sink = core == in0_core_order.back();
+        bool is_in1_sink = core == in1_core_order.back();
+
+        std::vector<uint32_t> in0_args = {
+            in0_addr,
+            in2_addr,
+            in3_addr,
+            is_in0_sink,
+            (std::uint32_t)in0_next_core_physical.x,  // in0_dest_noc_x
+            (std::uint32_t)in0_next_core_physical.y,  // in0_dest_noc_y
+            (std::uint32_t)in0_prev_core_physical.x,  // in0_sender_noc_x
+            (std::uint32_t)in0_prev_core_physical.y,  // in0_sender_noc_y
+            M_start_tile,
+            M_end_tile,
+            N_start_tile,
+            N_end_tile,
+            defer_write_k_block,
+            max_defer_write_k_block,
+            num_local_k_blocks,
+        };
+        // Add ternary addresses if present (after defer_write_k_block, before output addresses)
+        if (use_fused_ternary) {
+            in0_args.push_back(fused_ternary_input_a.value().buffer()->address());
+            in0_args.push_back(fused_ternary_input_b.value().buffer()->address());
+            uint32_t ternary_b_M_tiles = fused_ternary_input_b.value().padded_shape()[-2] / tt::constants::TILE_HEIGHT;
+            in0_args.push_back(ternary_b_M_tiles == 1 ? 1u : 0u);  // broadcast_ternary_b
+        }
+        // Add output addresses at the end (unified layout for both regular and split)
+        for (const auto& output_tensor : output_tensors) {
+            in0_args.push_back(output_tensor.buffer()->address());
+        }
+        if (fuse_op) {
+            fused_op_signaler->push_matmul_fused_op_rt_args(in0_args, padded_K_tiles / K_block_tiles, K_block_tiles);
+        }
+        if (fuse_srs) {
+            in0_args.push_back(static_cast<uint32_t>(num_cores));
+            in0_args.push_back(static_cast<uint32_t>(core_id));
+            in0_args.push_back(static_cast<uint32_t>(srs_fuse_signaler_sync_semaphore_id));
+            for (const auto& noc_core : all_worker_cores_noc) {
+                in0_args.push_back(static_cast<uint32_t>(noc_core.x));
+                in0_args.push_back(static_cast<uint32_t>(noc_core.y));
+            }
+            in0_args.push_back(static_cast<uint32_t>(srs_fused_op_signaler->num_fused_op_cores_to_signal));
+            for (const auto& noc_core : srs_fused_op_signaler->fused_op_receiver_cores_noc) {
+                in0_args.push_back(static_cast<uint32_t>(noc_core.x));
+                in0_args.push_back(static_cast<uint32_t>(noc_core.y));
+            }
+            in0_args.push_back(static_cast<uint32_t>(srs_fused_op_signaler->fused_op_receiver_signal_semaphore));
+            in0_args.push_back(1);  // mcast_signal_op_cores
+        }
+        if (in1_idx == 0) {
+            // in0 sender
+            SetRuntimeArgs(program, in0_sender_kernels_id, core, in0_args);
+        } else {
+            // in0 receiver
+            SetRuntimeArgs(program, in0_receiver_kernels_id, core, in0_args);
+        }
+
+        std::vector<uint32_t> in1_args = {
+            in1_addr,
+            in2_addr,
+            is_in1_sink,
+            (std::uint32_t)in1_next_core_physical.x,  // in1_dest_noc_x
+            (std::uint32_t)in1_next_core_physical.y,  // in1_dest_noc_y
+            (std::uint32_t)in1_prev_core_physical.x,  // in1_sender_noc_x
+            (std::uint32_t)in1_prev_core_physical.y,  // in1_sender_noc_y
+            M_start_tile,
+            M_end_tile,
+            N_start_tile,
+            N_end_tile,
+            defer_write_k_block,
+            max_defer_write_k_block,
+            num_local_k_blocks,
+        };
+        // Add ternary addresses if present (after defer_write_k_block, before output addresses)
+        if (use_fused_ternary) {
+            in1_args.push_back(fused_ternary_input_a.value().buffer()->address());
+            in1_args.push_back(fused_ternary_input_b.value().buffer()->address());
+            uint32_t ternary_b_M_tiles = fused_ternary_input_b.value().padded_shape()[-2] / tt::constants::TILE_HEIGHT;
+            in1_args.push_back(ternary_b_M_tiles == 1 ? 1u : 0u);  // broadcast_ternary_b
+        }
+        // Add output addresses at the end (unified layout for both regular and split)
+        for (const auto& output_tensor : output_tensors) {
+            in1_args.push_back(output_tensor.buffer()->address());
+        }
+        if (fuse_op) {
+            fused_op_signaler->push_matmul_fused_op_rt_args(in1_args, padded_K_tiles / K_block_tiles, K_block_tiles);
+        }
+        if (fuse_srs) {
+            in1_args.push_back(static_cast<uint32_t>(num_cores));
+            in1_args.push_back(static_cast<uint32_t>(core_id));
+            in1_args.push_back(static_cast<uint32_t>(srs_fuse_signaler_sync_semaphore_id));
+            for (const auto& noc_core : all_worker_cores_noc) {
+                in1_args.push_back(static_cast<uint32_t>(noc_core.x));
+                in1_args.push_back(static_cast<uint32_t>(noc_core.y));
+            }
+            in1_args.push_back(static_cast<uint32_t>(srs_fused_op_signaler->num_fused_op_cores_to_signal));
+            for (const auto& noc_core : srs_fused_op_signaler->fused_op_receiver_cores_noc) {
+                in1_args.push_back(static_cast<uint32_t>(noc_core.x));
+                in1_args.push_back(static_cast<uint32_t>(noc_core.y));
+            }
+            in1_args.push_back(static_cast<uint32_t>(srs_fused_op_signaler->fused_op_receiver_signal_semaphore));
+            in1_args.push_back(1);  // mcast_signal_op_cores
+        }
+        if (in0_idx == 0) {
+            // in1 sender
+            SetRuntimeArgs(program, in1_sender_kernels_id, core, in1_args);
+        } else {
+            // in1 receiver
+            SetRuntimeArgs(program, in1_receiver_kernels_id, core, in1_args);
+        }
+
+        std::vector<uint32_t> compute_runtime_args = {
+            M_start_tile,
+            M_end_tile,
+            N_start_tile,
+            N_end_tile,
+        };
+        if (use_fused_ternary) {
+            compute_runtime_args.push_back(*reinterpret_cast<const uint32_t*>(&fused_ternary_scalar.value()));
+            uint32_t ternary_b_M_tiles = fused_ternary_input_b.value().padded_shape()[-2] / tt::constants::TILE_HEIGHT;
+            compute_runtime_args.push_back(ternary_b_M_tiles == 1 ? 1u : 0u);  // broadcast_ternary_b
+        }
+        SetRuntimeArgs(program, compute_kernels_id, core, compute_runtime_args);
+    }
+
+    return MinimalMatmulFabricBoundProgramFactory::shared_variables_t{
+        num_cores,
+        cores,
+        in0_sender_kernels_id,
+        in0_receiver_kernels_id,
+        in1_sender_kernels_id,
+        in1_receiver_kernels_id,
+        compute_kernels_id,
+        transpose_core_grid,
+        fuse_op && fused_op_signaler->read_local_slice_from_input};
+}
+
+MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric_bound_factory_helper(
+    tt::tt_metal::Program& program,
+    const Tensor& input_tensor,
+    const Tensor& weight_tensor,
+    const std::optional<const Tensor>& bias_tensor,
+    const std::optional<operations::unary::UnaryWithParam>& fused_activation,
+    const std::optional<const MinimalMatmulConfig>& config,
+    const Tensor& output_tensor,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    std::optional<ttnn::experimental::ccl::MinimalMatmulFusedOpSignaler>& fused_op_signaler,
+    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler>& srs_fused_op_signaler,
+    bool fuse_swiglu) {
+    std::vector<Tensor> output_tensors = {output_tensor};
+    return minimal_matmul_fabric_bound_factory_helper_common(
+        program,
+        input_tensor,
+        weight_tensor,
+        bias_tensor,
+        fused_activation,
+        config,
+        output_tensors,
+        compute_kernel_config,
+        fused_op_signaler,
+        1,  // N_chunks = 1 for regular minimal_matmul
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        srs_fused_op_signaler,
+        fuse_swiglu);
+}
+
+MinimalMatmulFabricBoundProgramFactory::cached_program_t MinimalMatmulFabricBoundProgramFactory::create(
+    const MinimalMatmulParams& operation_attributes,
+    const MinimalMatmulInputs& tensor_args,
+    std::vector<Tensor>& tensor_return_value) {
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+    std::optional<ttnn::experimental::ccl::MinimalMatmulFusedOpSignaler> empty_fused_op_signaler;
+    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> empty_srs_fused_op_signaler;
+
+    auto shared_vars = minimal_matmul_fabric_bound_factory_helper_common(
+        program,
+        tensor_args.input_tensor,
+        tensor_args.weight_tensor,
+        tensor_args.bias_tensor,
+        operation_attributes.fused_activation,
+        operation_attributes.config,
+        tensor_return_value,
+        operation_attributes.compute_kernel_config,
+        empty_fused_op_signaler,
+        static_cast<uint32_t>(operation_attributes.chunks),
+        operation_attributes.fused_ternary_scalar,
+        tensor_args.fused_ternary_input_a,
+        tensor_args.fused_ternary_input_b,
+        empty_srs_fused_op_signaler,
+        operation_attributes.fuse_swiglu);
+
+    return {std::move(program), std::move(shared_vars)};
+}
+
+// Common helper for override_runtime_arguments - works with both single and multiple output tensors
+void MinimalMatmulFabricBoundProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const MinimalMatmulParams& operation_attributes,
+    const MinimalMatmulInputs& tensor_args,
+    std::vector<Tensor>& tensor_return_value) {
+    auto& program = cached_program.program;
+    auto& override_variables = cached_program.shared_variables;
+
+    auto& in0_sender_runtime_args = GetRuntimeArgs(program, override_variables.in0_sender_kernels_id);
+    auto& in0_receiver_runtime_args = GetRuntimeArgs(program, override_variables.in0_receiver_kernels_id);
+    auto& in1_sender_runtime_args = GetRuntimeArgs(program, override_variables.in1_sender_kernels_id);
+    auto& in1_receiver_runtime_args = GetRuntimeArgs(program, override_variables.in1_receiver_kernels_id);
+    auto& compute_runtime_args = GetRuntimeArgs(program, override_variables.compute_kernels_id);
+
+    // RT args layout for in0: [in0_addr, in2_addr, in3_addr, is_sink, noc_coords(4), tile_ranges(4),
+    //   defer_write_k_block, max_defer_write_k_block,
+    //   [optional: ternary_a_addr, ternary_b_addr, broadcast_ternary_b], out_addrs(N)...]
+    // RT args layout for in1: [in1_addr, in2_addr, is_sink, noc_coords(4), tile_ranges(4),
+    //   defer_write_k_block, max_defer_write_k_block,
+    //   [optional: ternary_a_addr, ternary_b_addr, broadcast_ternary_b], out_addrs(N)...]
+    constexpr uint32_t in0_in0_addr_idx = 0;
+    constexpr uint32_t in0_in2_addr_idx = 1;
+    constexpr uint32_t in0_in3_addr_idx = 2;
+    constexpr uint32_t in0_ternary_a_addr_idx = 15;  // After max_defer_write_k_block (13), num_local_k_blocks (14)
+    constexpr uint32_t in0_ternary_b_addr_idx = 16;
+
+    constexpr uint32_t in1_in0_addr_idx = 0;
+    constexpr uint32_t in1_bias_addr_idx = 1;
+    constexpr uint32_t in1_ternary_a_addr_idx = 14;  // After max_defer_write_k_block (12), num_local_k_blocks (13)
+    constexpr uint32_t in1_ternary_b_addr_idx = 15;
+
+    // Check if ternary addresses are present
+    bool has_fused_ternary =
+        tensor_args.fused_ternary_input_a.has_value() && tensor_args.fused_ternary_input_b.has_value();
+    // Output addresses start after max_defer_write_k_block, num_local_k_blocks, and optional ternary addresses.
+    // in0: max_defer(13), num_local(14) -> outputs at 15 (+3 for ternary a/b/broadcast = 18).
+    // in1: max_defer(12), num_local(13) -> outputs at 14 (+3 for ternary = 17).
+    uint32_t in0_out_addr_start_idx = has_fused_ternary ? 18 : 15;
+    uint32_t in1_out_addr_start_idx = has_fused_ternary ? 17 : 14;
+
+    for (uint32_t i = 0; i < override_variables.num_cores; ++i) {
+        CoreCoord core = override_variables.cores.at(i);
+        uint32_t in0_idx = override_variables.transpose_core_grid ? core.x : core.y;
+        uint32_t in1_idx = override_variables.transpose_core_grid ? core.y : core.x;
+
+        if (in1_idx == 0) {
+            auto& in0_sender_args = in0_sender_runtime_args[core.x][core.y];
+
+            in0_sender_args[in0_in0_addr_idx] = tensor_args.input_tensor.buffer()->address();
+            in0_sender_args[in0_in2_addr_idx] =
+                tensor_args.bias_tensor.has_value() ? tensor_args.bias_tensor.value().buffer()->address() : 0;
+            in0_sender_args[in0_in3_addr_idx] = tensor_args.optional_input_tensor.has_value() &&
+                                                        cached_program.shared_variables.read_local_slice_from_input
+                                                    ? tensor_args.optional_input_tensor.value().buffer()->address()
+                                                    : 0;
+            // Update ternary addresses if present
+            if (has_fused_ternary) {
+                in0_sender_args[in0_ternary_a_addr_idx] = tensor_args.fused_ternary_input_a.value().buffer()->address();
+                in0_sender_args[in0_ternary_b_addr_idx] = tensor_args.fused_ternary_input_b.value().buffer()->address();
+            }
+            // Update N output addresses at the end
+            for (size_t out_idx = 0; out_idx < tensor_return_value.size(); ++out_idx) {
+                in0_sender_args[in0_out_addr_start_idx + out_idx] = tensor_return_value[out_idx].buffer()->address();
+            }
+        } else {
+            auto& in0_receiver_args = in0_receiver_runtime_args[core.x][core.y];
+            in0_receiver_args[in0_in2_addr_idx] =
+                tensor_args.bias_tensor.has_value() ? tensor_args.bias_tensor.value().buffer()->address() : 0;
+            // Update ternary addresses if present
+            if (has_fused_ternary) {
+                in0_receiver_args[in0_ternary_a_addr_idx] =
+                    tensor_args.fused_ternary_input_a.value().buffer()->address();
+                in0_receiver_args[in0_ternary_b_addr_idx] =
+                    tensor_args.fused_ternary_input_b.value().buffer()->address();
+            }
+            // Update N output addresses at the end
+            for (size_t out_idx = 0; out_idx < tensor_return_value.size(); ++out_idx) {
+                in0_receiver_args[in0_out_addr_start_idx + out_idx] = tensor_return_value[out_idx].buffer()->address();
+            }
+        }
+
+        if (in0_idx == 0) {
+            auto& in1_sender_args = in1_sender_runtime_args[core.x][core.y];
+            in1_sender_args[in1_in0_addr_idx] = tensor_args.weight_tensor.buffer()->address();
+            in1_sender_args[in1_bias_addr_idx] =
+                tensor_args.bias_tensor.has_value() ? tensor_args.bias_tensor.value().buffer()->address() : 0;
+            // Update ternary addresses if present
+            if (has_fused_ternary) {
+                in1_sender_args[in1_ternary_a_addr_idx] = tensor_args.fused_ternary_input_a.value().buffer()->address();
+                in1_sender_args[in1_ternary_b_addr_idx] = tensor_args.fused_ternary_input_b.value().buffer()->address();
+            }
+            // Update N output addresses at the end
+            for (size_t out_idx = 0; out_idx < tensor_return_value.size(); ++out_idx) {
+                in1_sender_args[in1_out_addr_start_idx + out_idx] = tensor_return_value[out_idx].buffer()->address();
+            }
+        } else {
+            auto& in1_receiver_args = in1_receiver_runtime_args[core.x][core.y];
+            in1_receiver_args[in1_bias_addr_idx] =
+                tensor_args.bias_tensor.has_value() ? tensor_args.bias_tensor.value().buffer()->address() : 0;
+            // Update ternary addresses if present
+            if (has_fused_ternary) {
+                in1_receiver_args[in1_ternary_a_addr_idx] =
+                    tensor_args.fused_ternary_input_a.value().buffer()->address();
+                in1_receiver_args[in1_ternary_b_addr_idx] =
+                    tensor_args.fused_ternary_input_b.value().buffer()->address();
+            }
+            // Update N output addresses at the end
+            for (size_t out_idx = 0; out_idx < tensor_return_value.size(); ++out_idx) {
+                in1_receiver_args[in1_out_addr_start_idx + out_idx] = tensor_return_value[out_idx].buffer()->address();
+            }
+        }
+    }
+
+    // Update compute kernel runtime args for scalar
+    for (uint32_t i = 0; i < override_variables.num_cores; ++i) {
+        CoreCoord core = override_variables.cores.at(i);
+        auto& compute_args = compute_runtime_args[core.x][core.y];
+
+        // Compute RT args: [M_start, M_end, N_start, N_end, [optional: scalar]]
+        // If ternary is present and scalar arg exists, update it at index 4
+        if (has_fused_ternary && operation_attributes.fused_ternary_scalar.has_value()) {
+            float scalar = operation_attributes.fused_ternary_scalar.value();
+            uint32_t scalar_as_uint = *reinterpret_cast<const uint32_t*>(&scalar);
+            compute_args[4] = scalar_as_uint;
+        }
+    }
+}
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_fabric_bound_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_fabric_bound_program_factory.cpp
@@ -233,11 +233,7 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
     auto large_input_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
     auto large_input_risc = tt::tt_metal::DataMovementProcessor::RISCV_0;
 
-    // Transpose core grid if the output is wide (M > N)
-    // If transpose core grid, we parallelize M on cores_x and N on cores_y and swap the NOCs and RISCVs
-    // When fusing with strided reduce scatter, transposing is disabled
-    // because it resulted in slightly lower performance on a case of interest.
-    // (This can be revisited if needed.)
+    // Transpose core grid if the output is wide (M > N) If transpose core grid
     const bool fuse_srs = srs_fused_op_signaler.has_value();
     bool transpose_core_grid = M > N && !fuse_srs;
 
@@ -262,8 +258,7 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
     uint32_t padded_N_tiles;
     uint32_t N_tiles_per_core;
     if (fuse_swiglu) {
-        // Partition on gate/up PAIRS (= output tiles), so every core's weight-tile range is
-        // 2 * (pairs per core): even, and never splitting a pair across cores.
+        // Partition on gate/up PAIRS (= output tiles), so every core's weight-tile range is 2 *
         uint32_t out_N_tiles = N_tiles / 2;
         uint32_t padded_out_N_tiles = tt::round_up(out_N_tiles, in1_parallel_axis_cores);
         padded_N_tiles = 2 * padded_out_N_tiles;
@@ -281,9 +276,7 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
     uint32_t N_blocks_per_core = tt::div_up(N_tiles_per_core, N_block_tiles);
 
     if (fuse_swiglu) {
-        // The gate/up tile pairs are interleaved along N (gate=2p, up=2p+1). Every core's
-        // N range and every N block must start on an even tile and span an even number of
-        // tiles so a pair is never split across cores or blocks.
+        // The gate/up tile pairs are interleaved along N (gate=2p, up=2p+1)
         TT_FATAL(
             N_tiles % 2 == 0 && N_tiles_per_core % 2 == 0 && N_block_tiles % 2 == 0,
             "minimal_matmul fuse_swiglu requires N_tiles ({}), N_tiles_per_core ({}) and N_block_tiles ({}) all even",
@@ -302,9 +295,7 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
     uint32_t out_block_num_tiles = M_block_tiles * N_block_tiles;
     uint32_t in2_block_num_tiles = N_block_tiles;
 
-    // Sub-chunk (M-row band) count for the fused AG in0 delivery; only meaningful when fusing AG.
-    // Parsed here so the in1 scratch CB, the divisibility checks, and the per-kernel define all agree
-    // on one value.
+    // Sub-chunk (M-row band) count for the fused AG in0 delivery
     uint32_t in0_sub_chunks = 1;
     if (fuse_op) {
         if (const char* e = std::getenv("IN0_SUB_CHUNKS")) {
@@ -315,21 +306,16 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
         }
     }
     // Band-interleave: process a forward remote k-block and the following backward one one-band-at-a-time
-    // (fwd.b0, bwd.b0, ...) instead of draining each whole. Needs two k-blocks resident in the in1 scratch
-    // at once, so it also drives the scratch CB size below. Always enabled on the banded path.
     bool interleave_bands = fuse_op && in0_sub_chunks > 1;
-    // Number of leading (self/local) k-block positions this device owns (see kernels). Placeholder
-    // K_blocks when not fusing / not banding (value only consumed on the IN0_SUB_CHUNKS > 1 path).
+    // Number of leading (self/local) k-block positions this device owns (see kernels)
     uint32_t num_local_k_blocks = K_blocks;
 
     const uint32_t double_buffer_factor = 2;
     uint32_t in0_cb_num_tiles = in0_block_num_tiles * double_buffer_factor;
     uint32_t in1_cb_num_tiles = in1_block_num_tiles * double_buffer_factor;
-    // SwiGLU emits half the N tiles per block (one per gate/up pair), so the output CB only
-    // needs to hold half a block. The intermediate CB still holds the full (2N) block.
+    // SwiGLU emits half the N tiles per block (one per gate/up pair)
     uint32_t out_block_num_tiles_written = fuse_swiglu ? (out_block_num_tiles / 2) : out_block_num_tiles;
-    // out_cb_num_tiles is sized below, after split_output_write is known: the two-NoC split path only
-    // runs with a single output block per core, so it does not need the double buffer (see there).
+    // out_cb_num_tiles is sized below, after split_output_write is known: the two-NoC split path only runs
     uint32_t interm_cb_num_tiles = out_block_num_tiles;  // not double buffered
     uint32_t in2_cb_num_tiles = in2_block_num_tiles;     // not double buffered
 
@@ -359,11 +345,7 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
     tt::tt_metal::create_cb(in1_cb_id, program, core_grid, in1_tile_size, in1_cb_num_tiles, in1_data_format);
 
     {
-        // Scratch holds one K_block x N_block so the in1 injector can read it once and re-present it to
-        // compute per M-row band without re-reading DRAM (see dm_in1_sender_out.cpp). Single-buffered.
-        // Created unconditionally: the in1 dataflow always reads through it (nb == 1 when not banding).
-        // Band-interleave needs the forward and backward k-blocks of a pair resident at once, so it holds
-        // two blocks.
+        // Scratch holds one K_block x N_block so the in1 injector can read it once and re-present it to compute
         uint32_t in1_scratch_cb_id = tt::CBIndex::c_7;
         tt::tt_metal::create_cb(
             in1_scratch_cb_id,
@@ -374,39 +356,20 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
             in1_data_format);
     }
 
-    // Two-NoC output-write split: the whole-block post-loop write is split across M-rows so dm_in1 writes
-    // the low rows on NOC_1 and dm_in0 writes the high rows on NOC_0. Both DMs are idle at the write
-    // (reads/mcasts done), so no input contention and no dynamic-NoC needed. Only valid for the plain (copy)
-    // epilogue with a single output and one M-block per core (defer_write always false). split_noc1_pct
-    // (0..100) sets the percent of rows going to NOC_1 (dm_in1); the rest go to NOC_0.
+    // Two-NoC output-write split: the whole-block post-loop write is split across M-rows so dm_in1 writes the low
     const uint32_t split_noc1_pct = 50;
-    // Works with bias (compute uses add_bias_block_split; dm_in1 reads the bias since both DMs are writers)
-    // and with chunks (N_chunks > 1): compute still packs low/high M-rows into c_2/c_8 and each writer demuxes
-    // its M-row half's N columns into the chunk tensors. Not compatible with ternary/swiglu epilogues.
+    // Works with bias
     bool split_output_write = !use_fused_ternary && !fuse_swiglu && M_blocks_per_core == 1 && M_block_tiles > 1;
-    // Interleaved two-NoC output write: replace the contiguous [0, split_rows) / [split_rows, M) row split
-    // with an interleaved (ratio-preserving Bresenham) ownership so both NoC writers are fed from the first
-    // rows and overlap, instead of running back-to-back (see split_row_to_noc1 in subchunk_bands.hpp). Only
-    // the N_chunks == 1 write path is interleaved; the chunked (N_chunks > 1) path stays contiguous, so the
-    // define is gated on N_chunks == 1 below to keep compute and both DM writers consistent. Set to false to
-    // restore the contiguous split.
+    // Interleaved two-NoC output write: replace the contiguous [0, split_rows) / [split_rows
     const bool interleaved_output_write = true;
 
-    // Output CB double-buffering only earns its L1 when there is a *next* M-block for compute to work on
-    // while the writer drains the current one. When M_blocks_per_core == 1 there is exactly one output block
-    // per core, so the second buffer overlaps nothing and is dead L1 -- single-buffer it. This is the real
-    // condition (not split_output_write): it also covers the fused-ternary/addcmul epilogue, where
-    // split_output_write is false but M_blocks_per_core is still 1, so that op reclaims the buffer too. It
-    // reclaims one full output block per core (out_block_num_tiles_written tiles) -- the L1 we want back for
-    // the fabric AG buffers on the banded (IN0_SUB_CHUNKS > 1) path rather than paying for it by cutting
-    // num_buffers_per_channel. (c_8, only created on the split path, is already single-buffered.)
+    // Output CB double-buffering only earns its L1 when there is a *next* M-block for compute to work
     uint32_t out_cb_num_tiles = out_block_num_tiles_written * (M_blocks_per_core == 1 ? 1u : double_buffer_factor);
 
     uint32_t out_cb_id = tt::CBIndex::c_2;
     tt::tt_metal::create_cb(out_cb_id, program, core_grid, out_tile_size, out_cb_num_tiles, output_data_format);
     if (split_output_write) {
-        // Second output CB (c_8): the high-row half drained by dm_in0 on NOC_0. Full-block size upper-bounds
-        // the high half; total out-CB L1 stays modest.
+        // Second output CB (c_8): the high-row half drained by dm_in0 on NOC_0
         uint32_t out_cb_b_id = tt::CBIndex::c_8;
         tt::tt_metal::create_cb(
             out_cb_b_id, program, core_grid, out_tile_size, out_block_num_tiles, output_data_format);
@@ -490,8 +453,6 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
         defines["FUSE_TERNARY"] = "1";
 
         // Workaround for LLK bug (https://github.com/tenstorrent/tt-llk/issues/1338)
-        // - If ternary_b / gate is float32 then use unary_bcast (row broadcast) + mul_binary_tile (accurate)
-        // - If ternary_b / gate is bfloat16 then use mul_tiles_bcast (row broadcast) (workaround)
         if (fused_ternary_input_b.value().dtype() == DataType::FLOAT32) {
             defines["TERNARY_B_IS_FLOAT32"] = "1";
         }
@@ -501,23 +462,10 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
         // Create semaphores
         fused_op_signaler->init_fused_op(program, device, in0_sender_cores);
         defines["FUSE_AG"] = "1";
-        // Stream the in0 read in this many M-row bands (parsed above), matching the AG's per-band
-        // delivery/signal. On the IN0_SUB_CHUNKS > 1 path the matmul also matmuls + forwards per band
-        // (see compute.cpp / dm_in0_sender.cpp / dm_in1_sender_out.cpp). Must equal the AG program's
-        // IN0_SUB_CHUNKS so the per-band signal counts match.
+        // Stream the in0 read in this many M-row bands (parsed above), matching the AG's per-band delivery/signal
         defines["IN0_SUB_CHUNKS"] = std::to_string(in0_sub_chunks);
         if (in0_sub_chunks > 1) {
-            // Every band occupies a uniform in0 CB slot of (M_block_tiles / in0_sub_chunks) rows, so a
-            // ragged band (height not a multiple of subblock_h, e.g. a partial final M-block) still
-            // reserves a slot that tiles the CB exactly -- no mid-block fifo wrap. matmul reads the full
-            // subblock_h into the slot's slack rows and packs only the real rows. Two divisibility
-            // invariants make that exact:
-            //   1. in0_sub_chunks | M_block_tiles           -- uniform slot is a whole number of rows
-            //   2. subblock_h | (M_block_tiles/in0_sub_chunks) -- the deep read never runs past the slot
-            // Plus every band must be non-empty: balanced_band yields a zero band only when a block has
-            // fewer rows than in0_sub_chunks, and the in1 sender / signal aggregator fire IN0_SUB_CHUNKS
-            // times unconditionally -- a zero band would desync them against the in0/compute early-exit
-            // and deadlock. The smallest block is the (possibly partial) last one.
+            // Every band occupies a uniform in0 CB slot of (M_block_tiles / in0_sub_chunks) rows
             uint32_t last_m_block_tiles = M_tiles_per_core - (M_blocks_per_core - 1) * M_block_tiles;
             TT_FATAL(
                 last_m_block_tiles >= in0_sub_chunks,
@@ -537,10 +485,7 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
                 M_block_tiles,
                 in0_sub_chunks,
                 M_block_tiles / in0_sub_chunks);
-            // Count this device's local (self) k-blocks = the leading schedule positions the AG delivers
-            // whole (never sub-chunked). Mirrors compute_device_chunk_stats for start_ring_index. v1
-            // requires K_block_tiles-aligned device boundaries: a straddling (co-owned) k-block would
-            // break the local-first band schedule, so assert none exist.
+            // Count this device's local (self) k-blocks = the leading schedule positions the AG delivers whole
             uint32_t my_chip = fused_op_signaler->start_ring_index;
             uint32_t in_Wt = fused_op_signaler->input_tensor_Wt;
             uint32_t curr_device = 0;
@@ -570,10 +515,8 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
             num_local_k_blocks = my_count;
         }
         // Consume the middle forward/backward k-blocks 1-backward-1-forward instead of grouped
-        // (see fused_receiver_utils.hpp::compute_actual_k_block_iter).
         defines["AG_ALTERNATE_MIDDLE"] = "1";
-        // Band-interleave a forward remote k-block with the following backward one (see dm_in0_sender.cpp).
-        // Assigned to the shared defines map so in0/in1 senders and compute all agree on the paired path.
+        // Band-interleave a forward remote k-block with the following backward one (see dm_in0_sender.cpp)
         if (interleave_bands) {
             defines["AG_INTERLEAVE_BANDS"] = "1";
         }
@@ -597,10 +540,7 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
     uint32_t in0_addr = input_tensor.buffer()->address();
     uint32_t in1_addr = weight_tensor.buffer()->address();
     uint32_t in2_addr = use_bias ? bias_tensor.value().buffer()->address() : 0;
-    // Note: Dataflow kernels can take a variable number of output tensors.
-    // They are appended as a variable-length array at the end of the runtime-args:
-    //   - for in0 output-writer cores the first output address is at index 13
-    //   - for in1 output-writer cores the first output address is at index 12
+    // Note: Dataflow kernels can take a variable number of output tensors
     uint32_t in3_addr = (fuse_op && fused_op_signaler->read_local_slice_from_input)
                             ? fused_op_signaler->ag_input.value().buffer()->address()
                             : 0;
@@ -615,13 +555,11 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
      * Create kernels
      */
 
-    // Under the two-NoC split both DMs write (dm_in1 the low rows on NOC_1, dm_in0 the high rows on NOC_0);
-    // otherwise exactly one writes.
+    // Under the two-NoC split both DMs write (dm_in1 the low rows on NOC_1, dm_in0 the high rows on NOC_0)
     bool in0_is_output_writer = split_output_write ? true : !transpose_core_grid;
     bool in1_is_output_writer = split_output_write ? true : transpose_core_grid;
 
-    // Per-DM-family defines. Under the split: dm_in1 writes rows [0, split) from c_2; dm_in0 drains c_8 and
-    // writes [split, M). Both get the same split percent so their ranges line up with compute's copy.
+    // Per-DM-family defines
     auto in0_defines = defines;
     auto in1_defines = defines;
     if (split_output_write) {
@@ -870,10 +808,7 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
         max_defer_write_k_block = std::max(max_defer_write_k_block, dwk);
     }
 
-    // NOTE: Uniform per-core M/N ranges are required for DM forward handshakes to match across links.
-    // If neighboring cores along a forwarding chain iterate different (M,N) counts, the sender can wait
-    // for requests that the receiver will never issue, leading to deadlock. Keep the original uniform
-    // div_up-based ranges for M and N.
+    // NOTE: Uniform per-core M/N ranges are required for DM forward handshakes to match across links
 
     for (uint32_t core_id = 0; core_id < num_cores; ++core_id) {
         CoreCoord core = cores.at(core_id);
@@ -920,8 +855,7 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
         uint32_t N_start_tile = N_tiles_per_core * in1_idx;
         uint32_t N_end_tile = N_tiles_per_core * (in1_idx + 1);
 
-        // Defer write to K block with same coordinate as core
-        // The writer receiver cores always have core.x > 0
+        // Defer write to K block with same coordinate as core The writer receiver cores always have core.x > 0
         uint32_t defer_write_k_block = std::min(static_cast<uint32_t>(core.y) * k_blocks_per_core, K_blocks - 1);
 
         bool is_in0_sink = core == in0_core_order.back();
@@ -1136,12 +1070,7 @@ void MinimalMatmulFabricBoundProgramFactory::override_runtime_arguments(
     auto& in1_receiver_runtime_args = GetRuntimeArgs(program, override_variables.in1_receiver_kernels_id);
     auto& compute_runtime_args = GetRuntimeArgs(program, override_variables.compute_kernels_id);
 
-    // RT args layout for in0: [in0_addr, in2_addr, in3_addr, is_sink, noc_coords(4), tile_ranges(4),
-    //   defer_write_k_block, max_defer_write_k_block,
-    //   [optional: ternary_a_addr, ternary_b_addr, broadcast_ternary_b], out_addrs(N)...]
-    // RT args layout for in1: [in1_addr, in2_addr, is_sink, noc_coords(4), tile_ranges(4),
-    //   defer_write_k_block, max_defer_write_k_block,
-    //   [optional: ternary_a_addr, ternary_b_addr, broadcast_ternary_b], out_addrs(N)...]
+    // RT args layout for in0: [in0_addr, in2_addr, in3_addr, is_sink, noc_coords(4), tile_ranges(4)
     constexpr uint32_t in0_in0_addr_idx = 0;
     constexpr uint32_t in0_in2_addr_idx = 1;
     constexpr uint32_t in0_in3_addr_idx = 2;
@@ -1156,9 +1085,7 @@ void MinimalMatmulFabricBoundProgramFactory::override_runtime_arguments(
     // Check if ternary addresses are present
     bool has_fused_ternary =
         tensor_args.fused_ternary_input_a.has_value() && tensor_args.fused_ternary_input_b.has_value();
-    // Output addresses start after max_defer_write_k_block, num_local_k_blocks, and optional ternary addresses.
-    // in0: max_defer(13), num_local(14) -> outputs at 15 (+3 for ternary a/b/broadcast = 18).
-    // in1: max_defer(12), num_local(13) -> outputs at 14 (+3 for ternary = 17).
+    // Output addresses start after max_defer_write_k_block, num_local_k_blocks, and optional ternary addresses
     uint32_t in0_out_addr_start_idx = has_fused_ternary ? 18 : 15;
     uint32_t in1_out_addr_start_idx = has_fused_ternary ? 17 : 14;
 
@@ -1240,8 +1167,7 @@ void MinimalMatmulFabricBoundProgramFactory::override_runtime_arguments(
         CoreCoord core = override_variables.cores.at(i);
         auto& compute_args = compute_runtime_args[core.x][core.y];
 
-        // Compute RT args: [M_start, M_end, N_start, N_end, [optional: scalar]]
-        // If ternary is present and scalar arg exists, update it at index 4
+        // Compute RT args: [M_start, M_end, N_start, N_end, [optional: scalar]] If ternary is present and scalar arg
         if (has_fused_ternary && operation_attributes.fused_ternary_scalar.has_value()) {
             float scalar = operation_attributes.fused_ternary_scalar.value();
             uint32_t scalar_as_uint = *reinterpret_cast<const uint32_t*>(&scalar);

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_fabric_bound_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_fabric_bound_program_factory.hpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "minimal_matmul_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct MinimalMatmulFabricBoundProgramFactory {
+    struct shared_variables_t {
+        uint32_t num_cores{};
+        std::vector<CoreCoord> cores;
+        tt::tt_metal::KernelHandle in0_sender_kernels_id{};
+        tt::tt_metal::KernelHandle in0_receiver_kernels_id{};
+        tt::tt_metal::KernelHandle in1_sender_kernels_id{};
+        tt::tt_metal::KernelHandle in1_receiver_kernels_id{};
+        tt::tt_metal::KernelHandle compute_kernels_id{};
+        bool transpose_core_grid{};
+        bool read_local_slice_from_input{};
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const MinimalMatmulParams& operation_attributes,
+        const MinimalMatmulInputs& tensor_args,
+        std::vector<Tensor>& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const MinimalMatmulParams& operation_attributes,
+        const MinimalMatmulInputs& tensor_args,
+        std::vector<Tensor>& tensor_return_value);
+};
+
+MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric_bound_factory_helper(
+    tt::tt_metal::Program& program,
+    const Tensor& input_tensor,
+    const Tensor& weight_tensor,
+    const std::optional<const Tensor>& bias_tensor,
+    const std::optional<operations::unary::UnaryWithParam>& fused_activation,
+    const std::optional<const MinimalMatmulConfig>& config,
+    const Tensor& output_tensor,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    std::optional<ttnn::experimental::ccl::MinimalMatmulFusedOpSignaler>& fused_op_signaler,
+    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler>& srs_fused_op_signaler,
+    bool fuse_swiglu = false);
+
+// Shared implementation for variable number of output tensors (used by both minimal_matmul and minimal_matmul_split)
+// Unlike minimal_matmul_fabric_bound_factory_helper, this function takes a number of output tensors as an argument
+// (N_chunks) and a vector of output tensors.
+MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric_bound_factory_helper_common(
+    tt::tt_metal::Program& program,
+    const Tensor& input_tensor,
+    const Tensor& weight_tensor,
+    const std::optional<const Tensor>& bias_tensor,
+    const std::optional<operations::unary::UnaryWithParam>& fused_activation,
+    const std::optional<const MinimalMatmulConfig>& config,
+    const std::vector<Tensor>& output_tensors,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    std::optional<ttnn::experimental::ccl::MinimalMatmulFusedOpSignaler>& fused_op_signaler,
+    uint32_t N_chunks,
+    std::optional<float> fused_ternary_scalar = std::nullopt,
+    const std::optional<const Tensor>& fused_ternary_input_a = std::nullopt,
+    const std::optional<const Tensor>& fused_ternary_input_b = std::nullopt,
+    std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler> srs_fused_op_signaler = std::nullopt,
+    bool fuse_swiglu = false);
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_fabric_bound_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_fabric_bound_program_factory.hpp
@@ -49,9 +49,7 @@ MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric
     std::optional<ttnn::experimental::ccl::StridedReduceScatterFusedOpSignaler>& srs_fused_op_signaler,
     bool fuse_swiglu = false);
 
-// Shared implementation for variable number of output tensors (used by both minimal_matmul and minimal_matmul_split)
-// Unlike minimal_matmul_fabric_bound_factory_helper, this function takes a number of output tensors as an argument
-// (N_chunks) and a vector of output tensors.
+// Shared implementation for variable number of output tensors
 MinimalMatmulFabricBoundProgramFactory::shared_variables_t minimal_matmul_fabric_bound_factory_helper_common(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -788,8 +788,7 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
             }
             in0_args.push_back(static_cast<uint32_t>(srs_fused_op_signaler->fused_op_receiver_signal_semaphore));
             in0_args.push_back(1);  // mcast_signal_op_cores
-            // Per-core signaling: L1 base of the RS cores' per-MM-core progress counter array. Read
-            // by the sender right after constructing its OpSignaler; each MM core increments its own slot.
+            // Per-core signaling: L1 base of the RS cores' per-MM-core progress counter array
             in0_args.push_back(static_cast<uint32_t>(srs_fused_op_signaler->mm_progress_counters_addr));
         }
         if (in1_idx == 0) {
@@ -844,8 +843,7 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
             }
             in1_args.push_back(static_cast<uint32_t>(srs_fused_op_signaler->fused_op_receiver_signal_semaphore));
             in1_args.push_back(1);  // mcast_signal_op_cores
-            // Per-core signaling: L1 base of the RS cores' per-MM-core progress counter array. Read
-            // by the sender right after constructing its OpSignaler; each MM core increments its own slot.
+            // Per-core signaling: L1 base of the RS cores' per-MM-core progress counter array
             in1_args.push_back(static_cast<uint32_t>(srs_fused_op_signaler->mm_progress_counters_addr));
         }
         if (in0_idx == 0) {

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -788,6 +788,9 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
             }
             in0_args.push_back(static_cast<uint32_t>(srs_fused_op_signaler->fused_op_receiver_signal_semaphore));
             in0_args.push_back(1);  // mcast_signal_op_cores
+            // Per-core signaling: L1 base of the RS cores' per-MM-core progress counter array. Read
+            // by the sender right after constructing its OpSignaler; each MM core increments its own slot.
+            in0_args.push_back(static_cast<uint32_t>(srs_fused_op_signaler->mm_progress_counters_addr));
         }
         if (in1_idx == 0) {
             // in0 sender
@@ -841,6 +844,9 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
             }
             in1_args.push_back(static_cast<uint32_t>(srs_fused_op_signaler->fused_op_receiver_signal_semaphore));
             in1_args.push_back(1);  // mcast_signal_op_cores
+            // Per-core signaling: L1 base of the RS cores' per-MM-core progress counter array. Read
+            // by the sender right after constructing its OpSignaler; each MM core increments its own slot.
+            in1_args.push_back(static_cast<uint32_t>(srs_fused_op_signaler->mm_progress_counters_addr));
         }
         if (in0_idx == 0) {
             // in1 sender

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/sources.cmake
@@ -12,6 +12,7 @@ set(TTNN_OP_EXPERIMENTAL_MINIMAL_MATMUL_SRCS
     minimal_matmul_split.cpp
     device/minimal_matmul_device_operation.cpp
     device/minimal_matmul_program_factory.cpp
+    device/minimal_matmul_fabric_bound_program_factory.cpp
 )
 
 # Registered on the shared `ttnn` Python module target from

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
@@ -16,6 +16,13 @@ struct RingSDPAOpReceiver {
     std::array<uint32_t, 2> signal_op_semaphore_ids = {0, 0};
     bool initialized = false;
 
+    // Even-ring split-forwarding: the diametric shard arrives split across both links and is signaled
+    // on both direction semaphores. Its second half is the extra increment on direction 1's all-gather
+    // semaphore (index 0); the step that releases the split shard must wait for it before compute reads.
+    bool split_forwarding_enabled = false;
+    uint32_t split_shard_id = 0;
+    uint32_t split_second_half_wait = 0;
+
     RingSDPAOpReceiver() {}
 
     RingSDPAOpReceiver(bool wait_for_op_signal, uint32_t& rt_args_idx) : wait_for_op_signal(wait_for_op_signal) {
@@ -29,6 +36,9 @@ struct RingSDPAOpReceiver {
             signal_op_semaphore_ids[1] = get_arg_val<uint32_t>(rt_args_idx++);
             // Second is AllGather's FWD semaphore. It belongs to direction 0.
             signal_op_semaphore_ids[0] = get_arg_val<uint32_t>(rt_args_idx++);
+            split_forwarding_enabled = get_arg_val<uint32_t>(rt_args_idx++) == 1;
+            split_shard_id = get_arg_val<uint32_t>(rt_args_idx++);
+            split_second_half_wait = get_arg_val<uint32_t>(rt_args_idx++);
         }
 
         seq = RingIdSequencer(ring_index, ring_size, backward_writes_expected, forward_writes_expected);
@@ -37,11 +47,17 @@ struct RingSDPAOpReceiver {
 
     uint32_t get_next_ring_id_and_sync() {
         ASSERT(initialized);
-        return seq.get_next_ring_id([&](uint32_t dir, uint32_t val) {
+        uint32_t ring_id = seq.get_next_ring_id([&](uint32_t dir, uint32_t val) {
             if (this->wait_for_op_signal) {
                 Semaphore<>(this->signal_op_semaphore_ids[dir]).wait_min(val);
             }
         });
+        // The split shard's second half lands via direction 1 (all-gather semaphore index 0). The
+        // sequencer only waits one direction per step, so wait the second half here explicitly.
+        if (this->wait_for_op_signal && this->split_forwarding_enabled && ring_id == this->split_shard_id) {
+            Semaphore<>(this->signal_op_semaphore_ids[0]).wait_min(this->split_second_half_wait);
+        }
+        return ring_id;
     }
 
     uint32_t get_next_ring_id_and_consume_one_signal() {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
@@ -16,9 +16,7 @@ struct RingSDPAOpReceiver {
     std::array<uint32_t, 2> signal_op_semaphore_ids = {0, 0};
     bool initialized = false;
 
-    // Even-ring split-forwarding: the diametric shard arrives split across both links and is signaled
-    // on both direction semaphores. Its second half is the extra increment on direction 1's all-gather
-    // semaphore (index 0); the step that releases the split shard must wait for it before compute reads.
+    // Even-ring split-forwarding: the diametric shard arrives split across both links and is signaled on both
     bool split_forwarding_enabled = false;
     uint32_t split_shard_id = 0;
     uint32_t split_second_half_wait = 0;
@@ -52,8 +50,7 @@ struct RingSDPAOpReceiver {
                 Semaphore<>(this->signal_op_semaphore_ids[dir]).wait_min(val);
             }
         });
-        // The split shard's second half lands via direction 1 (all-gather semaphore index 0). The
-        // sequencer only waits one direction per step, so wait the second half here explicitly.
+        // The split shard's second half lands via direction 1 (all-gather semaphore index 0)
         if (this->wait_for_op_signal && this->split_forwarding_enabled && ring_id == this->split_shard_id) {
             Semaphore<>(this->signal_op_semaphore_ids[0]).wait_min(this->split_second_half_wait);
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
@@ -69,5 +69,17 @@ void RingSDPAFusedOpSignaler::push_ring_sdpa_fused_op_rt_args(std::vector<uint32
     out_rt_args.push_back(static_cast<uint32_t>(this->backward_writes_expected));
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[0]));
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[1]));
+
+    // Even-ring split-forwarding: the diametric shard S arrives split across both links. Direction 1
+    // (all-gather semaphore index 0) carries its second half as one extra signal, so the SDPA reader
+    // must wait backward_writes_expected + 1 on that semaphore at S's step. S is direction 1's
+    // terminal received shard: ring_index + backward_writes_expected + 1 (== ring_index - num_targets
+    // _forward, mod ring_size). Values are ignored downstream when split_forwarding_enabled is false.
+    const uint32_t split_shard_id =
+        this->ring_size ? ((this->ring_index + this->backward_writes_expected + 1) % this->ring_size) : 0;
+    const uint32_t split_second_half_wait = this->backward_writes_expected + 1;
+    out_rt_args.push_back(static_cast<uint32_t>(this->split_forwarding_enabled ? 1 : 0));
+    out_rt_args.push_back(static_cast<uint32_t>(split_shard_id));
+    out_rt_args.push_back(static_cast<uint32_t>(split_second_half_wait));
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
@@ -70,11 +70,7 @@ void RingSDPAFusedOpSignaler::push_ring_sdpa_fused_op_rt_args(std::vector<uint32
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[0]));
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[1]));
 
-    // Even-ring split-forwarding: the diametric shard S arrives split across both links. Direction 1
-    // (all-gather semaphore index 0) carries its second half as one extra signal, so the SDPA reader
-    // must wait backward_writes_expected + 1 on that semaphore at S's step. S is direction 1's
-    // terminal received shard: ring_index + backward_writes_expected + 1 (== ring_index - num_targets
-    // _forward, mod ring_size). Values are ignored downstream when split_forwarding_enabled is false.
+    // Even-ring split-forwarding: the diametric shard S arrives split across both links
     const uint32_t split_shard_id =
         this->ring_size ? ((this->ring_index + this->backward_writes_expected + 1) % this->ring_size) : 0;
     const uint32_t split_second_half_wait = this->backward_writes_expected + 1;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
@@ -24,6 +24,11 @@ struct RingSDPAFusedOpSignaler {
     uint32_t forward_writes_expected = 0;
     uint32_t backward_writes_expected = 0;
 
+    // Set by the program factory when the all-gather relays the diametric slice split across both
+    // links (even ring, size > 2). Must match the all-gather kernels' gate exactly. Drives the SDPA
+    // reader's dual-half wait on the split shard.
+    bool split_forwarding_enabled = false;
+
     bool initialized_all_gather = false;
     bool initialized_fused_op = false;
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
@@ -24,9 +24,7 @@ struct RingSDPAFusedOpSignaler {
     uint32_t forward_writes_expected = 0;
     uint32_t backward_writes_expected = 0;
 
-    // Set by the program factory when the all-gather relays the diametric slice split across both
-    // links (even ring, size > 2). Must match the all-gather kernels' gate exactly. Drives the SDPA
-    // reader's dual-half wait on the split shard.
+    // Set by the program factory when the all-gather relays the diametric slice split across both links
     bool split_forwarding_enabled = false;
 
     bool initialized_all_gather = false;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -1182,6 +1182,13 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         sdpa_fused_op_signaler->initialized_fused_op = true;
     }
 
+    // Must match the all-gather kernels' split-forwarding gate exactly (ring geometry only) so the
+    // SDPA reader's dual-half wait and the kernels agree on whether the diametric slice is split.
+    sdpa_fused_op_signaler->split_forwarding_enabled =
+        (args.all_gather_operation_attributes.topology == ttnn::ccl::Topology::Ring) &&
+        (args.all_gather_operation_attributes.ring_size % 2 == 0) &&
+        (args.all_gather_operation_attributes.ring_size > 2);
+
     log_debug(tt::LogOp, "num_cores: {}", num_cores);
     log_debug(
         tt::LogOp, "mesh_device->compute_with_storage_grid_size(): {}", mesh_device->compute_with_storage_grid_size());

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -1182,8 +1182,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         sdpa_fused_op_signaler->initialized_fused_op = true;
     }
 
-    // Must match the all-gather kernels' split-forwarding gate exactly (ring geometry only) so the
-    // SDPA reader's dual-half wait and the kernels agree on whether the diametric slice is split.
+    // Must match the all-gather kernels' split-forwarding gate exactly
     sdpa_fused_op_signaler->split_forwarding_enabled =
         (args.all_gather_operation_attributes.topology == ttnn::ccl::Topology::Ring) &&
         (args.all_gather_operation_attributes.ring_size % 2 == 0) &&


### PR DESCRIPTION
# [Feature] LTX-2.3 distilled AV pipeline: fabric-bound AGMM/MMRS and neighbor-pad halo conv3d

### PR Category

Feature

---

## Summary

Brings the LTX-2.3 distilled two-stage audio-video pipeline up on a Blackhole
4x8 galaxy (32 chips, `FABRIC_1D_RING`, `num_links=2`) at **6.1 s end-to-end
compute** for a 6 s 1920x1088 video. Reaching that needed new CCL and matmul
machinery rather than model-level tuning, so most of the diff is ops:
`127 files changed, 14665 insertions(+), 761 deletions(-)` across 26 commits,
including 11 new device kernels and 4 new kernel headers.

**No changes to existing public APIs.** New ops land under
`ttnn.experimental.*`; existing signatures gain optional parameters only
(`fused_ternary_input_a/b`, `mm_progress_counters`, `num_ag_workers`), each
defaulting to prior behavior.

Each subsection below ends with the commits it covers, so a reviewer can read the
rationale and then go straight to the diff. Subjects are given alongside the
short SHAs because the SHAs move on every rebase.

### Fused CCL + matmul: overlapping the collective with the math

The pipeline's cost is dominated by TP matmuls whose operands must be gathered
or whose results must be scattered. Previously the collective completed into
DRAM and the matmul then read it back — the collective and the math never
overlapped, and the round-trip itself cost DRAM/NoC bandwidth.

Three pieces remove that serialization:

**Per-worker, per-core signaling.** `AllGatherFusedOpSignaler` generalizes from
a fixed 3-semaphore layout to `2N+1` —
`[backward_0..N-1, forward_0..N-1, self]` where `N = num_ag_workers`. Each
all-gather worker increments its own semaphore, so a consumer can wait on all N
portions of a k-block rather than a single aggregated per-direction signal.
`N=1` reproduces the legacy layout byte-for-byte, so existing callers are
untouched. A second mechanism, `signal_op_per_core`, drops the worker barrier
entirely: each worker bumps its own slot in a per-core counter array on every
receiver core and continues, so per-block skew flows into the consumer's
pipeline instead of stalling the whole grid. Producer and consumer must derive
the same row-major core index for this to be correct.

**Banded all-gather delivery.** The strided all-gather now splits each chunk
into M-row bands, letting the matmul start on a partial k-block. An
interleaved-middle schedule runs two independent direction cursors so the middle
forward/backward region is consumed one-backward-one-forward rather than drained
as whole-device groups, with each cursor preserving its within-direction order so
the monotonic per-direction semaphores stay valid. Interleaving is disabled when
any k-block straddles a device boundary (`expected == 2`), because two devices
co-complete such a block on different direction passes and interleaving would
reorder those pair-completions.

**A matmul-signal aggregator.** One aggregator core per all-gather direction on
the receiving device. Each of the N writer workers fabric-increments its own
semaphore there as its portion lands (ordered after the data on that worker's
connection); the aggregator waits for all N, then increments the matmul's single
direction semaphore once. The matmul is decoupled from the AG reader's forwarding
pace while its cores still see only 3 semaphores. The aggregator's iteration
cadence deliberately mirrors the reader's remote-receive loop so the number and
order of matmul signals match the legacy reader-signaled path exactly.

Transport-level additions: scatter-write packs up to 4 tiles with distinct
destination NoC addresses per fabric packet, capped by real per-packet page
capacity so 4 degrades gracefully; the worker-to-fabric path moves to Mux V2
(dual-RISC forwarder + manager); and on an even ring the diametric slice is
split-forwarded across both links, with direction 1 receiving and relaying one
extra half. Split-forwarding is gated on
`Ring && ring_size % 2 == 0 && ring_size > 2`. The same even-ring split applies
to ring-attention all-gather.

*Commits:* `7d0bf83f638` ccl: per-core op signaling · `94be2d93adb` M-row bands
with per-band signaling · `1d0753984c8` matmul-signal aggregator core ·
`0edf8dfccf8` split-forward the diametric slice · `24820812bc8` SCATTER4, mux v2
sender, aggregator placement

### Fabric-bound minimal-matmul

A matmul variant that consumes `in0` directly from fabric-delivered bands
instead of a completed DRAM tensor — 3 new kernels plus a shared dataflow header
and a 1,179-line program factory. The dataflow primitives that make it work:
block reads that can skip the completion barrier so band *s*'s reads stay in
flight while band *s+1* is awaited (a single barrier after the last band),
CB-base byte offsets so bands land in their own slots rather than the base, and a
row-ownership predicate for an interleaved two-NoC output write that overlaps row
writes instead of running them back-to-back.

Band-interleave processes a forward remote k-block and the following backward one
a band at a time (`fwd.b0, bwd.b0, …`) rather than draining each whole; this
requires two k-blocks resident in the in1 scratch simultaneously, which is what
sizes that CB. The in1 scratch also lets compute run per band without re-reading
DRAM, and is created unconditionally (`nb == 1` when not banding) so the in1
dataflow keeps a single code path.

Hooking this into the default factory also fixed two latent issues: compile-time
arg offsets were advanced by a fixed `NUM_TENSOR_ACCESSOR_ARGS()` multiple even
though accessor arg counts are tensor-config dependent (now
`get_tensor_accessor_args_cta_offset<N, offset>()` /
`next_compile_time_args_offset()`), and a deferred-write branch fired on the
fused RS path where `defer_write` is false.

*Commits:* `9f13f79c798` fabric-bound kernel variants · `28f7e5876cb`
fabric-bound program factory · `0ce0be2ef53` hook the fabric-bound path into the
default factory (also carries the two fixes above)

### sAGMM and MMRS

**`strided_all_gather_minimal_matmul_async`** wires the fabric-bound factory in
and adds the core placement it needs: fabric senders sit beside the mux at the
in0 chain's far (high-coordinate) end, with the sender index on the axis
perpendicular to the chain so senders up to `full_grid_size.y - 1` hops from
their mux funnel their writes together. Forward and backward senders each bind to
one direction's mux. It also gains a fused addcmul epilogue,
`out = ternary_a + scalar * matmul_out * ternary_b`; supplying both ternary
inputs enables `FUSE_TERNARY`, with the scalar riding in `matmul_struct`.

**`minimal_matmul_strided_reduce_scatter_async`** fuses matmul with strided
reduce-scatter and hands the matmul output off in L1: the output is block-sharded
across the matmul core grid so the RS reader's `TensorAccessor` reads it straight
from the matmul cores' L1, removing the ~M*N DRAM write plus read that was
driving DRAM/NoC contention. RS intermediate and output specs keep their DRAM
config.

Its progress signaling is per-core rather than aggregate: a flat L1 array of
`mm_cores_x * mm_cores_y` uint32 counters, at the same L1 address on every RS
worker core. Each MM core increments its own slot per completed output block and
the RS reader waits **per tile** on the slot of the core that produced that tile,
so a fast MM core never stalls behind a slow peer. Counters are monotonic across
batches; the reader zeroes them at kernel start, which is safe because both
kernels launch together while the MM's first signal is a full output block
(~100 us) away.

That array is allocated once by `CCLManager` and shared across all MMRS programs
rather than per program. Per-program arrays are retained for each program's
cached life, and because L1 is handed out top-down each small permanent block
pins the freed space above it — after enough cached MMRS programs a later op (the
VAE's ring joint SDPA) has no contiguous L1 left for its circular buffers. The
shared array's address is baked into reader and MM runtime args at build time and
never re-pointed, so it must be allocated once and stay at that address for the
life of every cached program that uses it; a `TT_FATAL` enforces this.

*Commits:* `e6825dacd08` sagmm: fabric-bound all-gather-matmul op · `1e15644b257`
mmrs: strided reduce-scatter with L1 hand-off · `e94c6da4633` mmrs: share one L1
progress counter across all MMRS programs · `6e2cf646bcd` restore the 8 KB fabric
payload on the traced 4x8 ring config

### Neighbor-pad halo and conv3d

Spatially sharded conv3d needs its neighbors' rows and columns. Two new ops
provide that:

**`neighbor_pad_halo`** exchanges halo rows/columns between neighbors and writes
only the compact halo buffer `[H-top | H-bot | W-left | W-right]` — no interior
copy. H and W exchanges are separated so the W pass is H-independent: H rows
first (`nf * input_H_dev`), then corner rows (`nf * 2 * padding_h`). The
halo-buffer addressing helper is shared between the W reader and W writer
specifically so the two cannot drift. Zero-padding covers both in-place
border-only fill on an already-padded buffer and a repack that grows H and W.

**`halo_scatter`** writes the exchanged halo into a persistent padded activation,
so a conv3d that wants a fully padded input gets one without a per-step interior
copy.

**Standalone conv3d** gains halo-mode reads — the conv reads its boundary taps
straight from the compact halo buffer instead of a materialized padded tensor —
plus a padded-output mode (allocate a spatially padded output, writer fills only
the interior), opt-in logical-pad masking on the halo path, and conservative
default blocking under two stated constraints:
`kernel_vol * C_in_block ≡ 0 (mod TILE_WIDTH)` for weight tile alignment and
`C_in_block % l1_alignment == 0`.

*Commits:* `4200ad1e254` neighbor-pad: halo exchange op for spatially-sharded
conv3d · `62728d6b75b` conv3d: halo-mode reads and per-shape blocking

### Supporting ops

**Cross-padded joint ring SDPA**, plus the even-ring split-forwarding described
above, so the VAE's joint attention runs on the same ring topology as the rest of
the pipeline.

*Commits:* `844408f7c9b` sdpa: ring-attention all-gather and cross-padded joint
SDPA

### LTX model wiring

VAE conv3d routes through `neighbor_pad_halo` + `halo_scatter` into a standalone
conv3d. `get_conv3d_config` carries a per-shape table marking shapes `halo_last`
(interior-then-boundary two-pass) or `force_spatial_parallel`, so the interior
conv pass hides the halo exchange. Those entries carry their measured numbers
in-comment.

The per-head attention gate folds into the QKV/Q matmul via variable-width
chunks, honored only on the fused AGMM path (TP>1 on Ring) with a standalone gate
op elsewhere; the gate is `num_heads/TP` columns per device (sub-tile), padded to
a whole tile so it is a legal chunk.

`CCLManager` gains halo-buffer geometry derivation, per-call halo buffer
addressing, and a fixed 16-slot region/link config array
(`[region * num_links + link]`, zero-padded). `LTX_YUV_EXPORT` routes the mp4
path through a device-side gather built on the existing
`ttnn.experimental.rgb_to_yuv`, keeping the color conversion off the host; the
mp4 is `yuv420p` either way.

`run_safe_pytest.sh` becomes configurable: `SAFE_PYTEST_DISPATCH_TIMEOUT` (the
5 s default false-trips on full-mesh fabric ops like a 4x8 ring all-gather) and
`SAFE_PYTEST_RESET_CMD` (a 4x8 galaxy needs `tt-smi -glx_reset`).

*Commits:* `1013a420250` route VAE conv3d through halo CCL ops · `199f735915e`
fold the per-head attention gate into the QKV/Q matmul · `90cd402e022` on-device
YUV export and planar concat · `48d0a4c4e92` wire the distilled AV pipeline to the
fast decode path · `fe2c17ac35b` parallel-config plumbing for halo and
fabric-bound ops · `1ddddacb45f` build: register the new experimental ops ·
`6a97eef5bf5` give the two-stages Pro test the vocoder's L1_SMALL pool ·
`0a94f8f7092` comments: collapse multi-line explanatory blocks to one line

---

## Test results

Blackhole galaxy, 32 chips, 4x8 mesh, 12x10 compute grid, `FABRIC_1D_RING`,
`num_links=2`, `l1_small_size=32768`, `trace_region_size=500M`.

**LTX distilled 4x8 ring**, `LTX_TRACED=1 RUN_WARMUP=1 LTX_YUV_EXPORT=1`:

| | cold | warm (traced) |
|---|---|---|
| Stage 1 denoise (544x960, 8 steps) | 15.6 s | 2.3 s |
| Stage 2 denoise (1088x1920, 3 steps) | 15.1 s | 2.6 s |
| **Total (compute)** | 45.1 s | **6.1 s** |

`pytest models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py -k
"4x8sp1tp0nl2_ring_is_fsdp0 and not i2v"` — 1 passed.

**MMRS unit test**, `ltx_ff2 4864x4096x4096`, b457 blocking, fabric_ring, fused,
axis_1 — 1 passed, PCC 0.99998 across all devices.

New coverage across strided AGMM (including variable-chunk), MMRS, neighbor-pad
halo, ring joint SDPA including cross-padded, and the LTX pipeline and
transformer.

*Commits:* `11706fde128` test: ltx pipeline and transformer coverage ·
`1ad197d72fd` test: wan2_2 neighbor-pad, conv3d and AGMM coverage ·
`2935bb79b0b` test: coverage for sAGMM, MMRS, halo and joint-SDPA ops

---

## Notes for reviewers

**Where to focus.** The fabric-bound kernels and their program factory are ~3,800
lines with no top-level design comment; the band pipeline's architecture is the
hardest thing here to review and would benefit most from a design note.

**Blackhole-specific DRAM bank count.** The neighbor-pad halo kernels
(`np_h_reader.cpp`, `np_h_mux_writer.cpp`, `np_phase2_w_reader.cpp`) hardcode
`constexpr uint32_t NP_NUM_DRAM_BANKS = 8` to drive their bank-strided coalescing
loops. That matches Blackhole, which is the only platform this has been brought
up on, but it should become a compile-time arg from the device before the op is
used elsewhere.

**Shared MMRS counter lifetime.** The shared L1 progress-counter address is baked
into runtime args and never rebound, so correctness depends on the allocation
outliving every cached program that references it. This is enforced by a
`TT_FATAL` rather than by rebinding on `override_runtime_arguments`; rebinding
would be the more robust design.

---

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nwoodall/ltx-mmrs-l1-counter-2026-08-05)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nwoodall/ltx-mmrs-l1-counter-2026-08-05)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nwoodall/ltx-mmrs-l1-counter-2026-08-05)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nwoodall/ltx-mmrs-l1-counter-2026-08-05)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nwoodall/ltx-mmrs-l1-counter-2026-08-05)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nwoodall/ltx-mmrs-l1-counter-2026-08-05)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nwoodall/ltx-mmrs-l1-counter-2026-08-05)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nwoodall/ltx-mmrs-l1-counter-2026-08-05)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nwoodall/ltx-mmrs-l1-counter-2026-08-05)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nwoodall/ltx-mmrs-l1-counter-2026-08-05)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nwoodall/ltx-mmrs-l1-counter-2026-08-05)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nwoodall/ltx-mmrs-l1-counter-2026-08-05)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nwoodall/ltx-mmrs-l1-counter-2026-08-05)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nwoodall/ltx-mmrs-l1-counter-2026-08-05)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nwoodall/ltx-mmrs-l1-counter-2026-08-05)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nwoodall/ltx-mmrs-l1-counter-2026-08-05)