### PR TITLE
[feature] Implement vararg CTA for metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4168,6 +4168,7 @@ constexpr bool compile_time_varargs_match_expected() {
     return true;
 }
 void kernel_main() {
+    static_assert(get_num_compile_time_varargs() == 3u);
     static_assert(compile_time_varargs_match_expected());
     static_assert(get_compile_time_vararg<0>() == 0xCAFEBABEu);
     static_assert(get_compile_time_vararg<1>() == 0xDEADBEEFu);
@@ -4195,6 +4196,7 @@ TEST_F(ProgramSpecTestGen1, EmptyCompileTimeVarargsReadableFromKernel) {
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
 void kernel_main() {
+    static_assert(get_num_compile_time_varargs() == 0u);
     static_assert(get_compile_time_varargs().size() == 0u);
 }
 )"};
@@ -4244,6 +4246,9 @@ TEST_F(ProgramSpecTestGen1, CompileTimeVarargsIota1024ReadableFromKernel) {
     dm_kernel.source = KernelSpec::SourceCode{R"(
 constexpr bool compile_time_varargs_are_iota() {
     constexpr auto varargs = get_compile_time_varargs();
+    if (get_num_compile_time_varargs() != 1024u) {
+        return false;
+    }
     if (varargs.size() != 1024u) {
         return false;
     }
@@ -4282,6 +4287,7 @@ TEST_F(ProgramSpecTestGen1, CompileTimeVarargsPrefixBeforeTensorBindingCTAs) {
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
 void kernel_main() {
+    static_assert(get_num_compile_time_varargs() == 2u);
     static_assert(get_compile_time_vararg<0>() == 0xCAFEBABEu);
     static_assert(get_compile_time_vararg<1>() == 0xDEADBEEFu);
     // Binding CTA_OFFSET is shifted past the CTA-vararg prefix.

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4138,13 +4138,12 @@ TEST_F(ProgramSpecTestGen1, TtKernelComputeShimCompiles) {
 }
 
 // ============================================================================
-// Compile-time varargs — mock-device JIT smoke
+// Compile-time varargs — mock-device bake & JIT smoke
 // ============================================================================
 //
 // Host: KernelAdvancedOptions::compile_time_varargs (values fixed at ProgramSpec time).
-// Kernel: get_compile_time_vararg(idx), 0-based into the CTA-vararg section.
-// Compile-only on mock Wormhole — the static_assert fires at JIT time if the value is wrong
-// or the helper/offset plumbing is broken. No silicon, no dispatch.
+// Kernel: get_compile_time_vararg* — literals baked into kernel_args_generated.h (Metal 2.0).
+// Separate from positional KERNEL_COMPILE_TIME_ARGS (TensorBinding DSpec / legacy CreateKernel).
 
 TEST_F(ProgramSpecTestGen1, CompileTimeVarargsReadableFromKernel) {
     NodeCoord node{0, 0};
@@ -4153,6 +4152,7 @@ TEST_F(ProgramSpecTestGen1, CompileTimeVarargsReadableFromKernel) {
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
 void kernel_main() {
+    static_assert(get_compile_time_vararg<0>() == 0xCAFEBABEu);
     static_assert(get_compile_time_vararg(0) == 0xCAFEBABEu);
 }
 )"};
@@ -4166,6 +4166,94 @@ void kernel_main() {
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
     IDevice* device = mesh_device_->get_devices()[0];
     EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+// CTA varargs must not share KERNEL_COMPILE_TIME_ARGS with TensorBinding payloads.
+// Verifies independence: binding cta_offset stays 0; positional compile_args are binding-only;
+// baked get_compile_time_vararg* and TensorAccessor still both work.
+TEST_F(ProgramSpecTestGen1, CompileTimeVarargsIndependentOfTensorBindingCTAs) {
+    NodeCoord node{0, 0};
+    constexpr uint32_t kVararg0 = 0xCAFEBABEu;
+    constexpr uint32_t kVararg1 = 0xDEADBEEFu;
+    const std::vector<uint32_t> cta_varargs = {kVararg0, kVararg1};
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    static_assert(get_compile_time_vararg<0>() == 0xCAFEBABEu);
+    static_assert(get_compile_time_vararg<1>() == 0xDEADBEEFu);
+    // Binding CTA_OFFSET stays 0 (varargs are not a positional prefix).
+    static_assert(tensor::input_ta_t::args_t::is_dram);
+    TensorAccessor accessor(tensor::input_ta);
+    auto noc_addr = accessor.get_noc_addr(0);
+    (void)noc_addr;
+}
+)"};
+    dm_kernel.advanced_options.compile_time_varargs = cta_varargs;
+
+    ProgramSpec spec;
+    spec.name = "cta_varargs_with_tensor_binding";
+    spec.kernels = {dm_kernel};
+    spec.tensor_parameters = {MakeMinimalTensorParameter("input_tensor", tt::tt_metal::BufferType::DRAM)};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    const auto kernel = program.impl().get_kernel_by_spec_name("dm_kernel");
+    const auto& handles = kernel->tensor_binding_handles();
+    ASSERT_EQ(handles.size(), 1u);
+    EXPECT_EQ(handles[0].cta_offset, 0u)
+        << "TensorBinding CTA payload must start at 0; user CTA varargs are not a positional prefix";
+
+    const auto compile_args = kernel->compile_time_args();
+    ASSERT_FALSE(compile_args.empty()) << "positional CTAs should hold the binding args_config word";
+    EXPECT_THAT(kernel->get_compile_time_varargs(), ::testing::ElementsAreArray(cta_varargs));
+    const auto args_config =
+        tensor_accessor::ArgsConfig(static_cast<tensor_accessor::ArgsConfig::Underlying>(compile_args[0]));
+    EXPECT_TRUE(args_config.test(tensor_accessor::ArgConfig::IsDram))
+        << "positional compile_args[0] must be the tensor args_config, not a CTA vararg";
+
+    IDevice* device = mesh_device_->get_devices()[0];
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+TEST_F(ProgramSpecTestGen1, DifferentCompileTimeVarargsProducesDifferentKernelHash) {
+    auto make_program = [this](std::vector<uint32_t> varargs) {
+        NodeCoord node{0, 0};
+        auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+        dm_kernel.advanced_options.compile_time_varargs = std::move(varargs);
+        ProgramSpec spec;
+        spec.name = "cta_varargs_hash";
+        spec.kernels = {dm_kernel};
+        spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+        return MakeProgramFromSpec(*mesh_device_, spec);
+    };
+
+    Program prog_a = make_program({0x11112222u, 0x33334444u});
+    Program prog_b = make_program({0xAAAABBBBu, 0xCCCCDDDDu});
+    EXPECT_NE(
+        prog_a.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash(),
+        prog_b.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash());
+}
+
+TEST_F(ProgramSpecTestGen1, IdenticalCompileTimeVarargsProducesIdenticalKernelHash) {
+    auto make_program = [this] {
+        NodeCoord node{0, 0};
+        auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+        dm_kernel.advanced_options.compile_time_varargs = {0xCAFEBABEu, 0xDEADBEEFu};
+        ProgramSpec spec;
+        spec.name = "cta_varargs_hash_ident";
+        spec.kernels = {dm_kernel};
+        spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+        return MakeProgramFromSpec(*mesh_device_, spec);
+    };
+
+    Program prog_a = make_program();
+    Program prog_b = make_program();
+    EXPECT_EQ(
+        prog_a.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash(),
+        prog_b.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash());
 }
 
 // ============================================================================

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -32,10 +32,12 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <filesystem>
+#include <numeric>
 #include <optional>
 #include <type_traits>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -4147,19 +4149,120 @@ TEST_F(ProgramSpecTestGen1, TtKernelComputeShimCompiles) {
 
 TEST_F(ProgramSpecTestGen1, CompileTimeVarargsReadableFromKernel) {
     NodeCoord node{0, 0};
-    constexpr uint32_t kExpected = 0xCAFEBABEu;
+    const std::vector<uint32_t> cta_varargs = {0xCAFEBABEu, 0xDEADBEEFu, 0x11112222u};
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+// std::array::operator== is not constexpr until C++20; walk elements instead.
+constexpr bool compile_time_varargs_match_expected() {
+    constexpr auto& varargs = get_compile_time_varargs();
+    constexpr std::array<uint32_t, 3> expected = {0xCAFEBABEu, 0xDEADBEEFu, 0x11112222u};
+    if (varargs.size() != expected.size()) {
+        return false;
+    }
+    for (uint32_t i = 0; i < varargs.size(); ++i) {
+        if (varargs[i] != expected[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+void kernel_main() {
+    static_assert(compile_time_varargs_match_expected());
+    static_assert(get_compile_time_vararg<0>() == 0xCAFEBABEu);
+    static_assert(get_compile_time_vararg<1>() == 0xDEADBEEFu);
+    static_assert(get_compile_time_vararg<2>() == 0x11112222u);
+    static_assert(get_compile_time_vararg(0) == 0xCAFEBABEu);
+    static_assert(get_compile_time_vararg(1) == 0xDEADBEEFu);
+    static_assert(get_compile_time_vararg(2) == 0x11112222u);
+}
+)"};
+    dm_kernel.advanced_options.compile_time_varargs = cta_varargs;
+
+    ProgramSpec spec;
+    spec.name = "cta_varargs_readable";
+    spec.kernels = {dm_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    IDevice* device = mesh_device_->get_devices()[0];
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+TEST_F(ProgramSpecTestGen1, EmptyCompileTimeVarargsReadableFromKernel) {
+    NodeCoord node{0, 0};
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
 void kernel_main() {
-    static_assert(get_compile_time_vararg<0>() == 0xCAFEBABEu);
-    static_assert(get_compile_time_vararg(0) == 0xCAFEBABEu);
+    static_assert(get_compile_time_varargs().size() == 0u);
 }
 )"};
-    dm_kernel.advanced_options.compile_time_varargs = {kExpected};
+    // Default / empty compile_time_varargs — accessors must still be emitted and compile.
 
     ProgramSpec spec;
-    spec.name = "cta_varargs_readable";
+    spec.name = "cta_varargs_empty";
+    spec.kernels = {dm_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    IDevice* device = mesh_device_->get_devices()[0];
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+// Template accessor bounds-checks at compile time: size==1 but get_compile_time_vararg<1>()
+// must fail JIT (static_assert in the generated helper).
+TEST_F(ProgramSpecTestGen1, OutOfRangeCompileTimeVarargTemplateFailsToCompile) {
+    NodeCoord node{0, 0};
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    // Should not compile
+    (void)get_compile_time_vararg<1>();
+}
+)"};
+    dm_kernel.advanced_options.compile_time_varargs = {0xCAFEBABEu};
+
+    ProgramSpec spec;
+    spec.name = "cta_varargs_oob_template";
+    spec.kernels = {dm_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    // MakeProgramFromSpec compiles; OOB template index must fail that build.
+    EXPECT_ANY_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+// Stress: bake 1024 iota words and constexpr-walk them on the kernel side.
+TEST_F(ProgramSpecTestGen1, CompileTimeVarargsIota1024ReadableFromKernel) {
+    NodeCoord node{0, 0};
+    constexpr uint32_t kNumVarargs = 1024u;
+    std::vector<uint32_t> cta_varargs(kNumVarargs);
+    std::iota(cta_varargs.begin(), cta_varargs.end(), 0u);
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+constexpr bool compile_time_varargs_are_iota() {
+    constexpr auto& varargs = get_compile_time_varargs();
+    if (varargs.size() != 1024u) {
+        return false;
+    }
+    for (uint32_t i = 0; i < varargs.size(); ++i) {
+        if (varargs[i] != i) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static_assert(compile_time_varargs_are_iota());
+
+void kernel_main() {}
+)"};
+    dm_kernel.advanced_options.compile_time_varargs = cta_varargs;
+
+    ProgramSpec spec;
+    spec.name = "cta_varargs_iota_1024";
     spec.kernels = {dm_kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4153,23 +4153,8 @@ TEST_F(ProgramSpecTestGen1, CompileTimeVarargsReadableFromKernel) {
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
-// std::array::operator== is not constexpr until C++20; walk elements instead.
-constexpr bool compile_time_varargs_match_expected() {
-    constexpr auto varargs = get_compile_time_varargs();
-    constexpr std::array<uint32_t, 3> expected = {0xCAFEBABEu, 0xDEADBEEFu, 0x11112222u};
-    if (varargs.size() != expected.size()) {
-        return false;
-    }
-    for (uint32_t i = 0; i < varargs.size(); ++i) {
-        if (varargs[i] != expected[i]) {
-            return false;
-        }
-    }
-    return true;
-}
 void kernel_main() {
     static_assert(get_num_compile_time_varargs() == 3u);
-    static_assert(compile_time_varargs_match_expected());
     static_assert(get_compile_time_vararg<0>() == 0xCAFEBABEu);
     static_assert(get_compile_time_vararg<1>() == 0xDEADBEEFu);
     static_assert(get_compile_time_vararg<2>() == 0x11112222u);
@@ -4197,7 +4182,6 @@ TEST_F(ProgramSpecTestGen1, EmptyCompileTimeVarargsReadableFromKernel) {
     dm_kernel.source = KernelSpec::SourceCode{R"(
 void kernel_main() {
     static_assert(get_num_compile_time_varargs() == 0u);
-    static_assert(get_compile_time_varargs().size() == 0u);
 }
 )"};
     // Default / empty compile_time_varargs — accessors must still be emitted and compile.
@@ -4245,15 +4229,11 @@ TEST_F(ProgramSpecTestGen1, CompileTimeVarargsIota1024ReadableFromKernel) {
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
 constexpr bool compile_time_varargs_are_iota() {
-    constexpr auto varargs = get_compile_time_varargs();
     if (get_num_compile_time_varargs() != 1024u) {
         return false;
     }
-    if (varargs.size() != 1024u) {
-        return false;
-    }
-    for (uint32_t i = 0; i < varargs.size(); ++i) {
-        if (varargs[i] != i) {
+    for (uint32_t i = 0; i < get_num_compile_time_varargs(); ++i) {
+        if (get_compile_time_vararg(i) != i) {
             return false;
         }
     }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4138,6 +4138,37 @@ TEST_F(ProgramSpecTestGen1, TtKernelComputeShimCompiles) {
 }
 
 // ============================================================================
+// Compile-time varargs — mock-device JIT smoke
+// ============================================================================
+//
+// Host: KernelAdvancedOptions::compile_time_varargs (values fixed at ProgramSpec time).
+// Kernel: get_compile_time_vararg(idx), 0-based into the CTA-vararg section.
+// Compile-only on mock Wormhole — the static_assert fires at JIT time if the value is wrong
+// or the helper/offset plumbing is broken. No silicon, no dispatch.
+
+TEST_F(ProgramSpecTestGen1, CompileTimeVarargsReadableFromKernel) {
+    NodeCoord node{0, 0};
+    constexpr uint32_t kExpected = 0xCAFEBABEu;
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    static_assert(get_compile_time_vararg(0) == 0xCAFEBABEu);
+}
+)"};
+    dm_kernel.advanced_options.compile_time_varargs = {kExpected};
+
+    ProgramSpec spec;
+    spec.name = "cta_varargs_readable";
+    spec.kernels = {dm_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    IDevice* device = mesh_device_->get_devices()[0];
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+// ============================================================================
 // Kernel hash sensitivity to TensorParameter spec
 // ============================================================================
 //

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4256,6 +4256,43 @@ void kernel_main() {}
     EXPECT_NO_THROW(detail::CompileProgram(device, program));
 }
 
+// Same stress as above, on a compute (TRISC) kernel — CTA varargs are available on DM and compute.
+TEST_F(ProgramSpecTestGen1, CompileTimeVarargsIota1024ReadableFromComputeKernel) {
+    NodeCoord node{0, 0};
+    constexpr uint32_t kNumVarargs = 1024u;
+    std::vector<uint32_t> cta_varargs(kNumVarargs);
+    std::iota(cta_varargs.begin(), cta_varargs.end(), 0u);
+
+    auto compute_kernel = MakeMinimalGen1ComputeKernel("compute_kernel");
+    compute_kernel.source = KernelSpec::SourceCode{R"(
+constexpr bool compile_time_varargs_are_iota() {
+    if (get_num_compile_time_varargs() != 1024u) {
+        return false;
+    }
+    for (uint32_t i = 0; i < get_num_compile_time_varargs(); ++i) {
+        if (get_compile_time_vararg(i) != i) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static_assert(compile_time_varargs_are_iota());
+
+void kernel_main() {}
+)"};
+    compute_kernel.advanced_options.compile_time_varargs = cta_varargs;
+
+    ProgramSpec spec;
+    spec.name = "cta_varargs_iota_1024_compute";
+    spec.kernels = {compute_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    IDevice* device = mesh_device_->get_devices()[0];
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
 // CTA varargs are a positional prefix ahead of TensorBinding CTA payloads.
 TEST_F(ProgramSpecTestGen1, CompileTimeVarargsPrefixBeforeTensorBindingCTAs) {
     NodeCoord node{0, 0};

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4140,12 +4140,12 @@ TEST_F(ProgramSpecTestGen1, TtKernelComputeShimCompiles) {
 }
 
 // ============================================================================
-// Compile-time varargs — mock-device bake & JIT smoke
+// Compile-time varargs — positional CTA prefix + JIT smoke
 // ============================================================================
 //
-// Host: KernelAdvancedOptions::compile_time_varargs (values fixed at ProgramSpec time).
-// Kernel: get_compile_time_vararg* — literals baked into kernel_args_generated.h (Metal 2.0).
-// Separate from positional KERNEL_COMPILE_TIME_ARGS (TensorBinding DSpec / legacy CreateKernel).
+// Host: KernelAdvancedOptions::compile_time_varargs (folded into compile_time_args_ as a prefix).
+// Kernel: get_compile_time_vararg* — thin wrappers over kernel_compile_time_args[0..N).
+// TensorBinding CTA payloads follow that prefix in KERNEL_COMPILE_TIME_ARGS.
 
 TEST_F(ProgramSpecTestGen1, CompileTimeVarargsReadableFromKernel) {
     NodeCoord node{0, 0};
@@ -4155,7 +4155,7 @@ TEST_F(ProgramSpecTestGen1, CompileTimeVarargsReadableFromKernel) {
     dm_kernel.source = KernelSpec::SourceCode{R"(
 // std::array::operator== is not constexpr until C++20; walk elements instead.
 constexpr bool compile_time_varargs_match_expected() {
-    constexpr auto& varargs = get_compile_time_varargs();
+    constexpr auto varargs = get_compile_time_varargs();
     constexpr std::array<uint32_t, 3> expected = {0xCAFEBABEu, 0xDEADBEEFu, 0x11112222u};
     if (varargs.size() != expected.size()) {
         return false;
@@ -4243,7 +4243,7 @@ TEST_F(ProgramSpecTestGen1, CompileTimeVarargsIota1024ReadableFromKernel) {
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
 constexpr bool compile_time_varargs_are_iota() {
-    constexpr auto& varargs = get_compile_time_varargs();
+    constexpr auto varargs = get_compile_time_varargs();
     if (varargs.size() != 1024u) {
         return false;
     }
@@ -4271,21 +4271,20 @@ void kernel_main() {}
     EXPECT_NO_THROW(detail::CompileProgram(device, program));
 }
 
-// CTA varargs must not share KERNEL_COMPILE_TIME_ARGS with TensorBinding payloads.
-// Verifies independence: binding cta_offset stays 0; positional compile_args are binding-only;
-// baked get_compile_time_vararg* and TensorAccessor still both work.
-TEST_F(ProgramSpecTestGen1, CompileTimeVarargsIndependentOfTensorBindingCTAs) {
+// CTA varargs are a positional prefix ahead of TensorBinding CTA payloads.
+TEST_F(ProgramSpecTestGen1, CompileTimeVarargsPrefixBeforeTensorBindingCTAs) {
     NodeCoord node{0, 0};
     constexpr uint32_t kVararg0 = 0xCAFEBABEu;
     constexpr uint32_t kVararg1 = 0xDEADBEEFu;
     const std::vector<uint32_t> cta_varargs = {kVararg0, kVararg1};
+    const uint32_t n = static_cast<uint32_t>(cta_varargs.size());
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
 void kernel_main() {
     static_assert(get_compile_time_vararg<0>() == 0xCAFEBABEu);
     static_assert(get_compile_time_vararg<1>() == 0xDEADBEEFu);
-    // Binding CTA_OFFSET stays 0 (varargs are not a positional prefix).
+    // Binding CTA_OFFSET is shifted past the CTA-vararg prefix.
     static_assert(tensor::input_ta_t::args_t::is_dram);
     TensorAccessor accessor(tensor::input_ta);
     auto noc_addr = accessor.get_noc_addr(0);
@@ -4306,16 +4305,18 @@ void kernel_main() {
     const auto kernel = program.impl().get_kernel_by_spec_name("dm_kernel");
     const auto& handles = kernel->tensor_binding_handles();
     ASSERT_EQ(handles.size(), 1u);
-    EXPECT_EQ(handles[0].cta_offset, 0u)
-        << "TensorBinding CTA payload must start at 0; user CTA varargs are not a positional prefix";
+    EXPECT_EQ(handles[0].cta_offset, n) << "TensorBinding CTA payload must start after the CTA-vararg prefix";
+    EXPECT_EQ(kernel->get_compile_time_vararg_count(), n);
 
     const auto compile_args = kernel->compile_time_args();
-    ASSERT_FALSE(compile_args.empty()) << "positional CTAs should hold the binding args_config word";
-    EXPECT_THAT(kernel->get_compile_time_varargs(), ::testing::ElementsAreArray(cta_varargs));
+    ASSERT_GE(compile_args.size(), n + 1u) << "positional CTAs should hold varargs then binding args_config";
+    EXPECT_THAT(
+        std::vector<uint32_t>(compile_args.begin(), compile_args.begin() + n),
+        ::testing::ElementsAreArray(cta_varargs));
     const auto args_config =
-        tensor_accessor::ArgsConfig(static_cast<tensor_accessor::ArgsConfig::Underlying>(compile_args[0]));
+        tensor_accessor::ArgsConfig(static_cast<tensor_accessor::ArgsConfig::Underlying>(compile_args[n]));
     EXPECT_TRUE(args_config.test(tensor_accessor::ArgConfig::IsDram))
-        << "positional compile_args[0] must be the tensor args_config, not a CTA vararg";
+        << "positional compile_args[N] must be the tensor args_config after the CTA-vararg prefix";
 
     IDevice* device = mesh_device_->get_devices()[0];
     EXPECT_NO_THROW(detail::CompileProgram(device, program));

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4366,6 +4366,28 @@ TEST_F(ProgramSpecTestGen1, IdenticalCompileTimeVarargsProducesIdenticalKernelHa
         prog_b.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash());
 }
 
+// Prefix length is part of the cache key even when positional CTA words are unchanged.
+TEST_F(ProgramSpecTestGen1, DifferentCompileTimeVarargCountProducesDifferentKernelHash) {
+    NodeCoord node{0, 0};
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.advanced_options.compile_time_varargs = {0xCAFEBABEu, 0xDEADBEEFu};
+    ProgramSpec spec;
+    spec.name = "cta_varargs_hash_count";
+    spec.kernels = {dm_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program prog_a = MakeProgramFromSpec(*mesh_device_, spec);
+    Program prog_b = MakeProgramFromSpec(*mesh_device_, spec);
+    auto kernel_a = prog_a.impl().get_kernel_by_spec_name("dm_kernel");
+    auto kernel_b = prog_b.impl().get_kernel_by_spec_name("dm_kernel");
+    ASSERT_EQ(kernel_a->get_compile_time_vararg_count(), 2u);
+    ASSERT_EQ(kernel_b->get_compile_time_vararg_count(), 2u);
+    ASSERT_EQ(kernel_a->compute_hash(), kernel_b->compute_hash());
+
+    kernel_b->set_compile_time_vararg_count(1u);
+    EXPECT_NE(kernel_a->compute_hash(), kernel_b->compute_hash());
+}
+
 // ============================================================================
 // Kernel hash sensitivity to TensorParameter spec
 // ============================================================================

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -61,9 +61,8 @@ struct KernelAdvancedOptions {
     //--------------------------------
     // Compile time varargs
     //--------------------------------
-    // TODO: This is currently unimplemented.
-    //       However, certain variadic kernels require this workaround.
-    //       (#45388 tracks the implementation of this feature.)
+    // Values of the varargs for the kernel.
+    std::vector<uint32_t> compile_time_varargs;
 
     //--------------------------------
     // Runtime varargs

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -59,21 +59,27 @@ struct KernelAdvancedOptions {
     // It will later be deprecated and replaced by std::array typed arguments.
 
     //--------------------------------
-    // Compile time varargs
-    //--------------------------------
-    // Values of the compile-time varargs for the kernel.
-    std::vector<uint32_t> compile_time_varargs;
-
-    //--------------------------------
     // Runtime varargs
     //--------------------------------
     // Number of runtime varargs for the kernel.
     // Set the vararg values (per node) via ProgramRunArgs.
+    //
+    // To retrieve these values in kernel code, use:
+    //   get_vararg(uint32_t idx); // index in [0, num_runtime_varargs - 1]
+    //
+    // CAUTION: This feature exists to address niche uses cases only.
+    //          Prefer regular, named runtime arguments unless varargs are strictly necessary.
     uint32_t num_runtime_varargs = 0;
 
     // Number of common runtime varargs for the kernel.
     // Set the vararg values via ProgramRunArgs.
     // (The same argument values are broadcast to every node the kernel runs on.)
+    //
+    // To retrieve these values in kernel code, use:
+    //    get_common_vararg(uint32_t idx); // index in [0, num_common_runtime_varargs - 1]
+    //
+    // CAUTION: This feature exists to address niche uses cases only.
+    //          Prefer named common runtime arguments unless varargs are strictly necessary.
     uint32_t num_common_runtime_varargs = 0;
 
     // Per-node runtime vararg-count override.
@@ -84,6 +90,24 @@ struct KernelAdvancedOptions {
     //       existing uses are refactored to avoid it.
     [[deprecated("Per-node-vararg-count feature is deprecated and will be removed.")]]
     Table<Nodes, /* num_varargs */ uint32_t> num_runtime_varargs_per_node;
+
+    //--------------------------------
+    // Compile time varargs
+    //--------------------------------
+    // Compile-time vararg VALUES for the kernel.
+    // (Unlike the runtime varargs fields above, these values are baked into the Program
+    // at kernel compile time.)
+    //
+    // To retrieve these values in kernel code, use:
+    //   - get_compile_time_vararg(idx)   // for a computed index
+    //   - get_compile_time_vararg<idx>() // for a compile-time constant index
+    //   - get_num_compile_time_varargs() // for the count
+    //
+    // CAUTION: This is a temporary API that will removed in favor of compile-time array arguments.
+    //          It exists to solve a niche, isolated use case.
+    //          Always prefer regular, named compile-time arguments.
+    [[deprecated("Compile-time varargs is a temporary feature that will be removed in the future.")]]
+    std::vector<uint32_t> compile_time_varargs;
 };
 
 struct DFBAdvancedOptions {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -61,7 +61,7 @@ struct KernelAdvancedOptions {
     //--------------------------------
     // Compile time varargs
     //--------------------------------
-    // Values of the varargs for the kernel.
+    // Values of the compile-time varargs for the kernel.
     std::vector<uint32_t> compile_time_varargs;
 
     //--------------------------------

--- a/tt_metal/hw/inc/api/compile_time_args.h
+++ b/tt_metal/hw/inc/api/compile_time_args.h
@@ -20,8 +20,14 @@ FORCE_INLINE constexpr std::array<T, sizeof...(Ts)> make_array(Ts... values) {
 #define KERNEL_COMPILE_TIME_ARGS
 #endif
 
+// Positional CTAs for pre-metal 2.0 kernels / TensorBinding static CTAs.
+// Metal 2.0 CTA varargs are NOT EXPOSED through this array.
+// Metal 2.0 user should use: get_compile_time_varargs() / get_compile_time_vararg() instead.
 constexpr auto kernel_compile_time_args = make_array<std::uint32_t>(KERNEL_COMPILE_TIME_ARGS);
 
+// Index into positional CTAs for pre-metal 2.0 kernels / TensorBinding static CTAs.
+// Metal 2.0 CTA varargs are NOT EXPOSED through this array.
+// Metal 2.0 user should use: get_compile_time_varargs() / get_compile_time_vararg() instead.
 template <uint32_t Idx>
 constexpr uint32_t get_ct_arg() {
     static_assert(Idx < kernel_compile_time_args.size(), "Index out of range");

--- a/tt_metal/hw/inc/api/compile_time_args.h
+++ b/tt_metal/hw/inc/api/compile_time_args.h
@@ -22,12 +22,12 @@ FORCE_INLINE constexpr std::array<T, sizeof...(Ts)> make_array(Ts... values) {
 
 // Positional CTAs for pre-metal 2.0 kernels / TensorBinding static CTAs.
 // Metal 2.0 CTA varargs are NOT EXPOSED through this array.
-// Metal 2.0 user should use: get_compile_time_varargs() / get_compile_time_vararg() instead.
+// Metal 2.0 users should use: get_compile_time_varargs() / get_compile_time_vararg() instead.
 constexpr auto kernel_compile_time_args = make_array<std::uint32_t>(KERNEL_COMPILE_TIME_ARGS);
 
 // Index into positional CTAs for pre-metal 2.0 kernels / TensorBinding static CTAs.
 // Metal 2.0 CTA varargs are NOT EXPOSED through this array.
-// Metal 2.0 user should use: get_compile_time_varargs() / get_compile_time_vararg() instead.
+// Metal 2.0 users should use: get_compile_time_varargs() / get_compile_time_vararg() instead.
 template <uint32_t Idx>
 constexpr uint32_t get_ct_arg() {
     static_assert(Idx < kernel_compile_time_args.size(), "Index out of range");

--- a/tt_metal/hw/inc/api/compile_time_args.h
+++ b/tt_metal/hw/inc/api/compile_time_args.h
@@ -20,14 +20,8 @@ FORCE_INLINE constexpr std::array<T, sizeof...(Ts)> make_array(Ts... values) {
 #define KERNEL_COMPILE_TIME_ARGS
 #endif
 
-// Positional CTAs for pre-metal 2.0 kernels / TensorBinding static CTAs.
-// Metal 2.0 CTA varargs are NOT EXPOSED through this array.
-// Metal 2.0 users should use: get_compile_time_varargs() / get_compile_time_vararg() instead.
 constexpr auto kernel_compile_time_args = make_array<std::uint32_t>(KERNEL_COMPILE_TIME_ARGS);
 
-// Index into positional CTAs for pre-metal 2.0 kernels / TensorBinding static CTAs.
-// Metal 2.0 CTA varargs are NOT EXPOSED through this array.
-// Metal 2.0 users should use: get_compile_time_varargs() / get_compile_time_vararg() instead.
 template <uint32_t Idx>
 constexpr uint32_t get_ct_arg() {
     static_assert(Idx < kernel_compile_time_args.size(), "Index out of range");

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -620,7 +620,7 @@ uint64_t Kernel::compute_hash() const {
     ////////////////////////////////////////////////////////////
     hasher.update(this->kernel_src_.source_);
     hasher.update(this->compile_time_args_.begin(), this->compile_time_args_.end());
-    // Metal 2.0's vararg CTAs does not reuse the legacy CTA infrastructure.
+    // Metal 2.0's vararg CTAs do not reuse the legacy CTA infrastructure.
     hasher.update(static_cast<uint64_t>(this->compile_time_varargs_.size()));
     hasher.update(this->compile_time_varargs_.begin(), this->compile_time_varargs_.end());
     hasher.update(this->config_hash());

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -620,6 +620,9 @@ uint64_t Kernel::compute_hash() const {
     ////////////////////////////////////////////////////////////
     hasher.update(this->kernel_src_.source_);
     hasher.update(this->compile_time_args_.begin(), this->compile_time_args_.end());
+    // Metal 2.0's vararg CTAs does not reuse the legacy CTA infrastructure.
+    hasher.update(static_cast<uint64_t>(this->compile_time_varargs_.size()));
+    hasher.update(this->compile_time_varargs_.begin(), this->compile_time_varargs_.end());
     hasher.update(this->config_hash());
 
     // Include paths affect compilation: the gcc -I order is significant (left-to-right

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -620,6 +620,9 @@ uint64_t Kernel::compute_hash() const {
     ////////////////////////////////////////////////////////////
     hasher.update(this->kernel_src_.source_);
     hasher.update(this->compile_time_args_.begin(), this->compile_time_args_.end());
+    // Prefix length baked into kernel_args_generated.h (array size / accessor bounds).
+    // Independent of compile_time_args_ values: same words with a different split must not collide.
+    hasher.update(static_cast<uint64_t>(this->compile_time_vararg_count_));
     hasher.update(this->config_hash());
 
     // Include paths affect compilation: the gcc -I order is significant (left-to-right

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -620,9 +620,6 @@ uint64_t Kernel::compute_hash() const {
     ////////////////////////////////////////////////////////////
     hasher.update(this->kernel_src_.source_);
     hasher.update(this->compile_time_args_.begin(), this->compile_time_args_.end());
-    // Metal 2.0's vararg CTAs do not reuse the legacy CTA infrastructure.
-    hasher.update(static_cast<uint64_t>(this->compile_time_varargs_.size()));
-    hasher.update(this->compile_time_varargs_.begin(), this->compile_time_varargs_.end());
     hasher.update(this->config_hash());
 
     // Include paths affect compilation: the gcc -I order is significant (left-to-right

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -241,7 +241,7 @@ public:
         scratchpad_binding_handles_ = std::move(handles);
     }
     // Only used by Metal 2.0.
-    // Metal 2.0's vararg CTAs does not reuse the legacy CTA infrastructure.
+    // Metal 2.0's vararg CTAs do not reuse the legacy CTA infrastructure.
     const std::vector<uint32_t>& get_compile_time_varargs() const override { return compile_time_varargs_; }
     void set_compile_time_varargs(std::vector<uint32_t> varargs) { compile_time_varargs_ = std::move(varargs); }
     const std::vector<std::string>& get_runtime_arg_names() const override { return runtime_arg_names_; }

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -340,8 +340,8 @@ protected:
     // and allocate_scratchpads fills each handle's allocated_address after L1 allocation.
     // NOTE: Scratchpad allocated addresses can change between enqueues if DFB size overrides are used.
     std::vector<ScratchpadBindingHandle> scratchpad_binding_handles_;
-    // Metal 2.0 user compile-time varargs (set post-construction via set_compile_time_varargs).
-    // Hashed into compute_hash; genfiles bakes literals into kernel_args_generated.h.
+    // Metal 2.0 CTA varargs
+    // This is not the same as compile_time_args_ and is exclusively used for Metal 2.0 vararg CTA support.
     std::vector<uint32_t> compile_time_varargs_;
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
     std::vector<std::vector<RuntimeArgsData>> core_to_runtime_args_data_;

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -240,10 +240,10 @@ public:
     void set_scratchpad_binding_handles(std::vector<ScratchpadBindingHandle> handles) {
         scratchpad_binding_handles_ = std::move(handles);
     }
-    // Only used by Metal 2.0.
-    // Metal 2.0's vararg CTAs do not reuse the legacy CTA infrastructure.
-    const std::vector<uint32_t>& get_compile_time_varargs() const override { return compile_time_varargs_; }
-    void set_compile_time_varargs(std::vector<uint32_t> varargs) { compile_time_varargs_ = std::move(varargs); }
+    // Metal 2.0: length of the CTA-vararg prefix in compile_time_args_.
+    // Values live in compile_time_args_.
+    uint32_t get_compile_time_vararg_count() const override { return compile_time_vararg_count_; }
+    void set_compile_time_vararg_count(uint32_t count) { compile_time_vararg_count_ = count; }
     const std::vector<std::string>& get_runtime_arg_names() const override { return runtime_arg_names_; }
     const std::vector<std::string>& get_common_runtime_arg_names() const override { return common_runtime_arg_names_; }
     KernelCrtaLayout get_crta_layout() const override { return crta_layout_; }
@@ -340,9 +340,8 @@ protected:
     // and allocate_scratchpads fills each handle's allocated_address after L1 allocation.
     // NOTE: Scratchpad allocated addresses can change between enqueues if DFB size overrides are used.
     std::vector<ScratchpadBindingHandle> scratchpad_binding_handles_;
-    // Metal 2.0 CTA varargs
-    // This is not the same as compile_time_args_ and is exclusively used for Metal 2.0 vararg CTA support.
-    std::vector<uint32_t> compile_time_varargs_;
+    // Metal 2.0: number of user CTA-vararg words at the start of compile_time_args_.
+    uint32_t compile_time_vararg_count_{0};
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
     std::vector<std::vector<RuntimeArgsData>> core_to_runtime_args_data_;
     uint32_t common_runtime_args_count_{0};

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -240,6 +240,10 @@ public:
     void set_scratchpad_binding_handles(std::vector<ScratchpadBindingHandle> handles) {
         scratchpad_binding_handles_ = std::move(handles);
     }
+    // Only used by Metal 2.0.
+    // Metal 2.0's vararg CTAs does not reuse the legacy CTA infrastructure.
+    const std::vector<uint32_t>& get_compile_time_varargs() const override { return compile_time_varargs_; }
+    void set_compile_time_varargs(std::vector<uint32_t> varargs) { compile_time_varargs_ = std::move(varargs); }
     const std::vector<std::string>& get_runtime_arg_names() const override { return runtime_arg_names_; }
     const std::vector<std::string>& get_common_runtime_arg_names() const override { return common_runtime_arg_names_; }
     KernelCrtaLayout get_crta_layout() const override { return crta_layout_; }
@@ -336,6 +340,9 @@ protected:
     // and allocate_scratchpads fills each handle's allocated_address after L1 allocation.
     // NOTE: Scratchpad allocated addresses can change between enqueues if DFB size overrides are used.
     std::vector<ScratchpadBindingHandle> scratchpad_binding_handles_;
+    // Metal 2.0 user compile-time varargs (set post-construction via set_compile_time_varargs).
+    // Hashed into compute_hash; genfiles bakes literals into kernel_args_generated.h.
+    std::vector<uint32_t> compile_time_varargs_;
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
     std::vector<std::vector<RuntimeArgsData>> core_to_runtime_args_data_;
     uint32_t common_runtime_args_count_{0};

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2390,7 +2390,8 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
 struct TensorBindingsForKernel {
     std::vector<TensorBindingHandle> handles;
     std::vector<uint32_t> cta_words;  // appended after any pre-existing positional CTAs
-                                      // (currently, this is the only Metal 2.0 use of positional CTAs)
+                                      // (currently, this is the only Metal 2.0 use of positional CTAs,
+                                      // CTA varargs are piped in separately)
     KernelCrtaLayout crta_layout;
 };
 
@@ -3131,6 +3132,9 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         // part of the kernel cache key, so this must run before the kernel is compiled). allocate_scratchpads
         // will later fill each handle's allocated_address.
         kernel->set_scratchpad_binding_handles(std::move(sp_bindings.handles));
+
+        // Metal 2.0 path for injecting compile time varargs.
+        kernel->set_compile_time_varargs(kernel_spec.advanced_options.compile_time_varargs);
 
         // Add the kernel to the ProgramImpl and register the name -> handle mapping
         KernelHandle handle = program_impl->add_kernel(kernel, HalProgrammableCoreType::TENSIX);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2389,9 +2389,8 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
 //    boundaries by walking handles. See KernelCrtaLayout in jit_build_settings.hpp.
 struct TensorBindingsForKernel {
     std::vector<TensorBindingHandle> handles;
-    std::vector<uint32_t> cta_words;  // appended after any pre-existing positional CTAs
-                                      // (currently, this is the only Metal 2.0 use of positional CTAs,
-                                      // CTA varargs are piped in separately)
+    // Binding-only CTA payload; appended after the user CTA-vararg positional prefix.
+    std::vector<uint32_t> cta_words;
     KernelCrtaLayout crta_layout;
 };
 
@@ -2411,11 +2410,14 @@ struct TensorBindingsForKernel {
 TensorBindingsForKernel ResolveTensorBindingsForKernel(
     const KernelSpec& kernel,
     const std::unordered_map<TensorParamName, ResolvedTensorParameter>& resolved_tensor_parameters,
-    size_t base_named_crta_count) {
+    size_t base_named_crta_count,
+    uint32_t base_cta_offset = 0) {
     TensorBindingsForKernel out;
     out.handles.reserve(kernel.tensor_bindings.size());
 
-    uint32_t cta_word_offset = 0;
+    // Absolute word index into the unified positional CTA buffer:
+    //   [ CTA varargs (base_cta_offset words) | TensorBinding payloads ... ]
+    uint32_t cta_word_offset = base_cta_offset;
     size_t crta_word_index = base_named_crta_count;
     uint32_t binding_section_words = 0;
     for (const auto& binding : kernel.tensor_bindings) {
@@ -2927,7 +2929,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
     //
     // TensorBindings ride two existing kernel-arg channels:
     //   - Static layout (rank, shape, bank coords, ...) flows through the kernel's positional
-    //     CTA buffer. (Empty in Metal 2.0 today; the binding payload is its first user.)
+    //     CTA buffer, after any user CTA-vararg prefix (KernelAdvancedOptions::compile_time_varargs).
     //   - Per-enqueue base address flows through a reserved-prefix named CRTA, appended to
     //     the kernel's user-named CRTAs and filled by SetProgramRunArgs from the
     //     corresponding TensorArgument entry. TensorParameters that opt into a dynamic accessor
@@ -3030,10 +3032,16 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
 
         // Resolve TensorBindings for this kernel:
         //  - pack each binding's pre-resolved CTA payload into the kernel's positional CTA buffer
+        //    (after the user CTA-vararg prefix)
         //  - assign each binding a slot in the kernel's CRTA buffer (TensorBinding address section)
         const auto& user_named_crtas = kernel_spec.runtime_arg_schema.common_runtime_arg_names;
+        const auto& cta_varargs = kernel_spec.advanced_options.compile_time_varargs;
+        const uint32_t vararg_cta_count = static_cast<uint32_t>(cta_varargs.size());
         TensorBindingsForKernel ta_bindings = ResolveTensorBindingsForKernel(
-            kernel_spec, resolved_tensor_parameters, /*base_named_crta_count=*/user_named_crtas.size());
+            kernel_spec,
+            resolved_tensor_parameters,
+            /*base_named_crta_count=*/user_named_crtas.size(),
+            /*base_cta_offset=*/vararg_cta_count);
 
         // Create TensorBindingHandles for this kernel
         const std::vector<TensorBindingHandle>& tensor_binding_handles = ta_bindings.handles;
@@ -3055,6 +3063,10 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         // CRTA list through unchanged.
         const auto& named_rtas = kernel_spec.runtime_arg_schema.runtime_arg_names;
 
+        // Positional CTAs: [ user CTA varargs | TensorBinding CTA payloads ]
+        std::vector<uint32_t> compile_args = cta_varargs;
+        compile_args.insert(compile_args.end(), ta_bindings.cta_words.begin(), ta_bindings.cta_words.end());
+
         // Create the kernel object
         std::shared_ptr<Kernel> kernel;
 
@@ -3065,7 +3077,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
             uint16_t risc_mask = kernel_to_risc_mask.at(&kernel_spec);
             if (kernel_spec.is_data_movement_kernel()) {
                 auto config = MakeQuasarDataMovementConfig(kernel_spec);
-                config.compile_args = ta_bindings.cta_words;  // populate positional CTAs from tensor bindings
+                config.compile_args = std::move(compile_args);
                 auto processors = GetDMProcessorSet(DMProcessorMask{(uint8_t)(risc_mask & 0xFF)});
                 kernel = std::make_shared<experimental::quasar::QuasarDataMovementKernel>(
                     kernel_src,
@@ -3081,7 +3093,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
                     ta_bindings.crta_layout);
             } else {
                 auto config = MakeGen2ComputeConfig(kernel_spec, dfb_name_to_slot);
-                config.compile_args = ta_bindings.cta_words;
+                config.compile_args = std::move(compile_args);
                 auto processors = GetComputeProcessorSet(ComputeEngineMask{(uint8_t)(risc_mask >> 8)});
                 kernel = std::make_shared<experimental::quasar::QuasarComputeKernel>(
                     kernel_src,
@@ -3099,7 +3111,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         } else {  // gen1
             if (kernel_spec.is_data_movement_kernel()) {
                 auto config = MakeGen1DataMovementConfig(kernel_spec);
-                config.compile_args = ta_bindings.cta_words;
+                config.compile_args = std::move(compile_args);
                 kernel = std::make_shared<DataMovementKernel>(
                     kernel_src,
                     node_ranges,
@@ -3113,7 +3125,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
                     ta_bindings.crta_layout);
             } else {
                 auto config = MakeGen1ComputeConfig(kernel_spec, dfb_name_to_slot);
-                config.compile_args = ta_bindings.cta_words;
+                config.compile_args = std::move(compile_args);
                 kernel = std::make_shared<ComputeKernel>(
                     kernel_src,
                     node_ranges,
@@ -3133,8 +3145,8 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         // will later fill each handle's allocated_address.
         kernel->set_scratchpad_binding_handles(std::move(sp_bindings.handles));
 
-        // Metal 2.0 path for injecting compile time varargs.
-        kernel->set_compile_time_varargs(kernel_spec.advanced_options.compile_time_varargs);
+        // Prefix length for device get_compile_time_vararg* bounds (values are in compile_time_args_).
+        kernel->set_compile_time_vararg_count(vararg_cta_count);
 
         // Add the kernel to the ProgramImpl and register the name -> handle mapping
         KernelHandle handle = program_impl->add_kernel(kernel, HalProgrammableCoreType::TENSIX);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2411,7 +2411,7 @@ TensorBindingsForKernel ResolveTensorBindingsForKernel(
     const KernelSpec& kernel,
     const std::unordered_map<TensorParamName, ResolvedTensorParameter>& resolved_tensor_parameters,
     size_t base_named_crta_count,
-    uint32_t base_cta_offset = 0) {
+    uint32_t base_cta_offset) {
     TensorBindingsForKernel out;
     out.handles.reserve(kernel.tensor_bindings.size());
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -275,16 +275,16 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
         });
     sort(cta_entries.begin(), cta_entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
 
-    // Metal 2.0 user compile-time varargs: baked as literals below (separate from positional
-    // KERNEL_COMPILE_TIME_ARGS, which TensorBindings / legacy CreateKernel still use).
-    const std::vector<uint32_t>& cta_varargs = settings.get_compile_time_varargs();
-    const uint32_t cta_vararg_size = static_cast<uint32_t>(cta_varargs.size());
+    // Metal 2.0 CTA-vararg prefix length in positional KERNEL_COMPILE_TIME_ARGS.
+    // Values live in kernel_compile_time_args[0..N); TensorBinding payloads follow.
+    const uint32_t cta_vararg_size = settings.get_compile_time_vararg_count();
 
     ostringstream content;
     content << "// AUTO-GENERATED — do not edit.\n\n"
                "#pragma once\n\n"
                "#include <array>\n"
-               "#include \"experimental/kernel_args.h\"\n\n";
+               "#include \"experimental/kernel_args.h\"\n"
+               "#include \"api/compile_time_args.h\"\n\n";
 
     // Named args namespace: emit only when the kernel has at least one named arg or CTA.
     // A kernel with only varargs (and no named anything) still needs the vararg helpers below,
@@ -332,37 +332,29 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
             << crta_layout.vararg_section_offset << " + idx); }\n";
 
     // Compile-time vararg helpers — always emitted (separate from RTA/CRTA varargs).
-    // Values are baked as literals (same spirit as named CtaVal); not read from
-    // KERNEL_COMPILE_TIME_ARGS. Three accessors:
-    //   1. get_compile_time_varargs() — const ref baked CTA varargs
-    //   2. get_compile_time_vararg<idx>() — template index (static_assert bounds)
-    //   3. get_compile_time_vararg(idx) — function-parameter index (no assert)
-    std::string cta_vararg_literals;
-    if (!cta_varargs.empty()) {
-        // e.g. {1, 2, 3} → "1u, 2u, 3u"
-        auto cta_vararg_u_literals =
-            cta_varargs | std::views::transform([](uint32_t v) { return fmt::format("{}u", v); });
-        cta_vararg_literals = fmt::format("{}", fmt::join(cta_vararg_u_literals, ", "));
-    }
+    // Three accessors:
+    //   1. get_compile_time_varargs() — std::array by value (copy of the prefix)
+    //   2. get_compile_time_vararg<idx>() — template index (with bounds check)
+    //   3. get_compile_time_vararg(idx) — function-parameter index
     content << fmt::format(
         R"(
-namespace cta_vararg_detail {{
-inline constexpr std::array<uint32_t, {0}u> COMPILE_TIME_VARARGS = {{{{{1}}}}};
-}}  // namespace cta_vararg_detail
-FORCE_INLINE constexpr const std::array<uint32_t, {0}u>& get_compile_time_varargs() {{
-    return cta_vararg_detail::COMPILE_TIME_VARARGS;
+FORCE_INLINE constexpr std::array<uint32_t, {0}u> get_compile_time_varargs() {{
+    std::array<uint32_t, {0}u> out{{}};
+    for (uint32_t i = 0; i < {0}u; ++i) {{
+        out[i] = kernel_compile_time_args[i];
+    }}
+    return out;
 }}
 template <uint32_t idx>
 FORCE_INLINE constexpr uint32_t get_compile_time_vararg() {{
     static_assert(idx < {0}u, "Compile-time vararg index out of range");
-    return get_compile_time_varargs()[idx];
+    return kernel_compile_time_args[idx];
 }}
 FORCE_INLINE constexpr uint32_t get_compile_time_vararg(uint32_t idx) {{
-    return get_compile_time_varargs()[idx];
+    return kernel_compile_time_args[idx];
 }}
 )",
-        cta_vararg_size,
-        cta_vararg_literals);
+        cta_vararg_size);
 
     write_file(path, content.str());
 }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -284,7 +284,8 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
                "#pragma once\n\n"
                "#include <array>\n"
                "#include \"experimental/kernel_args.h\"\n"
-               "#include \"api/compile_time_args.h\"\n\n";
+               "#include \"api/compile_time_args.h\"\n"
+               "#include \"api/debug/assert.h\"\n\n";
 
     // Named args namespace: emit only when the kernel has at least one named arg or CTA.
     // A kernel with only varargs (and no named anything) still needs the vararg helpers below,
@@ -332,25 +333,30 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
             << crta_layout.vararg_section_offset << " + idx); }\n";
 
     // Compile-time vararg helpers — always emitted (separate from RTA/CRTA varargs).
-    // Three accessors:
-    //   1. get_compile_time_varargs() — std::array by value (copy of the prefix)
-    //   2. get_compile_time_vararg<idx>() — template index (with bounds check)
-    //   3. get_compile_time_vararg(idx) — function-parameter index
+    // Four accessors:
+    //   1. get_num_compile_time_varargs() — baked prefix length
+    //   2. get_compile_time_varargs() — std::array by value (copy of the prefix)
+    //   3. get_compile_time_vararg<idx>() — template index (with bounds check)
+    //   4. get_compile_time_vararg(idx) — function-parameter index
     content << fmt::format(
         R"(
+FORCE_INLINE constexpr uint32_t get_num_compile_time_varargs() {{
+    return {0}u;
+}}
 FORCE_INLINE constexpr std::array<uint32_t, {0}u> get_compile_time_varargs() {{
     std::array<uint32_t, {0}u> out{{}};
-    for (uint32_t i = 0; i < {0}u; ++i) {{
+    for (uint32_t i = 0; i < get_num_compile_time_varargs(); ++i) {{
         out[i] = kernel_compile_time_args[i];
     }}
     return out;
 }}
 template <uint32_t idx>
 FORCE_INLINE constexpr uint32_t get_compile_time_vararg() {{
-    static_assert(idx < {0}u, "Compile-time vararg index out of range");
+    static_assert(idx < get_num_compile_time_varargs(), "Compile-time vararg index out of range");
     return kernel_compile_time_args[idx];
 }}
 FORCE_INLINE constexpr uint32_t get_compile_time_vararg(uint32_t idx) {{
+    ASSERT(idx < get_num_compile_time_varargs());  // Attempt to access out of bound vararg CTA.
     return kernel_compile_time_args[idx];
 }}
 )",

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -333,22 +333,14 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
             << crta_layout.vararg_section_offset << " + idx); }\n";
 
     // Compile-time vararg helpers — always emitted (separate from RTA/CRTA varargs).
-    // Four accessors:
+    // Three accessors:
     //   1. get_num_compile_time_varargs() — baked prefix length
-    //   2. get_compile_time_varargs() — std::array by value (copy of the prefix)
-    //   3. get_compile_time_vararg<idx>() — template index (with bounds check)
-    //   4. get_compile_time_vararg(idx) — function-parameter index
+    //   2. get_compile_time_vararg<idx>() — template index (with bounds check)
+    //   3. get_compile_time_vararg(idx) — function-parameter index
     content << fmt::format(
         R"(
 FORCE_INLINE constexpr uint32_t get_num_compile_time_varargs() {{
     return {0}u;
-}}
-FORCE_INLINE constexpr std::array<uint32_t, {0}u> get_compile_time_varargs() {{
-    std::array<uint32_t, {0}u> out{{}};
-    for (uint32_t i = 0; i < get_num_compile_time_varargs(); ++i) {{
-        out[i] = kernel_compile_time_args[i];
-    }}
-    return out;
 }}
 template <uint32_t idx>
 FORCE_INLINE constexpr uint32_t get_compile_time_vararg() {{

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -284,7 +284,6 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     content << "// AUTO-GENERATED — do not edit.\n\n"
                "#pragma once\n\n"
                "#include <array>\n"
-               "#include \"api/compile_time_args.h\"\n"
                "#include \"experimental/kernel_args.h\"\n\n";
 
     // Named args namespace: emit only when the kernel has at least one named arg or CTA.
@@ -335,9 +334,9 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     // Compile-time vararg helpers — always emitted (separate from RTA/CRTA varargs).
     // Values are baked as literals (same spirit as named CtaVal); not read from
     // KERNEL_COMPILE_TIME_ARGS. Three accessors:
-    //   1. get_compile_time_varargs() — constexpr std::array of the baked words
+    //   1. get_compile_time_varargs() — const ref baked CTA varargs
     //   2. get_compile_time_vararg<idx>() — template index (static_assert bounds)
-    //   3. get_compile_time_vararg(idx) — function-parameter index
+    //   3. get_compile_time_vararg(idx) — function-parameter index (no assert)
     std::string cta_vararg_literals;
     if (!cta_varargs.empty()) {
         // e.g. {1, 2, 3} → "1u, 2u, 3u"
@@ -347,9 +346,11 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     }
     content << fmt::format(
         R"(
-// Compile-time varargs (Metal 2.0; baked literals — not KERNEL_COMPILE_TIME_ARGS)
-FORCE_INLINE constexpr std::array<uint32_t, {0}u> get_compile_time_varargs() {{
-    return std::array<uint32_t, {0}u>{{{{{1}}}}};
+namespace cta_vararg_detail {{
+inline constexpr std::array<uint32_t, {0}u> COMPILE_TIME_VARARGS = {{{{{1}}}}};
+}}  // namespace cta_vararg_detail
+FORCE_INLINE constexpr const std::array<uint32_t, {0}u>& get_compile_time_varargs() {{
+    return cta_vararg_detail::COMPILE_TIME_VARARGS;
 }}
 template <uint32_t idx>
 FORCE_INLINE constexpr uint32_t get_compile_time_vararg() {{

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -275,9 +275,16 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
         });
     sort(cta_entries.begin(), cta_entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
 
+    // Metal 2.0 user compile-time varargs: baked as literals below (separate from positional
+    // KERNEL_COMPILE_TIME_ARGS, which TensorBindings / legacy CreateKernel still use).
+    const std::vector<uint32_t>& cta_varargs = settings.get_compile_time_varargs();
+    const uint32_t cta_vararg_size = static_cast<uint32_t>(cta_varargs.size());
+
     ostringstream content;
     content << "// AUTO-GENERATED — do not edit.\n\n"
                "#pragma once\n\n"
+               "#include <array>\n"
+               "#include \"api/compile_time_args.h\"\n"
                "#include \"experimental/kernel_args.h\"\n\n";
 
     // Named args namespace: emit only when the kernel has at least one named arg or CTA.
@@ -312,7 +319,7 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
         content << "}  // namespace args\n\n";
     }
 
-    // Vararg helpers — always emitted.
+    // Runtime / common-runtime vararg helpers — always emitted.
     // The starting offset (named_arg_count) is baked in so kernel code uses 0-based
     // indexing: get_vararg(0) is the first vararg, regardless of named-arg count. When
     // there are no named args, the offset is zero and these helpers are just thin wrappers
@@ -324,6 +331,37 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
             << " + idx); }\n"
             << "FORCE_INLINE uint32_t get_common_vararg(uint32_t idx) { return get_common_arg_val<uint32_t>("
             << crta_layout.vararg_section_offset << " + idx); }\n";
+
+    // Compile-time vararg helpers — always emitted (separate from RTA/CRTA varargs).
+    // Values are baked as literals (same spirit as named CtaVal); not read from
+    // KERNEL_COMPILE_TIME_ARGS. Three accessors:
+    //   1. get_compile_time_varargs() — constexpr std::array of the baked words
+    //   2. get_compile_time_vararg<idx>() — template index (static_assert bounds)
+    //   3. get_compile_time_vararg(idx) — function-parameter index
+    std::string cta_vararg_literals;
+    if (!cta_varargs.empty()) {
+        // e.g. {1, 2, 3} → "1u, 2u, 3u"
+        auto cta_vararg_u_literals =
+            cta_varargs | std::views::transform([](uint32_t v) { return fmt::format("{}u", v); });
+        cta_vararg_literals = fmt::format("{}", fmt::join(cta_vararg_u_literals, ", "));
+    }
+    content << fmt::format(
+        R"(
+// Compile-time varargs (Metal 2.0; baked literals — not KERNEL_COMPILE_TIME_ARGS)
+FORCE_INLINE constexpr std::array<uint32_t, {0}u> get_compile_time_varargs() {{
+    return std::array<uint32_t, {0}u>{{{{{1}}}}};
+}}
+template <uint32_t idx>
+FORCE_INLINE constexpr uint32_t get_compile_time_vararg() {{
+    static_assert(idx < {0}u, "Compile-time vararg index out of range");
+    return get_compile_time_varargs()[idx];
+}}
+FORCE_INLINE constexpr uint32_t get_compile_time_vararg(uint32_t idx) {{
+    return get_compile_time_varargs()[idx];
+}}
+)",
+        cta_vararg_size,
+        cta_vararg_literals);
 
     write_file(path, content.str());
 }

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -145,13 +145,9 @@ public:
     // which matches the legacy-kernel case where the buffer has only varargs.
     virtual KernelCrtaLayout get_crta_layout() const { return {}; }
 
-    // Metal 2.0: user compile-time varargs.
-    // Separate from positional compile_args / Legacy CTA infrastructure
-    // Default empty for non–Metal 2.0 kernels.
-    virtual const std::vector<uint32_t>& get_compile_time_varargs() const {
-        static const std::vector<uint32_t> k_empty;
-        return k_empty;
-    }
+    // Metal 2.0: length of the CTA-vararg prefix in positional compile_time_args.
+    // Default 0 for non–Metal 2.0 kernels.
+    virtual uint32_t get_compile_time_vararg_count() const { return 0; }
 
     ////////////////////////////////////////////////////////////
     // Blaze-only experimental named args

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -145,6 +145,14 @@ public:
     // which matches the legacy-kernel case where the buffer has only varargs.
     virtual KernelCrtaLayout get_crta_layout() const { return {}; }
 
+    // Metal 2.0: user compile-time varargs.
+    // Separate from positional compile_args / Legacy CTA infrastructure
+    // Default empty for non–Metal 2.0 kernels.
+    virtual const std::vector<uint32_t>& get_compile_time_varargs() const {
+        static const std::vector<uint32_t> k_empty;
+        return k_empty;
+    }
+
     ////////////////////////////////////////////////////////////
     // Blaze-only experimental named args
     // Removal is tracked by issue #50953


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

vararg CTA allows an op writer to specify a dynamic number of positional CTA for their kernel.

This PR adds Metal 2.0 support for this feature, this is needed to unblock porting of concat op.

Closes #45388

### Notes for reviewers
- This PR reuses the old positional CTA injection system, where vararg CTA are placed at the 0-th index of the CTA array, while other systems using the positional CTA (mainly tensor binding) follows the vararg CTA.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/vararg-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/vararg-cta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/vararg-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/vararg-cta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/vararg-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/vararg-cta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/vararg-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/vararg-cta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/vararg-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/vararg-cta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/vararg-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/vararg-cta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/vararg-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/vararg-cta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/vararg-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/vararg-cta)