### PR TITLE
Skip OOO owners when picking random pending reviewers

### DIFF
--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -1976,6 +1976,8 @@ jobs:
       - name: Select owners for notification
         if: needs.parse-comment.outputs.is-direct-ping != 'true'
         id: select-owners
+        env:
+          GITHUB_TOKEN: ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}
         run: |
           # Read TEAM_MEMBERS from file (saved in generate-comment step)
           TEAM_MEMBERS=$(cat "${RUNNER_TEMP}/team_members.txt")
@@ -2002,6 +2004,97 @@ jobs:
           is_pr_author() {
             local username="$1"
             [ "$username" = "$PR_AUTHOR_LOGIN" ]
+          }
+
+          # Filter out out-of-office (OOO) users from a comma-separated login list.
+          # A user is treated as OOO if their GitHub status is non-null AND either
+          # indicatesLimitedAvailability is true (the "Busy" flag) OR the status
+          # message matches OOO/out-of-office/vacation/PTO (case-insensitive).
+          # GitHub auto-clears an expired status to null, so no expiry check is needed.
+          # Batches all logins into ONE GraphQL request via aliases to stay well
+          # within rate limits. Fails open: on any API/parse error or if filtering
+          # would leave the pool EMPTY, the original CSV is returned unchanged so we
+          # never ping nobody. Echoes the surviving CSV; also sets the global
+          # OOO_SKIPPED_USERS with any logins that were dropped (for logging).
+          OOO_SKIPPED_USERS=""
+          filter_out_ooo() {
+            local csv="$1"
+            [ -z "$csv" ] && { echo ""; return 0; }
+            if [ -z "${GITHUB_TOKEN:-}" ]; then
+              echo "$csv"
+              return 0
+            fi
+
+            local -a logins
+            IFS=',' read -ra logins <<< "$csv"
+            [ "${#logins[@]}" -eq 0 ] && { echo "$csv"; return 0; }
+
+            # Build a single aliased GraphQL query: u0: user(login:"a"){...}
+            local sub="" i=0 login
+            for login in "${logins[@]}"; do
+              [ -z "$login" ] && continue
+              # Guard against anything that is not a plausible GitHub login.
+              case "$login" in
+                *[!A-Za-z0-9-]*) continue ;;
+              esac
+              sub="${sub}u${i}: user(login: \"${login}\") { login status { message indicatesLimitedAvailability } } "
+              i=$((i + 1))
+            done
+            [ -z "$sub" ] && { echo "$csv"; return 0; }
+
+            local query resp
+            query=$(printf 'query { %s }' "$sub")
+            resp=$(curl -s --max-time 30 -X POST \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --arg q "$query" '{query: $q}')" \
+              "https://api.github.com/graphql")
+
+            # Fail open on transport error or GraphQL errors block.
+            if [ -z "$resp" ] || ! echo "$resp" | jq -e '.data' >/dev/null 2>&1; then
+              echo "Warning: OOO lookup failed, using full owner list" >&2
+              echo "$csv"
+              return 0
+            fi
+
+            # Logins whose status marks them OOO.
+            local ooo
+            ooo=$(echo "$resp" | jq -r '
+              .data
+              | to_entries[]
+              | .value
+              | select(. != null and .status != null)
+              | select(
+                  (.status.indicatesLimitedAvailability == true)
+                  or ((.status.message // "") | test("OOO|out of office|vacation|PTO"; "i"))
+                )
+              | .login
+            ' 2>/dev/null | tr '\n' ' ')
+
+            [ -z "$ooo" ] && { echo "$csv"; return 0; }
+
+            # Rebuild CSV without OOO logins, in original order.
+            local kept="" dropped=""
+            for login in "${logins[@]}"; do
+              [ -z "$login" ] && continue
+              if echo " $ooo " | grep -q " $login "; then
+                dropped="$dropped$login,"
+              else
+                kept="$kept$login,"
+              fi
+            done
+            kept=$(echo "$kept" | sed 's/,$//')
+            dropped=$(echo "$dropped" | sed 's/,$//')
+
+            # Fail open if everyone in the pool is OOO — ping the full list anyway.
+            if [ -z "$kept" ]; then
+              echo "Note: all candidate owners appear OOO ($dropped); pinging full list anyway" >&2
+              echo "$csv"
+              return 0
+            fi
+
+            [ -n "$dropped" ] && OOO_SKIPPED_USERS="$OOO_SKIPPED_USERS$dropped,"
+            echo "$kept"
           }
 
           # GitHub team to Slack group mapping
@@ -2345,6 +2438,8 @@ jobs:
                       # Common selection logic: select up to 2 owners from remaining unapproved members
                       # For metalium-api-owners API files: this is in addition to akerteszTT (if added above)
                       # For all other cases: this is the primary selection
+                      # Drop OOO members before the random pick (fails open to the full list).
+                      TEAM_UNAPPROVED=$(filter_out_ooo "$TEAM_UNAPPROVED")
                       if [ -n "$TEAM_UNAPPROVED" ]; then
                         IFS=',' read -ra TEAM_MEMBERS_ARRAY <<< "$TEAM_UNAPPROVED"
                         TEAM_MEMBER_COUNT=${#TEAM_MEMBERS_ARRAY[@]}
@@ -2404,6 +2499,9 @@ jobs:
                 fi
               done
               PATTERN_UNAPPROVED=$(echo "$PATTERN_UNAPPROVED" | sed 's/,$//')
+
+              # Drop OOO owners before the random pick (fails open to the full list).
+              PATTERN_UNAPPROVED=$(filter_out_ooo "$PATTERN_UNAPPROVED")
 
               # Select up to 2 owners from this pending pattern
               if [ -n "$PATTERN_UNAPPROVED" ]; then

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -2050,14 +2050,19 @@ jobs:
               -d "$(jq -n --arg q "$query" '{query: $q}')" \
               "https://api.github.com/graphql")
 
-            # Fail open on transport error or GraphQL errors block.
-            if [ -z "$resp" ] || ! echo "$resp" | jq -e '.data' >/dev/null 2>&1; then
-              echo "Warning: OOO lookup failed, using full owner list" >&2
+            # Fail open on transport error, malformed/null data, OR a GraphQL
+            # errors array (partial-data responses are valid GraphQL but may omit
+            # some users' status — treat them as "lookup failed").
+            if [ -z "$resp" ] \
+              || ! echo "$resp" | jq -e '.data != null' >/dev/null 2>&1 \
+              || echo "$resp" | jq -e '(.errors // []) | length > 0' >/dev/null 2>&1; then
+              echo "Warning: OOO lookup failed or returned partial data, using full owner list" >&2
               echo "$csv"
               return 0
             fi
 
-            # Logins whose status marks them OOO.
+            # Logins whose status marks them OOO. Match keywords as whole words
+            # (\b...\b) so e.g. "PTO" does not match "laptop".
             local ooo
             ooo=$(echo "$resp" | jq -r '
               .data
@@ -2066,7 +2071,7 @@ jobs:
               | select(. != null and .status != null)
               | select(
                   (.status.indicatesLimitedAvailability == true)
-                  or ((.status.message // "") | test("OOO|out of office|vacation|PTO"; "i"))
+                  or ((.status.message // "") | test("\\b(OOO|out of office|vacation|PTO)\\b"; "i"))
                 )
               | .login
             ' 2>/dev/null | tr '\n' ' ')
@@ -2093,7 +2098,7 @@ jobs:
               return 0
             fi
 
-            [ -n "$dropped" ] && OOO_SKIPPED_USERS="$OOO_SKIPPED_USERS$dropped,"
+            [ -n "$dropped" ] && echo "OOO owners skipped from ping pool: $dropped" >&2
             echo "$kept"
           }
 


### PR DESCRIPTION
## What

The **CodeOwners Group Analysis** workflow (`.github/workflows/codeowners-group-analysis.yaml`) pings up to 2 randomly-selected owners from each pending approval group. Today that random pick can land on someone who is **out of office**, which silently delays review.

This PR skips OOO owners before the random pick.

## How

- Adds a `filter_out_ooo()` helper in the `select-owners` step. It batches **all** candidate logins into a **single** GraphQL `user.status` query (aliased `u0/u1/...`) — one request per group, not one per user — and drops anyone whose GitHub status marks them out of office:
  - `indicatesLimitedAvailability == true` (the "Busy" flag set via GitHub → *Set status* → **Busy**), **or**
  - status `message` matches `OOO | out of office | vacation | PTO` (case-insensitive), since many people type "OOO" without ticking Busy.
- Applied at **both** random-selection sites — team-member selection and individual-pattern selection — immediately before the existing `RANDOM % count` pick, so the selection logic itself is untouched.
- Exposes `GITHUB_TOKEN: ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}` to the step (same PAT the rest of the workflow already uses) for the GraphQL call.

## Fail-open by design

The filter never blocks a ping:
- Missing token, API error, or malformed response → returns the **full** original list.
- A group where **every** candidate is OOO → returns the full list anyway (better to ping an OOO owner than nobody). Logged to the step output.
- Expired statuses are auto-nulled by GitHub, so no expiry handling is needed.

## Notes on the OOO signal

GitHub user status is **self-reported and optional**, and only exposed via **GraphQL** (REST `GET /users/{login}` has no status field). A `null` status means "unknown", not "available" — so a user is only ever *excluded* for an explicit OOO signal, never for lacking one.

## Validation

- `python3 yaml.safe_load` parses the workflow.
- `bash -n` on the extracted `select-owners` run block passes.
- The jq OOO selector was validated against a live GraphQL response (`fvranicTT` OOO=true → dropped; `Aswinmcw` status "Focusing"/false → kept; `akerteszTT` null status → kept).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aswin/codeowners-skip-ooo-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aswin/codeowners-skip-ooo-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aswin/codeowners-skip-ooo-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aswin/codeowners-skip-ooo-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=aswin/codeowners-skip-ooo-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:aswin/codeowners-skip-ooo-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aswin/codeowners-skip-ooo-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aswin/codeowners-skip-ooo-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aswin/codeowners-skip-ooo-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aswin/codeowners-skip-ooo-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aswin/codeowners-skip-ooo-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aswin/codeowners-skip-ooo-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aswin/codeowners-skip-ooo-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aswin/codeowners-skip-ooo-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aswin/codeowners-skip-ooo-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aswin/codeowners-skip-ooo-owners)