### PR TITLE
Treat unsupported legacy perf benchmarks as skips in slow dispatch

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -926,7 +926,8 @@ std::vector<bfloat16> select_columns(std::vector<bfloat16> data, int M, int K, i
 
 int main(int argc, char** argv) {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
-        TT_THROW("Test not supported w/ slow dispatch, exiting");
+        log_info(tt::LogTest, "Test not supported w/ slow dispatch, skipping");
+        return 0;
     }
 
     bool pass = true;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
@@ -131,7 +131,8 @@ std::vector<T> slice(std::vector<T> const& v, int m, int n) {
 
 int main(int argc, char** argv) {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
-        TT_THROW("Test not supported w/ slow dispatch, exiting");
+        log_info(tt::LogTest, "Test not supported w/ slow dispatch, skipping");
+        return 0;
     }
 
     bool pass = true;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -56,7 +56,8 @@ std::vector<T> slice_vec(std::vector<T> const& v, int m, int n) {
 
 int main(int argc, char** argv) {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
-        TT_THROW("Test not supported w/ slow dispatch, exiting");
+        log_info(tt::LogTest, "Test not supported w/ slow dispatch, skipping");
+        return 0;
     }
 
     bool pass = true;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
@@ -54,7 +54,8 @@ std::vector<T> slice_vec(std::vector<T> const& v, int m, int n) {
 
 int main(int argc, char** argv) {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
-        TT_THROW("Test not supported w/ slow dispatch, exiting");
+        log_info(tt::LogTest, "Test not supported w/ slow dispatch, skipping");
+        return 0;
     }
 
     bool pass = true;


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The legacy old/matmul and old/noc perf microbenchmarks explicitly do not support slow dispatch, but they reported that unsupported configuration by throwing, which makes generic test runners classify the binaries as failures even though no benchmark logic was actually run. This is especially noisy for simulator and slow-dispatch sweeps that execute broad test sets without per-binary knowledge. Change the slow-dispatch guard in these four legacy benchmarks to log that the test is unsupported and return success, matching the behavior expected for an environment-based skip while leaving normal fast-dispatch execution unchanged.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/legacy-perf-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/legacy-perf-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/legacy-perf-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/legacy-perf-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/legacy-perf-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/legacy-perf-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/legacy-perf-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/legacy-perf-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/legacy-perf-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/legacy-perf-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/legacy-perf-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/legacy-perf-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/legacy-perf-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/legacy-perf-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/legacy-perf-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/legacy-perf-sd)