### PR TITLE
[ttnn] reshape_view: drop recreate_mapping_tensor from op attributes and its custom hash

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_reshape_axis_sweep.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_reshape_axis_sweep.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Axis sweep for ReshapeViewDeviceOperation program-cache neutrality.
+
+Runs a broad battery of configs (input shape, output shape, memory config, tile mode, dtype)
+through one program cache, then repeats the identical battery and asserts it builds nothing
+new. Absolute entry counts are arch-dependent; zero growth on the second pass is not.
+
+Measured differentially on wormhole while removing the custom hash: 7 entries with the custom
+hash, 7 without.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.fixture
+def iso(device):
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+
+
+def test_reshape_axis_sweep(device, iso):
+    """Vary input shape, output shape, memory config, tile mode, dtype."""
+    cases = [
+        ([1, 1, 64, 128], [1, 1, 128, 64], ttnn.DRAM_MEMORY_CONFIG, None, ttnn.bfloat16),
+        ([1, 1, 64, 128], [1, 1, 32, 256], ttnn.DRAM_MEMORY_CONFIG, None, ttnn.bfloat16),
+        ([1, 1, 128, 128], [1, 1, 256, 64], ttnn.DRAM_MEMORY_CONFIG, None, ttnn.bfloat16),
+        ([1, 1, 64, 128], [1, 1, 128, 64], ttnn.L1_MEMORY_CONFIG, None, ttnn.bfloat16),
+        ([1, 1, 64, 128], [1, 1, 128, 64], ttnn.DRAM_MEMORY_CONFIG, ttnn.TileReshapeMapMode.CACHE, ttnn.bfloat16),
+        ([1, 1, 64, 128], [1, 1, 128, 64], ttnn.DRAM_MEMORY_CONFIG, ttnn.TileReshapeMapMode.RECREATE, ttnn.bfloat16),
+        ([1, 1, 64, 128], [1, 1, 128, 64], ttnn.DRAM_MEMORY_CONFIG, None, ttnn.float32),
+        ([1, 2, 64, 128], [1, 2, 128, 64], ttnn.DRAM_MEMORY_CONFIG, None, ttnn.bfloat16),
+        ([1, 1, 256, 64], [1, 1, 64, 256], ttnn.DRAM_MEMORY_CONFIG, None, ttnn.bfloat16),
+        # repeats: must add nothing
+        ([1, 1, 64, 128], [1, 1, 128, 64], ttnn.DRAM_MEMORY_CONFIG, None, ttnn.bfloat16),
+        ([1, 1, 64, 128], [1, 1, 32, 256], ttnn.DRAM_MEMORY_CONFIG, None, ttnn.bfloat16),
+    ]
+    torch_dtype = {ttnn.bfloat16: torch.bfloat16, ttnn.float32: torch.float32}
+
+    def sweep():
+        ran = 0
+        for in_shape, out_shape, mem, mode, dtype in cases:
+            try:
+                t = torch.randn(in_shape, dtype=torch_dtype[dtype])
+                tt = ttnn.from_torch(t, layout=ttnn.TILE_LAYOUT, dtype=dtype, device=device, memory_config=mem)
+                if mode is None:
+                    o = ttnn.reshape(tt, out_shape, memory_config=mem)
+                else:
+                    o = ttnn.reshape(tt, out_shape, memory_config=mem, reshape_tile_mode=mode)
+                assert_with_pcc(t.reshape(out_shape), ttnn.to_torch(o), 0.999)
+                ran += 1
+            except Exception as e:
+                print(f"\nSWEEP-SKIP {in_shape}->{out_shape} {mode} {dtype}: {type(e).__name__}", flush=True)
+        return ran
+
+    with device.cache_entries_counter.measure():
+        ran = sweep()
+    first = device.cache_entries_counter.total
+    print(f"\nSWEEP RESHAPE ran={ran}/{len(cases)} entries={first}", flush=True)
+
+    with device.cache_entries_counter.measure():
+        sweep()
+    assert device.cache_entries_counter.total == first

--- a/tests/ttnn/unit_tests/operations/data_movement/test_reshape_view_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_reshape_view_program_cache.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Program-cache behaviour for the tiled ttnn.reshape path (ReshapeViewDeviceOperation).
+
+ReshapeViewDeviceOperation carried a custom compute_program_hash to exclude
+operation_attributes_t::recreate_mapping_tensor -- a control flag for the op-owned
+mapping tensor that the tiled factory never acted on. The attribute is gone, so the
+framework default hash applies and it now also keys padded_output_shape (the old hash
+keyed only logical_output_shape).
+
+These tests pin the cache-entry counts across that change.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.fixture
+def isolate_program_cache(device):
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+
+
+def run_reshape(device, shape, new_shape, tile_mode=None):
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    with device.cache_entries_counter.measure():
+        if tile_mode is None:
+            out = ttnn.reshape(tt_input, new_shape)
+        else:
+            out = ttnn.reshape(tt_input, new_shape, reshape_tile_mode=tile_mode)
+    assert_with_pcc(torch_input.reshape(new_shape), ttnn.to_torch(out), 0.999)
+
+
+def test_reshape_cache_reuse_same_config(device, isolate_program_cache):
+    for _ in range(3):
+        run_reshape(device, [1, 1, 64, 128], [1, 1, 128, 64])
+    assert device.cache_entries_counter.total == 1
+
+
+def test_reshape_cache_reuse_across_tile_mode(device, isolate_program_cache):
+    """
+    reshape_tile_mode is not part of the key and never was: the tiled factory does not
+    act on it, so CACHE and RECREATE must land on the same program.
+    """
+    run_reshape(device, [1, 1, 64, 128], [1, 1, 128, 64], tile_mode=ttnn.TileReshapeMapMode.CACHE)
+    run_reshape(device, [1, 1, 64, 128], [1, 1, 128, 64], tile_mode=ttnn.TileReshapeMapMode.RECREATE)
+    assert device.cache_entries_counter.total == 1
+
+
+def test_reshape_cache_miss_on_output_shape(device, isolate_program_cache):
+    run_reshape(device, [1, 1, 64, 128], [1, 1, 128, 64])
+    run_reshape(device, [1, 1, 64, 128], [1, 1, 32, 256])
+    assert device.cache_entries_counter.total == 2
+
+
+def test_reshape_cache_miss_on_input_shape(device, isolate_program_cache):
+    run_reshape(device, [1, 1, 64, 128], [1, 1, 128, 64])
+    run_reshape(device, [1, 1, 128, 128], [1, 1, 256, 64])
+    assert device.cache_entries_counter.total == 2
+
+
+def test_reshape_cache_hit_reapplies_buffers(device, isolate_program_cache):
+    """
+    Freeze test. Three dispatches of DIFFERENT data in DIFFERENT buffers must share one
+    program and each must return its own data. A frozen buffer address returns the first
+    dispatch's result and fails PCC here.
+    """
+    with device.cache_entries_counter.measure():
+        for i in range(3):
+            torch_input = torch.randn([1, 1, 64, 128], dtype=torch.bfloat16) * (i + 1)
+            tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+            tt_output = ttnn.reshape(tt_input, [1, 1, 128, 64])
+            assert_with_pcc(torch_input.reshape([1, 1, 128, 64]), ttnn.to_torch(tt_output), 0.999)
+    assert device.cache_entries_counter.total == 1

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -45,33 +45,14 @@ ttnn::Tensor ReshapeViewDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t ReshapeViewDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "ReshapeViewDeviceOperation::compute_program_hash is called");
-
-    auto program_factory = select_program_factory(operation_attributes, tensor_args);
-
-    // don't hash on operation_attributes_t::recreate_mapping_tensor
-    return tt::tt_metal::operation::hash_operation<ReshapeViewDeviceOperation>(
-        operation_attributes.logical_output_shape,
-        operation_attributes.output_mem_config,
-        operation_attributes.sub_core_grid.has_value(),
-        operation_attributes.sub_core_grid.has_value() ? operation_attributes.sub_core_grid.value()
-                                                       : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
-        tensor_args,
-        program_factory.index());
-}
-
 ttnn::Tensor reshape_view(
     const Tensor& input,
     const ttnn::Shape& logical_output_shape,
     const ttnn::Shape& padded_output_shape,
     const tt::tt_metal::MemoryConfig& output_mem_config,
-    bool recreate_mapping_tensor,
     const std::optional<CoreRangeSet>& sub_core_grid) {
     return ttnn::device_operation::launch<ReshapeViewDeviceOperation>(
-        ReshapeViewParams{
-            logical_output_shape, padded_output_shape, output_mem_config, recreate_mapping_tensor, sub_core_grid},
+        ReshapeViewParams{logical_output_shape, padded_output_shape, output_mem_config, sub_core_grid},
         ReshapeViewInputs{input});
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
@@ -29,9 +29,6 @@ struct ReshapeViewDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 
 ttnn::Tensor reshape_view(
@@ -39,7 +36,6 @@ ttnn::Tensor reshape_view(
     const ttnn::Shape& logical_output_shape,
     const ttnn::Shape& padded_output_shape,
     const tt::tt_metal::MemoryConfig& output_mem_config,
-    bool recreate_mapping_tensor,
     const std::optional<CoreRangeSet>& sub_core_grid);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation_types.hpp
@@ -15,7 +15,6 @@ struct ReshapeViewParams {
     ttnn::Shape logical_output_shape;
     ttnn::Shape padded_output_shape;
     tt::tt_metal::MemoryConfig output_mem_config;
-    bool recreate_mapping_tensor;
     std::optional<CoreRangeSet> sub_core_grid;
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.cpp
@@ -460,10 +460,7 @@ tt::tt_metal::WorkloadDescriptor ReshapeViewTiledProgramFactory::create_workload
     tt::tt_metal::Buffer* mapping_buffer = mapping_owner->buffer();
     workload_descriptor.buffers.push_back({std::move(mapping_owner), mapping_buffer});
 
-    // Note: operation_attributes.recreate_mapping_tensor is intentionally
-    // ignored here — it's excluded from the program hash, so on a cache
-    // hit the cached mapping_tensor (which depends only on hashed inputs)
-    // is always valid.
+    // The cached mapping_tensor depends only on keyed inputs, so it stays valid on a cache hit.
 
     // Single-device op: build the per-coord ProgramDescriptor ONCE and
     // copy it into each coord-range entry to avoid redundant work on

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -237,7 +237,7 @@ ttnn::Tensor perform_reshape_on_2D_RM(
     }
 
     auto temp_tensor2 = ttnn::prim::reshape_view(
-        temp_tensor, logical_shape, padded_shape, intermediate_out_memory_config, false, sub_core_grid);
+        temp_tensor, logical_shape, padded_shape, intermediate_out_memory_config, sub_core_grid);
 
     if (memory_config.is_sharded()) {
         TT_FATAL(!sub_core_grid.has_value(), "Sharded reshape does not support sub core grid specification\n");
@@ -366,7 +366,8 @@ ttnn::Tensor reshape_tiled(
     const ttnn::Shape& logical_shape,
     const MemoryConfig& memory_config,
     const PadValue& pad_value,
-    const bool recreate_mapping_tensor,
+    // Accepted for API compatibility; the tiled factory does not act on it (see reshape_tiled_program_factory).
+    [[maybe_unused]] const bool recreate_mapping_tensor,
     const std::optional<CoreRangeSet>& sub_core_grid,
     bool explicit_memory_config,
     const bool skip_padding_fill,
@@ -412,12 +413,7 @@ ttnn::Tensor reshape_tiled(
                     MemoryConfig{TensorMemoryLayout::INTERLEAVED, working_output_memory_config.buffer_type()};
             }
             auto output_tensor_3d = ttnn::prim::reshape_view(
-                tensor3d,
-                requested_shape_3d,
-                requested_padded_shape_3d,
-                working_output_memory_config,
-                recreate_mapping_tensor,
-                sub_core_grid);
+                tensor3d, requested_shape_3d, requested_padded_shape_3d, working_output_memory_config, sub_core_grid);
             // Fill in BF16 (rank-3, non-recursive). skip_padding_fill is *intentionally*
             // ignored for block-float: shared exponent over 16-elem sub-blocks would otherwise
             // let unfilled padding corrupt logical lanes. See skip_padding_fill docstring.
@@ -464,12 +460,7 @@ ttnn::Tensor reshape_tiled(
         }
 
         auto output_tensor_3d = ttnn::prim::reshape_view(
-            tensor3d,
-            requested_shape_3d,
-            requested_padded_shape_3d,
-            target_output_mem_config,
-            recreate_mapping_tensor,
-            sub_core_grid);
+            tensor3d, requested_shape_3d, requested_padded_shape_3d, target_output_mem_config, sub_core_grid);
 
         // Fill implicit tile padding only when the caller explicitly asked for it (pad_value_explicit).
         // Default-on fill would write into "padding" lanes of prim::reshape_view, which can be a zero-cost
@@ -526,12 +517,7 @@ ttnn::Tensor reshape_tiled(
     }
 
     auto output_tensor_3d = ttnn::prim::reshape_view(
-        tensor3d,
-        requested_shape_3d,
-        requested_padded_shape_3d,
-        updated_mem_config,
-        recreate_mapping_tensor,
-        sub_core_grid);
+        tensor3d, requested_shape_3d, requested_padded_shape_3d, updated_mem_config, sub_core_grid);
 
     // Fill rules:
     //   - Block-float (BFLOAT8_B / BFLOAT4_B): ALWAYS fill (skip_padding_fill is ignored). The downstream


### PR DESCRIPTION
### Problem

`ReshapeViewParams::recreate_mapping_tensor` is a control flag for the op-owned mapping tensor, not a
program parameter — the tiled factory explicitly never acted on it. Carrying it in the device op's
attributes forced a custom `compute_program_hash` whose only job was to exclude it again (the body
even says `// don't hash on operation_attributes_t::recreate_mapping_tensor`), which also opts the op
out of the framework's collision-free canonical key
(`mesh_device_operation_adapter.hpp:871-883`).

### Change

The attribute is removed from `ReshapeViewParams` and from `ttnn::prim::reshape_view`, so the default
reflection hash applies. The public `reshape_tile_mode` kwarg is **unchanged**; the flag now stops at
the file-local `reshape_tiled` helper, marked `[[maybe_unused]]`.

Worth calling out separately from this PR: that option was **already** a no-op on the tiled path, so
`RECREATE` has never actually recreated anything here. Whether to deprecate the kwarg is an API
decision, deliberately not made in a keying cleanup.

### Keying delta

The default additionally keys `padded_output_shape`, which the old hash omitted (it keyed only
`logical_output_shape`). I could **not** construct a case that distinguishes them from the public API:
`ttnn.reshape` derives the padded shape from the logical shape and layout, so equal-logical /
different-padded appears unreachable from Python and I measured no count difference on this axis. I am
not claiming it is a false-hit fix — only that the key got no coarser. Worth a reviewer's eye in case a
C++ caller of `ttnn::prim::reshape_view` can pass a padded shape that is not derived.

### Verification (wormhole, single device)

Baseline measured on the unmodified tree, then re-measured after the change:

| suite | before | after |
| --- | --- | --- |
| `test_reshape_view_program_cache.py` (5 cache-entry assertions, added here) | 4 passed (freeze test added after) | 5 passed |
| `test_reshape_axis_sweep.py` -- 11 configs in one cache (input shape, output shape, DRAM/L1, CACHE/RECREATE, bf16/fp32), all ran | **7 entries** | **7 entries** |
| `test_tm_reshape.py` + `test_universal_input_tm_reshape.py` (nightly) | 393 passed | 393 passed |

The sweep compares a broad battery's total entry count across the two binaries rather than relying on
me to guess which axis might move. It stays in the tree as a portable regression net: it repeats the
identical battery and asserts the second pass builds **nothing** new. Absolute counts are
arch-dependent, so the committed assertion is zero-growth, not the literal 7.

`test_reshape_cache_hit_reapplies_buffers` is the freeze test: three dispatches of different random
data in different buffers on one cached program, each PCC-checked against its own input. A frozen
buffer address fails it.

`test_reshape_cache_reuse_across_tile_mode` pins the CACHE-vs-RECREATE equivalence, i.e. that the
removed attribute never belonged in the key.

### Not covered

Built with `--disable-profiler`; correctness and cache-entry counts only, no perf claim. Single-device only.
