### PR TITLE
llk tests: fix the undefined name in counter_report

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -867,7 +867,7 @@ def counter_report(request, worker_id):
 
     PerfConfig.COUNTER_REPORT = None
 
-    if TestConfig.MODE == TestMode.PRODUCE:
+    if TestConfig.BUILD_MODE == BuildMode.PRODUCE:
         return
 
     if PerfConfig.TEST_COUNTER == 0:


### PR DESCRIPTION
## What

`counter_report` in `conftest.py` guards on `TestConfig.MODE == TestMode.PRODUCE`. Neither name exists.

`TestConfig` defines `BUILD_MODE`, not `MODE`. `TestMode` is not imported by `conftest.py` and is not defined anywhere in `python_tests`; that line is its only occurrence in the tree. The fixture raises as soon as it reaches the line.

`conftest.py` already imports `BuildMode`, and every other guard in the same file, including the two just below this one, uses `TestConfig.BUILD_MODE`.

## Why it is separate

One line, no dependencies, and it is broken on `main` today, so there is no reason to hold it behind the rest of the perf-counter work.

## Testing

`TestMode` no longer appears in the file, and the module parses with no undefined name.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-conftest-buildmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvlahovic/perf-conftest-buildmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-conftest-buildmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvlahovic/perf-conftest-buildmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-conftest-buildmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mvlahovic/perf-conftest-buildmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvlahovic/perf-conftest-buildmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvlahovic/perf-conftest-buildmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvlahovic/perf-conftest-buildmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvlahovic/perf-conftest-buildmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvlahovic/perf-conftest-buildmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvlahovic/perf-conftest-buildmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvlahovic/perf-conftest-buildmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvlahovic/perf-conftest-buildmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvlahovic/perf-conftest-buildmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvlahovic/perf-conftest-buildmode)

This is why `--dump-csv-counters` currently raises `AttributeError` in teardown and never writes a counters CSV. Part of #50211.