### PR TITLE
[skip ci] Update llama3.1-8b bh_quietbox_2 b4 perf targets

### DIFF
--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -606,13 +606,18 @@ targets:
       p300x2:
         entries:
           # Catch-all (no batch_size/seq_len): serves the data-parallel b4 perf run and the
-          # token-matching (b1) accuracy check. Perf seeded from data-parallel run 27016350392
-          # (b4 aggregate); accuracy is the token-matching (b1) target.
+          # token-matching (b1) accuracy check. Accuracy is the token-matching (b1) target.
+          # Perf re-seeded 2026-08-07 from the b4 data-parallel run 31146018726 after #48886
+          # (0a0510e7fc1, "Enable force_argmax fast-path on non-Galaxy") landed: measured
+          # 37.34 t/s/u / 149.35 t/s / 14.44 ms vs the old 20.88 / 83.5 / 19 targets, which
+          # tripped the validator's "much better than expected" upper bound. The 14 scheduled
+          # runs before #48886 sat at 18.9-21.3 t/s/u with no runner correlation, so this is a
+          # genuine step change from that optimization, not machine variance.
           - status: active
             perf:
-              prefill_time_to_first_token: 19
-              decode_t/s/u: 20.88
-              decode_t/s: 83.5
+              prefill_time_to_first_token: 14.4
+              decode_t/s/u: 37.3
+              decode_t/s: 149.4
             accuracy:
               top1: 90.0
               top5: 97.6


### PR DESCRIPTION
## Problem

The **Llama 3.1-8B data-parallel e2e** leg on `bh_quietbox_2` fails the perf gate — the test itself **passes**, but all three metrics trip the validator's *"much better than expected"* bound:

| metric | measured | expected | bound |
|---|---|---|---|
| `decode_t/s` | 149.35 | 83.5 | > ub 96.02 |
| `decode_t/s/u` | 37.34 | 20.88 | > ub 24.01 |
| `prefill_time_to_first_token` | 14.44 ms | 19 ms | < lb 16.15 |

Failing job (2026-08-07 scheduled T2 E2E): https://github.com/tenstorrent/tt-metal/actions/runs/31146018726/job/92773128115

## Cause — a real optimization, not machine variance

**#48886** (`0a0510e7fc1`, *"[Performance] Enable force_argmax fast-path on non-Galaxy (single-chip P150/N150)"*) merged 2026-08-06 19:17 — present in the 08-07 scheduled sha, absent from 08-06's. Its own description cites single-chip Blackhole Llama-3.1-8B greedy decode going **~22 → ~35 t/s/u**, matching the observed jump.

I checked runner correlation before re-seeding (a slow/fast machine can fake this):

| date | runner | decode_t/s/u |
|---|---|---|
| **08-07** | qb2-120-p03t01 | **37.338** |
| 08-06 | p06t02 | 19.716 |
| 08-05 | p02t04 | 21.321 |
| 08-04 | p05t04 | 19.740 |
| 08-01 … 07-23 | p02t04 / p03t03 / p05t04 / p02t06 / p05t09 | 18.93 – 21.33 |

All **14** pre-#48886 runs sit in 18.93–21.33 with **no runner correlation** (p02t04 gave both 21.32 and 18.94; p05t04 gave both 19.74 and 18.96). So the old 20.88 center was right for the pre-#48886 code, and 37.3 is a clean step change — not the bimodal-runner pattern.

## Change

Re-seed the `llama3.1-8b` → `p300x2` **catch-all** (b4 data-parallel) entry to the post-#48886 measurements. `bh_quietbox_2` normalizes to canonical `p300x2`. Default 0.15 tolerance ⇒ `[31.7, 42.9]` t/s/u, `[127.0, 171.8]` t/s, `[12.2, 16.6]` ms — all three measured values land in-band.

**Scope:** only the b4 catch-all. The non-DP job resolves to the separate `batch=32 / seq=712` entry (`decode_t/s/u` 57.0), which still matches its measured 56.8–58.9 and is untouched.

## Caveat

There is currently **one** post-#48886 datapoint (08-07). The new level is expected-stable given #48886's stated effect, but if a later run shows the fast-path not engaging, this target would then flag a false regression — worth a glance at the next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-dp-qb2-perf-target-refresh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/llama8b-dp-qb2-perf-target-refresh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-dp-qb2-perf-target-refresh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/llama8b-dp-qb2-perf-target-refresh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/llama8b-dp-qb2-perf-target-refresh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/llama8b-dp-qb2-perf-target-refresh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/llama8b-dp-qb2-perf-target-refresh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/llama8b-dp-qb2-perf-target-refresh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/llama8b-dp-qb2-perf-target-refresh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/llama8b-dp-qb2-perf-target-refresh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/llama8b-dp-qb2-perf-target-refresh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/llama8b-dp-qb2-perf-target-refresh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/llama8b-dp-qb2-perf-target-refresh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/llama8b-dp-qb2-perf-target-refresh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/llama8b-dp-qb2-perf-target-refresh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/llama8b-dp-qb2-perf-target-refresh)