### PR TITLE
Add is_fp32_dest_acc_en template to core compute APIs

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -17,7 +17,7 @@ template <
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy(std::uint32_t dst_index, std::uint32_t operand) {
-    LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Dst index exceeds max tiles for the given configuration");
 
     const std::uint32_t operand_id = get_operand_id(operand);
     _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
@@ -34,7 +34,7 @@ inline void llk_math_eltwise_unary_datacopy_block(
     const std::uint32_t operand_id = get_operand_id(operand);
 
     for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
-        LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+        LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Dst index exceeds max tiles for the given configuration");
 
         _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
             dst_index, unpack_src_format[operand_id], unpack_dst_format[operand_id]);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
@@ -48,7 +48,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
     LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     LLK_ASSERT(
-        (tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
+        (tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en>()),
         "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
     llk::san::pack_operand_check(
@@ -73,7 +73,7 @@ inline void llk_matmul_pack(
         !((pack_mode == PackMode::Untilize) && out_of_order_output), "untilize out of order packing is not supported!");
     LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
     LLK_ASSERT(
-        ((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
+        ((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en>()),
         "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
     llk::san::pack_operand_check(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -18,7 +18,7 @@ template <
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy(std::uint32_t dst_index, std::uint32_t operand) {
-    LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "");
 
     const std::uint32_t operand_id = get_operand_id(operand);
     _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
@@ -35,7 +35,7 @@ inline void llk_math_eltwise_unary_datacopy_block(
     const std::uint32_t operand_id = get_operand_id(operand);
 
     for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
-        LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+        LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "");
 
         _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
             dst_index, unpack_src_format[operand_id], unpack_dst_format[operand_id]);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_tile_api.h
@@ -36,7 +36,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
 template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, PackMode pack_mode = PackMode::Default>
 inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32_t output_tile_index = 0) {
     LLK_ASSERT(
-        (tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
+        (tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en>()),
         "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
     std::uint8_t output_id = get_output_id(output);
@@ -71,7 +71,7 @@ inline void llk_matmul_pack(
         !((pack_mode == PackMode::Untilize) && out_of_order_output), "untilize out of order packing is not supported!");
     LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
     LLK_ASSERT(
-        ((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
+        ((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, is_fp32_dest_acc_en>()),
         "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
     llk::san::pack_operand_check(

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -80,17 +80,21 @@ ALWI void pack_init(uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
  * | Param Type | Name             | Description                                       | Type     | Valid Range                                          | Required |
  * |------------|------------------|---------------------------------------------------|----------|------------------------------------------------------|----------|
  * | Template   | out_of_order_output | Whether to allow out-of-order output           | bool     | true/false                                           | False    |
+ * | Template   | is_fp32_dest_acc_en | Select FP32 DEST packer read mode              | bool     | true/false (default: DST_ACCUM_MODE). A non-default value is only valid while enable_fp32_dest_acc() is in effect. | False |
  * | Function   | ifrom_dst        | The index of the tile in the DEST register        | uint32_t | Must be less than the size of the DEST register (16) | True     |
  * | Function   | icb              | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31                                              | True     |
  * | Function   | output_tile_index| The index of the tile in the output CB to copy to | uint32_t | Must be less than the size of the CB                 | False    |
  */
 // clang-format on
-template <bool out_of_order_output = false>
+template <bool out_of_order_output = false, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_index = 0) {
     LLK_SAN_FUNCTION();
 #ifndef ARCH_QUASAR
-    PACK((llk_pack<DST_ACCUM_MODE, out_of_order_output, PackMode::Default>(ifrom_dst, icb, output_tile_index)));
+    PACK((llk_pack<is_fp32_dest_acc_en, out_of_order_output, PackMode::Default>(ifrom_dst, icb, output_tile_index)));
 #else
+    static_assert(
+        is_fp32_dest_acc_en == DST_ACCUM_MODE,
+        "Quasar pack_tile does not support runtime FP32 DEST accumulation mode override");
     PACK((llk_pack<out_of_order_output>(ifrom_dst, icb, output_tile_index)));
 #endif
 }
@@ -130,13 +134,18 @@ ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_
  * | Function   | ifrom_dst | The index of the first tile in the DEST register  | uint32_t | Must be less than the size of the DEST register (16) | True     |
  * | Function   | icb       | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31                                              | True     |
  * | Function   | ntiles    | The number of tiles to copy from DEST to CB       | uint32_t | Must be less than the size of the DEST register (16) | True     |
+ * | Template   | is_fp32_dest_acc_en | Select FP32 DEST packer read mode | bool | true/false (default: DST_ACCUM_MODE). A non-default value is only valid while enable_fp32_dest_acc() is in effect. | False |
  */
 // clang-format on
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void pack_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
     LLK_SAN_FUNCTION();
 #ifndef ARCH_QUASAR
-    PACK((llk_matmul_pack<DST_ACCUM_MODE, false, PackMode::Default>(ifrom_dst, icb, ntiles)));
+    PACK((llk_matmul_pack<is_fp32_dest_acc_en, false, PackMode::Default>(ifrom_dst, icb, ntiles)));
 #else
+    static_assert(
+        is_fp32_dest_acc_en == DST_ACCUM_MODE,
+        "Quasar pack_block does not support runtime FP32 DEST accumulation mode override");
     PACK((llk_pack_block(ifrom_dst, icb, ntiles)));
 #endif
 }
@@ -155,9 +164,10 @@ ALWI void pack_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
  * | Function   | ntiles    | The number of tiles to copy from DEST to CB       | uint32_t | Must be less than the size of the DEST register (16) | True     |
  */
 // clang-format on
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 [[deprecated("Renamed to pack_block(); pack_tile_block will be removed after August 15th, 2026.")]] ALWI void
 pack_tile_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
-    pack_block(ifrom_dst, icb, ntiles);
+    pack_block<is_fp32_dest_acc_en>(ifrom_dst, icb, ntiles);
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/reg_api.h
+++ b/tt_metal/hw/inc/api/compute/reg_api.h
@@ -68,24 +68,33 @@ ALWI void tile_regs_wait() {
  * How the destination register will be shared and synchronized between TRISC threads will depend on the compute kernel
  * configuration.
  */
-[[deprecated("Use tile_regs_release() instead")]]
-ALWI void release_dst() {
-    MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
-    PACK((llk_pack_dest_section_done<DST_ACCUM_MODE>()));
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
+[[deprecated("Use tile_regs_release() instead")]] ALWI void
+release_dst() {
+    MATH((llk_math_dest_section_done<is_fp32_dest_acc_en>()));
+    PACK((llk_pack_dest_section_done<is_fp32_dest_acc_en>()));
 }
 
 // new APIs, TODO: migrate all kernels to these
 
 /**
  * Release lock on DST register by MATH thread. The lock had to be previously acquired with tile_regs_acquire.
+ *
+ * | is_fp32_dest_acc_en | Select FP32 DEST section for commit handoff | bool | true/false (default: DST_ACCUM_MODE). Must match tile_regs_release. A non-default value is only valid while enable_fp32_dest_acc() is in effect. | False |
  */
-ALWI void tile_regs_commit() { MATH((llk_math_dest_section_done<DST_ACCUM_MODE>())); }
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
+ALWI void tile_regs_commit() {
+    MATH((llk_math_dest_section_done<is_fp32_dest_acc_en>()));
+}
 
 /**
  * Release lock on DST register by PACK thread. The lock had to be previously acquired with tile_regs_wait.
+ *
+ * | is_fp32_dest_acc_en | Select FP32 DEST section for release handoff | bool | true/false (default: DST_ACCUM_MODE). Must match tile_regs_commit. A non-default value is only valid while enable_fp32_dest_acc() is in effect. | False |
  */
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void tile_regs_release() {
-    PACK((llk_pack_dest_section_done<DST_ACCUM_MODE>()));
+    PACK((llk_pack_dest_section_done<is_fp32_dest_acc_en>()));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -28,8 +28,10 @@ namespace ckernel {
  * | cbid        | The identifier of the input circular buffer (CB)  | uint32_t | 0 to 31                                            | False    |
  * | transpose   | Flag to perform transpose on SrcA                 | uint32_t | Any positive value will indicate transpose is set  | False    |
  * | transpose_within_16x16_face | Flag to perform transpose within 16x16 face | uint32_t | Any positive value will indicate transpose within 16x16 face is set        | False    |
+ * | is_fp32_dest_acc_en | Select FP32 DEST layout for datacopy MOP addressing | bool | true/false (default: DST_ACCUM_MODE). Must match the template parameter used in copy_tile. A non-default value is only valid while enable_fp32_dest_acc() is in effect. | False |
  */
 // clang-format on
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void copy_tile_to_dst_init_short(
     uint32_t cbid,
     uint32_t transpose = 0,
@@ -47,9 +49,9 @@ ALWI void copy_tile_to_dst_init_short(
     // 4th template arg is arch-divergent (unpack_to_dest on Quasar, is_int_fpu_en on WH/BH); keep it
     // arch-specific so WH/BH don't wrongly enable the integer-FPU datacopy MOP.
 #ifndef ARCH_QUASAR
-    MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(cbid)));
+    MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE>(cbid)));
 #else
-    MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
+    MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, UnpackToDestEn>(
         cbid)));
 #endif
 }
@@ -57,9 +59,10 @@ ALWI void copy_tile_to_dst_init_short(
  * Perform a init for the copy tile operation. This calls the short init function and initializes packer dst offset
  * registers.
  */
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void copy_tile_init(uint32_t cbid, uint32_t call_line = __builtin_LINE()) {
     LLK_SAN_FUNCTION();
-    copy_tile_to_dst_init_short(cbid, 0, false, call_line);
+    copy_tile_to_dst_init_short<is_fp32_dest_acc_en>(cbid, 0, false, call_line);
 }
 
 // clang-format off
@@ -103,15 +106,17 @@ ALWI void copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cb
  * | in_cb_id       | The identifier of the source circular buffer (CB) | uint32_t  | 0 to 31                                             | True     |
  * | in_tile_index  | The index of the tile to copy from the input CB   | uint32_t  | Must be less than the size of the CB                | True     |
  * | dst_tile_index | The index of the tile in the DST register         | uint32_t  | Must be less than the size of the DST register (16) | True     |
+ * | is_fp32_dest_acc_en | Select FP32 DEST layout for datacopy MOP addressing | bool | true/false (default: DST_ACCUM_MODE). Must match the template parameter used in copy_tile_init. A non-default value is only valid while enable_fp32_dest_acc() is in effect. | False |
  * */
 // clang-format on
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile_index) {
 #ifndef ARCH_QUASAR
     LLK_SAN_FUNCTION();
 #endif
     UNPACK((llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         in_cb_id, in_tile_index)));
-    MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
+    MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, UnpackToDestEn>(
         dst_tile_index, in_cb_id)));
 }
 
@@ -138,15 +143,17 @@ ALWI void copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile
  * | start_in_tile_index  | The index of the first tile to copy from the input CB      | uint32_t  | Must be less than the size of the CB                | True     |
  * | start_dst_tile_index | The index of the first destination tile in the DST register| uint32_t  | Must be less than the size of the DST register (16) | True     |
  * | ntiles               | The number of consecutive tiles to copy                    | uint32_t  | start_dst_tile_index + ntiles <= DST register size  | True     |
+ * | is_fp32_dest_acc_en  | Select FP32 DEST layout for datacopy MOP addressing        | bool      | true/false (default: DST_ACCUM_MODE). Must match the template parameter used in copy_tile_init. A non-default value is only valid while enable_fp32_dest_acc() is in effect. | False |
  * */
 // clang-format on
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles) {
 #ifndef ARCH_QUASAR
     LLK_SAN_FUNCTION();
 #endif
     UNPACK((llk_unpack_A_block<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         in_cb_id, start_in_tile_index, ntiles)));
-    MATH((llk_math_eltwise_unary_datacopy_block<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
+    MATH((llk_math_eltwise_unary_datacopy_block<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, UnpackToDestEn>(
         start_dst_tile_index, ntiles, in_cb_id)));
 }
 
@@ -166,10 +173,11 @@ ALWI void copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t s
  * | ntiles               | The number of consecutive tiles to copy                    | uint32_t  | start_dst_tile_index + ntiles <= DST register size  | True     |
  * */
 // clang-format on
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 [[deprecated("Use copy_block(); copy_block_matmul_partials will be removed after August 15th, 2026.")]] ALWI void
 copy_block_matmul_partials(
     uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles) {
-    copy_block(in_cb_id, start_in_tile_index, start_dst_tile_index, ntiles);
+    copy_block<is_fp32_dest_acc_en>(in_cb_id, start_in_tile_index, start_dst_tile_index, ntiles);
 }
 
 }  // namespace ckernel


### PR DESCRIPTION
## Summary
- Add `bool is_fp32_dest_acc_en = DST_ACCUM_MODE` template parameter to core compute APIs that previously hardcoded `DST_ACCUM_MODE`, allowing kernels compiled with `DST_ACCUM_MODE=0` to opt into FP32 DEST layout via explicit template arguments.
- Updated APIs: `tile_regs_commit` / `tile_regs_release`, `reconfig_data_format` family, `pack_reconfig_data_format`, `copy_tile_init` / `copy_tile` / `copy_block` / `copy_tile_to_dst_init_short_with_dt`, `pack_tile` / `pack_block` / `pack_tile_block`.
- All changes are backward compatible: bare calls retain the compile-time `DST_ACCUM_MODE` default.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=halgh/fp32runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:halgh/fp32runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=halgh/fp32runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:halgh/fp32runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=halgh/fp32runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:halgh/fp32runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=halgh/fp32runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:halgh/fp32runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=halgh/fp32runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:halgh/fp32runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=halgh/fp32runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:halgh/fp32runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=halgh/fp32runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:halgh/fp32runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=halgh/fp32runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:halgh/fp32runtime)