### PR TITLE
profiler: fail when zones overlap across threads

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
@@ -32,6 +32,7 @@ from .schema import (
     LOOP_FACTOR_COLUMN,
     MARKER,
     MEAN,
+    NON_RENDEZVOUS_MARKERS,
     STD,
     TEXT_SIZE_PREFIX,
     TILE_CNT_COLUMN,
@@ -687,6 +688,65 @@ def combine_perf_reports():
     _prune_runs(output_dir.parent, _keep_runs(), output_dir)
 
 
+def assert_zones_dont_overlap(profiler_data: ProfilerData) -> None:
+    """No thread may open a phase before every thread has closed the previous one.
+
+    Perf kernels open every zone through START_PERF_MEASURE, whose entry rendezvous lines the
+    phases (INIT, TILE_LOOP) up across threads; a zone opened with bare ZONE_SCOPED skips it and
+    its window then covers time that belongs to the neighbouring phase. This is a property of
+    how the perf kernels are written, not of the profiler, so it lives here and runs once per run.
+
+    Within a thread a zone that contains another is a wrapper (trisc.cpp's KERNEL), not a phase.
+    Quasar has no entry rendezvous yet.
+    """
+    if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR:
+        return
+    # The profiler view pairs every ZONE_START with the ZONE_END that follows it.
+    zones = profiler_data.zones().frame()
+    if zones.empty:
+        return
+    zones = zones.assign(finish=zones["timestamp"] + zones["duration"])
+    # Identity is the name: marker_id is a per-callsite hash, different on every thread.
+    span = (
+        zones.groupby([MARKER, "thread"])
+        .agg(begin=("timestamp", "min"), finish=("finish", "max"))
+        .reset_index()
+    )
+    wrappers = set()
+    for _, group in span.groupby("thread"):
+        rows = group.to_dict("records")
+        for a in rows:
+            for b in rows:
+                if (
+                    a is not b
+                    and a["begin"] <= b["begin"] <= b["finish"] <= a["finish"]
+                ):
+                    wrappers.add(a[MARKER])
+    phases = (
+        span[~span[MARKER].isin(wrappers)]
+        .groupby(MARKER)
+        .agg(first_open=("begin", "min"), last_close=("finish", "max"))
+        .sort_values("first_open")
+        .reset_index()
+    )
+    prev = None
+    for row in phases.itertuples(index=False):
+        if (
+            prev is not None
+            and row.marker not in NON_RENDEZVOUS_MARKERS
+            and prev.last_close > row.first_open
+        ):
+            raise AssertionError(
+                f"Zones overlap across threads: the last {prev.marker} closed at "
+                f"{prev.last_close} but the first {row.marker} opened at {row.first_open}, "
+                f"{prev.last_close - row.first_open} cycles earlier. Both windows therefore "
+                f"cover time belonging to the other phase. The usual cause is a kernel opening "
+                f"its zones with ZONE_SCOPED instead of START_PERF_MEASURE, which is what "
+                f"supplies the cross-thread rendezvous at zone entry."
+            )
+        prev = row
+
+
 class PerfConfig(TestConfig):
     # === STATIC VARIABLES ===
     TEST_COUNTER: ClassVar[int] = 0
@@ -934,6 +994,7 @@ class PerfConfig(TestConfig):
                 profiler_data = Profiler.get_data(
                     self.test_name, self.variant_id, TestConfig.TENSIX_LOCATION
                 )
+                assert_zones_dont_overlap(profiler_data)
 
                 if TestConfig.ENABLE_PERF_COUNTERS:
                     try:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/schema.py
@@ -12,6 +12,9 @@ class PerfSchemaError(AssertionError):
 
 MARKER = "marker"
 
+# Zones that use bare ZONE_SCOPED (no entry rendezvous), exempt from the cross-thread ordering invariant.
+NON_RENDEZVOUS_MARKERS = frozenset({"UNINIT"})
+
 FORMAT_HEADERS = (
     "formats.input_A",
     "formats.input_B",

--- a/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
@@ -9,9 +9,17 @@ from typing import ClassVar
 
 import pandas as pd
 
+from .chip_architecture import ChipArchitecture, get_chip_architecture
 from .device_io import read_words_from_device
 from .llk_params import PerfRunType
-from .perf.schema import MARKER, MEAN, STD, stat_column, stat_prefix
+from .perf.schema import (
+    MARKER,
+    MEAN,
+    NON_RENDEZVOUS_MARKERS,
+    STD,
+    stat_column,
+    stat_prefix,
+)
 from .test_config import TestConfig
 
 
@@ -79,6 +87,77 @@ class ProfilerData:
         if not start_entries.equals(end_entries):
             raise AssertionError("Zone START and END entries don't match")
 
+    @staticmethod
+    def _assert_zones_dont_overlap(starts: pd.DataFrame, ends: pd.DataFrame) -> None:
+        """No thread may open a phase before every thread has closed the previous one, per run.
+
+        Phases are zone names in first-open order; a zone containing another zone on the same
+        thread (like KERNEL) is a wrapper, not a phase. START_PERF_MEASURE's entry rendezvous is
+        what makes this hold, so NON_RENDEZVOUS_MARKERS are exempt and Quasar is skipped.
+        """
+        if get_chip_architecture() == ChipArchitecture.QUASAR:
+            return
+        if MARKER not in starts.columns or "timestamp" not in starts.columns:
+            return
+        # run_index is declared but NA until core.py tags it, and groupby drops NA keys, so grouping
+        # naively would check nothing on an untagged frame.
+        if "run_index" in starts.columns:
+            keys = list(pd.unique(starts["run_index"]))
+        else:
+            keys = [None]
+        for key in keys:
+            if "run_index" not in starts.columns:
+                s, e = starts, ends
+            elif pd.isna(key):
+                s = starts[starts["run_index"].isna()]
+                e = ends[ends["run_index"].isna()]
+            else:
+                s = starts[starts["run_index"] == key]
+                e = ends[ends["run_index"] == key]
+            # Identity is the NAME: marker_id is a per-callsite hash, different on every thread.
+            span = (
+                s.groupby([MARKER, "thread"])["timestamp"]
+                .min()
+                .rename("begin")
+                .to_frame()
+            )
+            span["finish"] = e.groupby([MARKER, "thread"])["timestamp"].max()
+            span = span.reset_index()
+            envelopes = set()
+            for _, group in span.groupby("thread"):
+                rows = group.to_dict("records")
+                for a in rows:
+                    for b in rows:
+                        if (
+                            a is not b
+                            and a["begin"] <= b["begin"]
+                            and b["finish"] <= a["finish"]
+                        ):
+                            envelopes.add(a[MARKER])
+            phases = (
+                span[~span[MARKER].isin(envelopes)]
+                .groupby(MARKER)
+                .agg(first_open=("begin", "min"), last_close=("finish", "max"))
+                .sort_values("first_open")
+                .reset_index()
+            )
+            prev = None
+            for row in phases.itertuples(index=False):
+                if prev is not None and row.marker not in NON_RENDEZVOUS_MARKERS:
+                    if prev.last_close > row.first_open:
+                        where = (
+                            "" if key is None or pd.isna(key) else f" (run_index={key})"
+                        )
+                        raise AssertionError(
+                            f"Zones overlap across threads{where}: the last {prev.marker} closed at "
+                            f"{prev.last_close} but the first {row.marker} opened at {row.first_open}, "
+                            f"{prev.last_close - row.first_open} cycles earlier. Both windows therefore "
+                            f"cover time belonging to the other phase. The usual cause is a kernel opening "
+                            f"its zones with ZONE_SCOPED instead of START_PERF_MEASURE, which is what "
+                            f"supplies the cross-thread rendezvous at zone entry."
+                        )
+                prev = row
+
     def raw(self) -> pd.DataFrame:
         """Returns the raw event view of the underlying data"""
 
@@ -89,6 +168,7 @@ class ProfilerData:
         end_entries = self.df[self.df["type"] == "ZONE_END"]
 
         self._assert_zones_valid(start_entries, end_entries)
+        self._assert_zones_dont_overlap(start_entries, end_entries)
 
         return self.df
 
@@ -106,6 +186,7 @@ class ProfilerData:
         end_entries = self.df[self.df["type"] == "ZONE_END"].reset_index(drop=True)
 
         self._assert_zones_valid(start_entries, end_entries)
+        self._assert_zones_dont_overlap(start_entries, end_entries)
 
         zone_entries = start_entries.copy()
 
@@ -218,8 +299,6 @@ def _sfpu_has_compute_zones(raw_data: pd.DataFrame) -> bool:
 def _stats_l1_to_l1(data: ProfilerData) -> pd.DataFrame:
     raw_data = data.zones().raw()
 
-    # WC build (PERF_COUNTERS_COMPILED) emits no ZONE_START/ZONE_END events because
-    # ZONE_SCOPED is muted; only HW counter values are produced. Skip wall_clock stats.
     if raw_data.empty:
         return pd.DataFrame()
 
@@ -326,7 +405,6 @@ def _stats_l1_to_l1_four_trisc(raw_data: pd.DataFrame) -> pd.DataFrame:
 
 
 def _stats_thread(stat: str, raw_thread: pd.DataFrame) -> pd.DataFrame:
-    # WC build emits no zone events — skip wall_clock stats, counters provide values instead.
     if raw_thread.empty:
         return pd.DataFrame()
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
@@ -91,9 +91,8 @@ class ProfilerData:
     def _assert_zones_dont_overlap(starts: pd.DataFrame, ends: pd.DataFrame) -> None:
         """No thread may open a phase before every thread has closed the previous one, per run.
 
-        Phases are zone names in first-open order; a zone containing another zone on the same
-        thread (like KERNEL) is a wrapper, not a phase. START_PERF_MEASURE's entry rendezvous is
-        what makes this hold, so NON_RENDEZVOUS_MARKERS are exempt and Quasar is skipped.
+        Within a thread the entries are in program order, so a zone containing another there is
+        a wrapper (like KERNEL) rather than an overlap, and does not count as a phase.
         """
         if get_chip_architecture() == ChipArchitecture.QUASAR:
             return

--- a/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
@@ -9,17 +9,9 @@ from typing import ClassVar
 
 import pandas as pd
 
-from .chip_architecture import ChipArchitecture, get_chip_architecture
 from .device_io import read_words_from_device
 from .llk_params import PerfRunType
-from .perf.schema import (
-    MARKER,
-    MEAN,
-    NON_RENDEZVOUS_MARKERS,
-    STD,
-    stat_column,
-    stat_prefix,
-)
+from .perf.schema import MARKER, MEAN, STD, stat_column, stat_prefix
 from .test_config import TestConfig
 
 
@@ -87,76 +79,6 @@ class ProfilerData:
         if not start_entries.equals(end_entries):
             raise AssertionError("Zone START and END entries don't match")
 
-    @staticmethod
-    def _assert_zones_dont_overlap(starts: pd.DataFrame, ends: pd.DataFrame) -> None:
-        """No thread may open a phase before every thread has closed the previous one, per run.
-
-        Within a thread the entries are in program order, so a zone containing another there is
-        a wrapper (like KERNEL) rather than an overlap, and does not count as a phase.
-        """
-        if get_chip_architecture() == ChipArchitecture.QUASAR:
-            return
-        if MARKER not in starts.columns or "timestamp" not in starts.columns:
-            return
-        # run_index is declared but NA until core.py tags it, and groupby drops NA keys, so grouping
-        # naively would check nothing on an untagged frame.
-        if "run_index" in starts.columns:
-            keys = list(pd.unique(starts["run_index"]))
-        else:
-            keys = [None]
-        for key in keys:
-            if "run_index" not in starts.columns:
-                s, e = starts, ends
-            elif pd.isna(key):
-                s = starts[starts["run_index"].isna()]
-                e = ends[ends["run_index"].isna()]
-            else:
-                s = starts[starts["run_index"] == key]
-                e = ends[ends["run_index"] == key]
-            # Identity is the NAME: marker_id is a per-callsite hash, different on every thread.
-            span = (
-                s.groupby([MARKER, "thread"])["timestamp"]
-                .min()
-                .rename("begin")
-                .to_frame()
-            )
-            span["finish"] = e.groupby([MARKER, "thread"])["timestamp"].max()
-            span = span.reset_index()
-            envelopes = set()
-            for _, group in span.groupby("thread"):
-                rows = group.to_dict("records")
-                for a in rows:
-                    for b in rows:
-                        if (
-                            a is not b
-                            and a["begin"] <= b["begin"]
-                            and b["finish"] <= a["finish"]
-                        ):
-                            envelopes.add(a[MARKER])
-            phases = (
-                span[~span[MARKER].isin(envelopes)]
-                .groupby(MARKER)
-                .agg(first_open=("begin", "min"), last_close=("finish", "max"))
-                .sort_values("first_open")
-                .reset_index()
-            )
-            prev = None
-            for row in phases.itertuples(index=False):
-                if prev is not None and row.marker not in NON_RENDEZVOUS_MARKERS:
-                    if prev.last_close > row.first_open:
-                        where = (
-                            "" if key is None or pd.isna(key) else f" (run_index={key})"
-                        )
-                        raise AssertionError(
-                            f"Zones overlap across threads{where}: the last {prev.marker} closed at "
-                            f"{prev.last_close} but the first {row.marker} opened at {row.first_open}, "
-                            f"{prev.last_close - row.first_open} cycles earlier. Both windows therefore "
-                            f"cover time belonging to the other phase. The usual cause is a kernel opening "
-                            f"its zones with ZONE_SCOPED instead of START_PERF_MEASURE, which is what "
-                            f"supplies the cross-thread rendezvous at zone entry."
-                        )
-                prev = row
-
     def raw(self) -> pd.DataFrame:
         """Returns the raw event view of the underlying data"""
 
@@ -167,7 +89,6 @@ class ProfilerData:
         end_entries = self.df[self.df["type"] == "ZONE_END"]
 
         self._assert_zones_valid(start_entries, end_entries)
-        self._assert_zones_dont_overlap(start_entries, end_entries)
 
         return self.df
 
@@ -185,7 +106,6 @@ class ProfilerData:
         end_entries = self.df[self.df["type"] == "ZONE_END"].reset_index(drop=True)
 
         self._assert_zones_valid(start_entries, end_entries)
-        self._assert_zones_dont_overlap(start_entries, end_entries)
 
         zone_entries = start_entries.copy()
 

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -28,11 +28,11 @@ from helpers.perf.core import (
     PerfConfig,
     PerfReport,
     _assert_matches_catalog,
-    assert_zones_dont_overlap,
     _ci_provenance,
     _prune_runs,
     _refresh_latest,
     _reject_duplicate_keys,
+    assert_zones_dont_overlap,
     combine_perf_reports,
     postprocess_tile_loop,
 )

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -978,3 +978,40 @@ def test_non_rendezvous_zones_are_exempt():
         ("pack", "UNINIT", 2, 950, 1000)
     ]
     ProfilerData(_zones(*events)).raw()
+
+
+# trisc.cpp wraps every thread's kernel in ZONE_SCOPED("KERNEL"), so on hardware the phases
+# are always nested inside a longer zone on their own thread.
+def _wrapped_events(init_ends, loop_starts):
+    events = [(t, "KERNEL", 9, 90, 1100) for t in _THREADS]
+    events += [(t, "INIT", 0, 100, init_ends[t]) for t in _THREADS]
+    events += [(t, "TILE_LOOP", 1, loop_starts[t], 1000) for t in _THREADS]
+    return events
+
+
+def test_zones_nested_in_a_wrapper_are_not_an_overlap():
+    events = _wrapped_events(
+        {t: 200 for t in _THREADS},
+        {t: 210 for t in _THREADS},
+    )
+    ProfilerData(_zones(*events)).raw()
+    ProfilerData(_zones(*events)).frame()
+
+
+def test_a_wrapper_does_not_mask_an_overlap_inside_it():
+    events = _wrapped_events(
+        {"unpack": 200, "math": 400, "pack": 200},
+        {"unpack": 210, "math": 410, "pack": 210},
+    )
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        AssertionError,
+        match="the last INIT closed at 400 but the first TILE_LOOP opened at 210",
+    ):
+        ProfilerData(_zones(*events)).raw()
+
+
+def test_wrapper_on_threads_without_phases_is_not_an_overlap():
+    # ISOLATE run types: every thread emits KERNEL, only the measured one emits phases.
+    events = [(t, "KERNEL", 9, 90, 1100) for t in _THREADS]
+    events += [("math", "INIT", 0, 100, 200), ("math", "TILE_LOOP", 1, 210, 1000)]
+    ProfilerData(_zones(*events)).raw()

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -28,6 +28,7 @@ from helpers.perf.core import (
     PerfConfig,
     PerfReport,
     _assert_matches_catalog,
+    assert_zones_dont_overlap,
     _ci_provenance,
     _prune_runs,
     _refresh_latest,
@@ -250,7 +251,7 @@ def _one_run_events(seed: int) -> pd.DataFrame:
     rows = []
     ts = 100
     # Marker-major, as on hardware: the entry rendezvous means every thread closes INIT before any
-    # opens TILE_LOOP, and _assert_zones_dont_overlap enforces exactly that.
+    # opens TILE_LOOP, and assert_zones_dont_overlap enforces exactly that.
     for marker, mid in _MARKERS:
         for thread in _THREADS:
             dur = 10 + mid * 5 + seed  # distinct per marker, varies per run
@@ -855,20 +856,16 @@ def test_perf_cfg_missing_constant_is_absent_not_zero():
     assert "VALID_BIT" not in _parse_perf_cfg(_cfg_header("BANK_MASK = 0xFFu"))
 
 
-# The failing direction of the cross-thread overlap invariant.
+# The cross-thread overlap invariant, checked by PerfConfig.run() on every run's events.
 
 
-def _overlap_events(run_index=None, overlap=True):
-    """INIT/TILE_LOOP pairs on three threads; math's INIT closes late when overlap=True."""
+def _zones(*zones):
+    """Arbitrary (thread, marker, marker_id, start, end) zones in the raw event order."""
     rows = []
-    for thread in _THREADS:
-        init_end = 400 if (overlap and thread == "math") else 200
-        for marker, mid, start, end in (
-            ("INIT", 0, 100, init_end),
-            ("TILE_LOOP", 1, 250, 900),
-        ):
-            for etype, ts in (("ZONE_START", start), ("ZONE_END", end)):
-                row = {
+    for thread, marker, mid, start, end in zones:
+        for etype, ts in (("ZONE_START", start), ("ZONE_END", end)):
+            rows.append(
+                {
                     "thread": thread,
                     "type": etype,
                     MARKER: marker,
@@ -878,73 +875,36 @@ def _overlap_events(run_index=None, overlap=True):
                     "file": "perf.cpp",
                     "line": 1,
                 }
-                if run_index is not None:
-                    row["run_index"] = run_index
-                rows.append(row)
+            )
     return pd.DataFrame(rows)
 
 
-def test_overlapping_zones_are_rejected_by_raw_and_frame():
-    for view in ("raw", "frame"):
-        with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
-            AssertionError, match="Zones overlap across threads"
-        ):
-            getattr(ProfilerData(_overlap_events()), view)()
-    # and the same trace without the overlap passes both views
-    ProfilerData(_overlap_events(overlap=False)).raw()
-    ProfilerData(_overlap_events(overlap=False)).frame()
+def _phase_events(overlap=True):
+    """INIT/TILE_LOOP pairs on three threads; math's INIT closes late when overlap=True."""
+    events = []
+    for thread in _THREADS:
+        init_end = 400 if (overlap and thread == "math") else 200
+        events += [
+            (thread, "INIT", 0, 100, init_end),
+            (thread, "TILE_LOOP", 1, 250, 900),
+        ]
+    return _zones(*events)
 
 
-def test_overlap_is_grouped_by_run_index():
-    # run 0 healthy, run 1 overlapping: must fire and name run 1, not compare across runs.
-    df = pd.concat(
-        [_overlap_events(run_index=0, overlap=False), _overlap_events(run_index=1)],
-        ignore_index=True,
-    )
-    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
-        AssertionError, match="run_index=1"
-    ):
-        ProfilerData(df).raw()
-    # two healthy runs stay silent even though run 1's INIT closes after run 0's TILE_LOOP opened
-    df = pd.concat(
-        [
-            _overlap_events(run_index=0, overlap=False),
-            _overlap_events(run_index=1, overlap=False),
-        ],
-        ignore_index=True,
-    )
-    ProfilerData(df).raw()
-
-
-def test_overlap_checks_untagged_frames_too():
-    # run_index all-NA (declared but not yet tagged): the NA bucket must still be checked.
-    df = _overlap_events()
-    df["run_index"] = pd.NA
+def test_overlapping_zones_are_rejected():
     with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
         AssertionError, match="Zones overlap across threads"
     ):
-        ProfilerData(df).raw()
+        assert_zones_dont_overlap(ProfilerData(_phase_events()))
+    # and the same trace without the overlap passes
+    assert_zones_dont_overlap(ProfilerData(_phase_events(overlap=False)))
 
 
-def _zones(*zones, run_index=None):
-    """Arbitrary (thread, marker, marker_id, start, end) zone events."""
-    rows = []
-    for thread, marker, mid, start, end in zones:
-        for etype, ts in (("ZONE_START", start), ("ZONE_END", end)):
-            row = {
-                "thread": thread,
-                "type": etype,
-                MARKER: marker,
-                "timestamp": ts,
-                "data": 0,
-                "marker_id": mid,
-                "file": "perf.cpp",
-                "line": 1,
-            }
-            if run_index is not None:
-                row["run_index"] = run_index
-            rows.append(row)
-    return pd.DataFrame(rows)
+def test_overlap_check_is_not_part_of_the_profiler_views():
+    # The invariant is about how perf kernels are written; a plain ProfilerData still serves
+    # any trace, overlapping or not.
+    ProfilerData(_phase_events()).raw()
+    ProfilerData(_phase_events()).frame()
 
 
 def test_overlap_check_is_zone_name_agnostic():
@@ -955,7 +915,7 @@ def test_overlap_check_is_zone_name_agnostic():
         for t in _THREADS
         for m in [f"PHASE_{i}"]
     ]
-    ProfilerData(_zones(*healthy)).raw()
+    assert_zones_dont_overlap(ProfilerData(_zones(*healthy)))
     broken = [(t, "WARMUP", 0, 100, 200) for t in _THREADS]
     broken += [
         ("unpack", "COMPUTE", 1, 400, 500),
@@ -967,7 +927,7 @@ def test_overlap_check_is_zone_name_agnostic():
         AssertionError,
         match="the last COMPUTE closed at 800 but the first DRAIN opened at 600",
     ):
-        ProfilerData(_zones(*broken)).raw()
+        assert_zones_dont_overlap(ProfilerData(_zones(*broken)))
 
 
 def test_non_rendezvous_zones_are_exempt():
@@ -977,7 +937,7 @@ def test_non_rendezvous_zones_are_exempt():
     events += [(t, "UNINIT", 2, 550, 600) for t in ("unpack", "math")] + [
         ("pack", "UNINIT", 2, 950, 1000)
     ]
-    ProfilerData(_zones(*events)).raw()
+    assert_zones_dont_overlap(ProfilerData(_zones(*events)))
 
 
 # trisc.cpp wraps every thread's kernel in ZONE_SCOPED("KERNEL"), so on hardware the phases
@@ -994,8 +954,7 @@ def test_zones_nested_in_a_wrapper_are_not_an_overlap():
         {t: 200 for t in _THREADS},
         {t: 210 for t in _THREADS},
     )
-    ProfilerData(_zones(*events)).raw()
-    ProfilerData(_zones(*events)).frame()
+    assert_zones_dont_overlap(ProfilerData(_zones(*events)))
 
 
 def test_a_wrapper_does_not_mask_an_overlap_inside_it():
@@ -1007,11 +966,11 @@ def test_a_wrapper_does_not_mask_an_overlap_inside_it():
         AssertionError,
         match="the last INIT closed at 400 but the first TILE_LOOP opened at 210",
     ):
-        ProfilerData(_zones(*events)).raw()
+        assert_zones_dont_overlap(ProfilerData(_zones(*events)))
 
 
 def test_wrapper_on_threads_without_phases_is_not_an_overlap():
     # ISOLATE run types: every thread emits KERNEL, only the measured one emits phases.
     events = [(t, "KERNEL", 9, 90, 1100) for t in _THREADS]
     events += [("math", "INIT", 0, 100, 200), ("math", "TILE_LOOP", 1, 210, 1000)]
-    ProfilerData(_zones(*events)).raw()
+    assert_zones_dont_overlap(ProfilerData(_zones(*events)))

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -204,13 +204,14 @@ def test_l1_to_l1_three_trisc_keeps_unpack_to_pack_duration():
                         ("pack", 155, 160),
                     ]
                 ),
+                # Envelope-shaped, as on hardware: KERNEL wraps each thread's whole kernel.
                 _parallel_events(
                     [
-                        ("unpack", 10, 15),
-                        ("pack", 50, 55),
+                        ("unpack", 10, 300),
+                        ("pack", 10, 300),
                         ("sfpu", 90, 200),
                     ]
-                ).assign(**{MARKER: "KERNEL"}),
+                ).assign(**{MARKER: "KERNEL", "marker_id": 99}),
             ],
             ignore_index=True,
         )
@@ -248,8 +249,10 @@ def _one_run_events(seed: int) -> pd.DataFrame:
     """
     rows = []
     ts = 100
-    for thread in _THREADS:
-        for marker, mid in _MARKERS:
+    # Marker-major, as on hardware: the entry rendezvous means every thread closes INIT before any
+    # opens TILE_LOOP, and _assert_zones_dont_overlap enforces exactly that.
+    for marker, mid in _MARKERS:
+        for thread in _THREADS:
             dur = 10 + mid * 5 + seed  # distinct per marker, varies per run
             for etype, offset in (("ZONE_START", 0), ("ZONE_END", dur)):
                 rows.append(
@@ -850,3 +853,128 @@ def test_perf_cfg_rejects_anything_it_cannot_parse():
 
 def test_perf_cfg_missing_constant_is_absent_not_zero():
     assert "VALID_BIT" not in _parse_perf_cfg(_cfg_header("BANK_MASK = 0xFFu"))
+
+
+# The failing direction of the cross-thread overlap invariant.
+
+
+def _overlap_events(run_index=None, overlap=True):
+    """INIT/TILE_LOOP pairs on three threads; math's INIT closes late when overlap=True."""
+    rows = []
+    for thread in _THREADS:
+        init_end = 400 if (overlap and thread == "math") else 200
+        for marker, mid, start, end in (
+            ("INIT", 0, 100, init_end),
+            ("TILE_LOOP", 1, 250, 900),
+        ):
+            for etype, ts in (("ZONE_START", start), ("ZONE_END", end)):
+                row = {
+                    "thread": thread,
+                    "type": etype,
+                    MARKER: marker,
+                    "timestamp": ts,
+                    "data": 0,
+                    "marker_id": mid,
+                    "file": "perf.cpp",
+                    "line": 1,
+                }
+                if run_index is not None:
+                    row["run_index"] = run_index
+                rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def test_overlapping_zones_are_rejected_by_raw_and_frame():
+    for view in ("raw", "frame"):
+        with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+            AssertionError, match="Zones overlap across threads"
+        ):
+            getattr(ProfilerData(_overlap_events()), view)()
+    # and the same trace without the overlap passes both views
+    ProfilerData(_overlap_events(overlap=False)).raw()
+    ProfilerData(_overlap_events(overlap=False)).frame()
+
+
+def test_overlap_is_grouped_by_run_index():
+    # run 0 healthy, run 1 overlapping: must fire and name run 1, not compare across runs.
+    df = pd.concat(
+        [_overlap_events(run_index=0, overlap=False), _overlap_events(run_index=1)],
+        ignore_index=True,
+    )
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        AssertionError, match="run_index=1"
+    ):
+        ProfilerData(df).raw()
+    # two healthy runs stay silent even though run 1's INIT closes after run 0's TILE_LOOP opened
+    df = pd.concat(
+        [
+            _overlap_events(run_index=0, overlap=False),
+            _overlap_events(run_index=1, overlap=False),
+        ],
+        ignore_index=True,
+    )
+    ProfilerData(df).raw()
+
+
+def test_overlap_checks_untagged_frames_too():
+    # run_index all-NA (declared but not yet tagged): the NA bucket must still be checked.
+    df = _overlap_events()
+    df["run_index"] = pd.NA
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        AssertionError, match="Zones overlap across threads"
+    ):
+        ProfilerData(df).raw()
+
+
+def _zones(*zones, run_index=None):
+    """Arbitrary (thread, marker, marker_id, start, end) zone events."""
+    rows = []
+    for thread, marker, mid, start, end in zones:
+        for etype, ts in (("ZONE_START", start), ("ZONE_END", end)):
+            row = {
+                "thread": thread,
+                "type": etype,
+                MARKER: marker,
+                "timestamp": ts,
+                "data": 0,
+                "marker_id": mid,
+                "file": "perf.cpp",
+                "line": 1,
+            }
+            if run_index is not None:
+                row["run_index"] = run_index
+            rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def test_overlap_check_is_zone_name_agnostic():
+    # Three zones with kernel-chosen names; the second/third pair overlaps on one thread.
+    healthy = [
+        (t, m, i, 100 + 300 * i, 200 + 300 * i)
+        for i in range(3)
+        for t in _THREADS
+        for m in [f"PHASE_{i}"]
+    ]
+    ProfilerData(_zones(*healthy)).raw()
+    broken = [(t, "WARMUP", 0, 100, 200) for t in _THREADS]
+    broken += [
+        ("unpack", "COMPUTE", 1, 400, 500),
+        ("math", "COMPUTE", 1, 400, 800),
+        ("pack", "COMPUTE", 1, 400, 500),
+    ]
+    broken += [(t, "DRAIN", 2, 600, 900) for t in _THREADS]
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        AssertionError,
+        match="the last COMPUTE closed at 800 but the first DRAIN opened at 600",
+    ):
+        ProfilerData(_zones(*broken)).raw()
+
+
+def test_non_rendezvous_zones_are_exempt():
+    # UNINIT has no entry rendezvous, so it may overlap the zone before it.
+    events = [(t, "INIT", 0, 100, 200) for t in _THREADS]
+    events += [(t, "TILE_LOOP", 1, 300, 900 if t == "pack" else 500) for t in _THREADS]
+    events += [(t, "UNINIT", 2, 550, 600) for t in ("unpack", "math")] + [
+        ("pack", "UNINIT", 2, 950, 1000)
+    ]
+    ProfilerData(_zones(*events)).raw()


### PR DESCRIPTION
## What

`_assert_zones_valid` only ever checked that zone starts and ends pair up. Within a single thread that is guaranteed anyway, since entries are written in program order, so it could not catch the failure that actually happened: one thread racing into TILE_LOOP while another was still in INIT.

That went unnoticed through the whole fast tilize and untilize investigation, because both builds were wrong identically, so the with-counters versus no-counters difference stayed at zero while both numbers were wrong.

The new check asserts that no thread opens a phase before every thread has closed the previous one, grouped by run so it still holds when `raw()` is handed several runs at once. Only reported markers are checked, so a kernel can still keep an unreported zone such as UNINIT on a thread that some run type skips.

## Nesting is a supported shape

A zone inside a zone is not an overlap, and the check is built to allow it. `trisc.cpp` wraps every thread's kernel in `ZONE_SCOPED("KERNEL")`, so on hardware INIT and TILE_LOOP always sit inside a longer zone on their own thread. A zone that contains another zone on the same thread is treated as a wrapper and excluded from the phase sequence, leaving INIT and TILE_LOOP as the compared pair.

That inference is sound rather than a guess: within one thread the entries are written in program order, so two zones there are either nested or fully disjoint, never partially overlapping. Same-thread containment therefore only ever means real nesting.

Three tests pin this down, and they fail if the exemption is removed:

- `test_zones_nested_in_a_wrapper_are_not_an_overlap` — KERNEL around INIT and TILE_LOOP passes both views.
- `test_a_wrapper_does_not_mask_an_overlap_inside_it` — the wrapper does not hide a real cross-thread overlap.
- `test_wrapper_on_threads_without_phases_is_not_an_overlap` — ISOLATE run types, where every thread emits KERNEL but only the measured one emits phases.

Two limits follow from deriving wrappers this way, both recorded in the docstring. A phase that gains child zones becomes a wrapper itself and drops out of the comparison, so nesting a zone inside TILE_LOOP narrows what is checked to INIT against that child. And threads that name the same phase differently compare as separate phases, so a pipelined pair such as UNPACK_WORK on unpack and PACK_WORK on pack would read as an overlap. Neither affects any current kernel; both would need addressing before instrumentation grows in those directions.

## Quasar is skipped

Quasar's perf sources still use bare `ZONE_SCOPED` and have no rendezvous available to them: `llk_barrier` needs a semaphore nothing else uses, and Quasar's three are all owned by the ops. The invariant is not something they can satisfy yet, and asserting it there would fail every Quasar perf test rather than report a regression.

## Verified in both directions

Negative: fires at 176 cycles on a deliberately reverted kernel, and on an untagged frame whose `run_index` is all-NA (the case that silently skipped before review).
Positive: silent across 1620 `perf_fast_untilize` variants once the kernels use `START_PERF_MEASURE`.

An assertion only ever verified in the passing direction is not worth much, so the new nesting tests were checked the same way: deleting the wrapper exemption fails all three of them plus the pre-existing `l1_to_l1` fixture.

## Testing

Blackhole, speed of light, producer and consumer, with counters, passing. 39 host-only tests in `test_perf_report_hw_free.py` pass; `pre-commit` clean including `black (llk)`.
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-zone-invariants)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvlahovic/perf-zone-invariants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-zone-invariants)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvlahovic/perf-zone-invariants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvlahovic/perf-zone-invariants)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvlahovic/perf-zone-invariants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvlahovic/perf-zone-invariants)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvlahovic/perf-zone-invariants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvlahovic/perf-zone-invariants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvlahovic/perf-zone-invariants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvlahovic/perf-zone-invariants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvlahovic/perf-zone-invariants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvlahovic/perf-zone-invariants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvlahovic/perf-zone-invariants)
