### PR TITLE
Fix CI path to model weights so they don't get downloaded from HF

### DIFF
--- a/.github/workflows/blackhole-e2e-tests-impl.yaml
+++ b/.github/workflows/blackhole-e2e-tests-impl.yaml
@@ -141,7 +141,7 @@ jobs:
         - ${{ (!contains(join(matrix.test-group.runs_on, ' '), 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
         - "${{ (matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && '/mnt/MLPerf/huggingface:/localdev/blackhole_demos/huggingface_data:ro') || (matrix.test-group['weights-cache-mode'] == 'local-disk' && '/localdev/blackhole_demos/huggingface_data:/localdev/blackhole_demos/huggingface_data:ro') || '/no_hf_cache' }}"
         - "${{ (matrix.test-group['model-name'] == 'deepseek_prefill' && '/mnt/MLPerf/deepseek-prefill-cache:/mnt/MLPerf/deepseek-prefill-cache:ro') || '/no_deepseek_traces' }}"
-        - "${{ (matrix.test-group['model-name'] == 'deepseek_prefill' && '/mnt/MLPerf/tt_dnn-models/deepseek-ai:/mnt/MLPerf/tt_dnn-models/deepseek-ai:ro') || '/no_deepseek_weights' }}"
+        - "${{ (matrix.test-group['model-name'] == 'deepseek_prefill' && '/mnt/MLPerf/huggingface:/mnt/MLPerf/huggingface:ro') || '/no_deepseek_weights' }}"
       options: "--device /dev/tenstorrent -e TT_GH_CI_INFRA"
     defaults:
       run:

--- a/.github/workflows/blackhole-e2e-tests-impl.yaml
+++ b/.github/workflows/blackhole-e2e-tests-impl.yaml
@@ -141,6 +141,7 @@ jobs:
         - ${{ (!contains(join(matrix.test-group.runs_on, ' '), 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
         - "${{ (matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && '/mnt/MLPerf/huggingface:/localdev/blackhole_demos/huggingface_data:ro') || (matrix.test-group['weights-cache-mode'] == 'local-disk' && '/localdev/blackhole_demos/huggingface_data:/localdev/blackhole_demos/huggingface_data:ro') || '/no_hf_cache' }}"
         - "${{ (matrix.test-group['model-name'] == 'deepseek_prefill' && '/mnt/MLPerf/deepseek-prefill-cache:/mnt/MLPerf/deepseek-prefill-cache:ro') || '/no_deepseek_traces' }}"
+        - "${{ (matrix.test-group['model-name'] == 'deepseek_prefill' && '/mnt/MLPerf/tt_dnn-models/deepseek-ai:/mnt/MLPerf/tt_dnn-models/deepseek-ai:ro') || '/no_deepseek_weights' }}"
       options: "--device /dev/tenstorrent -e TT_GH_CI_INFRA"
     defaults:
       run:

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -165,7 +165,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/huggingface/hub/models--deepseek-ai--DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
     export DEEPSEEK_V32_MLA_REF_CACHE=/tmp/deepseek_v32_mla_ref_cache GLM52_MLA_REF_CACHE=/tmp/glm_5_2_mla_ref_cache
     export DS_SPARSE_FABRIC=fabric2d
     # Sparse MLA (V3.2 + GLM-5.2) vs MLACPU. Random weights + on-the-fly CPU truth -> no staged weights.

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -148,6 +148,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
+    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
     pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64 and ((mesh-4x2 or mesh-2x4 or linear-8) or not (moe_gate_prefill2d or moe_routing_setup or ttnn_moe)) and not (linear-8 and (pcc-device or (5k and not 25k))) and not (ttnn_moe and kimi and perf) and not (ttnn_moe and deepseek_v3 and mesh-4x2 and not fabric2d-) and not pad50" --timeout 1800 || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "balanced and not non_balanced and fabric2d and not pretrained" -vvv --tb=short --timeout=900 || exit_code=$?
@@ -201,6 +202,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
+    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
     # pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -m models_device_performance_bare_metal -vvv --tb=short --timeout=900 || exit_code=$? Commented out until problems with various results on different runners is resolved Issue https://github.com/tenstorrent/tt-metal/issues/47287
     pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py -vvv --tb=short || exit_code=$?

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -148,7 +148,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/huggingface/hub/models--deepseek-ai--DeepSeek-R1-0528
     pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64 and ((mesh-4x2 or mesh-2x4 or linear-8) or not (moe_gate_prefill2d or moe_routing_setup or ttnn_moe)) and not (linear-8 and (pcc-device or (5k and not 25k))) and not (ttnn_moe and kimi and perf) and not (ttnn_moe and deepseek_v3 and mesh-4x2 and not fabric2d-) and not pad50" --timeout 1800 || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "balanced and not non_balanced and fabric2d and not pretrained" -vvv --tb=short --timeout=900 || exit_code=$?
@@ -165,7 +165,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/huggingface/hub/models--deepseek-ai--DeepSeek-R1-0528
     export DEEPSEEK_V32_MLA_REF_CACHE=/tmp/deepseek_v32_mla_ref_cache GLM52_MLA_REF_CACHE=/tmp/glm_5_2_mla_ref_cache
     export DS_SPARSE_FABRIC=fabric2d
     # Sparse MLA (V3.2 + GLM-5.2) vs MLACPU. Random weights + on-the-fly CPU truth -> no staged weights.
@@ -202,7 +202,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/huggingface/hub/models--deepseek-ai--DeepSeek-R1-0528
     # pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -m models_device_performance_bare_metal -vvv --tb=short --timeout=900 || exit_code=$? Commented out until problems with various results on different runners is resolved Issue https://github.com/tenstorrent/tt-metal/issues/47287
     pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py -vvv --tb=short || exit_code=$?


### PR DESCRIPTION
### PR Category
Bug fix (CI)

### Summary
`DEEPSEEK_V3_HF_MODEL` pointed at `/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528`, which is a symlink into `/mnt/MLPerf/huggingface/hub` — a folder that was not mounted in the CI container, so the link dangled and every run downloaded ~17GB of weights from HF.

Fix: mount the hub at its host path and point `DEEPSEEK_V3_HF_MODEL` directly at it. Weights are no longer downloaded from HF — [verified run](https://github.com/tenstorrent/tt-metal/actions/runs/31166901781) shows `Using existing model from DEEPSEEK_V3_HF_MODEL` and no download lines.

Proof:
No download - https://github.com/tenstorrent/tt-metal/actions/runs/31166901781/job/92832698381#step:8:27480
Download - https://github.com/tenstorrent/tt-metal/actions/runs/31161343725/job/92814382874#step:8:27476

No download - https://github.com/tenstorrent/tt-metal/actions/runs/31166901781/job/92832698274#step:8:45113
Download - https://github.com/tenstorrent/tt-metal/actions/runs/31161343725/job/92814382866#step:8:45099