### PR TITLE
[Bug Fix] Flush pending non-posted atomic before deepseek_prefill dispatch reader exits

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
@@ -486,4 +486,8 @@ void kernel_main() {
     sentinel_plan->entry_count = 0;
     sentinel_entries[0].flags = PLAN_FLAG_END;
     cb_push_back(cb_plan_id, 1);
+
+    // The baton hand-off above (next_turn_sem.up) is a non-posted atomic; nothing else in this
+    // kernel waits on it. Flush before exit so the next kernel doesn't inherit a pending atomic.
+    noc_async_atomic_barrier();
 }


### PR DESCRIPTION
### Ticket
N/A — found while enabling `TT_METAL_WATCHER` to debug an unrelated hang.

### Problem description

Running a GLM-5.2 prefill test on blackhole (8×4 mesh) with `TT_METAL_WATCHER=10 TT_METAL_LLK_ASSERTS=1` tripped a firmware epilogue assert:

```
Device 9 worker core(x=1,y=0): NCRISC detected an inter-kernel data race due to kernel
completing with pending NOC transactions (missing NOC non-posted atomics flushed barrier).
Current kernel: .../deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
Last waypoint:  NTW,NKFW,   W,   W,   W
```

This is `ASSERT(ncrisc_noc_nonposted_atomics_flushed(...))` in `ncrisck.cc`, which runs after `kernel_main()` returns and requires the NOC to be left idle for the next kernel.

### Root cause

The inter-batch baton hand-off at `reader_worker_dispatch.cpp:446`:

```cpp
next_turn_sem.up(noc, next_noc_x, next_noc_y, 1);
```

`Semaphore::up(noc, ...)` resolves to `noc_semaphore_inc()` with the default `posted = false` — a **non-posted** atomic that must be acked. The kernel had no atomic barrier anywhere (`grep` for `async_atomic_barrier` returned nothing), so an unacked increment could still be outstanding when `kernel_main()` returned.

Being ack-timing dependent, it surfaced on a different device than the deterministic asserts around it, which is consistent with a race rather than a fixed misconfiguration.

### What's changed

Added `noc_async_atomic_barrier()` before returning. The kernel has a single exit path (no early `return`), so one call covers it.

### Checklist
- [x] Reproduced the assert, confirmed the fix by rerunning with watcher enabled
- [x] Audited the other 29 `deepseek_prefill` dataflow kernels for the same defect — the remaining atomic users are covered (`unified_routed_expert_ffn_reader.cpp` ends with `noc.async_atomic_barrier()`, `writer_sender_dispatch.cpp` ends with `noc_async_full_barrier()`, and the uncovered sites in `reader_combine.cpp` / `writer_untilize.cpp` use `noc_semaphore_inc<true>`, i.e. posted)
- [x] Pre-commit / clang-format clean
- [ ] CI — not yet run

### Notes for reviewers

This PR originally carried four fixes. Three of them have since landed on `main` independently — #52431 (one-tile all-gather scatter header), #52432 (dispatch writer trid), #52433 (combine writer trid) — so this branch has been rebased and reduced to the one fix that is still needed. Same investigation, arrived at separately; the upstream versions use the public `noc_async_write_set_trid(0)` and also clear inside the loop, which is better than what this branch had, so they were taken as-is.

With all four in place the test goes from failing inside layer 3 to **38 completed 78-layer forward passes**. It then hits a separate deadlock in `all_gather_async` (cores spinning in `noc_semaphore_wait_min`, no assert — devices 17/29, with a starved matmul on 21). **That is not addressed here** and is still under investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
