### PR TITLE
[ttnn] pool: drop memory_used from op attributes and the custom hash

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_pool_axis_sweep.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_pool_axis_sweep.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Axis sweep for Pool2D program-cache neutrality.
+
+Runs a broad battery of configs (shape, channels, kernel, stride, padding, ceil_mode, dtype,
+shard scheme, output layout) through one program cache, then repeats the identical battery
+and asserts it builds nothing new. Absolute entry counts are arch-dependent; zero growth on
+the second pass is not, and it is what catches a key that varies per dispatch -- the failure
+mode that keying the removed `memory_used` would have produced.
+
+Measured differentially on wormhole while removing the custom hash: 41 entries with the custom
+hash, 41 without.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from tests.ttnn.nightly.unit_tests.operations.pool.test_maxpool2d import run_max_pool2d
+
+pytestmark = pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+
+
+@pytest.fixture
+def iso(device):
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+
+
+HS = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+BS = ttnn.TensorMemoryLayout.BLOCK_SHARDED
+WS = ttnn.TensorMemoryLayout.WIDTH_SHARDED
+
+
+def test_pool_axis_sweep(device, iso):
+    """Vary shape, channels, kernel, stride, padding, ceil_mode, dtype, layout, shard scheme."""
+    cases = [
+        ([1, 16, 25, 23], (2, 2), (2, 2), (0, 0), False, ttnn.bfloat16, HS, None),
+        ([1, 16, 25, 23], (3, 3), (2, 2), (1, 1), False, ttnn.bfloat16, HS, None),
+        ([1, 16, 25, 23], (2, 2), (2, 2), (0, 0), True, ttnn.bfloat16, HS, None),
+        ([1, 32, 32, 32], (2, 2), (2, 2), (0, 0), False, ttnn.bfloat16, HS, None),
+        ([1, 64, 16, 16], (2, 2), (2, 2), (0, 0), False, ttnn.bfloat16, HS, None),
+        ([1, 128, 8, 8], (2, 2), (2, 2), (0, 0), False, ttnn.bfloat16, BS, None),
+        ([1, 256, 8, 8], (2, 2), (2, 2), (0, 0), False, ttnn.bfloat16, WS, None),
+        # dtype axis (bfloat8_b enters via TILE layout in the harness)
+        ([1, 16, 25, 23], (2, 2), (2, 2), (0, 0), False, ttnn.bfloat8_b, HS, None),
+        ([1, 32, 32, 32], (2, 2), (2, 2), (0, 0), False, ttnn.bfloat8_b, HS, None),
+        # output layout axis
+        ([1, 16, 25, 23], (2, 2), (2, 2), (0, 0), False, ttnn.bfloat16, HS, ttnn.TILE_LAYOUT),
+        ([1, 32, 32, 32], (2, 2), (2, 2), (0, 0), False, ttnn.bfloat16, HS, ttnn.TILE_LAYOUT),
+        # repeats of earlier cases: must add nothing
+        ([1, 16, 25, 23], (2, 2), (2, 2), (0, 0), False, ttnn.bfloat16, HS, None),
+        ([1, 32, 32, 32], (2, 2), (2, 2), (0, 0), False, ttnn.bfloat16, HS, None),
+    ]
+
+    def sweep():
+        ran = 0
+        for shape, kernel, stride, pad, ceil_mode, dtype, scheme, out_layout in cases:
+            kwargs = {}
+            if out_layout is not None:
+                kwargs["output_layout"] = out_layout
+            try:
+                run_max_pool2d(
+                    list(shape),
+                    list(kernel),
+                    list(pad),
+                    list(stride),
+                    [1, 1],
+                    device,
+                    {},
+                    dtype,
+                    shard_scheme=scheme,
+                    ceil_mode=ceil_mode,
+                    nightly_skips=False,
+                    **kwargs,
+                )
+                ran += 1
+            except Exception as e:  # unsupported combo on this arch: skip, but report it
+                print(f"\nSWEEP-SKIP {shape} {kernel} {dtype} {scheme} {out_layout}: {type(e).__name__}", flush=True)
+        return ran
+
+    with device.cache_entries_counter.measure():
+        ran = sweep()
+    first = device.cache_entries_counter.total
+    print(f"\nSWEEP POOL ran={ran}/{len(cases)} entries={first}", flush=True)
+
+    # Second pass over the identical battery must build nothing new. Absolute counts are
+    # arch-dependent; zero growth is not, and it is what catches a key that varies per call.
+    with device.cache_entries_counter.measure():
+        sweep()
+    assert device.cache_entries_counter.total == first

--- a/tests/ttnn/unit_tests/operations/pool/test_pool_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_pool_program_cache.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Program-cache behaviour for ttnn.max_pool2d (Pool2D device op).
+
+Pool2D carried a custom compute_program_hash whose only job was to EXCLUDE
+operation_attributes_t::memory_used -- a live L1 allocator reading captured by the
+host op and threaded into the device op's attributes so a TT_FATAL in the factory
+could cross-check CB sizes. Being live allocator state it varies with unrelated
+allocations, so keying on it would miss the cache on nearly every call.
+
+memory_used is now gone from the attributes and the default hash applies. Counts are
+asserted as growth / no-growth because run_max_pool2d also dispatches halo; the
+absolute number of entries is not the point, whether a repeat adds any is.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from tests.ttnn.nightly.unit_tests.operations.pool.test_maxpool2d import run_max_pool2d
+
+
+@pytest.fixture
+def isolate_program_cache(device):
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+
+
+@pytest.fixture
+def tensor_map():
+    return {}
+
+
+pytestmark = pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+
+
+def run_pool(device, tensor_map, shape, kernel=(2, 2), stride=(2, 2), padding=(0, 0), dilation=(1, 1)):
+    run_max_pool2d(
+        list(shape),
+        list(kernel),
+        list(padding),
+        list(stride),
+        list(dilation),
+        device,
+        tensor_map,
+        ttnn.bfloat16,
+        shard_scheme=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ceil_mode=False,
+        nightly_skips=False,
+    )
+
+
+def test_pool_cache_reuse_same_config(device, tensor_map, isolate_program_cache):
+    """A repeat of an identical config must add no cache entries."""
+    with device.cache_entries_counter.measure():
+        run_pool(device, tensor_map, [1, 16, 25, 23])
+    after_first = device.cache_entries_counter.total
+
+    with device.cache_entries_counter.measure():
+        run_pool(device, tensor_map, [1, 16, 25, 23])
+        run_pool(device, tensor_map, [1, 16, 25, 23])
+    assert device.cache_entries_counter.total == after_first
+
+
+def test_pool_cache_reuse_under_l1_churn(device, tensor_map, isolate_program_cache):
+    """
+    The regression memory_used would cause if it were keyed: unrelated L1 allocations
+    move the allocator total, so a key containing it would rebuild every dispatch.
+    No growth here proves the key carries no live allocator state.
+    """
+    with device.cache_entries_counter.measure():
+        run_pool(device, tensor_map, [1, 16, 25, 23])
+    after_first = device.cache_entries_counter.total
+
+    held = []
+    with device.cache_entries_counter.measure():
+        for i in range(3):
+            held.append(
+                ttnn.from_torch(
+                    torch.randn([1, 1, 32, 32 * (i + 1)]),
+                    layout=ttnn.TILE_LAYOUT,
+                    device=device,
+                    memory_config=ttnn.L1_MEMORY_CONFIG,
+                )
+            )
+            run_pool(device, tensor_map, [1, 16, 25, 23])
+    assert device.cache_entries_counter.total == after_first
+
+
+def test_pool_cache_miss_on_kernel_size(device, tensor_map, isolate_program_cache):
+    """sliding_window_config is keyed."""
+    with device.cache_entries_counter.measure():
+        run_pool(device, tensor_map, [1, 16, 25, 23], kernel=(2, 2), stride=(2, 2))
+    after_first = device.cache_entries_counter.total
+
+    with device.cache_entries_counter.measure():
+        run_pool(device, tensor_map, [1, 16, 25, 23], kernel=(3, 3), stride=(2, 2), padding=(1, 1))
+    assert device.cache_entries_counter.total > after_first
+
+
+def test_pool_cache_miss_on_input_shape(device, tensor_map, isolate_program_cache):
+    with device.cache_entries_counter.measure():
+        run_pool(device, tensor_map, [1, 16, 25, 23])
+    after_first = device.cache_entries_counter.total
+
+    with device.cache_entries_counter.measure():
+        run_pool(device, tensor_map, [1, 16, 50, 46])
+    assert device.cache_entries_counter.total > after_first
+
+
+def test_pool_cache_hit_reapplies_buffers(device, isolate_program_cache):
+    """
+    Freeze test with data the shared harness cannot dedupe: run_max_pool2d reuses torch
+    tensors via tensor_map, so a fresh map per iteration is required for this to be able to
+    fail at all. Three dispatches of DIFFERENT data in DIFFERENT buffers must share one
+    program, and run_max_pool2d PCC-checks each against its own input.
+    """
+    with device.cache_entries_counter.measure():
+        run_pool(device, {}, [1, 16, 25, 23])
+    after_first = device.cache_entries_counter.total
+
+    with device.cache_entries_counter.measure():
+        for _ in range(3):
+            run_pool(device, {}, [1, 16, 25, 23])
+    assert device.cache_entries_counter.total == after_first

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -290,7 +290,6 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
     uint32_t num_shards_c,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<int32_t> divisor_override,
-    uint32_t memory_used,
     const Layout& output_layout,
     bool config_tensor_in_dram) {
     using namespace tt::tt_metal;
@@ -982,10 +981,8 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
     }
     desc.kernels.push_back(std::move(compute_desc));
 
-    // Validate local and global CB sizes separately to prevent two errors from cancelling out.
-    // Note: local CBs are non-globally-allocated (computed by the program); global CBs are
-    // tensor-backed (sharded onto an existing buffer). We compute these directly from the
-    // descriptor's CBs rather than from a Program object since we no longer create one here.
+    // Local CBs are non-globally-allocated (computed by the program); we compute the total directly
+    // from the descriptor's CBs rather than from a Program object since we no longer create one here.
     uint32_t actual_local_cb_size = 0;
     for (const auto& cb : desc.cbs) {
         if (cb.buffer == nullptr) {
@@ -993,23 +990,15 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
         }
     }
 
-    uint32_t post_allocate_size =
-        input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
-    uint32_t actual_global_cb_size = post_allocate_size == 0 ? 0 : post_allocate_size - memory_used;
-
     // For now assume that if post_op_l1_allocation_size == 0 op is being run
     // in graph capture NO_DISPATCH mode.
-    bool is_graph_capture_no_dispatch_mode = post_allocate_size == 0;
+    bool is_graph_capture_no_dispatch_mode =
+        input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes == 0;
     TT_FATAL(
         actual_local_cb_size == cb_sizes.local_cb_total() || is_graph_capture_no_dispatch_mode,
         "Local CB size mismatch: actual {} != expected {}",
         actual_local_cb_size,
         cb_sizes.local_cb_total());
-    TT_FATAL(
-        actual_global_cb_size == cb_sizes.global_cb_total() || is_graph_capture_no_dispatch_mode,
-        "Global CB size mismatch: actual {} != expected {}",
-        actual_global_cb_size,
-        cb_sizes.global_cb_total());
 
     {  // debug
         log_debug(tt::LogOp, "raw_in_cb :: PS = {}, NP = {}", raw_in_cb_pagesize, raw_in_cb_npages);
@@ -1267,7 +1256,6 @@ tt::tt_metal::WorkloadDescriptor Pool2D::MultiCore::create_workload_descriptor(
         setup.num_shards_c,
         compute_kernel_config,
         divisor_override,
-        op_attr.memory_used,
         output_layout,
         op_attr.config_tensor_in_dram);
     auto ranges = tensor_coords.ranges();

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -165,25 +165,6 @@ Pool2D::tensor_return_value_t Pool2D::create_output_tensors(
     return {create_device_tensor(output_spec_data, tensor.input_tensor_.device())};
 }
 
-ttsl::hash::hash_t Pool2D::compute_program_hash(const operation_attributes_t& op_attr, const tensor_args_t& tensor) {
-    auto input_mem_config = tensor.input_tensor_.memory_config();
-    auto in_dtype = tensor.input_tensor_.dtype();
-    auto out_dtype = op_attr.output_dtype_;
-    return tt::tt_metal::operation::hash_operation<Pool2D>(
-        op_attr.sliding_window_config_.get_hash(),
-        op_attr.pool_type_,
-        op_attr.output_layout_,
-        op_attr.memory_config_,
-        op_attr.compute_kernel_config_,
-        op_attr.divisor_override_,
-        op_attr.count_include_pad_,
-        op_attr.return_indices_,
-        op_attr.config_tensor_in_dram,
-        input_mem_config,
-        in_dtype,
-        out_dtype);
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<Pool2D::tensor_return_value_t> Pool2D::create_op_performance_model(
     const operation_attributes_t& op_attr, const tensor_args_t& tensor, const tensor_return_value_t& outputs) {
     const auto& input = tensor.input_tensor_;
@@ -233,7 +214,6 @@ std::vector<ttnn::Tensor> pool2d(
     bool count_include_pad,
     std::optional<int32_t> divisor_override,
     bool return_indices,
-    uint32_t memory_used,
     bool config_tensor_in_dram) {
     using OperationType = ttnn::operations::pool::Pool2D;
     return ttnn::device_operation::launch<OperationType>(
@@ -247,7 +227,6 @@ std::vector<ttnn::Tensor> pool2d(
             .count_include_pad_ = count_include_pad,
             .divisor_override_ = divisor_override,
             .return_indices_ = return_indices,
-            .memory_used = memory_used,
             .config_tensor_in_dram = config_tensor_in_dram},
         OperationType::tensor_args_t{input_tensor});
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -34,7 +34,6 @@ struct Pool2D {
         bool count_include_pad_{};
         std::optional<int32_t> divisor_override_;
         bool return_indices_{};
-        uint32_t memory_used{};
         bool config_tensor_in_dram{};
     };
 
@@ -65,7 +64,6 @@ struct Pool2D {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 };
@@ -84,6 +82,5 @@ std::vector<ttnn::Tensor> pool2d(
     bool count_include_pad,
     std::optional<int32_t> divisor_override,
     bool return_indices,
-    uint32_t memory_used,
     bool config_tensor_in_dram);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -355,11 +355,6 @@ static std::vector<Tensor> pool2d_L1(
         haloed_tensor = ttnn::move(haloed_tensor);
     }
 
-    // NOLINTBEGIN(bugprone-use-after-move)
-    const uint32_t pre_allocate_size =
-        haloed_tensor.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
-    // NOLINTEND(bugprone-use-after-move)
-
     // call the pool2d uop
     std::vector<Tensor> output_tensors = ttnn::prim::pool2d(
         haloed_tensor,
@@ -372,7 +367,6 @@ static std::vector<Tensor> pool2d_L1(
         count_include_pad,
         divisor_override,
         return_indices,
-        pre_allocate_size,
         config_tensor_in_dram);
 
     // format and return the result


### PR DESCRIPTION
### Problem

`Pool2D::operation_attributes_t::memory_used` is not an op parameter. It is a **live L1 allocator
reading**, sampled by the host op immediately before invoking `pool2d`
(`generic_pools.cpp`, `get_statistics(BufferType::L1).total_allocated_bytes`) and threaded into the
device op's attributes so the factory could cross-check the global CB size against the allocation
delta (`post_allocate_size - memory_used`).

Because that value moves with completely unrelated allocations, keying on it would miss the program
cache on nearly every dispatch. The op therefore carried a custom `compute_program_hash` whose only
job was to exclude it again — which also opts the op out of the framework's collision-free canonical
key (`mesh_device_operation_adapter.hpp:871-883`).

### Change

The attribute and its plumbing are removed, so the framework default hash applies. Everything the
custom hash listed is still keyed: the remaining 10 attributes are reflected in full (no
`attribute_names` narrowing), and the tensor side moves from hand-picked `memory_config` + `dtype` to
the whole `TensorSpec`, a superset.

**The global-CB `TT_FATAL` goes with it.** It needs a pre-allocation reading that only exists before
the op is invoked, and `create_descriptor` runs after the outputs are allocated, so it cannot be
reconstructed inside the factory. The local-CB check and the graph-capture no-dispatch guard are
unchanged. Flagging this explicitly as the judgment call in this PR.

`sliding_window_config_` keys identically before and after: `hash_object` takes its
`is_std_hashable_v` branch (`reflection.hpp:1309-1313`) ahead of any reflection branch, and
`std::hash<SlidingWindowConfig>` is specialized to call `get_hash()` (`sliding_window.hpp:202-207`) --
the exact term the old hash used. `get_hash()` is `hash(to_string())` and `to_string()` omits
`ceil_pad_hw`, so that field remains unkeyed exactly as it was; this PR neither fixes nor worsens it.

### Verification (wormhole, single device)

Baseline measured on the unmodified tree, then re-measured after the change:

| suite | before | after |
| --- | --- | --- |
| `test_pool_program_cache.py` (5 cache-entry assertions, added here) | 4 passed (freeze test added after) | 5 passed |
| `test_pool_axis_sweep.py` -- 13 configs in one cache (shape, channels, kernel, stride, padding, ceil_mode, dtype bf16/bf8_b, shard scheme HS/BS/WS, output layout), all ran | **41 entries** | **41 entries** |
| `test_maxpool2d.py` + `test_avgpool2d.py` | 380 passed, 157 skipped | 380 passed, 157 skipped |

The sweep is the answer to "are we missing cache or staling a parameter": rather than reasoning about
which axis might move, it runs a broad battery through one cache and compares the total across the two
binaries. It stays in the tree as a portable regression net -- it repeats the identical battery and
asserts the second pass builds **nothing** new, which is what catches a key that varies per dispatch
(the failure keying `memory_used` would have produced). Absolute counts are arch-dependent, so the
committed assertion is zero-growth, not the literal 41.

`test_pool_cache_hit_reapplies_buffers` is the freeze test. It passes a fresh `tensor_map` per call on
purpose: `run_max_pool2d` dedupes torch tensors by shape through that map, so a shared map would feed
identical data every dispatch and the test could not fail even with a frozen buffer address.

The added `test_pool_cache_reuse_under_l1_churn` is the direct regression net: it allocates unrelated
L1 tensors between pool calls and asserts no new cache entries — the exact miss storm that keying
`memory_used` would cause.

### Not covered

Built with `--disable-profiler`; correctness and cache-entry counts only, no perf claim. Single-device only.
