### PR TITLE
Fix build-wrapper.yaml fetch-depth type error on workflow_dispatch

### DIFF
--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -132,7 +132,7 @@ jobs:
       tracy: true
       runs-on: ${{ inputs['runs-on'] }}
       ref: ${{ inputs.ref }}
-      fetch-depth: ${{ inputs.fetch-depth }}
+      fetch-depth: ${{ inputs.fetch-depth || 500 }}
 
   # build job runs the matrix - either when called from merge-gate with pre-built tags,
   # or when called via workflow_call without the platform dropdown
@@ -177,7 +177,7 @@ jobs:
       tracy: true
       runs-on: ${{ inputs['runs-on'] }}
       ref: ${{ inputs.ref }}
-      fetch-depth: ${{ inputs.fetch-depth }}
+      fetch-depth: ${{ inputs.fetch-depth || 500 }}
       # Pass pre-built docker image tags based on platform
       ci-build-docker-image: ${{
         (matrix.config.platform == 'Ubuntu 24.04' && inputs.ubuntu-2404-ci-build-tag) ||

--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -95,6 +95,11 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      fetch-depth:
+        required: false
+        type: string
+        default: "500"
+        description: "Git fetch depth passed through to build-artifact (0 fetches full history)"
 
 permissions:
   contents: read
@@ -132,7 +137,7 @@ jobs:
       tracy: true
       runs-on: ${{ inputs['runs-on'] }}
       ref: ${{ inputs.ref }}
-      fetch-depth: ${{ inputs.fetch-depth || 500 }}
+      fetch-depth: ${{ inputs.fetch-depth }}
 
   # build job runs the matrix - either when called from merge-gate with pre-built tags,
   # or when called via workflow_call without the platform dropdown
@@ -177,7 +182,7 @@ jobs:
       tracy: true
       runs-on: ${{ inputs['runs-on'] }}
       ref: ${{ inputs.ref }}
-      fetch-depth: ${{ inputs.fetch-depth || 500 }}
+      fetch-depth: ${{ inputs.fetch-depth }}
       # Pass pre-built docker image tags based on platform
       ci-build-docker-image: ${{
         (matrix.config.platform == 'Ubuntu 24.04' && inputs.ubuntu-2404-ci-build-tag) ||

--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -95,11 +95,6 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
-      fetch-depth:
-        required: false
-        type: string
-        default: "500"
-        description: "Git fetch depth passed through to build-artifact (0 fetches full history)"
 
 permissions:
   contents: read
@@ -137,7 +132,7 @@ jobs:
       tracy: true
       runs-on: ${{ inputs['runs-on'] }}
       ref: ${{ inputs.ref }}
-      fetch-depth: ${{ inputs.fetch-depth }}
+      fetch-depth: ${{ github.event_name == 'workflow_dispatch' && 500 || inputs.fetch-depth }}
 
   # build job runs the matrix - either when called from merge-gate with pre-built tags,
   # or when called via workflow_call without the platform dropdown
@@ -182,7 +177,7 @@ jobs:
       tracy: true
       runs-on: ${{ inputs['runs-on'] }}
       ref: ${{ inputs.ref }}
-      fetch-depth: ${{ inputs.fetch-depth }}
+      fetch-depth: ${{ github.event_name == 'workflow_dispatch' && 500 || inputs.fetch-depth }}
       # Pass pre-built docker image tags based on platform
       ci-build-docker-image: ${{
         (matrix.config.platform == 'Ubuntu 24.04' && inputs.ubuntu-2404-ci-build-tag) ||


### PR DESCRIPTION
## Summary
- `build-wrapper.yaml` passes `fetch-depth: ${{ inputs.fetch-depth }}` into `build-artifact.yaml`'s number-typed `fetch-depth` input, but `fetch-depth` is only declared under the `workflow_call` trigger, not `workflow_dispatch`.
- On manual dispatch, `inputs.fetch-depth` is undefined and GHA coerces it to `''`, which the reusable-workflow input evaluator rejects against `type: number` ("Unexpected value ''" at line 135, col 20), killing the whole run before any build job starts.
- Fixed both occurrences (`build-dispatch` job and the matrix `build` job) with `${{ inputs.fetch-depth || 500 }}`, matching the existing `||` fallback pattern already used in this file for `harbor-prefix`/`build-type`/`enable-lto`.

## Test plan
- [x] Dispatched `build-wrapper.yaml` manually on this branch — run completed `success` (previously every manual dispatch failed in ~1m45s before any build started): https://github.com/tenstorrent/tt-metal/actions/runs/31143905298

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=afuller/fix-build-workflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:afuller/fix-build-workflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=afuller/fix-build-workflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:afuller/fix-build-workflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=afuller/fix-build-workflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:afuller/fix-build-workflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=afuller/fix-build-workflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:afuller/fix-build-workflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=afuller/fix-build-workflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:afuller/fix-build-workflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=afuller/fix-build-workflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:afuller/fix-build-workflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=afuller/fix-build-workflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:afuller/fix-build-workflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=afuller/fix-build-workflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:afuller/fix-build-workflow)