### PR TITLE
Reset DeepSeek combine writer transaction tag per row

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
@@ -306,7 +306,13 @@ void kernel_main() {
                                 untilize_row_addr + off, dst_addr + off, chunk, TRID_NON_LOCAL_WRITE);
                             off += chunk;
                         }
-                        noc_async_write_barrier_with_trid(TRID_NON_LOCAL_WRITE);  // zone measures only row-data landing
+                        // The tagged barrier drains this row's remote metadata and
+                        // data writes without waiting for local DRAM writes.
+                        noc_async_write_barrier_with_trid(TRID_NON_LOCAL_WRITE);
+                        // A transaction ID is retained by the command buffer after
+                        // its barrier. Clear it before the next row so a later local
+                        // noc.async_write remains untagged.
+                        noc_async_write_set_trid(0);
                     }
 
                     noc_semaphore_inc<true>(sender_data_ready_noc_addr, 1);
@@ -342,5 +348,11 @@ void kernel_main() {
     Semaphore<> sender_data_ready_sem(data_ready_semaphore_id);
     sender_data_ready_sem.up(noc, sender_noc_x, sender_noc_y, 1);
     noc.async_atomic_barrier();
+
+    // The per-row remote path resets the transaction ID after every tagged
+    // barrier. Repeat it at exit so the firmware's dynamic-NoC handoff check
+    // sees an idle command buffer on every path.
+    noc_async_write_set_trid(0);
+
     cb_experts_tok_counter.pop_front(cb_counter_total_pages);
 }


### PR DESCRIPTION
## Summary

Reset the combine writer transaction tag immediately after each tagged remote-row barrier and defensively before kernel exit. This prevents subsequent untagged local writes from inheriting the non-local transaction ID and satisfies the dev kernel-exit invariant.

## Validation
- Four-chip Kimi device smoke through `scripts/run_safe_pytest.sh --dev` (watcher and LLK asserts enabled).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-combine-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-deepseek-prefill-combine-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-combine-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-deepseek-prefill-combine-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-combine-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/fix-deepseek-prefill-combine-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-combine-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-deepseek-prefill-combine-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-combine-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-deepseek-prefill-combine-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-combine-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-deepseek-prefill-combine-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-combine-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-deepseek-prefill-combine-trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-combine-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-deepseek-prefill-combine-trid)

### Targeted CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-prefill-combine-trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/fix-deepseek-prefill-combine-trid)