### PR TITLE
Single-source the dispatch metadata routing-field count

### DIFF
--- a/models/demos/deepseek_v3_d_p/reference/tt/moe/dispatch.py
+++ b/models/demos/deepseek_v3_d_p/reference/tt/moe/dispatch.py
@@ -18,7 +18,7 @@ Goals:
 import torch
 from loguru import logger
 
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import DISPATCH_METADATA_FIELDS, ExpertMapping
 
 
 class TorchDispatchModule(torch.nn.Module):
@@ -138,9 +138,9 @@ class TorchDispatchModule(torch.nn.Module):
         ), f"Last dimension of indices must match num_experts_per_tok {self.num_experts_per_tok}, got {indices.shape[-1]}"
 
         if scales is not None:
-            assert self.metadata_len == 3 + scales.shape[-1], (
-                f"metadata_len ({self.metadata_len}) must equal 3 + scales.shape[-1] "
-                f"({3 + scales.shape[-1]}) when scales are provided"
+            assert self.metadata_len == DISPATCH_METADATA_FIELDS + scales.shape[-1], (
+                f"metadata_len ({self.metadata_len}) must equal DISPATCH_METADATA_FIELDS + scales.shape[-1] "
+                f"({DISPATCH_METADATA_FIELDS + scales.shape[-1]}) when scales are provided"
             )
 
         dispatched_buffer = torch.zeros(self.dispatched_shape, dtype=torch.float32)
@@ -178,7 +178,7 @@ class TorchDispatchModule(torch.nn.Module):
                         if scales is not None:
                             scale_tail = scales[chip, token].to(torch.float32).view(torch.int32).tolist()
                         else:
-                            scale_tail = [0] * (self.metadata_len - 3)
+                            scale_tail = [0] * (self.metadata_len - DISPATCH_METADATA_FIELDS)
                         dispatched_metadata[group, expert_chip, dst_index] = torch.tensor(
                             [linearized_coord, token, topk_idx] + scale_tail,
                             dtype=dispatched_metadata.dtype,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
@@ -26,6 +26,7 @@ from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM2
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import ALL_MESH_CONFIGS
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    DISPATCH_METADATA_FIELDS,
     ExpertMapping,
     compute_constants,
     extract_mesh_config,
@@ -425,9 +426,9 @@ def run_dispatch(
     # is >= 0 only for real dispatched tokens), since unfilled device slots are uninitialized.
     if fp8_scaled_input:
         filled = torch_metadata[..., 1] >= 0
-        mask = filled.unsqueeze(-1).expand_as(torch_metadata[..., 3:])
-        ref_tail = torch_metadata[..., 3:][mask]
-        out_tail = tt_out_metadata[..., 3:].to(torch.int32)[mask]
+        mask = filled.unsqueeze(-1).expand_as(torch_metadata[..., DISPATCH_METADATA_FIELDS:])
+        ref_tail = torch_metadata[..., DISPATCH_METADATA_FIELDS:][mask]
+        out_tail = tt_out_metadata[..., DISPATCH_METADATA_FIELDS:].to(torch.int32)[mask]
         assert torch.equal(ref_tail, out_tail), (
             "fp8 per-token scales in the metadata tail (fields 3..) do not match the reference "
             "(dispatch must byte-copy each token's scales unchanged)."

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -21,6 +21,8 @@ from tqdm import tqdm
 import ttnn
 from models.common.utility_functions import is_blackhole
 
+DISPATCH_METADATA_FIELDS = 3
+
 # Fabric packet payload limits (conservative round values below hardware maximums).
 MAX_PAYLOAD_SIZE_BH = 14 * 1024  # Blackhole hardware max ~15232 B
 MAX_PAYLOAD_SIZE_WH = 7 * 1024  # Wormhole hardware max ~7616 B
@@ -482,7 +484,7 @@ def compute_constants(
         experts_per_chip = experts_per_chip_override
     else:
         experts_per_chip = num_routed_experts // num_devices
-    metadata_len = 3  # chip, token, topk_idx
+    metadata_len = DISPATCH_METADATA_FIELDS  # chip, token, topk_idx
     if fp8_scaled_input:
         # Each token appends its emb_dim/128 fp32 scales (bit-cast int32) after the 3 routing fields.
         assert emb_dim is not None, "emb_dim is required when fp8_scaled_input is True"

--- a/models/demos/deepseek_v3_d_p/tt/moe/validation_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/validation_helpers.py
@@ -11,7 +11,7 @@ import torch
 from loguru import logger
 
 from models.common.utility_functions import comp_pcc
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import DISPATCH_METADATA_FIELDS, ExpertMapping
 
 
 def score_activation(logits: torch.Tensor, score_func: str) -> torch.Tensor:
@@ -1130,8 +1130,8 @@ def validate_dispatch_metadata(
                 start = int(expert_region_offsets[r, dst_chip_id, global_expert_idx].item())
 
                 # Compare fields 1-2 (global token idx, top-k slot) directly
-                out = ttnn_metadata[r, dst_chip_id, start : start + count, 1:3]
-                ref = torch_metadata[r, dst_chip_id, start : start + count, 1:3]
+                out = ttnn_metadata[r, dst_chip_id, start : start + count, 1:DISPATCH_METADATA_FIELDS]
+                ref = torch_metadata[r, dst_chip_id, start : start + count, 1:DISPATCH_METADATA_FIELDS]
 
                 # Both Torch and TTNN embed linearized mesh coord in field 0
                 out_linearized_mesh_coord = ttnn_metadata[r, dst_chip_id, start : start + count, 0]
@@ -1152,8 +1152,8 @@ def validate_dispatch_metadata(
 
                     if verbose:
                         for slot in range(count):
-                            torch_data = torch_metadata[r, dst_chip_id, start + slot, :3]
-                            kernel_data = ttnn_metadata[r, dst_chip_id, start + slot, :3]
+                            torch_data = torch_metadata[r, dst_chip_id, start + slot, :DISPATCH_METADATA_FIELDS]
+                            kernel_data = ttnn_metadata[r, dst_chip_id, start + slot, :DISPATCH_METADATA_FIELDS]
                             slot_data_match = torch.allclose(torch_data, kernel_data, atol=1e-6)
                             if not slot_data_match:
                                 logger.error(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/tensor/types.hpp"
 #include "dispatch_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::dispatch {
@@ -117,11 +118,12 @@ void DispatchDeviceOperation::validate_on_program_cache_miss(
         const uint32_t num_scales = scales.logical_shape()[-1];
         // metadata_len reserves 3 routing fields + one word per scale
         TT_FATAL(
-            operation_attributes.metadata_len == 3 + num_scales,
-            "metadata_len ({}) must equal 3 routing fields + scales last dim ({}) = {}",
+            operation_attributes.metadata_len == DISPATCH_METADATA_FIELDS + num_scales,
+            "metadata_len ({}) must equal {} routing fields + scales last dim ({}) = {}",
             operation_attributes.metadata_len,
+            DISPATCH_METADATA_FIELDS,
             num_scales,
-            3 + num_scales);
+            DISPATCH_METADATA_FIELDS + num_scales);
         // total scale rows match total input tokens (flattened over all leading dims, as the reader does)
         const uint32_t input_hidden = tensor_args.input_tensor.logical_shape()[-1];
         const uint32_t input_tokens = tensor_args.input_tensor.logical_shape().volume() / input_hidden;
@@ -144,6 +146,11 @@ void DispatchDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             !tensor_args.scales_tensor.has_value(),
             "scales_tensor was provided but fp8_scaled_input is false; pass fp8_scaled_input=True to use scales");
+        TT_FATAL(
+            operation_attributes.metadata_len == DISPATCH_METADATA_FIELDS,
+            "metadata_len ({}) must equal the {} routing fields the dispatch kernel writes",
+            operation_attributes.metadata_len,
+            DISPATCH_METADATA_FIELDS);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dispatch_device_operation.hpp"
+#include "ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp"
 #include "kernels/dataflow/dispatch_plan.hpp"  // PlanHeader / PlanEntry layout (host sizes the plan CB from these)
 #include <algorithm>
 #include <array>
@@ -798,6 +799,7 @@ tt::tt_metal::ProgramDescriptor create_dispatch_program(
 
         auto worker_kernel_defines = fabric_defines;  // carries AXIS define if set
         auto worker_writer_defines = fabric_defines;
+        worker_writer_defines["DISPATCH_METADATA_FIELDS"] = std::to_string(DISPATCH_METADATA_FIELDS);
         if (has_padding_config) {
             worker_kernel_defines["HAS_PADDING_CONFIG"] = "1";
             worker_writer_defines["HAS_PADDING_CONFIG"] = "1";

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_worker_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_worker_dispatch.cpp
@@ -261,9 +261,15 @@ void kernel_main() {
                     uint32_t meta_addr =
                         metadata_scratch_addr + (local_count % meta_scratch_slots) * aligned_metadata_page_size;
                     volatile tt_l1_ptr int32_t* meta = reinterpret_cast<volatile tt_l1_ptr int32_t*>(meta_addr);
-                    meta[0] = (int32_t)linearized_mesh_coord;
-                    meta[1] = (int32_t)token_idx;
-                    meta[2] = (int32_t)k;
+                    // Any new routing field must be added to this initializer AND
+                    // DISPATCH_METADATA_FIELDS (dispatch.hpp) bumped with it — the constant is what
+                    // sizes the metadata rows and scale-tail offsets everywhere else (validator,
+                    // Python init_helpers, torch reference). A missing bump fails compilation here.
+                    const int32_t routing_fields[DISPATCH_METADATA_FIELDS] = {
+                        (int32_t)linearized_mesh_coord, (int32_t)token_idx, (int32_t)k};
+                    for (uint32_t f = 0; f < DISPATCH_METADATA_FIELDS; f++) {
+                        meta[f] = routing_fields[f];
+                    }
 #ifdef FP8_SCALED
                     // Copy this token's fp32 scale words (bit-for-bit) into the metadata tail so the
                     // routed buffer can be dequantized downstream. token_t indexes the scales CB.
@@ -271,7 +277,7 @@ void kernel_main() {
                         tt_l1_ptr uint32_t* src_scales =
                             reinterpret_cast<tt_l1_ptr uint32_t*>(scales_read_ptr + token_t * aligned_scales_page_size);
                         for (uint32_t w = 0; w < num_scale_words; w++) {
-                            meta[3 + w] = (int32_t)src_scales[w];
+                            meta[DISPATCH_METADATA_FIELDS + w] = (int32_t)src_scales[w];
                         }
                     }
 #endif
@@ -331,9 +337,15 @@ void kernel_main() {
                     // the cross-device scratch slot, then written to the sender's c_6 slot.
                     volatile tt_l1_ptr int32_t* meta =
                         reinterpret_cast<volatile tt_l1_ptr int32_t*>(xdev_metadata_scratch_addr);
-                    meta[0] = (int32_t)linearized_mesh_coord;
-                    meta[1] = (int32_t)token_idx;
-                    meta[2] = (int32_t)k;
+                    // Any new routing field must be added to this initializer AND
+                    // DISPATCH_METADATA_FIELDS (dispatch.hpp) bumped with it — the constant is what
+                    // sizes the metadata rows and scale-tail offsets everywhere else (validator,
+                    // Python init_helpers, torch reference). A missing bump fails compilation here.
+                    const int32_t routing_fields[DISPATCH_METADATA_FIELDS] = {
+                        (int32_t)linearized_mesh_coord, (int32_t)token_idx, (int32_t)k};
+                    for (uint32_t f = 0; f < DISPATCH_METADATA_FIELDS; f++) {
+                        meta[f] = routing_fields[f];
+                    }
 #ifdef FP8_SCALED
                     // Same scale-tail copy as the local path; the full aligned_metadata_page_size
                     // (which already accounts for the scale fields) is sent to the sender's c_6 slot.
@@ -341,7 +353,7 @@ void kernel_main() {
                         tt_l1_ptr uint32_t* src_scales =
                             reinterpret_cast<tt_l1_ptr uint32_t*>(scales_read_ptr + token_t * aligned_scales_page_size);
                         for (uint32_t w = 0; w < num_scale_words; w++) {
-                            meta[3 + w] = (int32_t)src_scales[w];
+                            meta[DISPATCH_METADATA_FIELDS + w] = (int32_t)src_scales[w];
                         }
                     }
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp
@@ -13,6 +13,8 @@
 
 namespace ttnn::operations::experimental::deepseek_prefill::dispatch {
 
+inline constexpr uint32_t DISPATCH_METADATA_FIELDS = 3;
+
 std::array<ttnn::Tensor, 2> dispatch(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& indices_tensor,


### PR DESCRIPTION
### Problem

The deepseek_prefill dispatch metadata wire format — 3 leading routing fields per token row (`linearized_mesh_coord`, `token_idx`, `topk_idx`) — is restated as a bare literal in many places: the C++ device validator, the writer kernel's fp8 scale-tail offset, and ~10 Python sites (metadata sizing in `compute_constants`, metadata slicing in validation helpers, the torch reference dispatch, op unit tests). Changing the field count means hand-editing all of them.

### Change

- `dispatch.hpp`: `inline constexpr uint32_t DISPATCH_METADATA_FIELDS = 3;` — the single C++ definition (dispatch owns the wire format, same ownership style as `fp8::BLOCK_W` living in `per_token_cast_to_fp8.hpp`).
- Device validator (`dispatch_device_operation.cpp`) derives the `metadata_len == routing + scales` check from it.
- The worker-writer kernel receives it as a compile-time define (same mechanism as `FP8_SCALED`) and uses it for both the routing-field stores and the fp8 scale-tail offset. The routing fields are written through a `routing_fields[DISPATCH_METADATA_FIELDS]` array initializer, so adding a field without bumping the constant fails kernel compilation ("too many initializers"), and bumping the constant without adding the field zero-fills — caught by the op unit test's field-by-field metadata comparison.
- Python side mirrors the constant (`DISPATCH_METADATA_FIELDS = 3` in `models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py`, the `ttnn.TILE_SIZE` pattern from `ttnn/types.py`) and all Python metadata sizing/slicing sites use it. The two definitions cannot drift silently: Python sizes `metadata_len` from its constant and the device validator checks it against the C++ one, so a mismatch fails loudly at op validation.

### Testing

- Incremental `ninja ttnn` build clean.
- `models/demos/deepseek_v3_d_p/tests/torch/test_moe.py::test_moe[random-weights]` passes. (`test_torch_dispatch_combine` failures are pre-existing on `main` — dispatch-buffer overflow unrelated to this change.)
- Kernel change is JIT-compiled; first device run / dispatch op unit tests in CI validate it.
- No behavior change: the constant still resolves to 3 everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_metadata_routing_fields)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/dispatch_metadata_routing_fields)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_metadata_routing_fields)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/dispatch_metadata_routing_fields)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_metadata_routing_fields)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nostojic/dispatch_metadata_routing_fields)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/dispatch_metadata_routing_fields)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/dispatch_metadata_routing_fields)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/dispatch_metadata_routing_fields)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/dispatch_metadata_routing_fields)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/dispatch_metadata_routing_fields)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/dispatch_metadata_routing_fields)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/dispatch_metadata_routing_fields)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/dispatch_metadata_routing_fields)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/dispatch_metadata_routing_fields)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/dispatch_metadata_routing_fields)