### PR TITLE
Clear DeepSeek dispatch writer NOC transaction tags

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_worker_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_worker_dispatch.cpp
@@ -352,6 +352,10 @@ void kernel_main() {
                     // Wait only on this entry's cross-device writes — in-flight local
                     // DRAM writes are tagged-out by TRID and keep flying.
                     noc_async_write_barrier_with_trid(TRID_NON_LOCAL_WRITE);
+                    // The transaction ID is a command-buffer register, not a per-write
+                    // argument. Restore the default ID before this worker hands its NOC
+                    // interface to another kernel (or issues an untagged local write).
+                    noc_async_write_set_trid(0);
 
                     noc_semaphore_inc<true>(sender_data_avail_noc_addr, 1);
 
@@ -398,6 +402,7 @@ void kernel_main() {
     noc_async_write_one_packet_with_trid(
         route_info_scratch_addr, sentinel_c4_slot, route_info_slot_stride, TRID_NON_LOCAL_WRITE);
     noc_async_write_barrier_with_trid(TRID_NON_LOCAL_WRITE);
+    noc_async_write_set_trid(0);
     data_avail_sem.up(noc, sender_noc_x, sender_noc_y, 1);
 
     // noc_async_full_barrier flushes everything in-flight (including the inc) before exit.


### PR DESCRIPTION
## Summary

Clear the dispatch writer command buffer transaction tag after each tagged remote write barrier, including the sentinel path. The public reset API also records the watcher waypoint.

This satisfies the dev firmware invariant that tagged NOC transactions are cleared before the kernel continues or exits, and prevents later local writes from inheriting the non-local transaction ID.

## Validation
- Four-chip Kimi device smoke through `scripts/run_safe_pytest.sh --dev` (watcher and LLK asserts enabled).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-dispatch-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-deepseek-prefill-dispatch-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-dispatch-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-deepseek-prefill-dispatch-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-dispatch-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/fix-deepseek-prefill-dispatch-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-dispatch-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-deepseek-prefill-dispatch-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-dispatch-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-deepseek-prefill-dispatch-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-dispatch-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-deepseek-prefill-dispatch-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-dispatch-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-deepseek-prefill-dispatch-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-dispatch-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-deepseek-prefill-dispatch-trid)

### Targeted CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-dispatch-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/fix-deepseek-prefill-dispatch-trid)