### PR TITLE
DO NOT MERGE: scratch CI proof of fetch-mechanism fix for #52290

### DIFF
--- a/.github/workflows/git-fetch-mechanism-proof.yml
+++ b/.github/workflows/git-fetch-mechanism-proof.yml
@@ -1,0 +1,88 @@
+name: "[repro] git fetch mechanism proof for #52290"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  compare-fetch-mechanisms:
+    name: Compare current vs proposed fetch mechanism
+    runs-on: tt-ubuntu-2204-N150-viommu-stable
+    steps:
+      - name: Current mechanism — remote add -f (fetches every ref)
+        run: |
+          set -x
+          mkdir -p /tmp/slow && cd /tmp/slow
+          git init --quiet
+          time (
+            git remote add -f origin https://github.com/tenstorrent/tt-metal.git
+            git config core.sparseCheckout true
+            echo ".github" >> .git/info/sparse-checkout
+            git pull origin main --quiet
+          )
+          echo "refs=$(git for-each-ref --format='%(refname)' refs/remotes/origin | wc -l)" >> "$GITHUB_ENV"
+          git count-objects -vH
+
+      - name: Record slow-path stats
+        if: always()
+        run: |
+          cd /tmp/slow
+          {
+            echo "SLOW_REFS=$(git for-each-ref --format='%(refname)' refs/remotes/origin | wc -l)"
+            echo "SLOW_PACK=$(du -sh .git 2>/dev/null | cut -f1)"
+          } >> "$GITHUB_ENV"
+
+      - name: Proposed mechanism — single-ref fetch + blob:none partial clone
+        run: |
+          set -x
+          mkdir -p /tmp/fast && cd /tmp/fast
+          git init --quiet
+          git remote add origin https://github.com/tenstorrent/tt-metal.git
+          git config core.sparseCheckout true
+          echo ".github" >> .git/info/sparse-checkout
+          time git fetch --filter=blob:none --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git checkout -b main origin/main --quiet
+          git count-objects -vH
+
+      - name: Record fast-path stats
+        if: always()
+        run: |
+          cd /tmp/fast
+          {
+            echo "FAST_REFS=$(git for-each-ref --format='%(refname)' refs/remotes/origin | wc -l)"
+            echo "FAST_PACK=$(du -sh .git 2>/dev/null | cut -f1)"
+          } >> "$GITHUB_ENV"
+
+      - name: Correctness — true negative (no .github change vs a known clean fork branch)
+        run: |
+          cd /tmp/fast
+          git remote add fork https://github.com/afuller-TT/tt-metalium.git
+          git fetch --filter=blob:none --no-tags fork repro/ci-52290-fork-clone-timeout
+          if git diff --name-only --exit-code origin/main...fork/repro/ci-52290-fork-clone-timeout -- ".github"; then
+            echo "CORRECT: no .github changes detected (exit 0), as expected"
+          else
+            echo "UNEXPECTED: .github diff reported changes"; exit 1
+          fi
+
+      - name: Correctness — true positive (last real commit that touched .github)
+        run: |
+          cd /tmp/fast
+          COMMIT=$(git log --format=%H -1 -- .github)
+          PARENT=$(git rev-parse "$COMMIT^")
+          echo "commit=$COMMIT parent=$PARENT"
+          if git diff --name-only --exit-code "$PARENT...$COMMIT" -- ".github"; then
+            echo "UNEXPECTED: no .github diff detected"; exit 1
+          else
+            echo "CORRECT: .github change detected (exit 1, file(s) listed above)"
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Git fetch mechanism proof — tt-metal#52290"
+            echo ""
+            echo "| Mechanism | Refs fetched | .git size |"
+            echo "|---|---|---|"
+            echo "| Current (\`remote add -f\`) | ${SLOW_REFS:-?} | ${SLOW_PACK:-?} |"
+            echo "| Proposed (single-ref + \`blob:none\`) | ${FAST_REFS:-?} | ${FAST_PACK:-?} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/git-fetch-mechanism-proof.yml
+++ b/.github/workflows/git-fetch-mechanism-proof.yml
@@ -1,7 +1,8 @@
 name: "[repro] git fetch mechanism proof for #52290"
 
 on:
-  workflow_dispatch:
+  pull_request:
+    types: [opened]
 
 jobs:
   compare-fetch-mechanisms:


### PR DESCRIPTION
**DO NOT MERGE — scratch/throwaway PR, to be closed once the run is captured.**

Adds a single new workflow, `.github/workflows/git-fetch-mechanism-proof.yml`,
that runs on the same runner label as the affected jobs in #52290
(`tt-ubuntu-2204-N150-viommu-stable`) and directly compares, on real hardware
behind the same corporate proxy:

- the **current** mechanism the `Set up runner` hook uses
  (`git remote add -f origin ...`, fetches every ref)
- the **proposed** mechanism (single-ref fetch + `--filter=blob:none`
  partial clone)

It also re-runs the exact `compare_workflow_directories()` diff command
against both a known-clean and a known-changed `.github` commit, to confirm
the proposed mechanism gives identical (correct) answers.

This is an internal, non-fork PR purely so the workflow (which only exists
on this branch) actually executes — `workflow_dispatch` requires the file to
already be on the default branch, which isn't the case here.

Will close this PR (not merge) once the summary is captured.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-repro/git-fetch-mechanism-proof-52290)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-repro/git-fetch-mechanism-proof-52290)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-repro/git-fetch-mechanism-proof-52290)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-repro/git-fetch-mechanism-proof-52290)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ci-repro/git-fetch-mechanism-proof-52290)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ci-repro/git-fetch-mechanism-proof-52290)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-repro/git-fetch-mechanism-proof-52290)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-repro/git-fetch-mechanism-proof-52290)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-repro/git-fetch-mechanism-proof-52290)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-repro/git-fetch-mechanism-proof-52290)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-repro/git-fetch-mechanism-proof-52290)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-repro/git-fetch-mechanism-proof-52290)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-repro/git-fetch-mechanism-proof-52290)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-repro/git-fetch-mechanism-proof-52290)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-repro/git-fetch-mechanism-proof-52290)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-repro/git-fetch-mechanism-proof-52290)