### PR TITLE
Gate high_bw_all_gather tests to Blackhole

### DIFF
--- a/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
@@ -288,6 +288,7 @@ def _run_high_bw_all_gather_accuracy(
     _assert_exact_all_gather(device_input, persistent_output, mesh_device, dtype)
 
 
+@run_for_blackhole("high_bw_all_gather requires Blackhole fabric")
 @pytest.mark.parametrize("device_params", [_FABRIC_2D_TORUS_XY_DEVICE_PARAMS], indirect=True)
 @pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
 def test_high_bw_all_gather_preserves_same_dim_sharding_on_other_axis(mesh_device, expect_error):
@@ -641,6 +642,7 @@ def test_high_bw_all_gather_galaxy_ci_perf(mesh_device):
     )
 
 
+@run_for_blackhole("high_bw_all_gather requires Blackhole fabric")
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -682,6 +684,7 @@ def test_high_bw_all_gather_quietbox_ci_perf(mesh_device):
     )
 
 
+@run_for_blackhole("high_bw_all_gather requires Blackhole fabric")
 @pytest.mark.parametrize(
     "device_params,axis_0_min_bandwidth_gbps,axis_1_min_bandwidth_gbps",
     _LINE_PERF_DEVICE_PARAMS,
@@ -717,6 +720,7 @@ def test_high_bw_all_gather_512k(mesh_device, axis_0_min_bandwidth_gbps, axis_1_
         )
 
 
+@run_for_blackhole("high_bw_all_gather requires Blackhole fabric")
 @pytest.mark.parametrize("device_params", [_FABRIC_2D_LINE_DEVICE_PARAMS], indirect=True)
 def test_high_bw_all_gather_512k_fabric_2d_line(mesh_device):
     # QuietBox uses its physical 4x1 line directly. LoudBox uses a physical
@@ -725,6 +729,7 @@ def test_high_bw_all_gather_512k_fabric_2d_line(mesh_device):
     _run_high_bw_all_gather_test_cases(rank_line, min_bandwidth_gbps=45.0, cluster_axis=cluster_axis)
 
 
+@run_for_blackhole("high_bw_all_gather requires Blackhole fabric")
 @pytest.mark.parametrize("device_params", [_FABRIC_2D_TORUS_XY_DEVICE_PARAMS], indirect=True)
 def test_high_bw_all_gather_ragged_accuracy(mesh_device):
     if os.getenv("TT_METAL_HIGH_BW_ALL_GATHER_RUN_RAGGED_ACCURACY") != "1":
@@ -847,6 +852,7 @@ def _run_high_bw_all_gather_token_sweep(
             gc.collect()
 
 
+@run_for_blackhole("high_bw_all_gather requires Blackhole fabric")
 @pytest.mark.parametrize(
     "device_params,axis_0_min_bandwidth_gbps,axis_1_min_bandwidth_gbps",
     _LINE_PERF_DEVICE_PARAMS,


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The high_bw_all_gather test file configures Blackhole-specific fabric modes and a 14 KiB fabric router payload, but most tests were not explicitly gated to Blackhole. On Wormhole these tests attempted to initialize unsupported Blackhole fabric settings, first failing the payload-size limit and then cascading into fabric-config override errors across later parametrizations. Add per-test `run_for_blackhole` decorators to the remaining high_bw_all_gather tests so unsupported architectures skip before device/fabric setup, matching the existing Galaxy perf gate while preserving the Blackhole coverage unchanged.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/high-bw-skip-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/high-bw-skip-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/high-bw-skip-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/high-bw-skip-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/high-bw-skip-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/high-bw-skip-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/high-bw-skip-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/high-bw-skip-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/high-bw-skip-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/high-bw-skip-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/high-bw-skip-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/high-bw-skip-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/high-bw-skip-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/high-bw-skip-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/high-bw-skip-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/high-bw-skip-wh)