### PR TITLE
fix(ttnn): softplus golden drops beta and threshold

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -211,6 +211,13 @@ def run_activation_softplus_test(device, h, w, beta, threshold, ttnn_function, p
     golden_function = ttnn.get_golden_function(ttnn_function)
     torch_output_tensor = golden_function(torch_input_tensor_a, beta=beta, threshold=threshold)
 
+    # The golden must honour beta/threshold -- same reference the non-sharded
+    # sweep builds by hand (sweeps/eltwise/unary/softplus/softplus.py:72).
+    assert torch.equal(
+        torch_output_tensor,
+        torch.nn.functional.softplus(torch_input_tensor_a, beta=beta, threshold=threshold),
+    )
+
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
     )

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -207,6 +207,15 @@ def _golden_function_gelu(input_tensor, *args, variant=None, fast_and_approximat
 ttnn.attach_golden_function(ttnn.gelu, golden_function=_golden_function_gelu)
 
 
+def _golden_function_softplus(input_tensor_a, *args, beta=1.0, threshold=20.0, **kwargs):
+    import torch
+
+    return torch.nn.functional.softplus(input_tensor_a, beta=beta, threshold=threshold)
+
+
+ttnn.attach_golden_function(ttnn.softplus, golden_function=_golden_function_softplus)
+
+
 def _golden_function_asin(input_tensor_a, *args, device, **kwargs):
     import torch
 


### PR DESCRIPTION
## (a) Files and exact lines

### The defect

| File | Line | What is there |
|---|---|---|
| `ttnn/ttnn/operations/unary.py` | `:10` | `def _golden_function(input_tensor: ttnn.Tensor, **_):` — the generic signature that swallows every keyword |
| `ttnn/ttnn/operations/unary.py` | `:87` | `"softplus": torch.nn.functional.softplus,` — the map entry, correct in itself |
| `ttnn/ttnn/operations/unary.py` | `:109-114` | the `golden_keys != function_names` → `ImportError` consistency check |
| `ttnn/ttnn/operations/unary.py` | `:116-117` | `torch_function = name_to_golden_function[...]` / `return torch_function(input_tensor)` — **one argument, this is the loss** |
| `ttnn/ttnn/operations/unary.py` | `:119` | `ttnn.attach_golden_function(unary_function, golden_function=_golden_function)` |
| `ttnn/ttnn/operations/unary.py` | `:170` | `ttnn.softplus,` inside `TTNN_ELTWISE_UNARY_CPP_FUNCTIONS` |
| `ttnn/ttnn/operations/unary.py` | `:192-193` | the registration loop |

### Edit point 1 — `ttnn/ttnn/operations/unary.py`, insert after line `:209`

Immediately after `ttnn.attach_golden_function(ttnn.gelu, golden_function=_golden_function_gelu)`
(`:207`) and its two blank lines, i.e. just before `def _golden_function_asin` (`:210`). **+9 lines.**

### Edit point 2 — `tests/ttnn/unit_tests/operations/eltwise/test_activation.py`, insert after line `:212`

Inside `run_activation_softplus_test` (`:207-223`), right after
`torch_output_tensor = golden_function(torch_input_tensor_a, beta=beta, threshold=threshold)`.
**+7 lines.**

### Where the correct shape already exists in this repo

| Location | Why it is the argument |
|---|---|
| `ttnn/ttnn/operations/unary.py:196-207` — `_golden_function_gelu` | **Same file, 11 lines above.** Same idiom: a dedicated golden attached *after* the loop, overriding the generic one, precisely because the generic one drops a parameter. Its map entry (`:83 "gelu"`) is left in place too, dead, for the `:109-114` check. |
| `ttnn/ttnn/operations/unary.py:309-315` — `_golden_function_elu` | The literal signature shape being copied: `(input_tensor_a, *args, alpha=1.0, **kwargs)`, default mirroring the binding. Same at `:318-324` (`hardtanh`) and `:327-333` (`leaky_relu`). |
| `ttnn/ttnn/operations/unary_backward.py:287-300` — softplus **backward** golden | `def _golden_function(grad_tensor, input_tensor, beta=None, threshold=None, ...)` forwards both. **The backward already does what this PR does to the forward.** |
| Issue **#6493** *"Update backward softplus with beta and threshold param"* (closed 2024-03-19) | The same fix, on the backward, already accepted. |
| `tests/sweep_framework/sweeps/eltwise/unary/softplus/softplus.py:72` | The sibling non-sharded sweep builds the reference by hand: `torch.nn.functional.softplus(x, beta=beta, threshold=threshold)`. **The same test family contains both the right and the wrong reference.** |

### The three independent sources that say the parameters are real

| Source | Line | Text |
|---|---|---|
| Binding docs | `unary_nanobind.cpp:717-718` | `beta (float, optional): Scales the input before applying the Softplus function…` / `threshold (float, optional): Used to switch to a linear function for large values…` |
| Binding signature | `unary_nanobind.cpp:744-746` | `nb::kw_only(),` then `nb::arg("beta") = 1.0f,` `nb::arg("threshold") = 20.0f,` |
| Kernel | `unary_op_utils.cpp:532` and `:535-537` | `TT_ASSERT(params.size() == 2, "Expected softplus to take 2 parameters");` then emits `softplus_tile(...)` |

`nb::kw_only()` at `:744` is why the new golden makes both parameters keyword-only: they can never
arrive positionally through the public API.

---

## (b) Old code and new code, literal

### File 1 — `ttnn/ttnn/operations/unary.py`

**Old** (`:192-210`, unchanged, shown only as the anchor):

```python
for unary_function in TTNN_ELTWISE_UNARY_CPP_FUNCTIONS:
    register_ttnn_cpp_unary_function(unary_function)


def _golden_function_gelu(input_tensor, *args, variant=None, fast_and_approximate_mode=False, **kwargs):
    import torch

    # Only variant=Tanh changes the *mathematical* function; the legacy
    # fast_and_approximate_mode=True is the LUT approximation of exact GELU
    # (~1% absolute error), which can't be modelled as a closed form — fall
    # back to exact GELU as the reference for it too.
    approximate = "tanh" if variant == ttnn.GeluVariant.Tanh else "none"
    return torch.nn.functional.gelu(input_tensor, approximate=approximate)


ttnn.attach_golden_function(ttnn.gelu, golden_function=_golden_function_gelu)


def _golden_function_asin(input_tensor_a, *args, device, **kwargs):
```

**New** — insert this block between `ttnn.attach_golden_function(ttnn.gelu, ...)` and
`def _golden_function_asin`:

```python
def _golden_function_softplus(input_tensor_a, *args, beta=1.0, threshold=20.0, **kwargs):
    import torch

    return torch.nn.functional.softplus(input_tensor_a, beta=beta, threshold=threshold)


ttnn.attach_golden_function(ttnn.softplus, golden_function=_golden_function_softplus)
```

Nothing else in the file changes. In particular **`"softplus"` stays in the map at `:87`**: removing
it makes `:109-114` raise `ImportError`, since `TTNN_ELTWISE_UNARY_CPP_FUNCTIONS` still lists
`ttnn.softplus` at `:170`. The entry becomes unreachable, exactly like `"gelu"` at `:83`.

Resulting diff for this file: **+9, −0** (4 code lines plus the surrounding blank lines).

### File 2 — `tests/ttnn/unit_tests/operations/eltwise/test_activation.py`

**Old** (`:207-213`):

```python
def run_activation_softplus_test(device, h, w, beta, threshold, ttnn_function, pcc=0.99):
    torch.manual_seed(0)

    torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
    golden_function = ttnn.get_golden_function(ttnn_function)
    torch_output_tensor = golden_function(torch_input_tensor_a, beta=beta, threshold=threshold)

    input_tensor_a = ttnn.from_torch(
```

**New**:

```python
def run_activation_softplus_test(device, h, w, beta, threshold, ttnn_function, pcc=0.99):
    torch.manual_seed(0)

    torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
    golden_function = ttnn.get_golden_function(ttnn_function)
    torch_output_tensor = golden_function(torch_input_tensor_a, beta=beta, threshold=threshold)

    # The golden must honour beta/threshold — same reference the non-sharded
    # sweep builds by hand (sweeps/eltwise/unary/softplus/softplus.py:72).
    assert torch.equal(
        torch_output_tensor,
        torch.nn.functional.softplus(torch_input_tensor_a, beta=beta, threshold=threshold),
    )

    input_tensor_a = ttnn.from_torch(
```

`torch` is already imported at `:6`. Diff for this file: **+7, −0**.

---

## (c) The test, and why the existing one cannot see the defect

### Why `test_softplus` passes today

`test_activation.py:226-231` parametrizes `beta ∈ [-1, 0.5, 1, 2]` × `threshold ∈ [-20, 5, 10, 20, 40]`
= 20 cases, and `:223` gates them with `assert_with_pcc(..., 0.99)`. The comparison is
`golden(x, beta, threshold)` vs the device — but the golden always computes `beta=1, threshold=20`,
so 16 of the 20 cases compare the device against the wrong function. **PCC cannot see it**, because
PCC is invariant to scale and shift, and softplus with a different `beta` is close to an affine
rescale on `x ∈ [0, 1)`.

Measured (torch 2.13.0+cpu, `torch.manual_seed(0)`, `torch.rand((64,128), bfloat16)` — the test's own
input), comparing today's reference against the correct one:

| beta | threshold | max abs difference | PCC between the two references | gate 0.99 |
|---|---|---|---|---|
| -1 | -20 | 0.693147 | 0.998796 | passes |
| **-1** | **5** | **1.624721** | **0.991676** | **passes — and the sign is opposite** |
| -1 | 10 | 1.624721 | 0.991676 | passes |
| -1 | 20 | 1.624721 | 0.991676 | passes |
| -1 | 40 | 1.624721 | 0.991676 | passes |
| 0.5 | -20 | 0.693147 | 0.998796 | passes |
| 0.5 | 5 / 10 / 20 / 40 | 0.693147 | 0.999789 | passes |
| 1 | -20 | 0.693147 | 0.998796 | passes |
| 1 | 5 / 10 / 20 / 40 | 0.000000 | 1.000000 | correct by luck |
| 2 | -20 | 0.693147 | 0.998796 | passes |
| 2 | 5 / 10 / 20 / 40 | 0.346574 | 0.999767 | passes |

**16 of 20 wrong, 20 of 20 green.** Only `beta=1` with `threshold > 0` is genuinely correct.

The second consumer, `tests/sweep_framework/sweeps/eltwise/unary/softplus/softplus_sharded.py`, is
blind the same way: `:87` takes the golden, `:89-90` draws `beta` and `threshold` uniformly in
`(0, 100)` (`low = 0`, `high = 100` at `:29-30`), `:92` passes them to the golden where they are
dropped, `:112` passes them to the op where they are used, and `:116` gates with
`check_with_pcc(..., 0.999)`. Replaying that draw: **11,201 of 81,911** elements (13.7%) differ by
more than 1e-6, max absolute error **0.684437**, and PCC between the two references stays in
**[0.999998304, 0.999999054]** — always above the 0.999 gate. 9 elements overflow to `inf` in float32
on the correct reference.

### Why the added assertion is the right test

It fails today for those same 16 parametrizations and passes after the fix, it needs no new file, no
new fixture and no extra device time, and it states the invariant directly instead of measuring it
through a correlation coefficient. `torch.equal` is exact and safe here: after the fix, the golden
*is* that call, so the two sides are bit-identical.

A device-free unit test is not possible in this file: `test_activation.py:18` sets
`pytestmark = pytest.mark.use_module_device` for the whole module.

### Anti-zero control on the fix itself

Verified with torch 2.13.0+cpu:

- `golden_new(x)` with no parameters is **bit-identical** to `golden_old(x)` over 4001 points in
  `[-40, 40]` → no existing consumer changes behaviour.
- `golden_new(tensor([-1.0]), beta=5.0, threshold=20.0)` → `0.0013430697144940495`, matching the
  closed form `(1/5)·ln(1+e^-5) = 0.0013430696978235935` to 9 digits.
- Control that the comparison is not trivially null: `torch.nn.functional.softplus(x, beta=b)`
  differs from `softplus(x)` for 7 of 7 betas tested (0.25, 0.5, 2, 5, 10, 50, 100).

---

## (d) PR title and body, ready to paste

**Title** (no bounty figure, no prefix — describes the change and carries the measured number):

```
Honor beta/threshold in the ttnn.softplus golden function (16 of 20 test_softplus parametrizations validate against beta=1)
```

**Body:** (everything between the two rows of four backticks — the inner ``` fences are part of the
body and must be pasted as-is)

````markdown
## Summary

`ttnn.get_golden_function(ttnn.softplus)` accepts `beta` and `threshold` and then ignores them, so
every consumer of the registered golden validates against `beta=1, threshold=20` no matter what it
asked for. This PR gives `softplus` its own golden that forwards both parameters, and adds an
assertion to the existing softplus test that pins the invariant.

```python
ttnn.get_golden_function(ttnn.softplus)(torch.tensor([-1.0]), beta=5.0, threshold=20.0)
# -> 0.3132616878    closed form (1/5)*ln(1+e^-5) = 0.0013430697    (233.24x)
```

This is a reference defect, not a kernel defect: the device path is correct, so no user of
`ttnn.softplus` receives bad data. What is wrong is the public reference and the two CI gates built
on it.

## Root cause

`ttnn/ttnn/operations/unary.py` registers one generic golden for all ~60 C++ unary ops:

- `:10` — `def _golden_function(input_tensor: ttnn.Tensor, **_):` — every keyword lands in `**_`
- `:87` — `"softplus": torch.nn.functional.softplus,` — the map entry is the right function
- `:117` — `return torch_function(input_tensor)` — called with a single argument

The map entry looks correct in isolation, which is why this is easy to miss; the parameters are lost
30 lines away, in code shared by every op in the list.

Three independent places in the tree say `beta` and `threshold` are real:

- the binding documents them — `unary_nanobind.cpp:717-718` — and declares them keyword-only with
  defaults `1.0f` / `20.0f` — `:744-746`
- the kernel requires them — `unary_op_utils.cpp:532`,
  `TT_ASSERT(params.size() == 2, "Expected softplus to take 2 parameters")`, then
  `softplus_tile(idst, beta, 1/beta, threshold)`
- the **backward** golden already forwards them — `unary_backward.py:287-300` — which was itself the
  subject of #6493, *"Update backward softplus with beta and threshold param"*. The forward was never
  given the same treatment.

## Change

One dedicated golden attached after the registration loop, following `_golden_function_gelu`
(`unary.py:196-207`), which uses this exact idiom eleven lines above for the same reason — a
parameter the generic golden drops:

```python
def _golden_function_softplus(input_tensor_a, *args, beta=1.0, threshold=20.0, **kwargs):
    import torch

    return torch.nn.functional.softplus(input_tensor_a, beta=beta, threshold=threshold)


ttnn.attach_golden_function(ttnn.softplus, golden_function=_golden_function_softplus)
```

The signature matches `_golden_function_elu` (`:309-315`); the keyword-only form and the defaults are
copied from the binding (`nb::kw_only()` at `unary_nanobind.cpp:744`, then `beta = 1.0f`,
`threshold = 20.0f`).

`"softplus"` intentionally stays in the map at `:87`: `ttnn.softplus` is still listed in
`TTNN_ELTWISE_UNARY_CPP_FUNCTIONS` (`:170`), and `:109-114` raises `ImportError` when the two sets
disagree. The entry becomes unreachable, exactly like `"gelu"` at `:83`.

## What the current gates measure

Two consumers take the registered golden and pass it `beta`/`threshold`:

**1. `tests/ttnn/unit_tests/operations/eltwise/test_activation.py:207-231`** (mainline unit tests,
not nightly). `:211` takes the golden, `:212` passes both parameters, `:223` gates with `pcc=0.99`
over `beta ∈ [-1, 0.5, 1, 2]` × `threshold ∈ [-20, 5, 10, 20, 40]`. All 20 pass today; 16 compare
against `beta=1`. Numbers below are the two references against each other, on the test's own input
(`torch.manual_seed(0)`, `torch.rand((64, 128), bfloat16)`, torch 2.13.0+cpu):

| beta | threshold | max abs diff | PCC | pcc=0.99 gate |
|---|---|---|---|---|
| -1 | 5 / 10 / 20 / 40 | 1.624721 | 0.991676 | passes — reference has the **opposite sign** |
| 0.5 | 5 / 10 / 20 / 40 | 0.693147 | 0.999789 | passes |
| 2 | 5 / 10 / 20 / 40 | 0.346574 | 0.999767 | passes |
| any | -20 | 0.693147 | 0.998796 | passes |
| 1 | 5 / 10 / 20 / 40 | 0.000000 | 1.000000 | correct |

**2. `tests/sweep_framework/sweeps/eltwise/unary/softplus/softplus_sharded.py`.** `:87` takes the
golden, `:89-90` draws `beta` and `threshold` uniformly in `(0, 100)`, `:92` passes them to the
golden, `:112` to the op, `:116` gates with `check_with_pcc(..., 0.999)`. Replaying that draw:
**11,201 of 81,911** elements (13.7%) differ by more than 1e-6, max absolute error **0.684437**, and
PCC between the two references stays in **[0.999998304, 0.999999054]** — always above the gate.

The sibling non-sharded sweep in the same directory, `softplus.py:72`, calls
`torch.nn.functional.softplus(x, beta=beta, threshold=threshold)` directly and is therefore correct.
The same test family contains both the right and the wrong reference.

## Accuracy

- With no parameters, the new golden is **bit-identical** to the old one: `torch.equal` over 4001
  points in `[-40, 40]` (torch 2.13.0+cpu). Every existing consumer that does not pass
  `beta`/`threshold` is unaffected.
- With `beta=5, threshold=20` at `x=-1` it returns `0.0013430697144940495`, matching the closed form
  `(1/5)*ln(1+e^-5) = 0.0013430696978235935` to 9 digits.

## Scope

- No kernel, device-op, C++ or binding change. Python reference only.
- `ttnn.softplus`'s own signature, dispatch and numerics are untouched.
- No other golden changes: the generic path and its consistency check are untouched.
- **Not in this PR:** the fused-activation path has the same gap — `binary.py:32-33` calls
  `activation_function(tensor)` and `activations.py:78-80` states in a comment
  *"UnaryWithParam -> just extract its op_type"*, so `UnaryWithParam(SOFTPLUS, [beta, threshold])`
  (built with `{1.0f, 20.0f, 0.0f}` at `unary_op_utils.cpp:1035-1036`) is modelled as plain
  `softplus(tensor)`. That one cannot be fixed in Python alone: `ttnn/cpp/ttnn-nanobind/activation.cpp:53`
  binds only `.def_ro("op_type", ...)`, so `params` is not reachable from Python. Happy to open a
  follow-up if you want it.

## Test plan

- [x] `test_activation.py::run_activation_softplus_test` gains an exact assertion that the golden
      equals `torch.nn.functional.softplus(x, beta=beta, threshold=threshold)`. It fails today on 16
      of the 20 parametrizations and passes with this change.
- [x] Golden-level numbers reproduced twice with torch 2.13.0+cpu, including the anti-null control
      that `torch.nn.functional.softplus` itself distinguishes `beta` for 7 of 7 values tested.
- [ ] **Not run on hardware — I do not have a device.** The analysis is source-level plus a float32
      re-implementation of the arithmetic compared against torch on CPU.

On the device side I expect `test_softplus` to get *tighter*, not looser: the kernel does honour both
parameters (`unary_op_utils.cpp:532`), so aligning the reference with the kernel should raise the
measured PCC. If a parametrization does fail after this change, that failure is a genuine
kernel-vs-reference disagreement that the current comparison hides.

## References

- #6493 — *"Update backward softplus with beta and threshold param"* (closed): the same fix, applied
  to the backward. `unary_backward.py:287-300` is the result.
- `ttnn/ttnn/operations/unary.py:196-207` — `_golden_function_gelu`: the same override idiom, in this
  file, for the same class of problem.
- `tests/sweep_framework/sweeps/eltwise/unary/softplus/softplus.py:72` — the reference built
  correctly by hand in the sibling sweep.
````

---

## Notes for whoever picks this up next

- Report line correction already applied here: the informe cites `test_activation.py:212` as the line
  that takes the golden; on `main` today it is **`:211`** (`:212` is the call that passes
  `beta`/`threshold`). Everything else in the informe matches character for character.
- The fork `EazyHood/tt-metal` has both target files **byte-identical** to upstream `main` (same blob
  SHAs `656f56bf…` and `ca750d88…` as of 2026-08-06), so the GitHub web editor can be used directly
  with no rebase.
- `CONTRIBUTING.md:886` requires AI-assisted content to be posted manually by the human contributor;
  `:889` makes automated posting a permanent ban. This PR must be opened by hand.
