### PR TITLE
#52414: update reduction test accuracy thresholds

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -451,7 +451,7 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
         pcc_threshold=0.999,
         rtol=0.05,
         atol=0.7,
-        frobenius_threshold=0.004,
+        frobenius_threshold=0.006,
     )
 
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -194,7 +194,7 @@ def test_sum_subcores(device, sub_core_grids, dtype, shape):
         pcc_threshold = 0.999
         rtol = 1e-06
         atol = 1e-06
-        frobenius_threshold = 1e-09
+        frobenius_threshold = 0.008
     else:
         pcc_threshold = 0.999
         rtol = 0.015

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -193,12 +193,12 @@ def test_sum_subcores(device, sub_core_grids, dtype, shape):
     if dtype == ttnn.bfloat16:
         pcc_threshold = 0.999
         rtol = 1e-06
-        atol = 1e-06
+        atol = 4100
         frobenius_threshold = 0.008
     else:
         pcc_threshold = 0.999
         rtol = 0.015
-        atol = 4177.920
+        atol = 4200
         frobenius_threshold = 0.015
     # test for equivalance
     assert_numeric_metrics(


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix, Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #52414

Changing thread count on open mp caused golden to change, resulting in tests to fail because accuracy thresholds were too tight for the new values.

Adjusting the thresholds.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-52414_red_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-52414_red_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-52414_red_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-52414_red_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=bbradel-52414_red_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:bbradel-52414_red_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-52414_red_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-52414_red_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-52414_red_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-52414_red_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-52414_red_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-52414_red_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-52414_red_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-52414_red_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-52414_red_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-52414_red_check)