### PR TITLE
Reserve tile-aligned routed-expert dispatch capacity

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/torch/test_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_moe.py
@@ -37,6 +37,22 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
 )
 
 
+def test_compute_constants_reserves_local_expert_tile_padding():
+    """A raw 256-token budget needs 736 rows when it spans 16 experts."""
+    experts_per_chip, _, dispatch_buffer_rows, max_tokens_per_expert = compute_constants(
+        seq_len_per_chip=64,
+        num_routed_experts=64,
+        num_experts_per_tok=1,
+        num_devices=4,
+        dispatch_group_size=4,
+        dispatch_buffer_capacity_factor=1,
+    )
+
+    assert experts_per_chip == 16
+    assert max_tokens_per_expert == 256
+    assert dispatch_buffer_rows == 736
+
+
 # dispatch_buffer_capacity_factor below is ceil(N/2) of the most conservative
 # integer N such that dgs*seq*N >= theoretical worst-case dispatch buffer.
 # Real traffic never approaches the worst case, so half-capacity is sufficient.

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -454,7 +454,8 @@ def compute_constants(
         dispatch_buffer_capacity_factor: Multiplier for the flat dispatch
             buffer; callers must pick the smallest integer such that
             dgs*seq*factor is not smaller than the theoretical worst-case
-            required buffer size.
+            raw token count. The returned buffer also reserves the tile
+            padding required by each local expert region.
         experts_per_chip_override: If not None, bypass the
             num_routed_experts // num_devices derivation and use this value.
             Required when simulating one Galaxy column on a single-column LB
@@ -474,6 +475,7 @@ def compute_constants(
     assert (
         seq_len_per_chip % ttnn.TILE_SIZE == 0
     ), f"seq_len_per_chip ({seq_len_per_chip}) must be a multiple of TILE_SIZE ({ttnn.TILE_SIZE})"
+    assert dispatch_buffer_capacity_factor > 0, "dispatch_buffer_capacity_factor must be positive"
 
     if experts_per_chip_override is not None:
         assert (
@@ -491,7 +493,16 @@ def compute_constants(
     # TODO: For now, we are ignoring the num_experts_per_tok, but it will be needed once
     # we support replicated experts (See Issue #41293)
     max_dispatched_tokens_per_expert = dispatch_group_size * seq_len_per_chip
-    max_dispatch_buffer_token_size = max_dispatched_tokens_per_expert * dispatch_buffer_capacity_factor
+    raw_dispatch_buffer_token_capacity = max_dispatched_tokens_per_expert * dispatch_buffer_capacity_factor
+
+    # `offset_cumsum` lays out each nonempty local expert in a TILE_SIZE-aligned
+    # region. With a raw capacity of B tokens spread across E local experts,
+    # the alignment overhead is at most (min(B, E) - 1) complete tiles: reserve
+    # it here so dispatch, the routed FFN, and combine share a safe buffer size.
+    max_active_local_experts = min(raw_dispatch_buffer_token_capacity, experts_per_chip)
+    max_dispatch_buffer_token_size = raw_dispatch_buffer_token_capacity + ttnn.TILE_SIZE * (
+        max_active_local_experts - 1
+    )
 
     return experts_per_chip, metadata_len, max_dispatch_buffer_token_size, max_dispatched_tokens_per_expert
 


### PR DESCRIPTION
## Summary

Reserve the per-expert tile padding consumed by routed-expert dispatch offsets. A raw 256-token four-chip dispatch group spread across 16 local experts requires 736 physical rows, not 256.

Add an exact-bound regression test for that layout.

## Validation

- `./build_metal.sh --release`
- Unit regression: `test_compute_constants_reserves_local_expert_tile_padding`
- Four-chip Kimi device smoke through `scripts/run_safe_pytest.sh --dev`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-moe-routed-expert-capacity)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-moe-routed-expert-capacity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-moe-routed-expert-capacity)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-moe-routed-expert-capacity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-moe-routed-expert-capacity)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/fix-moe-routed-expert-capacity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-moe-routed-expert-capacity)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-moe-routed-expert-capacity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-moe-routed-expert-capacity)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-moe-routed-expert-capacity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-moe-routed-expert-capacity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-moe-routed-expert-capacity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-moe-routed-expert-capacity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-moe-routed-expert-capacity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-moe-routed-expert-capacity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-moe-routed-expert-capacity)

## Scope

This surfaced in the reduced four-chip Kimi device-debug smoke: 256 raw tokens spread across 16 local experts require 736 physical rows after tile alignment. Production-style prefill configurations use a capacity factor of 8 and are not known to be affected. This corrects physical-buffer sizing for valid lower-capacity configurations; it is not a known deployed-production regression.

### Targeted CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/fix-moe-routed-expert-capacity)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/fix-moe-routed-expert-capacity)