### PR TITLE
[Feature] Tensor prefetcher: mcast-in0 on K-row-major weights, and stop requiring a page-multiple GCB size

### DIFF
--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -101,7 +101,7 @@ def make_recv_contig_weight(
     """
     K = pt_weight.shape[-2]
     N = pt_weight.shape[-1]
-    assert N % ring_size == 0, f"N={N} must divide ring_size={ring_size}"
+    assert N % ring_size == 0, f"N={N} must be divisible by ring_size={ring_size}"
     n_per_recv = N // ring_size
     dram_core_range_set = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
@@ -130,7 +130,7 @@ def make_krow_major_weight(device, pt_weight, num_dram_banks: int, dtype):
     """
     K = pt_weight.shape[-2]
     N = pt_weight.shape[-1]
-    assert N % num_dram_banks == 0, f"N={N} must divide num_dram_banks={num_dram_banks}"
+    assert N % num_dram_banks == 0, f"N={N} must be divisible by num_dram_banks={num_dram_banks}"
     dram_core_range_set = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
     )

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -116,6 +116,32 @@ def make_recv_contig_weight(
     return ttnn.as_tensor(pt_weight, device=device, dtype=dtype, memory_config=mem_config, layout=ttnn.TILE_LAYOUT)
 
 
+def make_krow_major_weight(device, pt_weight, num_dram_banks: int, dtype):
+    """Allocate ``pt_weight`` ((1, 1, K, N)) in the legacy K-row-major layout: one
+    WIDTH_SHARDED ``(K, N // num_dram_banks)`` shard per DRAM bank, K-row-major
+    within the bank so one sender read serves every receiver on that bank.
+
+    The counterpart to ``make_recv_contig_weight``. Bank b owns N-columns
+    ``[b * N // num_dram_banks, (b + 1) * N // num_dram_banks)`` and hands its
+    receivers consecutive sub-slices of that range, so pair it with
+    ``bank_receivers_contiguous`` (bank b -> ring positions
+    ``[b * recv_per_bank, (b + 1) * recv_per_bank)``) to make shard index equal
+    ring position.
+    """
+    K = pt_weight.shape[-2]
+    N = pt_weight.shape[-1]
+    assert N % num_dram_banks == 0, f"N={N} must divide num_dram_banks={num_dram_banks}"
+    dram_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+    )
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_core_range_set, [K, N // num_dram_banks], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    return ttnn.as_tensor(pt_weight, device=device, dtype=dtype, memory_config=mem_config, layout=ttnn.TILE_LAYOUT)
+
+
 @contextlib.contextmanager
 def tensor_prefetcher_session(device):
     """Open a Tensor prefetcher Start/Stop window. Stop (and a device sync)

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -481,6 +481,156 @@ def test_create_global_circular_buffer_for_matmul_1d_rejects_undersized(device, 
         )
 
 
+def _krow_major_program_config(ring_cols, ring_rows, recv_per_bank, in0_block_w, per_core_N, *, gather):
+    """A 1D matmul config for a K-row-major weight, as either consumer."""
+    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(ring_cols, ring_rows),
+        in0_block_w=in0_block_w,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=1,
+        per_core_N=per_core_N,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=not gather,
+        gather_in0=gather,
+        hop_cores=ttnn.CoreRangeSet([]),
+        num_global_cb_receivers=recv_per_bank,
+        untilize_out=False,
+        stream_in1=False,
+    )
+
+
+def test_create_global_circular_buffer_for_matmul_1d_sizes_per_config(device, expect_error):
+    """Each consumer sharing a GCB is sized against its own window, not against the
+    largest page paired with the largest block count over all configs.
+
+    A batched gather (small page, whole layer resident) beside an mcast (large page,
+    double-buffered window) is the case that separates the two rules: the cross-config
+    product asks for the gather's block count at the mcast's page size, which neither
+    consumer needs and which can exceed the 2 MB remote-CB cap outright.
+    """
+    num_dram_banks = device.dram_grid_size().x
+    recv_per_bank = 1
+    receiver_count = num_dram_banks * recv_per_bank
+    dtype = ttnn.bfloat16
+    tile_bytes = _bytes_per_tile(dtype)
+
+    # Gather: one K-tile per ring position at per_core_N=1, so a whole layer is
+    # receiver_count small pages.
+    gather_k_tiles = receiver_count
+    gather_weight = _make_krow_major_weight(
+        device,
+        torch.zeros(1, 1, gather_k_tiles * ttnn.TILE_SIZE, receiver_count * ttnn.TILE_SIZE),
+        num_dram_banks=num_dram_banks,
+        dtype=dtype,
+    )
+    gather_config = _krow_major_program_config(
+        num_dram_banks, recv_per_bank, recv_per_bank, in0_block_w=1, per_core_N=1, gather=True
+    )
+    gather_floor = receiver_count * (gather_k_tiles // receiver_count) * gather_config.per_core_N * tile_bytes
+
+    # Mcast: 4-tile K-blocks at per_core_N=4, so one page is 16x the gather's and only
+    # two need to be resident.
+    mcast_k_tiles = 8
+    mcast_in0_block_w = 4
+    mcast_per_core_N = 4
+    mcast_weight = _make_krow_major_weight(
+        device,
+        torch.zeros(1, 1, mcast_k_tiles * ttnn.TILE_SIZE, mcast_per_core_N * receiver_count * ttnn.TILE_SIZE),
+        num_dram_banks=num_dram_banks,
+        dtype=dtype,
+    )
+    mcast_config = _krow_major_program_config(
+        num_dram_banks,
+        recv_per_bank,
+        recv_per_bank,
+        in0_block_w=mcast_in0_block_w,
+        per_core_N=mcast_per_core_N,
+        gather=False,
+    )
+    mcast_page = mcast_in0_block_w * mcast_per_core_N * tile_bytes
+    mcast_floor = 2 * mcast_page
+
+    min_size = max(gather_floor, mcast_floor)
+    bank_to_receivers = [
+        (b, _bank_receivers_row_major(b, recv_per_bank, num_dram_banks)) for b in range(num_dram_banks)
+    ]
+    # The cross-config product (largest page x largest block count) would demand this much.
+    assert mcast_page * receiver_count > min_size
+
+    # Accepted: the size clears every consumer's own floor.
+    ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device,
+        [gather_config, mcast_config],
+        [gather_weight, mcast_weight],
+        bank_to_receivers=bank_to_receivers,
+        size=min_size,
+    )
+
+    # One byte under, and the config that needs the larger window is the one named.
+    with expect_error(RuntimeError, r"must be at least num_blocks.*program_configs\[1\]"):
+        ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+            device,
+            [gather_config, mcast_config],
+            [gather_weight, mcast_weight],
+            bank_to_receivers=bank_to_receivers,
+            size=min_size - 1,
+        )
+
+
+def test_tensor_prefetcher_block_count_rejects_uneven_krow_major_fanout(device, expect_error):
+    """A K-row-major weight needs every GCB sender to drive the same receiver count.
+
+    The sender slices its bank's shard by one receivers-per-bank number, so an uneven
+    fan-out that still averages out — (1, 3, 2, 2, ...) over the banks — would be sliced
+    at the average and deliver the wrong pages. The matmul-1d factory enforces uniformity
+    where it builds the mapping; this covers a hand-built GCB reaching the matmul through
+    the block-count entry point instead.
+    """
+    num_dram_banks = device.dram_grid_size().x
+    if num_dram_banks < 3:
+        pytest.skip(f"uneven fan-out needs at least 3 DRAM banks; device has {num_dram_banks}")
+    recv_per_bank = 2
+    receiver_count = num_dram_banks * recv_per_bank
+    dtype = ttnn.bfloat16
+
+    # Same total receivers as a uniform recv_per_bank=2 mapping, redistributed so bank 0
+    # gives up a receiver to bank 1.
+    uneven_receiver_counts = [1, 3] + [recv_per_bank] * (num_dram_banks - 2)
+    bank_to_receivers = []
+    next_ring_pos = 0
+    for bank, count in enumerate(uneven_receiver_counts):
+        cores = []
+        for pos in range(next_ring_pos, next_ring_pos + count):
+            core = ttnn.CoreCoord(pos % num_dram_banks, pos // num_dram_banks)
+            cores.append(ttnn.CoreRange(core, core))
+        bank_to_receivers.append((bank, ttnn.CoreRangeSet(cores)))
+        next_ring_pos += count
+
+    k_tiles = 2 * receiver_count
+    per_core_N = 1
+    weight = _make_krow_major_weight(
+        device,
+        torch.zeros(1, 1, k_tiles * ttnn.TILE_SIZE, receiver_count * ttnn.TILE_SIZE),
+        num_dram_banks=num_dram_banks,
+        dtype=dtype,
+    )
+    program_config = _krow_major_program_config(
+        num_dram_banks, recv_per_bank, recv_per_bank, in0_block_w=1, per_core_N=per_core_N, gather=False
+    )
+
+    # The generic factory takes the mapping as given (a dual-sender split legitimately
+    # produces uneven per-sender counts), so the weight-vs-GCB rule is checked here.
+    gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(
+        device,
+        bank_to_receivers,
+        size=4 * per_core_N * _bytes_per_tile(dtype),
+    )
+    with expect_error(RuntimeError, "same fan-out of num_global_cb_receivers"):
+        ttnn.experimental.tensor_prefetcher_block_count_for_matmul_1d(program_config, weight, gcb)
+
+
 # ---------------------------------------------------------------------------
 # Multi-tensor smoke (discard receiver)
 # ---------------------------------------------------------------------------

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -61,6 +61,7 @@ from tests.ttnn.unit_tests.operations.prefetcher_common import (
     bank_receivers_strided as _bank_receivers_strided,
     bank_receivers_contiguous as _bank_receivers_contiguous,
     make_recv_contig_weight as _make_recv_contig_weight,
+    make_krow_major_weight as _make_krow_major_weight,
     tensor_prefetcher_session,
 )
 
@@ -1153,13 +1154,29 @@ def test_tensor_prefetcher_streaming_matmul(
     assert passing, f"[{name} win={window_blocks} {distribution_strategy}] PCC check failed: {output_str}"
 
 
-@pytest.mark.parametrize(
-    "distribution_strategy",
-    [ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D, ttnn.ShardDistributionStrategy.CONTIGUOUS_1D],
-    ids=["strided", "contiguous"],
-)
-def test_tensor_prefetcher_streaming_mcast_in0(device, distribution_strategy):
-    """Mcast-in0 consumes receiver-contiguous in1 K-blocks in natural FIFO order."""
+# Weight layouts an mcast-in0 consumer accepts. The consumer sees the same per-receiver page stream
+# either way -- recv-contig gives each receiver its own shard, while K-row-major divides a bank's shard
+# into the requested K-blocks and slices each across that bank's receivers -- so every assertion below
+# is layout-agnostic. The bank pairing has to match the shard distribution (shard index == ring
+# position); ROUND_ROBIN_1D pairs strided, CONTIGUOUS_1D and K-row-major pair contiguous.
+_MCAST_IN0_LAYOUTS = {
+    "recv_contig_strided": ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    "recv_contig_contiguous": ttnn.ShardDistributionStrategy.CONTIGUOUS_1D,
+    "krow_major": None,
+}
+
+
+@pytest.mark.parametrize("weight_layout", list(_MCAST_IN0_LAYOUTS), ids=list(_MCAST_IN0_LAYOUTS))
+@pytest.mark.parametrize("gcb_size_misalign_bytes", [0, 64], ids=["page_multiple", "ragged_size"])
+def test_tensor_prefetcher_mcast_in0(device, weight_layout, gcb_size_misalign_bytes):
+    """Mcast-in0 consumes in1 K-blocks in natural FIFO order, on either DRAM weight layout.
+
+    ``block_count`` is ``K_tiles / in0_block_w``, deliberately different from the receiver count, so a
+    ring-derived block count would deliver the wrong pages rather than silently working.
+
+    ``gcb_size_misalign_bytes`` covers GCB sizes that are not a whole number of in1 K-block pages: the
+    window floors to whole pages, so the tail bytes go unused rather than raising.
+    """
     num_dram_banks = device.dram_grid_size().x
     recv_per_bank = 2
     receiver_count = num_dram_banks * recv_per_bank
@@ -1178,16 +1195,32 @@ def test_tensor_prefetcher_streaming_mcast_in0(device, distribution_strategy):
     block_count = k_tiles // in0_block_w
     assert block_count != receiver_count
 
-    torch.manual_seed(zlib.crc32(f"streaming_mcast_in0_{distribution_strategy}".encode()))
+    torch.manual_seed(zlib.crc32(f"mcast_in0_{weight_layout}_{gcb_size_misalign_bytes}".encode()))
     pt_weight = torch.randn(1, 1, K, N)
-    tt_weight = _make_recv_contig_weight(
-        device,
-        pt_weight,
-        num_dram_banks=num_dram_banks,
-        ring_size=receiver_count,
-        dtype=dtype,
-        distribution_strategy=distribution_strategy,
-    )
+    distribution_strategy = _MCAST_IN0_LAYOUTS[weight_layout]
+    if distribution_strategy is None:
+        tt_weight = _make_krow_major_weight(device, pt_weight, num_dram_banks=num_dram_banks, dtype=dtype)
+        bank_to_receivers = [
+            (b, _bank_receivers_contiguous(b, recv_per_bank, ring_cols=ring_cols)) for b in range(num_dram_banks)
+        ]
+    else:
+        tt_weight = _make_recv_contig_weight(
+            device,
+            pt_weight,
+            num_dram_banks=num_dram_banks,
+            ring_size=receiver_count,
+            dtype=dtype,
+            distribution_strategy=distribution_strategy,
+        )
+        if distribution_strategy == ttnn.ShardDistributionStrategy.CONTIGUOUS_1D:
+            bank_to_receivers = [
+                (b, _bank_receivers_contiguous(b, recv_per_bank, ring_cols=ring_cols)) for b in range(num_dram_banks)
+            ]
+        else:
+            bank_to_receivers = [
+                (b, _bank_receivers_strided(b, recv_per_bank, num_dram_banks, ring_cols=ring_cols))
+                for b in range(num_dram_banks)
+            ]
 
     pt_act = torch.randn(1, 1, M, K)
     act_mem_config = ttnn.create_sharded_memory_config(
@@ -1218,23 +1251,13 @@ def test_tensor_prefetcher_streaming_mcast_in0(device, distribution_strategy):
         stream_in1=False,
     )
 
-    if distribution_strategy == ttnn.ShardDistributionStrategy.CONTIGUOUS_1D:
-        bank_to_receivers = [
-            (b, _bank_receivers_contiguous(b, recv_per_bank, ring_cols=ring_cols)) for b in range(num_dram_banks)
-        ]
-    else:
-        bank_to_receivers = [
-            (b, _bank_receivers_strided(b, recv_per_bank, num_dram_banks, ring_cols=ring_cols))
-            for b in range(num_dram_banks)
-        ]
-
     page_size_bytes = in0_block_w * program_config.per_core_N * _bytes_per_tile(dtype)
     gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
         device,
         [program_config],
         [tt_weight],
         bank_to_receivers=bank_to_receivers,
-        size=2 * page_size_bytes,
+        size=4 * page_size_bytes + gcb_size_misalign_bytes,
     )
     output_mem_config = ttnn.create_sharded_memory_config(
         shape=(M, N // receiver_count),
@@ -1255,11 +1278,13 @@ def test_tensor_prefetcher_streaming_mcast_in0(device, distribution_strategy):
     expected = pt_act.float() @ pt_weight.float()
 
     # Run twice so the second invocation hits the program cache and exercises
-    # override_mcast_in0_program_parameters. The receiver-contiguous weight is
-    # ND-sharded, so a naive tensor-backed CB update would TT_FATAL on the
-    # GCB-backed in1 CB during the cache-hit path.
+    # override_mcast_in0_program_parameters. A recv-contig weight is ND-sharded, so a naive
+    # tensor-backed CB update would TT_FATAL on the GCB-backed in1 CB during the cache-hit path.
     cache_entries_after_first = None
     with tensor_prefetcher_session(device):
+        assert (
+            ttnn.experimental.tensor_prefetcher_block_count_for_matmul_1d(program_config, tt_weight, gcb) == block_count
+        )
         for run in range(2):
             tt_out = ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
                 tt_act,
@@ -1275,8 +1300,8 @@ def test_tensor_prefetcher_streaming_mcast_in0(device, distribution_strategy):
 
             out_torch = ttnn.to_torch(tt_out)
             passing, output_str = comp_pcc(expected, out_torch, 0.999)
-            logger.info(f"[streaming_mcast_in0 {distribution_strategy} run={run}] {output_str}")
-            assert passing, f"streaming_mcast_in0 run={run} PCC failed: {output_str}"
+            logger.info(f"[mcast_in0 {weight_layout} misalign={gcb_size_misalign_bytes} run={run}] {output_str}")
+            assert passing, f"mcast_in0 {weight_layout} run={run} PCC failed: {output_str}"
 
     # The second run must reuse the cached program (no new entries), i.e. it took
     # the override path rather than rebuilding.

--- a/tt_metal/impl/buffers/prefetcher_matmul_design.md
+++ b/tt_metal/impl/buffers/prefetcher_matmul_design.md
@@ -394,7 +394,7 @@ src = bank_local_base[t]
 
 #### Matmul consumer contracts
 
-Receiver-contiguous weights support two 1D matmul consumers:
+Two 1D matmul consumers can drain a DRAM-sender GCB:
 
 - **Ring gather-in0:** `block_count = receiver_count`. Batched mode uses no rotation and waits for
   all blocks. `stream_in1=true` uses an identity rotation request so each receiver sees its
@@ -405,10 +405,16 @@ Receiver-contiguous weights support two 1D matmul consumers:
   two-page GCB window. Initially this mode requires one output block per receiver and one effective
   activation batch, so each prefetched stream is consumed exactly once.
 
-For both contracts one page contains
-`(K_tiles / block_count) * per_core_N` weight tiles for one receiver. The GCB receiver set must
-exactly match the matmul output workers, and the receiver-contiguous NdShardSpec must provide one
-full-K, `per_core_N`-wide shard per receiver.
+For both contracts one page contains `(K_tiles / block_count) * per_core_N` weight tiles for one
+receiver, and the GCB receiver set must exactly match the matmul output workers.
+
+Both consumers work on either DRAM layout. The per-receiver page stream is what the consumer sees,
+and neither layout constrains it: the receiver-contiguous NdShardSpec provides one full-K,
+`per_core_N`-wide shard per receiver, while the K-row-major layout divides each bank's shard into the
+requested `block_count` K-blocks and slices every block across that bank's receivers. Streaming is
+the one exception — a per-receiver rotation is receiver-contiguous only — so a K-row-major gather
+consumer is always batched, whereas K-row-major mcast is not (its natural FIFO order needs no
+rotation).
 
 #### Fit ladder (receiver-contiguous)
 

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -98,7 +98,9 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
 //   * receiver-contiguous: an NdShardSpec DRAM tensor with one full-K, N/receiver_count shard per
 //     receiver;
 //   * legacy K-row-major: a WIDTH_SHARDED DRAM tensor with one full-K, N/num_senders shard per bank,
-//     each bank's per-receiver N split evenly across its num_global_cb_receivers cores;
+//     each bank's per-receiver N split evenly across its num_global_cb_receivers cores, and a `gcb`
+//     whose senders each drive exactly num_global_cb_receivers receivers (this layout's sender slices
+//     its shard by one receivers-per-bank number, so an uneven fan-out delivers the wrong pages);
 // and, for either layout:
 //   * weight K-tiles divides the consumer's block count exactly;
 //   * the weight's per-receiver N (in tiles) equals program_config.per_core_N — otherwise the

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -42,22 +42,28 @@ GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(
 // `create_global_circular_buffer_for_tensor_prefetcher` takes); this factory validates it against
 // the matmul program configs and weight shapes and sizes the GCB accordingly.
 //
+// For either layout, the rules are the consumer's rather than the layout's: gather takes one K-block
+// per ring position, mcast takes K_tiles / in0_block_w natural-order blocks; weight K must be
+// tile-aligned and divide evenly by that block count (the silent-hang case, where the matmul pads K
+// beyond what the prefetcher pushes and waits on pages that never come); matmul per_core_N must equal
+// the weight's per-receiver N, or the pushed page and the in1 remote-CB page disagree and the
+// page-credit accounting desyncs. `size` floors at one full layer (block_count * largest page),
+// relaxed to a double-buffer window when every config sharing the GCB drains it FIFO.
+//
 // The DRAM layout is detected from the weight allocation, NOT chosen by the caller — the tensor's
 // layout determines what the prefetcher does (mirrors tt_metal detect_layout_mode). All weights
-// sharing one GCB must use the same layout:
+// sharing one GCB must use the same layout. What differs per layout is the shard geometry and the
+// sender count:
 //   * Legacy K-row-major (WIDTH_SHARDED): one shard per bank, K-row-major within the bank, so one
-//     read serves all of a bank's receivers. Always single-sender per bank. Validated: weight K
-//     tile-aligned AND divisible by ring_size (the silent-hang case where the matmul pads K beyond
-//     what the prefetcher pushes); weight N shards evenly across senders and per-bank N splits
-//     evenly across receivers; matmul per_core_N == weight per-receiver N. `bank_to_receivers`
-//     shape is checked: num_senders * num_global_cb_receivers == ring_size, every bank owns exactly
-//     num_global_cb_receivers cores. `size` floor is one full layer (ring_size * largest in1 block).
+//     read serves all of a bank's receivers. Always single-sender per bank. Validated: weight N shards
+//     evenly across senders and per-bank N splits evenly across receivers. `bank_to_receivers` shape
+//     is checked: every bank owns exactly num_global_cb_receivers cores, and
+//     num_senders * num_global_cb_receivers == ring_size for gather (mcast only needs the grid to have
+//     capacity for them). Cannot serve a streaming gather — no per-receiver rotation.
 //   * Receiver-contiguous (NdShardSpec): num_shards == receiver_count, each shard
-//     (full K, N/receiver_count) owned by one receiver. Gather uses receiver_count K-blocks; mcast
-//     uses K_tiles / in0_block_w natural-order blocks. Validated: exact K divisibility and
-//     per_core_N == per-receiver N. Receivers need NOT be uniform per bank. `size` can use a
-//     double-buffer window for streaming gather or mcast FIFO consumers. This layout also permits
-//     dual senders per bank via `support_multi_receiver_shards=false` (see below).
+//     (full K, N/receiver_count) owned by one receiver. Receivers need NOT be uniform per bank. Permits
+//     dual senders per bank via `support_multi_receiver_shards=false` (see below), and is the only
+//     layout that supports streaming gather (stream_in1), which needs a per-receiver rotation.
 //
 // All configs must agree on compute_with_storage_grid_size (and, for legacy, num_global_cb_receivers)
 // — the GCB has one receiver rectangle shared across all consumer matmuls. The factory does NOT
@@ -86,11 +92,16 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
     std::optional<bool> support_multi_receiver_shards = std::nullopt);
 
 // Compute the validated `block_count` to pair with `weight` in a TensorPrefetcherInput when feeding a
-// gather-in0 or mcast-in0 1D matmul from a *receiver-contiguous* DRAM weight via `gcb`. Gather returns
-// the receiver/ring count; mcast returns `weight_K_tiles / program_config.in0_block_w`. It validates:
-//   * the weight is an NdShardSpec DRAM tensor with one full-K, N/receiver_count shard per receiver;
+// gather-in0 or mcast-in0 1D matmul from a DRAM weight via `gcb`. Gather returns the receiver/ring
+// count; mcast returns `weight_K_tiles / program_config.in0_block_w`. The weight's DRAM layout is
+// detected and the matching cross-checks run:
+//   * receiver-contiguous: an NdShardSpec DRAM tensor with one full-K, N/receiver_count shard per
+//     receiver;
+//   * legacy K-row-major: a WIDTH_SHARDED DRAM tensor with one full-K, N/num_senders shard per bank,
+//     each bank's per-receiver N split evenly across its num_global_cb_receivers cores;
+// and, for either layout:
 //   * weight K-tiles divides the consumer's block count exactly;
-//   * the weight's per-receiver N (shard N in tiles) equals program_config.per_core_N — otherwise the
+//   * the weight's per-receiver N (in tiles) equals program_config.per_core_N — otherwise the
 //     prefetcher's pushed page size and the matmul's in1 remote-CB page size disagree and the page-credit
 //     accounting desyncs.
 // Mcast uses natural FIFO order and therefore requires `stream_in1=false`.

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -381,7 +381,8 @@ uint32_t validate_krow_major_weight_for_matmul_1d(
         // has always required K to divide by it, so keep rejecting exactly the configs it always did.
         TT_FATAL(
             weight_K_tiles % program_config.in0_block_w == 0,
-            "weight K ({} tiles) must be divisible by in0_block_w ({})",
+            "legacy K-row-major gather still requires weight K ({} tiles) divisible by config in0_block_w ({}); "
+            "the matmul derives K-block width from K/ring_size, not this field",
             weight_K_tiles,
             program_config.in0_block_w);
     }

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -4,7 +4,6 @@
 
 #include "ttnn/global_circular_buffer.hpp"
 
-#include <algorithm>
 #include <memory>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/buffer.hpp>
@@ -149,14 +148,42 @@ void validate_grid_for_consumer(
     }
 }
 
-// Shared GCB size validation: the caller-supplied size must clear the floor its consumers need — a
-// full layer for a batched gather matmul (it does wait_front(num_blocks)), or a double-buffered
-// window when every consumer sharing the GCB reads K-blocks FIFO — and fit the remote-CB cap.
+// One consumer's own floor on the GCB window: a batched gather matmul does wait_front(block_count)
+// and needs a whole layer resident, while a FIFO consumer takes K-blocks as they land and needs only
+// a double-buffered window.
+//
+// Checked per (config, weight) as the builders walk them, rather than once against the largest page
+// and the largest block count over all configs — those two maxima can come from different configs,
+// and their product demands a buffer neither consumer asked for. A GCB shared by a batched gather
+// (small page, whole layer) and an mcast (large page, two blocks) is the case that bites: the
+// product can exceed kMaxCbPagesBytes and make the mix unconstructible even though each consumer
+// fits on its own.
 //
 // No L1 budget check here — receivers may have very different L1 usage on top of the GCB (matmul
 // in0/in1/out/interm CBs etc.) and we don't have enough context at the factory to compute a real cap.
 // Callers must size the GCB to fit their own L1.
-//
+void validate_gcb_size_for_config(
+    uint32_t size,
+    const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& config,
+    size_t config_index,
+    uint32_t page_bytes,
+    uint32_t block_count) {
+    const bool fifo = is_fifo_consumer(config);
+    const uint32_t num_blocks = fifo ? kFifoMinWindowBlocks : block_count;
+    const uint32_t min_size = page_bytes * num_blocks;
+    TT_FATAL(
+        size >= min_size,
+        "GCB size ({} B) must be at least num_blocks * page ({} * {} = {} B) for program_configs[{}]. {}",
+        size,
+        num_blocks,
+        page_bytes,
+        min_size,
+        config_index,
+        fifo ? "A FIFO consumer takes K-blocks as they arrive but still needs a double-buffered window."
+             : "A batched gather matmul does wait_front(num_blocks), so it needs that many pages "
+               "buffered before it consumes.");
+}
+
 // kMaxCbPagesBytes is a cap on fifo_aligned_num_pages = fifo_size /
 // REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE. Two reasons it exists:
 //   1. The NoC stream overlay's STREAM_REMOTE_DEST_BUF_SIZE register holds the buffer size in
@@ -171,20 +198,8 @@ void validate_grid_for_consumer(
 //      difference can never misfire.
 // 2 MB satisfies both — it's the hardware overlay-field max, and ~5 orders of magnitude under the
 // counter wrap.
-void validate_gcb_size(uint32_t size, uint32_t max_page_bytes, uint32_t max_block_count, bool all_configs_fifo) {
+void validate_gcb_size_cap(uint32_t size) {
     constexpr uint32_t kMaxCbPagesBytes = 131072u * 16u;
-    const uint32_t num_blocks = all_configs_fifo ? kFifoMinWindowBlocks : max_block_count;
-    const uint32_t min_size = max_page_bytes * num_blocks;
-    TT_FATAL(
-        size >= min_size,
-        "GCB size ({} B) must be at least num_blocks * largest page ({} * {} = {} B). {}",
-        size,
-        num_blocks,
-        max_page_bytes,
-        min_size,
-        all_configs_fifo ? "A FIFO consumer takes K-blocks as they arrive but still needs a double-buffered window."
-                         : "A batched gather matmul does wait_front(num_blocks), so it needs that many pages "
-                           "buffered before it consumes.");
     TT_FATAL(
         size <= kMaxCbPagesBytes,
         "GCB size ({} B) exceeds the remote-CB page-count cap ({} B). Reduce size.",
@@ -373,6 +388,37 @@ uint32_t validate_krow_major_weight_for_matmul_1d(
     return block_count;
 }
 
+// The K-row-major sender slices a bank's shard by a single receivers-per-bank number — the manager
+// derives it as total_receivers / num_banks in serialize_request_pages
+// (impl/buffers/tensor_prefetcher_manager.cpp) — so every sender must own the same receiver count.
+// The manager already rejects split and partial-bank sender topologies and requires the total to
+// divide evenly across banks, but a mapping whose per-bank counts are uneven yet still average out
+// ((1, 3, 2, 2) over four banks) clears both of those and then gets sliced at the average, silently
+// delivering the wrong pages. The GCB factory enforces uniformity where it builds the mapping
+// (build_matmul_1d_gcb_krow_major below); this is the same rule for a caller-supplied GCB, which
+// reaches the matmul through the entry point below rather than through the factory.
+//
+// Only meaningful for K-row-major: a receiver-contiguous weight takes its geometry from the shard
+// shape and tolerates non-uniform per-bank receivers (that's what the dual-sender split produces).
+void validate_krow_major_gcb_topology(
+    const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
+    const GlobalCircularBuffer& gcb) {
+    const uint32_t recv_per_bank = static_cast<uint32_t>(program_config.num_global_cb_receivers);
+    const auto& mapping = gcb.sender_receiver_core_mapping();
+    for (size_t s = 0; s < mapping.size(); ++s) {
+        const uint32_t sender_recv_count = mapping[s].second.num_cores();
+        TT_FATAL(
+            sender_recv_count == recv_per_bank,
+            "global_cb sender {} (core {}) drives {} receivers, but the legacy K-row-major layout gives every bank "
+            "the same fan-out of num_global_cb_receivers ({}); the sender would slice its shard at the average "
+            "receiver count and deliver the wrong pages",
+            s,
+            mapping[s].first.str(),
+            sender_recv_count,
+            recv_per_bank);
+    }
+}
+
 }  // namespace
 
 uint32_t tensor_prefetcher_block_count_for_matmul_1d(
@@ -381,9 +427,14 @@ uint32_t tensor_prefetcher_block_count_for_matmul_1d(
     const GlobalCircularBuffer& gcb) {
     const uint32_t receiver_count = gcb.receiver_cores().num_cores();
     TT_FATAL(receiver_count > 0, "global_cb has no receivers");
-    return is_receiver_contiguous_weight(weight)
-               ? validate_recv_contig_weight_for_matmul_1d(program_config, weight, receiver_count)
-               : validate_krow_major_weight_for_matmul_1d(program_config, weight, receiver_count);
+    if (is_receiver_contiguous_weight(weight)) {
+        return validate_recv_contig_weight_for_matmul_1d(program_config, weight, receiver_count);
+    }
+    // Weight checks first: they establish num_global_cb_receivers > 0 and that it divides the
+    // receiver count, which is what the per-sender rule below is stated against.
+    const uint32_t block_count = validate_krow_major_weight_for_matmul_1d(program_config, weight, receiver_count);
+    validate_krow_major_gcb_topology(program_config, gcb);
+    return block_count;
 }
 
 // Builds the GCB for a legacy K-row-major (WIDTH_SHARDED) weight: one shard per DRAM bank, the
@@ -429,11 +480,8 @@ static GlobalCircularBuffer build_matmul_1d_gcb_krow_major(
             num_recv_per_bank);
     }
 
-    // Validate every (config, weight) pair against the matmul invariants, and collect
-    // the largest in1_block_size to size the buffer.
-    uint32_t max_in1_block_size = 0;
-    uint32_t max_block_count = 0;
-    bool all_configs_fifo = true;
+    // Validate every (config, weight) pair against the matmul invariants, including the GCB window
+    // that pair needs on its own.
     for (size_t i = 0; i < program_configs.size(); ++i) {
         const auto& cfg = program_configs[i];
         const auto& w = weights[i];
@@ -460,15 +508,13 @@ static GlobalCircularBuffer build_matmul_1d_gcb_krow_major(
 
         // ---- Per-(config, weight) K-row-major cross-checks and consumer-specific K-block count ----
         const uint32_t block_count = validate_krow_major_weight_for_matmul_1d(cfg, w, receiver_count);
-        max_block_count = std::max(max_block_count, block_count);
-        all_configs_fifo = all_configs_fifo && is_fifo_consumer(cfg);
 
         const uint32_t in1_block_size = gcb_page_bytes(cfg, w, block_count);
         TT_FATAL(in1_block_size > 0, "config[{}] in1_block_size computed as 0", i);
-        max_in1_block_size = std::max(max_in1_block_size, in1_block_size);
+        validate_gcb_size_for_config(size, cfg, i, in1_block_size, block_count);
     }
 
-    validate_gcb_size(size, max_in1_block_size, max_block_count, all_configs_fifo);
+    validate_gcb_size_cap(size);
 
     return tt::tt_metal::experimental::CreateGlobalCircularBufferForTensorPrefetcher(
         *mesh_device, bank_to_receivers, size, buffer_type, /*support_multi_receiver_shards=*/true);
@@ -500,24 +546,19 @@ static GlobalCircularBuffer build_matmul_1d_gcb_recv_contig(
 
     // All matmuls share the GCB receiver rectangle, so they must agree on the ring shape, and that
     // ring must match bank_to_receivers' total receiver count.
-    uint32_t max_page_bytes = 0;
-    uint32_t max_block_count = 0;
-    bool all_configs_fifo = true;
     for (size_t i = 0; i < program_configs.size(); ++i) {
         const auto& cfg = program_configs[i];
         validate_grid_for_consumer(cfg, i, receiver_count);
 
         // Per-(config, weight) recv-contig cross-checks and consumer-specific K-block count.
         const uint32_t block_count = validate_recv_contig_weight_for_matmul_1d(cfg, weights[i], receiver_count);
-        max_block_count = std::max(max_block_count, block_count);
-        all_configs_fifo = all_configs_fifo && is_fifo_consumer(cfg);
 
         const uint32_t page_bytes = gcb_page_bytes(cfg, weights[i], block_count);
         TT_FATAL(page_bytes > 0, "program_configs[{}] page_bytes computed as 0", i);
-        max_page_bytes = std::max(max_page_bytes, page_bytes);
+        validate_gcb_size_for_config(size, cfg, i, page_bytes, block_count);
     }
 
-    validate_gcb_size(size, max_page_bytes, max_block_count, all_configs_fifo);
+    validate_gcb_size_cap(size);
 
     return tt::tt_metal::experimental::CreateGlobalCircularBufferForTensorPrefetcher(
         *mesh_device, bank_to_receivers, size, buffer_type, support_multi_receiver_shards);

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -45,218 +45,6 @@ GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(
         *mesh_device, bank_to_receivers, size, buffer_type, support_multi_receiver_shards);
 }
 
-// Builds the GCB for a legacy K-row-major (WIDTH_SHARDED) weight: one shard per DRAM bank, the
-// bank's shard interleaving all its receivers (one read serves every receiver on the bank). Always
-// single-sender per bank. Extracted from the former public create_global_circular_buffer_for_matmul_1d;
-// the public entry point now detects the layout and dispatches here or to build_matmul_1d_gcb_recv_contig.
-static GlobalCircularBuffer build_matmul_1d_gcb_krow_major(
-    MeshDevice* mesh_device,
-    const std::vector<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>& program_configs,
-    const std::vector<ttnn::Tensor>& weights,
-    const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
-    uint32_t size,
-    BufferType buffer_type) {
-    TT_FATAL(size > 0, "size must be > 0");
-    TT_FATAL(!bank_to_receivers.empty(), "bank_to_receivers must be non-empty");
-
-    // All matmuls share the same GCB receiver rectangle, so they must all agree on the
-    // ring shape and per-bank receiver count.
-    const auto& first = program_configs.front();
-    TT_FATAL(
-        first.gather_in0,
-        "create_global_circular_buffer_for_matmul_1d requires gather_in0=true on every program "
-        "config; config[0] has gather_in0=false");
-    TT_FATAL(first.num_global_cb_receivers > 0, "config[0].num_global_cb_receivers must be > 0");
-
-    const auto& grid = first.compute_with_storage_grid_size;
-    const uint32_t ring_cols = grid.x;
-    const uint32_t ring_rows = grid.y;
-    const uint32_t ring_size = ring_cols * ring_rows;
-    const uint32_t num_senders = static_cast<uint32_t>(bank_to_receivers.size());
-    const uint32_t num_recv_per_bank = static_cast<uint32_t>(first.num_global_cb_receivers);
-
-    // Validate bank_to_receivers shape against the program config:
-    //   - num_senders * num_recv_per_bank must equal ring_size (the matmul's worker count).
-    //   - Each bank must own exactly num_recv_per_bank receiver cores.
-    // We don't check that the receivers row-major-walk matches the matmul's activation grid in
-    // ring-position order — that's the matmul op's responsibility at op-construction time.
-    TT_FATAL(
-        num_senders * num_recv_per_bank == ring_size,
-        "bank_to_receivers has {} senders * {} receivers/bank = {} cores, but program_config "
-        "ring_size ({} x {} = {}) needs that many receivers",
-        num_senders,
-        num_recv_per_bank,
-        num_senders * num_recv_per_bank,
-        ring_cols,
-        ring_rows,
-        ring_size);
-    for (size_t b = 0; b < bank_to_receivers.size(); ++b) {
-        const uint32_t bank_recv_count = bank_to_receivers[b].second.num_cores();
-        TT_FATAL(
-            bank_recv_count == num_recv_per_bank,
-            "bank_to_receivers[{}] (bank_id={}) has {} receiver cores; expected num_global_cb_receivers={}",
-            b,
-            bank_to_receivers[b].first,
-            bank_recv_count,
-            num_recv_per_bank);
-    }
-
-    // Validate every (config, weight) pair against the matmul invariants, and collect
-    // the largest in1_block_size to size the buffer.
-    uint32_t max_in1_block_size = 0;
-    for (size_t i = 0; i < program_configs.size(); ++i) {
-        const auto& cfg = program_configs[i];
-        const auto& w = weights[i];
-
-        TT_FATAL(cfg.gather_in0, "config[{}].gather_in0 must be true", i);
-        TT_FATAL(cfg.num_global_cb_receivers > 0, "config[{}].num_global_cb_receivers must be > 0", i);
-        TT_FATAL(
-            cfg.compute_with_storage_grid_size.x == ring_cols && cfg.compute_with_storage_grid_size.y == ring_rows,
-            "config[{}] has compute_with_storage_grid_size {{{}, {}}}; must match config[0] {{{}, {}}} "
-            "(all matmuls sharing a GCB must use the same receiver rectangle)",
-            i,
-            cfg.compute_with_storage_grid_size.x,
-            cfg.compute_with_storage_grid_size.y,
-            ring_cols,
-            ring_rows);
-        TT_FATAL(
-            static_cast<uint32_t>(cfg.num_global_cb_receivers) == num_recv_per_bank,
-            "config[{}].num_global_cb_receivers ({}) must match config[0] ({}); the GCB has a single "
-            "receiver-per-bank count shared across all matmuls",
-            i,
-            cfg.num_global_cb_receivers,
-            num_recv_per_bank);
-
-        // ---- Weight shape & dtype ----
-        const auto& wp = w.padded_shape();
-        TT_FATAL(wp.rank() >= 2, "weights[{}] must be at least 2D; got rank {}", i, wp.rank());
-        const auto& tile = w.tensor_spec().tile();
-        const uint32_t tile_h = tile.get_height();
-        const uint32_t tile_w = tile.get_width();
-        const uint32_t weight_K = wp[-2];
-        const uint32_t weight_N = wp[-1];
-        TT_FATAL(weight_K % tile_h == 0, "weights[{}] K ({}) must be tile-aligned (tile_h={})", i, weight_K, tile_h);
-        TT_FATAL(weight_N % tile_w == 0, "weights[{}] N ({}) must be tile-aligned (tile_w={})", i, weight_N, tile_w);
-        const uint32_t weight_K_tiles = weight_K / tile_h;
-        const uint32_t weight_N_tiles = weight_N / tile_w;
-
-        // ---- The silent-hang check ----
-        TT_FATAL(
-            weight_K_tiles % ring_size == 0,
-            "weights[{}] K must be divisible by ring_size in tiles. Got weight_K_tiles={}, ring_size={} "
-            "(remainder={}). The matmul activation grid would pad K beyond what the prefetcher pushes "
-            "and the receivers would wait forever for in1 pages.",
-            i,
-            weight_K_tiles,
-            ring_size,
-            weight_K_tiles % ring_size);
-        TT_FATAL(
-            weight_K_tiles % cfg.in0_block_w == 0,
-            "weights[{}] K ({} tiles) must be divisible by config[{}].in0_block_w ({})",
-            i,
-            weight_K_tiles,
-            i,
-            cfg.in0_block_w);
-        TT_FATAL(
-            weight_N_tiles % num_senders == 0,
-            "weights[{}] N ({} tiles) must be divisible by num_senders ({})",
-            i,
-            weight_N_tiles,
-            num_senders);
-
-        // ---- Weight DRAM shard layout ----
-        TT_FATAL(w.buffer() != nullptr && w.buffer()->is_dram(), "weights[{}] must live in DRAM", i);
-        const auto& shard_shape = w.buffer()->shard_spec().shape();
-        const uint32_t shard_K = shard_shape[0];
-        const uint32_t shard_N = shard_shape[1];
-        TT_FATAL(
-            shard_K == weight_K,
-            "weights[{}] DRAM shard K ({}) must equal full K ({}); weight must be width-sharded across "
-            "banks with each bank holding the full K dimension",
-            i,
-            shard_K,
-            weight_K);
-        TT_FATAL(
-            shard_N * num_senders == weight_N,
-            "weights[{}] DRAM shard N ({}) * num_senders ({}) must equal full N ({})",
-            i,
-            shard_N,
-            num_senders,
-            weight_N);
-        const uint32_t shard_N_tiles = shard_N / tile_w;
-        TT_FATAL(
-            shard_N_tiles % num_recv_per_bank == 0,
-            "weights[{}] per-bank N ({} tiles) must be divisible by num_global_cb_receivers ({})",
-            i,
-            shard_N_tiles,
-            num_recv_per_bank);
-
-        const uint32_t per_recv_N_tiles = shard_N_tiles / num_recv_per_bank;
-        TT_FATAL(
-            per_recv_N_tiles == cfg.per_core_N,
-            "config[{}].per_core_N ({}) must equal weights[{}] per-receiver N ({} = shard_N_tiles {} "
-            "/ num_global_cb_receivers {})",
-            i,
-            cfg.per_core_N,
-            i,
-            per_recv_N_tiles,
-            shard_N_tiles,
-            num_recv_per_bank);
-
-        // ---- This matmul's in1 block size ----
-        // gather_in0 matmul derives its effective in0_block_w from weight_K_tiles / ring_size,
-        // not from cfg.in0_block_w (which is typically left at 1 in the program config). Use the
-        // same derivation here so the GCB page matches what the matmul will actually consume.
-        const uint32_t actual_in0_block_w = weight_K_tiles / ring_size;
-        const uint32_t bytes_per_tile = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(w.dtype()));
-        const uint32_t in1_block_size = static_cast<uint32_t>(actual_in0_block_w * cfg.per_core_N) * bytes_per_tile;
-        TT_FATAL(in1_block_size > 0, "config[{}] in1_block_size computed as 0", i);
-        max_in1_block_size = std::max(max_in1_block_size, in1_block_size);
-    }
-
-    // ---- Validate the caller-supplied size fits the remote-CB page-count cap and at
-    // least one full layer's worth of pages (the matmul does wait_front(num_blocks)).
-    //
-    // No L1 budget check here — receivers may have very different L1 usage on top of the
-    // GCB (matmul in0/in1/out/interm CBs etc.) and we don't have enough context at the
-    // factory to compute a real cap. Callers must size the GCB to fit their own L1.
-    //
-    // kMaxCbPagesBytes is a cap on fifo_aligned_num_pages = fifo_size /
-    // REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE. Two reasons it exists:
-    //   1. The NoC stream overlay's STREAM_REMOTE_DEST_BUF_SIZE register holds the
-    //      buffer size in 16-byte words and is 17 bits wide on BH/WH (see
-    //      MEM_WORD_ADDR_WIDTH in noc_overlay_parameters.h), so the largest representable
-    //      buffer is (2^17 - 1) * 16 ≈ 2 MB. Paths that wire the GCB through the overlay
-    //      would silently truncate beyond that.
-    //   2. The remote-CB receiver tracks pages with 32-bit counters wrapped at 2^31
-    //      (noc_fast_atomic_increment wrap=31) and computes
-    //      free_pages = fifo_aligned_num_pages - (pages_sent - pages_acked) in unsigned
-    //      32-bit arithmetic. Keeping fifo_aligned_num_pages well under 2^30 leaves
-    //      plenty of headroom between the counter range and any plausible in-flight count
-    //      so signed/unsigned interpretation of the difference can never misfire.
-    // 2 MB satisfies both — it's the hardware overlay-field max, and ~5 orders of magnitude
-    // under the counter wrap.
-    constexpr uint32_t kMaxCbPagesBytes = 131072u * 16u;
-    const uint32_t num_blocks = ring_size;
-    const uint32_t min_size = max_in1_block_size * num_blocks;
-    TT_FATAL(
-        size >= min_size,
-        "GCB size ({} B) must be at least num_blocks * largest in1_block ({} * {} = {} B); the "
-        "matmul does wait_front(num_blocks) so it needs that many pages buffered before it consumes.",
-        size,
-        num_blocks,
-        max_in1_block_size,
-        min_size);
-    TT_FATAL(
-        size <= kMaxCbPagesBytes,
-        "GCB size ({} B) exceeds the remote-CB page-count cap ({} B). Reduce size.",
-        size,
-        kMaxCbPagesBytes);
-
-    return tt::tt_metal::experimental::CreateGlobalCircularBufferForTensorPrefetcher(
-        *mesh_device, bank_to_receivers, size, buffer_type, /*support_multi_receiver_shards=*/true);
-}
-
 namespace {
 
 // Classify a prefetcher weight's DRAM layout. This mirrors tt_metal's detect_layout_mode
@@ -274,6 +62,134 @@ bool is_receiver_contiguous_weight(const ttnn::Tensor& weight) {
         return false;  // legacy K-row-major (WIDTH_SHARDED)
     }
     return weight.nd_shard_spec().has_value();
+}
+
+// A FIFO consumer takes K-blocks as they land, so it needs only a double-buffered window rather than
+// the whole tensor resident.
+constexpr uint32_t kFifoMinWindowBlocks = 2;
+
+// True when the consumer drains the GCB block-at-a-time: mcast_in0 in natural FIFO order, or a
+// gather_in0 matmul streaming in ring-rotated order. Only a batched gather waits for a whole layer.
+// Phrased as a property of the config rather than a list of the consumers we know about today, so a
+// new non-gather consumer gets the shallow floor rather than silently inheriting the full-layer one.
+bool is_fifo_consumer(const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& config) {
+    return !config.gather_in0 || config.stream_in1;
+}
+
+// The consumer -> block_count contract, shared by every weight layout: gather takes one K-block per
+// ring position, mcast takes K_tiles / in0_block_w natural-order blocks. This is the silent-hang
+// guard — an indivisible K makes the prefetcher round the K-block width up and over-read past the
+// weight while the matmul waits on pages that never come — so it lives in one place for all layouts.
+uint32_t block_count_for_consumer(
+    const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
+    uint32_t weight_K_tiles,
+    uint32_t receiver_count) {
+    if (program_config.gather_in0) {
+        TT_FATAL(
+            weight_K_tiles % receiver_count == 0,
+            "weight K ({} tiles) must be divisible by ring_size ({}) for gather_in0; remainder {}. The matmul "
+            "activation grid would pad K beyond what the prefetcher pushes and the receivers would wait forever "
+            "for in1 pages.",
+            weight_K_tiles,
+            receiver_count,
+            weight_K_tiles % receiver_count);
+        return receiver_count;
+    }
+    TT_FATAL(program_config.in0_block_w > 0, "mcast_in0 requires in0_block_w > 0");
+    TT_FATAL(
+        weight_K_tiles % program_config.in0_block_w == 0,
+        "weight K ({} tiles) must be divisible by mcast_in0 in0_block_w ({}); remainder {}",
+        weight_K_tiles,
+        program_config.in0_block_w,
+        weight_K_tiles % program_config.in0_block_w);
+    return weight_K_tiles / static_cast<uint32_t>(program_config.in0_block_w);
+}
+
+// One GCB page is one consumer K-block for one receiver. A gather_in0 matmul derives its effective
+// in0_block_w from weight_K_tiles / ring_size rather than from cfg.in0_block_w (which is typically
+// left at 1), so dividing K by the consumer's block count gives the width each consumer actually
+// reads: that same derived width for gather, cfg.in0_block_w for mcast.
+uint32_t gcb_page_bytes(
+    const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
+    const ttnn::Tensor& weight,
+    uint32_t block_count) {
+    const auto& tile = weight.tensor_spec().tile();
+    const uint32_t weight_K_tiles = static_cast<uint32_t>(weight.padded_shape()[-2]) / tile.get_height();
+    const uint32_t k_block_w_tiles = weight_K_tiles / block_count;
+    const uint32_t bytes_per_tile = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(weight.dtype()));
+    return static_cast<uint32_t>(k_block_w_tiles * program_config.per_core_N) * bytes_per_tile;
+}
+
+// gather_in0 consumes on a ring of exactly receiver_count workers, so its grid must hold that many;
+// mcast_in0 only needs capacity for them (the matmul op pins receivers == cores-with-work).
+void validate_grid_for_consumer(
+    const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
+    size_t config_index,
+    uint32_t receiver_count) {
+    const auto& grid = program_config.compute_with_storage_grid_size;
+    const uint32_t grid_capacity = grid.x * grid.y;
+    if (program_config.gather_in0) {
+        TT_FATAL(
+            grid_capacity == receiver_count,
+            "gather_in0 program_configs[{}] grid {}x{} = {} workers, but the GCB has {} receivers; they must match",
+            config_index,
+            grid.x,
+            grid.y,
+            grid_capacity,
+            receiver_count);
+    } else {
+        TT_FATAL(
+            grid_capacity >= receiver_count,
+            "mcast_in0 program_configs[{}] grid {}x{} has capacity for {} workers, but the GCB has {} receivers",
+            config_index,
+            grid.x,
+            grid.y,
+            grid_capacity,
+            receiver_count);
+    }
+}
+
+// Shared GCB size validation: the caller-supplied size must clear the floor its consumers need — a
+// full layer for a batched gather matmul (it does wait_front(num_blocks)), or a double-buffered
+// window when every consumer sharing the GCB reads K-blocks FIFO — and fit the remote-CB cap.
+//
+// No L1 budget check here — receivers may have very different L1 usage on top of the GCB (matmul
+// in0/in1/out/interm CBs etc.) and we don't have enough context at the factory to compute a real cap.
+// Callers must size the GCB to fit their own L1.
+//
+// kMaxCbPagesBytes is a cap on fifo_aligned_num_pages = fifo_size /
+// REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE. Two reasons it exists:
+//   1. The NoC stream overlay's STREAM_REMOTE_DEST_BUF_SIZE register holds the buffer size in
+//      16-byte words and is 17 bits wide on BH/WH (see MEM_WORD_ADDR_WIDTH in
+//      noc_overlay_parameters.h), so the largest representable buffer is (2^17 - 1) * 16 ~= 2 MB.
+//      Paths that wire the GCB through the overlay would silently truncate beyond that.
+//   2. The remote-CB receiver tracks pages with 32-bit counters wrapped at 2^31
+//      (noc_fast_atomic_increment wrap=31) and computes
+//      free_pages = fifo_aligned_num_pages - (pages_sent - pages_acked) in unsigned 32-bit
+//      arithmetic. Keeping fifo_aligned_num_pages well under 2^30 leaves plenty of headroom between
+//      the counter range and any plausible in-flight count so signed/unsigned interpretation of the
+//      difference can never misfire.
+// 2 MB satisfies both — it's the hardware overlay-field max, and ~5 orders of magnitude under the
+// counter wrap.
+void validate_gcb_size(uint32_t size, uint32_t max_page_bytes, uint32_t max_block_count, bool all_configs_fifo) {
+    constexpr uint32_t kMaxCbPagesBytes = 131072u * 16u;
+    const uint32_t num_blocks = all_configs_fifo ? kFifoMinWindowBlocks : max_block_count;
+    const uint32_t min_size = max_page_bytes * num_blocks;
+    TT_FATAL(
+        size >= min_size,
+        "GCB size ({} B) must be at least num_blocks * largest page ({} * {} = {} B). {}",
+        size,
+        num_blocks,
+        max_page_bytes,
+        min_size,
+        all_configs_fifo ? "A FIFO consumer takes K-blocks as they arrive but still needs a double-buffered window."
+                         : "A batched gather matmul does wait_front(num_blocks), so it needs that many pages "
+                           "buffered before it consumes.");
+    TT_FATAL(
+        size <= kMaxCbPagesBytes,
+        "GCB size ({} B) exceeds the remote-CB page-count cap ({} B). Reduce size.",
+        size,
+        kMaxCbPagesBytes);
 }
 
 // Shared receiver-contiguous weight ↔ matmul cross-checks. Returns the number of K-blocks the
@@ -343,32 +259,7 @@ uint32_t validate_recv_contig_weight_for_matmul_1d(
         wp[-1]);
 
     const uint32_t weight_K_tiles = shard_K / tile_h;
-    uint32_t block_count = 0;
-    if (program_config.gather_in0) {
-        // Gather consumes one rotated K-block per ring position. Silent-hang / over-read guard: K must
-        // divide evenly into receiver_count blocks. Otherwise the K-block width the prefetcher lays out
-        // rounds up, the kernel reads past the receiver's slab, and the matmul (which pads K to a
-        // multiple of receiver_count) waits on pages that never come.
-        TT_FATAL(
-            weight_K_tiles % receiver_count == 0,
-            "weight K ({} tiles) must be divisible by receiver_count ({}) for gather_in0; remainder {}",
-            weight_K_tiles,
-            receiver_count,
-            weight_K_tiles % receiver_count);
-        block_count = receiver_count;
-    } else {
-        // Mcast consumes the same natural K-block sequence on every output worker. Same silent-hang /
-        // over-read guard, keyed on in0_block_w: an indivisible K rounds the block width up and the
-        // kernel over-reads while the matmul waits forever.
-        TT_FATAL(program_config.in0_block_w > 0, "mcast_in0 requires in0_block_w > 0");
-        TT_FATAL(
-            weight_K_tiles % program_config.in0_block_w == 0,
-            "weight K ({} tiles) must be divisible by mcast_in0 in0_block_w ({}); remainder {}",
-            weight_K_tiles,
-            program_config.in0_block_w,
-            weight_K_tiles % program_config.in0_block_w);
-        block_count = weight_K_tiles / static_cast<uint32_t>(program_config.in0_block_w);
-    }
+    const uint32_t block_count = block_count_for_consumer(program_config, weight_K_tiles, receiver_count);
 
     // Page-size guard: the matmul sizes its in1 remote-CB page from per_core_N; the prefetcher pushes
     // pages of n_per_recv tiles. A mismatch desyncs the page-credit accounting (wrong output / hang).
@@ -383,6 +274,105 @@ uint32_t validate_recv_contig_weight_for_matmul_1d(
     return block_count;
 }
 
+// Shared legacy K-row-major (WIDTH_SHARDED) weight ↔ matmul cross-checks, the counterpart to
+// validate_recv_contig_weight_for_matmul_1d above. One shard per DRAM bank spanning the full K and
+// N/num_banks columns, K-row-major within the bank so one read serves all of that bank's receivers.
+// Returns the number of K-blocks the prefetcher must push per receiver: gather-in0 uses one block per
+// ring position, mcast-in0 uses the configured inner-dimension block width.
+//
+// The layout carries no ring assumption of its own — the sender divides K into whatever block count the
+// request names (compute_tensor_layout_krow_major in tensor_prefetcher_manager.cpp) and each receiver
+// gets its own N-slice of every block — so the per-receiver page stream is the same shape either
+// consumer sees on a receiver-contiguous weight.
+uint32_t validate_krow_major_weight_for_matmul_1d(
+    const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
+    const ttnn::Tensor& weight,
+    uint32_t receiver_count) {
+    TT_FATAL(
+        program_config.gather_in0 != program_config.mcast_in0,
+        "legacy K-row-major Tensor prefetcher requires exactly one of gather_in0 or mcast_in0 to be true");
+    // Streaming needs a per-receiver rotation table, and the K-row-major sender has no rotation
+    // parameter at all (compute_tensor_layout_krow_major in tensor_prefetcher_manager.cpp), so a
+    // rotation would be silently dropped and the streaming matmul would wait on blocks delivered in
+    // natural order. Reject it here, where every other layout rule lives.
+    TT_FATAL(
+        !program_config.stream_in1,
+        "stream_in1 requires a receiver-contiguous weight: the legacy K-row-major sender cannot deliver a "
+        "per-receiver ring rotation, so a streaming matmul would wait forever on natural-order blocks");
+    TT_FATAL(receiver_count > 0, "receiver_count must be > 0");
+    const uint32_t recv_per_bank = static_cast<uint32_t>(program_config.num_global_cb_receivers);
+    TT_FATAL(recv_per_bank > 0, "num_global_cb_receivers must be > 0");
+    TT_FATAL(
+        receiver_count % recv_per_bank == 0,
+        "global_cb receiver count ({}) must be a whole number of banks at num_global_cb_receivers ({}) per bank; "
+        "the legacy K-row-major layout gives every bank the same receiver fan-out",
+        receiver_count,
+        recv_per_bank);
+    const uint32_t num_senders = receiver_count / recv_per_bank;
+
+    TT_FATAL(weight.buffer() != nullptr && weight.buffer()->is_dram(), "weight must live in DRAM");
+    TT_FATAL(
+        weight.buffer()->has_shard_spec(),
+        "weight must be WIDTH_SHARDED across the DRAM banks (ttnn.MemoryConfig(TensorMemoryLayout.WIDTH_SHARDED, "
+        "BufferType.DRAM, ShardSpec(...))) for the legacy K-row-major Tensor prefetcher path");
+
+    const auto& wp = weight.padded_shape();
+    TT_FATAL(wp.rank() >= 2, "weight must be at least 2D; got rank {}", wp.rank());
+    const auto& tile = weight.tensor_spec().tile();
+    const uint32_t tile_h = tile.get_height();
+    const uint32_t tile_w = tile.get_width();
+    const uint32_t weight_K = wp[-2];
+    const uint32_t weight_N = wp[-1];
+    TT_FATAL(weight_K % tile_h == 0, "weight K ({}) must be tile-aligned (tile_h={})", weight_K, tile_h);
+    TT_FATAL(weight_N % tile_w == 0, "weight N ({}) must be tile-aligned (tile_w={})", weight_N, tile_w);
+    const uint32_t weight_K_tiles = weight_K / tile_h;
+
+    const auto& shard_shape = weight.buffer()->shard_spec().shape();
+    const uint32_t shard_K = shard_shape[0];
+    const uint32_t shard_N = shard_shape[1];
+    TT_FATAL(
+        shard_K == weight_K,
+        "DRAM shard K ({}) must equal full K ({}); the weight must be width-sharded across banks with each bank "
+        "holding the full K dimension",
+        shard_K,
+        weight_K);
+    TT_FATAL(
+        shard_N * num_senders == weight_N,
+        "DRAM shard N ({}) * num_senders ({}) must equal full N ({})",
+        shard_N,
+        num_senders,
+        weight_N);
+    const uint32_t shard_N_tiles = shard_N / tile_w;
+    TT_FATAL(
+        shard_N_tiles % recv_per_bank == 0,
+        "per-bank N ({} tiles) must be divisible by num_global_cb_receivers ({})",
+        shard_N_tiles,
+        recv_per_bank);
+    const uint32_t per_recv_N_tiles = shard_N_tiles / recv_per_bank;
+    TT_FATAL(
+        per_recv_N_tiles == program_config.per_core_N,
+        "program_config.per_core_N ({}) must equal the weight's per-receiver N ({} tiles = per-bank N {} tiles / "
+        "num_global_cb_receivers {}); otherwise the prefetcher's pushed page size and the matmul's in1 remote-CB "
+        "page size disagree and the page-credit accounting desyncs",
+        program_config.per_core_N,
+        per_recv_N_tiles,
+        shard_N_tiles,
+        recv_per_bank);
+
+    const uint32_t block_count = block_count_for_consumer(program_config, weight_K_tiles, receiver_count);
+    if (program_config.gather_in0) {
+        // Legacy-only extra guard, predating this layout's mcast consumer: gather ignores
+        // cfg.in0_block_w (it derives the K-block width from K/ring_size), but the K-row-major builder
+        // has always required K to divide by it, so keep rejecting exactly the configs it always did.
+        TT_FATAL(
+            weight_K_tiles % program_config.in0_block_w == 0,
+            "weight K ({} tiles) must be divisible by in0_block_w ({})",
+            weight_K_tiles,
+            program_config.in0_block_w);
+    }
+    return block_count;
+}
+
 }  // namespace
 
 uint32_t tensor_prefetcher_block_count_for_matmul_1d(
@@ -391,7 +381,97 @@ uint32_t tensor_prefetcher_block_count_for_matmul_1d(
     const GlobalCircularBuffer& gcb) {
     const uint32_t receiver_count = gcb.receiver_cores().num_cores();
     TT_FATAL(receiver_count > 0, "global_cb has no receivers");
-    return validate_recv_contig_weight_for_matmul_1d(program_config, weight, receiver_count);
+    return is_receiver_contiguous_weight(weight)
+               ? validate_recv_contig_weight_for_matmul_1d(program_config, weight, receiver_count)
+               : validate_krow_major_weight_for_matmul_1d(program_config, weight, receiver_count);
+}
+
+// Builds the GCB for a legacy K-row-major (WIDTH_SHARDED) weight: one shard per DRAM bank, the
+// bank's shard interleaving all its receivers (one read serves every receiver on the bank). Always
+// single-sender per bank. Extracted from the former public create_global_circular_buffer_for_matmul_1d;
+// the public entry point now detects the layout and dispatches here or to build_matmul_1d_gcb_recv_contig.
+static GlobalCircularBuffer build_matmul_1d_gcb_krow_major(
+    MeshDevice* mesh_device,
+    const std::vector<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>& program_configs,
+    const std::vector<ttnn::Tensor>& weights,
+    const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
+    uint32_t size,
+    BufferType buffer_type) {
+    TT_FATAL(size > 0, "size must be > 0");
+    TT_FATAL(!bank_to_receivers.empty(), "bank_to_receivers must be non-empty");
+
+    // All matmuls share the same GCB receiver rectangle, so they must all agree on the
+    // ring shape and per-bank receiver count.
+    const auto& first = program_configs.front();
+    TT_FATAL(first.num_global_cb_receivers > 0, "config[0].num_global_cb_receivers must be > 0");
+
+    const auto& grid = first.compute_with_storage_grid_size;
+    const uint32_t ring_cols = grid.x;
+    const uint32_t ring_rows = grid.y;
+    const uint32_t num_senders = static_cast<uint32_t>(bank_to_receivers.size());
+    const uint32_t num_recv_per_bank = static_cast<uint32_t>(first.num_global_cb_receivers);
+    // A bank's single K-row-major read serves all of that bank's receivers, so the receiver count is
+    // fixed by the bank fan-out rather than by the program config's grid.
+    const uint32_t receiver_count = num_senders * num_recv_per_bank;
+
+    // Validate bank_to_receivers shape against the program config: each bank must own exactly
+    // num_recv_per_bank receiver cores (the grid rule is per-config, in the loop below). We don't check
+    // that the receivers row-major-walk matches the matmul's activation grid in ring-position order —
+    // that's the matmul op's responsibility at op-construction time.
+    for (size_t b = 0; b < bank_to_receivers.size(); ++b) {
+        const uint32_t bank_recv_count = bank_to_receivers[b].second.num_cores();
+        TT_FATAL(
+            bank_recv_count == num_recv_per_bank,
+            "bank_to_receivers[{}] (bank_id={}) has {} receiver cores; expected num_global_cb_receivers={}",
+            b,
+            bank_to_receivers[b].first,
+            bank_recv_count,
+            num_recv_per_bank);
+    }
+
+    // Validate every (config, weight) pair against the matmul invariants, and collect
+    // the largest in1_block_size to size the buffer.
+    uint32_t max_in1_block_size = 0;
+    uint32_t max_block_count = 0;
+    bool all_configs_fifo = true;
+    for (size_t i = 0; i < program_configs.size(); ++i) {
+        const auto& cfg = program_configs[i];
+        const auto& w = weights[i];
+
+        TT_FATAL(cfg.num_global_cb_receivers > 0, "config[{}].num_global_cb_receivers must be > 0", i);
+        TT_FATAL(
+            cfg.compute_with_storage_grid_size.x == ring_cols && cfg.compute_with_storage_grid_size.y == ring_rows,
+            "config[{}] has compute_with_storage_grid_size {{{}, {}}}; must match config[0] {{{}, {}}} "
+            "(all matmuls sharing a GCB must use the same receiver rectangle)",
+            i,
+            cfg.compute_with_storage_grid_size.x,
+            cfg.compute_with_storage_grid_size.y,
+            ring_cols,
+            ring_rows);
+        TT_FATAL(
+            static_cast<uint32_t>(cfg.num_global_cb_receivers) == num_recv_per_bank,
+            "config[{}].num_global_cb_receivers ({}) must match config[0] ({}); the GCB has a single "
+            "receiver-per-bank count shared across all matmuls",
+            i,
+            cfg.num_global_cb_receivers,
+            num_recv_per_bank);
+
+        validate_grid_for_consumer(cfg, i, receiver_count);
+
+        // ---- Per-(config, weight) K-row-major cross-checks and consumer-specific K-block count ----
+        const uint32_t block_count = validate_krow_major_weight_for_matmul_1d(cfg, w, receiver_count);
+        max_block_count = std::max(max_block_count, block_count);
+        all_configs_fifo = all_configs_fifo && is_fifo_consumer(cfg);
+
+        const uint32_t in1_block_size = gcb_page_bytes(cfg, w, block_count);
+        TT_FATAL(in1_block_size > 0, "config[{}] in1_block_size computed as 0", i);
+        max_in1_block_size = std::max(max_in1_block_size, in1_block_size);
+    }
+
+    validate_gcb_size(size, max_in1_block_size, max_block_count, all_configs_fifo);
+
+    return tt::tt_metal::experimental::CreateGlobalCircularBufferForTensorPrefetcher(
+        *mesh_device, bank_to_receivers, size, buffer_type, /*support_multi_receiver_shards=*/true);
 }
 
 // Builds the GCB for a receiver-contiguous (NdShardSpec) weight: num_shards == ring_size, each shard
@@ -425,70 +505,19 @@ static GlobalCircularBuffer build_matmul_1d_gcb_recv_contig(
     bool all_configs_fifo = true;
     for (size_t i = 0; i < program_configs.size(); ++i) {
         const auto& cfg = program_configs[i];
-        const auto& grid = cfg.compute_with_storage_grid_size;
-        const uint32_t grid_capacity = grid.x * grid.y;
-        if (cfg.gather_in0) {
-            TT_FATAL(
-                grid_capacity == receiver_count,
-                "gather_in0 program_configs[{}] grid {}x{} = {} workers, but bank_to_receivers has {} total "
-                "receivers; they must match",
-                i,
-                grid.x,
-                grid.y,
-                grid_capacity,
-                receiver_count);
-        } else {
-            TT_FATAL(
-                grid_capacity >= receiver_count,
-                "mcast_in0 program_configs[{}] grid {}x{} has capacity for {} workers, but bank_to_receivers has "
-                "{} receivers",
-                i,
-                grid.x,
-                grid.y,
-                grid_capacity,
-                receiver_count);
-        }
+        validate_grid_for_consumer(cfg, i, receiver_count);
 
         // Per-(config, weight) recv-contig cross-checks and consumer-specific K-block count.
         const uint32_t block_count = validate_recv_contig_weight_for_matmul_1d(cfg, weights[i], receiver_count);
         max_block_count = std::max(max_block_count, block_count);
-        all_configs_fifo = all_configs_fifo && (cfg.mcast_in0 || cfg.stream_in1);
+        all_configs_fifo = all_configs_fifo && is_fifo_consumer(cfg);
 
-        // One GCB page is one consumer K-block for one receiver.
-        const auto& w = weights[i];
-        const auto& tile = w.tensor_spec().tile();
-        const uint32_t weight_K_tiles = static_cast<uint32_t>(w.padded_shape()[-2]) / tile.get_height();
-        const uint32_t k_block_w_tiles = weight_K_tiles / block_count;
-        const uint32_t bytes_per_tile = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(w.dtype()));
-        const uint32_t page_bytes = k_block_w_tiles * cfg.per_core_N * bytes_per_tile;
+        const uint32_t page_bytes = gcb_page_bytes(cfg, weights[i], block_count);
         TT_FATAL(page_bytes > 0, "program_configs[{}] page_bytes computed as 0", i);
         max_page_bytes = std::max(max_page_bytes, page_bytes);
     }
 
-    // A batched gather matmul waits for all blocks before consuming. A stream_in1 gather or a
-    // GCB-backed mcast consumes K-blocks FIFO as they land, so a shallow window is valid. Relax the
-    // floor to a double-buffer when every matmul sharing this GCB is a FIFO consumer; otherwise keep
-    // enough space for the largest full tensor. Same cap as the
-    // K-row-major builder (see create_global_circular_buffer_for_matmul_1d for why kMaxCbPagesBytes
-    // exists); no L1 budget check — callers size to fit their own receiver L1.
-    constexpr uint32_t kMaxCbPagesBytes = 131072u * 16u;
-    constexpr uint32_t kFifoMinWindowBlocks = 2;
-    const uint32_t min_blocks = all_configs_fifo ? kFifoMinWindowBlocks : max_block_count;
-    const uint32_t min_size = max_page_bytes * min_blocks;
-    TT_FATAL(
-        size >= min_size,
-        "GCB size ({} B) must be at least {} * largest page ({} B) = {} B. {}",
-        size,
-        min_blocks,
-        max_page_bytes,
-        min_size,
-        all_configs_fifo ? "FIFO matmuls consume K-blocks as they arrive but still need a double-buffered window."
-                         : "A batched gather matmul needs a full layer buffered before it consumes.");
-    TT_FATAL(
-        size <= kMaxCbPagesBytes,
-        "GCB size ({} B) exceeds the remote-CB page-count cap ({} B). Reduce size.",
-        size,
-        kMaxCbPagesBytes);
+    validate_gcb_size(size, max_page_bytes, max_block_count, all_configs_fifo);
 
     return tt::tt_metal::experimental::CreateGlobalCircularBufferForTensorPrefetcher(
         *mesh_device, bank_to_receivers, size, buffer_type, support_multi_receiver_shards);
@@ -529,13 +558,6 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
         const bool single_sender = support_multi_receiver_shards.value_or(false);
         return build_matmul_1d_gcb_recv_contig(
             mesh_device, program_configs, weights, bank_to_receivers, size, buffer_type, single_sender);
-    }
-
-    for (size_t i = 0; i < program_configs.size(); ++i) {
-        TT_FATAL(
-            program_configs[i].gather_in0,
-            "program_configs[{}] uses mcast_in0, which requires a receiver-contiguous NdShardSpec weight",
-            i);
     }
 
     // Legacy K-row-major is single-sender per bank by construction (a bank's shard feeds all its

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
@@ -209,14 +209,14 @@ void bind_tensor_prefetcher(nb::module_& mod) {
     ttnn::bind_function<"tensor_prefetcher_block_count_for_matmul_1d", "ttnn.experimental.">(
         mod,
         R"doc(
-            Compute and validate the block_count to pair with a receiver-contiguous DRAM weight
-            in queue_tensor_prefetcher_request for a gather_in0 or mcast_in0 1D matmul fed via
+            Compute and validate the block_count to pair with a DRAM weight in
+            queue_tensor_prefetcher_request for a gather_in0 or mcast_in0 1D matmul fed via
             global_cb. Gather returns the receiver/ring count. Mcast returns
             weight_K_tiles / in0_block_w and uses natural FIFO order.
 
             Args:
                 program_config: The 1D matmul program config that will consume the weight.
-                weight: The receiver-contiguous (NdShardSpec) DRAM weight tensor.
+                weight: The DRAM weight tensor, in either layout.
                 global_cb: The DRAM-sender GCB the prefetcher and matmul share.
 
             Returns:

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -815,15 +815,23 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
     uint32_t src1_cb_index = tt::CBIndex::c_1;
     tt::tt_metal::CBHandle cb_src1 = 0;
+    uint32_t in1_remote_cb_size = 0;
     if (use_global_cb) {
         const uint32_t remote_cb_index = tt::CBIndex::c_31;
         const uint32_t in1_block_size_bytes = in1_block_tiles * in1_single_tile_size;
+        // Floor the GCB to a whole number of in1 K-block pages, as the gather_in0 path does. The
+        // caller sizes the GCB in bytes and need not know this op's page size; any bytes past the
+        // last whole page are simply unused rather than a hard error. The reader streams through a
+        // two-page window (remote_cb_wait_front of 1 then 2), so that much has to survive the floor —
+        // op validation checks this too, but a GCB built via the raw factory skips that path.
+        in1_remote_cb_size = tt::round_down(global_cb->size(), in1_block_size_bytes);
         TT_FATAL(
-            global_cb->size() % in1_block_size_bytes == 0,
-            "mcast_in0 global_cb size {} must be a multiple of in1 K-block size {}",
+            in1_remote_cb_size >= 2 * in1_block_size_bytes,
+            "mcast_in0 global_cb size {} holds {} whole in1 K-block pages of {} B; the reader needs at least 2",
             global_cb->size(),
+            in1_remote_cb_size / in1_block_size_bytes,
             in1_block_size_bytes);
-        tt_metal::CircularBufferConfig remote_cb_config(global_cb->size());
+        tt_metal::CircularBufferConfig remote_cb_config(in1_remote_cb_size);
         remote_cb_config.remote_index(remote_cb_index)
             .set_page_size(in1_block_size_bytes)
             .set_data_format(in1_data_format);
@@ -848,8 +856,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         "CB {} :: PS = {}, NP = {}, TOTAL = {}",
         src1_cb_index,
         in1_single_tile_size,
-        use_global_cb ? global_cb->size() / in1_single_tile_size : in1_CB_size / in1_single_tile_size,
-        use_global_cb ? global_cb->size() : in1_CB_size);
+        use_global_cb ? in1_remote_cb_size / in1_single_tile_size : in1_CB_size / in1_single_tile_size,
+        use_global_cb ? in1_remote_cb_size : in1_CB_size);
 
     uint32_t src2_cb_index = tt::CBIndex::c_2;
     tt::tt_metal::CBHandle cb_src2 = 0;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1052,27 +1052,28 @@ void validate_dram_sender_global_cb_mcast_in0_geometry(
         program_config.out_block_w,
         program_config.per_core_N);
 
-    // The receiver-contiguous weight ↔ matmul cross-checks (DRAM NdShardSpec, one full-K × per_core_N
-    // shard per receiver, num_shards == receiver_count, K % in0_block_w == 0, per_core_N == per-receiver
-    // N, stream_in1 == false) are owned by the shared prefetcher helper. Call it rather than re-deriving
-    // them here, so the recv-contig contract lives in one place.
+    // The weight ↔ matmul cross-checks (per-receiver shard geometry, K % in0_block_w == 0, per_core_N ==
+    // per-receiver N, stream_in1 == false) are owned by the shared prefetcher helper, which dispatches on
+    // the weight's detected DRAM layout — receiver-contiguous NdShardSpec or legacy K-row-major
+    // WIDTH_SHARDED. Call it rather than re-deriving them here, so each layout's contract lives in one
+    // place.
     ttnn::global_circular_buffer::tensor_prefetcher_block_count_for_matmul_1d(program_config, input_tensor_b, gcb);
 
-    // GCB-window guards specific to this op: the mcast reader streams K-blocks through a two-page
-    // remote-CB window, so the GCB must be an exact multiple of the in1 K-block page and hold >= 2 pages.
+    // GCB-window guard specific to this op: the mcast reader streams K-blocks through a remote-CB
+    // window, so the GCB has to hold at least a double buffer of them. The window itself is floored to
+    // whole pages when the CB is created, so a size that is not an exact multiple is fine — the leftover
+    // bytes are simply unused.
     const uint32_t in1_block_size_bytes =
         program_config.in0_block_w * program_config.per_core_N *
         in1_tile.get_tile_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor_b.dtype()));
+    const uint32_t resident_blocks = gcb.size() / in1_block_size_bytes;
     TT_FATAL(
-        gcb.size() % in1_block_size_bytes == 0,
-        "mcast_in0 global_cb size {} must be a multiple of its in1 K-block page size {}",
+        resident_blocks >= 2,
+        "mcast_in0 global_cb requires a two-page streaming window: size {} holds {} whole in1 K-block pages of {} B, "
+        "need at least 2",
         gcb.size(),
+        resident_blocks,
         in1_block_size_bytes);
-    TT_FATAL(
-        gcb.size() >= 2 * in1_block_size_bytes,
-        "mcast_in0 global_cb requires a two-page streaming window: size {} must be at least {}",
-        gcb.size(),
-        2 * in1_block_size_bytes);
 }
 
 // Helper: warns if a caller of MatmulDeviceOperation's static API hasn't populated

--- a/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
+++ b/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
@@ -16,7 +16,7 @@ couplings nothing enforces.
 it derives ``block_count``, queues the request, then runs the consuming
 ``ttnn.linear`` with the same GCB and program config. Gather-in0 uses one block
 per ring receiver. Mcast-in0 uses ``K_tiles / in0_block_w`` natural-order blocks
-per receiver and requires a receiver-contiguous weight.
+per receiver.
 
 This is a host-side composition, not a device-level fusion: the prefetch still
 runs on the DRAM-core (DRISC) path off the command queue while the matmul is
@@ -42,12 +42,14 @@ def prefetch_and_linear(
 
     Gather-in0 preserves its existing batched/streaming behavior selected by
     ``program_config.stream_in1``. Mcast-in0 always uses natural FIFO order with
-    ``stream_in1=False`` and can consume from a shallow GCB without a rotation table.
+    ``stream_in1=False`` and can consume from a shallow GCB without a rotation table,
+    on either DRAM weight layout.
 
     Args:
         input_tensor_a: Activation (in0).
-        weight: DRAM-sharded weight (in1) to prefetch and multiply by. Streaming gather
-            and GCB-backed mcast require a receiver-contiguous weight layout.
+        weight: DRAM-sharded weight (in1) to prefetch and multiply by, in either the legacy
+            WIDTH_SHARDED K-row-major or the receiver-contiguous layout. Streaming gather
+            (``stream_in1``) requires the receiver-contiguous layout.
         global_cb: DRAM-sender GlobalCircularBuffer shared by the prefetch and
             the matmul.
         program_config: 1D matmul program config driving the matmul.


### PR DESCRIPTION
### PR Category
Feature, Cleanup

### Summary
Initial mcast-in0 support for the Tensor prefetcher carried three restrictions the mechanism underneath it does not have.

**Legacy K-row-major weights were rejected.** The mcast geometry check delegated to the receiver-contiguous validator, which requires an `NdShardSpec`, and the GCB factory refused any mcast config on a `WIDTH_SHARDED` weight outright. Nothing below that needed the restriction: the sender divides a bank's shard into whatever `block_count` the request names (`compute_tensor_layout_krow_major`) and slices each block across that bank's receivers, so the per-receiver page stream is the same one mcast already reads off a receiver-contiguous weight. Production models carry K-row-major weights, so feeding one to an mcast-in0 matmul previously meant reallocating it.

`validate_krow_major_weight_for_matmul_1d` is the K-row-major counterpart to the recv-contig validator, so each layout's weight↔matmul contract lives in exactly one place, and `tensor_prefetcher_block_count_for_matmul_1d` dispatches to it on the detected layout. `build_matmul_1d_gcb_krow_major` delegates its per-weight checks there rather than inlining them, accepts mcast configs (grid capacity ≥ receiver count, as the recv-contig builder already allowed), and derives the GCB page from the consumer's block count instead of assuming a ring.

Streaming (`stream_in1`) stays receiver-contiguous-only — it needs a per-receiver rotation, which only that layout supports.

**A GCB size that wasn't a whole number of in1 K-block pages was fatal.** The mcast path asserted `gcb.size() % in1_block_size == 0` in both the device op and the program factory, forcing callers to know the op's page size to allocate a buffer. The gather path has always floored instead (`(size / page) * page`), so the mcast CB now floors the same way and the surviving check is the one that matters: the window must hold at least two whole pages.

**The GCB size floor was computed across configs instead of per config.** It took the largest page over all configs and multiplied it by the largest block count over all configs. Those two maxima can come from different configs, so a GCB shared by a batched gather (small page, whole layer resident) and an mcast (large page, two-page window) was held to a size neither consumer asked for — and the product can exceed the 2 MB remote-CB cap, making a mix unconstructible that each consumer fits individually. Each `(config, weight)` pair is now checked against its own window as the builders walk them (`validate_gcb_size_for_config`); the cap is size-independent and stays a single check after the loop. The floor only ever drops, so nothing that passed before starts failing.

One guard goes the other way. The K-row-major sender slices its bank's shard by a single receivers-per-bank number, so `tensor_prefetcher_block_count_for_matmul_1d` now requires every GCB sender to drive exactly `num_global_cb_receivers` receivers. The manager rejects split and partial-bank sender topologies and requires the receiver total to divide evenly across banks, but an uneven fan-out that still averages out — `(1, 3, 2, 2)` over four banks — clears both of those and then gets sliced at the average, silently delivering the wrong pages. `build_matmul_1d_gcb_krow_major` already enforces uniformity where it builds the mapping; the exposure was a hand-built GCB reaching a matmul through this entry point.

Docs-wise this also corrects `prefetcher_matmul_design.md`, which stated the layout restriction as contract.

### Notes for reviewers
- **The layout restriction came down to which validator the mcast path happened to call** — worth confirming that reading. The claim is that `compute_tensor_layout_krow_major` already accepts an arbitrary per-tensor `block_count` (it ceil-divides K by it), so nothing under the factory rejected legacy weights. The mcast test pins this: `block_count` is `K_tiles / in0_block_w`, deliberately *different* from the receiver count, so a ring-derived block count would deliver the wrong pages rather than silently working.
- `build_matmul_1d_gcb_krow_major` is the biggest diff, but most of it is deletion — ~75 lines of inlined per-weight checks replaced by the shared validator call. The gather path through it should be behavior-identical, size floor included: a batched gather's `block_count` is `ring_size`, so its own floor is the same `max_page * ring_size` the cross-config rule produced for a gather-only GCB.
- The gather-vs-mcast grid rule is checked per config rather than once from `program_configs[0]`, matching the recv-contig builder, so a GCB shared by a gather and an mcast matmul gets the right rule for each.
- `in1_remote_cb_size` in the mcast factory is hoisted out of the `if` only so the existing `log_debug` reports the floored size rather than the raw GCB size.
- The per-sender fan-out check is a no-op for any GCB built through `create_global_circular_buffer_for_matmul_1d`. It only reaches callers who hand-build one through the generic `create_global_circular_buffer_for_tensor_prefetcher`.

### Test coverage
- `test_tensor_prefetcher_mcast_in0[weight_layout × gcb_size_misalign_bytes]` — mcast PCC on all three weight layouts (`krow_major`, `recv_contig_strided`, `recv_contig_contiguous`), each at an exact page multiple and at a ragged size (`4 * page + 64`), asserting the derived block count on the way through.
- `test_create_global_circular_buffer_for_matmul_1d_sizes_per_config` — a batched gather sharing a GCB with an mcast whose page is 16× larger. Asserts that the cross-config product exceeds what either consumer needs, that the real floor is accepted, and that one byte under it fails naming the config that needs the larger window.
- `test_tensor_prefetcher_block_count_rejects_uneven_krow_major_fanout` — a hand-built GCB with `(1, 3, 2, 2, …)` fan-out, same receiver total as a uniform mapping, is rejected.

On p150 (7 DRAM banks, harvested):
- `test_prefetcher_BH_tensor_large.py`: 56 passed, 3 skipped (pre-existing "expects 8 unharvested DRAM banks" gate)
- `test_prefetcher_BH_validator.py`: 27 passed, 3 skipped (same gate)

One existing test needed a change: `test_..._rejects_undersized` matches the assert message on the literal `num_blocks`, and the reworded floor message keeps that token deliberately so the test still covers the case it was written for.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/mcast-in0-krow-major-gcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/mcast-in0-krow-major-gcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/mcast-in0-krow-major-gcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/mcast-in0-krow-major-gcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/mcast-in0-krow-major-gcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/mcast-in0-krow-major-gcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/mcast-in0-krow-major-gcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/mcast-in0-krow-major-gcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/mcast-in0-krow-major-gcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/mcast-in0-krow-major-gcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/mcast-in0-krow-major-gcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/mcast-in0-krow-major-gcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/mcast-in0-krow-major-gcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/mcast-in0-krow-major-gcb)
