### PR TITLE
[LLK][Feature] Implement cumsum for Quasar

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_ops.h"
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// Dest geometry of a 32x32 tile as the SFPU addresses it: 64 addr units of 16 datums, laid out
+// row-interleaved - addr unit 2*row covers tile columns 0-15 of a tile row, 2*row+1 covers columns
+// 16-31 of the same row. One access therefore reaches two tile rows, and that row pair is the unit
+// this kernel walks the tile in.
+constexpr std::uint32_t CUMSUM_ADDR_UNITS_PER_ROW = 2;
+constexpr std::uint32_t CUMSUM_ROWS_PER_PAIR = 2;
+constexpr std::uint32_t CUMSUM_ROW_PAIRS = TILE_R_DIM / CUMSUM_ROWS_PER_PAIR;
+
+// Addr units one pass advances Dest by.
+constexpr std::uint32_t CUMSUM_ROW_PAIR_STRIDE = CUMSUM_ADDR_UNITS_PER_ROW * CUMSUM_ROWS_PER_PAIR;
+
+// Address offset of a pass's second access: address bit 1 selects which half of each addr unit's 16
+// datums the 32 lanes cover, so the pair base and base + this offset cover the pair's 64 datums.
+constexpr std::uint32_t CUMSUM_SECOND_ACCESS_OFF = 2;
+
+// The two LREG banks the transpose network swizzles: LREGS1 = LREG0-3, LREGS2 = LREG4-7. Passes
+// alternate between them so each pass's running totals survive in the bank the next pass does not
+// load into.
+constexpr std::uint32_t CUMSUM_LREG_BANK_A = p_sfpu::LREG0;
+constexpr std::uint32_t CUMSUM_LREG_BANK_B = p_sfpu::LREG4;
+
+// Bank-relative register roles, in post-transpose order. The ROW1 pair is also the pass's carry out.
+constexpr std::uint32_t CUMSUM_ROW0_LO = 0;  // even tile row, columns 0-15
+constexpr std::uint32_t CUMSUM_ROW0_HI = 1;  // even tile row, columns 16-31
+constexpr std::uint32_t CUMSUM_ROW1_LO = 2;  // odd tile row, columns 0-15
+constexpr std::uint32_t CUMSUM_ROW1_HI = 3;  // odd tile row, columns 16-31
+
+// Advances Dest by one row pair on the last store of every pass, so every pass addresses Dest with
+// the same two pair-relative immediates - which is what lets one recording cover every row pair. The
+// pass's other three memory ops use ADDR_MOD_7, the all-zeroes mod the SFPU framework programs.
+constexpr std::uint32_t CUMSUM_ADDR_MOD = ADDR_MOD_6;
+
+// Passes alternate banks, so the shortest sequence that repeats byte-for-byte is two passes, one per
+// bank. Recorded once into replay slot 0 and run over the 8 bank pairs, that turns 160 instruction
+// issues into 28.
+constexpr std::uint32_t CUMSUM_PASS_INSTRS = 10;  // 2 SFPLOAD + SFPTRANSP + 4 SFPADD + SFPTRANSP + 2 SFPSTORE
+constexpr std::uint32_t CUMSUM_PASSES_PER_RECORDING = 2;
+constexpr std::uint32_t CUMSUM_REPLAY_SLOT = 0;
+constexpr std::uint32_t CUMSUM_REPLAY_LEN = CUMSUM_PASSES_PER_RECORDING * CUMSUM_PASS_INSTRS;
+constexpr std::uint32_t CUMSUM_REPLAY_ITERS = CUMSUM_ROW_PAIRS / CUMSUM_PASSES_PER_RECORDING;
+static_assert(CUMSUM_ROW_PAIRS % CUMSUM_PASSES_PER_RECORDING == 0, "the recorded body must tile the Dest tile exactly");
+
+/**
+ * @brief Configure the SFPU state the cumsum tile walk depends on.
+ *
+ * Resets the RWC counters so the pair-relative Dest immediates start from 0, and programs
+ * ADDR_MOD_6 with the per-pass Dest advance the replayed body rides on.
+ *
+ * @note Call this before @ref calculate_cumsum.
+ */
+inline void cumsum_init() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+
+    addr_mod_t{
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = CUMSUM_ROW_PAIR_STRIDE},
+    }
+        .set(CUMSUM_ADDR_MOD);
+}
+
+/**
+ * @brief Accumulate one tile row pair on top of the previous pair's running totals.
+ *
+ * Two SFPLOADs bring in the pair's 64 datums. SFPTRANSP then redistributes this bank's four
+ * registers so each holds one (tile row, tile column half) of the pair, so the pair carries two
+ * running totals - one per column half - which four SFPADDs chain: carry -> even row -> odd row.
+ * The pass's own totals stay in the ROW1 pair for the next pass to pick up as its carry.
+ *
+ * @tparam LREG_BASE: First LREG of this pass's bank, values = <CUMSUM_LREG_BANK_A/CUMSUM_LREG_BANK_B>
+ * @note Alternate LREG_BASE between passes. The carry only survives because it sits in the bank
+ *       this pass's SFPLOADs do not overwrite, so SFPTRANSP's involution restores it untouched.
+ * @note Call @ref cumsum_init first - the last SFPSTORE uses the address mode it programs to step
+ *       Dest to the next row pair.
+ */
+template <std::uint32_t LREG_BASE>
+inline void _calculate_cumsum_row_pair_() {
+    constexpr std::uint32_t ROW0_LO = LREG_BASE + CUMSUM_ROW0_LO;
+    constexpr std::uint32_t ROW0_HI = LREG_BASE + CUMSUM_ROW0_HI;
+    constexpr std::uint32_t ROW1_LO = LREG_BASE + CUMSUM_ROW1_LO;
+    constexpr std::uint32_t ROW1_HI = LREG_BASE + CUMSUM_ROW1_HI;
+
+    // The previous pass ran on the other bank and left its totals in that bank's ROW1 pair.
+    constexpr std::uint32_t OTHER_BANK = (LREG_BASE == CUMSUM_LREG_BANK_A) ? CUMSUM_LREG_BANK_B : CUMSUM_LREG_BANK_A;
+    constexpr std::uint32_t CARRY_LO = OTHER_BANK + CUMSUM_ROW1_LO;
+    constexpr std::uint32_t CARRY_HI = OTHER_BANK + CUMSUM_ROW1_HI;
+
+    // The row pair's 64 datums into the first two LREGs of this bank
+    TTI_SFPLOAD(ROW0_LO, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0 /* done */, 0 /* dest_reg_addr */);
+    TTI_SFPLOAD(ROW0_HI, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0 /* done */, CUMSUM_SECOND_ACCESS_OFF);
+
+    // Both banks transpose; this bank's registers now split by (tile row, tile column half)
+    TTI_SFPTRANSP;
+
+    // Serial column-wise prefix sum, one chain per tile column half. SFPADD is dest = a*b + c, so
+    // a = 1.0 makes it dest = prev + cur. No SFPNOP between them - the hardware interlocks a
+    // dependent consumer of a 2-cycle MAD.
+    TTI_SFPADD(p_sfpu::LCONST_1, CARRY_LO, ROW0_LO, ROW0_LO, 0 /* instr_mod1 */);  // even row = carry + row
+    TTI_SFPADD(p_sfpu::LCONST_1, CARRY_HI, ROW0_HI, ROW0_HI, 0 /* instr_mod1 */);
+    TTI_SFPADD(p_sfpu::LCONST_1, ROW0_LO, ROW1_LO, ROW1_LO, 0 /* instr_mod1 */);  // odd row = even row + row
+    TTI_SFPADD(p_sfpu::LCONST_1, ROW0_HI, ROW1_HI, ROW1_HI, 0 /* instr_mod1 */);  // the new carry pair
+
+    // Involution: this bank returns to store order, the other bank to its pre-transpose contents -
+    // that is what keeps the previous pair's carry intact.
+    TTI_SFPTRANSP;
+
+    // Write the row pair back to the same two slots, then step Dest to the next row pair
+    TTI_SFPSTORE(ROW0_LO, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0 /* done */, 0 /* dest_reg_addr */);
+    TTI_SFPSTORE(ROW0_HI, p_sfpu::sfpmem::DEFAULT, CUMSUM_ADDR_MOD, 0 /* done */, CUMSUM_SECOND_ACCESS_OFF);
+}
+
+/**
+ * @brief Column-wise (top-to-bottom) cumulative sum of one whole 32x32 Dest tile, in place.
+ *
+ * Walks the tile as CUMSUM_ROW_PAIRS passes on alternating LREG banks, issued as one recorded
+ * two-pass replay body run CUMSUM_REPLAY_ITERS times.
+ *
+ * @param first: Whether this is the first tile of a top-to-bottom chain; zeroes the carry bank.
+ * @note Run this once per tile under VectorMode::RC_custom, not once per face - the chain spans the
+ *       whole tile. It leaves the Dest RWC counter advanced by a whole tile, which
+ *       @ref _llk_math_eltwise_sfpu_done_ resets.
+ * @note On return CUMSUM_LREG_BANK_B's ROW1 pair (LREG6/LREG7) holds this tile's 32 column totals -
+ *       the carry the next call consumes with first == false. Feed tiles top-to-bottom and write
+ *       nothing to LREG4-7 in between.
+ * @note Uses replay slot 0 on the math thread.
+ * @note Call @ref cumsum_init before this to program the address mode it depends on.
+ */
+inline void calculate_cumsum(const bool first) {
+    if (first) {
+        // Zero the whole carry bank, not just its ROW1 pair: SFPTRANSP swizzles lanes across the
+        // entire bank, so a non-zero ROW0 pair would surface in the carry pair's lanes.
+        TTI_SFPMOV(p_sfpu::LCONST_0, CUMSUM_LREG_BANK_B + CUMSUM_ROW0_LO, 0 /* instr_mod1: plain copy */);
+        TTI_SFPMOV(p_sfpu::LCONST_0, CUMSUM_LREG_BANK_B + CUMSUM_ROW0_HI, 0 /* instr_mod1: plain copy */);
+        TTI_SFPMOV(p_sfpu::LCONST_0, CUMSUM_LREG_BANK_B + CUMSUM_ROW1_LO, 0 /* instr_mod1: plain copy */);
+        TTI_SFPMOV(p_sfpu::LCONST_0, CUMSUM_LREG_BANK_B + CUMSUM_ROW1_HI, 0 /* instr_mod1: plain copy */);
+    }
+
+    // Record the bank-A + bank-B pass pair; exec_while_loading runs row pairs 0-1 while recording.
+    load_replay_buf<CUMSUM_REPLAY_SLOT, CUMSUM_REPLAY_LEN, true /* exec_while_loading */>([] {
+        _calculate_cumsum_row_pair_<CUMSUM_LREG_BANK_A>();
+        _calculate_cumsum_row_pair_<CUMSUM_LREG_BANK_B>();
+    });
+
+    // Replay the remaining bank pairs; Dest auto-increment carries them down the tile.
+    for (std::uint32_t iter = 1; iter < CUMSUM_REPLAY_ITERS; iter++) {
+        TTI_REPLAY(
+            CUMSUM_REPLAY_SLOT,
+            CUMSUM_REPLAY_LEN,
+            0 /* last */,
+            0 /* set_mutex */,
+            0 /* execute_while_loading */,
+            0 /* load_mode */);
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -18,6 +18,7 @@
 #include "experimental/ckernel_sfpu_abs.h"
 #include "llk_sfpu/ckernel_sfpu_clamp.h"
 #include "llk_sfpu/ckernel_sfpu_comp.h"
+#include "llk_sfpu/ckernel_sfpu_cumsum.h"
 #include "llk_sfpu/ckernel_sfpu_exp.h"
 #include "llk_sfpu/ckernel_sfpu_gelu.h"
 #include "llk_sfpu/ckernel_sfpu_negative.h"
@@ -108,6 +109,10 @@ void init_unary_sfpu_operation_quasar()
     {
         _init_rsqrt_<APPROX>();
     }
+    else if constexpr (OPERATION == SfpuType::cumsum)
+    {
+        cumsum_init();
+    }
     else if constexpr (OPERATION == SfpuType::reciprocal)
     {
         _init_reciprocal_<APPROX>();
@@ -197,6 +202,8 @@ void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_fo
  * @param dst_index Destination tile index operated on (already offset by DST_INDEX).
  * @param sfpu_format SFPU math format; only the comp family reads it (see
  *        @ref call_zero_comp_operation_quasar), float-only ops ignore it.
+ * @param first Whether this is the first tile of a column-tile chain; only cumsum reads it,
+ *        to zero its cross-tile carry. Every other op ignores it.
  * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op.
  */
 template <
@@ -207,7 +214,7 @@ template <
     int ITERATIONS                 = SFPU_ITERATIONS,
     DataFormat TYPECAST_IN_FORMAT  = DataFormat::Float32,
     DataFormat TYPECAST_OUT_FORMAT = DataFormat::Float16_b>
-void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_format = DataFormat::Float32)
+void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_format = DataFormat::Float32, bool first = true)
 {
     if constexpr (OPERATION == SfpuType::abs)
     {
@@ -299,6 +306,12 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_f
             VectorMode::RC,
             static_cast<std::uint32_t>(0xBF800000),  // min = -1.0 (fp32)
             static_cast<std::uint32_t>(0x3F800000)); // max = +1.0 (fp32)
+    }
+    else if constexpr (OPERATION == SfpuType::cumsum)
+    {
+        // Whole-tile op: VectorMode::RC_custom calls the functor once with Dest parked at the tile
+        // base, because the column-wise chain crosses the face boundary. `first` zeroes the carry.
+        SFPU_UNARY_CALL_NO_TEMPLATE_ARGS(DST_SYNC, is_fp32_dest_acc_en, calculate_cumsum, dst_index, VectorMode::RC_custom, first);
     }
     else if constexpr (is_zero_comp_op(OPERATION))
     {

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2247,6 +2247,7 @@ class UnarySFPUGolden:
             MathOperation.LogicalNotUnary: self._logical_not,
             MathOperation.ReduceColumn: self._reduce_columns,
             MathOperation.ReduceRow: self._reduce_rows,
+            MathOperation.Cumsum: self._cumsum,
             MathOperation.Typecast: self._typecast,
             # Integer unary ops (routed through the integer path in __call__).
             MathOperation.LeftShift: self._left_shift,
@@ -2347,8 +2348,26 @@ class UnarySFPUGolden:
 
         result = tensor.clone().flatten()
 
+        # Whole-tensor ops are evaluated here, on the untilized (row-major) view, because
+        # they are not element-wise and so cannot go through the per-element map below:
+        # cumsum accumulates down each tile's columns. The tilize that follows moves the
+        # computed values into the same layout the element-wise path produces, so every
+        # later stage (dest-format rounding, untilize, output-format conversion) is shared.
+        whole_tensor_res = (
+            self._cumsum(result, dimensions)
+            if operation == MathOperation.Cumsum
+            else None
+        )
+
         if not skip_tilize:
             result = tilize_block(result, dimensions, input_format).flatten()
+            if whole_tensor_res is not None:
+                # Tilized as Float32 so this permutation does not round the accumulated
+                # values; the single Dest-format rounding is applied below, together with
+                # the element-wise path's.
+                whole_tensor_res = tilize_block(
+                    whole_tensor_res, dimensions, DataFormat.Float32
+                ).flatten()
 
         start = ELEMENTS_PER_TILE * dest_idx
         elements_to_process = TILE_SIZE * iterations
@@ -2360,17 +2379,23 @@ class UnarySFPUGolden:
                 f"but tensor has only {tensor.numel()} elements)"
             )
 
-        op_res = [
-            (
-                self.ops[operation](x, fill_const_value)
-                if operation == MathOperation.Fill
-                else self.ops[operation](x)
-            )
-            for x in result.tolist()[
+        if whole_tensor_res is not None:
+            op_res = whole_tensor_res.tolist()[
                 ELEMENTS_PER_TILE * dest_idx : ELEMENTS_PER_TILE * dest_idx
                 + TILE_SIZE * iterations
             ]
-        ]
+        else:
+            op_res = [
+                (
+                    self.ops[operation](x, fill_const_value)
+                    if operation == MathOperation.Fill
+                    else self.ops[operation](x)
+                )
+                for x in result.tolist()[
+                    ELEMENTS_PER_TILE * dest_idx : ELEMENTS_PER_TILE * dest_idx
+                    + TILE_SIZE * iterations
+                ]
+            ]
 
         op_dtype = (
             torch.float32
@@ -3044,6 +3069,24 @@ class UnarySFPUGolden:
     def _sigmoid_appx(self, x):
         # Golden is the exact sigmoid; the kernel is a LUT approximation of it.
         return self._torch_unary(x, torch.sigmoid)
+
+    def _cumsum(self, x, dimensions: tuple[int, int]):
+        """Column-wise (top-to-bottom) cumulative sum inside each 32x32 tile.
+
+        Not element-wise, so it is reached through the whole-tensor branch of __call__
+        instead of the per-element dispatch. ``x`` is the untilized (row-major) view of
+        the [H, W] tensor already converted to the Dest format, so one tile is a
+        (TILE_DIM, TILE_DIM) block and the sum runs down its rows. Each tile is
+        independent because the kernel is called once per tile with ``first = true``,
+        which zeroes the cross-tile carry.
+
+        The accumulation is done in float32 because the SFPU keeps the running total in
+        an FP32 LREG and rounds only the element it stores; the caller applies that
+        single Dest-format rounding to the returned values.
+        """
+        rows, cols = dimensions[0], dimensions[1]
+        tiles = x.reshape(rows // TILE_DIM, TILE_DIM, cols // TILE_DIM, TILE_DIM)
+        return torch.cumsum(tiles.to(torch.float32), dim=1).flatten()
 
     def _reduce_columns(self, x, reduce_pool: ReducePool):
         """Reduce columns across tiles, computing sum, average, or max."""

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -113,6 +113,9 @@ class MathOperation(Enum):
     I0 = OpSpec("i0", MathOpType.SFPU_UNARY)
     Rdiv = OpSpec("rdiv", MathOpType.SFPU_UNARY)
     Clamp = OpSpec("clamp", MathOpType.SFPU_UNARY)
+    # Column-wise cumulative sum of a whole tile (not element-wise; needs a
+    # whole-tensor golden and runs under VectorMode::RC_custom).
+    Cumsum = OpSpec("cumsum", MathOpType.SFPU_UNARY)
     Hardtanh = OpSpec("hardtanh", MathOpType.SFPU_UNARY)
     Tanhshrink = OpSpec("tanhshrink", MathOpType.SFPU_UNARY)
     Floor = OpSpec("floor", MathOpType.SFPU_UNARY)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -410,6 +410,23 @@ def prepare_trig_inputs(
     return (lo + u * (hi - lo)).to(torch_format)
 
 
+def prepare_cumsum_inputs(
+    src_A: torch.Tensor,
+    input_format: DataFormat,
+) -> torch.Tensor:
+    """
+    Map the uniform [0, 1] stimulus into [-1, 1] for the column-wise cumulative sum.
+
+    A column total is a chain of up to 32 adds, so the magnitude ceiling must leave room
+    for 32x growth: |x| <= 1 keeps every partial sum inside +-32, comfortably inside
+    Float16's range, and keeps the stimulus away from the subnormal magnitudes the SFPU
+    MAD datapath flushes to zero. Both signs are covered so the chain sees cancellation
+    as well as growth.
+    """
+    u = src_A.to(torch.float32)  # uniform [0, 1] from the uniform stimuli spec
+    return (-1.0 + 2.0 * u).to(format_dict[input_format])
+
+
 def prepare_unary_inputs(
     mathop: MathOperation,
     src_A: torch.Tensor,
@@ -422,6 +439,8 @@ def prepare_unary_inputs(
         return prepare_abs_inputs(src_A, src_B, input_format, output_format)
     if mathop == MathOperation.Square:
         return prepare_square_inputs(src_A, src_B, input_format, output_format)
+    if mathop == MathOperation.Cumsum:
+        return prepare_cumsum_inputs(src_A, input_format)
     if mathop in TRIGONOMETRY_OPS:
         return prepare_trig_inputs(src_A, mathop, input_format)
     if mathop in COMP_OPS:
@@ -655,6 +674,12 @@ OP_CONFIGS = [
     OpConfig(MathOperation.Clamp, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Neg, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Softplus, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
+    # Column-wise cumulative sum: a whole-tile op (VectorMode::RC_custom, one call per
+    # tile) whose running total lives in LREG4-7 between calls. Swept at [32, 32] only —
+    # one tile per call with first=true, which zeroes that carry. Covering the cross-tile
+    # carry (first=false) requires the shared C++ source to thread `first = (i == 0)`
+    # through its tile loop, so it is a follow-on.
+    OpConfig(MathOperation.Cumsum, ([32, 32],), DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Typecast, TENSOR_DIMS, DEST_SYNC_MODES),
     # Trigonometry / inverse-hyperbolic ops: same matrix as the other transcendentals,
     # fed a uniform [0, 1] stimulus that prepare_trig_inputs maps into each op's domain.
@@ -805,8 +830,8 @@ def test_eltwise_unary_sfpu_quasar(
     """
     Consolidated unary-SFPU test on Quasar. One compile-time-selected op per
     variant (abs, exp, gelu, relu, reciprocal, sqrt, tanh, sigmoid, silu, rsqrt,
-    square, typecast, and the six compare-to-zero modes), validated against the
-    UnarySFPUGolden reference. Typecast sweeps explicit (src, dst) format pairs;
+    square, cumsum, typecast, and the six compare-to-zero modes), validated against
+    the UnarySFPUGolden reference. Typecast sweeps explicit (src, dst) format pairs;
     every other op sweeps the shared format matrix.
     """
     (

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -120,6 +120,7 @@ enum class SfpuType : std::uint32_t
     greater_than_zero,
     less_than_equal_zero,
     greater_than_equal_zero,
+    cumsum,
 };
 
 enum class DstSync : std::uint8_t


### PR DESCRIPTION
### PR Category

Feature

### Summary

Implements the `cumsum` kernel for `quasar` from CodeGen run `2026-08-07_cumsum_quasar_ee955e26`.

Generated file: `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h`.

CodeGen reported 52/52 tests passing.

### Notes for reviewers

This is an AI-generated draft. Please review the implementation and the recorded verification before marking it ready.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-cumsum-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/generated-cumsum-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-cumsum-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/generated-cumsum-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-cumsum-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/generated-cumsum-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/generated-cumsum-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/generated-cumsum-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/generated-cumsum-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/generated-cumsum-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/generated-cumsum-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/generated-cumsum-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/generated-cumsum-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/generated-cumsum-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/generated-cumsum-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/generated-cumsum-quasar-v1)