### PR TITLE
docs: bring the perf-counter guide in line with the harness

### DIFF
--- a/tt_metal/tt-llk/docs/performance_counters/performance_counters.md
+++ b/tt_metal/tt-llk/docs/performance_counters/performance_counters.md
@@ -433,6 +433,9 @@ Unpacker1 Write Eff = SRCB_WRITE_ACTUAL / UNPACK1_BUSY_THREAD0 * 100
 
 #### 28. Fidelity Stall Rate
 
+> **Dead counter:** `MATH_FIDELITY_STALL` is tied to zero in the RTL of both Wormhole and Blackhole (`fidelity_phases_ongoing` is a constant `1'b0`), so this metric always reads 0. It is kept here only to document the formula; the tracy tooling removes it.
+
+
 Fraction of math-valid cycles spent in a fidelity phase (multi-HF-cycle math instruction).
 
 *Counter group: TDMA_UNPACK. Computed, exported as `fidelity_stall_pct`.*

--- a/tt_metal/tt-llk/docs/performance_counters/performance_counters.md
+++ b/tt_metal/tt-llk/docs/performance_counters/performance_counters.md
@@ -183,7 +183,7 @@ The NC build emits per-zone wall-clock cycle counts in the same results DataFram
 | FPU slots | 3 | 3 |
 | TDMA_UNPACK slots | 22 | 22 |
 | TDMA_PACK slots | 14 | 5 |
-| L1 mux positions (Tensix) | 2 | 5 |
+| L1 mux positions (Tensix) | 2 | 6 (the harness captures 0 to 4) |
 | L1 slots in inventory | 32 (16 × 2 mux) | 80 (16 × 5 mux) |
 | Total slots in `BUILTIN_COUNTER_CONFIG` (one L1 mux group) | 114 | 105 |
 | Total config words in L1 | 200 (rest are zero-padded) | 200 |
@@ -286,13 +286,14 @@ Each L1 mux group exposes 8 client interfaces x 2 counters — request sels 0–
 
 | Mux | WH meaning | BH meaning |
 |-----|------------|------------|
-| 0 | unpacker, packer port 1, TDMA bundles 0/1, NoC Ring 0 | same |
-| 1 | TDMA packer 2, ext unpackers 1–3, NoC Ring 1 | RISC core, ext unpackers 1–3, NoC Ring 1 |
-| 2 | — | NoC Ring 2 |
-| 3 | — | NoC Ring 3 |
-| 4 | — | Misc L1 ports |
+| 0 | unpacker 0, packer port 1 (+ECC), TDMA bundles 0/1, NoC Ring 0 | unpacker 0, port 1 (unpacker 1 + ECC), TDMA bundles 0/1, NoC Ring 0 |
+| 1 | TDMA packer 2, ext unpackers 1–3, NoC Ring 1 | TDMA packer 2, ext unpackers 1–3, NoC Ring 1 |
+| 2 | — | ext unpackers 4–7, NoC Ring 0 secondary channels |
+| 3 | — | NoC Ring 1 secondary channels, ext packers 2–5 |
+| 4 | — | ext packers 6–7, tag search / packer 1, ext unpackers 8–12 |
+| 5 | — | ext unpackers 13–14 (only slots 0 and 1 are wired; slots 2–7 read 0) |
 
-These labels come from `hw_counters.h` and are unverified: because the mux routes interfaces at count time, they are labels on indices rather than confirmed client functions, and several Blackhole identities are known to be wrong (see the note in `counters.py`).
+The Blackhole column is taken from the A0 tapeout RTL (ws-tensix `BH_A0_RC6`, `tt_tensix.sv`) and was confirmed on silicon by reading every selector under real workloads; positions 6 and 7 have no decode case and fall back to position 0. The labels in `hw_counters.h` and in the harness `counters.py` predate that check and are being brought in line by PR #55162 (the old `NOC_RING2/3` and `MISC_PORT` names describe a 4-NOC build that never shipped).
 
 The mux routes interfaces into the counters while they count and is written once by BRISC before arming, so the freeze path cannot re-aim it. A zone snapshot therefore contains exactly one mux position: the group that was selected while the counters ran. Sweep it by exporting `LLK_PERF_L1_MUX_GROUP` before the producer phase (it is an environment variable, not a CLI flag, and is baked in at compile time, so each value needs its own `--compile-producer`). Sweep across runs to cover the other groups.
 

--- a/tt_metal/tt-llk/docs/performance_counters/performance_counters.md
+++ b/tt_metal/tt-llk/docs/performance_counters/performance_counters.md
@@ -4,6 +4,8 @@
 - Device-side counter HW driver: [tests/helpers/include/counters.h](../../tests/helpers/include/counters.h)
 - Test-helper mock functions: [tests/helpers/include/perf.h](../../tests/helpers/include/perf.h)
 - Profiler zone macros: [tests/helpers/include/profiler.h](../../tests/helpers/include/profiler.h)
+- Cross-thread rendezvous: [tests/helpers/include/barrier.h](../../tests/helpers/include/barrier.h)
+- Report schema (must be updated with any metric rename): [tests/python_tests/helpers/perf_schema.py](../../tests/python_tests/helpers/perf_schema.py)
 - Host-side counter readback: [tests/python_tests/helpers/counters.py](../../tests/python_tests/helpers/counters.py)
 - Host-side derived metrics: [tests/python_tests/helpers/metrics.py](../../tests/python_tests/helpers/metrics.py)
 - Test driver: [tests/python_tests/helpers/perf/core.py](../../tests/python_tests/helpers/perf/core.py)
@@ -15,7 +17,7 @@
 
 This guide documents the LLK test-suite interface for collecting Tensix hardware performance counters. The LLK suite runs bare-metal kernels in `tests/sources/*_perf.cpp` directly on the TRISC cores. There is no firmware or NoC stack involved, so the counter-collection path is implemented entirely inside the test kernels: a C++ macro arms and freezes the hardware counters around a measured scope, writes the snapshot to a fixed L1 buffer, and the host process reads that buffer back from outside the kernel.
 
-Tensix cores contain five hardware performance counter banks. Every bank exposes two values per measurement: total elapsed cycles (`OUT_L`) and an event count for the selected `counter_sel` (`OUT_H`). The Python driver enumerates every per-architecture counter slot, configures the HW, runs the kernel, then iterates each slot to pull both values out into a pandas DataFrame and optionally a CSV. Derived metrics (utilisation %, stall %, backpressure %, composite ratios) are computed in Python on top of the raw counts.
+Tensix cores contain five hardware performance counter banks. Every bank exposes two values per measurement: total elapsed cycles (`OUT_L`) and an event count for the selected `counter_sel` (`OUT_H`). The counter set is fixed at compile time in `counters.h` and written to L1 by BRISC; the host no longer configures anything, it reads the shared config back to decode the snapshot. The device walks the slots at freeze and the driver pulls the results into a pandas DataFrame and optionally a CSV. The 16 derived metrics (utilisation %, stall %, and per-unit efficiency ratios) are computed in Python on top of the raw counts.
 
 | Bank | Description |
 |------|-------------|
@@ -31,12 +33,12 @@ Tensix cores contain five hardware performance counter banks. Every bank exposes
 
 Every test source under `tests/sources/*_perf.cpp` is compiled twice from the same C++ file. The build is selected by two preprocessor flags:
 
-| Build | `LLK_PROFILER` | `PERF_COUNTERS_COMPILED` | Active half of `START_PERF_MEASURE` | What it measures |
+| Build | `LLK_PROFILER` | `PERF_COUNTERS_COMPILED` | Active half(s) of `START_PERF_MEASURE` | What it measures |
 |-------|----------------|--------------------------|--------------------------------------|------------------|
-| NC (no counters) | defined | undefined | `ZONE_SCOPED` | Per-zone wall-clock cycles (`RISCV_DEBUG_REG_WALL_CLOCK_L`) |
-| WC (with counters) | defined | defined | `MEASURE_PERF_COUNTERS` | Per-zone HW counter snapshot |
+| NC (no counters) | defined | undefined | `ZONE_SCOPED` (timing) + `MEASURE_PERF_COUNTERS` (barrier only) | Per-zone wall-clock cycles (`RISCV_DEBUG_REG_WALL_CLOCK_L`), reported differently per run type: `L1_TO_L1` is the unpack-start to pack-end cross-thread span, the isolates are the measured thread's own zone, and `L1_CONGESTION` yields two columns, `[UNPACK]` and `[PACK]` |
+| WC (with counters) | defined | defined | `MEASURE_PERF_COUNTERS` **and** `ZONE_SCOPED` | Per-zone HW counter snapshot **and** wall-clock cycles |
 
-`START_PERF_MEASURE(name)` expands to `MEASURE_PERF_COUNTERS(name)` + `ZONE_SCOPED(name)`. The two halves are mutually exclusive — only one of them is non-empty in any given build, so wall-clock and counter measurements are never taken simultaneously and cannot perturb each other. The single name keeps NC wall-clock data and WC counter data joinable by zone name in the host driver; the driver runs whichever build is needed and merges the resulting DataFrames on that name.
+`START_PERF_MEASURE(name)` expands to `MEASURE_PERF_COUNTERS(name)` + `ZONE_SCOPED(name)`. In the NC build, `MEASURE_PERF_COUNTERS` performs the same real three-thread rendezvous with an empty action (so it is not free, and it moves the NC baseline); on Quasar it expands to nothing and `ZONE_SCOPED` records the per-zone wall-clock timestamps. In the WC build **both** are live: the counter scope performs the rendezvous *and* arms/freezes the HW counters, while `ZONE_SCOPED` records the per-zone wall-clock timestamps without adding another rendezvous. A single WC run therefore yields both counter and wall-clock data per zone under the same name; the host driver keys everything by `(test_variant, zone)` and can merge NC and WC results (or use the WC wall-clock directly).
 
 Source-side, this is the pattern:
 
@@ -60,53 +62,69 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 Each zone is registered once at its first encounter (the counter half is RAII-scoped and assigns a stable zone id by hashing the name), so placing `START_PERF_MEASURE` **outside** the loop is preferred — counter start is not a no-op and would dominate per-iteration cost if done on every tile.
 
-### `PerfRunType` and the split arm/freeze model
+### `PerfRunType` and the single-thread arm/freeze model
 
-Each LLK perf test is associated with a `PerfRunType` (declared in `perf.h`):
+Each LLK perf test is associated with a `PerfRunType` (declared in `perf.h`): `L1_TO_L1` runs the full handshaked unpack → math → pack pipeline. `L1_CONGESTION` keeps unpack and pack real but decouples them — math is reduced to a dvalid drain and pack free-runs — so the two hammer L1 concurrently instead of forming a pipeline; `UNPACK_ISOLATE` / `MATH_ISOLATE` / `PACK_ISOLATE` exercise a single stage. The run type selects which threads do real work, whether they are handshaked or free-running, and whether the exit rendezvous exists. The other threads are not idle: they run the minimum dvalid and semaphore mocks in `perf.h` that the measured stage's hardware handshake requires.
 
-| Run type | Purpose | Arm thread | Freeze thread |
-|----------|---------|-----------|---------------|
-| `L1_TO_L1` | End-to-end pipeline cycles, unpack → math → pack | UNPACK | PACK |
-| `L1_CONGESTION` | Pipeline cycles under L1 traffic contention, unpack → pack | UNPACK | PACK |
-| `UNPACK_ISOLATE` | Unpack-only kernels (no math/pack) | UNPACK | UNPACK |
-| `MATH_ISOLATE` | Math/SFPU-only kernels (no unpack/pack) | MATH | MATH |
-| `PACK_ISOLATE` | Pack-only kernels (no unpack/math) | PACK | PACK |
+**Pack arms the counters for every run type.** `llk_barrier::is_action_thread()` in `barrier.h` returns true only on pack. Freezing is not uniform: see the table below. Arming can be fixed to one thread because:
 
-The arm thread runs first in the natural pipeline, the freeze thread runs last. For end-to-end measurements (`L1_TO_L1`, `L1_CONGESTION`) the window opens when unpack starts producing and closes when pack stops consuming. For single-thread isolate modes the same thread arms and freezes — the other two threads are idle for the run type and only participate in the entry/exit barrier.
+- The perf counters are **global hardware** driven by shared debug registers (`PERF_CNT_ALL` and the per-bank `*2` command registers), so any RISC can arm/freeze them — the identity of the issuing thread does not change what is counted.
+- The entry rendezvous waits for every thread before arming, so the window opens after all of them have finished the previous zone.
 
-The arm/freeze split is determined at compile time by `is_arm_thread<run_type>()` and `is_freeze_thread<run_type>()` in `counters.h`.
+Pack is chosen because a sweep found arming there halves the total `L1_CONGESTION` error against arming on TRISC0. Fixing it also matters for its own sake: letting the arming thread vary is how the two builds ended up releasing from different threads.
+
+**Freezing is per run type**, decided by `exit_barrier_for()` in `counters.h`, which defaults to `wants_exit_barrier()` unless `LLK_PERF_EXIT_BARRIER` overrides it:
+
+| Run type | Exit rendezvous | Freezing thread |
+|---|---|---|
+| `L1_TO_L1`, `L1_CONGESTION` | yes | pack, once all three have arrived |
+| `UNPACK_ISOLATE` | yes | pack, once all three have arrived |
+| `MATH_ISOLATE`, `PACK_ISOLATE` | no | the measured thread, just after its own `ZONE_END` |
+
+So for `MATH_ISOLATE` the freeze is done by math, with no barrier at all. Note that `START_PERF_MEASURE` declares the counter scope before the profiler zone, so on every run type the counters are armed before `ZONE_START` and frozen after `ZONE_END`: `OUT_L` always exceeds the wall-clock span, by the arrival spread where the exit barrier is kept (largest for `UNPACK_ISOLATE`) and by the peers' epilogue where it is not. Without the exit barrier the other two threads leave the scope while the counters are still armed, so their `tensix_sync`, `KERNEL` `ZONE_END` and completion-mailbox write land inside the measured window. `LLK_PERF_EXIT_BARRIER` overrides the table (default `-1` = per run type) but has no harness plumbing, so it must be passed by hand; a `static_assert` rejects forcing it off for a run type where no thread would freeze.
 
 ### The `MEASURE_PERF_COUNTERS` macro
 
-Expands to a `perf_counter_scoped<PERF_RUN_TYPE>` RAII object. Its constructor and destructor execute the following sequence (only on the WC build):
+Expands to a `perf_counter_scoped<PERF_RUN_TYPE>` RAII object; the run type is a template parameter because it selects the exit shape above. Its constructor and destructor execute the following sequence (only on the WC build):
 
-1. **Constructor (zone entry).** The **arm thread** writes the rising-edge start bit to `PERF_CNT_ALL` (FPU + INSTRN), `PERF_CNT_TDMA_UNPACK2`, `PERF_CNT_L1_2`, and `PERF_CNT_TDMA_PACK2`, clearing all banks and starting the count. It then posts the entry semaphore (`pc_buf` slot `FPU_SFPU`) twice. The two non-arm threads spinwait on that semaphore, then `semaphore_get` it. The barrier guarantees no thread is inside the measured scope before the arm thread has armed the HW.
+1. **Constructor (zone entry).** Calls `llk_barrier::rendezvous(llk_barrier::is_action_thread(), arm_all_counters)`. All three threads rendezvous; the **action thread (pack)** then writes the rising-edge start bit to `PERF_CNT_ALL` (FPU + INSTRN), `PERF_CNT_TDMA_UNPACK2`, `PERF_CNT_L1_2`, and `PERF_CNT_TDMA_PACK2` — clearing all banks and starting the count — and releases the others.
 
 2. **Body.** All three threads run the work inside the scope. Counters tick continuously on the shared backend.
 
-3. **Destructor (zone exit).** The **freeze thread** writes the rising-edge stop bit to the same four registers, then walks the shared 200-word config buffer at `0x169000` and reads every valid slot. For each slot it programs the bank's mode register with the `counter_sel`, reads `OUT_H` (the event count), and stores the value in the per-zone data area. The bank's elapsed-cycles value (`OUT_L`) is sampled once per bank from the first slot. After all slots are read it posts the exit semaphore (`pc_buf` slot `UNPACK_TO_DEST`) twice. The two non-freeze threads spinwait then `semaphore_get` the exit semaphore.
+3. **Destructor (zone exit).** For the run types that keep the exit rendezvous, calls `llk_barrier::rendezvous(llk_barrier::is_action_thread(), freeze_and_read_all_counters)`; otherwise the measured thread freezes directly. Note `PROFILER_SYNC()` (`tensix_sync`) is a hand-written statement in each kernel and the isolate and congestion paths can `return` past it, so a thread's backend is not guaranteed drained when the stop bit is written; `fence_compiler()` around the rendezvous is a compiler barrier only. The **action thread (pack)** writes the rising-edge stop bit to the same four registers, then walks the shared 200-word config buffer at `0x169000` and reads every valid slot: for each it programs the bank's mode register with the `counter_sel`, reads `OUT_H` (the event count), and stores it in the per-zone data area (`OUT_L` is read once from the INSTRN_THREAD bank and copied into all five per-bank cycle words, so those five words always hold the same value). It then sets the zone's `SYNC_ZONE_COMPLETE` flag and releases the others.
 
-Each zone gets its own data block in L1 (see [L1 Layout](#l1-layout-and-zone-buffers)) so multiple measurement scopes in the same kernel produce independent snapshots. The kernel may contain up to `PERF_COUNTERS_MAX_ZONES = 8` distinct zone names; identical names share a zone.
+Each zone gets its own data block in L1 (see [L1 Layout](#l1-layout-and-zone-buffers)) so multiple measurement scopes in the same kernel produce independent snapshots. The device supports `PERF_COUNTERS_MAX_ZONES = 8` zones, but the host names only two — `perf.py` hard-codes zone 0 as `INIT` and zone 1 as `TILE_LOOP`, so a third counter zone appears in the CSV as the literal `ZONE_2` and never joins the wall-clock rows. Zone names in use are `INIT`, `TILE_LOOP`, and `UNINIT` in `fast_tilize_bh` / `fast_untilize` only; `UNINIT` uses bare `ZONE_SCOPED`, so it is timing-only with no rendezvous; identical names share a zone.
 
-The `pc_buf` semaphores are the cheapest synchronisation primitive available on Tensix — they're consumed by the backend without involving the FPU or unpacker pipelines, so the barrier itself contributes negligible cycles to the measured window.
+#### The `llk_barrier::rendezvous` barrier
+
+The barrier is `llk_barrier::rendezvous` in `barrier.h`, on the `PACK_DONE` **hardware semaphore**, and both builds compile the identical one. It replaced three separate rendezvous, including `llk_profiler::sync_point`, which was an actor-release protocol on an L1 epoch word. `sync_point` was removed because that release gave the actor a head start worth about one cycle per tile on a strict producer/consumer loop, and because the no-counter build could not reach the semaphore version and silently fell back to it, so the two builds measured the same zone with different instruments.
+
+Every thread announces by incrementing; the action thread waits for all of them, runs its action, then drains the count back to zero, and that return to zero is the release. Two consequences worth being explicit about. The action thread spins **twice**, once before the action and once draining after it, so on entry that drain runs inside the counter window. And the barrier is not free: ablation showed the exit rendezvous merely existing was worth +11 of the +12 cycles by which the counter build differed from the no-counter build on `MATH_ISOLATE`. What the shared barrier buys is that both builds pay the same cost at zone entry, not that the cost is zero.
+
+The semaphore is used rather than L1 because its release is symmetric, detection is a short `pc_buf` poll, and it puts no traffic on the L1 being measured. Quasar has no spare semaphore and keeps the L1 form in `profiler.h`.
 
 ### Configure-once from BRISC
 
 Before any TRISC kernel runs, BRISC executes `configure_and_arm_from_brisc()` once (called from `brisc.cpp` when the WC build flag is set). This:
 
-- Writes the per-architecture `BUILTIN_COUNTER_CONFIG` (130 slots on WH, 169 on BH) into the shared L1 config buffer at `0x169000`.
+- Writes the per-architecture `BUILTIN_COUNTER_CONFIG` (114 slots on WH, 105 on BH, since only one L1 mux group is emitted) into the shared L1 config buffer at `0x169000`. That array is built at compile time from the canonical metal inventory — see [Counter inventory single source](#counter-inventory-single-source).
 - Clears every per-zone data area and sync word.
+- Clears `DBG_FEATURE_DISABLE` to `0` — see [DBG_FEATURE_DISABLE scrub](#dbg_feature_disable-scrub) below.
 - Programs each bank's reference-period and mode registers, sets `PERF_CNT_MUX_CTRL` for L1, and does an initial global arm (later overridden by the first `MEASURE_PERF_COUNTERS` zone).
 
 After BRISC releases the TRISCs, the shared config is read-only for the rest of the run.
+
+##### `DBG_FEATURE_DISABLE` scrub
+
+`DBG_FEATURE_DISABLE` is a 16-bit debug/chicken-bit register whose bits toggle low-level behaviors — notably randomized L1 arbitration (bit 3; the name is from the RTL and is not a symbol in this tree), L1 atomic serialization, and L1 read-enable override. It resets to `0` (all normal), but HW register state **leaks between tests** run back-to-back on an un-reset device, so a prior test that set one of these bits would silently perturb — and make nondeterministic — the L1 counters (16 per run, since one mux group is captured). BRISC writes `0` here to guarantee a clean baseline regardless of leaked state; the blanket write (rather than clearing one bit) is deliberate because any of the bits, not just LFSR, would skew the measurement. Verified: with a leaked `0x8` present, the L1 metrics jitter 40–98 % run-to-run without this scrub and are byte-identical with it. Note this scrub is WC-only (it lives in the counter path); the NC path has no equivalent.
 
 ### Reading results from host
 
 After the kernel completes:
 
 1. The host process reads the per-zone data area back from device L1.
-2. `read_counters()` decodes each 32-bit config word (bit 31 valid, bits 7:0 bank, bits 16:8 `counter_sel`, bits 19:17 `l1_mux`), looks up the human-readable counter name from the per-architecture inventory, and pairs every event count with that zone's bank cycle count.
-3. The result is a long-format DataFrame: one row per `(zone, bank, counter_id, l1_mux)` tuple with columns `cycles`, `count`, and (optionally) derived metrics from `compute_metrics()`.
+2. `read_counters()` decodes each 32-bit config word (bit 31 valid, bits 7:0 bank, bits 16:8 `counter_sel`, bits 19:17 `l1_mux`), looks up the human-readable counter name (parsed at import from the same `hw_counters.h` — see [Counter inventory single source](#counter-inventory-single-source)), and pairs every event count with that zone's bank cycle count.
+3. `read_counters()` returns an in-memory long-format DataFrame with columns `zone`, `bank`, `counter_name`, `counter_id`, `cycles`, `count`, `l1_mux`. `compute_metrics()` produces its own separate rows; it does not add columns to that frame. Host-side only zone 0 and zone 1 are named (hard-coded to `INIT` and `TILE_LOOP`); further zones stay `ZONE_n` and never join the wall-clock rows.
 
 Because both wall-clock cycles (NC build, `ZONE_SCOPED` start/end timestamps from `RISCV_DEBUG_REG_WALL_CLOCK_L`) and HW counter cycles (WC build, `OUT_L`) are tagged with the same zone name, the test driver merges them by `(test_variant, zone)`.
 
@@ -115,9 +133,9 @@ Because both wall-clock cycles (NC build, `ZONE_SCOPED` start/end timestamps fro
 The LLK test suite uses a two-phase pytest flow: a compile-producer phase that builds every variant in parallel and a compile-consumer phase that runs them on hardware.
 
 ```bash
-source setup_testing_env.sh   # required: sets LLK_HOME, PATH, virtualenv
-cd $LLK_HOME/tests
-export CHIP_ARCH=blackhole   # or wormhole / quasar
+./setup_testing_env.sh        # installs the SFPI toolchain; run it, do not source it (it calls exit)
+cd tt_metal/tt-llk/tests     # LLK_HOME is defaulted by conftest.py; you do not need to set it
+export CHIP_ARCH=blackhole   # or wormhole; counters are not compiled on quasar
 
 # Phase 1 — build all variants (no HW access)
 pytest --compile-producer --enable-perf-counters -n 8 -x ./python_tests/perf_eltwise_binary.py
@@ -126,10 +144,15 @@ pytest --compile-producer --enable-perf-counters -n 8 -x ./python_tests/perf_elt
 pytest --compile-consumer --enable-perf-counters -x ./python_tests/perf_eltwise_binary.py
 ```
 
+Wipe the artefact root (`/tmp/tt-llk-build`, or `$RUNNER_TEMP/tt-llk-build`) when switching between the two builds: the variant hash and the build markers ignore the counter flags, so the ELFs are otherwise reused.
+
+To capture a different L1 mux group, `export LLK_PERF_L1_MUX_GROUP=<0-4>` before **both** phases. It is an environment variable rather than a CLI flag and is compiled into `brisc.elf`, so each group needs its own producer run; the readout detects a disagreement between the group found in L1 and the one requested, but `perf.py` catches it and logs `Error reading counters:` as a warning, so the run still passes with no counter data at all rather than failing.
+
+
 The `--enable-perf-counters` flag triggers two things:
 
 1. Test sources are compiled with `-DPERF_COUNTERS_COMPILED` (the WC build). BRISC is compiled with the same flag so it runs `configure_and_arm_from_brisc()` once at startup.
-2. The Python driver runs `read_counters()` per variant after the kernel finishes and merges raw counts into the result CSV.
+2. The Python driver calls `read_counters()` after every run, writes the derived percentage metrics into the main CSV, and writes raw counts only to `*.counters.csv` under `--dump-csv-counters`.
 
 Without the flag the suite still runs the same sources but builds the NC variant, and only `ZONE_SCOPED` wall-clock data is collected.
 
@@ -146,8 +169,9 @@ Without the flag the suite still runs the same sources but builds the NC variant
 
 For each test variant, the WC build emits:
 
-- A row per `(zone, bank, counter_id, l1_mux)` in the main results DataFrame, with raw `cycles` and `count` columns.
-- A `*.counters.csv` file if `--dump-perf-counters` was passed.
+- One row per zone in `perf_data/<test>/<test>.csv`, with wide `<RUN_TYPE>_<stat>(<metric>)` columns. `<test>.post.csv` is the same data with `TILE_LOOP` wall-clock divided by `loop_factor x tile_cnt`; `INIT` rows and every counter/`OUT_L` column stay absolute, so multiply before comparing the two cycle numbers.
+- A `*.counters.csv` file if `--dump-csv-counters` was passed.
+- A per-zone console dump of the derived metrics for the last run, plus a mean/std stability block when `run_count >= 2`, if `--dump-raw-metrics` was passed. There is no min/median/max aggregation.
 
 The NC build emits per-zone wall-clock cycle counts in the same results DataFrame so a single run with both builds (different pytest invocations) can be merged off-line to compare wall-clock cycles against counter-derived cycle counts.
 
@@ -161,19 +185,30 @@ The NC build emits per-zone wall-clock cycle counts in the same results DataFram
 | TDMA_PACK slots | 14 | 5 |
 | L1 mux positions (Tensix) | 2 | 5 |
 | L1 slots in inventory | 32 (16 × 2 mux) | 80 (16 × 5 mux) |
-| Total slots in `BUILTIN_COUNTER_CONFIG` | 130 | 169 |
+| Total slots in `BUILTIN_COUNTER_CONFIG` (one L1 mux group) | 114 | 105 |
 | Total config words in L1 | 200 (rest are zero-padded) | 200 |
 
-**Wormhole** has `PACK_COUNT = 4` (per-engine packer busy signals are live in RTL), so `TDMA_PACK` exposes counters 11–18 for per-engine busy and 267–272 for per-engine dest-read availability and grant counts. The L1 mux is 1-bit wide: position 0 covers NoC Ring 0 plus L1 arbitration, position 1 covers NoC Ring 1 plus TDMA-extended signals.
+**Wormhole** has `PACK_COUNT = 4` (per-engine packer busy signals are live in RTL), so `TDMA_PACK` exposes counters 11–14 for dest-read availability, 15–18 for per-engine plus aggregate packer busy, and 267–272 for per-engine dest-read grants plus `MATH_NOT_STALLED_DEST_WR_PORT` and `AVAILABLE_MATH`. The L1 mux is 1-bit wide: position 0 covers NoC Ring 0 plus L1 arbitration, position 1 covers NoC Ring 1 plus TDMA-extended signals.
 
 **Blackhole** has `PACK_COUNT = 1`; per-engine packer busy and dest-read signals for engines 1–3 are tied to constants in RTL and are omitted from the inventory. Only counters 11, 18, 267, 271, 272 remain on the `TDMA_PACK` bank. BH compensates with more L1 mux positions (3 extra) which expose additional NoC rings and miscellaneous L1 ports.
 
-**INSTRN_THREAD bank.** Counters 0–23 are per-thread instruction-type availability (CFG/SYNC/THCON/XSEARCH/MOVE/FPU/UNPACK/PACK, 3 threads each). Counters 24–26 are per-thread total stall cycles. The stall-reason layout differs:
+**INSTRN_THREAD bank.** Counters 0–8 and 12–23 are per-thread instruction-type availability (CFG/SYNC/THCON/MOVE/FPU/UNPACK/PACK, 3 threads each — 21 slots; the XSEARCH sels 9–11 are tied off in RTL and are not in the inventory). Counters 24–26 are per-thread total stall cycles. The stall-reason layout differs:
 
-- WH: shared stall reasons (SRCA/B clear/valid) are replicated three times each (counters 27–38), then per-thread stall reasons occupy counters 39–65.
+- WH: the four shared stall reasons (SRCA/B clear/valid) are replicated per thread in HW but only the first slot of each is enumerated, at sels 27/30/33/36; per-thread stall reasons then occupy counters 39–65.
 - BH: shared stall reasons occupy single slots (27–30), per-thread stall reasons occupy 31–57.
 
-Bit-8-extended counters 256/264/272 expose `THREAD_INSTRUCTIONS_{0,1,2}` (one per per-thread instance), and 283 exposes `ANY_THREAD_STALL`. The full per-arch inventory is in `BUILTIN_COUNTER_CONFIG[]` inside `counters.h`.
+Bit-8-extended counters 256/264/272 expose `THREAD_INSTRUCTIONS_{0,1,2}` (one per per-thread instance), and 283 exposes `ANY_THREAD_STALL`.
+
+### Counter inventory single source
+
+The counter id↔name inventory is **defined once**, in metal's canonical `tt_metal/hw/inc/internal/tt-1xx/<arch>/hw_counters.h` — grouped `{PerfCounterType, id}` arrays per bank (`instrn_counters`, `fpu_counters`, `unpack_counters`, `pack_counters`, `l1_0..4_counters`). Both sides of the perf infra derive from it, so the list is never hand-maintained twice:
+
+- **Device (`counters.h`)** `#include`s `hw_counters.h` (with the `PerfCounterType` enum from `perf_counters.hpp`) and builds `BUILTIN_COUNTER_CONFIG[]` from those arrays at compile time — a `constexpr` concatenation in the fixed bank order the readout expects (INSTRN, FPU, TDMA_UNPACK, TDMA_PACK, then the single selected L1 mux group).
+
+Only **one** L1 mux group is emitted per build, chosen by `LLK_PERF_L1_MUX_GROUP` (default 0). There are only eight physical L1 counters and `PERF_CNT_MUX_CTRL` routes a group of eight client interfaces into them *while they count*, not when they are read, so a run observes exactly one group. Sweep the flag across runs to cover the others; a metric documented below as requiring the mux-1 slot is not obtainable from a default run. The group is a compile-time constant baked into `brisc.elf`, so a sweep must recompile the producer — the readout checks the group decoded from L1 against the requested one and fails if they disagree.
+- **Host (`counters.py`)** parses the same `hw_counters.h` at import to recover the id→name tables used for decoding.
+
+Adding or removing a counter in `hw_counters.h` therefore propagates to both automatically; the only pieces still mirrored by hand are the config-word bit layout (`PERF_CFG_*`) and the bank-id↔name mapping, which are this test infra's own L1 ABI rather than part of the HW inventory.
 
 ## L1 Layout and Zone Buffers
 
@@ -201,9 +236,9 @@ Counter state lives at a fixed L1 address determined entirely at compile time. N
          +────────────────────────────────────────────+
 ```
 
-The layout is bounded by a `static_assert` to stay below `0x16AFF4` (the profiler region boundary). Each zone reserves `PERF_COUNTERS_ZONE_SIZE = (5 + 200) × 4 + 40 = 860` bytes, supporting up to `PERF_COUNTERS_MAX_ZONES = 8` zones per kernel.
+The layout is bounded by two `static_assert`s to stay below `0x16AFF0` (the profiler region boundary). Each zone reserves `PERF_COUNTERS_ZONE_SIZE = (5 + 200) × 4 + 40 = 860` bytes, supporting up to `PERF_COUNTERS_MAX_ZONES = 8` zones per kernel.
 
-The 200-word shared config supplies a single source of truth for which counters are recorded for every zone. There is no per-zone configuration — every zone records the same set of counters but stores its own snapshot.
+The 200-word shared config is the authoritative runtime record of which counters are recorded for every zone (the host reads it back to decode). There is no per-zone configuration — every zone records the same set of counters but stores its own snapshot.
 
 ## Hardware Register Reference
 
@@ -229,7 +264,7 @@ The following addresses are used (offsets from `RISCV_DEBUG_REGS_START_ADDR = 0x
 | `PERF_CNT_OUT_H_DBG_L1` | 0x11C | … |
 | `PERF_CNT_OUT_L_FPU` | 0x120 | … |
 | `PERF_CNT_OUT_H_FPU` | 0x124 | … |
-| `PERF_CNT_MUX_CTRL` | 0x218 | L1 mux selector (bits 6:4) |
+| `PERF_CNT_MUX_CTRL` | 0x218 | L1 mux selector: bit 4 on Wormhole (`L1_MUX_MASK = 0x1 << 4`), bits 6:4 on Blackhole (`0x7 << 4`) |
 
 ### Mode register (`PERF_CNT_*1`)
 
@@ -243,25 +278,27 @@ The macro path always uses mode 0. Mode 1 is unused in the LLK test suite. The `
 
 ### Start/Stop register (`PERF_CNT_*2`)
 
-Rising-edge triggered. Bit 0 = start (0→1 also clears the counter), bit 1 = stop. The macro writes `1` then immediately writes `0` on both arm and freeze paths to guarantee the next arm sees a clean 0→1 transition.
+Rising-edge triggered. Bit 0 = start (0→1 also clears the counter), bit 1 = stop. The per-zone path writes `1` to arm and `2` to freeze, so each write is itself a rising edge on the opposite bit and the stop write is what re-creates the next 0→1 edge. Only BRISC's boot `arm_hardware()` writes `1` then `0`.
 
 ### L1 mux (`PERF_CNT_MUX_CTRL`)
 
-The L1 bank has 8 `counter_id` values (0–7) but hardware exposes 16 (WH) or 40 (BH) distinct signals. Bits 6:4 of `PERF_CNT_MUX_CTRL` select which set of 8 signals is routed:
+Each L1 mux group exposes 8 client interfaces x 2 counters — request sels 0–7 and grant sels 256–263 — so 16 `counter_sel` values per group, giving the 32 (WH, 2 groups) and 80 (BH, 5 groups) inventory totals above. The mux field selects the group: bit 4 on Wormhole, bits 6:4 on Blackhole (5 of 8 encodings populated):
 
 | Mux | WH meaning | BH meaning |
 |-----|------------|------------|
-| 0 | NoC Ring 0 + L1 arbitration + unpacker | NoC Ring 0 |
-| 1 | NoC Ring 1 + TDMA extended | NoC Ring 1 |
+| 0 | unpacker, packer port 1, TDMA bundles 0/1, NoC Ring 0 | same |
+| 1 | TDMA packer 2, ext unpackers 1–3, NoC Ring 1 | RISC core, ext unpackers 1–3, NoC Ring 1 |
 | 2 | — | NoC Ring 2 |
 | 3 | — | NoC Ring 3 |
 | 4 | — | Misc L1 ports |
 
-The mux is latched at counter-start time. The macro path re-writes it before each slot read during freeze, so a single zone snapshot can contain counters from multiple mux positions interleaved.
+These labels come from `hw_counters.h` and are unverified: because the mux routes interfaces at count time, they are labels on indices rather than confirmed client functions, and several Blackhole identities are known to be wrong (see the note in `counters.py`).
+
+The mux routes interfaces into the counters while they count and is written once by BRISC before arming, so the freeze path cannot re-aim it. A zone snapshot therefore contains exactly one mux position: the group that was selected while the counters ran. Sweep it by exporting `LLK_PERF_L1_MUX_GROUP` before the producer phase (it is an environment variable, not a CLI flag, and is baked in at compile time, so each value needs its own `--compile-producer`). Sweep across runs to cover the other groups.
 
 ## Derived Metrics Reference
 
-Derived metrics are computed in `tests/python_tests/helpers/metrics.py` from the raw counter DataFrame. The metric set mirrors the metal-level [PerfCounters tech report](../../../../tech_reports/PerfCounters/perf-counters.md) — the same catalogue applies to **both Wormhole and Blackhole** (architecture differences are confined to a few WH-only or BH-only counters, called out per-metric). The LLK driver operates on per-zone snapshots rather than per-op aggregates, so all derived values appear in the merged CSV.
+The LLK driver computes **16** derived metrics (the `*_pct` keys in `metrics.py` and `perf_schema.py::METRIC_BASES`). The other entries below are upstream formulas that this driver does **not** compute; their raw counters are still in the per-zone CSV, so they can be re-derived by hand. Renaming or adding a `*_pct` key requires updating `perf_schema.py::METRIC_BASES` in the same change, or the report's schema check fails. Derived metrics are computed in `tests/python_tests/helpers/metrics.py` from the raw counter DataFrame. The metric set mirrors the metal-level [PerfCounters tech report](../../../../tech_reports/PerfCounters/perf-counters.md) — the same catalogue applies to **both Wormhole and Blackhole** (architecture differences are confined to a few WH-only or BH-only counters, called out per-metric). The LLK driver operates on per-zone snapshots rather than per-op aggregates, so all derived values appear in the merged CSV and the `--dump-raw-metrics` console output.
 
 > **Full catalogue.** Metrics #1–#47 in `tech_reports/PerfCounters/perf-counters.md` are the authoritative list. The sections below document the ones the LLK driver surfaces directly; raw counters for every other upstream metric are present in the per-zone CSV, so any upstream formula can be re-evaluated on LLK data without code changes.
 
@@ -269,17 +306,18 @@ Derived metrics are computed in `tests/python_tests/helpers/metrics.py` from the
 
 ### Compute Utilisation
 
-**1. FPU Utilisation**
+### Computed metrics
+
+These are the entries the LLK driver evaluates.
+
+#### 1. FPU Utilisation
 
 Fraction of elapsed cycles the FPU was executing an instruction.
 
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | FPU |
+*Counter group: FPU. Computed, exported as `fpu_utilization_pct`.*
 
 ```
-FPU Util = FPU_INSTRUCTION / FPU_OUT_L * 100
+FPU Util = FPU_COUNTER / FPU_OUT_L * 100
 ```
 
 - **High value (>20%)**: FPU is the active compute unit. Expected for matmul, eltwise multiply.
@@ -287,39 +325,14 @@ FPU Util = FPU_INSTRUCTION / FPU_OUT_L * 100
 
 **Use case:** Primary indicator of compute utilisation for FPU-path kernels.
 
----
-
-**2. SFPU Utilisation**
-
-Fraction of cycles the SFPU was active.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | FPU |
-
-```
-SFPU Util = SFPU_INSTRUCTION / FPU_OUT_L * 100
-```
-
-- **High value (>20%)**: SFPU-heavy kernel (sqrt, gelu, exp).
-- **Low value (~0%)**: SFPU unused (FPU-path or data movement).
-
-**Use case:** Confirms whether a zone exercises the SFPU pipeline.
-
----
-
-**3. Math Utilisation**
+#### 3. Math Utilisation
 
 Combined FPU+SFPU active cycles. Counter 257 is the OR of both unit-active signals.
 
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | FPU |
+*Counter group: FPU. Computed, exported as `compute_utilization_pct`.*
 
 ```
-Math Util = FPU_OR_SFPU_INSTRN / FPU_OUT_L * 100
+Math Util = MATH_COUNTER / FPU_OUT_L * 100
 ```
 
 **Use case:** Single-number compute utilisation across FPU and SFPU.
@@ -328,14 +341,11 @@ Math Util = FPU_OR_SFPU_INSTRN / FPU_OUT_L * 100
 
 ### Pipeline Efficiency
 
-**4. Packer Efficiency**
+#### 4. Packer Efficiency
 
 Fraction of packer-busy cycles where destination data was available.
 
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_PACK |
+*Counter group: TDMA_PACK. Computed, exported as `pack_dest_eff_pct`.*
 
 ```
 Packer Efficiency = PACKER_DEST_READ_AVAILABLE / PACKER_BUSY * 100
@@ -346,100 +356,31 @@ Packer Efficiency = PACKER_DEST_READ_AVAILABLE / PACKER_BUSY * 100
 
 **Use case:** Detects destination-register stalls indicating the math stage cannot keep up.
 
----
+#### 8. Unpacker-to-Math Data Flow
 
-**5. Math Pipeline Utilisation**
+Unpacker write duty cycle. Despite the name this is **not** backpressure: the numerators are bare write-enable counts, so a low value means the unpacker was not writing, which is not evidence that math refused data.
 
-Math-instruction issue rate relative to availability.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_UNPACK |
+*Counter group: TDMA_UNPACK. Computed, exported as `unpack_to_math_flow0_pct`, `unpack_to_math_flow1_pct`, `unpack_to_math_flow_pct`.*
 
 ```
-Math Pipeline Utilisation = MATH_INSTRN_STARTED / MATH_INSTRN_AVAILABLE * 100
+flow0 = SRCA_WRITE_AVAILABLE / UNPACK0_BUSY_THREAD0 * 100
+flow1 = SRCB_WRITE_AVAILABLE / UNPACK1_BUSY_THREAD0 * 100
+combined = mean(flow0, flow1)          # mean of the two ratios, not the ratio of two means
 ```
 
-- **High value (>95%)**: Math instructions issue as fast as they arrive at the front end.
-- **Low value (<60%)**: Math is stalled in flight (scoreboard, dest port, fidelity).
-
-**Use case:** Distinguishes "math has nothing to do" from "math is stalled while busy".
-
----
-
-**6. FPU Execution Efficiency**
-
-FPU active cycles relative to math-instruction availability on the math thread.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | FPU + INSTRN_THREAD |
-
-```
-FPU Execution Efficiency = FPU_INSTRUCTION / FPU_INSTRN_AVAILABLE_1 * 100
-```
-
-- **High value (>80%)**: FPU executes whenever math work is pending — compute-bound.
-- **Low value (<30%)**: Math instructions queued but FPU not running — pipeline-stall-bound.
-
-**Use case:** Compute-bound vs stall-bound discriminator on the math path.
-
----
-
-**7. Math-to-Pack Handoff Ratio**
-
-Ratio of math-output availability to packer consumption.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_PACK |
-
-```
-Math-to-Pack Handoff = AVAILABLE_MATH / PACKER_BUSY * 100
-```
-
-- **>100%**: Math produces output faster than packer can consume (packer is the bottleneck).
-- **~100%**: Balanced.
-- **<100%**: Packer is stalled waiting on math — math is the bottleneck.
-
-**Use case:** Identifies math-vs-pack pipeline imbalance.
-
----
-
-**8. Unpacker-to-Math Data Flow**
-
-Backpressure from math stage onto the unpackers.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_UNPACK |
-
-```
-Unpacker-to-Math = avg(SRCA_WRITE_AVAILABLE, SRCB_WRITE_AVAILABLE) /
-                   avg(UNPACK0_BUSY_THREAD0, UNPACK1_BUSY_THREAD0) * 100
-```
-
-- **High value (>80%)**: Unpackers always have somewhere to write — no backpressure.
-- **Low value (<30%)**: Source-register buffers are full; math is not consuming fast enough.
-
-**Use case:** Cross-check against per-unpacker write efficiency to isolate math-driven backpressure from DMA port contention.
+- **High value**: the unpacker was writing for most of the cycles it was busy.
+- **Low value**: the unpacker was mostly not writing. That is all this says. It is not evidence that math
+  refused data, because the numerator counts write-enables rather than accepted writes.
 
 ---
 
 ### Thread Analysis
 
-**9. Thread N Stall Rate**
+#### 9. Thread N Stall Rate
 
 Fraction of cycles each TRISC thread was stalled.
 
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | INSTRN_THREAD |
+*Counter group: INSTRN_THREAD. Computed, exported as `unpack_thread_stall_pct`, `math_thread_stall_pct`, `pack_thread_stall_pct`.*
 
 ```
 Thread N Stall Rate = THREAD_STALLS_N / INSTRN_OUT_L * 100
@@ -452,101 +393,11 @@ Thread mapping: T0 = UNPACK, T1 = MATH, T2 = PACK.
 
 **Use case:** First-pass localisation of which thread is losing time. Follow up with the stall-reason breakdown.
 
----
-
-**10. Thread N Issue Rate**
-
-Average instructions issued per cycle, per thread.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | INSTRN_THREAD |
-
-```
-TN Issue Rate = THREAD_INSTRUCTIONS_N / INSTRN_OUT_L
-```
-
-- **High (~1.0)**: Thread issues an instruction nearly every cycle.
-- **Low (<0.1)**: Thread is idle or blocked.
-
-**Use case:** Detects threads that look "busy" by stall-rate but actually never issue work.
-
----
-
-### Pipeline Wait Metrics
-
-**11. SrcA/SrcB Valid Wait**
-
-Cycles math waited for unpack to provide source data.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | INSTRN_THREAD |
-
-```
-SrcA Valid Wait = WAITING_FOR_SRCA_VALID / INSTRN_OUT_L * 100
-SrcB Valid Wait = WAITING_FOR_SRCB_VALID / INSTRN_OUT_L * 100
-```
-
-- **High (>5%)**: Math is starved by the unpacker.
-- **Low (~0%)**: Unpack keeps pace with math.
-
-**Use case:** Detects unpack-side data starvation.
-
----
-
-**12. SrcA/SrcB Clear Wait**
-
-Cycles unpack waited for math to release a source register before overwriting.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | INSTRN_THREAD |
-
-```
-SrcA Clear Wait = WAITING_FOR_SRCA_CLEAR / INSTRN_OUT_L * 100
-SrcB Clear Wait = WAITING_FOR_SRCB_CLEAR / INSTRN_OUT_L * 100
-```
-
-- **High (>10%)**: Math holds source registers longer than unpack can wait. Common for SFPU-heavy SrcA reuse.
-- **Low (~0%)**: No register pressure between unpack and math.
-
-**Use case:** Identifies source-register contention.
-
----
-
-**13. Math / Pack / Unpack Idle Wait**
-
-Cycles each thread waited for its primary HW unit to become idle.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | INSTRN_THREAD |
-
-```
-Math Idle Wait T1 = WAITING_FOR_MATH_IDLE_1 / INSTRN_OUT_L * 100
-Pack Idle Wait T2 = WAITING_FOR_PACK_IDLE_2 / INSTRN_OUT_L * 100
-Unpack Idle Wait T0 = WAITING_FOR_UNPACK_IDLE_0 / INSTRN_OUT_L * 100
-```
-
-**Use case:** Pinpoints which HW unit is the bottleneck.
-
----
-
-### Semaphore Waits
-
-**14. Semaphore Zero/Full Wait per Thread**
+#### 14. Semaphore Zero/Full Wait per Thread
 
 Cycles each thread spent blocked on a semaphore.
 
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | INSTRN_THREAD |
+*Counter group: INSTRN_THREAD. Computed, exported as `math_sem_wait_pct`, `pack_sem_wait_pct`.*
 
 ```
 Zero Wait TN = WAITING_FOR_NONZERO_SEM_N / INSTRN_OUT_L * 100
@@ -562,178 +413,15 @@ Full Wait TN = WAITING_FOR_NONFULL_SEM_N / INSTRN_OUT_L * 100
 
 ### TDMA Stall Metrics
 
-**15. Data Hazard Stall Rate**
-
-Fraction of math-valid cycles stalled by dest-to-src hazards (MOVD2A / MOVD2B).
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_UNPACK |
-
-```
-Data Hazard Stall = (MATH_INSTRN_AVAILABLE - DATA_HAZARD_STALLS_MOVD2A) /
-                    MATH_INSTRN_AVAILABLE * 100
-```
-
-`DATA_HAZARD_STALLS_MOVD2A` is `math_instrn_valid & ~dest2src_post_stall` — cycles math was available *and not* D2A-stalled. Subtracting from `MATH_INSTRN_AVAILABLE` gives the stall count.
-
-**Use case:** Surfaces dest-to-src register-movement overhead.
-
----
-
-**16. SrcA/SrcB Write Port Blocked**
-
-Fraction of srcA/B DMA write attempts blocked by port unavailability.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_UNPACK |
-
-```
-SrcA Port Blocked = (SRCA_WRITE_AVAILABLE - SRCA_WRITE_NOT_BLOCKED_PORT) /
-                    SRCA_WRITE_AVAILABLE * 100
-SrcB Port Blocked = (SRCB_WRITE_AVAILABLE - SRCB_WRITE_NOT_BLOCKED_PORT) /
-                    SRCB_WRITE_AVAILABLE * 100
-```
-
-**Use case:** Isolates DMA-port contention from overwrite contention.
-
----
-
-**17. SrcA/SrcB Write Overwrite Blocked**
-
-Fraction of write attempts blocked because math has not consumed the previous value.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_UNPACK |
-
-```
-SrcA Overwrite Blocked = (SRCA_WRITE_AVAILABLE - SRCA_WRITE_NOT_BLOCKED_OVR) /
-                         SRCA_WRITE_AVAILABLE * 100
-SrcB Overwrite Blocked = (SRCB_WRITE_AVAILABLE - SRCB_WRITE) /
-                         SRCB_WRITE_AVAILABLE * 100
-```
-
-- **High (>30%)**: Math is slow to consume — typical for SFPU-heavy SrcA reuse.
-
-**Use case:** Separates math-consumer bottleneck from DMA arbitration bottleneck.
-
----
-
-**18. Dest Read Backpressure**
-
-Fraction of packer dest-read requests not granted.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_PACK |
-
-```
-Dest Read BP = (PACKER_DEST_READ_AVAILABLE - DEST_READ_GRANTED_0) /
-               PACKER_DEST_READ_AVAILABLE * 100
-```
-
-**Use case:** Detects math-to-pack register handoff stalls.
-
----
-
-**19. Math Scoreboard Stall Rate**
-
-Fraction of math-available cycles stalled by FPU data-hazard scoreboard.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_PACK |
-
-```
-Math Scoreboard Stall = (MATH_INSTRN_AVAILABLE - AVAILABLE_MATH) /
-                        MATH_INSTRN_AVAILABLE * 100
-```
-
-**Use case:** Identifies FPU pipeline hazards (RAW / WAW) blocking math issue.
-
----
-
-### Instruction Availability
-
-**20. Per-type Instruction Availability**
-
-Fraction of cycles each instruction type was queued in its primary thread's buffer.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | INSTRN_THREAD |
-
-```
-TYPE Avail Rate = TYPE_INSTRN_AVAILABLE_N / INSTRN_OUT_L * 100
-```
-
-Types: CFG, SYNC, THCON, MOVE (T0), FPU/MATH (T1), UNPACK (T0), PACK (T2), XSEARCH.
-
-**Use case:** Shows which instruction types dominate the scheduling pipeline.
-
----
-
-### Write Port Analysis
-
-**21. SrcA Write Actual Efficiency**
-
-Fraction of srcA write attempts that succeeded at the DMA port.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_UNPACK |
-
-```
-SrcA Write Actual Efficiency = SRCA_WRITE / SRCA_WRITE_AVAILABLE * 100
-```
-
-- **High (100%)**: Every srcA write succeeds — no write-port blocking.
-- **Low (<80%)**: A significant fraction of srcA writes are blocked.
-
-**Use case:** Measures effective srcA write throughput; low values indicate port contention.
-
----
-
-**22. SrcB Write Actual Efficiency**
-
-Fraction of srcB write attempts that succeeded at the DMA port.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_UNPACK |
-
-```
-SrcB Write Actual Efficiency = SRCB_WRITE / SRCB_WRITE_AVAILABLE * 100
-```
-
-Mirrors metric 21 for srcB; both archs expose this independently.
-
-**Use case:** Effective srcB write throughput. Compare with srcA for asymmetric blocking.
-
----
-
-**23. Unpacker N Write Efficiency**
+#### 23. Unpacker N Write Efficiency
 
 Fraction of unpacker-busy cycles that actually completed a write.
 
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_UNPACK |
+*Counter group: TDMA_UNPACK. Computed, exported as `unpack0_write_eff_pct`, `unpack1_write_eff_pct`, `unpack_write_eff_pct`.*
 
 ```
-Unpacker0 Write Eff = SRCA_WRITE / UNPACK0_BUSY_THREAD0 * 100
-Unpacker1 Write Eff = SRCB_WRITE / UNPACK1_BUSY_THREAD0 * 100
+Unpacker0 Write Eff = SRCA_WRITE_ACTUAL / UNPACK0_BUSY_THREAD0 * 100
+Unpacker1 Write Eff = SRCB_WRITE_ACTUAL / UNPACK1_BUSY_THREAD0 * 100
 ```
 
 **Use case:** Identifies whether unpacker stalls are from port contention or overwrite blocking — compare with metrics 16 and 17.
@@ -742,95 +430,11 @@ Unpacker1 Write Eff = SRCB_WRITE / UNPACK1_BUSY_THREAD0 * 100
 
 ### L1 Memory and NoC
 
-**24. L1 Port / NoC Ring Utilisation**
-
-Per-port and per-NoC-channel utilisation.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 |
-
-```
-L1 Port Util  = L1_PORT_REQ / L1_OUT_L * 100
-NoC Ring Util = avg(NOC_RINGN_CHANNEL_0, NOC_RINGN_CHANNEL_1) / L1_OUT_L * 100
-```
-
-**Use case:** Identifies which L1 ports and NoC rings carry traffic in the measured zone. BH exposes additional rings via `l1_mux = 2..4`.
-
----
-
-**25. L1 Backpressure**
-
-Fraction of requested cycles where L1 did not grant.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 |
-
-```
-L1 BP = (REQ - GRANT) / REQ * 100
-```
-
-Computed per port and per NoC channel.
-
-**Use case:** Detects L1 port contention. Compare unpacker port BP with Thread 0 stall rate to confirm L1 is the bottleneck.
-
----
-
-### Composite
-
-**26. Stall Cause Overlap Factor per Thread**
-
-Ratio of summed per-thread stall reasons to total thread stalls.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | INSTRN_THREAD |
-
-```
-Stall Overlap TN = sum(all WAITING_FOR_*_N) / THREAD_STALLS_N
-```
-
-- **~1.0×**: Single dominant stall reason at any given cycle.
-- **>2.0×**: Multiple HW units busy simultaneously when the thread stalls.
-
-**Use case:** Tells you whether to chase a single bottleneck or a set of interacting ones.
-
----
-
-**27. Compute-to-Unpack Ratio**
-
-Whether the zone is compute-bound or memory-bound.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | FPU + TDMA_UNPACK |
-
-```
-Compute-to-Unpack = FPU_OR_SFPU_INSTRN / (UNPACK0_BUSY_THREAD0 + UNPACK1_BUSY_THREAD0) * 100
-```
-
-- **>100%**: Compute-bound.
-- **<20%**: Memory-bound (unpackers busier than math).
-
-**Use case:** Quick one-number diagnostic per zone.
-
----
-
-### Fidelity
-
-**28. Fidelity Stall Rate**
+#### 28. Fidelity Stall Rate
 
 Fraction of math-valid cycles spent in a fidelity phase (multi-HF-cycle math instruction).
 
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_UNPACK |
+*Counter group: TDMA_UNPACK. Computed, exported as `fidelity_stall_pct`.*
 
 ```
 Fidelity Stall Rate = MATH_FIDELITY_STALL / MATH_INSTRN_AVAILABLE * 100
@@ -839,412 +443,87 @@ Fidelity Stall Rate = MATH_FIDELITY_STALL / MATH_INSTRN_AVAILABLE * 100
 - **0%**: Pure LoFi (every math instruction completes in 1 HF cycle).
 - **>0%**: HiFi2 or HiFi4 active — multi-cycle math contributes to wall time.
 
-> **Known issue:** On HiFi variants this metric can exceed 100% because the formula's numerator counts every HF cycle of multi-HF instructions while the denominator counts only the issued instructions. The math is being re-calibrated; treat values >100% as "fidelity is the dominant cost" rather than a literal percentage.
+> **Known issue:** On HiFi variants this metric can exceed 100% because the formula's numerator counts every HF cycle of multi-HF instructions while the denominator counts only the issued instructions. treat values >100% as "fidelity is the dominant cost" rather than a literal percentage.
 
 **Use case:** Detects whether fidelity is contributing to the cycle budget.
 
----
-
-**29. HiFi Fraction**
-
-Fraction of issued math instructions that took more than 1 HF cycle.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_UNPACK |
-
-```
-HiFi Fraction = (MATH_INSTRN_HF_2_CYCLE + MATH_INSTRN_HF_4_CYCLE) /
-                (MATH_INSTRN_HF_1_CYCLE + MATH_INSTRN_HF_2_CYCLE + MATH_INSTRN_HF_4_CYCLE) * 100
-```
-
-**Use case:** Quick check of fidelity mix in a workload. 0% = pure LoFi, 100% = pure HiFi.
-
----
-
-**30. Avg HF Cycles Per Instrn**
-
-Weighted average of HF cycles per issued math instruction (1 for LoFi, 2 for HiFi2, 4 for HiFi4).
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_UNPACK |
-
-```
-Avg HF Cycles = (HF_1 + 2*HF_2 + 4*HF_4) / (HF_1 + HF_2 + HF_4)
-```
-
-**Use case:** Single-number summary of fidelity impact on math execution.
-
----
-
-### TDMA / Math Stall (cont.)
-
-**31. Math Dest Write Port Stall Rate**
-
-Fraction of math cycles stalled by destination register write port contention.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | TDMA_PACK |
-
-```
-Math Dest Write Port Stall = (MATH_INSTRN_AVAILABLE - MATH_NOT_STALLED_DEST_WR_PORT) /
-                             MATH_INSTRN_AVAILABLE * 100
-```
-
-- **High value (>10%)**: Math is stalled waiting for write port to destination register.
-- **Low value (~0%)**: No write port stalls.
-
-The metric is skipped when `MATH_NOT_STALLED_DEST_WR_PORT` reads 0 across the whole zone (would otherwise read a misleading 100%). Common on BH for workloads that don't drive the write-port path.
-
-**Use case:** Detects destination register write contention from the math side.
-
----
-
-### Additional Idle Waits
-
-**32. MMIO / SFPU / THCON / MOVE Idle Wait**
-
-Fraction of total cycles each thread spent waiting for specific hardware units.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | INSTRN_THREAD |
-
-```
-MMIO Idle Wait T0  = WAITING_FOR_MMIO_IDLE_0  / INSTRN_OUT_L * 100
-SFPU Idle Wait T1  = WAITING_FOR_SFPU_IDLE_1  / INSTRN_OUT_L * 100
-THCON Idle Wait T0 = WAITING_FOR_THCON_IDLE_0 / INSTRN_OUT_L * 100
-MOVE Idle Wait T0  = WAITING_FOR_MOVE_IDLE_0  / INSTRN_OUT_L * 100
-```
-
-- **High value (>5%)**: Significant time waiting on this unit. MOVE wait at ~3% for tilize is expected.
-- **Low value (~0%)**: HW unit never bottlenecks the thread. THCON and MMIO are typically ~0%.
-
-**Use case:** Absolute (not relative to total stalls) measure of time lost to each HW unit.
-
----
-
-### L1 Memory and NoC (cont.)
-
-**33. L1 TDMA Bundle Util**
-
-Average utilisation of the two TDMA/RISC L1 ports.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 (mux 0) |
-
-```
-L1 TDMA Bundle Util = avg(L1_0_TDMA_BUNDLE_0_RISC, L1_0_TDMA_BUNDLE_1_TRISC) / L1_OUT_L * 100
-```
-
-**Use case:** Measures firmware + TDMA data movement overhead through L1.
-
----
-
-**34. NoC Ring 0/1 Outgoing/Incoming Util**
-
-Average utilisation of NoC channels per ring direction.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 (Ring 0 on mux 0, Ring 1 on mux 1) |
-
-```
-NoC Ring 0 Outgoing Util = avg(L1_0_NOC_RING0_OUTGOING_0, L1_0_NOC_RING0_OUTGOING_1) / L1_OUT_L * 100
-NoC Ring 0 Incoming Util = avg(L1_0_NOC_RING0_INCOMING_0, L1_0_NOC_RING0_INCOMING_1) / L1_OUT_L * 100
-```
-
-**Use case:** Per-ring, per-direction NoC bandwidth utilisation. Compare outgoing vs incoming for data-flow direction.
-
----
-
-**35. RISC Core L1 Util**
-
-RISC core L1 memory access utilisation.
-
-| | |
-|---|---|
-| **Architectures** | Blackhole only |
-| **Counter group** | L1 (mux 1) |
-
-```
-RISC Core L1 Util = L1_1_RISC_CORE / L1_OUT_L * 100
-```
-
-- **High (>10%)**: RISC core is actively touching L1 — firmware memory overhead.
-- **Low (~0%)**: Minimal RISC L1 traffic.
-
-**Use case:** Quantifies firmware memory access overhead on BH. Requires the L1 mux-1 slot enabled.
-
----
-
-### L1 Backpressure
-
-**36. NoC Ring 0/1 Outgoing/Incoming Backpressure**
-
-Fraction of NoC transaction cycles where L1 was not ready.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 |
-
-```
-NoC Ring 0 Outgoing BP = (req0 + req1 - grant0 - grant1) / (req0 + req1) * 100
-```
-
-- **High (>15%)**: NoC is stalled by L1 contention.
-- **Low (<5%)**: NoC traffic flows freely.
-
-**Use case:** High outgoing BP means produced data can't leave the core fast enough.
-
----
-
-**37. L1 Unpacker / Packer Port Backpressure**
-
-L1 port contention for unpacker and packer.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 (mux 0) |
-
-```
-L1 Unpacker BP   = (L1_0_UNPACKER_0 - L1_0_UNPACKER_0_GRANT) / L1_0_UNPACKER_0 * 100
-L1 Packer Port BP = (L1_0_PORT1     - L1_0_PORT1_GRANT)      / L1_0_PORT1 * 100
-```
-
-- **Unpacker BP high (>80%)**: L1 is busy when unpacker wants in — common (other ports compete).
-- **Packer Port BP low (<5%)**: Normal.
-
-**Blackhole note:** Unpacker grant counter can exceed request on some cores (signal-semantics difference); the metric is suppressed rather than reported as a meaningless negative.
-
-**Use case:** Investigate only when combined with high Thread 0 stall rate.
-
----
-
-### L1 Composite
-
-**38. L1 Total Bandwidth Util**
-
-Overall L1 bandwidth saturation across all 8 mux-0 ports.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 (mux 0) |
-
-```
-L1 Total BW Util = sum(all 8 port req counts) / (8 * L1_OUT_L) * 100
-```
-
-- **High (>30%)**: L1 heavily utilised — possible bottleneck.
-- **Medium (10-20%)**: Moderate.
-- **Low (<5%)**: Underutilised.
-
-**Use case:** Single-number L1 saturation indicator.
-
----
-
-**39. L1 Read vs Write Ratio**
-
-Balance between read and write traffic on L1.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 (mux 0) |
-
-```
-L1 R/W Ratio = (Unpacker + NoC_Out) / (Unpacker + NoC_Out + Packer + NoC_In) * 100
-```
-
-Read ports: unpacker, NoC outgoing. Write ports: packer, NoC incoming.
-
-- **~50%**: Balanced (matmul).
-- **>70%**: Read-heavy.
-- **<30%**: Write-heavy.
-
-**Use case:** Diagnoses the dominant L1 data-flow direction.
-
----
-
-**40. NoC Ring Asymmetry**
-
-Balance between outgoing and incoming NoC traffic.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 (mux 0) |
-
-```
-NoC Asymmetry = NoC_Outgoing / (NoC_Outgoing + NoC_Incoming) * 100
-```
-
-- **~50%**: Balanced send/receive.
-- **>70%**: Send-heavy.
-- **<30%**: Receive-heavy.
-
-**Use case:** Surfaces directional NoC imbalance pointing to data-placement issues.
-
----
-
-**41. L1 Contention Index**
-
-Average backpressure across active L1 ports.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 (mux 0) |
-
-```
-L1 Contention Index = avg(BP of Unpacker, NoC Out 0, NoC Out 1, NoC In 0, NoC In 1)
-```
-
-- **High (>40%)**: Significant L1 stress.
-- **Medium (15-30%)**: Moderate.
-- **Low (<10%)**: Minimal.
-
-**Use case:** Single-number L1 stress level — easier to compare across zones than individual port BPs.
-
----
-
-**42. Unpacker L1 Efficiency**
-
-When the unpacker is busy, how often does L1 actually serve it.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 (mux 0) + TDMA_UNPACK |
-
-```
-Unpacker L1 Efficiency = L1_0_UNPACKER_0_GRANT / UNPACK0_BUSY_THREAD0 * 100
-```
-
-- **High (>50%)**: L1 serves unpacker requests efficiently.
-- **Low (<5%)**: L1 is the data-delivery bottleneck.
-
-**Use case:** Low values combined with high unpacker BP confirm L1 is starving the unpacker.
-
----
-
-**43. Packer L1 Efficiency**
-
-When the packer is busy, how often does L1 serve it.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 (mux 0) + TDMA_PACK |
-
-```
-Packer L1 Efficiency = L1_0_PORT1_GRANT / PACKER_BUSY * 100
-```
-
-- **High (>100%)**: L1 port has headroom (shared with ECC/other clients).
-- **Low (<50%)**: Packer is L1-starved.
-
-**Use case:** Confirms whether L1 write-back is the limiting factor for pack.
-
----
-
-**44. NoC vs Compute Balance**
-
-Whether the operation is NoC-bound or compute-bound.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 (mux 0) + FPU |
-
-```
-NoC vs Compute = (NoC_Out + NoC_In) / (FPU_COUNTER + NoC_Out + NoC_In) * 100
-```
-
-- **>60%**: NoC-bound.
-- **~50%**: Balanced.
-- **<40%**: Compute-bound (FPU/SFPU is the bottleneck).
-
-**Use case:** Quick optimisation-target picker (compute kernels vs NoC routing).
-
----
-
-**45. TDMA vs NoC L1 Share**
-
-Fraction of L1 bandwidth used by RISC/TDMA versus NoC.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole, Blackhole |
-| **Counter group** | L1 (mux 0) |
-
-```
-TDMA vs NoC = (TDMA_Bundle_0 + TDMA_Bundle_1) / (TDMA + NoC_Out + NoC_In) * 100
-```
-
-- **High (>20%)**: Firmware uses significant L1 bandwidth.
-- **Low (<5%)**: NoC dominates L1 traffic.
-
-**Use case:** Spots firmware L1 overhead worth optimising.
-
----
-
-### Wormhole-only (per-engine packer)
-
-**46. Packer Load Imbalance**
-
-Spread between the most and least utilised packer engines.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole only (`PACK_COUNT=4`) |
-| **Counter group** | TDMA_PACK |
-
-```
-Packer Load Imbalance = (max(BUSY_0..3) - min(BUSY_0..3)) / max(BUSY_0..3) * 100
-```
-
-- **Low (<10%)**: Even distribution across engines.
-- **High (>25%)**: Some engines idle while others saturate — suboptimal tile packing.
-
-**Use case:** WH only — per-engine busy signals are tied to 0 in BH RTL (`PACK_COUNT=1`).
-
----
-
-**47. Packer Engine N Util**
-
-Per-engine packer utilisation.
-
-| | |
-|---|---|
-| **Architectures** | Wormhole only |
-| **Counter group** | TDMA_PACK |
-
-```
-Packer Engine N Util = PACKER_BUSY_N / TDMA_PACK_OUT_L * 100
-```
-
-**Use case:** WH only. On BH the per-engine `PACKER_BUSY_N` signals are tied off; only the aggregate `PACKER_BUSY` is exposed.
-
----
+### Upstream formulas, not computed here
+
+These come from the upstream report and nothing in tt-llk evaluates them. The counters are in the
+per-zone CSV, so they can be worked out by hand. Counter names are as they appear in
+`hw_counters.h`; anything missing on an arch reads as 0 rather than erroring.
+
+| # | Metric | Counter group | Formula | Arch |
+|---|---|---|---|---|
+| 2 | SFPU Utilisation | FPU | `SFPU Util = SFPU_COUNTER / FPU_OUT_L * 100` | both |
+| 5 | Math Pipeline Utilisation | TDMA_UNPACK | `Math Pipeline Utilisation = MATH_INSTRN_STARTED / MATH_INSTRN_AVAILABLE * 100` | both |
+| 6 | FPU Execution Efficiency | FPU + INSTRN_THREAD | `FPU Execution Efficiency = FPU_COUNTER / FPU_INSTRN_AVAILABLE_1 * 100` | both |
+| 7 | Math-to-Pack Handoff Ratio | TDMA_PACK | `Math-to-Pack Handoff = AVAILABLE_MATH / PACKER_BUSY * 100` | both |
+| 10 | Thread N Issue Rate | INSTRN_THREAD | `TN Issue Rate = THREAD_INSTRUCTIONS_N / INSTRN_OUT_L` | both |
+| 11 | SrcA/SrcB Valid Wait | INSTRN_THREAD | `SrcA Valid Wait = WAITING_FOR_SRCA_VALID / INSTRN_OUT_L * 100 SrcB Valid Wait = WAITING_FOR_SRCB_VALID / INSTRN_OUT_L * 100` | both |
+| 12 | SrcA/SrcB Clear Wait | INSTRN_THREAD | `SrcA Clear Wait = WAITING_FOR_SRCA_CLEAR / INSTRN_OUT_L * 100 SrcB Clear Wait = WAITING_FOR_SRCB_CLEAR / INSTRN_OUT_L * 100` | both |
+| 13 | Math / Pack / Unpack Idle Wait | INSTRN_THREAD | `Math Idle Wait T1 = WAITING_FOR_MATH_IDLE_1 / INSTRN_OUT_L * 100 Pack Idle Wait T2 = WAITING_FOR_PACK_IDLE_2 / INSTRN_OUT_L * 100 Unpack Idle Wait T0 = WAITING_FOR_UNPACK_IDLE_0 / INSTRN_OUT_L * 100` | both |
+| 15 | Data Hazard Stall Rate | TDMA_UNPACK | `Data Hazard Stall = (MATH_INSTRN_AVAILABLE - DATA_HAZARD_STALLS_MOVD2A) / MATH_INSTRN_AVAILABLE * 100` | both |
+| 16 | SrcA/SrcB Write Port Blocked | TDMA_UNPACK | `SrcA Port Blocked = (SRCA_WRITE_AVAILABLE - SRCB_WRITE_NOT_BLOCKED_PORT) / SRCA_WRITE_AVAILABLE * 100 SrcB Port Blocked = (SRCB_WRITE_AVAILABLE - SRCB_WRITE_NOT_BLOCKED_PORT) / SRCB_WRITE_AVAILABLE * 100` | both |
+| 17 | SrcA/SrcB Write Overwrite Blocked | TDMA_UNPACK | `SrcA Overwrite Blocked = (SRCA_WRITE_AVAILABLE - SRCA_WRITE_NOT_BLOCKED_OVR) / SRCA_WRITE_AVAILABLE * 100 SrcB Overwrite Blocked = (SRCB_WRITE_AVAILABLE - SRCB_WRITE_ACTUAL) / SRCB_WRITE_AVAILABLE * 100` | both |
+| 18 | Dest Read Backpressure | TDMA_PACK | `Dest Read BP = (PACKER_DEST_READ_AVAILABLE - DEST_READ_GRANTED_0) / PACKER_DEST_READ_AVAILABLE * 100` | both |
+| 19 | Math Scoreboard Stall Rate | TDMA_PACK | `Math Scoreboard Stall = (MATH_INSTRN_AVAILABLE - AVAILABLE_MATH) / MATH_INSTRN_AVAILABLE * 100` | both |
+| 20 | Per-type Instruction Availability | INSTRN_THREAD | `TYPE Avail Rate = TYPE_INSTRN_AVAILABLE_N / INSTRN_OUT_L * 100` | both |
+| 21 | SrcA Write Actual Efficiency | TDMA_UNPACK | `SrcA Write Actual Efficiency = SRCA_WRITE_ACTUAL / SRCA_WRITE_AVAILABLE * 100` | both |
+| 22 | SrcB Write Actual Efficiency | TDMA_UNPACK | `SrcB Write Actual Efficiency = SRCB_WRITE_ACTUAL / SRCB_WRITE_AVAILABLE * 100` | both |
+| 24 | L1 Port / NoC Ring Utilisation | L1 | `L1 Port Util = L1_PORT_REQ / L1_OUT_L * 100 NoC Ring Util = avg(NOC_RINGN_CHANNEL_0, NOC_RINGN_CHANNEL_1) / L1_OUT_L * 100` | both |
+| 25 | L1 Backpressure | L1 | `L1 BP = (REQ - GRANT) / REQ * 100` | both |
+| 26 | Stall Cause Overlap Factor per Thread | INSTRN_THREAD | `Stall Overlap TN = sum(all WAITING_FOR_*_N) / THREAD_STALLS_N` | both |
+| 27 | Compute-to-Unpack Ratio | FPU + TDMA_UNPACK | `Compute-to-Unpack = MATH_COUNTER / (UNPACK0_BUSY_THREAD0 + UNPACK1_BUSY_THREAD0) * 100` | both |
+| 29 | HiFi Fraction | TDMA_UNPACK | `HiFi Fraction = (MATH_INSTRN_HF_2_CYCLE + MATH_INSTRN_HF_4_CYCLE) / (MATH_INSTRN_HF_1_CYCLE + MATH_INSTRN_HF_2_CYCLE + MATH_INSTRN_HF_4_CYCLE) * 100` | both |
+| 30 | Avg HF Cycles Per Instrn | TDMA_UNPACK | `Avg HF Cycles = (HF_1 + 2*HF_2 + 4*HF_4) / (HF_1 + HF_2 + HF_4)` | both |
+| 31 | Math Dest Write Port Stall Rate | TDMA_PACK | `Math Dest Write Port Stall = (MATH_INSTRN_AVAILABLE - MATH_NOT_STALLED_DEST_WR_PORT) / MATH_INSTRN_AVAILABLE * 100` | both |
+| 32 | MMIO / SFPU / THCON / MOVE Idle Wait | INSTRN_THREAD | `MMIO Idle Wait T0 = WAITING_FOR_MMIO_IDLE_0 / INSTRN_OUT_L * 100 SFPU Idle Wait T1 = WAITING_FOR_SFPU_IDLE_1 / INSTRN_OUT_L * 100 THCON Idle Wait T0 = WAITING_FOR_THCON_IDLE_0 / INSTRN_OUT_L * 100 MOVE Idle Wait T0 = WAITING_FOR_MOVE_IDLE_0 / INSTRN_OUT_L * 100` | both |
+| 33 | L1 TDMA Bundle Util | L1 (mux 0) | `L1 TDMA Bundle Util = avg(L1_0_TDMA_BUNDLE_0_RISC, L1_0_TDMA_BUNDLE_1_TRISC) / L1_OUT_L * 100` | both |
+| 34 | NoC Ring 0/1 Outgoing/Incoming Util | L1 (Ring 0 on mux 0, Ring 1 on mux 1) | `NoC Ring 0 Outgoing Util = avg(L1_0_NOC_RING0_OUTGOING_0, L1_0_NOC_RING0_OUTGOING_1) / L1_OUT_L * 100 NoC Ring 0 Incoming Util = avg(L1_0_NOC_RING0_INCOMING_0, L1_0_NOC_RING0_INCOMING_1) / L1_OUT_L * 100` | both |
+| 35 | RISC Core L1 Util | L1 (mux 1) | `RISC Core L1 Util = L1_1_RISC_CORE / L1_OUT_L * 100` | Blackhole only |
+| 36 | NoC Ring 0/1 Outgoing/Incoming Backpressure | L1 | `NoC Ring 0 Outgoing BP = (req0 + req1 - grant0 - grant1) / (req0 + req1) * 100` | both |
+| 37 | L1 Unpacker / Packer Port Backpressure | L1 (mux 0) | `L1 Unpacker BP = (L1_0_UNPACKER_0 - L1_0_UNPACKER_0_GRANT) / L1_0_UNPACKER_0 * 100 L1 Packer Port BP = (L1_0_PORT1 - L1_0_PORT1_GRANT) / L1_0_PORT1 * 100` | both |
+| 38 | L1 Total Bandwidth Util | L1 (mux 0) | `L1 Total BW Util = sum(all 8 port req counts) / (8 * L1_OUT_L) * 100` | both |
+| 39 | L1 Read vs Write Ratio | L1 (mux 0) | `L1 R/W Ratio = (Unpacker + NoC_Out) / (Unpacker + NoC_Out + Packer + NoC_In) * 100` | both |
+| 40 | NoC Ring Asymmetry | L1 (mux 0) | `NoC Asymmetry = NoC_Outgoing / (NoC_Outgoing + NoC_Incoming) * 100` | both |
+| 41 | L1 Contention Index | L1 (mux 0) | `L1 Contention Index = avg(BP of Unpacker, NoC Out 0, NoC Out 1, NoC In 0, NoC In 1)` | both |
+| 42 | Unpacker L1 Efficiency | L1 (mux 0) + TDMA_UNPACK | `Unpacker L1 Efficiency = L1_0_UNPACKER_0_GRANT / UNPACK0_BUSY_THREAD0 * 100` | both |
+| 43 | Packer L1 Efficiency | L1 (mux 0) + TDMA_PACK | `Packer L1 Efficiency = L1_0_PORT1_GRANT / PACKER_BUSY * 100` | both |
+| 44 | NoC vs Compute Balance | L1 (mux 0) + FPU | `NoC vs Compute = (NoC_Out + NoC_In) / (FPU_COUNTER + NoC_Out + NoC_In) * 100` | both |
+| 45 | TDMA vs NoC L1 Share | L1 (mux 0) | `TDMA vs NoC = (TDMA_Bundle_0 + TDMA_Bundle_1) / (TDMA + NoC_Out + NoC_In) * 100` | both |
+| 46 | Packer Load Imbalance | TDMA_PACK | `Packer Load Imbalance = (max(BUSY_0..2) - min(BUSY_0..2)) / max(BUSY_0..2) * 100` | Wormhole only (`PACK_COUNT=4`) |
+| 47 | Packer Engine N Util | TDMA_PACK | `Packer Engine N Util = PACKER_BUSY_N / TDMA_PACK_OUT_L * 100` | Wormhole only |
 
 ## Notes and Caveats
 
-- **NC vs WC are mutually exclusive.** A given pytest invocation produces one build, so wall-clock and counter data come from separate runs. Merge them off-line by `(test_variant, zone)`.
-- **The arm/freeze split shifts zone boundaries slightly.** For `L1_TO_L1` and `L1_CONGESTION`, the measurement window opens when unpack arms (before unpack issues its first instruction inside the scope) and closes when pack freezes (after pack issues its last). Counter values from these run types are not directly comparable to a hypothetical "all three threads start and stop simultaneously" baseline.
+- **Four tests sit on a bistable L1 operating point.** `matmul`, `math_matmul`, `pack_dest_bank` and
+  `pack_untilize` each land on one of two discrete levels, chosen deterministically per binary and re-rolled
+  by any change to code layout. Worst observed spread is about 31 percent on `pack_dest_bank`. This is build
+  sensitivity, not counter cost: the same two levels appear when one no-counter build is compared against
+  another that differs only in layout. If you see a large outlier on those four, check which level both
+  sides landed on before treating it as a regression. Tracked in #51901, #51902 and #51904.
+
+- **Never guard `PERF_RUN_TYPE` with `#ifndef`.** It arrives as a `constexpr` in the generated `build.h`, so a preprocessor guard cannot see it, always fires, and silently compiles every run type as the fallback. Identical values and identical `TEXT_SIZE` across run types is the symptom (PR #51918).
+- **`L1_CONGESTION` is not free-running everywhere yet.** `eltwise_binary_sfpu`, `eltwise_unary_sfpu`, `eltwise_unary_typecast`, `sfpu_binop_scalar` and `sfpu_ternary` still run its pack path on the math handshake, so they measure the handshake rather than L1 contention.
+- **`PACK_DONE` is reserved by the barrier.** It is safe only because the count returns to zero each time, so a measured kernel must not use `semaphore::PACK_DONE` for its own handshake.
+- **The host asserts zones do not overlap across threads.** No thread may open `TILE_LOOP` before every thread has closed `INIT`. A failure almost always means a kernel used `ZONE_SCOPED` instead of `START_PERF_MEASURE`, which is what supplies the entry rendezvous. Skipped on Quasar.
+- **Both builds write the same report path.** `perf_data/<module>/<module>.csv` is written by whichever invocation ran last, so move the first report aside before running the second build; there is no cross-build merge in code.
+- **`--dump-csv-counters` is broken until #52439 lands.** `conftest.py` references a non-existent `TestConfig.MODE` in the counter-report teardown, so the flag raises `AttributeError` and never writes a counters CSV.
+- **`--logging-level DEBUG` or `TRACE` recompiles the measured kernel** with `-DDEBUG_PRINT_ENABLED`, which perturbs the numbers. Do not use it for a measurement run.
+- **`no zone returned counter data` means the test was never measured.** The counter and metric columns will be absent; a with-counters versus no-counters comparison for that test is meaningless, not zero.
+- **Instrumenting a kernel moves its no-counter baseline.** The rendezvous is real in both builds, so converting a kernel from `ZONE_SCOPED` to `START_PERF_MEASURE` shifts its timings; numbers from before and after are not comparable.
+- **`PROFILER_SYNC()` is per-kernel and not universal.** `fast_tilize_bh_test.cpp` omits it entirely and no `UNINIT` zone has one, so those windows close without draining the backend.
+
+- **A pytest invocation compiles one build.** `--enable-perf-counters` selects WC, otherwise NC — a single invocation cannot produce both. The WC build records wall-clock (`ZONE_SCOPED`) *alongside* the counters, so it is self-contained; the NC build is run separately only when a counter-overhead-free timing baseline is wanted. Results merge off-line by `(test_variant, zone)`.
+- **The window is `[all threads armed … all threads finished]`.** The rendezvous arms after every thread has entered, and freezes after every thread has finished for the run types that keep the exit barrier. Each thread stamps the release with its own wall-clock read, and those reads serialize on the single shared clock, so the per-thread zone starts differ by ~12–40 cyc (irreducible; not a bug).
 - **`PERF_COUNTERS_MAX_ZONES = 8` per kernel.** Adding a 9th distinct `MEASURE_PERF_COUNTERS("...")` name silently reuses zone 0. Reuse the same name across multiple call sites if you want them in the same bucket.
-- **L1 mux mutual exclusion is handled inside `MEASURE_PERF_COUNTERS`.** The freeze path re-programs `PERF_CNT_MUX_CTRL` before each L1 slot read, so a single zone snapshot contains counters from multiple mux positions without per-zone configuration changes.
+- **One L1 mux group per run.** `PERF_CNT_MUX_CTRL` selects the group while the counters count, not when they are read, so the freeze path cannot re-aim it and a run observes exactly one group. Select it with `LLK_PERF_L1_MUX_GROUP` and sweep it across runs.
 - **BRISC compile flag.** When `--enable-perf-counters` is set, BRISC is rebuilt with `-DPERF_COUNTERS_COMPILED`. Otherwise BRISC does not touch the counter HW at all — this keeps the NC build free of any counter-armed monitoring overhead.
 - **Test isolation.** As with every LLK test, counter state at kernel entry is whatever the previous test left behind. The BRISC reset path clears the shared config and zone buffers, so each test starts from a known L1 state, but HW counter registers themselves may carry residual values until the first `MEASURE_PERF_COUNTERS` rising-edge clear.
+- **NC/WC bit-identity is fragile.** The goal is that the WC counter code doesn't perturb the measured timing, which requires WC codegen to match NC outside the counter parts. `get_counter_base_addr` uses a `volatile` index cast specifically to stop GCC from emitting a `CSWTCH` jump table (it would shift GP-relative offsets and break that bit-identity), and `freeze_and_read_all_counters` uses `#pragma GCC unroll 0`. Measured counters are sensitive to BRISC boot *timing* at the ~0.1 % level, so avoid reshaping the BRISC boot path (e.g. the config scan) even when it looks logically equivalent.
+- **The BRISC boot arm is redundant but retained.** The RTL (see `tech_reports/PerfCounters/perf-counters.md`) confirms a rising-edge start both *clears* and starts the counters, so the per-zone `arm_all_counters` fully resets them from any prior state — the boot-time `arm_hardware()` measures a window nobody reads. It is kept only because removing it changes boot timing (see previous point). The essential BRISC work is `configure_hardware` (period/mode) + the `DBG_FEATURE_DISABLE` scrub.
+- **L1 layout must stay below the profiler region.** `PERF_COUNTERS_LAYOUT_END` must not overlap the profiler's lowest L1 address (`llk_profiler::EPOCH_ADDR`). Two `static_assert`s enforce this — a literal one in the always-compiled section (BRISC has no `llk_profiler` namespace) and a symbolic one in the `LLK_PROFILER` section that tracks the profiler layout automatically.
+- **Minimum window size.** Size every measured window above ~1k cycles using the test's `LOOP_FACTOR`; PR #51912 raised the suite's factors for exactly this reason. Below that, a few cycles of instrument floor read as a large percentage, and the timing `mean` is affected as well as the derived ratios. Note the report divides `TILE_LOOP` wall-clock by `loop_factor x tile_cnt` but leaves `INIT` and every counter column absolute.
+
+- **The single-inventory source couples the perf build to two metal headers.** `counters.h` `#include`s `perf_counters.hpp` (`PerfCounterType` enum, reached via `-I…/tools/profiler`) and the arch `hw_counters.h`; the host `counters.py` parses the same `hw_counters.h` at import. This removes the hand-duplicated inventory, at the cost that if those headers move or the enum/array shape changes, the LLK perf build and decoder must follow. The config-word bit layout (`PERF_CFG_*`) and bank-id↔name mapping are still mirrored between `counters.h` and `counters.py` — they are this infra's own L1 ABI, not part of `hw_counters.h`.

--- a/tt_metal/tt-llk/docs/performance_counters/performance_counters.md
+++ b/tt_metal/tt-llk/docs/performance_counters/performance_counters.md
@@ -60,15 +60,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
 }
 ```
 
-Each zone is registered once at its first encounter (the counter half is RAII-scoped and assigns a stable zone id by hashing the name), so placing `START_PERF_MEASURE` **outside** the loop is preferred — counter start is not a no-op and would dominate per-iteration cost if done on every tile.
+Each zone is registered once at its first encounter (the counter half is RAII-scoped and assigns a stable zone id by hashing the name), so placing `START_PERF_MEASURE` **outside** the loop is preferred: counter start is not a no-op and would dominate per-iteration cost if done on every tile.
 
 ### `PerfRunType` and the single-thread arm/freeze model
 
-Each LLK perf test is associated with a `PerfRunType` (declared in `perf.h`): `L1_TO_L1` runs the full handshaked unpack → math → pack pipeline. `L1_CONGESTION` keeps unpack and pack real but decouples them — math is reduced to a dvalid drain and pack free-runs — so the two hammer L1 concurrently instead of forming a pipeline; `UNPACK_ISOLATE` / `MATH_ISOLATE` / `PACK_ISOLATE` exercise a single stage. The run type selects which threads do real work, whether they are handshaked or free-running, and whether the exit rendezvous exists. The other threads are not idle: they run the minimum dvalid and semaphore mocks in `perf.h` that the measured stage's hardware handshake requires.
+Each LLK perf test is associated with a `PerfRunType` (declared in `perf.h`): `L1_TO_L1` runs the full handshaked unpack → math → pack pipeline. `L1_CONGESTION` keeps unpack and pack real but decouples them (math is reduced to a dvalid drain and pack free-runs), so the two hammer L1 concurrently instead of forming a pipeline; `UNPACK_ISOLATE` / `MATH_ISOLATE` / `PACK_ISOLATE` exercise a single stage. The run type selects which threads do real work, whether they are handshaked or free-running, and whether the exit rendezvous exists. The other threads are not idle: they run the minimum dvalid and semaphore mocks in `perf.h` that the measured stage's hardware handshake requires.
 
 **Pack arms the counters for every run type.** `llk_barrier::is_action_thread()` in `barrier.h` returns true only on pack. Freezing is not uniform: see the table below. Arming can be fixed to one thread because:
 
-- The perf counters are **global hardware** driven by shared debug registers (`PERF_CNT_ALL` and the per-bank `*2` command registers), so any RISC can arm/freeze them — the identity of the issuing thread does not change what is counted.
+- The perf counters are **global hardware** driven by shared debug registers (`PERF_CNT_ALL` and the per-bank `*2` command registers), so any RISC can arm/freeze them. The identity of the issuing thread does not change what is counted.
 - The entry rendezvous waits for every thread before arming, so the window opens after all of them have finished the previous zone.
 
 Pack is chosen because a sweep found arming there halves the total `L1_CONGESTION` error against arming on TRISC0. Fixing it also matters for its own sake: letting the arming thread vary is how the two builds ended up releasing from different threads.
@@ -87,13 +87,13 @@ So for `MATH_ISOLATE` the freeze is done by math, with no barrier at all. Note t
 
 Expands to a `perf_counter_scoped<PERF_RUN_TYPE>` RAII object; the run type is a template parameter because it selects the exit shape above. Its constructor and destructor execute the following sequence (only on the WC build):
 
-1. **Constructor (zone entry).** Calls `llk_barrier::rendezvous(llk_barrier::is_action_thread(), arm_all_counters)`. All three threads rendezvous; the **action thread (pack)** then writes the rising-edge start bit to `PERF_CNT_ALL` (FPU + INSTRN), `PERF_CNT_TDMA_UNPACK2`, `PERF_CNT_L1_2`, and `PERF_CNT_TDMA_PACK2` — clearing all banks and starting the count — and releases the others.
+1. **Constructor (zone entry).** Calls `llk_barrier::rendezvous(llk_barrier::is_action_thread(), arm_all_counters)`. All three threads rendezvous; the **action thread (pack)** then writes the rising-edge start bit to `PERF_CNT_ALL` (FPU + INSTRN), `PERF_CNT_TDMA_UNPACK2`, `PERF_CNT_L1_2`, and `PERF_CNT_TDMA_PACK2`, which clears all banks and starts the count, and releases the others.
 
 2. **Body.** All three threads run the work inside the scope. Counters tick continuously on the shared backend.
 
 3. **Destructor (zone exit).** For the run types that keep the exit rendezvous, calls `llk_barrier::rendezvous(llk_barrier::is_action_thread(), freeze_and_read_all_counters)`; otherwise the measured thread freezes directly. Note `PROFILER_SYNC()` (`tensix_sync`) is a hand-written statement in each kernel and the isolate and congestion paths can `return` past it, so a thread's backend is not guaranteed drained when the stop bit is written; `fence_compiler()` around the rendezvous is a compiler barrier only. The **action thread (pack)** writes the rising-edge stop bit to the same four registers, then walks the shared 200-word config buffer at `0x169000` and reads every valid slot: for each it programs the bank's mode register with the `counter_sel`, reads `OUT_H` (the event count), and stores it in the per-zone data area (`OUT_L` is read once from the INSTRN_THREAD bank and copied into all five per-bank cycle words, so those five words always hold the same value). It then sets the zone's `SYNC_ZONE_COMPLETE` flag and releases the others.
 
-Each zone gets its own data block in L1 (see [L1 Layout](#l1-layout-and-zone-buffers)) so multiple measurement scopes in the same kernel produce independent snapshots. The device supports `PERF_COUNTERS_MAX_ZONES = 8` zones, but the host names only two — `perf.py` hard-codes zone 0 as `INIT` and zone 1 as `TILE_LOOP`, so a third counter zone appears in the CSV as the literal `ZONE_2` and never joins the wall-clock rows. Zone names in use are `INIT`, `TILE_LOOP`, and `UNINIT` in `fast_tilize_bh` / `fast_untilize` only; `UNINIT` uses bare `ZONE_SCOPED`, so it is timing-only with no rendezvous; identical names share a zone.
+Each zone gets its own data block in L1 (see [L1 Layout](#l1-layout-and-zone-buffers)) so multiple measurement scopes in the same kernel produce independent snapshots. The device supports `PERF_COUNTERS_MAX_ZONES = 8` zones, but the host names only two: `perf.py` hard-codes zone 0 as `INIT` and zone 1 as `TILE_LOOP`, so a third counter zone appears in the CSV as the literal `ZONE_2` and never joins the wall-clock rows. Zone names in use are `INIT`, `TILE_LOOP`, and `UNINIT` in `fast_tilize_bh` / `fast_untilize` only; `UNINIT` uses bare `ZONE_SCOPED`, so it is timing-only with no rendezvous; identical names share a zone.
 
 #### The `llk_barrier::rendezvous` barrier
 
@@ -107,23 +107,23 @@ The semaphore is used rather than L1 because its release is symmetric, detection
 
 Before any TRISC kernel runs, BRISC executes `configure_and_arm_from_brisc()` once (called from `brisc.cpp` when the WC build flag is set). This:
 
-- Writes the per-architecture `BUILTIN_COUNTER_CONFIG` (114 slots on WH, 105 on BH, since only one L1 mux group is emitted) into the shared L1 config buffer at `0x169000`. That array is built at compile time from the canonical metal inventory — see [Counter inventory single source](#counter-inventory-single-source).
+- Writes the per-architecture `BUILTIN_COUNTER_CONFIG` (114 slots on WH, 105 on BH, since only one L1 mux group is emitted) into the shared L1 config buffer at `0x169000`. That array is built at compile time from the canonical metal inventory, see [Counter inventory single source](#counter-inventory-single-source).
 - Clears every per-zone data area and sync word.
-- Clears `DBG_FEATURE_DISABLE` to `0` — see [DBG_FEATURE_DISABLE scrub](#dbg_feature_disable-scrub) below.
+- Clears `DBG_FEATURE_DISABLE` to `0`, see [DBG_FEATURE_DISABLE scrub](#dbg_feature_disable-scrub) below.
 - Programs each bank's reference-period and mode registers, sets `PERF_CNT_MUX_CTRL` for L1, and does an initial global arm (later overridden by the first `MEASURE_PERF_COUNTERS` zone).
 
 After BRISC releases the TRISCs, the shared config is read-only for the rest of the run.
 
 ##### `DBG_FEATURE_DISABLE` scrub
 
-`DBG_FEATURE_DISABLE` is a 16-bit debug/chicken-bit register whose bits toggle low-level behaviors — notably randomized L1 arbitration (bit 3; the name is from the RTL and is not a symbol in this tree), L1 atomic serialization, and L1 read-enable override. It resets to `0` (all normal), but HW register state **leaks between tests** run back-to-back on an un-reset device, so a prior test that set one of these bits would silently perturb — and make nondeterministic — the L1 counters (16 per run, since one mux group is captured). BRISC writes `0` here to guarantee a clean baseline regardless of leaked state; the blanket write (rather than clearing one bit) is deliberate because any of the bits, not just LFSR, would skew the measurement. Verified: with a leaked `0x8` present, the L1 metrics jitter 40–98 % run-to-run without this scrub and are byte-identical with it. Note this scrub is WC-only (it lives in the counter path); the NC path has no equivalent.
+`DBG_FEATURE_DISABLE` is a 16-bit debug/chicken-bit register whose bits toggle low-level behaviors, notably randomized L1 arbitration (bit 3; the name is from the RTL and is not a symbol in this tree), L1 atomic serialization, and L1 read-enable override. It resets to `0` (all normal), but HW register state **leaks between tests** run back-to-back on an un-reset device, so a prior test that set one of these bits would silently perturb, and make nondeterministic, the L1 counters (16 per run, since one mux group is captured). BRISC writes `0` here to guarantee a clean baseline regardless of leaked state; the blanket write (rather than clearing one bit) is deliberate because any of the bits, not just LFSR, would skew the measurement. Verified: with a leaked `0x8` present, the L1 metrics jitter 40–98 % run-to-run without this scrub and are byte-identical with it. Note this scrub is WC-only (it lives in the counter path); the NC path has no equivalent.
 
 ### Reading results from host
 
 After the kernel completes:
 
 1. The host process reads the per-zone data area back from device L1.
-2. `read_counters()` decodes each 32-bit config word (bit 31 valid, bits 7:0 bank, bits 16:8 `counter_sel`, bits 19:17 `l1_mux`), looks up the human-readable counter name (parsed at import from the same `hw_counters.h` — see [Counter inventory single source](#counter-inventory-single-source)), and pairs every event count with that zone's bank cycle count.
+2. `read_counters()` decodes each 32-bit config word (bit 31 valid, bits 7:0 bank, bits 16:8 `counter_sel`, bits 19:17 `l1_mux`), looks up the human-readable counter name (parsed at import from the same `hw_counters.h`, see [Counter inventory single source](#counter-inventory-single-source)), and pairs every event count with that zone's bank cycle count.
 3. `read_counters()` returns an in-memory long-format DataFrame with columns `zone`, `bank`, `counter_name`, `counter_id`, `cycles`, `count`, `l1_mux`. `compute_metrics()` produces its own separate rows; it does not add columns to that frame. Host-side only zone 0 and zone 1 are named (hard-coded to `INIT` and `TILE_LOOP`); further zones stay `ZONE_n` and never join the wall-clock rows.
 
 Because both wall-clock cycles (NC build, `ZONE_SCOPED` start/end timestamps from `RISCV_DEBUG_REG_WALL_CLOCK_L`) and HW counter cycles (WC build, `OUT_L`) are tagged with the same zone name, the test driver merges them by `(test_variant, zone)`.
@@ -137,10 +137,10 @@ The LLK test suite uses a two-phase pytest flow: a compile-producer phase that b
 cd tt_metal/tt-llk/tests     # LLK_HOME is defaulted by conftest.py; you do not need to set it
 export CHIP_ARCH=blackhole   # or wormhole; counters are not compiled on quasar
 
-# Phase 1 — build all variants (no HW access)
+# Phase 1: build all variants (no HW access)
 pytest --compile-producer --enable-perf-counters -n 8 -x ./python_tests/perf_eltwise_binary.py
 
-# Phase 2 — run on HW
+# Phase 2: run on HW
 pytest --compile-consumer --enable-perf-counters -x ./python_tests/perf_eltwise_binary.py
 ```
 
@@ -152,7 +152,7 @@ To capture a different L1 mux group, `export LLK_PERF_L1_MUX_GROUP=<0-4>` before
 The `--enable-perf-counters` flag triggers two things:
 
 1. Test sources are compiled with `-DPERF_COUNTERS_COMPILED` (the WC build). BRISC is compiled with the same flag so it runs `configure_and_arm_from_brisc()` once at startup.
-2. The Python driver calls `read_counters()` after every run, writes the derived percentage metrics into the main CSV, and writes raw counts only to `*.counters.csv` under `--dump-csv-counters`.
+2. The Python driver calls `read_counters()` after every run, writes the derived percentage metrics into the main CSV, and writes raw counts only to `*.counters.csv` under `--dump-perf-counters`.
 
 Without the flag the suite still runs the same sources but builds the NC variant, and only `ZONE_SCOPED` wall-clock data is collected.
 
@@ -160,7 +160,7 @@ Without the flag the suite still runs the same sources but builds the NC variant
 
 | Flag | Implies `--enable-perf-counters` | Effect |
 |------|----------------------------------|--------|
-| `--enable-perf-counters` | — | Build the WC variant and collect raw counters per zone |
+| `--enable-perf-counters` | no | Build the WC variant and collect raw counters per zone |
 | `--dump-perf-counters` | yes | Export raw counter values to a separate `<test>.counters.csv` alongside the main results CSV |
 
 `--dump-perf-counters` implicitly enables counter collection; you don't need to specify `--enable-perf-counters` separately.
@@ -170,8 +170,7 @@ Without the flag the suite still runs the same sources but builds the NC variant
 For each test variant, the WC build emits:
 
 - One row per zone in `perf_data/<test>/<test>.csv`, with wide `<RUN_TYPE>_<stat>(<metric>)` columns. `<test>.post.csv` is the same data with `TILE_LOOP` wall-clock divided by `loop_factor x tile_cnt`; `INIT` rows and every counter/`OUT_L` column stay absolute, so multiply before comparing the two cycle numbers.
-- A `*.counters.csv` file if `--dump-csv-counters` was passed.
-- A per-zone console dump of the derived metrics for the last run, plus a mean/std stability block when `run_count >= 2`, if `--dump-raw-metrics` was passed. There is no min/median/max aggregation.
+- A `*.counters.csv` file if `--dump-perf-counters` was passed. There is no console dump and no min/median/max aggregation.
 
 The NC build emits per-zone wall-clock cycle counts in the same results DataFrame so a single run with both builds (different pytest invocations) can be merged off-line to compare wall-clock cycles against counter-derived cycle counts.
 
@@ -192,7 +191,7 @@ The NC build emits per-zone wall-clock cycle counts in the same results DataFram
 
 **Blackhole** has `PACK_COUNT = 1`; per-engine packer busy and dest-read signals for engines 1–3 are tied to constants in RTL and are omitted from the inventory. Only counters 11, 18, 267, 271, 272 remain on the `TDMA_PACK` bank. BH compensates with more L1 mux positions (3 extra) which expose additional NoC rings and miscellaneous L1 ports.
 
-**INSTRN_THREAD bank.** Counters 0–8 and 12–23 are per-thread instruction-type availability (CFG/SYNC/THCON/MOVE/FPU/UNPACK/PACK, 3 threads each — 21 slots; the XSEARCH sels 9–11 are tied off in RTL and are not in the inventory). Counters 24–26 are per-thread total stall cycles. The stall-reason layout differs:
+**INSTRN_THREAD bank.** Counters 0–8 and 12–23 are per-thread instruction-type availability (CFG/SYNC/THCON/MOVE/FPU/UNPACK/PACK, 3 threads each, 21 slots; the XSEARCH sels 9–11 are tied off in RTL and are not in the inventory). Counters 24–26 are per-thread total stall cycles. The stall-reason layout differs:
 
 - WH: the four shared stall reasons (SRCA/B clear/valid) are replicated per thread in HW but only the first slot of each is enumerated, at sels 27/30/33/36; per-thread stall reasons then occupy counters 39–65.
 - BH: shared stall reasons occupy single slots (27–30), per-thread stall reasons occupy 31–57.
@@ -201,11 +200,11 @@ Bit-8-extended counters 256/264/272 expose `THREAD_INSTRUCTIONS_{0,1,2}` (one pe
 
 ### Counter inventory single source
 
-The counter id↔name inventory is **defined once**, in metal's canonical `tt_metal/hw/inc/internal/tt-1xx/<arch>/hw_counters.h` — grouped `{PerfCounterType, id}` arrays per bank (`instrn_counters`, `fpu_counters`, `unpack_counters`, `pack_counters`, `l1_0..4_counters`). Both sides of the perf infra derive from it, so the list is never hand-maintained twice:
+The counter id↔name inventory is **defined once**, in metal's canonical `tt_metal/hw/inc/internal/tt-1xx/<arch>/hw_counters.h`, as grouped `{PerfCounterType, id}` arrays per bank (`instrn_counters`, `fpu_counters`, `unpack_counters`, `pack_counters`, `l1_0..4_counters`). Both sides of the perf infra derive from it, so the list is never hand-maintained twice:
 
-- **Device (`counters.h`)** `#include`s `hw_counters.h` (with the `PerfCounterType` enum from `perf_counters.hpp`) and builds `BUILTIN_COUNTER_CONFIG[]` from those arrays at compile time — a `constexpr` concatenation in the fixed bank order the readout expects (INSTRN, FPU, TDMA_UNPACK, TDMA_PACK, then the single selected L1 mux group).
+- **Device (`counters.h`)** `#include`s `hw_counters.h` (with the `PerfCounterType` enum from `perf_counters.hpp`) and builds `BUILTIN_COUNTER_CONFIG[]` from those arrays at compile time, a `constexpr` concatenation in the fixed bank order the readout expects (INSTRN, FPU, TDMA_UNPACK, TDMA_PACK, then the single selected L1 mux group).
 
-Only **one** L1 mux group is emitted per build, chosen by `LLK_PERF_L1_MUX_GROUP` (default 0). There are only eight physical L1 counters and `PERF_CNT_MUX_CTRL` routes a group of eight client interfaces into them *while they count*, not when they are read, so a run observes exactly one group. Sweep the flag across runs to cover the others; a metric documented below as requiring the mux-1 slot is not obtainable from a default run. The group is a compile-time constant baked into `brisc.elf`, so a sweep must recompile the producer — the readout checks the group decoded from L1 against the requested one and fails if they disagree.
+Only **one** L1 mux group is emitted per build, chosen by `LLK_PERF_L1_MUX_GROUP` (default 0). There are only eight physical L1 counters and `PERF_CNT_MUX_CTRL` routes a group of eight client interfaces into them *while they count*, not when they are read, so a run observes exactly one group. Sweep the flag across runs to cover the others; a metric documented below as requiring the mux-1 slot is not obtainable from a default run. The group is a compile-time constant baked into `brisc.elf`, so a sweep must recompile the producer. The readout checks the group decoded from L1 against the requested one and fails if they disagree.
 - **Host (`counters.py`)** parses the same `hw_counters.h` at import to recover the id→name tables used for decoding.
 
 Adding or removing a counter in `hw_counters.h` therefore propagates to both automatically; the only pieces still mirrored by hand are the config-word bit layout (`PERF_CFG_*`) and the bank-id↔name mapping, which are this test infra's own L1 ABI rather than part of the HW inventory.
@@ -238,7 +237,7 @@ Counter state lives at a fixed L1 address determined entirely at compile time. N
 
 The layout is bounded by two `static_assert`s to stay below `0x16AFF0` (the profiler region boundary). Each zone reserves `PERF_COUNTERS_ZONE_SIZE = (5 + 200) × 4 + 40 = 860` bytes, supporting up to `PERF_COUNTERS_MAX_ZONES = 8` zones per kernel.
 
-The 200-word shared config is the authoritative runtime record of which counters are recorded for every zone (the host reads it back to decode). There is no per-zone configuration — every zone records the same set of counters but stores its own snapshot.
+The 200-word shared config is the authoritative runtime record of which counters are recorded for every zone (the host reads it back to decode). There is no per-zone configuration: every zone records the same set of counters but stores its own snapshot.
 
 ## Hardware Register Reference
 
@@ -272,7 +271,7 @@ The following addresses are used (offsets from `RISCV_DEBUG_REGS_START_ADDR = 0x
 |------|-------|-------------|
 | 7:0 | mode | 0 = continuous with cycle tracking; 1 = stop after `PERF_CNT_*0` cycles; 2 = continuous without cycle tracking |
 | 16:8 | counter_sel | Selects which counter event is routed to `OUT_H` |
-| 31:17 | reserved | — |
+| 31:17 | reserved | unused |
 
 The macro path always uses mode 0. Mode 1 is unused in the LLK test suite. The `counter_sel` field is rewritten on each slot read so a single bank can multiplex multiple counters into one measurement window.
 
@@ -282,16 +281,16 @@ Rising-edge triggered. Bit 0 = start (0→1 also clears the counter), bit 1 = st
 
 ### L1 mux (`PERF_CNT_MUX_CTRL`)
 
-Each L1 mux group exposes 8 client interfaces x 2 counters — request sels 0–7 and grant sels 256–263 — so 16 `counter_sel` values per group, giving the 32 (WH, 2 groups) and 80 (BH, 5 groups) inventory totals above. The mux field selects the group: bit 4 on Wormhole, bits 6:4 on Blackhole (5 of 8 encodings populated):
+Each L1 mux group exposes 8 client interfaces x 2 counters (request sels 0–7 and grant sels 256–263), so 16 `counter_sel` values per group, giving the 32 (WH, 2 groups) and 80 (BH, 5 groups) inventory totals above. The mux field selects the group: bit 4 on Wormhole, bits 6:4 on Blackhole (5 of 8 encodings populated):
 
 | Mux | WH meaning | BH meaning |
 |-----|------------|------------|
 | 0 | unpacker 0, packer port 1 (+ECC), TDMA bundles 0/1, NoC Ring 0 | unpacker 0, port 1 (unpacker 1 + ECC), TDMA bundles 0/1, NoC Ring 0 |
 | 1 | TDMA packer 2, ext unpackers 1–3, NoC Ring 1 | TDMA packer 2, ext unpackers 1–3, NoC Ring 1 |
-| 2 | — | ext unpackers 4–7, NoC Ring 0 secondary channels |
-| 3 | — | NoC Ring 1 secondary channels, ext packers 2–5 |
-| 4 | — | ext packers 6–7, tag search / packer 1, ext unpackers 8–12 |
-| 5 | — | ext unpackers 13–14 (only slots 0 and 1 are wired; slots 2–7 read 0) |
+| 2 | not present | ext unpackers 4–7, NoC Ring 0 secondary channels |
+| 3 | not present | NoC Ring 1 secondary channels, ext packers 2–5 |
+| 4 | not present | ext packers 6–7, tag search / packer 1, ext unpackers 8–12 |
+| 5 | not present | ext unpackers 13–14 (only slots 0 and 1 are wired; slots 2–7 read 0) |
 
 The Blackhole column is taken from the A0 tapeout RTL (ws-tensix `BH_A0_RC6`, `tt_tensix.sv`) and was confirmed on silicon by reading every selector under real workloads; positions 6 and 7 have no decode case and fall back to position 0. The labels in `hw_counters.h` and in the harness `counters.py` predate that check and are being brought in line by PR #55162 (the old `NOC_RING2/3` and `MISC_PORT` names describe a 4-NOC build that never shipped).
 
@@ -299,7 +298,7 @@ The mux routes interfaces into the counters while they count and is written once
 
 ## Derived Metrics Reference
 
-The LLK driver computes **16** derived metrics (the `*_pct` keys in `metrics.py` and `perf/schema.py::METRIC_BASES`). The other entries below are upstream formulas that this driver does **not** compute; their raw counters are still in the per-zone CSV, so they can be re-derived by hand. Renaming or adding a `*_pct` key requires updating `perf/schema.py::METRIC_BASES` in the same change, or the report's schema check fails. Derived metrics are computed in `tests/python_tests/helpers/metrics.py` from the raw counter DataFrame. The metric set mirrors the metal-level [PerfCounters tech report](../../../../tech_reports/PerfCounters/perf-counters.md) — the same catalogue applies to **both Wormhole and Blackhole** (architecture differences are confined to a few WH-only or BH-only counters, called out per-metric). The LLK driver operates on per-zone snapshots rather than per-op aggregates, so all derived values appear in the merged CSV and the `--dump-raw-metrics` console output.
+The LLK driver computes the `*_pct` metrics defined in `metrics.py` and mirrored by `perf/schema.py::METRIC_BASES`. The other entries below are upstream formulas that this driver does **not** compute; their raw counters are still in the per-zone CSV, so they can be re-derived by hand. Renaming or adding a `*_pct` key requires updating `perf/schema.py::METRIC_BASES` in the same change, or the report's schema check fails. Derived metrics are computed in `tests/python_tests/helpers/metrics.py` from the raw counter DataFrame. The metric set mirrors the metal-level [PerfCounters tech report](../../../../tech_reports/PerfCounters/perf-counters.md). The same catalogue applies to **both Wormhole and Blackhole** (architecture differences are confined to a few WH-only or BH-only counters, called out per-metric). The LLK driver operates on per-zone snapshots rather than per-op aggregates, so all derived values appear in the merged CSV.
 
 > **Full catalogue.** Metrics #1–#47 in `tech_reports/PerfCounters/perf-counters.md` are the authoritative list. The sections below document the ones the LLK driver surfaces directly; raw counters for every other upstream metric are present in the per-zone CSV, so any upstream formula can be re-evaluated on LLK data without code changes.
 
@@ -353,7 +352,7 @@ Packer Efficiency = PACKER_DEST_READ_AVAILABLE / PACKER_BUSY * 100
 ```
 
 - **High value (~100%)**: Packer never waits for math output (no dest-read stalls).
-- **Low value (<80%)**: Packer is busy but math has not finished writing the destination — math is the bottleneck.
+- **Low value (<80%)**: Packer is busy but math has not finished writing the destination, so math is the bottleneck.
 
 **Use case:** Detects destination-register stalls indicating the math stage cannot keep up.
 
@@ -406,7 +405,7 @@ Full Wait TN = WAITING_FOR_NONFULL_SEM_N / INSTRN_OUT_L * 100
 ```
 
 - **Zero Wait high**: Thread waits for a producer to signal.
-- **Full Wait high**: Thread waits for a consumer to drain — downstream backpressure.
+- **Full Wait high**: Thread waits for a consumer to drain, downstream backpressure.
 
 **Use case:** Identifies producer/consumer imbalance across threads.
 
@@ -425,7 +424,7 @@ Unpacker0 Write Eff = SRCA_WRITE_ACTUAL / UNPACK0_BUSY_THREAD0 * 100
 Unpacker1 Write Eff = SRCB_WRITE_ACTUAL / UNPACK1_BUSY_THREAD0 * 100
 ```
 
-**Use case:** Identifies whether unpacker stalls are from port contention or overwrite blocking — compare with metrics 16 and 17.
+**Use case:** Identifies whether unpacker stalls are from port contention or overwrite blocking. Compare with metrics 16 and 17.
 
 ---
 
@@ -445,9 +444,9 @@ Fidelity Stall Rate = MATH_FIDELITY_STALL / MATH_INSTRN_AVAILABLE * 100
 ```
 
 - **0%**: Pure LoFi (every math instruction completes in 1 HF cycle).
-- **>0%**: HiFi2 or HiFi4 active — multi-cycle math contributes to wall time.
+- **>0%**: HiFi2 or HiFi4 active, multi-cycle math contributes to wall time.
 
-> **Known issue:** On HiFi variants this metric can exceed 100% because the formula's numerator counts every HF cycle of multi-HF instructions while the denominator counts only the issued instructions. treat values >100% as "fidelity is the dominant cost" rather than a literal percentage.
+> **Known issue:** On HiFi variants this metric can exceed 100% because the formula's numerator counts every HF cycle of multi-HF instructions while the denominator counts only the issued instructions. Treat values >100% as "fidelity is the dominant cost" rather than a literal percentage.
 
 **Use case:** Detects whether fidelity is contributing to the cycle budget.
 
@@ -513,21 +512,20 @@ per-zone CSV, so they can be worked out by hand. Counter names are as they appea
 - **`PACK_DONE` is reserved by the barrier.** It is safe only because the count returns to zero each time, so a measured kernel must not use `semaphore::PACK_DONE` for its own handshake.
 - **The host asserts zones do not overlap across threads.** No thread may open `TILE_LOOP` before every thread has closed `INIT`. A failure almost always means a kernel used `ZONE_SCOPED` instead of `START_PERF_MEASURE`, which is what supplies the entry rendezvous. Skipped on Quasar.
 - **Both builds write the same report path.** `perf_data/<module>/<module>.csv` is written by whichever invocation ran last, so move the first report aside before running the second build; there is no cross-build merge in code.
-- **`--dump-csv-counters` is broken until #52439 lands.** `conftest.py` references a non-existent `TestConfig.MODE` in the counter-report teardown, so the flag raises `AttributeError` and never writes a counters CSV.
 - **`--logging-level DEBUG` or `TRACE` recompiles the measured kernel** with `-DDEBUG_PRINT_ENABLED`, which perturbs the numbers. Do not use it for a measurement run.
 - **`no zone returned counter data` means the test was never measured.** The counter and metric columns will be absent; a with-counters versus no-counters comparison for that test is meaningless, not zero.
 - **Instrumenting a kernel moves its no-counter baseline.** The rendezvous is real in both builds, so converting a kernel from `ZONE_SCOPED` to `START_PERF_MEASURE` shifts its timings; numbers from before and after are not comparable.
 - **`PROFILER_SYNC()` is per-kernel and not universal.** `fast_tilize_bh_test.cpp` omits it entirely and no `UNINIT` zone has one, so those windows close without draining the backend.
 
-- **A pytest invocation compiles one build.** `--enable-perf-counters` selects WC, otherwise NC — a single invocation cannot produce both. The WC build records wall-clock (`ZONE_SCOPED`) *alongside* the counters, so it is self-contained; the NC build is run separately only when a counter-overhead-free timing baseline is wanted. Results merge off-line by `(test_variant, zone)`.
+- **A pytest invocation compiles one build.** `--enable-perf-counters` selects WC, otherwise NC, so a single invocation cannot produce both. The WC build records wall-clock (`ZONE_SCOPED`) *alongside* the counters, so it is self-contained; the NC build is run separately only when a counter-overhead-free timing baseline is wanted. Results merge off-line by `(test_variant, zone)`.
 - **The window is `[all threads armed … all threads finished]`.** The rendezvous arms after every thread has entered, and freezes after every thread has finished for the run types that keep the exit barrier. Each thread stamps the release with its own wall-clock read, and those reads serialize on the single shared clock, so the per-thread zone starts differ by ~12–40 cyc (irreducible; not a bug).
 - **`PERF_COUNTERS_MAX_ZONES = 8` per kernel.** Adding a 9th distinct `MEASURE_PERF_COUNTERS("...")` name silently reuses zone 0. Reuse the same name across multiple call sites if you want them in the same bucket.
 - **One L1 mux group per run.** `PERF_CNT_MUX_CTRL` selects the group while the counters count, not when they are read, so the freeze path cannot re-aim it and a run observes exactly one group. Select it with `LLK_PERF_L1_MUX_GROUP` and sweep it across runs.
-- **BRISC compile flag.** When `--enable-perf-counters` is set, BRISC is rebuilt with `-DPERF_COUNTERS_COMPILED`. Otherwise BRISC does not touch the counter HW at all — this keeps the NC build free of any counter-armed monitoring overhead.
+- **BRISC compile flag.** When `--enable-perf-counters` is set, BRISC is rebuilt with `-DPERF_COUNTERS_COMPILED`. Otherwise BRISC does not touch the counter HW at all, which keeps the NC build free of any counter-armed monitoring overhead.
 - **Test isolation.** As with every LLK test, counter state at kernel entry is whatever the previous test left behind. The BRISC reset path clears the shared config and zone buffers, so each test starts from a known L1 state, but HW counter registers themselves may carry residual values until the first `MEASURE_PERF_COUNTERS` rising-edge clear.
 - **NC/WC bit-identity is fragile.** The goal is that the WC counter code doesn't perturb the measured timing, which requires WC codegen to match NC outside the counter parts. `get_counter_base_addr` uses a `volatile` index cast specifically to stop GCC from emitting a `CSWTCH` jump table (it would shift GP-relative offsets and break that bit-identity), and `freeze_and_read_all_counters` uses `#pragma GCC unroll 0`. Measured counters are sensitive to BRISC boot *timing* at the ~0.1 % level, so avoid reshaping the BRISC boot path (e.g. the config scan) even when it looks logically equivalent.
-- **The BRISC boot arm is redundant but retained.** The RTL (see `tech_reports/PerfCounters/perf-counters.md`) confirms a rising-edge start both *clears* and starts the counters, so the per-zone `arm_all_counters` fully resets them from any prior state — the boot-time `arm_hardware()` measures a window nobody reads. It is kept only because removing it changes boot timing (see previous point). The essential BRISC work is `configure_hardware` (period/mode) + the `DBG_FEATURE_DISABLE` scrub.
-- **L1 layout must stay below the profiler region.** `PERF_COUNTERS_LAYOUT_END` must not overlap the profiler's lowest L1 address (`llk_profiler::EPOCH_ADDR`). Two `static_assert`s enforce this — a literal one in the always-compiled section (BRISC has no `llk_profiler` namespace) and a symbolic one in the `LLK_PROFILER` section that tracks the profiler layout automatically.
+- **The BRISC boot arm is redundant but retained.** The RTL (see `tech_reports/PerfCounters/perf-counters.md`) confirms a rising-edge start both *clears* and starts the counters, so the per-zone `arm_all_counters` fully resets them from any prior state, so the boot-time `arm_hardware()` measures a window nobody reads. It is kept only because removing it changes boot timing (see previous point). The essential BRISC work is `configure_hardware` (period/mode) + the `DBG_FEATURE_DISABLE` scrub.
+- **L1 layout must stay below the profiler region.** `PERF_COUNTERS_LAYOUT_END` must not overlap the profiler's lowest L1 address (`llk_profiler::EPOCH_ADDR`). Two `static_assert`s enforce this: a literal one in the always-compiled section (BRISC has no `llk_profiler` namespace) and a symbolic one in the `LLK_PROFILER` section that tracks the profiler layout automatically.
 - **Minimum window size.** Size every measured window above ~1k cycles using the test's `LOOP_FACTOR`; PR #51912 raised the suite's factors for exactly this reason. Below that, a few cycles of instrument floor read as a large percentage, and the timing `mean` is affected as well as the derived ratios. Note the report divides `TILE_LOOP` wall-clock by `loop_factor x tile_cnt` but leaves `INIT` and every counter column absolute.
 
-- **The single-inventory source couples the perf build to two metal headers.** `counters.h` `#include`s `perf_counters.hpp` (`PerfCounterType` enum, reached via `-I…/tools/profiler`) and the arch `hw_counters.h`; the host `counters.py` parses the same `hw_counters.h` at import. This removes the hand-duplicated inventory, at the cost that if those headers move or the enum/array shape changes, the LLK perf build and decoder must follow. The config-word bit layout (`PERF_CFG_*`) and bank-id↔name mapping are still mirrored between `counters.h` and `counters.py` — they are this infra's own L1 ABI, not part of `hw_counters.h`.
+- **The single-inventory source couples the perf build to two metal headers.** `counters.h` `#include`s `perf_counters.hpp` (`PerfCounterType` enum, reached via `-I…/tools/profiler`) and the arch `hw_counters.h`; the host `counters.py` parses the same `hw_counters.h` at import. This removes the hand-duplicated inventory, at the cost that if those headers move or the enum/array shape changes, the LLK perf build and decoder must follow. The config-word bit layout (`PERF_CFG_*`) and bank-id↔name mapping are still mirrored between `counters.h` and `counters.py`. They are this infra's own L1 ABI, not part of `hw_counters.h`.

--- a/tt_metal/tt-llk/docs/performance_counters/performance_counters.md
+++ b/tt_metal/tt-llk/docs/performance_counters/performance_counters.md
@@ -5,7 +5,7 @@
 - Test-helper mock functions: [tests/helpers/include/perf.h](../../tests/helpers/include/perf.h)
 - Profiler zone macros: [tests/helpers/include/profiler.h](../../tests/helpers/include/profiler.h)
 - Cross-thread rendezvous: [tests/helpers/include/barrier.h](../../tests/helpers/include/barrier.h)
-- Report schema (must be updated with any metric rename): [tests/python_tests/helpers/perf_schema.py](../../tests/python_tests/helpers/perf_schema.py)
+- Report schema (must be updated with any metric rename): [tests/python_tests/helpers/perf/schema.py](../../tests/python_tests/helpers/perf/schema.py)
 - Host-side counter readback: [tests/python_tests/helpers/counters.py](../../tests/python_tests/helpers/counters.py)
 - Host-side derived metrics: [tests/python_tests/helpers/metrics.py](../../tests/python_tests/helpers/metrics.py)
 - Test driver: [tests/python_tests/helpers/perf/core.py](../../tests/python_tests/helpers/perf/core.py)
@@ -146,7 +146,7 @@ pytest --compile-consumer --enable-perf-counters -x ./python_tests/perf_eltwise_
 
 Wipe the artefact root (`/tmp/tt-llk-build`, or `$RUNNER_TEMP/tt-llk-build`) when switching between the two builds: the variant hash and the build markers ignore the counter flags, so the ELFs are otherwise reused.
 
-To capture a different L1 mux group, `export LLK_PERF_L1_MUX_GROUP=<0-4>` before **both** phases. It is an environment variable rather than a CLI flag and is compiled into `brisc.elf`, so each group needs its own producer run; the readout detects a disagreement between the group found in L1 and the one requested, but `perf.py` catches it and logs `Error reading counters:` as a warning, so the run still passes with no counter data at all rather than failing.
+To capture a different L1 mux group, `export LLK_PERF_L1_MUX_GROUP=<0-4>` before **both** phases. It is an environment variable rather than a CLI flag and is compiled into `brisc.elf`, so each group needs its own producer run; the readout checks the group found in L1 against the one requested and fails the run if they disagree, so a stale `brisc.elf` cannot return a self-consistently mislabelled dataset.
 
 
 The `--enable-perf-counters` flag triggers two things:
@@ -298,7 +298,7 @@ The mux routes interfaces into the counters while they count and is written once
 
 ## Derived Metrics Reference
 
-The LLK driver computes **16** derived metrics (the `*_pct` keys in `metrics.py` and `perf_schema.py::METRIC_BASES`). The other entries below are upstream formulas that this driver does **not** compute; their raw counters are still in the per-zone CSV, so they can be re-derived by hand. Renaming or adding a `*_pct` key requires updating `perf_schema.py::METRIC_BASES` in the same change, or the report's schema check fails. Derived metrics are computed in `tests/python_tests/helpers/metrics.py` from the raw counter DataFrame. The metric set mirrors the metal-level [PerfCounters tech report](../../../../tech_reports/PerfCounters/perf-counters.md) — the same catalogue applies to **both Wormhole and Blackhole** (architecture differences are confined to a few WH-only or BH-only counters, called out per-metric). The LLK driver operates on per-zone snapshots rather than per-op aggregates, so all derived values appear in the merged CSV and the `--dump-raw-metrics` console output.
+The LLK driver computes **16** derived metrics (the `*_pct` keys in `metrics.py` and `perf/schema.py::METRIC_BASES`). The other entries below are upstream formulas that this driver does **not** compute; their raw counters are still in the per-zone CSV, so they can be re-derived by hand. Renaming or adding a `*_pct` key requires updating `perf/schema.py::METRIC_BASES` in the same change, or the report's schema check fails. Derived metrics are computed in `tests/python_tests/helpers/metrics.py` from the raw counter DataFrame. The metric set mirrors the metal-level [PerfCounters tech report](../../../../tech_reports/PerfCounters/perf-counters.md) — the same catalogue applies to **both Wormhole and Blackhole** (architecture differences are confined to a few WH-only or BH-only counters, called out per-metric). The LLK driver operates on per-zone snapshots rather than per-op aggregates, so all derived values appear in the merged CSV and the `--dump-raw-metrics` console output.
 
 > **Full catalogue.** Metrics #1–#47 in `tech_reports/PerfCounters/perf-counters.md` are the authoritative list. The sections below document the ones the LLK driver surfaces directly; raw counters for every other upstream metric are present in the per-zone CSV, so any upstream formula can be re-evaluated on LLK data without code changes.
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
@@ -32,6 +32,7 @@ from .schema import (
     LOOP_FACTOR_COLUMN,
     MARKER,
     MEAN,
+    NON_RENDEZVOUS_MARKERS,
     STD,
     TEXT_SIZE_PREFIX,
     TILE_CNT_COLUMN,
@@ -687,6 +688,65 @@ def combine_perf_reports():
     _prune_runs(output_dir.parent, _keep_runs(), output_dir)
 
 
+def assert_zones_dont_overlap(profiler_data: ProfilerData) -> None:
+    """No thread may open a phase before every thread has closed the previous one.
+
+    Perf kernels open every zone through START_PERF_MEASURE, whose entry rendezvous lines the
+    phases (INIT, TILE_LOOP) up across threads; a zone opened with bare ZONE_SCOPED skips it and
+    its window then covers time that belongs to the neighbouring phase. This is a property of
+    how the perf kernels are written, not of the profiler, so it lives here and runs once per run.
+
+    Within a thread a zone that contains another is a wrapper (trisc.cpp's KERNEL), not a phase.
+    Quasar has no entry rendezvous yet.
+    """
+    if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR:
+        return
+    # The profiler view pairs every ZONE_START with the ZONE_END that follows it.
+    zones = profiler_data.zones().frame()
+    if zones.empty:
+        return
+    zones = zones.assign(finish=zones["timestamp"] + zones["duration"])
+    # Identity is the name: marker_id is a per-callsite hash, different on every thread.
+    span = (
+        zones.groupby([MARKER, "thread"])
+        .agg(begin=("timestamp", "min"), finish=("finish", "max"))
+        .reset_index()
+    )
+    wrappers = set()
+    for _, group in span.groupby("thread"):
+        rows = group.to_dict("records")
+        for a in rows:
+            for b in rows:
+                if (
+                    a is not b
+                    and a["begin"] <= b["begin"] <= b["finish"] <= a["finish"]
+                ):
+                    wrappers.add(a[MARKER])
+    phases = (
+        span[~span[MARKER].isin(wrappers)]
+        .groupby(MARKER)
+        .agg(first_open=("begin", "min"), last_close=("finish", "max"))
+        .sort_values("first_open")
+        .reset_index()
+    )
+    prev = None
+    for row in phases.itertuples(index=False):
+        if (
+            prev is not None
+            and row.marker not in NON_RENDEZVOUS_MARKERS
+            and prev.last_close > row.first_open
+        ):
+            raise AssertionError(
+                f"Zones overlap across threads: the last {prev.marker} closed at "
+                f"{prev.last_close} but the first {row.marker} opened at {row.first_open}, "
+                f"{prev.last_close - row.first_open} cycles earlier. Both windows therefore "
+                f"cover time belonging to the other phase. The usual cause is a kernel opening "
+                f"its zones with ZONE_SCOPED instead of START_PERF_MEASURE, which is what "
+                f"supplies the cross-thread rendezvous at zone entry."
+            )
+        prev = row
+
+
 class PerfConfig(TestConfig):
     # === STATIC VARIABLES ===
     TEST_COUNTER: ClassVar[int] = 0
@@ -934,6 +994,7 @@ class PerfConfig(TestConfig):
                 profiler_data = Profiler.get_data(
                     self.test_name, self.variant_id, TestConfig.TENSIX_LOCATION
                 )
+                assert_zones_dont_overlap(profiler_data)
 
                 if TestConfig.ENABLE_PERF_COUNTERS:
                     try:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/schema.py
@@ -12,6 +12,9 @@ class PerfSchemaError(AssertionError):
 
 MARKER = "marker"
 
+# Zones that use bare ZONE_SCOPED (no entry rendezvous), exempt from the cross-thread ordering invariant.
+NON_RENDEZVOUS_MARKERS = frozenset({"UNINIT"})
+
 FORMAT_HEADERS = (
     "formats.input_A",
     "formats.input_B",

--- a/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
@@ -9,9 +9,17 @@ from typing import ClassVar
 
 import pandas as pd
 
+from .chip_architecture import ChipArchitecture, get_chip_architecture
 from .device_io import read_words_from_device
 from .llk_params import PerfRunType
-from .perf.schema import MARKER, MEAN, STD, stat_column, stat_prefix
+from .perf.schema import (
+    MARKER,
+    MEAN,
+    NON_RENDEZVOUS_MARKERS,
+    STD,
+    stat_column,
+    stat_prefix,
+)
 from .test_config import TestConfig
 
 
@@ -79,6 +87,77 @@ class ProfilerData:
         if not start_entries.equals(end_entries):
             raise AssertionError("Zone START and END entries don't match")
 
+    @staticmethod
+    def _assert_zones_dont_overlap(starts: pd.DataFrame, ends: pd.DataFrame) -> None:
+        """No thread may open a phase before every thread has closed the previous one, per run.
+
+        Phases are zone names in first-open order; a zone containing another zone on the same
+        thread (like KERNEL) is a wrapper, not a phase. START_PERF_MEASURE's entry rendezvous is
+        what makes this hold, so NON_RENDEZVOUS_MARKERS are exempt and Quasar is skipped.
+        """
+        if get_chip_architecture() == ChipArchitecture.QUASAR:
+            return
+        if MARKER not in starts.columns or "timestamp" not in starts.columns:
+            return
+        # run_index is declared but NA until core.py tags it, and groupby drops NA keys, so grouping
+        # naively would check nothing on an untagged frame.
+        if "run_index" in starts.columns:
+            keys = list(pd.unique(starts["run_index"]))
+        else:
+            keys = [None]
+        for key in keys:
+            if "run_index" not in starts.columns:
+                s, e = starts, ends
+            elif pd.isna(key):
+                s = starts[starts["run_index"].isna()]
+                e = ends[ends["run_index"].isna()]
+            else:
+                s = starts[starts["run_index"] == key]
+                e = ends[ends["run_index"] == key]
+            # Identity is the NAME: marker_id is a per-callsite hash, different on every thread.
+            span = (
+                s.groupby([MARKER, "thread"])["timestamp"]
+                .min()
+                .rename("begin")
+                .to_frame()
+            )
+            span["finish"] = e.groupby([MARKER, "thread"])["timestamp"].max()
+            span = span.reset_index()
+            envelopes = set()
+            for _, group in span.groupby("thread"):
+                rows = group.to_dict("records")
+                for a in rows:
+                    for b in rows:
+                        if (
+                            a is not b
+                            and a["begin"] <= b["begin"]
+                            and b["finish"] <= a["finish"]
+                        ):
+                            envelopes.add(a[MARKER])
+            phases = (
+                span[~span[MARKER].isin(envelopes)]
+                .groupby(MARKER)
+                .agg(first_open=("begin", "min"), last_close=("finish", "max"))
+                .sort_values("first_open")
+                .reset_index()
+            )
+            prev = None
+            for row in phases.itertuples(index=False):
+                if prev is not None and row.marker not in NON_RENDEZVOUS_MARKERS:
+                    if prev.last_close > row.first_open:
+                        where = (
+                            "" if key is None or pd.isna(key) else f" (run_index={key})"
+                        )
+                        raise AssertionError(
+                            f"Zones overlap across threads{where}: the last {prev.marker} closed at "
+                            f"{prev.last_close} but the first {row.marker} opened at {row.first_open}, "
+                            f"{prev.last_close - row.first_open} cycles earlier. Both windows therefore "
+                            f"cover time belonging to the other phase. The usual cause is a kernel opening "
+                            f"its zones with ZONE_SCOPED instead of START_PERF_MEASURE, which is what "
+                            f"supplies the cross-thread rendezvous at zone entry."
+                        )
+                prev = row
+
     def raw(self) -> pd.DataFrame:
         """Returns the raw event view of the underlying data"""
 
@@ -89,6 +168,7 @@ class ProfilerData:
         end_entries = self.df[self.df["type"] == "ZONE_END"]
 
         self._assert_zones_valid(start_entries, end_entries)
+        self._assert_zones_dont_overlap(start_entries, end_entries)
 
         return self.df
 
@@ -106,6 +186,7 @@ class ProfilerData:
         end_entries = self.df[self.df["type"] == "ZONE_END"].reset_index(drop=True)
 
         self._assert_zones_valid(start_entries, end_entries)
+        self._assert_zones_dont_overlap(start_entries, end_entries)
 
         zone_entries = start_entries.copy()
 
@@ -218,8 +299,6 @@ def _sfpu_has_compute_zones(raw_data: pd.DataFrame) -> bool:
 def _stats_l1_to_l1(data: ProfilerData) -> pd.DataFrame:
     raw_data = data.zones().raw()
 
-    # WC build (PERF_COUNTERS_COMPILED) emits no ZONE_START/ZONE_END events because
-    # ZONE_SCOPED is muted; only HW counter values are produced. Skip wall_clock stats.
     if raw_data.empty:
         return pd.DataFrame()
 
@@ -326,7 +405,6 @@ def _stats_l1_to_l1_four_trisc(raw_data: pd.DataFrame) -> pd.DataFrame:
 
 
 def _stats_thread(stat: str, raw_thread: pd.DataFrame) -> pd.DataFrame:
-    # WC build emits no zone events — skip wall_clock stats, counters provide values instead.
     if raw_thread.empty:
         return pd.DataFrame()
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
@@ -91,9 +91,8 @@ class ProfilerData:
     def _assert_zones_dont_overlap(starts: pd.DataFrame, ends: pd.DataFrame) -> None:
         """No thread may open a phase before every thread has closed the previous one, per run.
 
-        Phases are zone names in first-open order; a zone containing another zone on the same
-        thread (like KERNEL) is a wrapper, not a phase. START_PERF_MEASURE's entry rendezvous is
-        what makes this hold, so NON_RENDEZVOUS_MARKERS are exempt and Quasar is skipped.
+        Within a thread the entries are in program order, so a zone containing another there is
+        a wrapper (like KERNEL) rather than an overlap, and does not count as a phase.
         """
         if get_chip_architecture() == ChipArchitecture.QUASAR:
             return

--- a/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
@@ -9,17 +9,9 @@ from typing import ClassVar
 
 import pandas as pd
 
-from .chip_architecture import ChipArchitecture, get_chip_architecture
 from .device_io import read_words_from_device
 from .llk_params import PerfRunType
-from .perf.schema import (
-    MARKER,
-    MEAN,
-    NON_RENDEZVOUS_MARKERS,
-    STD,
-    stat_column,
-    stat_prefix,
-)
+from .perf.schema import MARKER, MEAN, STD, stat_column, stat_prefix
 from .test_config import TestConfig
 
 
@@ -87,76 +79,6 @@ class ProfilerData:
         if not start_entries.equals(end_entries):
             raise AssertionError("Zone START and END entries don't match")
 
-    @staticmethod
-    def _assert_zones_dont_overlap(starts: pd.DataFrame, ends: pd.DataFrame) -> None:
-        """No thread may open a phase before every thread has closed the previous one, per run.
-
-        Within a thread the entries are in program order, so a zone containing another there is
-        a wrapper (like KERNEL) rather than an overlap, and does not count as a phase.
-        """
-        if get_chip_architecture() == ChipArchitecture.QUASAR:
-            return
-        if MARKER not in starts.columns or "timestamp" not in starts.columns:
-            return
-        # run_index is declared but NA until core.py tags it, and groupby drops NA keys, so grouping
-        # naively would check nothing on an untagged frame.
-        if "run_index" in starts.columns:
-            keys = list(pd.unique(starts["run_index"]))
-        else:
-            keys = [None]
-        for key in keys:
-            if "run_index" not in starts.columns:
-                s, e = starts, ends
-            elif pd.isna(key):
-                s = starts[starts["run_index"].isna()]
-                e = ends[ends["run_index"].isna()]
-            else:
-                s = starts[starts["run_index"] == key]
-                e = ends[ends["run_index"] == key]
-            # Identity is the NAME: marker_id is a per-callsite hash, different on every thread.
-            span = (
-                s.groupby([MARKER, "thread"])["timestamp"]
-                .min()
-                .rename("begin")
-                .to_frame()
-            )
-            span["finish"] = e.groupby([MARKER, "thread"])["timestamp"].max()
-            span = span.reset_index()
-            envelopes = set()
-            for _, group in span.groupby("thread"):
-                rows = group.to_dict("records")
-                for a in rows:
-                    for b in rows:
-                        if (
-                            a is not b
-                            and a["begin"] <= b["begin"]
-                            and b["finish"] <= a["finish"]
-                        ):
-                            envelopes.add(a[MARKER])
-            phases = (
-                span[~span[MARKER].isin(envelopes)]
-                .groupby(MARKER)
-                .agg(first_open=("begin", "min"), last_close=("finish", "max"))
-                .sort_values("first_open")
-                .reset_index()
-            )
-            prev = None
-            for row in phases.itertuples(index=False):
-                if prev is not None and row.marker not in NON_RENDEZVOUS_MARKERS:
-                    if prev.last_close > row.first_open:
-                        where = (
-                            "" if key is None or pd.isna(key) else f" (run_index={key})"
-                        )
-                        raise AssertionError(
-                            f"Zones overlap across threads{where}: the last {prev.marker} closed at "
-                            f"{prev.last_close} but the first {row.marker} opened at {row.first_open}, "
-                            f"{prev.last_close - row.first_open} cycles earlier. Both windows therefore "
-                            f"cover time belonging to the other phase. The usual cause is a kernel opening "
-                            f"its zones with ZONE_SCOPED instead of START_PERF_MEASURE, which is what "
-                            f"supplies the cross-thread rendezvous at zone entry."
-                        )
-                prev = row
-
     def raw(self) -> pd.DataFrame:
         """Returns the raw event view of the underlying data"""
 
@@ -167,7 +89,6 @@ class ProfilerData:
         end_entries = self.df[self.df["type"] == "ZONE_END"]
 
         self._assert_zones_valid(start_entries, end_entries)
-        self._assert_zones_dont_overlap(start_entries, end_entries)
 
         return self.df
 
@@ -185,7 +106,6 @@ class ProfilerData:
         end_entries = self.df[self.df["type"] == "ZONE_END"].reset_index(drop=True)
 
         self._assert_zones_valid(start_entries, end_entries)
-        self._assert_zones_dont_overlap(start_entries, end_entries)
 
         zone_entries = start_entries.copy()
 

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -28,11 +28,11 @@ from helpers.perf.core import (
     PerfConfig,
     PerfReport,
     _assert_matches_catalog,
-    assert_zones_dont_overlap,
     _ci_provenance,
     _prune_runs,
     _refresh_latest,
     _reject_duplicate_keys,
+    assert_zones_dont_overlap,
     combine_perf_reports,
     postprocess_tile_loop,
 )

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -978,3 +978,40 @@ def test_non_rendezvous_zones_are_exempt():
         ("pack", "UNINIT", 2, 950, 1000)
     ]
     ProfilerData(_zones(*events)).raw()
+
+
+# trisc.cpp wraps every thread's kernel in ZONE_SCOPED("KERNEL"), so on hardware the phases
+# are always nested inside a longer zone on their own thread.
+def _wrapped_events(init_ends, loop_starts):
+    events = [(t, "KERNEL", 9, 90, 1100) for t in _THREADS]
+    events += [(t, "INIT", 0, 100, init_ends[t]) for t in _THREADS]
+    events += [(t, "TILE_LOOP", 1, loop_starts[t], 1000) for t in _THREADS]
+    return events
+
+
+def test_zones_nested_in_a_wrapper_are_not_an_overlap():
+    events = _wrapped_events(
+        {t: 200 for t in _THREADS},
+        {t: 210 for t in _THREADS},
+    )
+    ProfilerData(_zones(*events)).raw()
+    ProfilerData(_zones(*events)).frame()
+
+
+def test_a_wrapper_does_not_mask_an_overlap_inside_it():
+    events = _wrapped_events(
+        {"unpack": 200, "math": 400, "pack": 200},
+        {"unpack": 210, "math": 410, "pack": 210},
+    )
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        AssertionError,
+        match="the last INIT closed at 400 but the first TILE_LOOP opened at 210",
+    ):
+        ProfilerData(_zones(*events)).raw()
+
+
+def test_wrapper_on_threads_without_phases_is_not_an_overlap():
+    # ISOLATE run types: every thread emits KERNEL, only the measured one emits phases.
+    events = [(t, "KERNEL", 9, 90, 1100) for t in _THREADS]
+    events += [("math", "INIT", 0, 100, 200), ("math", "TILE_LOOP", 1, 210, 1000)]
+    ProfilerData(_zones(*events)).raw()

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -28,6 +28,7 @@ from helpers.perf.core import (
     PerfConfig,
     PerfReport,
     _assert_matches_catalog,
+    assert_zones_dont_overlap,
     _ci_provenance,
     _prune_runs,
     _refresh_latest,
@@ -250,7 +251,7 @@ def _one_run_events(seed: int) -> pd.DataFrame:
     rows = []
     ts = 100
     # Marker-major, as on hardware: the entry rendezvous means every thread closes INIT before any
-    # opens TILE_LOOP, and _assert_zones_dont_overlap enforces exactly that.
+    # opens TILE_LOOP, and assert_zones_dont_overlap enforces exactly that.
     for marker, mid in _MARKERS:
         for thread in _THREADS:
             dur = 10 + mid * 5 + seed  # distinct per marker, varies per run
@@ -855,20 +856,16 @@ def test_perf_cfg_missing_constant_is_absent_not_zero():
     assert "VALID_BIT" not in _parse_perf_cfg(_cfg_header("BANK_MASK = 0xFFu"))
 
 
-# The failing direction of the cross-thread overlap invariant.
+# The cross-thread overlap invariant, checked by PerfConfig.run() on every run's events.
 
 
-def _overlap_events(run_index=None, overlap=True):
-    """INIT/TILE_LOOP pairs on three threads; math's INIT closes late when overlap=True."""
+def _zones(*zones):
+    """Arbitrary (thread, marker, marker_id, start, end) zones in the raw event order."""
     rows = []
-    for thread in _THREADS:
-        init_end = 400 if (overlap and thread == "math") else 200
-        for marker, mid, start, end in (
-            ("INIT", 0, 100, init_end),
-            ("TILE_LOOP", 1, 250, 900),
-        ):
-            for etype, ts in (("ZONE_START", start), ("ZONE_END", end)):
-                row = {
+    for thread, marker, mid, start, end in zones:
+        for etype, ts in (("ZONE_START", start), ("ZONE_END", end)):
+            rows.append(
+                {
                     "thread": thread,
                     "type": etype,
                     MARKER: marker,
@@ -878,73 +875,36 @@ def _overlap_events(run_index=None, overlap=True):
                     "file": "perf.cpp",
                     "line": 1,
                 }
-                if run_index is not None:
-                    row["run_index"] = run_index
-                rows.append(row)
+            )
     return pd.DataFrame(rows)
 
 
-def test_overlapping_zones_are_rejected_by_raw_and_frame():
-    for view in ("raw", "frame"):
-        with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
-            AssertionError, match="Zones overlap across threads"
-        ):
-            getattr(ProfilerData(_overlap_events()), view)()
-    # and the same trace without the overlap passes both views
-    ProfilerData(_overlap_events(overlap=False)).raw()
-    ProfilerData(_overlap_events(overlap=False)).frame()
+def _phase_events(overlap=True):
+    """INIT/TILE_LOOP pairs on three threads; math's INIT closes late when overlap=True."""
+    events = []
+    for thread in _THREADS:
+        init_end = 400 if (overlap and thread == "math") else 200
+        events += [
+            (thread, "INIT", 0, 100, init_end),
+            (thread, "TILE_LOOP", 1, 250, 900),
+        ]
+    return _zones(*events)
 
 
-def test_overlap_is_grouped_by_run_index():
-    # run 0 healthy, run 1 overlapping: must fire and name run 1, not compare across runs.
-    df = pd.concat(
-        [_overlap_events(run_index=0, overlap=False), _overlap_events(run_index=1)],
-        ignore_index=True,
-    )
-    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
-        AssertionError, match="run_index=1"
-    ):
-        ProfilerData(df).raw()
-    # two healthy runs stay silent even though run 1's INIT closes after run 0's TILE_LOOP opened
-    df = pd.concat(
-        [
-            _overlap_events(run_index=0, overlap=False),
-            _overlap_events(run_index=1, overlap=False),
-        ],
-        ignore_index=True,
-    )
-    ProfilerData(df).raw()
-
-
-def test_overlap_checks_untagged_frames_too():
-    # run_index all-NA (declared but not yet tagged): the NA bucket must still be checked.
-    df = _overlap_events()
-    df["run_index"] = pd.NA
+def test_overlapping_zones_are_rejected():
     with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
         AssertionError, match="Zones overlap across threads"
     ):
-        ProfilerData(df).raw()
+        assert_zones_dont_overlap(ProfilerData(_phase_events()))
+    # and the same trace without the overlap passes
+    assert_zones_dont_overlap(ProfilerData(_phase_events(overlap=False)))
 
 
-def _zones(*zones, run_index=None):
-    """Arbitrary (thread, marker, marker_id, start, end) zone events."""
-    rows = []
-    for thread, marker, mid, start, end in zones:
-        for etype, ts in (("ZONE_START", start), ("ZONE_END", end)):
-            row = {
-                "thread": thread,
-                "type": etype,
-                MARKER: marker,
-                "timestamp": ts,
-                "data": 0,
-                "marker_id": mid,
-                "file": "perf.cpp",
-                "line": 1,
-            }
-            if run_index is not None:
-                row["run_index"] = run_index
-            rows.append(row)
-    return pd.DataFrame(rows)
+def test_overlap_check_is_not_part_of_the_profiler_views():
+    # The invariant is about how perf kernels are written; a plain ProfilerData still serves
+    # any trace, overlapping or not.
+    ProfilerData(_phase_events()).raw()
+    ProfilerData(_phase_events()).frame()
 
 
 def test_overlap_check_is_zone_name_agnostic():
@@ -955,7 +915,7 @@ def test_overlap_check_is_zone_name_agnostic():
         for t in _THREADS
         for m in [f"PHASE_{i}"]
     ]
-    ProfilerData(_zones(*healthy)).raw()
+    assert_zones_dont_overlap(ProfilerData(_zones(*healthy)))
     broken = [(t, "WARMUP", 0, 100, 200) for t in _THREADS]
     broken += [
         ("unpack", "COMPUTE", 1, 400, 500),
@@ -967,7 +927,7 @@ def test_overlap_check_is_zone_name_agnostic():
         AssertionError,
         match="the last COMPUTE closed at 800 but the first DRAIN opened at 600",
     ):
-        ProfilerData(_zones(*broken)).raw()
+        assert_zones_dont_overlap(ProfilerData(_zones(*broken)))
 
 
 def test_non_rendezvous_zones_are_exempt():
@@ -977,7 +937,7 @@ def test_non_rendezvous_zones_are_exempt():
     events += [(t, "UNINIT", 2, 550, 600) for t in ("unpack", "math")] + [
         ("pack", "UNINIT", 2, 950, 1000)
     ]
-    ProfilerData(_zones(*events)).raw()
+    assert_zones_dont_overlap(ProfilerData(_zones(*events)))
 
 
 # trisc.cpp wraps every thread's kernel in ZONE_SCOPED("KERNEL"), so on hardware the phases
@@ -994,8 +954,7 @@ def test_zones_nested_in_a_wrapper_are_not_an_overlap():
         {t: 200 for t in _THREADS},
         {t: 210 for t in _THREADS},
     )
-    ProfilerData(_zones(*events)).raw()
-    ProfilerData(_zones(*events)).frame()
+    assert_zones_dont_overlap(ProfilerData(_zones(*events)))
 
 
 def test_a_wrapper_does_not_mask_an_overlap_inside_it():
@@ -1007,11 +966,11 @@ def test_a_wrapper_does_not_mask_an_overlap_inside_it():
         AssertionError,
         match="the last INIT closed at 400 but the first TILE_LOOP opened at 210",
     ):
-        ProfilerData(_zones(*events)).raw()
+        assert_zones_dont_overlap(ProfilerData(_zones(*events)))
 
 
 def test_wrapper_on_threads_without_phases_is_not_an_overlap():
     # ISOLATE run types: every thread emits KERNEL, only the measured one emits phases.
     events = [(t, "KERNEL", 9, 90, 1100) for t in _THREADS]
     events += [("math", "INIT", 0, 100, 200), ("math", "TILE_LOOP", 1, 210, 1000)]
-    ProfilerData(_zones(*events)).raw()
+    assert_zones_dont_overlap(ProfilerData(_zones(*events)))

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -204,13 +204,14 @@ def test_l1_to_l1_three_trisc_keeps_unpack_to_pack_duration():
                         ("pack", 155, 160),
                     ]
                 ),
+                # Envelope-shaped, as on hardware: KERNEL wraps each thread's whole kernel.
                 _parallel_events(
                     [
-                        ("unpack", 10, 15),
-                        ("pack", 50, 55),
+                        ("unpack", 10, 300),
+                        ("pack", 10, 300),
                         ("sfpu", 90, 200),
                     ]
-                ).assign(**{MARKER: "KERNEL"}),
+                ).assign(**{MARKER: "KERNEL", "marker_id": 99}),
             ],
             ignore_index=True,
         )
@@ -248,8 +249,10 @@ def _one_run_events(seed: int) -> pd.DataFrame:
     """
     rows = []
     ts = 100
-    for thread in _THREADS:
-        for marker, mid in _MARKERS:
+    # Marker-major, as on hardware: the entry rendezvous means every thread closes INIT before any
+    # opens TILE_LOOP, and _assert_zones_dont_overlap enforces exactly that.
+    for marker, mid in _MARKERS:
+        for thread in _THREADS:
             dur = 10 + mid * 5 + seed  # distinct per marker, varies per run
             for etype, offset in (("ZONE_START", 0), ("ZONE_END", dur)):
                 rows.append(
@@ -850,3 +853,128 @@ def test_perf_cfg_rejects_anything_it_cannot_parse():
 
 def test_perf_cfg_missing_constant_is_absent_not_zero():
     assert "VALID_BIT" not in _parse_perf_cfg(_cfg_header("BANK_MASK = 0xFFu"))
+
+
+# The failing direction of the cross-thread overlap invariant.
+
+
+def _overlap_events(run_index=None, overlap=True):
+    """INIT/TILE_LOOP pairs on three threads; math's INIT closes late when overlap=True."""
+    rows = []
+    for thread in _THREADS:
+        init_end = 400 if (overlap and thread == "math") else 200
+        for marker, mid, start, end in (
+            ("INIT", 0, 100, init_end),
+            ("TILE_LOOP", 1, 250, 900),
+        ):
+            for etype, ts in (("ZONE_START", start), ("ZONE_END", end)):
+                row = {
+                    "thread": thread,
+                    "type": etype,
+                    MARKER: marker,
+                    "timestamp": ts,
+                    "data": 0,
+                    "marker_id": mid,
+                    "file": "perf.cpp",
+                    "line": 1,
+                }
+                if run_index is not None:
+                    row["run_index"] = run_index
+                rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def test_overlapping_zones_are_rejected_by_raw_and_frame():
+    for view in ("raw", "frame"):
+        with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+            AssertionError, match="Zones overlap across threads"
+        ):
+            getattr(ProfilerData(_overlap_events()), view)()
+    # and the same trace without the overlap passes both views
+    ProfilerData(_overlap_events(overlap=False)).raw()
+    ProfilerData(_overlap_events(overlap=False)).frame()
+
+
+def test_overlap_is_grouped_by_run_index():
+    # run 0 healthy, run 1 overlapping: must fire and name run 1, not compare across runs.
+    df = pd.concat(
+        [_overlap_events(run_index=0, overlap=False), _overlap_events(run_index=1)],
+        ignore_index=True,
+    )
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        AssertionError, match="run_index=1"
+    ):
+        ProfilerData(df).raw()
+    # two healthy runs stay silent even though run 1's INIT closes after run 0's TILE_LOOP opened
+    df = pd.concat(
+        [
+            _overlap_events(run_index=0, overlap=False),
+            _overlap_events(run_index=1, overlap=False),
+        ],
+        ignore_index=True,
+    )
+    ProfilerData(df).raw()
+
+
+def test_overlap_checks_untagged_frames_too():
+    # run_index all-NA (declared but not yet tagged): the NA bucket must still be checked.
+    df = _overlap_events()
+    df["run_index"] = pd.NA
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        AssertionError, match="Zones overlap across threads"
+    ):
+        ProfilerData(df).raw()
+
+
+def _zones(*zones, run_index=None):
+    """Arbitrary (thread, marker, marker_id, start, end) zone events."""
+    rows = []
+    for thread, marker, mid, start, end in zones:
+        for etype, ts in (("ZONE_START", start), ("ZONE_END", end)):
+            row = {
+                "thread": thread,
+                "type": etype,
+                MARKER: marker,
+                "timestamp": ts,
+                "data": 0,
+                "marker_id": mid,
+                "file": "perf.cpp",
+                "line": 1,
+            }
+            if run_index is not None:
+                row["run_index"] = run_index
+            rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def test_overlap_check_is_zone_name_agnostic():
+    # Three zones with kernel-chosen names; the second/third pair overlaps on one thread.
+    healthy = [
+        (t, m, i, 100 + 300 * i, 200 + 300 * i)
+        for i in range(3)
+        for t in _THREADS
+        for m in [f"PHASE_{i}"]
+    ]
+    ProfilerData(_zones(*healthy)).raw()
+    broken = [(t, "WARMUP", 0, 100, 200) for t in _THREADS]
+    broken += [
+        ("unpack", "COMPUTE", 1, 400, 500),
+        ("math", "COMPUTE", 1, 400, 800),
+        ("pack", "COMPUTE", 1, 400, 500),
+    ]
+    broken += [(t, "DRAIN", 2, 600, 900) for t in _THREADS]
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        AssertionError,
+        match="the last COMPUTE closed at 800 but the first DRAIN opened at 600",
+    ):
+        ProfilerData(_zones(*broken)).raw()
+
+
+def test_non_rendezvous_zones_are_exempt():
+    # UNINIT has no entry rendezvous, so it may overlap the zone before it.
+    events = [(t, "INIT", 0, 100, 200) for t in _THREADS]
+    events += [(t, "TILE_LOOP", 1, 300, 900 if t == "pack" else 500) for t in _THREADS]
+    events += [(t, "UNINIT", 2, 550, 600) for t in ("unpack", "math")] + [
+        ("pack", "UNINIT", 2, 950, 1000)
+    ]
+    ProfilerData(_zones(*events)).raw()


### PR DESCRIPTION
## What

Brings `performance_counters.md` in line with what the harness now does.

Added:
- The L1 mux is count-time, not read-time, and what that means for a single run. This is the fact that makes the "40 L1 counters" reading wrong, so it belongs in the doc rather than only in a commit message.
- One shared barrier, why it is on a semaphore rather than L1, and the head-start failure that motivated it.
- The zone-overlap invariant the harness now enforces, and why pairing alone never caught it.

Removed the description of the three-barrier arrangement and the per-run-type rendezvous choice. Neither exists any more.

## Stack

Top of the perf-counter stack, on top of #52445.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-counter-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvlahovic/perf-counter-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-counter-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvlahovic/perf-counter-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvlahovic/perf-counter-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvlahovic/perf-counter-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvlahovic/perf-counter-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvlahovic/perf-counter-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvlahovic/perf-counter-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvlahovic/perf-counter-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvlahovic/perf-counter-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvlahovic/perf-counter-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvlahovic/perf-counter-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvlahovic/perf-counter-docs)