### PR TITLE
[quasar] tilizeA_B tiny tiles compute api bringup

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -603,7 +603,7 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
         .num_entries = std::max(2u, test_config.num_tiles_c),
         .data_format_metadata = test_config.input_fmt,
     };
-    const std::uint32_t scaler_tile_size = tt::datum_size(test_config.input_fmt) * 32 * 32;
+    const std::uint32_t scaler_tile_size = tt::tile_size(test_config.input_fmt);
     experimental::DataflowBufferSpec inp_scaler_dfb_spec{
         .unique_id = INP_SCALER_DFB,
         .entry_size = scaler_tile_size,
@@ -616,6 +616,9 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
         .num_entries = std::max(2u, test_config.num_tiles_c),
         .data_format_metadata = test_config.output_fmt,
     };
+    const auto fg = tt::tt_metal::FaceGeometry{test_config.face_r_dim, test_config.num_faces_per_tile};
+    inp_data_dfb_spec.unpack_face_geometry_metadata = fg;
+    out_dfb_spec.unpack_face_geometry_metadata = fg;
 
     experimental::DataMovementHardwareConfig reader_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
@@ -1423,6 +1426,42 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeA_B) {
                     .golden_function = ::unit_tests::compute::gold_standard_tilize_w_reduce_col_max};
                 unit_tests::compute::tilize::run_single_core_unpack_tilizeA_B_reduce_program(
                     this->devices_.at(0), test_config);
+            }
+        }
+    }
+}
+
+// Quasar Unpack TilizeA_B (tilize + reduce col max) for tiny tiles (1x32, 2x32)
+// Quasar's unpack_tilizeA_B is only compatible with the reduce math kernel.
+TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeA_BTinyTile) {
+    vector<vector<std::uint32_t>> test_config_values = {{1, 1, 2, 1}, {1, 2, 2, 1}, {1, 1, 2, 2}, {1, 2, 2, 2}};
+    std::uint32_t face_c_dim = tt::constants::FACE_WIDTH;
+    for (auto test_config_value : test_config_values) {
+        std::uint32_t num_faces_per_tile = test_config_value[2];
+        std::uint32_t face_r_dim = test_config_value[3];
+        for (bool dst_full_sync_en : {true, false}) {
+            for (bool fp32_dest_acc_en : {true, false}) {
+                for (tt::DataFormat input_data_format : {tt::DataFormat::Float16_b}) {
+                    tt::DataFormat output_data_format =
+                        fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+                    unit_tests::compute::tilize::TestConfig test_config = {
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .input_single_tile_size =
+                            tt::datum_size(input_data_format) * num_faces_per_tile * face_r_dim * face_c_dim,
+                        .output_single_tile_size =
+                            tt::datum_size(output_data_format) * num_faces_per_tile * face_r_dim * face_c_dim,
+                        .num_tiles_r = test_config_value[0],
+                        .num_tiles_c = test_config_value[1],
+                        .num_faces_per_tile = num_faces_per_tile,
+                        .face_r_dim = face_r_dim,
+                        .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A_B,
+                        .input_fmt = input_data_format,
+                        .output_fmt = output_data_format,
+                        .golden_function = ::unit_tests::compute::gold_standard_tilize_w_reduce_col_max};
+                    unit_tests::compute::tilize::run_single_core_unpack_tilizeA_B_reduce_program(
+                        this->devices_.at(0), test_config);
+                }
             }
         }
     }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B_reduce.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B_reduce.cpp
@@ -10,20 +10,64 @@
 #include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t per_core_block_cnt = get_arg(args::per_core_block_cnt);
-    constexpr uint32_t per_core_block_tile_cnt = get_arg(args::per_core_block_tile_cnt);
+    constexpr std::uint32_t per_core_block_cnt = get_arg(args::per_core_block_cnt);
+    constexpr std::uint32_t per_core_block_tile_cnt = get_arg(args::per_core_block_tile_cnt);
 
     DataflowBuffer dfb_in(dfb::in_data);
     DataflowBuffer dfb_in_scaler(dfb::in_scaler);
     DataflowBuffer dfb_out(dfb::out);
 
-    compute_kernel_hw_startup(dfb::in_data, dfb::in_scaler, dfb::out);
+    // Skip compute_kernel_hw_startup: its UNPACK/PACK sweeps walk every DFB and race each other
+    // on the shared bd_table[], so PACK can overwrite in_data's strided tilize descriptor with a
+    // continuous one. Inline the same startup, but program only the three DFBs this kernel uses.
+    // in_data's descriptor is left to tilizeA_B_reduce_init (strided); UNPACK only needs in_scaler
+    // continuous + the unpack format registers.
+    UNPACK({
+        const std::uint32_t unpA_id = get_operand_id(dfb::in_data);
+        const std::uint32_t unpB_id = get_operand_id(dfb::in_scaler);
+
+        const tdma_descriptor_t td_b = ckernel::trisc::construct_tdma_desc(
+            get_operand_tensor_shape(unpB_id),
+            get_local_dfb_interface(unpB_id).tc_slots[0].base_addr,
+            static_cast<std::uint32_t>(unpack_src_format[unpB_id]),
+            unpB_id,
+            static_cast<std::uint32_t>(unpack_dst_format[unpB_id]));
+        ckernel::trisc::_configure_buf_desc_table_(unpB_id, td_b.buf_desc);
+
+        tdma_descriptor_t td_val_A, td_val_B;
+        td_val_A.reg_data_format = static_cast<std::uint8_t>(unpack_dst_format[unpA_id]);
+        td_val_B.reg_data_format = static_cast<std::uint8_t>(unpack_dst_format[unpB_id]);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
+    });
+
+    MATH((llk_math_pack_sync_init()));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(dfb::in_data, dfb::in_scaler)));
+
+    PACK({
+        const std::uint32_t out_id = get_output_id(dfb::out);
+
+        const tdma_descriptor_t td = ckernel::trisc::construct_tdma_desc(
+            get_output_tensor_shape(out_id),
+            get_local_dfb_interface(out_id).tc_slots[0].base_addr,
+            pack_dst_format[out_id],
+            out_id,
+            pack_src_format[out_id]);
+        ckernel::trisc::_configure_buf_desc_table_(out_id, td.buf_desc);
+
+        tdma_descriptor_t td_val;
+        td_val.reg_data_format = static_cast<std::uint8_t>(pack_src_format[out_id]);
+        _llk_pack_hw_configure_<p_pacr::PACK0, DST_ACCUM_MODE>(td_val, ckernel::ReluConfig::none());
+    });
+    PACK((llk_pack_init(dfb::out)));
+    PACK((llk_pack_dest_init()));
+    PACK((llk_pack_reduce_mask_config<REDUCE_DIM, PackMode::Default>(dfb::out)));
+
     tilizeA_B_reduce_init<true /*neginf_srcA*/, false /*zero_srcA_reduce*/>(
         dfb::in_data, dfb::in_scaler, per_core_block_tile_cnt);
 
     dfb_in_scaler.wait_front(1);
 
-    for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
+    for (std::uint32_t b = 0; b < per_core_block_cnt; ++b) {
         dfb_in.wait_front(per_core_block_tile_cnt);
         dfb_out.reserve_back(per_core_block_tile_cnt);
         unpack_tilizeA_B_block<true /*neginf_srcA*/, true /*reload_srcB*/, false, false>(
@@ -31,7 +75,7 @@ void kernel_main() {
             dfb::in_scaler,
             per_core_block_tile_cnt,
             0 /*tile idx for Src b is 0 because only 1 scaler tile is loaded*/);
-        for (uint32_t i = 0; i < per_core_block_tile_cnt; ++i) {
+        for (std::uint32_t i = 0; i < per_core_block_tile_cnt; ++i) {
             tile_regs_acquire();
             reduce_tile_math<REDUCE_OP, REDUCE_DIM>(0);
             tile_regs_commit();


### PR DESCRIPTION
### PR Category
feature

### Summary
relates to #49309 

- created metal test for tilizeA_B tiny tiles (1x32, 2x32) on quasar. 
- modified the test kernel ([`unpack_tilizeA_B_reduce.cpp`](https://github.com/tenstorrent/tt-metal/blob/58a3fac09fe4e4ccc708b171a3043c6d99575ec0/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B_reduce.cpp#L4)) to bypass `hw_config`, to prevent PACK thread from overwriting UNPACK's strided buffer descriptor programming (for more information refer to [item 3](https://tenstorrent.atlassian.net/browse/TEN-4843))

### Notes for reviewers
- `tilizeA_B_reduce_init` in [`tilize.h`](https://github.com/tenstorrent/tt-metal/blob/58a3fac09fe4e4ccc708b171a3043c6d99575ec0/tt_metal/hw/inc/api/compute/tilize.h#L90) does not program pack reduce masks, unlike [`reduce.h`](https://github.com/tenstorrent/tt-metal/blob/58a3fac09fe4e4ccc708b171a3043c6d99575ec0/tt_metal/hw/inc/api/compute/reduce.h#L66), as `ocb` is not passed into `tilizeA_B_reduce_init`. for the moment these masks are programmed in the init sequence in the test kernel, but should be brought into the init api. 
- point 2 in the summary is a larger scale problem that will affect standard tilize/untilize as well
