### PR TITLE
[skip CI] [Models] Raise ValueError for invalid sampling_splits

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -108,8 +108,7 @@ def should_pad_sampling_logits_to_power_of_2(
 ) -> bool:
     # Enable optional sampling padding for models that regress to single-core TopK. More info at issue #40399
     if sampling_splits < 1:
-        logger.warning(f"Sampling_splits must be >= 1, got {sampling_splits}")
-        return False
+        raise ValueError(f"sampling_splits must be >= 1, got {sampling_splits}")
 
     per_device_vocab = padded_vocab_size // sampling_splits
     return per_device_vocab > 0 and (per_device_vocab & (per_device_vocab - 1)) != 0


### PR DESCRIPTION
### Problem

`should_pad_sampling_logits_to_power_of_2` and its test have contradicted each other since both were added in #40397.

The implementation warns and returns `False`:

```python
if sampling_splits < 1:
    logger.warning(f"Sampling_splits must be >= 1, got {sampling_splits}")
    return False
```

The test asserts it raises:

```python
def test_should_pad_sampling_logits_to_power_of_2_rejects_invalid_sampling_splits():
    with pytest.raises(ValueError, match="sampling_splits must be >= 1"):
        should_pad_sampling_logits_to_power_of_2("Llama-3.1-70B", 128256, 0)
```

This has gone unnoticed because `models/tt_transformers/tests/test_model_config_utils.py` is not referenced by any pipeline registry, so the test never runs in CI.

### Fix

Raise instead of warning. This matches the sibling function directly above it, `compute_padded_vocab_size`, which already raises `ValueError` for the same class of invalid input:

```python
if num_devices < 1:
    raise ValueError(f"num_devices must be >= 1, got {num_devices}")
```

### Impact

None in practice. The only production caller is `model_config.py:2731`, where `sampling_splits` is either `self.num_devices` (guarded `> 0`) or the constant `2`, so the branch is unreachable. The change matters for correctness rather than behaviour: an invalid argument now fails loudly instead of silently returning `False`, which would quietly disable the sampling-padding optimization rather than surfacing the bug.

Split out of #52072, where this one-line change was bundled with unrelated Gemma-2 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/fix-sampling-splits-valueerror)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/fix-sampling-splits-valueerror)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/fix-sampling-splits-valueerror)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/fix-sampling-splits-valueerror)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/fix-sampling-splits-valueerror)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/fix-sampling-splits-valueerror)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/fix-sampling-splits-valueerror)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/fix-sampling-splits-valueerror)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/fix-sampling-splits-valueerror)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/fix-sampling-splits-valueerror)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/fix-sampling-splits-valueerror)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/fix-sampling-splits-valueerror)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/fix-sampling-splits-valueerror)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/fix-sampling-splits-valueerror)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/fix-sampling-splits-valueerror)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/fix-sampling-splits-valueerror)