### PR TITLE
[Cleanup] Tighten vararg CTA comments

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4134,12 +4134,15 @@ TEST_F(ProgramSpecTestGen1, TtKernelComputeShimCompiles) {
 }
 
 // ============================================================================
-// Compile-time varargs — mock-device bake & JIT smoke
+// Compile-time varargs (Metal 2.0)
 // ============================================================================
 //
-// Host: KernelAdvancedOptions::compile_time_varargs (values fixed at ProgramSpec time).
-// Kernel: get_compile_time_vararg* — literals baked into kernel_args_generated.h (Metal 2.0).
-// Separate from positional KERNEL_COMPILE_TIME_ARGS (TensorBinding DSpec / legacy CreateKernel).
+// KernelAdvancedOptions::compile_time_varargs values are fixed at ProgramSpec time and baked into
+// kernel_args_generated.h as literals, which is what makes a static_assert in the kernel source a
+// usable assertion here: if a value did not reach the kernel, the JIT compile fails.
+//
+// These tests compile on a MOCK Wormhole device (no silicon, no dispatch) via
+// detail::CompileProgram, so they cover the host -> genfiles -> RISC-V compile path only.
 
 TEST_F(ProgramSpecTestGen1, CompileTimeVarargsReadableFromKernel) {
     NodeCoord node{0, 0};
@@ -4164,9 +4167,9 @@ void kernel_main() {
     EXPECT_NO_THROW(detail::CompileProgram(device, program));
 }
 
-// CTA varargs must not share KERNEL_COMPILE_TIME_ARGS with TensorBinding payloads.
-// Verifies independence: binding cta_offset stays 0; positional compile_args are binding-only;
-// baked get_compile_time_vararg* and TensorAccessor still both work.
+// Varargs must not share KERNEL_COMPILE_TIME_ARGS with TensorBinding payloads: the binding's
+// cta_offset stays 0, the positional compile_args hold binding words only, and the baked varargs
+// and the TensorAccessor both still work.
 TEST_F(ProgramSpecTestGen1, CompileTimeVarargsIndependentOfTensorBindingCTAs) {
     NodeCoord node{0, 0};
     constexpr uint32_t kVararg0 = 0xCAFEBABEu;
@@ -4178,7 +4181,7 @@ TEST_F(ProgramSpecTestGen1, CompileTimeVarargsIndependentOfTensorBindingCTAs) {
 void kernel_main() {
     static_assert(get_compile_time_vararg<0>() == 0xCAFEBABEu);
     static_assert(get_compile_time_vararg<1>() == 0xDEADBEEFu);
-    // Binding CTA_OFFSET stays 0 (varargs are not a positional prefix).
+    // The binding's CTAs still decode from index 0: varargs were not prepended to them.
     static_assert(tensor::input_ta_t::args_t::is_dram);
     TensorAccessor accessor(tensor::input_ta);
     auto noc_addr = accessor.get_noc_addr(0);

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -61,7 +61,9 @@ struct KernelAdvancedOptions {
     //--------------------------------
     // Compile time varargs
     //--------------------------------
-    // Values of the varargs for the kernel.
+    // Vararg values, fixed here at ProgramSpec time and baked into the kernel binary as literals.
+    // Read them in the kernel via get_compile_time_vararg<i>() / get_compile_time_varargs().
+    // The values are part of the kernel's cache key: each distinct set is a separate compile.
     std::vector<uint32_t> compile_time_varargs;
 
     //--------------------------------

--- a/tt_metal/hw/inc/api/compile_time_args.h
+++ b/tt_metal/hw/inc/api/compile_time_args.h
@@ -20,14 +20,12 @@ FORCE_INLINE constexpr std::array<T, sizeof...(Ts)> make_array(Ts... values) {
 #define KERNEL_COMPILE_TIME_ARGS
 #endif
 
-// Positional CTAs for pre-metal 2.0 kernels / TensorBinding static CTAs.
-// Metal 2.0 CTA varargs are NOT EXPOSED through this array.
-// Metal 2.0 user should use: get_compile_time_varargs() / get_compile_time_vararg() instead.
+// Positional CTAs, from -DKERNEL_COMPILE_TIME_ARGS: pre-Metal 2.0 kernels and TensorBinding
+// static CTAs. Metal 2.0 compile-time varargs are NOT exposed here — they are baked as literals
+// into the kernel's generated header. Read those with get_compile_time_vararg<Idx>() /
+// get_compile_time_varargs() instead of this array and the accessors below.
 constexpr auto kernel_compile_time_args = make_array<std::uint32_t>(KERNEL_COMPILE_TIME_ARGS);
 
-// Index into positional CTAs for pre-metal 2.0 kernels / TensorBinding static CTAs.
-// Metal 2.0 CTA varargs are NOT EXPOSED through this array.
-// Metal 2.0 user should use: get_compile_time_varargs() / get_compile_time_vararg() instead.
 template <uint32_t Idx>
 constexpr uint32_t get_ct_arg() {
     static_assert(Idx < kernel_compile_time_args.size(), "Index out of range");

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -620,7 +620,9 @@ uint64_t Kernel::compute_hash() const {
     ////////////////////////////////////////////////////////////
     hasher.update(this->kernel_src_.source_);
     hasher.update(this->compile_time_args_.begin(), this->compile_time_args_.end());
-    // Metal 2.0's vararg CTAs does not reuse the legacy CTA infrastructure.
+    // Metal 2.0 compile-time varargs are baked into the generated header rather than into
+    // compile_time_args_, so they need their own hash contribution. Size first, to avoid the
+    // [a, b] vs [ab] collision against the positional CTAs hashed just above.
     hasher.update(static_cast<uint64_t>(this->compile_time_varargs_.size()));
     hasher.update(this->compile_time_varargs_.begin(), this->compile_time_varargs_.end());
     hasher.update(this->config_hash());

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -240,8 +240,7 @@ public:
     void set_scratchpad_binding_handles(std::vector<ScratchpadBindingHandle> handles) {
         scratchpad_binding_handles_ = std::move(handles);
     }
-    // Only used by Metal 2.0.
-    // Metal 2.0's vararg CTAs does not reuse the legacy CTA infrastructure.
+    // Metal 2.0 compile-time varargs; set post-construction, from the KernelSpec.
     const std::vector<uint32_t>& get_compile_time_varargs() const override { return compile_time_varargs_; }
     void set_compile_time_varargs(std::vector<uint32_t> varargs) { compile_time_varargs_ = std::move(varargs); }
     const std::vector<std::string>& get_runtime_arg_names() const override { return runtime_arg_names_; }
@@ -340,8 +339,8 @@ protected:
     // and allocate_scratchpads fills each handle's allocated_address after L1 allocation.
     // NOTE: Scratchpad allocated addresses can change between enqueues if DFB size overrides are used.
     std::vector<ScratchpadBindingHandle> scratchpad_binding_handles_;
-    // Metal 2.0 user compile-time varargs (set post-construction via set_compile_time_varargs).
-    // Hashed into compute_hash; genfiles bakes literals into kernel_args_generated.h.
+    // Metal 2.0 compile-time varargs. Non-const: set post-construction via set_compile_time_varargs.
+    // genfiles bakes these into kernel_args_generated.h as literals, so they are part of compute_hash.
     std::vector<uint32_t> compile_time_varargs_;
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
     std::vector<std::vector<RuntimeArgsData>> core_to_runtime_args_data_;

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2390,8 +2390,8 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
 struct TensorBindingsForKernel {
     std::vector<TensorBindingHandle> handles;
     std::vector<uint32_t> cta_words;  // appended after any pre-existing positional CTAs
-                                      // (currently, this is the only Metal 2.0 use of positional CTAs,
-                                      // CTA varargs are piped in separately)
+                                      // (still the only Metal 2.0 use of positional CTAs; compile-time
+                                      // varargs bypass this buffer entirely)
     KernelCrtaLayout crta_layout;
 };
 
@@ -3133,7 +3133,8 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         // will later fill each handle's allocated_address.
         kernel->set_scratchpad_binding_handles(std::move(sp_bindings.handles));
 
-        // Metal 2.0 path for injecting compile time varargs.
+        // Same post-construction pattern: the vararg values are baked into the kernel's generated
+        // header and are part of its cache key, so they must be set before the kernel is compiled.
         kernel->set_compile_time_varargs(kernel_spec.advanced_options.compile_time_varargs);
 
         // Add the kernel to the ProgramImpl and register the name -> handle mapping

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -275,8 +275,8 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
         });
     sort(cta_entries.begin(), cta_entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
 
-    // Metal 2.0 user compile-time varargs: baked as literals below (separate from positional
-    // KERNEL_COMPILE_TIME_ARGS, which TensorBindings / legacy CreateKernel still use).
+    // Metal 2.0 compile-time varargs: baked as literals below, not into KERNEL_COMPILE_TIME_ARGS
+    // (which TensorBindings and legacy CreateKernel still use).
     const std::vector<uint32_t>& cta_varargs = settings.get_compile_time_varargs();
     const uint32_t cta_vararg_size = static_cast<uint32_t>(cta_varargs.size());
 
@@ -332,12 +332,10 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
             << "FORCE_INLINE uint32_t get_common_vararg(uint32_t idx) { return get_common_arg_val<uint32_t>("
             << crta_layout.vararg_section_offset << " + idx); }\n";
 
-    // Compile-time vararg helpers — always emitted (separate from RTA/CRTA varargs).
-    // Values are baked as literals (same spirit as named CtaVal); not read from
-    // KERNEL_COMPILE_TIME_ARGS. Three accessors:
-    //   1. get_compile_time_varargs() — constexpr std::array of the baked words
-    //   2. get_compile_time_vararg<idx>() — template index (static_assert bounds)
-    //   3. get_compile_time_vararg(idx) — function-parameter index
+    // Compile-time vararg helpers — always emitted, like the runtime ones above. Unlike those,
+    // the values are baked in as literals (same spirit as the named CtaVal above) rather than
+    // read out of a buffer at runtime. A kernel with no varargs gets a zero-length array, so any
+    // get_compile_time_vararg<idx>() call fails its static_assert.
     std::string cta_vararg_literals;
     if (!cta_varargs.empty()) {
         // e.g. {1, 2, 3} → "1u, 2u, 3u"

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -145,9 +145,9 @@ public:
     // which matches the legacy-kernel case where the buffer has only varargs.
     virtual KernelCrtaLayout get_crta_layout() const { return {}; }
 
-    // Metal 2.0: user compile-time varargs.
-    // Separate from positional compile_args / Legacy CTA infrastructure
-    // Default empty for non–Metal 2.0 kernels.
+    // Metal 2.0: user compile-time varargs, emitted as baked literals in the generated header.
+    // Separate from the positional compile_args / legacy CTA infrastructure.
+    // Default empty for non-Metal 2.0 kernels.
     virtual const std::vector<uint32_t>& get_compile_time_varargs() const {
         static const std::vector<uint32_t> k_empty;
         return k_empty;


### PR DESCRIPTION
Stacked on `riverwu/vararg-cta` — targets that branch, not `main`. Addresses the "Cleanup slop comments" TODO on #52391.

Comment-only. No functional change; no line of code moved.

### The main thing

The sentence *"Metal 2.0 CTA varargs do not use the legacy/positional CTA infrastructure"* appeared in **9 places** across the 8 files. It is now stated once, canonically, in `compile_time_args.h` — the header a confused kernel author actually opens — with short references elsewhere.

Two of those 9 were a **verbatim** duplicate: the same 3-line block above `kernel_compile_time_args` and again above `get_ct_arg` five lines later.

### Everything else

| | |
|---|---|
| Grammar / typos | `"vararg CTAs does not"` → *do not* (x2), `"Metal 2.0 user should"` (x2), a comma splice in `program_spec.cpp`, `Legacy` → `legacy`, en-dash in `non–Metal 2.0` |
| Wrong-line comment | `// Binding CTA_OFFSET stays 0` sat above `static_assert(...is_dram)`, which does not check `cta_offset` — that check is on the host side, 20 lines down. Retargeted to what the assert actually proves. (`CTA_OFFSET` also is not an identifier; the field is `cta_offset`.) |
| Thin public API doc | `KernelAdvancedOptions::compile_time_varargs` had *"Values of the varargs for the kernel."* — the least-documented field in the struct, despite being the feature. Now says how to read them in a kernel and that they are part of the cache key. |
| Unexplained non-obvious code | `compute_hash` hashing the vararg *length* had a comment that did not mention length. Now explains it, reusing the file's existing `[a, b] vs [ab] collision` phrasing. |
| Pure restatement | `// Metal 2.0 path for injecting compile time varargs.` above `kernel->set_compile_time_varargs(...)`, and the numbered list of three accessors directly above the code emitting exactly those three accessors. |

### Notes for reviewers

- **Design question left open, not answered.** Your PR body flags the `get_ct_arg` signpost as "open for debate". I kept the signpost and only deduplicated it. If the outcome is a hard error rather than a comment, this all changes.
- `get_compile_time_arg_val` (the documented public macro) has a doxygen block I did **not** touch. It already scopes itself to "provided during kernel creation using `CreateKernel` calls", which arguably excludes varargs on its own — but it is the one place a kernel author is most likely to read. Say the word and I will add a line there.
- The two hash tests sit under the new banner, but the pre-existing `Kernel hash sensitivity to TensorParameter spec` banner starts ~15 lines later. They may belong there instead. Left alone — that is a move, not a comment fix.

### Out of scope, flagged not fixed

- `get_compile_time_vararg(uint32_t idx)` (the runtime-index overload) has **no bounds check**. With zero varargs it indexes a zero-length array. The template overload `static_assert`s; this one does not.
- Nothing in the tree references **#45388** any more — the `TODO` that cited it was the thing this PR removed. Might be worth a `Closes #45388` in the #52391 description.

### Verification

Comment-only, so no rebuild. Confirmed clang-format-clean: every changed line is within the 120-col limit and `clang-format` (repo `.clang-format`, `ReflowComments: true`) reflows none of the new comments. The violations my local clang-format 20 reports in these files are all pre-existing and outside the changed lines — a version skew against the repo pin, not something this PR introduces.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/vararg-cta-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/vararg-cta-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brain/vararg-cta-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brain/vararg-cta-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=brain/vararg-cta-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:brain/vararg-cta-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/vararg-cta-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/vararg-cta-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brain/vararg-cta-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brain/vararg-cta-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/vararg-cta-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/vararg-cta-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/vararg-cta-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/vararg-cta-comments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/vararg-cta-comments)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/vararg-cta-comments)