### PR TITLE
Make ttnn.prod accuracy observable in test_prod_all

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
@@ -11,13 +11,49 @@ from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_prod
 
 
+# Dyadic factors (k / 2**n): each needs at most two stored mantissa bits, so every *operand*
+# survives the FPU source registers bit-for-bit, where those registers keep only 10 stored
+# mantissa bits and truncate the rest (see test_prod_all_fp32_truncation_accuracy below).
+# The running product is not exact - products of dyadic values are dyadic but their significands
+# grow, e.g. 1.5**15 = 3**15 / 2**15 needs 24 bits - so a few float32 ulps still accumulate in the
+# host-side reduction; measured worst case over these shapes is 3.9e-7, hence the 1e-5 tolerance.
+# The point is that no error comes from the input datapath, which keeps test_prod a check on
+# *what* prod computes rather than on how accurately it computes it.
+_DYADIC_FACTORS = (1.5, 0.75, 1.25, 0.625, 2.0, 0.5)
+
+
+def _exact_product_input(shape, cpu_dtype, seed=2023):
+    """Random dyadic factors, renormalised so the full product lands in [2**-0.5, 2**0.5].
+
+    A product of thousands of factors drifts exponentially. The previous `randint(1, 5)` stimulus
+    overflowed the golden to +inf for every shape in this test, which left `allclose(inf, inf)` as
+    the only assertion that still did anything; drawing factors around 1.0 instead pushes it the
+    other way, to ~1e-35 for the 4096-element shapes. That is only three orders of magnitude above
+    the smallest normal float32 (~1.2e-38, and bfloat16 has the same exponent range), so a
+    different seed or a larger shape would underflow into denormals where relative error stops
+    being meaningful.
+
+    Rounding log2 of the product to the nearest integer and dividing element 0 by that power of
+    two lands the product in [2**-0.5, 2**0.5]. Scaling by a power of two only changes an exponent
+    field, so no element becomes inexact.
+    """
+    torch.manual_seed(seed)
+    numel = 1
+    for dim in shape:
+        numel *= dim
+    factors = torch.tensor(_DYADIC_FACTORS, dtype=torch.float32)
+    torch_input = factors[torch.randint(0, len(factors), (numel,))].reshape(shape).contiguous()
+    exponent = int(torch.round(torch.log2(torch.prod(torch_input.to(torch.float64)).abs())).item())
+    torch_input.view(-1)[0] = torch_input.view(-1)[0] * (2.0**-exponent)
+    return torch_input.to(cpu_dtype)
+
+
 def get_tensors(input_shape, output_shape, device, npu_dtype):
-    torch.manual_seed(2023)
     cpu_dtype = torch.float32 if npu_dtype == ttnn.float32 else torch.bfloat16
     npu_layout = ttnn.TILE_LAYOUT
 
-    torch_input = torch.randint(1, 5, input_shape, dtype=cpu_dtype)
-    torch_output = torch.randint(1, 5, output_shape, dtype=cpu_dtype)
+    torch_input = _exact_product_input(input_shape, cpu_dtype)
+    torch_output = _exact_product_input(output_shape, cpu_dtype)
     tt_input = ttnn.Tensor(torch_input, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
     tt_output = ttnn.Tensor(torch_output, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
 
@@ -42,7 +78,12 @@ def test_prod(shapes, npu_dtype, device):
 
     (tt_input, tt_output, torch_input) = get_tensors(shapes, shapes, device, npu_dtype)
 
-    torch_output = torch.prod(torch_input)
+    # Reduce in float64 and cast back. torch.prod on a bfloat16 tensor runs its own serial
+    # bfloat16 reduction, which accumulates a different error than the device's and in a
+    # different order, so comparing the two compares two approximations rather than measuring
+    # the device against the true product: on the 4096-element shapes they land ~30% apart
+    # while each is within 17% of the exact answer.
+    torch_output = torch.prod(torch_input.to(torch.float64)).to(torch_input.dtype)
 
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
     tt_output_cpu = ttnn_prod(tt_input).cpu().to(cpu_layout).to_torch()
@@ -55,20 +96,101 @@ def test_prod(shapes, npu_dtype, device):
     logger.info("Torch Output")
     logger.info(torch_output)
 
-    if torch.isfinite(torch_output).all() and torch.isfinite(tt_output_cpu).all():
-        check_frobenius = True
-    else:
-        check_frobenius = False
-    # test for equivalance
+    assert torch.isfinite(torch_output).all(), "golden overflowed; the stimulus no longer bounds the product"
+    assert torch.isfinite(tt_output_cpu).all(), f"device produced a non-finite result: {tt_output_cpu}"
+
+    # float32 reproduces the exact product to within a few ulps because the stimulus is
+    # source-register exact. bfloat16 cannot: the intra-tile reduction is a serial host-side
+    # loop over all 1024 elements of the final tile carried out in the tensor dtype
+    # (prod_op_all.cpp -> prod_result_computation_WH_B0), so a bf16 run accumulates 1024
+    # round-to-nearest steps. Measured worst case over these shapes is 7.9e-2 relative.
+    tolerance = 1e-05 if npu_dtype == ttnn.float32 else 2e-01
     assert_numeric_metrics(
         torch_output,
         tt_output_cpu,
         pcc_threshold=0.9999,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
-        check_frobenius=check_frobenius,
+        rtol=tolerance,
+        atol=tolerance,
+        frobenius_threshold=tolerance,
     )
+
+
+# --------------------------------------------------------------------------------------------
+# Accuracy characterisation.
+#
+# Every operand reaching the FPU is first truncated to the source register's 11-bit significand
+# (10 stored mantissa bits plus the leading one). ttnn.prod multiplies *every* element of the
+# input together, so each element whose mantissa does not fit contributes about half an ulp of
+# that format, and the loss is one-sided (truncation, not round-to-nearest) so the errors
+# accumulate coherently and the result is systematically low.
+#
+# The bounds below record measured Blackhole behaviour so that it is visible and regressions are
+# caught. They are deliberately not a statement that this accuracy is good enough; if the fold is
+# ever moved off the source-register path these bounds should be tightened, not relaxed.
+# --------------------------------------------------------------------------------------------
+
+
+def _prod_relative_error(torch_input, device, npu_dtype=ttnn.float32):
+    """Run ttnn.prod and return (relative error vs a float64 golden, golden, device result)."""
+    golden = torch.prod(torch_input.to(torch.float64))
+    tt_input = ttnn.from_torch(torch_input, dtype=npu_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_output = ttnn.to_torch(ttnn.prod(tt_input)).flatten()[0].to(torch.float64)
+    assert torch.isfinite(tt_output), f"device produced a non-finite result: {tt_output}"
+    return ((tt_output - golden) / golden).item(), golden.item(), tt_output.item()
+
+
+# One full-mantissa factor per tile, everything else exactly 1.0, so the error isolates the
+# per-tile contribution. Measured on Blackhole: 4.8e-4 / 2.0e-3 / 1.6e-2.
+TRUNCATION_REL_ERROR_BOUND_BY_TILES = {1: 1e-03, 4: 4e-03, 16: 3e-02}
+
+
+@pytest.mark.parametrize("num_tiles", tuple(TRUNCATION_REL_ERROR_BOUND_BY_TILES))
+def test_prod_all_fp32_truncation_accuracy(num_tiles, device):
+    torch.manual_seed(0)
+    torch_input = torch.ones([1, num_tiles, 32, 32], dtype=torch.float32)
+    for tile in range(num_tiles):
+        torch_input[0, tile, 0, 0] = float(torch.empty(1).uniform_(0.7, 1.4).item())
+
+    rel_error, golden, got = _prod_relative_error(torch_input, device)
+    logger.info(f"{num_tiles} tiles: golden={golden} got={got} rel_error={rel_error}")
+
+    bound = TRUNCATION_REL_ERROR_BOUND_BY_TILES[num_tiles]
+    assert abs(rel_error) <= bound, f"{num_tiles} tiles: relative error {rel_error} exceeds documented bound {bound}"
+
+
+# The error tracks the number of elements that do not fit the source-register mantissa, not the
+# number of tiles: these all live in a *single* tile, where the cross-tile fold never runs at all.
+# Measured on Blackhole: 4.9e-4 / 2.3e-2 / 3.1e-1.
+TRUNCATION_REL_ERROR_BOUND_BY_ELEMENTS = {1: 1e-03, 64: 5e-02, 1024: 5e-01}
+
+
+@pytest.mark.parametrize("num_non_unit", tuple(TRUNCATION_REL_ERROR_BOUND_BY_ELEMENTS))
+def test_prod_all_fp32_truncation_scales_with_element_count(num_non_unit, device):
+    torch.manual_seed(1)
+    torch_input = torch.ones([1, 1, 32, 32], dtype=torch.float32)
+    torch_input.view(-1)[:num_non_unit] = torch.empty(num_non_unit).uniform_(0.95, 1.05)
+
+    rel_error, golden, got = _prod_relative_error(torch_input, device)
+    logger.info(f"{num_non_unit} non-unit elements: golden={golden} got={got} rel_error={rel_error}")
+
+    bound = TRUNCATION_REL_ERROR_BOUND_BY_ELEMENTS[num_non_unit]
+    assert abs(rel_error) <= bound, f"{num_non_unit} elements: relative error {rel_error} exceeds bound {bound}"
+
+
+def test_prod_all_fp32_exact_for_representable_input(device):
+    """Values that fit the source-register mantissa are reduced essentially exactly.
+
+    This is the control for the two tests above: same element count and same magnitudes, but
+    every factor is dyadic, so nothing is truncated on the way into SrcA and the accumulated
+    error drops by six orders of magnitude. It pins the cause to mantissa width rather than to
+    the number of multiplies.
+    """
+    torch_input = _exact_product_input([1, 1, 32, 32], torch.float32, seed=3)
+
+    rel_error, golden, got = _prod_relative_error(torch_input, device)
+    logger.info(f"dyadic input: golden={golden} got={got} rel_error={rel_error}")
+
+    assert abs(rel_error) <= 1e-05, f"exactly representable input should be near-exact, got {rel_error}"
 
 
 BLOCK_FLOAT_DTYPES = (ttnn.bfloat8_b, ttnn.bfloat4_b)

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
@@ -25,17 +25,18 @@ _DYADIC_FACTORS = (1.5, 0.75, 1.25, 0.625, 2.0, 0.5)
 def _exact_product_input(shape, cpu_dtype, seed=2023):
     """Random dyadic factors, renormalised so the full product lands in [2**-0.5, 2**0.5].
 
-    A product of thousands of factors drifts exponentially. The previous `randint(1, 5)` stimulus
-    overflowed the golden to +inf for every shape in this test, which left `allclose(inf, inf)` as
-    the only assertion that still did anything; drawing factors around 1.0 instead pushes it the
-    other way, to ~1e-35 for the 4096-element shapes. That is only three orders of magnitude above
-    the smallest normal float32 (~1.2e-38, and bfloat16 has the same exponent range), so a
-    different seed or a larger shape would underflow into denormals where relative error stops
-    being meaningful.
+    # A product of thousands of factors drifts exponentially. For example, taking randint(1, 5)
+    # as the stimulus easily overflows the golden to +inf, leaving allclose(inf, inf) as the only
+    # reasonable check at the end of the test.
 
-    Rounding log2 of the product to the nearest integer and dividing element 0 by that power of
-    two lands the product in [2**-0.5, 2**0.5]. Scaling by a power of two only changes an exponent
-    field, so no element becomes inexact.
+    # Conversely, drawing factors around 1.0 pushes the product the other way,
+    # to ~1e-35 for the 4096-element shapes. That is only three orders of magnitude above the smallest
+    # normal float32 (~1.2e-38, and bfloat16 has the same exponent range), so a different seed
+    # or a larger shape would underflow into denormals where relative error stops being meaningful.
+
+    # Dividing element 0 by 2**round(log2(product)) lands the product in [2**-0.5, 2**0.5].
+    # Scaling by a power of two only changes the exponent field, so no element becomes inexact,
+    # as long as the result stays in the normal range.
     """
     torch.manual_seed(seed)
     numel = 1
@@ -78,11 +79,10 @@ def test_prod(shapes, npu_dtype, device):
 
     (tt_input, tt_output, torch_input) = get_tensors(shapes, shapes, device, npu_dtype)
 
-    # Reduce in float64 and cast back. torch.prod on a bfloat16 tensor runs its own serial
-    # bfloat16 reduction, which accumulates a different error than the device's and in a
-    # different order, so comparing the two compares two approximations rather than measuring
-    # the device against the true product: on the 4096-element shapes they land ~30% apart
-    # while each is within 17% of the exact answer.
+    # Reduce in float64 and cast back.
+    # torch.prod on a bfloat16 tensor would run its own serial bfloat16 reduction,
+    # accumulating a different error from the device's, in a different order.
+    # Comparing the two would pit two approximations against each other rather than measuring the device against the true product.
     torch_output = torch.prod(torch_input.to(torch.float64)).to(torch_input.dtype)
 
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT


### PR DESCRIPTION
### Problem

Nothing in `test_prod_all.py` can reliably detect a numerical error in `ttnn.prod`.

- `test_prod` gets its stimulus from `torch.randint(1, 5, shape)`. Every shape and dtype overflows the golden to `+inf`. Once the golden is non-finite the Frobenius check is switched off, and PCC is skipped for scalar outputs because `ttnn.prod` with no `dim` returns a single value (rank-0) which leaves `torch.allclose(inf, inf)` as the only assertion still doing anything.
- `test_prod_all_block_float` uses ones and `2.0`s: powers of two are exact at any mantissa width.
- `test_prod_all_block_float_nontrivial` tests the numerics, but with thresholds several times looser than the error it would need to catch.

### What this changes

**`test_prod` gets a stimulus whose product is bounded.** Dyadic factors (`k/2**n`, each exact in a few mantissa bits), renormalised by an exact power of two so the result lands in `[2**-0.5, 2**0.5]`. That avoids `+inf` and the denormals.

**The golden is computed in float64.** `torch.prod` on a bfloat16 tensor runs its own serial bfloat16 reduction, so comparing against it compares two approximations with different accumulation orders.

**Three new characterisation tests.** Every operand entering the FPU is truncated to the source-register mantissa, and `prod` multiplies every element of its input, so the relative error grows with the number of elements whose mantissa does not fit — not with tile count. Measured on Blackhole p100a:

| stimulus | relative error |
|---|---|
| 16 tiles, one full-mantissa factor per tile | −1.64e−2 |
| 1024 non-unit elements in a single tile | −3.06e−1 |
| 1024 dyadic elements in a single tile (control) | +6.28e−7 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/prod-accuracy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/prod-accuracy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/prod-accuracy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/prod-accuracy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/prod-accuracy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/prod-accuracy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/prod-accuracy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/prod-accuracy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/prod-accuracy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/prod-accuracy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/prod-accuracy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/prod-accuracy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/prod-accuracy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/prod-accuracy-tests)