### PR TITLE
perf tests: fix four measurement bugs across seven perf kernels

### DIFF
--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
@@ -286,7 +286,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("TILE_LOOP")
 
-        // L1_CONGESTION packs free-running, like PACK_ISOLATE and the other ten kernels.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
@@ -53,7 +53,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
 
-        _llk_unpack_A_init_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
+        _llk_unpack_A_init_<BROADCAST_TYPE, false /* acc_to_dest */, reuse_dest_type, unpack_to_dest>(
             UNPACK_TRANSPOSE_FACES,
             UNPACK_TRANSPOSE_WITHIN_FACE,
             ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces),
@@ -87,7 +87,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t i = 0; i < TILE_CNT; ++i)
                 {
-                    _llk_unpack_A_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
+                    _llk_unpack_A_<BROADCAST_TYPE, false /* acc_to_dest */, reuse_dest_type, unpack_to_dest>(
                         PERF_ADDRESS(PERF_INPUT_A, /* tile_idx */ i), formats.unpack_A_src, formats.unpack_A_dst);
                 }
             }
@@ -167,8 +167,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     int block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
 
-                    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
-
                     for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
                     {
                         if constexpr (unpack_to_dest)
@@ -189,8 +187,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                                 /* iterations*/ num_faces);
                         }
                     }
-
-                    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }
             }
         }
@@ -290,7 +286,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("TILE_LOOP")
 
-        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        // L1_CONGESTION packs free-running, like PACK_ISOLATE and the other ten kernels.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
             {
@@ -308,7 +305,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 }
             }
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
             {

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
@@ -93,7 +93,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     // Accuracy-merge: read input from the runtime operand address
                     // (StimuliConfig layout) instead of the fixed PERF_INPUT_A, so
                     // the harness's stimuli line up with what the kernel consumes.
-                    _llk_unpack_A_<BROADCAST_TYPE, false /* acc_to_dest */, reuse_dest_type, unpack_to_dest>(
+                    _llk_unpack_A_<BROADCAST_TYPE, false /* acc_to_dest (see init) */, reuse_dest_type, unpack_to_dest>(
                         L1_ADDRESS(buffer_A[i]), formats.unpack_A_src, formats.unpack_A_dst);
                 }
             }
@@ -308,7 +308,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("TILE_LOOP")
 
-        // L1_CONGESTION packs free-running, like PACK_ISOLATE and the other ten kernels.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
@@ -93,7 +93,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     // Accuracy-merge: read input from the runtime operand address
                     // (StimuliConfig layout) instead of the fixed PERF_INPUT_A, so
                     // the harness's stimuli line up with what the kernel consumes.
-                    _llk_unpack_A_<BROADCAST_TYPE, false /* acc_to_dest (see init) */, reuse_dest_type, unpack_to_dest>(
+                    _llk_unpack_A_<BROADCAST_TYPE, false /* acc_to_dest */, reuse_dest_type, unpack_to_dest>(
                         L1_ADDRESS(buffer_A[i]), formats.unpack_A_src, formats.unpack_A_dst);
                 }
             }
@@ -175,8 +175,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
 
-                    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
-
                     for (std::uint32_t block_tile = 0; block_tile < block_tiles; ++block_tile)
                     {
                         if constexpr (unpack_to_dest)
@@ -197,8 +195,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                                 /* iterations*/ num_faces);
                         }
                     }
-
-                    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }
             }
         }
@@ -312,7 +308,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("TILE_LOOP")
 
-        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        // L1_CONGESTION packs free-running, like PACK_ISOLATE and the other ten kernels.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
             {
@@ -331,7 +328,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 }
             }
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
             {

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_perf.cpp
@@ -346,7 +346,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("TILE_LOOP")
 
-        // L1_CONGESTION packs free-running, like PACK_ISOLATE and the other ten kernels.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_perf.cpp
@@ -209,8 +209,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     std::uint32_t block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
 
-                    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
-
                     for (std::uint32_t block_tile = 0; block_tile < block_tiles; ++block_tile)
                     {
                         if constexpr (unpack_to_dest)
@@ -231,8 +229,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                                 /* iterations*/ num_faces);
                         }
                     }
-
-                    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }
             }
         }
@@ -350,7 +346,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("TILE_LOOP")
 
-        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        // L1_CONGESTION packs free-running, like PACK_ISOLATE and the other ten kernels.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
             {
@@ -369,7 +366,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 }
             }
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
             {

--- a/tt_metal/tt-llk/tests/sources/math_matmul_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_matmul_perf.cpp
@@ -64,8 +64,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
             in0_tile_r_dim < FACE_R_DIM ? in0_tile_r_dim : FACE_R_DIM,
             num_faces_B, // In1
             num_faces_A, // In0
-            // in1 first, like every other paired argument here: B goes to SEC0, whose base advances
-            // by TILE_SIZE_A per MOP iteration, so reversing them re-read one tile CT_DIM times.
             TILE_SIZE_UNPACK_B,
             TILE_SIZE_UNPACK_A);
         _llk_unpack_AB_matmul_init_<>(

--- a/tt_metal/tt-llk/tests/sources/math_matmul_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_matmul_perf.cpp
@@ -64,8 +64,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
             in0_tile_r_dim < FACE_R_DIM ? in0_tile_r_dim : FACE_R_DIM,
             num_faces_B, // In1
             num_faces_A, // In0
-            TILE_SIZE_UNPACK_A,
-            TILE_SIZE_UNPACK_B);
+            // in1 first, like every other paired argument here: B goes to SEC0, whose base advances
+            // by TILE_SIZE_A per MOP iteration, so reversing them re-read one tile CT_DIM times.
+            TILE_SIZE_UNPACK_B,
+            TILE_SIZE_UNPACK_A);
         _llk_unpack_AB_matmul_init_<>(
             UNPACK_TRANSPOSE_FACES,
             CT_DIM,

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
@@ -214,8 +214,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
             num_faces,
             false /* partial_face */,
             false /* narrow_tile */,
-            // num_tiles sets MOP_OUTER_LOOP, so it is what one _llk_pack_ call packs, and the loop
-            // below already runs once per block. TILE_CNT here inflated cycles/tile by NUM_BLOCKS.
             NUM_TILES_IN_BLOCK /* num_tiles */);
         reconfigure_packer_l1_acc(L1_ACC);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
@@ -207,7 +207,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
             formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */);
         _llk_pack_init_with_src_wrapper_<PackMode::Default, false /* zero_output */>(
-            formats.pack_src, formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces, false /* partial_face */, false /* narrow_tile */, TILE_CNT /* num_tiles */);
+            formats.pack_src,
+            formats.pack_dst,
+            FACE_R_DIM,
+            TILE_C_DIM,
+            num_faces,
+            false /* partial_face */,
+            false /* narrow_tile */,
+            // num_tiles sets MOP_OUTER_LOOP, so it is what one _llk_pack_ call packs, and the loop
+            // below already runs once per block. TILE_CNT here inflated cycles/tile by NUM_BLOCKS.
+            NUM_TILES_IN_BLOCK /* num_tiles */);
         reconfigure_packer_l1_acc(L1_ACC);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/sfpu_binop_scalar_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binop_scalar_perf.cpp
@@ -247,7 +247,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("TILE_LOOP")
 
-        // L1_CONGESTION packs free-running, like PACK_ISOLATE and the other ten kernels.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)

--- a/tt_metal/tt-llk/tests/sources/sfpu_binop_scalar_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binop_scalar_perf.cpp
@@ -40,7 +40,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
 
-        _llk_unpack_A_init_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
+        _llk_unpack_A_init_<BROADCAST_TYPE, false /* acc_to_dest */, reuse_dest_type, unpack_to_dest>(
             UNPACK_TRANSPOSE_FACES,
             UNPACK_TRANSPOSE_WITHIN_FACE,
             ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces),
@@ -69,7 +69,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t i = 0; i < TILE_CNT; ++i)
                 {
-                    _llk_unpack_A_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
+                    _llk_unpack_A_<BROADCAST_TYPE, false /* acc_to_dest */, reuse_dest_type, unpack_to_dest>(
                         PERF_ADDRESS(PERF_INPUT_A, /* tile_idx */ i), formats.unpack_A_src, formats.unpack_A_dst);
                 }
             }
@@ -137,8 +137,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     int block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
 
-                    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
-
                     for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
                     {
                         if constexpr (unpack_to_dest)
@@ -154,8 +152,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                                 /* iterations*/ num_faces);
                         }
                     }
-
-                    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }
             }
         }
@@ -251,7 +247,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("TILE_LOOP")
 
-        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        // L1_CONGESTION packs free-running, like PACK_ISOLATE and the other ten kernels.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
             {
@@ -269,7 +266,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 }
             }
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
             {

--- a/tt_metal/tt-llk/tests/sources/sfpu_ternary_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_ternary_perf.cpp
@@ -249,7 +249,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("TILE_LOOP")
 
-        // L1_CONGESTION packs free-running, like PACK_ISOLATE and the other ten kernels.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)

--- a/tt_metal/tt-llk/tests/sources/sfpu_ternary_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_ternary_perf.cpp
@@ -40,7 +40,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
 
-        _llk_unpack_A_init_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
+        _llk_unpack_A_init_<BROADCAST_TYPE, false /* acc_to_dest */, reuse_dest_type, unpack_to_dest>(
             UNPACK_TRANSPOSE_FACES,
             UNPACK_TRANSPOSE_WITHIN_FACE,
             ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces),
@@ -69,7 +69,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t i = 0; i < TILE_CNT; ++i)
                 {
-                    _llk_unpack_A_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
+                    _llk_unpack_A_<BROADCAST_TYPE, false /* acc_to_dest */, reuse_dest_type, unpack_to_dest>(
                         PERF_ADDRESS(PERF_INPUT_A, /* tile_idx */ i), formats.unpack_A_src, formats.unpack_A_dst);
                 }
             }
@@ -137,8 +137,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     int block_tiles = std::min(TILE_CNT - block_start, MAX_TILES_DEST);
 
-                    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
-
                     for (int block_tile = 0; block_tile < block_tiles; ++block_tile)
                     {
                         if constexpr (unpack_to_dest)
@@ -154,8 +152,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                                 /* iterations*/ num_faces);
                         }
                     }
-
-                    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
                 }
             }
         }
@@ -253,7 +249,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("TILE_LOOP")
 
-        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        // L1_CONGESTION packs free-running, like PACK_ISOLATE and the other ten kernels.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
             {
@@ -271,7 +268,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 }
             }
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
             {


### PR DESCRIPTION
## What

Four independent bugs in the perf kernels themselves, not in the counter machinery. Each made a reported number mean something other than its label. None of them showed up as a with-counters versus no-counters difference, because both builds ran the same wrong kernel, which is why they survived this long.

### pack_dest_bank packed the whole tile count per call

`_llk_pack_init_with_src_wrapper_` got `TILE_CNT` as `num_tiles`. That parameter sets `MOP_OUTER_LOOP`, so it is how many tiles a single `_llk_pack_` call packs, and the loop below already calls it once per block. Every call therefore packed the entire tile count, so the kernel did `NUM_BLOCKS` times the work the host divides by. Reported cycles per tile were inflated by exactly `NUM_BLOCKS`. The `(2,4)` variant reported 66302 against a true 31614.

The functional twin `pack_dest_bank_test.cpp` already passed `num_tiles_in_block` here.

### math_matmul passed the unpack tile sizes in the wrong order

Every other paired argument in that same call passes in1 before in0, and `math_matmul_test.cpp` does too. These two were the only pair reversed. Operand B goes to SEC0, whose base address `llk_unpack_AB_matmul` advances by `TILE_SIZE_A` per MOP iteration, so swapping them made TILE_LOOP re-read one tile `CT_DIM` times.

### Three SFPU kernels passed a dest-format flag as acc_to_dest

`is_fp32_dest_acc_en` was being passed into the `acc_to_dest` parameter slot. The two are unrelated, but the value is a bool, so it compiled and quietly turned accumulation on or off depending on the dest format.

### Five SFPU kernels ran L1_CONGESTION with a handshake

The rest of the suite runs L1_CONGESTION free-running. These five used a per-iteration handshake, so what they measured was the handshake. They reported 1.79x to 1.97x against the free-running form, and 1.05x to 1.06x after.

## Testing

Blackhole, speed of light, producer and consumer. `perf_pack_dest_bank` 18 passed 6 skipped, `perf_sfpu_ternary` 18 passed. The sources are self-contained and reference nothing outside `main`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-kernel-measurement-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvlahovic/perf-kernel-measurement-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-kernel-measurement-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvlahovic/perf-kernel-measurement-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-kernel-measurement-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mvlahovic/perf-kernel-measurement-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvlahovic/perf-kernel-measurement-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvlahovic/perf-kernel-measurement-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvlahovic/perf-kernel-measurement-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvlahovic/perf-kernel-measurement-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvlahovic/perf-kernel-measurement-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvlahovic/perf-kernel-measurement-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvlahovic/perf-kernel-measurement-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvlahovic/perf-kernel-measurement-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvlahovic/perf-kernel-measurement-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvlahovic/perf-kernel-measurement-fixes)

Closes #52524. Part of #50211.