### PR TITLE
Fix nightly DM ops failure - Update pad universal-input test for DRAM shard validation

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_pad_universal_input.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_pad_universal_input.py
@@ -483,8 +483,7 @@ def test_pad_dram_block_sharded_composite_fallback_unsupported(device, expect_er
     DRAM bank coordinates, so from_torch fails before pad runs.
 
     The grid spans multiple rows, which Buffer rejects up front ("Invalid DRAM shard
-    grid", added in #51542). Before that check existed the failure surfaced later, from
-    the DRAM bank lookup, so both messages are accepted.
+    grid", added in #51542).
     """
     in_cfg = make_sharded_memory_config(
         device,
@@ -494,7 +493,7 @@ def test_pad_dram_block_sharded_composite_fallback_unsupported(device, expect_er
         buffer_type=ttnn.BufferType.DRAM,
     )
     torch_input = torch.randn([1, 1, 64, 128], dtype=torch.bfloat16)
-    with expect_error(RuntimeError, "Invalid DRAM shard grid|Logical DRAM core|No DRAM bank exists for core"):
+    with expect_error(RuntimeError, "Invalid DRAM shard grid"):
         ttnn.from_torch(
             torch_input,
             layout=ttnn.ROW_MAJOR_LAYOUT,

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_pad_universal_input.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_pad_universal_input.py
@@ -481,6 +481,10 @@ def test_pad_dram_block_sharded_composite_fallback_unsupported(device, expect_er
 
     make_sharded_memory_config builds a compute-core grid; DRAM block sharding needs
     DRAM bank coordinates, so from_torch fails before pad runs.
+
+    The grid spans multiple rows, which Buffer rejects up front ("Invalid DRAM shard
+    grid", added in #51542). Before that check existed the failure surfaced later, from
+    the DRAM bank lookup, so both messages are accepted.
     """
     in_cfg = make_sharded_memory_config(
         device,
@@ -490,7 +494,7 @@ def test_pad_dram_block_sharded_composite_fallback_unsupported(device, expect_er
         buffer_type=ttnn.BufferType.DRAM,
     )
     torch_input = torch.randn([1, 1, 64, 128], dtype=torch.bfloat16)
-    with expect_error(RuntimeError, "Logical DRAM core|No DRAM bank exists for core"):
+    with expect_error(RuntimeError, "Invalid DRAM shard grid|Logical DRAM core|No DRAM bank exists for core"):
         ttnn.from_torch(
             torch_input,
             layout=ttnn.ROW_MAJOR_LAYOUT,


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Fix nightly DM ops failure - Update pad universal-input test for DRAM shard validation- #52405
 
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
Fix nightly DM ops failure - update error msg in pad_universal_input

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kalaivani/fix_nightly_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kalaivani/fix_nightly_pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kalaivani/fix_nightly_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kalaivani/fix_nightly_pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kalaivani/fix_nightly_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kalaivani/fix_nightly_pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kalaivani/fix_nightly_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kalaivani/fix_nightly_pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kalaivani/fix_nightly_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kalaivani/fix_nightly_pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kalaivani/fix_nightly_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kalaivani/fix_nightly_pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kalaivani/fix_nightly_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kalaivani/fix_nightly_pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kalaivani/fix_nightly_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kalaivani/fix_nightly_pad)