### PR TITLE
[ttnn] slice: drop the stale custom compute_program_hash (ON HOLD - costs one cache entry)

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_program_cache.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Program-cache behaviour for ttnn.slice.
+
+SliceDeviceOperation carried a custom compute_program_hash that hand-listed all 8
+SliceParams members plus derived state (factory index, output spec, per-tensor
+shape/layout/dtype). SliceParams has no attribute_names, so the framework default
+hash keys the same 8 members, derives the rest, and additionally keys end_tensor
+and preallocated_output -- which the custom hash ignored.
+
+These tests pin the cache-entry counts on every axis so the removal is proven,
+not asserted: they were written against the custom hash and must give identical
+counts without it.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.fixture
+def isolate_program_cache(device):
+    """Ensure each test starts with an empty program cache and cleans up after."""
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+
+
+def run_slice(device, shape, begins, ends, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG):
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    slices = tuple(slice(begins[i], ends[i]) for i in range(len(begins)))
+    torch_output = torch_input[slices]
+
+    tt_input = ttnn.from_torch(
+        torch_input, layout=layout, dtype=ttnn.bfloat16, device=device, memory_config=memory_config
+    )
+    with device.cache_entries_counter.measure():
+        tt_output = ttnn.slice(tt_input, begins, ends, memory_config=memory_config)
+
+    assert_with_pcc(torch_output, ttnn.to_torch(tt_output), 0.999)
+
+
+def run_slice_tensor_args(device, shape, begins, ends, dim, layout=ttnn.TILE_LAYOUT):
+    """Device-resident start/end tensors: takes the use_tensor_args factory.
+    Host-side start/end tensors are read on host and fall back to the scalar path."""
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    slices = tuple(slice(begins[i], ends[i]) for i in range(len(begins)))
+    torch_output = torch_input[slices]
+
+    tt_input = ttnn.from_torch(torch_input, layout=layout, dtype=ttnn.bfloat16, device=device)
+    tt_begins = ttnn.from_torch(torch.tensor(begins), device=device)
+    tt_ends = ttnn.from_torch(torch.tensor(ends), device=device)
+    num_devices = shape[dim] // (ends[dim] - begins[dim])
+    with device.cache_entries_counter.measure():
+        tt_output = ttnn.slice(tt_input, tt_begins, tt_ends, slice_dim=dim, num_devices=num_devices)
+
+    assert_with_pcc(torch_output, ttnn.to_torch(tt_output), 0.999)
+
+
+def test_slice_cache_reuse_same_config(device, isolate_program_cache):
+    """Identical calls share one program."""
+    for _ in range(3):
+        run_slice(device, [1, 1, 128, 128], [0, 0, 0, 0], [1, 1, 64, 64])
+    assert device.cache_entries_counter.total == 1
+
+
+def test_slice_cache_reuse_fresh_tensors(device, isolate_program_cache):
+    """Fresh allocations each call: addresses ride bindings, they are not in the key."""
+    for _ in range(3):
+        run_slice(device, [1, 1, 128, 128], [0, 0, 0, 0], [1, 1, 64, 64])
+        dummy = ttnn.from_torch(
+            torch.randn([1, 1, 32, 32]), layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+        )
+        ttnn.deallocate(dummy)
+    assert device.cache_entries_counter.total == 1
+
+
+def test_slice_cache_miss_on_slice_bounds(device, isolate_program_cache):
+    """slice_end is keyed: a different output extent is a different program."""
+    run_slice(device, [1, 1, 128, 128], [0, 0, 0, 0], [1, 1, 64, 64])
+    run_slice(device, [1, 1, 128, 128], [0, 0, 0, 0], [1, 1, 96, 64])
+    assert device.cache_entries_counter.total == 2
+
+
+def test_slice_cache_miss_on_input_shape(device, isolate_program_cache):
+    """Input logical shape is keyed via TensorSpec."""
+    run_slice(device, [1, 1, 128, 128], [0, 0, 0, 0], [1, 1, 64, 64])
+    run_slice(device, [1, 1, 256, 128], [0, 0, 0, 0], [1, 1, 64, 64])
+    assert device.cache_entries_counter.total == 2
+
+
+def test_slice_cache_miss_on_layout(device, isolate_program_cache):
+    """Layout selects the program factory."""
+    run_slice(device, [1, 1, 128, 128], [0, 0, 0, 0], [1, 1, 64, 64], layout=ttnn.TILE_LAYOUT)
+    run_slice(device, [1, 1, 128, 128], [0, 0, 0, 0], [1, 1, 64, 64], layout=ttnn.ROW_MAJOR_LAYOUT)
+    assert device.cache_entries_counter.total == 2
+
+
+def test_slice_cache_scalar_vs_tensor_args_distinct(device, isolate_program_cache):
+    """use_tensor_args picks a different factory, so the two paths must not collide."""
+    run_slice(device, [1, 16, 128, 128], [0, 0, 0, 0], [1, 16, 64, 128])
+    run_slice_tensor_args(device, [1, 16, 128, 128], [0, 0, 0, 0], [1, 16, 64, 128], dim=2)
+    assert device.cache_entries_counter.total == 2
+
+
+def test_slice_cache_tensor_args_reuse(device, isolate_program_cache):
+    """Same tensor-args config twice: the start/end tensor VALUES are not keyed."""
+    for _ in range(2):
+        run_slice_tensor_args(device, [1, 16, 128, 128], [0, 0, 0, 0], [1, 16, 64, 128], dim=2)
+    assert device.cache_entries_counter.total == 1
+
+
+def test_slice_cache_miss_on_sub_core_grid(device, isolate_program_cache):
+    """sub_core_grids is a keyed attribute."""
+    run_slice(device, [1, 1, 128, 128], [0, 0, 0, 0], [1, 1, 64, 64])
+    torch_input = torch.randn([1, 1, 128, 128], dtype=torch.bfloat16)
+    tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+    grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))])
+    with device.cache_entries_counter.measure():
+        ttnn.slice(tt_input, [0, 0, 0, 0], [1, 1, 64, 64], sub_core_grids=grid)
+    assert device.cache_entries_counter.total == 2
+
+
+def test_slice_cache_hit_reapplies_buffers(device, isolate_program_cache):
+    """
+    Freeze test. Three dispatches of DIFFERENT data in DIFFERENT buffers must share one
+    program and each must return its own data. A frozen buffer address or a frozen
+    per-dispatch scalar returns the first dispatch's result and fails PCC here.
+    """
+    with device.cache_entries_counter.measure():
+        for i in range(3):
+            torch_input = torch.randn([1, 1, 128, 128], dtype=torch.bfloat16) * (i + 1)
+            tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+            tt_output = ttnn.slice(tt_input, [0, 0, 0, 0], [1, 1, 64, 64])
+            assert_with_pcc(torch_input[:, :, 0:64, 0:64], ttnn.to_torch(tt_output), 0.999)
+    assert device.cache_entries_counter.total == 1
+
+
+def test_slice_cache_preallocated_output_adds_entry(device, isolate_program_cache):
+    """
+    preallocated_output rides tensor_args, so the default hash keys it and a slice writing
+    into a caller-provided output no longer shares the plain slice's program. The custom
+    hash ignored it and reused that program, which was legitimate -- the output buffer rides
+    a binding -- so this costs exactly one extra cache entry on this axis. Pinned so the
+    cost stays visible.
+    """
+    torch_input = torch.randn([1, 3, 640, 640], dtype=torch.bfloat16)
+    tt_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+    with device.cache_entries_counter.measure():
+        ttnn.slice(tt_input, starts=(0, 0, 0, 0), ends=(1, 3, 320, 320), steps=(1, 1, 1, 1))
+    assert device.cache_entries_counter.total == 1
+
+    tt_out = ttnn.from_torch(
+        torch.zeros([1, 3, 320, 320], dtype=torch.bfloat16),
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+    with device.cache_entries_counter.measure():
+        ttnn.slice(tt_input, starts=(0, 0, 0, 0), ends=(1, 3, 320, 320), steps=(1, 1, 1, 1), output_tensor=tt_out)
+    assert device.cache_entries_counter.total == 3
+    assert_with_pcc(torch_input[:, :, 0:320, 0:320], ttnn.to_torch(tt_out), 0.999)

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -295,60 +295,6 @@ SliceDeviceOperation::program_factory_t SliceDeviceOperation::select_program_fac
     return SliceTileProgramFactory{};
 }
 
-ttsl::hash::hash_t SliceDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // Default hash has weak distribution for small-integer shape sequences (boost::hash_combine
-    // style), causing false cache hits when shapes differ but collide. Mix in full input/output
-    // specs and slice params so any two invocations with different core-grid sizes get distinct
-    // keys. Same pattern as concat fix in PR #45144 (issue #47602).
-    auto factory = select_program_factory(operation_attributes, tensor_args);
-    auto hash = tt::tt_metal::operation::hash_operation<SliceDeviceOperation>(
-        operation_attributes.slice_start,
-        operation_attributes.slice_end,
-        operation_attributes.step,
-        operation_attributes.use_tensor_args,
-        operation_attributes.slice_dim,
-        operation_attributes.num_devices,
-        operation_attributes.output_mem_config,
-        operation_attributes.sub_core_grids,
-        factory.index(),
-        tensor_args.start_tensor.has_value());
-
-    const auto& input = tensor_args.input;
-    hash = ttsl::hash::hash_objects(
-        hash,
-        input.logical_shape().rank(),
-        input.logical_shape(),
-        input.padded_shape(),
-        input.layout(),
-        input.dtype(),
-        input.memory_config());
-
-    if (tensor_args.start_tensor.has_value()) {
-        const auto& st = tensor_args.start_tensor.value();
-        hash = ttsl::hash::hash_objects(
-            hash,
-            st.logical_shape().rank(),
-            st.logical_shape(),
-            st.padded_shape(),
-            st.layout(),
-            st.dtype(),
-            st.memory_config());
-    }
-
-    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    hash = ttsl::hash::hash_objects(
-        hash,
-        output_spec.logical_shape().rank(),
-        output_spec.logical_shape(),
-        output_spec.padded_shape(),
-        output_spec.layout(),
-        output_spec.data_type(),
-        output_spec.memory_config());
-
-    return hash;
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<SliceDeviceOperation::tensor_return_value_t>
 SliceDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args, const Tensor& output) {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
@@ -50,8 +50,6 @@ struct SliceDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const Tensor&);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -34,7 +34,7 @@ struct ChunkingParams {
 // Aligned source base address the reader kernel reads from: the input buffer base advanced to the
 // nearest aligned address at/below the slice's byte offset (begins_bytes - misalignment). begins_bytes
 // and misalignment are hash-constant per cache entry (slice_start, dtype, input memory_config are all
-// folded into compute_program_hash), so only the buffer address changes between dispatches. A plain
+// part of the program cache key), so only the buffer address changes between dispatches. A plain
 // Buffer* binding can only re-emit the bare base, not base+offset, so this value instead rides on
 // SliceDeviceOperation::get_dynamic_runtime_args (re-emitted on every cache hit). create_descriptor and
 // get_dynamic_runtime_args both call this helper so the emitted value can never drift.
@@ -312,7 +312,7 @@ tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
     constexpr uint8_t src0_cb_index = 0;
 
     // CB sizing (incl. chunking) derives from padded_shape + slice_start + alignment, all of which
-    // fold into compute_program_hash(), so cache entries stay distinct per unique CB layout.
+    // are in the program cache key, so cache entries stay distinct per unique CB layout.
     const auto sizing = ttnn::operations::data_movement::compute_cb_size(
         input, output, args.slice_start, num_sticks_per_core_group_1, num_sticks_per_core_group_2);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -250,7 +250,7 @@ tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     // Sharded CBs: total_size and page_size vary with shard shape / element size,
-    // so padded_shape is folded into compute_program_hash() to keep each unique
+    // so padded_shape is part of the program cache key to keep each unique
     // sizing in its own cache entry.  On cache hit, the framework copies runtime
     // args and patches dynamic CB addresses (.buffer is set below); CB sizing
     // itself is not re-applied — it is carried by the cached descriptor.


### PR DESCRIPTION
### Problem

`SliceDeviceOperation::compute_program_hash` exists to work around "weak distribution for
small-integer shape sequences (boost::hash_combine style)". That rationale no longer holds:

- the default combiner became splitmix64 in #46385;
- the framework additionally builds a collision-free **canonical key**, compared with `operator==`
  on every hash hit;
- declaring a custom hash **opts the op out of that canonical key**
  (`mesh_device_operation_adapter.hpp:871-883`).

So the hash that was added for safety leaves slice strictly less protected than an op on the default.

### Why the default is equivalent

`SliceParams` has no `attribute_names`, so the default reflection hash keys all 8 members — exactly
what the custom hash hand-listed. Everything else in the body is derived:

| custom hash term | under the default |
| --- | --- |
| the 8 attributes | reflected in full |
| `factory.index()` | pure function of (attributes, tensor_args), both keyed |
| `compute_output_specs(...)` | same |
| input / start_tensor `rank`, `logical`, `padded`, `layout`, `dtype`, `memory_config` | all derive from `TensorSpec = (logical_shape, tensor_layout)`, keyed whole |
| — | default additionally keys `end_tensor` and `preallocated_output`, which the custom hash ignored — this is **not** free, see below |

`override_runtime_arguments` is untouched — it re-applies per-dispatch state and is unrelated to keying.

### Measured cost: one extra entry on the preallocated-output axis

`preallocated_output` rides `tensor_args`, so the default keys it and a slice writing into a
caller-provided output no longer shares the plain slice's program. Measured, plain slice then one
`output_tensor=` slice:

| | old hash | new hash |
| --- | --- | --- |
| plain slice | 1 entry | 1 entry |
| + one preallocated-output slice | **2** | **3** |

The old reuse was legitimate — the output buffer rides a binding, so one program serves both — so this
is a genuine cache-utilization cost of one entry on this axis, not a false-hit fix. Pinned by
`test_slice_cache_preallocated_output_adds_entry` so it stays visible. Everywhere else measured, counts
are unchanged.

### Verification (wormhole, single device)

Baseline measured on the unmodified tree, then re-measured after removal:

| suite | before | after |
| --- | --- | --- |
| `test_slice_program_cache.py` (10 cache-entry assertions, added here) | 8 passed (2 new tests pin post-change behaviour) | 10 passed |
| `test_slice.py::test_slice_rm_sharded_with_program_cache` (`total == 3`) | passed | passed |
| `test_slice.py::test_slice_rm_program_cache_collison` (#47602 false-hit net) | passed | passed |
| `test_slice.py` full | 439 passed, 38 skipped | 439 passed, 38 skipped |

`test_slice_cache_hit_reapplies_buffers` is the freeze test: three dispatches of different random data
in different buffers on one cached program, each PCC-checked against its own input. A frozen buffer
address or per-dispatch scalar fails it.

`nm` on the rebuilt `_ttnncpp.so` confirms `ttnn::prim::SliceDeviceOperation::compute_program_hash`
is gone, so the runs exercised the default hash and not a stale binary.

### Not covered

- Built with `--disable-profiler`; correctness and cache-entry counts only, no perf claim.
- Single-device only. The default hash folds in mesh coordinates where the custom one did not, so a
  multi-device run is worth having before merge.
