### PR TITLE
Fix pad failure in Nightly tests

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_pad_universal_input.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_pad_universal_input.py
@@ -490,7 +490,12 @@ def test_pad_dram_block_sharded_composite_fallback_unsupported(device, expect_er
         buffer_type=ttnn.BufferType.DRAM,
     )
     torch_input = torch.randn([1, 1, 64, 128], dtype=torch.bfloat16)
-    with expect_error(RuntimeError, "Logical DRAM core|No DRAM bank exists for core"):
+    # PR #51542 may reject invalid DRAM shard grids at buffer creation ("Invalid DRAM shard grid")
+    # before the older "Logical DRAM core" / "No DRAM bank exists for core" errors.
+    with expect_error(
+        RuntimeError,
+        "Logical DRAM core|No DRAM bank exists for core|Invalid DRAM shard grid",
+    ):
         ttnn.from_torch(
             torch_input,
             layout=ttnn.ROW_MAJOR_LAYOUT,

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_pad_universal_input.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_pad_universal_input.py
@@ -490,12 +490,8 @@ def test_pad_dram_block_sharded_composite_fallback_unsupported(device, expect_er
         buffer_type=ttnn.BufferType.DRAM,
     )
     torch_input = torch.randn([1, 1, 64, 128], dtype=torch.bfloat16)
-    # PR #51542 may reject invalid DRAM shard grids at buffer creation ("Invalid DRAM shard grid")
-    # before the older "Logical DRAM core" / "No DRAM bank exists for core" errors.
-    with expect_error(
-        RuntimeError,
-        "Logical DRAM core|No DRAM bank exists for core|Invalid DRAM shard grid",
-    ):
+    # PR #51542 rejects invalid DRAM shard grids at buffer creation ("Invalid DRAM shard grid").
+    with expect_error(RuntimeError, "Invalid DRAM shard grid"):
         ttnn.from_torch(
             torch_input,
             layout=ttnn.ROW_MAJOR_LAYOUT,


### PR DESCRIPTION
Fixes #52390, https://github.com/tenstorrent/tt-auto-triage/issues/2546

## Summary

Updates the expected error regex in `test_pad_dram_block_sharded_composite_fallback_unsupported` to accept the new DRAM shard grid validation added in PR #51542.

## Problem

Nightly `data_movement` CI was failing on all architectures (`wh_n150`, `wh_n300`, `bh_p100`, `bh_p150b`) with:

```
AssertionError: Regex pattern did not match.
  Expected regex: 'Logical DRAM core|No DRAM bank exists for core'
  Actual message: 'TT_FATAL @ tt_metal/impl/buffers/buffer.cpp:118: core.y == 0
info:
Invalid DRAM shard grid: shard core (0, 1) is not on row 0. DRAM banks are 1D
(bank_id == logical x-coordinate), so every shard core must have y == 0.'
```

PR #51542 added an earlier `TT_FATAL` in `buffer.cpp` that rejects DRAM sharded buffers whose shard cores have `y != 0`. The test's BLOCK-sharded config (built via `make_sharded_memory_config` with compute-core grid coords) now hits this check before the previously expected errors.

## Fix

Extend the `expect_error` regex to also match `"Invalid DRAM shard grid"`. Test-only change — no production code modified.

### Pipeline status

- [x] Sanity
- [x] (Runtime) Sanity Tests
- [x] BHPC
- [x] Nightly for DM - Verified if the tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/31153482978/job/92793226935#:~:text=tests/ttnn/nightly/unit_tests/operations/data_movement/test_pad_universal_input.py%3A%3Atest_pad_dram_block_sharded_composite_fallback_unsupported,1831)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/pad_52390)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/pad_52390)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/pad_52390)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/pad_52390)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/pad_52390)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/pad_52390)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/pad_52390)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/pad_52390)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/pad_52390)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/pad_52390)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/pad_52390)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/pad_52390)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/pad_52390)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/pad_52390)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/pad_52390)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/pad_52390)