### PR TITLE
#52683: Fix slice RM chunked reader CB ring-wrap straddle for odd num_chunks

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -141,7 +141,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         if (num_sticks_per_core != 0) {
             if (chunking.num_chunks_per_stick > 1) {
                 num_sticks_per_core_read = num_sticks_per_core;
-                num_read_per_barrier = 2;
+                // Match `compute_cb_size`: nrpb=2 only when num_chunks is even, else 1 to avoid ring-wrap straddle.
+                num_read_per_barrier = (chunking.num_chunks_per_stick % 2 == 0) ? 2 : 1;
             } else {
                 auto num_sticks_per_core_pad32 = round_up_to_mul32(num_sticks_per_core);
                 num_sticks_per_core_read = tt::tt_metal::merge_num_sticks_to_read(
@@ -248,7 +249,22 @@ SliceCbSizing compute_cb_size(
             l1_budget,
             alignment);
 
-        const uint32_t num_chunks = (unpadded_row_size_bytes + max_chunk - 1) / max_chunk;
+        uint32_t num_chunks = (unpadded_row_size_bytes + max_chunk - 1) / max_chunk;
+        // Odd num_chunks with nrpb=2 straddles the 4-page CB ring on the next stick — try an aligned
+        // shrink to reach even; commit only if it lands, else let the nrpb=1 fallback do the work.
+        constexpr uint32_t nrpb = 2;
+        if ((num_chunks % nrpb) != 0) {
+            const uint32_t target_n = num_chunks + (nrpb - (num_chunks % nrpb));
+            uint32_t new_max = unpadded_row_size_bytes / target_n;
+            new_max = (new_max / alignment) * alignment;
+            const uint32_t candidate_num_chunks =
+                (new_max >= alignment) ? (unpadded_row_size_bytes + new_max - 1) / new_max : 0;
+            if (new_max >= alignment && (candidate_num_chunks % nrpb) == 0) {
+                max_chunk = new_max;
+                num_chunks = candidate_num_chunks;
+            }
+        }
+
         const uint32_t remainder = unpadded_row_size_bytes % max_chunk;
         s.chunking = {
             .chunk_size = max_chunk,
@@ -273,7 +289,8 @@ SliceCbSizing compute_cb_size(
                                          : num_sticks_per_core_group_2;
     if (num_input_pages != 0) {
         if (needs_chunking) {
-            s.num_read_per_barrier = 2;
+            // Fallback when the shrink above couldn't reach an even num_chunks: nrpb=1 makes a straddle impossible.
+            s.num_read_per_barrier = (s.chunking.num_chunks_per_stick % 2 == 0) ? 2 : 1;
         } else {
             auto num_sticks_per_core_pad32 = round_up_to_mul32(num_input_pages);
             uint32_t num_sticks_per_core_read =


### PR DESCRIPTION
### Ticket
Closes #52683

_Sub-issue of parent #51213 (which tracks all 9 items in this series)._

### Problem
The RM chunked slice reader/writer (`slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp` and its writer twin) batch chunked sub-row transfers by `num_read_per_barrier` (nrpb=2), reserving `batch` contiguous CB pages per NOC barrier. The CB is sized `2 * nrpb * chunk_size` = 4 pages when chunking is active.

When `num_chunks_per_stick` is odd, the per-stick reservation sequence becomes `{2, 2, …, 2, 1}` — the trailing 1-page reservation leaves the CB write pointer at an odd position modulo the 4-page ring, so the next stick's leading `reserve_back(2)` straddles the ring boundary. `get_write_ptr()` returns a single linear base, so the second page of that batch lands past `fifo_limit` into whichever L1 region follows.

The CB API contract in `dataflow_api.h` — *"producer always writes into contiguous memory, it cannot wrap"* — is guarded by `ASSERT(fifo_wr_ptr <= fifo_limit)`, but that assert is stripped in release builds, so the straddle is silent at runtime. Chunking only activates on rows wider than ~750 KB, and the tail overrun often lands on L1 regions that never feed the observable output, so PCC checks pass while the pipeline eats stale state.

### What this PR does
- **Prefer an aligned `max_chunk` shrink that yields even `num_chunks`.** If the initial `num_chunks = ceil(row_bytes / max_chunk)` is odd, try the smallest `max_chunk` (rounded down to alignment) that would land on the next even count. Commit the shrink only when it actually lands — align-down truncation often doesn't, in which case leave `max_chunk` alone.
- **Fall back to `nrpb = 1`** in `compute_cb_size` and the per-core runtime-args builder whenever `num_chunks` stays odd. One-page reservations make a straddle impossible by construction.
- **Keep reader and writer in sync** by mirroring the `nrpb` choice in the per-core runtime-args block.

### Tests
No new unit test in this PR: a WH-B0 release-build repro is not observable — the debug `ASSERT` is stripped, and the CB-tail overrun lands on L1 regions that don't feed `to_torch(output)`, so byte-exact checks pass even with the fix reverted. Same silent-corruption class as item 5 of #51213 (tilize retile OOB).

Existing coverage:
- `tests/ttnn/unit_tests/operations/data_movement/test_slice.py::test_slice_rm_wide_row_chunking` — exercises the RM chunked path (verified locally with the guarded shrink).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/slice_reader_chunk_wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/slice_reader_chunk_wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/slice_reader_chunk_wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/slice_reader_chunk_wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/slice_reader_chunk_wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/slice_reader_chunk_wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/slice_reader_chunk_wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/slice_reader_chunk_wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/slice_reader_chunk_wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/slice_reader_chunk_wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/slice_reader_chunk_wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/slice_reader_chunk_wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/slice_reader_chunk_wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/slice_reader_chunk_wrap)

