### PR TITLE
Re-enable Llama 3.3-70B unit tests (Galaxy)

### DIFF
--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -488,24 +488,25 @@
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
 
-# TODO See Issue: https://github.com/tenstorrent/tt-metal/issues/42139
-# - name: Llama 3.3-70B unit tests (Galaxy)
-#   cmd: |
-#     export LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG
-#     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_rms_norm.py
-#     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_mlp.py
-#     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_mlp_prefill.py
-#     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_attention.py
-#     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_attention_prefill.py
-#     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_decoder_prefill.py
-#     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_model_prefill.py
-#   model: llama3.3-70b-galaxy
-#   skus:
-#     wh_galaxy_perf:
-#       timeout: 30
-#       tier: 1
-#   owner_id: U053W15B6JF # Djordje Ivanovic
-#   team: models
+- name: Llama 3.3-70B unit tests (Galaxy)
+  cmd: |
+    unset TT_METAL_WATCHER  # blocked by #50886
+    export LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG
+    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_rms_norm.py
+    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_mlp.py
+    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_mlp_prefill.py
+    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_attention.py
+    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_attention_prefill.py
+    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_decoder_prefill.py
+    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_model_prefill.py
+  model: llama3.3-70b-galaxy
+  model_family: Llama
+  skus:
+    wh_galaxy_perf:
+      timeout: 30
+      tier: 1
+  owner_id: U053W15B6JF # Djordje Ivanovic
+  team: models
 
 - name: Qwen3-32B unit tests (Galaxy)
   cmd: |


### PR DESCRIPTION
### Ticket

Related to #42139 (Galaxy Llama HF migration) and #52181 (reported Galaxy accuracy drop).

### Problem description

The `Llama 3.3-70B unit tests (Galaxy)` entry in `tests/pipeline_reorg/models_unit_tests.yaml` has been commented out since the tiered-pipeline reorg landed it that way in b81b8d3332b (#37949, 2026-02-20), with a `TODO See Issue: #42139` pointing at the pending HuggingFace migration. As a result the galaxy Llama unit tests — rms_norm, mlp, attention, decoder and model prefill — run in no pipeline at all, and the only galaxy Llama coverage is the e2e demo job, which has been red for infra reasons for most of its life (see the triage in #52181).

That gap is what made the accuracy report in #52181 hard to pin down: when the e2e job breaks, there is no component-level signal to say whether the model itself is healthy.

### What's changed

Uncommented the block. No test code changes.

Two small alignments with the neighbouring galaxy entries while uncommenting:

- added `unset TT_METAL_WATCHER  # blocked by #50886`, which every other 70B/galaxy entry carries;
- added `model_family: Llama`, which postdates the original commented block.

`LLAMA_DIR`, `FAKE_DEVICE=TG`, the pytest list, the sku, the 30 min timeout, tier and owner are unchanged from the commented version.

### Validation

All seven tests pass on `wh-glx6u-04` (6U Wormhole Galaxy, 32 ASICs), main at `01d8c346676`, Meta-format Llama-3.3-70B-Instruct weights. Nine test cases, **11m24s total** against the entry's 30 min budget:

| Test | Cases | Time | PCC |
|---|---|---|---|
| `test_llama_rms_norm.py` | 1 | 33 s | 0.99999 |
| `test_llama_mlp.py` | 1 | 94 s | 0.99623 |
| `test_llama_mlp_prefill.py` | 2 | 96 s | 0.99609 / 0.99632 |
| `test_llama_attention.py` | 1 | 80 s | 0.99939 |
| `test_llama_attention_prefill.py` | 1 | 74 s | 0.99846 |
| `test_llama_decoder_prefill.py` | 2 | 84 s | 0.99999 / 0.99999 |
| `test_llama_model_prefill.py` | 1 | 182 s | 0.92366 |

Both CI-side validators pass on the edited yaml:

- `verify_time_budget.py … unit 1` → `models` / `wh_galaxy_perf` requests 40 of 45 min, OK;
- `prepare_test_matrix.py … wh_galaxy_perf` emits the entry correctly with `runs_on: [arch-wormhole_b0, pipeline-perf, topology-6u, in-service]`, `tier: 1`.

### Open questions for review — please read before approving

This is a draft because three things need a reviewer who knows the runner state:

1. **`LLAMA_DIR` may not exist on the runner.** The entry keeps `/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/`, which is the exact path the galaxy e2e job has been failing on since 2026-08-03 with `Checkpoint directory … does not exist`, and the same tree behind six `tensor-cache-open-failed` runs (the mount is `:ro` on scheduled runs, so a cache miss cannot be repaired in place). My run used local Meta weights and a writable local `TT_CACHE_PATH`, so it does **not** prove the runner path works. If the mount is still broken, this entry will go red for the same infra reason and should wait for the mount fix.

   **Switching this entry to HF weights is not an option today** — it is not a drop-in swap for the Meta form, so the mount is the only path for now. Weight *loading* would be fine (`TtModelArgs` handles `HF_MODEL`, and `load_checkpoints.convert_hf_to_meta` renames `mlp.gate_proj.weight` → `feed_forward.w1.weight`, so the sliced state dicts come out Meta-named). What breaks is the reference module: with an HF config, `intermediate_size` is present so `model_config.py:2069-2070` sets `ffn_dim_multiplier = None` and `multiple_of = None`, and the tests hand `model_args.multiple_of` straight to the submodule `FeedForward`, which does `hidden_dim = multiple_of * (...)` unconditionally (`llama31_8b/model.py:233`). That `TypeError` takes out `test_llama_mlp.py`, `test_llama_mlp_prefill.py` and `test_llama_decoder_prefill.py` (the last via `TransformerBlock`). `test_llama_model_prefill.py` fails earlier still, at `Tokenizer(model_args.tokenizer_path)`, since under `HF_MODEL` that path is the literal string `meta-llama/Llama-3.3-70B-Instruct/tokenizer.model` and the Meta tokenizer asserts a real file. Only rms_norm and the two attention tests would survive. The Qwen galaxy entry gets away with `HF_MODEL` because its reference lives in-repo at `reference/qwen.py` and hardcodes its dims, ignoring `multiple_of`. Making the HF form work needs the `reference_mlp()` / `reference_decoder()` / … factories that #42139 asks for (only `create_tokenizer()` exists on the galaxy `TtModelArgs` today), or as a stopgap passing `model_args.hidden_dim` directly and routing the tokenizer through `create_tokenizer()`. This is static analysis — I could not run the HF variant, as the dev galaxy I used has no `/mnt/MLPerf` mount.
2. **`test_llama_model_prefill.py` has thin margin.** PCC 0.92366 against a 0.915 threshold that carries its own `# TODO Look on improving PCC`. That is the entry most likely to flake.
3. **Budget headroom is 5 minutes.** `wh_galaxy_perf` unit goes from 10 to 40 min against a 45 min budget.

Also worth noting, though out of scope here: these tests still import their reference model from the `models/demos/t3000/llama2_70b/reference/llama` submodule, which is what #42139 wants removed. It is not a functional blocker — `models-unit-tests-impl.yaml` checks out with `submodules: recursive` — but re-enabling them does re-introduce a CI dependency on that submodule.

### Checklist

- [x] Galaxy Llama 3.3-70B unit tests run and pass locally on a 6U galaxy
- [x] `verify_time_budget.py` and `prepare_test_matrix.py` pass on the edited yaml
- [ ] Confirm `LLAMA_DIR` / tensor cache is available and writable on `wh_galaxy_perf` runners
- [ ] New/existing tests provide coverage for changes
