### PR TITLE
prefill: consume trace metadata on-device and run the D2H layer-ack under trace

### DIFF
--- a/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
@@ -41,7 +41,7 @@ case "${MODEL}" in
     export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/prefill_runner_kv}"
     MGD="${MGD_DIR}/kimi27_mgd.textproto"
     MANIFEST="${MANIFEST_DIR}/kimi27.json"
-    RUNNER_ENV="export PREFILL_HF_MODEL=/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized; export PREFILL_USE_TRACE=1;"
+    RUNNER_ENV="export PREFILL_HF_MODEL=/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized; export PREFILL_USE_TRACE=1; export PREFILL_LAYER_ACK_D2H=1;"
     PRODUCER_ENV="export PREFILL_PRODUCER_MANIFEST='${MANIFEST}';"
     ;;
   glm52)
@@ -50,6 +50,9 @@ case "${MODEL}" in
     # multi-galaxy pipeline prefill, so the descriptor declares no wrap and the fabric mode stays 2d.
     MGD="${MGD_DIR}/glm52_mgd.textproto"
     MANIFEST="${MANIFEST_DIR}/glm52.json"
+    # No traced prefill path for glm52 yet, so exercise the D2H layer-ack backend untraced (no
+    # PREFILL_USE_TRACE) -- the same ack backend kimi27 runs under trace.
+    RUNNER_ENV="export PREFILL_LAYER_ACK_D2H=1;"
     # Sparse DSA: TWO device caches (MLA KVPE over all 78 layers + the lightning-indexer KEY cache over the
     # 21 `full` layers), both PCC'd. The trace must be the indexer-K dump -- the adapter's default golden
     # carries no dsa/indexer_k_layer_*, which would silently downgrade this leg to a KVPE-only check.

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -35,6 +35,7 @@ import signal
 import time
 from typing import Optional
 
+import torch
 from loguru import logger
 
 import ttnn
@@ -261,8 +262,6 @@ def build_layer_completion_sink(producer, *, source_rank, num_layers):
 def _decode_metadata(metadata_msg) -> dict:
     """Read the packed [1,1,1,3] metadata device tensor to host: {slot_id, actual_start, actual_end}.
     This is the device->host half of the round trip the traced path avoids (see _socket_next)."""
-    import torch
-
     m = ttnn.to_torch(ttnn.get_device_tensors(metadata_msg)[0]).view(torch.int32).flatten()
     return {"slot_id": int(m[0]), "actual_start": int(m[1]), "actual_end": int(m[2])}
 
@@ -375,8 +374,6 @@ def _d2d_send(
     if metadata_msg is not None:
         md_tensor = metadata_msg
     else:
-        import torch
-
         backing = outbound.get_backing_tensor()
         words = [meta["slot_id"], meta["actual_start"], meta["actual_end"]]
         # The outbound op ships metadata as a replicated device tensor (3 uint32 words), not a Python list.
@@ -404,8 +401,6 @@ def _forward_shutdown(d2d_out, rank: int, hidden_size: int) -> None:
     is irrelevant — the downstream discards it once it sees the sentinel — but outbound_socket_service_sync
     requires the input's per-shard spec to equal the sender backing's, so build the dummy exactly like a
     real activation: the [1, 1, CHUNK_SIZE, hidden_size] bf16 TILE spec sharded by D2D_MAPPER_CONFIG."""
-    import torch
-
     dev = d2d_out.get_backing_tensor().device()
     dummy = ttnn.from_torch(
         torch.zeros(1, 1, CHUNK_SIZE, hidden_size),

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -33,6 +33,7 @@ import json
 import os
 import signal
 import time
+from typing import Optional
 
 from loguru import logger
 
@@ -89,6 +90,10 @@ _apply_manifest_env()
 # per-chunk overhead is the persistent service's fabric/NoC presence, not the push workers).
 SYNC_WORKER_CORES = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))
 METADATA_SIZE_BYTES = 12
+
+# The packed [1,1,1,3] uint32 message the sockets carry is `metadata_msg` everywhere; the model's
+# `metadata` is the per-element triple of [1,1,1,1] operands the device ops take. There is no device-side
+# conversion between them, so a name that blurs the two hides a required host round trip.
 
 # LayerAck D2H FIFO. Records are METADATA_SIZE_BYTES (12 B) each; 4 KB is a PCIe-aligned
 # one-page buffer with generous headroom for in-flight records.
@@ -253,6 +258,15 @@ def build_layer_completion_sink(producer, *, source_rank, num_layers):
 # ---------------------------------------------------------------------------
 
 
+def _decode_metadata(metadata_msg) -> dict:
+    """Read the packed [1,1,1,3] metadata device tensor to host: {slot_id, actual_start, actual_end}.
+    This is the device->host half of the round trip the traced path avoids (see _socket_next)."""
+    import torch
+
+    m = ttnn.to_torch(ttnn.get_device_tensors(metadata_msg)[0]).view(torch.int32).flatten()
+    return {"slot_id": int(m[0]), "actual_start": int(m[1]), "actual_end": int(m[2])}
+
+
 def _is_shutdown_sentinel(meta: dict) -> bool:
     """True for the all -1 end-of-stream sentinel (see SHUTDOWN_METADATA_WORD); false for every real
     chunk, whose slot_id and KV positions are non-negative and in range."""
@@ -263,17 +277,17 @@ def _is_shutdown_sentinel(meta: dict) -> bool:
     )
 
 
-def _socket_next(h2d_service) -> tuple:
-    """Block on the next producer push: returns (tt_tokens, {slot_id, actual_start, actual_end},
-    tt_metadata). The device metadata tensor is returned (not discarded) so it can be propagated into
-    the model's per-layer ack send. Used only by the unbounded request loop (rank 0 input)."""
-    import torch
+def _socket_next(h2d_service, *, decode_meta: bool) -> tuple:
+    """Block on the next producer push: returns (tt_tokens, meta, metadata_msg). The device metadata
+    tensor is returned (not discarded) so it can be propagated into the model's per-layer ack send.
+    Used only by the unbounded request loop (rank 0 input).
 
-    tt_tokens, tt_metadata = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
+    decode_meta=False (traced path) skips the device->host read of the metadata: the per-chunk scalars
+    are consumed on-device straight from metadata_msg, so meta is returned None and no to_torch runs."""
+    tt_tokens, metadata_msg = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
         h2d_service, metadata_size_bytes=METADATA_SIZE_BYTES
     )
-    m = ttnn.to_torch(ttnn.get_device_tensors(tt_metadata)[0]).view(torch.int32).flatten()
-    return tt_tokens, {"slot_id": int(m[0]), "actual_start": int(m[1]), "actual_end": int(m[2])}, tt_metadata
+    return tt_tokens, _decode_metadata(metadata_msg) if decode_meta else None, metadata_msg
 
 
 def build_d2d_pipeline_endpoints(mesh_device, rank: int, num_ranks: int, chunk_size: int, hidden_size: int):
@@ -323,57 +337,65 @@ def build_d2d_pipeline_endpoints(mesh_device, rank: int, num_ranks: int, chunk_s
     return inbound, outbound
 
 
-def _d2d_recv(inbound) -> tuple:
-    """Drain the next chunk that landed in the inbound receiver backing into a fresh device tensor and
-    decode the inline metadata. The returned tensor already has the embedding-output sharding, so it
-    feeds runtime.prefill with no reshard. Pairs with the upstream rank's _d2d_send."""
-    import torch
+def _d2d_recv(inbound, *, decode_meta: bool) -> tuple:
+    """Drain the next chunk that landed in the inbound receiver backing into a fresh device tensor. The
+    returned tensor already has the embedding-output sharding, so it feeds runtime.prefill with no
+    reshard. Pairs with the upstream rank's _d2d_send.
 
+    decode_meta=False (traced path) skips the device->host read of the inline metadata: meta is returned
+    None and the per-chunk scalars are consumed on-device straight from metadata_msg."""
     t0 = time.perf_counter()
-    act, metadata_device = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
+    act, metadata_msg = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
         inbound, metadata_size_bytes=METADATA_SIZE_BYTES
     )
-    m = ttnn.to_torch(ttnn.get_device_tensors(metadata_device)[0]).view(torch.int32).flatten()
-    meta = {"slot_id": int(m[0]), "actual_start": int(m[1]), "actual_end": int(m[2])}
-    logger.info(
-        f"[pp] RECV-d2d [{meta['actual_start']},{meta['actual_end']}) slot={meta['slot_id']} "
-        f"[xfer] sync={(time.perf_counter() - t0) * 1000.0:.2f}ms"
+    meta = _decode_metadata(metadata_msg) if decode_meta else None
+    where = (
+        f"[{meta['actual_start']},{meta['actual_end']}) slot={meta['slot_id']}" if meta is not None else "(on-device)"
     )
-    return act, meta, metadata_device
+    logger.info(f"[pp] RECV-d2d {where} [xfer] sync={(time.perf_counter() - t0) * 1000.0:.2f}ms")
+    return act, meta, metadata_msg
 
 
-def _d2d_send(outbound, activation: ttnn.Tensor, rank: int, meta: dict, *, deallocate: bool = True) -> None:
+def _d2d_send(
+    outbound, activation: ttnn.Tensor, rank: int, meta: Optional[dict], *, deallocate: bool = True, metadata_msg=None
+) -> None:
     """Push this rank's output hidden state + metadata to the downstream rank's receiver, then free it.
     The model already emits the activation in the sender backing's spec, and outbound_socket_service_sync
     TT_FATALs on any spec mismatch, so no host-side relayout is needed.
+
+    metadata_msg (traced path): the packed device tensor received on this rank is forwarded downstream
+    verbatim — it is already the [1,1,1,3] uint32 replicated form the op expects, so no host rebuild
+    runs (meta may be None). When metadata_msg is None (eager path) the tensor is rebuilt from meta.
 
     deallocate=False when the activation is the traced path's persistent _trace_output buffer: the socket
     sync copies it into the sender backing on the CQ (before the next replay, which reuses the same buffer,
     is enqueued), so it must NOT be freed — the next chunk's replay writes into it in place."""
     t0 = time.perf_counter()
-    backing = outbound.get_backing_tensor()
-    import torch
 
-    words = [meta["slot_id"], meta["actual_start"], meta["actual_end"]]
-    # The outbound op ships metadata as a replicated device tensor (3 uint32 words), not a Python list.
-    md_tensor = ttnn.from_torch(
-        torch.tensor(words, dtype=torch.int32).reshape(1, 1, 1, -1),
-        dtype=ttnn.uint32,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=backing.device(),
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ttnn.create_mesh_mapper(
-            backing.device(),
-            ttnn.MeshMapperConfig(placements=[ttnn.PlacementReplicate(), ttnn.PlacementReplicate()]),
-        ),
-    )
+    if metadata_msg is not None:
+        md_tensor = metadata_msg
+    else:
+        import torch
+
+        backing = outbound.get_backing_tensor()
+        words = [meta["slot_id"], meta["actual_start"], meta["actual_end"]]
+        # The outbound op ships metadata as a replicated device tensor (3 uint32 words), not a Python list.
+        md_tensor = ttnn.from_torch(
+            torch.tensor(words, dtype=torch.int32).reshape(1, 1, 1, -1),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=backing.device(),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.create_mesh_mapper(
+                backing.device(),
+                ttnn.MeshMapperConfig(placements=[ttnn.PlacementReplicate(), ttnn.PlacementReplicate()]),
+            ),
+        )
     ttnn.experimental.deepseek_prefill.outbound_socket_service_sync(outbound, activation, metadata=md_tensor)
     if deallocate:
         ttnn.deallocate(activation)
-    logger.info(
-        f"[pp rank {rank}] SEND-d2d [{meta['actual_start']},{meta['actual_end']}) "
-        f"[xfer] push={(time.perf_counter() - t0) * 1000.0:.2f}ms"
-    )
+    where = f"[{meta['actual_start']},{meta['actual_end']})" if meta is not None else "(on-device)"
+    logger.info(f"[pp rank {rank}] SEND-d2d {where} [xfer] push={(time.perf_counter() - t0) * 1000.0:.2f}ms")
 
 
 def _forward_shutdown(d2d_out, rank: int, hidden_size: int) -> None:
@@ -431,30 +453,31 @@ def _record_chunk_timing(rank: int, c: int, compute_start: float, compute_ms: fl
 
 
 def _compute_and_send(
-    runtime, kv_caches, rank: int, c: int, inp, meta: dict, d2d_out, d2h_service=None, record_dev=None
+    runtime, kv_caches, rank: int, c: int, inp, meta: Optional[dict], d2d_out, d2h_service=None, metadata_msg=None
 ) -> float:
     """Run one chunk: prefill into the engine-owned kv_caches, forward the output downstream (non-last
     rank) and grant the outbound sender so it ships over fabric. Returns the compute-start epoch
     (NTP-comparable). CHUNK_START is logged BEFORE the forward, with this chunk's metadata, so the
-    slot/KV-range is visible per rank even if prefill_chunk hangs. The trailing metadata is kept after
-    compute_start so the c=/compute_start= fields stay parseable (plot_pipeline_trace.py)."""
+    slot/KV-range is visible per rank even if prefill_chunk hangs. On the traced path meta is None (the
+    scalars live on-device in metadata_msg), so the range is logged as (on-device). The trailing metadata
+    is kept after compute_start so the c=/compute_start= fields stay parseable (plot_pipeline_trace.py)."""
     if SYNC_PER_CHUNK:
         ttnn.synchronize_device(runtime.mesh_device)
     t_start = time.time()
     t_perf = time.perf_counter()
-    logger.info(
-        f"[pp rank {rank}] CHUNK_START c={c} compute_start={t_start:.6f} "
-        f"slot={meta['slot_id']} [{meta['actual_start']},{meta['actual_end']})"
+    where = (
+        f"slot={meta['slot_id']} [{meta['actual_start']},{meta['actual_end']})" if meta is not None else "(on-device)"
     )
+    logger.info(f"[pp rank {rank}] CHUNK_START c={c} compute_start={t_start:.6f} {where}")
     out = runtime.prefill_chunk(
         inp,
         kv_caches,
-        slot_id=meta["slot_id"],
-        actual_start=meta["actual_start"],
-        actual_end=meta["actual_end"],
+        slot_id=meta["slot_id"] if meta is not None else None,
+        actual_start=meta["actual_start"] if meta is not None else None,
+        actual_end=meta["actual_end"] if meta is not None else None,
         request_id=c,
         d2h_service=d2h_service,
-        record_dev=record_dev,
+        metadata_msg=metadata_msg,
     )
     if SYNC_PER_CHUNK:
         # Block on device completion so the delta is this rank's forward alone, not the downstream-start
@@ -465,8 +488,16 @@ def _compute_and_send(
         _record_chunk_timing(rank, c, t_start, compute_ms)
     if not runtime.config.is_last_rank:
         # Traced: `out` is the runtime's persistent _trace_output (the next replay overwrites it in place),
-        # so the send copies it into the socket backing but must not free it. Eager: `out` is fresh — free it.
-        _d2d_send(d2d_out, out, rank, meta, deallocate=not runtime.config.use_trace)  # grant below ships it
+        # so the send copies it into the socket backing but must not free it; the received metadata_msg is
+        # forwarded verbatim (no host rebuild, meta is None). Eager: `out` is fresh — free it, rebuild md.
+        _d2d_send(
+            d2d_out,
+            out,
+            rank,
+            meta,
+            deallocate=not runtime.config.use_trace,
+            metadata_msg=metadata_msg if runtime.config.use_trace else None,
+        )  # grant below ships it
     if d2d_out is not None:
         d2d_out.release_fabric_links()
     return t_start
@@ -502,13 +533,21 @@ def run_request_loop(
     producer decides the count); downstream ranks read from D2D. Runs until the producer/scheduler
     closes the stream with the all -1 shutdown sentinel (each rank forwards it and exits gracefully) or,
     as a hard fallback, until SIGTERM/SIGKILL. No fixed chunk bound, no trace input, no PCC, no
-    migration — the runner serves; migration is issued from outside (migration_driver.py)."""
+    migration — the runner serves; migration is issued from outside (migration_driver.py).
+
+    Traced path (cfg.use_trace): the per-chunk metadata is consumed on-device straight from metadata_msg
+    (no device->host->device round trip), so the host never sees the scalars and the in-band shutdown
+    sentinel cannot be detected. Trace serving therefore relies ONLY on SIGTERM/SIGKILL for teardown —
+    the producer's PREFILL_SEND_SHUTDOWN sentinel is ignored. Run untraced if graceful in-band shutdown
+    is required."""
     cfg = runtime.config
     if cfg.is_first_rank and h2d_service is None:
         raise ValueError("request mode requires the H2D service on the first rank for input")
+    decode_meta = not cfg.use_trace  # untraced needs host scalars (logging + sentinel); traced consumes on-device
     logger.info(
         f"[pp rank {rank}/{num_ranks}] request (unbounded) loop start "
-        f"(is_first={cfg.is_first_rank} is_last={cfg.is_last_rank} input={'h2d' if cfg.is_first_rank else 'd2d'})"
+        f"(is_first={cfg.is_first_rank} is_last={cfg.is_last_rank} input={'h2d' if cfg.is_first_rank else 'd2d'} "
+        f"metadata={'host' if decode_meta else 'on-device'})"
     )
     t0 = time.perf_counter()
     c = 0
@@ -516,20 +555,20 @@ def run_request_loop(
     while not _shutdown:
         _lease_reclaim(d2d_in, d2d_out)
         if cfg.is_first_rank:
-            inp, meta, metadata_device = _socket_next(h2d_service)  # slot/start/end from the producer
+            inp, meta, metadata_msg = _socket_next(h2d_service, decode_meta=decode_meta)  # slot/start/end from producer
         else:
-            inp, meta, metadata_device = _d2d_recv(d2d_in)
-        if _is_shutdown_sentinel(meta):
+            inp, meta, metadata_msg = _d2d_recv(d2d_in, decode_meta=decode_meta)
+        if meta is not None and _is_shutdown_sentinel(meta):
             # End of stream: drop the throwaway payload + its metadata tensor, hand the sentinel to the
             # next rank so it too unblocks and exits, then fall through to the graceful drain below.
             logger.info(f"[pp rank {rank}] SHUTDOWN sentinel received after {c} chunks; exiting request loop")
             ttnn.deallocate(inp)
-            ttnn.deallocate(metadata_device)
+            ttnn.deallocate(metadata_msg)
             if d2d_out is not None:
                 _forward_shutdown(d2d_out, rank, hidden_size)
             break
         t = _compute_and_send(
-            runtime, kv_caches, rank, c, inp, meta, d2d_out, d2h_service=d2h_service, record_dev=metadata_device
+            runtime, kv_caches, rank, c, inp, meta, d2d_out, d2h_service=d2h_service, metadata_msg=metadata_msg
         )
         if first is None:
             first = t
@@ -1046,17 +1085,6 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
     # LayerCompletionRouter the multi-rank host-callback path uses, so it is multi-host compatible: it
     # works on any rank count (single-rank => world_size=1 router, local ring + counter channel, no MPI).
     use_d2h = os.environ.get("PREFILL_LAYER_ACK_D2H", "0") == "1"
-    # D2H is NOT trace-capturable: its ack record is the per-chunk socket metadata tensor, whose address
-    # changes every chunk, so a capture would bake in a stale one (TtPrefillRuntime.prefill_chunk asserts
-    # the same thing). Reject the combination up front rather than replay a trace that silently emits no
-    # acks -- and reject rather than quietly downgrade, since PREFILL_LAYER_ACK_D2H=1 is an explicit ask.
-    # The host-callback backends DO work traced (the controller splits the capture at each ack point).
-    if use_d2h and runtime.config.use_trace:
-        raise ValueError(
-            "PREFILL_LAYER_ACK_D2H=1 is incompatible with PREFILL_USE_TRACE=1: the D2H ack record is a "
-            "per-chunk socket tensor whose address cannot be captured, so the replay would emit no acks. "
-            "Run untraced for the D2H backend, or leave PREFILL_LAYER_ACK_D2H unset to ack under trace."
-        )
     # The router path covers: (a) any multi-rank run (each rank owns only a layer slice, so it can't
     # inject the scheduler channel directly and must route to the master), and (b) the D2H backend on
     # any rank count (its LayerAckService is a pure producer into the ring). The single-rank non-D2H
@@ -1117,7 +1145,13 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
                 first_layer_idx=first_layer_idx,
                 local_layers=num_my_layers,
             )
-            layer_ack_service.start()  # connects to the router-owned ring (created above)
+            if runtime.config.use_trace:
+                # Traced: the ack op is recorded inside the capture, so register the service up front and
+                # defer the reader — it starts after the capture's warm records are drained below, or the
+                # scheduler would see a phantom chunk's acks and migrate a slot that was never filled.
+                runtime.set_d2h_ack_service(d2h_service)
+            else:
+                layer_ack_service.start()  # connects to the router-owned ring (created above)
             source_desc = "D2H device records"
         else:
             # Host-callback source: the runtime fires on_layer_complete(layer_idx, request_id) per layer
@@ -1155,6 +1189,17 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
     # No-op if already captured. See TtPrefillRuntime.capture_trace().
     if getattr(runtime, "capture_trace", None) and runtime.config.use_trace:
         runtime.capture_trace(kv_caches)
+        # D2H ack under trace: the capture's warm forward compiles the ack programs by running them, so
+        # num_layers real records already sit in the FIFO. Drain them before the reader starts, or the
+        # scheduler sees a phantom chunk's worth of layer acks and migrates a slot that was never filled.
+        # The host-callback source has no reader to defer and writes no D2H records, so it skips this.
+        if use_d2h and layer_ack_service is not None:
+            n_warm = getattr(runtime, "warmup_ack_count", lambda: 0)()
+            for _ in range(n_warm):
+                d2h_service.read_metadata()
+            if n_warm:
+                logger.info(f"[migration] drained {n_warm} D2H warm-up ack records from the trace capture")
+            layer_ack_service.start()
 
     logger.info(f"[pp rank {rank}] setup complete, entering request loop")
 

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -260,8 +260,7 @@ def build_layer_completion_sink(producer, *, source_rank, num_layers):
 
 
 def _decode_metadata(metadata_msg) -> dict:
-    """Read the packed [1,1,1,3] metadata device tensor to host: {slot_id, actual_start, actual_end}.
-    This is the device->host half of the round trip the traced path avoids (see _socket_next)."""
+    """Read the packed [1,1,1,3] metadata device tensor to host: {slot_id, actual_start, actual_end}."""
     m = ttnn.to_torch(ttnn.get_device_tensors(metadata_msg)[0]).view(torch.int32).flatten()
     return {"slot_id": int(m[0]), "actual_start": int(m[1]), "actual_end": int(m[2])}
 
@@ -276,17 +275,17 @@ def _is_shutdown_sentinel(meta: dict) -> bool:
     )
 
 
-def _socket_next(h2d_service, *, decode_meta: bool) -> tuple:
+def _socket_next(h2d_service) -> tuple:
     """Block on the next producer push: returns (tt_tokens, meta, metadata_msg). The device metadata
     tensor is returned (not discarded) so it can be propagated into the model's per-layer ack send.
     Used only by the unbounded request loop (rank 0 input).
 
-    decode_meta=False (traced path) skips the device->host read of the metadata: the per-chunk scalars
-    are consumed on-device straight from metadata_msg, so meta is returned None and no to_torch runs."""
+    The metadata is always read to host: the scalars are tiny and the read is what lets the loop see the
+    in-band shutdown sentinel, which is the runner's graceful teardown path under trace and eager alike."""
     tt_tokens, metadata_msg = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
         h2d_service, metadata_size_bytes=METADATA_SIZE_BYTES
     )
-    return tt_tokens, _decode_metadata(metadata_msg) if decode_meta else None, metadata_msg
+    return tt_tokens, _decode_metadata(metadata_msg), metadata_msg
 
 
 def build_d2d_pipeline_endpoints(mesh_device, rank: int, num_ranks: int, chunk_size: int, hidden_size: int):
@@ -336,21 +335,16 @@ def build_d2d_pipeline_endpoints(mesh_device, rank: int, num_ranks: int, chunk_s
     return inbound, outbound
 
 
-def _d2d_recv(inbound, *, decode_meta: bool) -> tuple:
+def _d2d_recv(inbound) -> tuple:
     """Drain the next chunk that landed in the inbound receiver backing into a fresh device tensor. The
     returned tensor already has the embedding-output sharding, so it feeds runtime.prefill with no
-    reshard. Pairs with the upstream rank's _d2d_send.
-
-    decode_meta=False (traced path) skips the device->host read of the inline metadata: meta is returned
-    None and the per-chunk scalars are consumed on-device straight from metadata_msg."""
+    reshard. Pairs with the upstream rank's _d2d_send."""
     t0 = time.perf_counter()
     act, metadata_msg = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
         inbound, metadata_size_bytes=METADATA_SIZE_BYTES
     )
-    meta = _decode_metadata(metadata_msg) if decode_meta else None
-    where = (
-        f"[{meta['actual_start']},{meta['actual_end']}) slot={meta['slot_id']}" if meta is not None else "(on-device)"
-    )
+    meta = _decode_metadata(metadata_msg)
+    where = f"[{meta['actual_start']},{meta['actual_end']}) slot={meta['slot_id']}"
     logger.info(f"[pp] RECV-d2d {where} [xfer] sync={(time.perf_counter() - t0) * 1000.0:.2f}ms")
     return act, meta, metadata_msg
 
@@ -453,23 +447,20 @@ def _compute_and_send(
     """Run one chunk: prefill into the engine-owned kv_caches, forward the output downstream (non-last
     rank) and grant the outbound sender so it ships over fabric. Returns the compute-start epoch
     (NTP-comparable). CHUNK_START is logged BEFORE the forward, with this chunk's metadata, so the
-    slot/KV-range is visible per rank even if prefill_chunk hangs. On the traced path meta is None (the
-    scalars live on-device in metadata_msg), so the range is logged as (on-device). The trailing metadata
-    is kept after compute_start so the c=/compute_start= fields stay parseable (plot_pipeline_trace.py)."""
+    slot/KV-range is visible per rank even if prefill_chunk hangs. The trailing metadata is kept after
+    compute_start so the c=/compute_start= fields stay parseable (plot_pipeline_trace.py)."""
     if SYNC_PER_CHUNK:
         ttnn.synchronize_device(runtime.mesh_device)
     t_start = time.time()
     t_perf = time.perf_counter()
-    where = (
-        f"slot={meta['slot_id']} [{meta['actual_start']},{meta['actual_end']})" if meta is not None else "(on-device)"
-    )
+    where = f"slot={meta['slot_id']} [{meta['actual_start']},{meta['actual_end']})"
     logger.info(f"[pp rank {rank}] CHUNK_START c={c} compute_start={t_start:.6f} {where}")
     out = runtime.prefill_chunk(
         inp,
         kv_caches,
-        slot_id=meta["slot_id"] if meta is not None else None,
-        actual_start=meta["actual_start"] if meta is not None else None,
-        actual_end=meta["actual_end"] if meta is not None else None,
+        slot_id=meta["slot_id"],
+        actual_start=meta["actual_start"],
+        actual_end=meta["actual_end"],
         request_id=c,
         d2h_service=d2h_service,
         metadata_msg=metadata_msg,
@@ -537,19 +528,16 @@ def run_request_loop(
     as a hard fallback, until SIGTERM/SIGKILL. No fixed chunk bound, no trace input, no PCC, no
     migration — the runner serves; migration is issued from outside (migration_driver.py).
 
-    Traced path (cfg.use_trace): the per-chunk metadata is consumed on-device straight from metadata_msg
-    (no device->host->device round trip), so the host never sees the scalars and the in-band shutdown
-    sentinel cannot be detected. Trace serving therefore relies ONLY on SIGTERM/SIGKILL for teardown —
-    the producer's PREFILL_SEND_SHUTDOWN sentinel is ignored. Run untraced if graceful in-band shutdown
-    is required."""
+    The per-chunk metadata is read to host on every chunk (traced and eager alike): the scalars are tiny
+    and the read is what lets the loop see the in-band shutdown sentinel and drain gracefully. Trace
+    replay still consumes the metadata on-device from the persistent buffer; this host read is only the
+    small sentinel/logging copy alongside it."""
     cfg = runtime.config
     if cfg.is_first_rank and h2d_service is None:
         raise ValueError("request mode requires the H2D service on the first rank for input")
-    decode_meta = not cfg.use_trace  # untraced needs host scalars (logging + sentinel); traced consumes on-device
     logger.info(
         f"[pp rank {rank}/{num_ranks}] request (unbounded) loop start "
-        f"(is_first={cfg.is_first_rank} is_last={cfg.is_last_rank} input={'h2d' if cfg.is_first_rank else 'd2d'} "
-        f"metadata={'host' if decode_meta else 'on-device'})"
+        f"(is_first={cfg.is_first_rank} is_last={cfg.is_last_rank} input={'h2d' if cfg.is_first_rank else 'd2d'})"
     )
     t0 = time.perf_counter()
     c = 0
@@ -557,10 +545,10 @@ def run_request_loop(
     while not _shutdown:
         _lease_reclaim(d2d_in, d2d_out)
         if cfg.is_first_rank:
-            inp, meta, metadata_msg = _socket_next(h2d_service, decode_meta=decode_meta)  # slot/start/end from producer
+            inp, meta, metadata_msg = _socket_next(h2d_service)  # slot/start/end from producer
         else:
-            inp, meta, metadata_msg = _d2d_recv(d2d_in, decode_meta=decode_meta)
-        if meta is not None and _is_shutdown_sentinel(meta):
+            inp, meta, metadata_msg = _d2d_recv(d2d_in)
+        if _is_shutdown_sentinel(meta):
             # End of stream: drop the throwaway payload + its metadata tensor, hand the sentinel to the
             # next rank so it too unblocks and exits, then fall through to the graceful drain below.
             logger.info(f"[pp rank {rank}] SHUTDOWN sentinel received after {c} chunks; exiting request loop")

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -488,15 +488,22 @@ def _compute_and_send(
         _record_chunk_timing(rank, c, t_start, compute_ms)
     if not runtime.config.is_last_rank:
         # Traced: `out` is the runtime's persistent _trace_output (the next replay overwrites it in place),
-        # so the send copies it into the socket backing but must not free it; the received metadata_msg is
-        # forwarded verbatim (no host rebuild, meta is None). Eager: `out` is fresh — free it, rebuild md.
+        # so the send copies it into the socket backing but must not free it. Forward the runtime's
+        # persistent metadata, NOT the raw received metadata_msg: that raw tensor is a fresh socket output
+        # the replay's writes can land on, so it can arrive corrupted downstream (per-shard-inconsistent),
+        # tripping the D2H ack's cross-socket identity check. The persistent buffer survives replay. Eager:
+        # `out` is fresh — free it, rebuild md from meta.
+        forward_md = None
+        if runtime.config.use_trace:
+            persistent_md = getattr(runtime, "trace_metadata_msg", None)
+            forward_md = persistent_md if persistent_md is not None else metadata_msg
         _d2d_send(
             d2d_out,
             out,
             rank,
             meta,
             deallocate=not runtime.config.use_trace,
-            metadata_msg=metadata_msg if runtime.config.use_trace else None,
+            metadata_msg=forward_md,
         )  # grant below ships it
     if d2d_out is not None:
         d2d_out.release_fabric_links()

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -760,10 +760,10 @@ def _run_chunked_prefill(
                     )
                     for val in (u, kv_actual, valid_end)
                 )
-            # Metadata path: pass ONLY the metadata tensor (the runner hands tt_metadata straight from
-            # inbound_socket_service_sync) -- actual_start/actual_end are read on-device, so leave them
-            # None to prove forward needs no host per-chunk scalars. cache_user_id is unused on this path
-            # (slot comes from metadata[0]).
+            # Metadata path: pass ONLY the per-element metadata operands (the runtime's _trace_metadata
+            # equivalent) -- actual_start/actual_end are read on-device, so leave them None to prove
+            # forward needs no host per-chunk scalars. cache_user_id is unused on this path (slot comes
+            # from metadata[0]).
             # Determinism re-issues the SAME forward on the same device inputs. forward takes
             # actual_start/cache_user_id from the caller, so a repeat rewrites the same cache slots
             # with the same data -- idempotent, like the repeated block() in test_prefill_block.

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -537,7 +537,7 @@ class TtPrefillBlock(LightweightModule):
         return_kv_cache: bool = False,
         return_intermediates: bool = False,
         d2h_service=None,
-        record_dev: Optional[ttnn.Tensor] = None,
+        metadata_msg: Optional[ttnn.Tensor] = None,
         on_layer_complete: Optional[Callable[[int], None]] = None,
         on_layer_hidden: Optional[Callable[[int, ttnn.Tensor], None]] = None,
         actual_start: Optional[int] = None,
@@ -564,8 +564,8 @@ class TtPrefillBlock(LightweightModule):
                 the chunk this block zeros the pad window past actual_end, then enqueues the ack via the
                 outbound_socket_service_sync device op on the same CQ — no host sync. This is the
                 single-host (LayerAckService) ack path; mutually exclusive with on_layer_complete.
-            record_dev: the chunk's PrefillMetadata device tensor sent as the ack record; required when
-                d2h_service is set. Distinct from `metadata`: record_dev is the socket record handed to
+            metadata_msg: the chunk's PrefillMetadata device tensor sent as the ack record; required when
+                d2h_service is set. Distinct from `metadata`: metadata_msg is the socket record handed to
                 the host, `metadata` is the per-element scalar triple read by the on-device ops.
             on_layer_complete: optional per-layer migration ack fired on the HOST. In chunked prefill,
                 after MLA writes the chunk this block zeros the pad window past actual_end, flushes, then
@@ -645,7 +645,7 @@ class TtPrefillBlock(LightweightModule):
         # cache_layer_idx is the LOCAL per-rank cache slot in both.
         if d2h_service is not None or on_layer_complete is not None:
             assert actual_end is not None or metadata is not None, "actual_end or metadata required for zero_pad"
-            assert d2h_service is None or record_dev is not None, "record_dev required when d2h_service is set"
+            assert d2h_service is None or metadata_msg is not None, "metadata_msg required when d2h_service is set"
             # zero_padded_kv_cache is a DENSE (TILE) kvpe-cache op. A DSA-sparse model's kvpe cache is
             # bf16/fp8 ROW_MAJOR (sparse_sdpa reads it natively) and the op asserts TILE, so skip it for
             # sparse.
@@ -677,10 +677,11 @@ class TtPrefillBlock(LightweightModule):
                 # Device-op ack, enqueued on the same CQ right after the zero: the record cannot reach the
                 # host before the zero has executed, so the ack implies zero-complete with no host sync —
                 # unlike the host-callback path below, which needs an explicit flush.
-                # NOT used under trace: record_dev is the per-chunk socket metadata tensor, so its address
-                # changes every chunk and a capture would bake in a stale one. TtPrefillRuntime.prefill_chunk
-                # asserts d2h_service is None when use_trace.
-                ttnn.experimental.deepseek_prefill.outbound_socket_service_sync(d2h_service, metadata=record_dev)
+                # Capture-safe only because metadata_msg is at a fixed address: the op registers it as a
+                # buffer binding, which trace replay does not re-patch. A traced caller must therefore
+                # pass a persistent record (TtPrefillRuntime._trace_metadata_msg), never the per-chunk
+                # socket tensor, whose address moves every chunk.
+                ttnn.experimental.deepseek_prefill.outbound_socket_service_sync(d2h_service, metadata=metadata_msg)
             else:
                 # Trace path: route the ack through the controller. At capture it splits the trace here (a host
                 # shm bump cannot live inside a trace); at replay the controller fires the ack between the two

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -144,6 +144,10 @@ class TtPrefillRuntime:
         #   _controller       — SubDeviceTraceController driving the segmented capture/replay
         #   _trace_input      — persistent per-chunk input buffer (captured address; updated in place)
         #   _trace_metadata   — 3 persistent 1-element uint32 tensors (slot_id, actual_start, actual_end)
+        #   _trace_metadata_msg — persistent packed [1,1,1,3] uint32 tensor holding the same three words;
+        #                       the D2H layer-ack ships it as the record, so it needs an address the
+        #                       capture can bake in (the per-chunk socket tensor's moves every chunk)
+        #   _trace_d2h_service — the D2H ack service baked into the capture by set_d2h_ack_service()
         #   _trace_output     — persistent output activation (non-last rank only; read by the D2D send)
         #   _trace_captured   — flips True once capture_trace() records the segmented capture (single-shot)
         #   _kv_cache         — the engine cache handle from compile(), used by capture_trace()
@@ -154,6 +158,8 @@ class TtPrefillRuntime:
         self._controller = None
         self._trace_input = None
         self._trace_metadata = None
+        self._trace_metadata_msg = None
+        self._trace_d2h_service = None
         self._trace_output = None
         self._trace_captured = False
         self._kv_cache = None
@@ -460,6 +466,13 @@ class TtPrefillRuntime:
             self._forward_traced(kv_cache)  # compile zero_padded_kv_cache + ack path (no real ack fires)
             ttnn.synchronize_device(self.mesh_device)
             controller.set_layer_ack_callback(self._on_layer_complete)
+        elif self._trace_d2h_service is not None:
+            # Same reason as above — the ack programs were not compiled by _prepare_trace's warm pass, and
+            # a capture cannot absorb a program-cache miss. The D2H ack has no no-op stand-in (it is a
+            # device op, not a callback), so this warm pass emits num_layers REAL records. The caller is
+            # required to drain them; see set_d2h_ack_service().
+            self._forward_traced(kv_cache)
+            ttnn.synchronize_device(self.mesh_device)
 
         controller.begin_capture()
         out = self._forward_traced(kv_cache)
@@ -484,14 +497,34 @@ class TtPrefillRuntime:
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
         )
 
-    def _meta1_host(self, val: int) -> ttnn.Tensor:
-        """Host-side 1-element uint32 tensor for the cheap in-place metadata update (copy_host_to_device)."""
+    def _meta3_dev(self, vals: tuple) -> ttnn.Tensor:
+        """One persistent packed [1,1,1,3] uint32 replicated-DRAM metadata record (captured address)."""
         return ttnn.from_torch(
-            torch.tensor([val], dtype=torch.int64).reshape(1, 1, 1, 1),
+            torch.tensor(list(vals), dtype=torch.int64).reshape(1, 1, 1, 3),
+            device=self.mesh_device,
             dtype=ttnn.uint32,
             layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
         )
+
+    def _metadata_from_msg(self, metadata_msg: ttnn.Tensor) -> None:
+        """Populate the persistent metadata — packed record and per-element scalars — IN PLACE from the
+        packed [1,1,1,3] socket message ON DEVICE, with no device->host->device round trip.
+
+        Everything the capture reads has to sit at a fixed address, and metadata_msg does not: the socket
+        hands back a fresh tensor per chunk. So the words land in two persistent forms. _trace_metadata_msg
+        keeps them packed for the D2H layer-ack, which ships the record verbatim; _trace_metadata splits
+        them into 1-element buffers because the traced ops read each field on-device from its own tensor.
+        ttnn.copy writes into the pre-allocated dst in place, preserving the captured address.
+
+        The per-element slices read from the persistent copy rather than metadata_msg so both forms are
+        guaranteed to carry the same chunk's words."""
+        ttnn.copy(metadata_msg, self._trace_metadata_msg)
+        for i, dst in enumerate(self._trace_metadata):
+            word = ttnn.slice(self._trace_metadata_msg, [0, 0, 0, i], [1, 1, 1, i + 1])
+            ttnn.copy(word, dst)
+            ttnn.deallocate(word)
 
     def _forward_traced(self, kv_cache: ttnn.Tensor):
         """The captured/warmed metadata forward: per-chunk scalars come from the persistent metadata
@@ -508,6 +541,8 @@ class TtPrefillRuntime:
             # capture; passing None would capture a program with no padding-aware path at all.
             actual_isl=self.config.chunk_size,
             on_layer_complete=self._on_layer_complete,
+            d2h_service=self._trace_d2h_service,
+            metadata_msg=self._trace_metadata_msg,
             actual_start=None,
             actual_end=None,
             cache_user_id=0,
@@ -524,6 +559,9 @@ class TtPrefillRuntime:
         self._trace_input = self.make_chunk_input([0] * chunk)
         # Per-element metadata: (slot_id, actual_start, actual_end), seeded for chunk 0.
         self._trace_metadata = (self._meta1_dev(0), self._meta1_dev(0), self._meta1_dev(chunk))
+        # Same three words packed, for the D2H ack record. Allocated whether or not the ack is wired:
+        # set_d2h_ack_service() runs after compile(), and the capture needs an address that predates it.
+        self._trace_metadata_msg = self._meta3_dev((0, 0, chunk))
 
         controller = SubDeviceTraceController(self.mesh_device)
         self.model.set_trace_controller(controller)
@@ -536,12 +574,12 @@ class TtPrefillRuntime:
         self,
         input_tensor: ttnn.Tensor,
         kv_caches: MlaKvCaches,
-        slot_id: int,
-        actual_start: int,
-        actual_end: int,
+        slot_id: Optional[int],
+        actual_start: Optional[int],
+        actual_end: Optional[int],
         request_id: int = 0,
         d2h_service=None,
-        record_dev: Optional[ttnn.Tensor] = None,
+        metadata_msg: Optional[ttnn.Tensor] = None,
     ) -> Optional[ttnn.Tensor]:
         """Prefill ONE chunk into user `slot_id`'s slice of the engine-owned `kv_caches`.
 
@@ -557,7 +595,7 @@ class TtPrefillRuntime:
         may be pad, so actual_end < actual_start + chunk_size). actual_end is the migration pad-zero
         boundary, passed straight through to MLA. The caller drives chunked prefill by
         calling this once per chunk, in order; a chunk's KV must be populated before the next reads
-        it. If d2h_service + record_dev are passed, the model sends one per-layer ack completion signal back
+        it. If d2h_service + metadata_msg are passed, the model sends one per-layer ack completion signal back
         to host (via the outbound_socket_service_sync device op) once each layer's KV cache is populated.
         Alternatively, if a host-side per-layer callback is registered (set_layer_ack_channel /
         set_layer_completion_sink), the model fires that once per layer instead.
@@ -573,28 +611,38 @@ class TtPrefillRuntime:
             kv_caches: the engine-owned KV cache (from the adapter's allocate_kv_cache): ``.kvpe`` is the
                 primary cache this chunk's KV is written into; ``.index`` is the sparse/DSA indexer cache
                 (None for dense). The same object is passed on every call; the runtime holds none of it.
-            slot_id: cache user slot to fill, in [0, num_users).
-            actual_start: absolute KV pos of the chunk's first real token (the cache write offset).
-            actual_end: absolute KV pos past the chunk's last real token.
+            slot_id: cache user slot to fill, in [0, num_users). None on the traced path (read on-device
+                from metadata_msg instead — see below).
+            actual_start: absolute KV pos of the chunk's first real token (the cache write offset). None
+                on the traced path.
+            actual_end: absolute KV pos past the chunk's last real token. None on the traced path.
             request_id: this chunk's request/chunk id. Only the pipelined layer-completion sink uses it
                 (to build the globally-dense ordering key); the single-host layer-ack paths ignore it.
             d2h_service: optional service used to send a layer-ack completion signal back to host once
                 each layer's KV cache has been populated on device. When set, each block zeros the cache
                 pad window and enqueues the ack via the outbound_socket_service_sync device op on the same
-                CQ (no host sync). When None, no ack or zeroing.
-            record_dev: the chunk's PrefillMetadata device tensor sent as each ack record; required when
-                d2h_service is set.
+                CQ (no host sync). When None, no ack or zeroing. Eager path only — a traced run registers
+                the service once via set_d2h_ack_service() because the ack op lives inside the capture.
+            metadata_msg: the chunk's packed [1,1,1,3] PrefillMetadata device tensor. On the traced path
+                it is REQUIRED and carries (slot_id, actual_start, actual_end): its words are copied
+                on-device into the persistent buffers the capture reads, replacing the host round trip. On
+                the eager path it is the ack record sent per layer, required only when d2h_service is set.
         """
         # Not gated on self.compiled: compile() warms up by calling prefill_chunk() once before
         # marking the runtime compiled. The model must exist, though.
         assert self.model_built, "build the model before prefill_chunk()"
-        assert 0 <= slot_id < self.config.num_users, f"slot_id {slot_id} out of range [0, {self.config.num_users})"
-        assert (
-            actual_start + self.config.chunk_size <= self.config.max_seq_len
-        ), f"chunk at actual_start={actual_start} exceeds per-user cache {self.config.max_seq_len}"
-        assert (
-            actual_start <= actual_end <= actual_start + self.config.chunk_size
-        ), f"[actual_start={actual_start}, actual_end={actual_end}) not within one chunk of {self.config.chunk_size}"
+        # Host-side scalars are validated only when supplied. On the traced serving path they arrive
+        # None: the per-chunk (slot_id, actual_start, actual_end) live on-device in metadata_msg and are
+        # copied into the persistent buffers below, so there are no host ints to range-check.
+        if slot_id is not None:
+            assert 0 <= slot_id < self.config.num_users, f"slot_id {slot_id} out of range [0, {self.config.num_users})"
+        if actual_start is not None:
+            assert (
+                actual_start + self.config.chunk_size <= self.config.max_seq_len
+            ), f"chunk at actual_start={actual_start} exceeds per-user cache {self.config.max_seq_len}"
+            assert (
+                actual_start <= actual_end <= actual_start + self.config.chunk_size
+            ), f"[actual_start={actual_start}, actual_end={actual_end}) not within one chunk of {self.config.chunk_size}"
 
         if self.config.use_trace:
             # Traced path: update the persistent input + per-element metadata IN PLACE, then replay the
@@ -609,14 +657,13 @@ class TtPrefillRuntime:
                 "use_trace: capture_trace() must run before the first prefill_chunk(); capturing here "
                 "would stall the first request by a warm pass + capture"
             )
-            # The D2H layer-ack is not on the traced path: record_dev is the per-chunk socket metadata
-            # tensor, whose address changes every chunk, so the capture would bake in a stale address.
-            # Fail loudly rather than silently replaying a trace that emits no acks. (Wiring it up needs
-            # record_dev to become a persistent, in-place-updated buffer like _trace_metadata.)
-            assert d2h_service is None, (
-                "use_trace does not support the D2H layer-ack path yet (record_dev is a per-chunk socket "
-                "tensor, so its address cannot be captured); run with PREFILL_USE_TRACE=0 or use the "
-                "host-callback ack (set_layer_ack_channel / set_layer_completion_sink)"
+            # The D2H ack is recorded INSIDE the capture, so the service is bound once by
+            # set_d2h_ack_service() rather than per call. A service arriving here instead means the caller
+            # wired the eager path on a traced run: the replay would emit acks from whatever was registered
+            # (or none at all) while the caller believes it passed one.
+            assert d2h_service is None or d2h_service is self._trace_d2h_service, (
+                "use_trace: pass the D2H layer-ack service to set_d2h_ack_service() before capture_trace(); "
+                "the per-call argument cannot reach a recorded device op"
             )
             # Per-layer completion callbacks live on the CONTROLLER, registered once at capture time (a
             # host-side callback cannot execute inside a trace, so the capture splits at each ack point).
@@ -624,9 +671,12 @@ class TtPrefillRuntime:
             # path does below — publish this chunk's id instead; the captured callback built by
             # set_layer_completion_sink() reads it at replay time.
             self._trace_request_id = request_id
+            assert metadata_msg is not None, (
+                "use_trace: prefill_chunk needs the packed metadata_msg to populate the per-chunk metadata "
+                "on-device (the traced serving loop always carries it; the eager warm-up passes host ints)"
+            )
             ttnn.copy(input_tensor, self._trace_input)
-            for dst, val in zip(self._trace_metadata, (slot_id, actual_start, actual_end)):
-                ttnn.copy_host_to_device_tensor(self._meta1_host(val), dst)
+            self._metadata_from_msg(metadata_msg)
             self._controller.replay()
             ttnn.deallocate(input_tensor)
             # Non-last rank: return the persistent output activation (replay just refreshed it) for the
@@ -659,7 +709,7 @@ class TtPrefillRuntime:
             kv_caches.kvpe,
             actual_isl=actual_end - actual_start,
             d2h_service=d2h_service,
-            record_dev=record_dev,
+            metadata_msg=metadata_msg,
             on_layer_complete=on_layer_complete,
             on_layer_hidden=self._on_layer_hidden,
             actual_start=actual_start,
@@ -747,6 +797,35 @@ class TtPrefillRuntime:
                 "to be known at capture time so the segments split at each ack point"
             )
             self._controller.set_layer_ack_callback(on_layer_complete)
+
+    def warmup_ack_count(self) -> int:
+        """How many D2H ack records capture_trace()'s warm pass will emit — one per layer of this rank's
+        slice. Zero unless a traced run has a D2H ack service registered."""
+        if not self.config.use_trace or self._trace_d2h_service is None:
+            return 0
+        return self.config.num_layers
+
+    def set_d2h_ack_service(self, d2h_service) -> None:
+        """Register the D2H layer-ack service for a TRACED run, baking it into the capture.
+
+        The eager path takes the service per prefill_chunk() call; a traced one cannot, because the ack is
+        a device op recorded inside the capture. Both the service's core/counter addresses and the record
+        tensor therefore have to be known here, before capture_trace() — hence the packed
+        _trace_metadata_msg, which is what the recorded op reads (see _metadata_from_msg).
+
+        Warm-pass records: capture_trace() runs one warm forward to compile the ack programs, and it fires
+        warmup_ack_count() real records into the FIFO. Drain exactly that many (read_metadata()) before
+        starting the LayerAckService reader, or the scheduler counts a phantom chunk's worth of acks."""
+        assert self.config.use_trace, "set_d2h_ack_service() is the traced path; eager passes d2h_service per call"
+        assert self._on_layer_complete is None, (
+            "d2h_service and the host ack callback are mutually exclusive transports; the block takes "
+            "d2h_service and would silently drop set_layer_ack_channel()'s callback"
+        )
+        assert not self._trace_captured, (
+            "use_trace: set_d2h_ack_service() must run BEFORE capture_trace() — the ack is a device op "
+            "recorded into the capture, so the service must be known at capture time"
+        )
+        self._trace_d2h_service = d2h_service
 
     def kv_migration_base_address(self, kv_caches: MlaKvCaches) -> int:
         """This stage's primary KV base DRAM address — the engine's single-cache hook for the

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -526,6 +526,15 @@ class TtPrefillRuntime:
             ttnn.copy(word, dst)
             ttnn.deallocate(word)
 
+    @property
+    def trace_metadata_msg(self) -> Optional[ttnn.Tensor]:
+        """The persistent packed metadata the D2D pipeline must forward downstream on the traced path.
+
+        The raw per-chunk metadata_msg is a fresh socket-output tensor at an allocator-chosen address
+        the replay's writes can land on; this buffer sits at the capture-safe fixed address the recorded
+        ops read, so it holds the current chunk's words intact after replay. None off the traced path."""
+        return self._trace_metadata_msg
+
     def _forward_traced(self, kv_cache: ttnn.Tensor):
         """The captured/warmed metadata forward: per-chunk scalars come from the persistent metadata
         tensor on-device (actual_start/actual_end = None host-side). Writes user slot metadata[0].

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -146,7 +146,7 @@ class TtPrefillRuntime:
         #   _trace_metadata   — 3 persistent 1-element uint32 tensors (slot_id, actual_start, actual_end)
         #   _trace_metadata_msg — persistent packed [1,1,1,3] uint32 tensor holding the same three words;
         #                       the D2H layer-ack ships it as the record, so it needs an address the
-        #                       capture can bake in (the per-chunk socket tensor's moves every chunk)
+        #                       capture can bake in (the per-chunk socket tensor moves every chunk)
         #   _trace_d2h_service — the D2H ack service baked into the capture by set_d2h_ack_service()
         #   _trace_output     — persistent output activation (non-last rank only; read by the D2D send)
         #   _trace_captured   — flips True once capture_trace() records the segmented capture (single-shot)

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -363,7 +363,7 @@ class TtPrefillTransformer(LightweightModule):
         read_profiler: bool = False,
         temperature: Union[float, list[float]] = 0.0,
         d2h_service=None,
-        record_dev: Optional[ttnn.Tensor] = None,
+        metadata_msg: Optional[ttnn.Tensor] = None,
         on_layer_complete: Optional[Callable[[int], None]] = None,
         on_layer_hidden: Optional[Callable[[int, ttnn.Tensor], None]] = None,
         actual_start: Optional[int] = None,
@@ -398,7 +398,7 @@ class TtPrefillTransformer(LightweightModule):
                         each layer's KV cache has been populated on device. When set, each block zeros the
                         cache pad window and enqueues the ack via the outbound_socket_service_sync device op
                         on the same CQ (no host sync). When None, no ack or zeroing.
-            record_dev: the chunk's PrefillMetadata device tensor sent as each ack record; required when
+            metadata_msg: the chunk's PrefillMetadata device tensor sent as each ack record; required when
                         d2h_service is set.
             on_layer_complete: the HOST-callback alternative to d2h_service (used by pipelined prefill's
                         layer-completion router). Called as on_layer_complete(layer_idx) after the same
@@ -477,7 +477,7 @@ class TtPrefillTransformer(LightweightModule):
                 cache_layer_idx=i,
                 return_intermediates=return_intermediates,
                 d2h_service=d2h_service,
-                record_dev=record_dev,
+                metadata_msg=metadata_msg,
                 on_layer_complete=on_layer_complete,
                 on_layer_hidden=on_layer_hidden,
                 actual_start=actual_start,


### PR DESCRIPTION
<img width="324" height="585" alt="image" src="https://github.com/user-attachments/assets/876217c3-8e4c-43cd-b26a-fa6fed8badb3" />

### Workflow runs
- [Blaze Models Prefill tests](https://github.com/tenstorrent/tt-metal/actions/runs/33405489671)
- [(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/33390312397)

### What this PR does
Runs the D2H per-layer ack copies inside the captured trace instead of eagerly.
Forwards persistent metadata on the traced D2D send so it survives replay.
Hoists the runner's torch import to module scope.
Turns on the D2H ack in the sc4 CI legs (kimi27 under trace, glm52 untraced).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-d2h-under-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/prefill-d2h-under-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-d2h-under-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/prefill-d2h-under-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/prefill-d2h-under-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/prefill-d2h-under-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/prefill-d2h-under-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/prefill-d2h-under-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/prefill-d2h-under-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/prefill-d2h-under-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/prefill-d2h-under-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/prefill-d2h-under-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/prefill-d2h-under-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/prefill-d2h-under-trace)

