### PR TITLE
Fix MoE reduce score-channel shape inference

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py
@@ -228,10 +228,23 @@ def run_reduce(
 # Model-independent sanity shape — small seq/emb that exercises the reduce kernel without
 # tying to any model's dimensions. Kept in a single test so it is not duplicated per model.
 @pytest.mark.parametrize("use_weights", [True, False], ids=["weighted", "unweighted"])
-@pytest.mark.parametrize("seq_len, emb_dim, topk", [(32, 2048, 8)], ids=["generic"])
+@pytest.mark.parametrize(
+    "seq_len, emb_dim, topk",
+    [(32, 2048, 8)],
+    ids=["generic"],
+)
 @pytest.mark.parametrize("mesh_device, device_params", REDUCE_MESH_PARAMS, indirect=["mesh_device", "device_params"])
 def test_ttnn_reduce(mesh_device, seq_len, emb_dim, topk, use_weights):
     run_reduce(mesh_device, seq_len, emb_dim, topk, use_weights)
+
+
+@pytest.mark.parametrize("use_weights", [True, False], ids=["weighted", "unweighted"])
+@pytest.mark.parametrize(
+    "mesh_device, device_params", REDUCE_MESH_PARAMS[:1], indirect=["mesh_device", "device_params"]
+)
+def test_ttnn_reduce_single_expert(mesh_device, use_weights):
+    """Top-k=1 cannot be sharded across the second axis of the 4x2 mapper."""
+    run_reduce(mesh_device, seq_len=32, emb_dim=1024, topk=1, use_weights=use_weights)
 
 
 # Per-model reduce shapes as (id_prefix, config, extended_model). Each model uses seq_len 640 and

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py
@@ -31,7 +31,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     get_tp_mesh_composer,
     initialize_test_inputs,
 )
-from models.demos.deepseek_v3_d_p.tt.moe.tt_reduce import TtReduceModule
+from models.demos.deepseek_v3_d_p.tt.moe.tt_reduce import TtReduceModule, _weights_have_output_channel_dim
 from tests.ttnn.utils_for_testing import comp_pcc
 
 REDUCE_MESH_PARAMS = [
@@ -48,6 +48,28 @@ REDUCE_MESH_PARAMS = [
         id="mesh-4x2",
     ),
 ]
+
+
+@pytest.mark.parametrize(
+    "weights_shape, combine_output_shape, expected",
+    [
+        # A top-k=1 score lacks the output channel and must be unsqueezed.
+        ((4, 64, 1), (1, 4, 64, 1, 1024), False),
+        # The same score with an explicit output channel omits only a leading
+        # mesh dimension and must not receive a second trailing singleton.
+        ((4, 64, 1, 1), (1, 4, 64, 1, 1024), True),
+        ((1, 4, 64, 1, 1), (1, 4, 64, 1, 1024), True),
+        # A top-k>1 score has no ambiguity: without the output channel it is
+        # not broadcastable to the complete combine output.
+        ((4, 64, 8), (1, 4, 64, 8, 1024), False),
+    ],
+)
+def test_weights_output_channel_shape_detection(weights_shape, combine_output_shape, expected):
+    actual = _weights_have_output_channel_dim(weights_shape, combine_output_shape)
+    assert actual is expected, (
+        f"Expected channel-dimension inference to be {expected} for weights={weights_shape} "
+        f"and combine_output={combine_output_shape}, but got {actual}"
+    )
 
 
 def run_reduce(

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_reduce.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_reduce.py
@@ -26,6 +26,25 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 
 
+def _weights_have_output_channel_dim(weights_shape: tuple[int, ...], combine_output_shape: tuple[int, ...]) -> bool:
+    """Return whether weights already broadcast as ``[..., topk, 1]``.
+
+    Gate scores may omit leading mesh dimensions.  For ``topk == 1``, their
+    final score dimension is also one, so it cannot by itself distinguish
+    ``[..., topk]`` from ``[..., topk, 1]``.  Right-align the candidate with
+    the complete combine output: only the latter form can broadcast through
+    the embedding dimension.
+    """
+    if not weights_shape or weights_shape[-1] != 1 or len(weights_shape) > len(combine_output_shape):
+        return False
+
+    padded_weights_shape = (1,) * (len(combine_output_shape) - len(weights_shape)) + weights_shape
+    return all(
+        weight_dim == 1 or weight_dim == output_dim
+        for weight_dim, output_dim in zip(padded_weights_shape, combine_output_shape)
+    )
+
+
 class TtReduceModule(LightweightModule):
     """TTNN implementation: fused weighted sum over topk + reduce_scatter."""
 
@@ -81,8 +100,11 @@ class TtReduceModule(LightweightModule):
             output: Per-chip tensor of shape [seq_len, emb_dim / num_chips_in_axis]
         """
         if weights is not None:
-            # Ensure weights has trailing dim=1 for broadcast: [..., topk] -> [..., topk, 1]
-            if weights.shape[-1] != 1:
+            # Scores can omit leading mesh dimensions. For topk=1 a trailing
+            # singleton is ambiguous. Treat it as an existing output-channel
+            # dimension only when the full right-aligned shape broadcasts to
+            # combine_output; otherwise append the missing channel dimension.
+            if not _weights_have_output_channel_dim(tuple(weights.shape), tuple(combine_output.shape)):
                 weights = ttnn.unsqueeze(weights, dim=-1)
 
             # Add batch dimensions if needed to match combine_output rank


### PR DESCRIPTION
## Summary

Infer an existing singleton output channel by right-aligning the score tensor against the combine-output prefix. This preserves already channel-shaped score tensors and appends exactly one channel dimension to rank-deficient forms.

Add top-k=1 weighted and unweighted regression coverage.

## Validation

- MoE reduce top-k=1 regression coverage
- Four-chip Kimi device smoke through `scripts/run_safe_pytest.sh --dev`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-moe-reduce-score-channel)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-moe-reduce-score-channel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-moe-reduce-score-channel)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-moe-reduce-score-channel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-moe-reduce-score-channel)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/fix-moe-reduce-score-channel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-moe-reduce-score-channel)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-moe-reduce-score-channel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-moe-reduce-score-channel)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-moe-reduce-score-channel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-moe-reduce-score-channel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-moe-reduce-score-channel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-moe-reduce-score-channel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-moe-reduce-score-channel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-moe-reduce-score-channel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-moe-reduce-score-channel)
## Scope

This surfaced in the reduced Kimi device-debug smoke, which uses top-k=1 to remain within the debug watchdog. Supported production model configurations use top-k 4, 6, or 8 and are not known to be affected. This corrects generic broadcasting for valid top-k=1 score tensors; it is not a known deployed-production regression.

### Targeted CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/fix-moe-reduce-score-channel)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/fix-moe-reduce-score-channel)