### PR TITLE
[perf] Optimize ProgramImpl kernel lookup

### DIFF
--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -544,18 +544,19 @@ KernelHandle detail::ProgramImpl::add_kernel(
     return id;
 }
 
-std::shared_ptr<Kernel> detail::ProgramImpl::get_kernel(KernelHandle kernel_id) const {
+const std::shared_ptr<Kernel>& detail::ProgramImpl::get_kernel(KernelHandle kernel_id) const {
     // TT_ASSERT(kernel_id < this->kernels_.size(), "Expected Kernel with ID {} to be in Program {}", kernel_id,
     // this->id);
     //  find coretype based on kernel_id
     for (const auto& kernels : this->kernels_) {
-        if (kernels.contains(kernel_id)) {
-            return kernels.at(kernel_id);
+        if (auto it = kernels.find(kernel_id); it != kernels.end()) {
+            return it->second;
         }
     }
 
     TT_ASSERT(false, "Did not find kernel id across all core types!");
-    return nullptr;
+    static const std::shared_ptr<Kernel> not_found;
+    return not_found;
 }
 
 // ============================================================================

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -245,7 +245,9 @@ public:
     void set_cached(uint64_t device_hash) { this->cached_device_hash_ = device_hash; }
     const std::optional<uint64_t>& get_cached() const { return this->cached_device_hash_; }
     void set_program_binary_status(ChipId device_id, ProgramBinaryStatus status);
-    std::shared_ptr<Kernel> get_kernel(KernelHandle kernel_id) const;
+    // Returns a reference into kernels_ so the hot runtime-arg patch path doesn't pay a shared_ptr
+    // refcount round trip per lookup. Stable: unordered_map values don't move on rehash.
+    const std::shared_ptr<Kernel>& get_kernel(KernelHandle kernel_id) const;
     ProgramConfig& get_program_config(uint32_t programmable_core_type_index);
     const ProgramConfig& get_program_config(uint32_t programmable_core_type_index) const;
     const std::vector<SubDeviceId>& determine_sub_device_ids(const IDevice* device);


### PR DESCRIPTION
### PR Category
Performance

### Summary
Use one map lookup and return the stored shared pointer by reference to reduce runtime-argument patching overhead.

### Performance

#### Single blackhole card

Command:
```bash
TT_METAL_DEVICE_PROFILER=1 python -m tracy -r -v --sync-host-device --profiler-capture-perf-counters=fpu,pack,unpack --op-support-count 1000 -o generated/profiler/copy_rm_sharded_4 -m pytest tests/ttnn/unit_tests/base_functionality/test_copy.py::test_copy_height_sharded 
```

OP CODE             | METRIC        | CALLS | BEFORE AVG [us] | AFTER AVG [us] | DELTA [us] | IMPROVEMENT [%] | SPEEDUP [x]
--------------------|---------------|-------|-----------------|----------------|------------|-----------------|------------
CopyDeviceOperation | HOST          |     4 |         486.033 |        534.414 |     48.382 |          -9.954 |       0.909
CopyDeviceOperation | DEVICE FW     |     4 |           4.085 |          4.095 |      0.009 |          -0.233 |       0.998
CopyDeviceOperation | DEVICE KERNEL |     4 |           1.633 |          1.626 |     -0.007 |           0.413 |       1.004

#### Galaxy

Comparing traced and non-traced runs, command is following

```bash
TT_METAL_DEVICE_PROFILER=1 python -m tracy -r --sync-host-device --op-support-count 20000 -o generated/profiler/kimi_l1_notrace_2 -m pytest "models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_perf[blackhole-kimi-mesh-8x4-L1-preload0-chunks1-two_iters-margin5pct-notrace]" -s --timeout=0 2>&1 | tee kimi_notrace_2.log
```

|                                  | **Main** | **PR** |
| -------------------------------- | -------- | ------ |
| **Chunk wall time (eager, ms)**  | 27.098   | 30.240 |
| **Chunk wall time (traced, ms)** | 1.618    | 1.632  |


### Notes for reviewers
Extracted from https://github.com/tenstorrent/tt-metal/pull/51732
Related to https://github.com/tenstorrent/tt-metal/issues/50932

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/op2op-host-hotpath-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/op2op-host-hotpath-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vlad/op2op-host-hotpath-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vlad/op2op-host-hotpath-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=vlad/op2op-host-hotpath-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:vlad/op2op-host-hotpath-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/op2op-host-hotpath-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/op2op-host-hotpath-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vlad/op2op-host-hotpath-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vlad/op2op-host-hotpath-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/op2op-host-hotpath-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/op2op-host-hotpath-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/op2op-host-hotpath-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/op2op-host-hotpath-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/op2op-host-hotpath-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/op2op-host-hotpath-metal)