### PR TITLE
[moe_compute] Fix dense token-map stride in selective_reduce_combine

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
@@ -770,6 +770,33 @@ def test_moe_compute_single_card_nontile_tokens_sweep(mesh_device, mesh_shape, c
     )
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW, "trace_region_size": 500000}],
+    indirect=True,
+)
+@pytest.mark.parametrize("mesh_shape, mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
+def test_moe_compute_single_card_full_local_b1(mesh_device, mesh_shape):
+    """Regression for tt-metal#52371: B=1 dense token-map stride in FullLocal mode."""
+    hidden_size = 2048
+    ring_n = effective_matmul_ring_size(mesh_device)
+    _run_moe_compute_single_card_test(
+        mesh_device=mesh_device,
+        mesh_shape=mesh_shape,
+        experts_per_device=16,
+        tokens_per_device=1,
+        selected_experts_k=8,
+        N=512,
+        hidden_size=hidden_size,
+        output_height_shard_dim=4,
+        output_width_shard_dim=auto_output_width_shard_dim(hidden_size, matmul_ring_size=ring_n),
+        dtype=ttnn.bfloat16,
+        activation_type=MoEActivationFunction.SILU,
+        has_bias=False,
+        compute_only=False,
+    )
+
+
 # Minimal sanity check that compute_only=True with conflicting CCL kwargs is rejected.
 @pytest.mark.parametrize("mesh_shape, mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
 def test_moe_compute_compute_only_rejects_cluster_axis(mesh_device, mesh_shape, expect_error):

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
@@ -65,6 +65,32 @@ void SelectiveReduceCombineDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         activations_stride_elm == expected_activations_stride_elm,
         "The token activations tensor is expected to have aligned 2 * experts_per_device + 1 elements per token");
+
+    // dense_token_maps rows are (total_tokens + 1) token indices (the extra slot is the -1 terminator), each index
+    // padded for NoC DMA. The kernels walk the maps CB as (e * (total_tokens + 1) + t) * dense_token_maps_stride_elm,
+    // with the stride derived on the host as last_dim / (total_tokens + 1). Two things must hold for that indexing to
+    // land on the right expert page, otherwise one expert's page silently aliases another's (or the walk runs off the
+    // end of the CB): the row must divide evenly into (total_tokens + 1) indices, and the row must need no further
+    // padding to reach the L1 page alignment the reader gives each expert page.
+    const auto& dense_token_maps_tensor = tensor_args.dense_token_maps_tensor;
+    const auto maps_row_elms = dense_token_maps_tensor.logical_shape()[-1];
+    const auto maps_datum_size =
+        tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(dense_token_maps_tensor.dtype()));
+
+    TT_FATAL(
+        maps_row_elms % (total_tokens + 1) == 0,
+        "The dense token maps tensor is expected to hold (total_tokens + 1) = {} equally strided token indices per "
+        "expert, but its last dim ({}) is not a multiple of that",
+        total_tokens + 1,
+        maps_row_elms);
+
+    const auto maps_row_bytes = maps_row_elms * maps_datum_size;
+    TT_FATAL(
+        tt::align(maps_row_bytes, tt::tt_metal::hal::get_l1_alignment()) == maps_row_bytes,
+        "The dense token maps tensor row ({} bytes) must already be L1 aligned ({} bytes); otherwise the per-expert "
+        "page padding breaks the kernels' maps indexing",
+        maps_row_bytes,
+        tt::tt_metal::hal::get_l1_alignment());
 }
 
 SelectiveReduceCombineDeviceOperation::spec_return_value_t SelectiveReduceCombineDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -413,7 +413,10 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
 
     // dense_token_maps_tensor page buffer
     // tensor pages are padded for alignment
-    const uint32_t dense_token_maps_stride_elm = dense_token_maps_tensor.logical_shape()[-1] / total_tokens;
+    // Each expert row holds (total_tokens + 1) token indices -- the extra slot is the -1 terminator -- and each index
+    // is padded to the alignment for NoC DMA. Divide by the real row count: dividing by total_tokens over-estimates
+    // the stride for small token counts (total_tokens == 1 -> 8, == 2 -> 6, <= 4 -> 5; all of them should be 4).
+    const uint32_t dense_token_maps_stride_elm = dense_token_maps_tensor.logical_shape()[-1] / (total_tokens + 1);
     constexpr auto dense_token_maps_cb_id = tt::CBIndex::c_4;
     const uint32_t aligned_dense_token_maps_buffer_size_bytes =
         tt::align(experts_per_device * aligned_dense_token_maps_page_size_bytes, l1_alignment);


### PR DESCRIPTION
Closes #52371

## Summary

Fix the dense token-map stride passed from the `selective_reduce_combine` program factory to its reader and writer kernels. Each expert row contains `total_tokens + 1` entries because the final entry is a `-1` terminator, but the current host code divides the row width by `total_tokens`.

- Derive the stride from all entries in the row.
- Validate the dense token-map row layout.
- Add a focused B=1 FullLocal regression to the existing single-card test.

## Background

The producer allocates `total_tokens + 1` aligned token-index entries per expert. The reader and writer kernels also index expert rows using `GlobalNumTokens + 1`.

For `total_tokens=1`, the producer layout places the two entries four `uint32_t` elements apart, while the current host expression computes a stride of eight. The reader accesses the wrong token-map position and reaches its guard assertion.

## Changes

- Compute `dense_token_maps_stride_elm` using `total_tokens + 1`.
- Validate row divisibility and L1 alignment before program creation.
- Cover the B=1 combine output and cached-program path in `test_moe_compute_single_card.py`.

## Testing

Prior hardware validation of this patch against `df31fd4a8471228adaa9f92ecf515676d87e5179`:

- The focused B1 FullLocal case passed with Watcher enabled on Blackhole and Wormhole.
- Blackhole passed 20 FullLocal cases covering B=1 through B=64, E=8 through E=256, bias, and SILU/SWIGLU/GELU with Watcher disabled.
- Three ComputeOnly controls passed.

The added B=1 FullLocal regression passed with Watcher enabled on Blackhole and Wormhole B0, including combine-output validation on both the initial and cached-program invocations. Local Python syntax and diff checks also passed; PR CI is running on the updated branch.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjett/52371-dense-token-map-stride-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjett/52371-dense-token-map-stride-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sjett/52371-dense-token-map-stride-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sjett/52371-dense-token-map-stride-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sjett/52371-dense-token-map-stride-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sjett/52371-dense-token-map-stride-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjett/52371-dense-token-map-stride-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjett/52371-dense-token-map-stride-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjett/52371-dense-token-map-stride-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjett/52371-dense-token-map-stride-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sjett/52371-dense-token-map-stride-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sjett/52371-dense-token-map-stride-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sjett/52371-dense-token-map-stride-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sjett/52371-dense-token-map-stride-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sjett/52371-dense-token-map-stride-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sjett/52371-dense-token-map-stride-v2)