### PR TITLE
Fix matmul integration tests for DRAM accessors and async completion

### DIFF
--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
@@ -262,6 +262,7 @@ bool matmul_multi_core_single_dram(const std::shared_ptr<distributed::MeshDevice
             int dram_src1_channel_id = 1;
             uint32_t dram_buffer_dst_addr =
                 (core_index * per_core_M * per_core_N * single_tile_size) + dram_unreserved_base;
+            int dram_dst_channel_id = 2;
 
             uint32_t dram_buffer_size_act =
                 single_tile_size * per_core_M * K;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
@@ -303,9 +304,9 @@ bool matmul_multi_core_single_dram(const std::shared_ptr<distributed::MeshDevice
 
             const std::array mm_reader_args = {
                 (std::uint32_t)dram_buffer_src0_addr,
-                (std::uint32_t)0,
+                (std::uint32_t)dram_src0_channel_id,
                 (std::uint32_t)dram_buffer_src1_addr,
-                (std::uint32_t)0,
+                (std::uint32_t)dram_src1_channel_id,
                 (std::uint32_t)(K / in0_block_w),                            // num_blocks
                 (std::uint32_t)per_core_M * in0_block_w,                     // input 0 block num tiles
                 (std::uint32_t)per_core_N * in0_block_w,                     // input 1 block num tiles
@@ -314,7 +315,7 @@ bool matmul_multi_core_single_dram(const std::shared_ptr<distributed::MeshDevice
 
             const std::array writer_args = {
                 (std::uint32_t)dram_buffer_dst_addr,
-                (std::uint32_t)0,
+                (std::uint32_t)dram_dst_channel_id,
                 (std::uint32_t)out_subblock_h,               // num tiles per sub block m
                 (std::uint32_t)out_subblock_w,               // num tiles per sub block n
                 (std::uint32_t)per_core_M / out_subblock_h,  // num sub blocks m
@@ -334,7 +335,9 @@ bool matmul_multi_core_single_dram(const std::shared_ptr<distributed::MeshDevice
 
     log_debug(LogTest, "Running Matmul {} core test", num_cores_c * num_cores_r);
 
-    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
     log_debug(LogTest, "Matmul test done");
     log_debug(LogTest, "Gathering data back from dram and checking against golden");
     for (int i = 0; i < num_cores_r; i++) {

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -548,7 +548,9 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(const std::shared_ptr<dist
 
     log_debug(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
 
-    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
     log_debug(LogTest, "Matmul test done");
 
     log_debug(LogTest, "Gathering data back from dram and checking against golden");

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
@@ -139,26 +140,38 @@ create_program(
                                 std::to_string(mcast_xy_offset) + "_mcast_sender.cpp";
     std::string kernel_receiver = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in" +
                                   std::to_string(mcast_xy_offset) + "_mcast_receiver.cpp";
+    vector<uint32_t> reader_compile_time_args;
+    tt::tt_metal::TensorAccessorArgs::create_dram_interleaved().append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs::create_dram_interleaved().append_to(reader_compile_time_args);
+
     auto mm_reader_kernel_sender = tt_metal::CreateKernel(
         program_,
         kernel_sender,
         mcast_senders,
         tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt_metal::NOC::RISCV_1_default,
+            .compile_args = reader_compile_time_args});
 
     auto mm_reader_kernel_receiver = tt_metal::CreateKernel(
         program_,
         kernel_receiver,
         mcast_receivers,
         tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt_metal::NOC::RISCV_1_default,
+            .compile_args = reader_compile_time_args});
 
+    vector<uint32_t> writer_compile_time_args;
+    tt::tt_metal::TensorAccessorArgs::create_dram_interleaved().append_to(writer_compile_time_args);
     auto unary_writer_kernel = tt_metal::CreateKernel(
         program_,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_matmul_tile_layout.cpp",
         all_cores,
         tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = writer_compile_time_args});
 
     int num_blocks = (K / in0_block_w);
 
@@ -443,7 +456,9 @@ bool matmul_multi_core_multi_dram_inX_mcast(
 
     log_debug(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
 
-    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
     log_debug(LogTest, "Matmul test done");
 
     log_debug(LogTest, "Gathering data back from dram and checking against golden");


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Several matmul integration tests could fail in simulator/slow-dispatch runs because they launched work asynchronously and then immediately read output DRAM, and some kernels were still relying on implicit DRAM accessor/channel assumptions. The tests therefore had races against workload completion and incorrect or underspecified DRAM addressing in the runtime arguments/compile-time kernel setup. Add the required DRAM interleaved tensor accessor compile arguments, pass the intended DRAM channel IDs through the reader/writer runtime args, and finish the mesh command queue before gathering output for validation. This makes the tests describe the memory accesses they actually perform and removes the host-side readback race without changing the matmul computation being tested.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/matmul-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/matmul-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/matmul-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/matmul-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/matmul-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/matmul-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/matmul-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/matmul-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/matmul-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/matmul-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/matmul-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/matmul-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/matmul-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/matmul-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/matmul-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/matmul-integration)