### PR TITLE
Add fused distributed GroupNorm

### DIFF
--- a/models/tt_dit/layers/normalization.py
+++ b/models/tt_dit/layers/normalization.py
@@ -11,7 +11,12 @@ import torch
 
 import ttnn
 
+from .linear import _apply_activation_fn
 from .module import Module, Parameter
+
+# Activations the fused distributed GroupNorm op can absorb into its output stage.
+# Anything else is applied as a separate op, exactly like Linear's unfused activations.
+_FUSABLE_GROUP_NORM_ACTIVATIONS = frozenset({"silu"})
 
 
 class RMSNorm(Module):
@@ -444,6 +449,7 @@ class GroupNorm(Module):
         mesh_device: ttnn.MeshDevice,
         mesh_axis: int | None = None,
         core_grid: ttnn.CoreGrid | None = None,
+        activation_fn: str | None = None,
     ) -> None:
         """
         Args:
@@ -454,9 +460,12 @@ class GroupNorm(Module):
             mesh_axis: The mesh axis to use for sharding.
             core_grid: The core grid to use.
             num_out_blocks: The number of output blocks to use.
+            activation_fn: Applied after the norm. ``ttnn.group_norm`` cannot fuse one, so it
+                always runs as a separate op here.
         """
         super().__init__()
 
+        self.activation_fn = activation_fn
         self.eps = eps
         self.mesh_device = mesh_device
         self.mesh_axis = mesh_axis
@@ -569,7 +578,231 @@ class GroupNorm(Module):
         x = ttnn.group_norm(x, **kwargs)
         x = x.reshape([batch_size, height, width, channels])
 
-        return x
+        return _apply_activation_fn(x, self.activation_fn)
+
+
+class DistributedGroupNorm(Module):
+    """GroupNorm with optional spatial stats all-gather on ``cluster_axis``.
+
+    ``cluster_axis=None``: local ``GroupNorm`` (including channel ``mesh_axis`` TP).
+    ``cluster_axis=int``: fused ``dit_fused_distributed_groupnorm``
+    (PRE → fabric AG on that axis → POST). γ/β and the input mask use the same
+    DRAM-packed row-major GroupNorm layout as ``ttnn.group_norm``, with
+    ``num_virtual_cols == 1``. Optional ``mesh_axis`` still shards channels
+    (whole groups per device); orthogonal to ``cluster_axis``. Per-device
+    channel count must be divisible by 32.
+
+    ``activation_fn`` (e.g. ``"silu"``) is applied after the norm. On the distributed path it
+    is folded into the op's output stage, removing the separate activation op's full-tensor
+    DRAM read/write; otherwise it runs as a separate op. Either way the caller gets
+    ``activation(group_norm(x))`` and does not need to know which happened.
+    """
+
+    def __init__(
+        self,
+        num_channels: int,
+        num_groups: int,
+        *,
+        eps: float = 1e-5,
+        mesh_device: ttnn.MeshDevice,
+        cluster_axis: int | None = None,
+        mesh_axis: int | None = None,
+        ccl_manager=None,
+        core_grid: ttnn.CoreGrid | None = None,
+        activation_fn: str | None = None,
+    ) -> None:
+        super().__init__()
+
+        assert num_channels % num_groups == 0, "num_channels must be divisible by num_groups"
+        assert num_channels % 32 == 0, "num_channels must be divisible by tile size (fused v1)"
+
+        # Consume the activation into the op when the fused path can absorb it; whatever is
+        # left in self.activation_fn is applied separately by forward().
+        self.activation_fn = activation_fn
+        self.fused_activation = None
+        if cluster_axis is not None and activation_fn in _FUSABLE_GROUP_NORM_ACTIVATIONS:
+            self.fused_activation = activation_fn
+            self.activation_fn = None
+
+        self.num_channels = num_channels
+        self.num_groups = num_groups
+        self.eps = eps
+        self.mesh_device = mesh_device
+        self.cluster_axis = cluster_axis
+        self.mesh_axis = mesh_axis
+        self.ccl_manager = ccl_manager
+        self.core_grid = core_grid or ttnn.CoreGrid(x=8, y=8)
+
+        self.channel_devices = tuple(mesh_device.shape)[mesh_axis] if mesh_axis is not None else 1
+        self.cluster_size = tuple(mesh_device.shape)[cluster_axis] if cluster_axis is not None else 1
+        assert num_groups % self.channel_devices == 0, "num_groups must be divisible by channel mesh width"
+
+        if cluster_axis is not None and self.cluster_size > 1:
+            assert ccl_manager is not None, "ccl_manager is required when cluster_axis width > 1"
+
+        self.num_local_channels = num_channels // self.channel_devices
+        self.num_local_groups = num_groups // self.channel_devices
+
+        if cluster_axis is not None:
+            assert (
+                self.num_local_channels % 32 == 0
+            ), f"fused path requires per-device C % 32 == 0, got {self.num_local_channels}"
+            assert core_grid is None, (
+                "core_grid is not supported on the fused path (cluster_axis is not None): "
+                "dit_fused_distributed_groupnorm always uses the full compute grid"
+            )
+
+        if cluster_axis is None:
+            # Existing GroupNorm path (packed γ/β/mask, channel TP).
+            self.inner = GroupNorm(
+                num_channels=num_channels,
+                num_groups=num_groups,
+                eps=eps,
+                mesh_device=mesh_device,
+                mesh_axis=mesh_axis,
+                core_grid=self.core_grid,
+            )
+            self.weight = None
+            self.bias = None
+        else:
+            # Fused path: reuses the welford GroupNorm kernels, so γ/β/mask are prepped exactly
+            # like ttnn.group_norm (DRAM-packed RM γ/β + input_mask), but with a single worker
+            # core per device (num_virtual_cols == 1).
+            self.inner = None
+            num_padded_channels = math.ceil(self.num_local_channels / 32) * 32
+            assert num_padded_channels % self.num_local_channels == 0, "padded channels must divide channels"
+            num_padded_groups = self.num_local_groups * (num_padded_channels // self.num_local_channels)
+            self.num_virtual_cols = 1
+            self.num_padded_channels = num_padded_channels
+            self.num_padded_groups = num_padded_groups
+
+            weight_shape = [
+                self.channel_devices,
+                1,
+                math.ceil(num_padded_channels // self.num_virtual_cols / 32) * self.num_virtual_cols,
+                32,
+            ]
+            block_wt = ttnn.operations.normalization.find_max_tile_span(
+                num_padded_channels, num_padded_channels // num_padded_groups, 32
+            )
+            mask_shape = [1, num_padded_groups, 32, 32 * block_wt]
+
+            self.weight = Parameter(
+                total_shape=weight_shape,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_axes=[mesh_axis, None, None, None],
+                device=mesh_device,
+            )
+            self.bias = Parameter(
+                total_shape=weight_shape,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_axes=[mesh_axis, None, None, None],
+                device=mesh_device,
+            )
+            self.mask = Parameter(total_shape=mask_shape, device=mesh_device)
+
+    @classmethod
+    def from_torch(
+        cls,
+        torch_ref: torch.nn.GroupNorm,
+        *,
+        mesh_device: ttnn.MeshDevice,
+        cluster_axis: int | None = None,
+        mesh_axis: int | None = None,
+        ccl_manager=None,
+        core_grid: ttnn.CoreGrid | None = None,
+        activation_fn: str | None = None,
+    ) -> DistributedGroupNorm:
+        module = cls(
+            num_channels=torch_ref.num_channels,
+            num_groups=torch_ref.num_groups,
+            eps=torch_ref.eps,
+            mesh_device=mesh_device,
+            cluster_axis=cluster_axis,
+            mesh_axis=mesh_axis,
+            ccl_manager=ccl_manager,
+            core_grid=core_grid,
+            activation_fn=activation_fn,
+        )
+        module.load_torch_state_dict(torch_ref.state_dict())
+        return module
+
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        if self.inner is not None:
+            renamed = {f"inner.{k}": v for k, v in list(state.items())}
+            state.clear()
+            state.update(renamed)
+            return
+        if "weight" in state:
+            state["weight"] = self._prepare_param(state["weight"])
+        if "bias" in state:
+            state["bias"] = self._prepare_param(state["bias"])
+        input_mask = ttnn.create_group_norm_input_mask(
+            self.num_padded_channels, self.num_padded_groups, self.num_virtual_cols
+        )
+        state["mask"] = ttnn.to_torch(input_mask)
+
+    def _prepare_param(self, param: torch.Tensor) -> torch.Tensor:
+        expected_shape = (self.num_local_channels * self.channel_devices,)
+        assert param.shape == expected_shape, f"expected shape {expected_shape}, got {param.shape}"
+        padding = self.num_padded_channels - self.num_local_channels
+        params = [torch.nn.functional.pad(t, (0, padding)) for t in param.chunk(self.channel_devices)]
+        torch_sharded_lst = [
+            ttnn.create_group_norm_weight_bias_rm(t, self.num_padded_channels, self.num_virtual_cols) for t in params
+        ]
+        return torch.cat(torch_sharded_lst, dim=0)
+
+    def forward(self, x: ttnn.Tensor, num_out_blocks=-1, compute_kernel_config=None) -> ttnn.Tensor:
+        if self.inner is not None:
+            out = self.inner.forward(x, num_out_blocks=num_out_blocks, compute_kernel_config=compute_kernel_config)
+            return _apply_activation_fn(out, self.activation_fn)
+
+        assert num_out_blocks == -1, (
+            "num_out_blocks is not supported on the fused path (cluster_axis is not None): "
+            "dit_fused_distributed_groupnorm derives its own block split"
+        )
+
+        batch_size, height, width, channels = x.shape
+        assert (
+            channels == self.num_local_channels
+        ), f"last dim {channels} != num_local_channels {self.num_local_channels}"
+        x4 = x.reshape([batch_size, 1, width * height, channels])
+
+        semaphores = self.ccl_manager.get_ag_ping_pong_semaphore(self.cluster_axis) if self.cluster_size > 1 else []
+        persistent = None
+        if self.cluster_size > 1:
+            # The fused activation does not change the stats geometry (it is applied after the
+            # AG, on the output tile), so it is deliberately NOT part of the cache key.
+            persistent = self.ccl_manager.get_fused_norm_stats_buffer(
+                ("gn", tuple(x4.shape), self.num_padded_groups, self.cluster_axis),
+                lambda: ttnn.experimental.dit_fused_distributed_groupnorm_create_stats_buffer(
+                    x4,
+                    self.num_padded_groups,
+                    self.cluster_axis,
+                    self.mesh_device,
+                ),
+            )
+
+        # Mirror GroupNorm.forward kwargs; cluster_axis / mesh / semaphore / topology
+        # are the only distributed additions.
+        out = ttnn.experimental.dit_fused_distributed_groupnorm(
+            x4,
+            num_groups=self.num_padded_groups,
+            epsilon=self.eps,
+            cluster_axis=self.cluster_axis,
+            mesh_device=self.mesh_device,
+            multi_device_global_semaphore=semaphores,
+            topology=self.ccl_manager.topology if self.ccl_manager is not None else ttnn.Topology.Linear,
+            input_mask=self.mask.data,
+            weight=self.weight.data,
+            bias=self.bias.data,
+            persistent_output_buffer=persistent,
+            compute_kernel_config=compute_kernel_config,
+            activation=self.fused_activation,
+        )
+        out = out.reshape([batch_size, height, width, channels])
+        # No-op when the activation was consumed into the op above.
+        return _apply_activation_fn(out, self.activation_fn)
 
 
 class GroupNorm3D(Module):

--- a/models/tt_dit/models/vae/vae.py
+++ b/models/tt_dit/models/vae/vae.py
@@ -12,9 +12,9 @@ import ttnn
 from models.common.utility_functions import is_blackhole
 
 from ...layers.conv2d import Conv2d
-from ...layers.linear import ColParallelLinear, RowParallelLinear
+from ...layers.linear import ColParallelLinear, RowParallelLinear, _apply_activation_fn
 from ...layers.module import Module, ModuleList, Parameter
-from ...layers.normalization import DistributedRMSNorm, GroupNorm, RMSNorm
+from ...layers.normalization import DistributedGroupNorm, DistributedRMSNorm, GroupNorm, RMSNorm
 from ...parallel.manager import CCLManager
 from ...utils import tensor
 from ...utils.conv3d import get_conv3d_config
@@ -109,8 +109,11 @@ def _get_neighbor_pad_num_links(ccl_manager: CCLManager, input_tensor: ttnn.Tens
 
 
 class VaeRmsNorm(Module):
-    def __init__(self, num_channels: int, *, eps: float, ctx: VaeContext) -> None:
+    def __init__(self, num_channels: int, *, eps: float, ctx: VaeContext, activation_fn: str | None = None) -> None:
         super().__init__()
+
+        # Neither RMSNorm path here fuses an activation, so it always runs as a separate op.
+        self.activation_fn = activation_fn
 
         tp_axis_size = ctx.device.shape[ctx.tp_axis] if ctx.tp_axis is not None else 1
 
@@ -156,7 +159,7 @@ class VaeRmsNorm(Module):
             bs, h, w, c = x.shape
             x = ttnn.reshape(x, [1, 1, bs * h * w, c])
             x = self.inner.forward(x)
-            return ttnn.reshape(x, [bs, h, w, c])
+            return _apply_activation_fn(ttnn.reshape(x, [bs, h, w, c]), self.activation_fn)
 
         norm = ttnn.mean(ttnn.pow(x, 2), dim=-1, keepdim=True)
 
@@ -171,7 +174,7 @@ class VaeRmsNorm(Module):
             norm = norm * (1 / n)
 
         norm = ttnn.rsqrt(norm + self._eps)
-        return x * (norm * self.gamma.data)
+        return _apply_activation_fn(x * (norm * self.gamma.data), self.activation_fn)
 
 
 class _VaeConv2dConv3d(Module):
@@ -391,9 +394,9 @@ class VaeResnetBlock(Module):
     def __init__(self, *, in_channels: int, out_channels: int, norm: VaeNormDesc, ctx: VaeContext) -> None:
         super().__init__()
 
-        self.norm1 = _norm(norm, num_channels=in_channels, ctx=ctx)
+        self.norm1 = _norm(norm, num_channels=in_channels, ctx=ctx, activation_fn="silu")
         self.conv1 = VaeConv2d(in_channels, out_channels, kernel_size=3, padding=1, ctx=ctx)
-        self.norm2 = _norm(norm, num_channels=out_channels, ctx=ctx)
+        self.norm2 = _norm(norm, num_channels=out_channels, ctx=ctx, activation_fn="silu")
         self.conv2 = VaeConv2d(out_channels, out_channels, kernel_size=3, padding=1, ctx=ctx)
 
         self.conv_shortcut = (
@@ -416,11 +419,9 @@ class VaeResnetBlock(Module):
         h = x
 
         h = self.norm1.forward(h)
-        h = ttnn.silu(h, output_tensor=h)
         h = self.conv1.forward(h)
 
         h = self.norm2.forward(h)
-        h = ttnn.silu(h, output_tensor=h)
         h = self.conv2.forward(h)
 
         if self.conv_shortcut is not None:
@@ -664,22 +665,41 @@ class VaeUpBlock(Module):
 
 
 class _VaeSpatialGroupNorm(Module):
-    """GroupNorm wrapper that AGs sharded H/W for correct stats and repartitions after.
+    """GroupNorm for spatially sharded VAE activations.
 
-    Uses HiFi4 compute config (matching Wan/Mochi convention for norms) and trims any
-    tile-padding rows added by mesh_partition before computing statistics, restoring them
-    after so that _partition_hw receives the same padded shape as before.
-    Channel TP is preserved on the inner ``GroupNorm`` via ``mesh_axis=ctx.tp_axis``.
+    ``DistributedGroupNorm`` all-gathers Welford stats on one mesh axis (H if H is
+    sharded, otherwise W). Activations stay sharded on that axis. If both H and W
+    are sharded, activations are all-gathered on the *other* spatial dim only so the
+    fused stats reduction still sees the full spatial extent, then re-partitioned.
+
+    Channel TP is preserved via ``mesh_axis=ctx.tp_axis``. HiFi4 matches Wan/Mochi norms.
     """
 
-    def __init__(self, num_groups: int, num_channels: int, *, eps: float, ctx: VaeContext) -> None:
+    def __init__(
+        self,
+        num_groups: int,
+        num_channels: int,
+        *,
+        eps: float,
+        ctx: VaeContext,
+        activation_fn: str | None = None,
+    ) -> None:
         super().__init__()
-        self.inner = GroupNorm(
+        h_sp = ctx.h_factor > 1
+        w_sp = ctx.w_factor > 1
+        # Stats AG prefers H when both are sharded (matches Flux2 H+TP).
+        cluster_axis = ctx.h_mesh_axis if h_sp else ctx.w_mesh_axis
+        # 2-D SP: gather the non-cluster spatial dim of the activations, not both.
+        self._gather_w = h_sp and w_sp
+        self.inner = DistributedGroupNorm(
             num_groups=num_groups,
             num_channels=num_channels,
             eps=eps,
             mesh_axis=ctx.tp_axis,
             mesh_device=ctx.device,
+            cluster_axis=cluster_axis,
+            ccl_manager=ctx.ccl_manager,
+            activation_fn=activation_fn,
         )
         self._ctx = ctx
         self._compute_kernel_config = ttnn.init_device_compute_kernel_config(
@@ -694,36 +714,47 @@ class _VaeSpatialGroupNorm(Module):
         rename_substate(state, "", "inner")
 
     def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
-        # logical_h_full: unpadded full-H = local H * h_factor. Used to detect and strip
-        # zero-padding rows that mesh_partition may have added for tile alignment.
-        logical_h_full = x.shape[1] * self._ctx.h_factor
+        if x.layout != ttnn.TILE_LAYOUT:
+            x = ttnn.to_layout(x, ttnn.TILE_LAYOUT)
 
-        x = _all_gather_hw(self._ctx, x)  # → [N, H_gathered, W, C], TILE_LAYOUT
-
-        padded_h = x.shape[1]
-        needs_trim = padded_h > logical_h_full
-        if needs_trim:
-            x = x[:, :logical_h_full, :, :]
+        if self._gather_w:
+            assert self._ctx.ccl_manager is not None
+            x = self._ctx.ccl_manager.all_gather(x, dim=2, mesh_axis=self._ctx.w_mesh_axis, use_hyperparams=True)
 
         x = self.inner.forward(x, compute_kernel_config=self._compute_kernel_config)
 
-        # Restore padding rows so _partition_hw receives the same padded shape.
-        if needs_trim:
-            x = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
-            x = ttnn.pad(x, [(0, 0), (0, padded_h - logical_h_full), (0, 0), (0, 0)], value=0.0)
+        if self._gather_w:
+            original_layout = x.layout
+            if x.layout != ttnn.ROW_MAJOR_LAYOUT:
+                x = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
+            x = ttnn.mesh_partition(x, dim=2, cluster_axis=self._ctx.w_mesh_axis, memory_config=x.memory_config())
+            if original_layout != ttnn.ROW_MAJOR_LAYOUT:
+                x = ttnn.to_layout(x, original_layout)
 
-        return _partition_hw(self._ctx, x)
+        return x
 
 
-def _norm(norm: VaeNormDesc, num_channels: int, *, ctx: VaeContext) -> GroupNorm | _VaeSpatialGroupNorm | VaeRmsNorm:
+def _norm(
+    norm: VaeNormDesc,
+    num_channels: int,
+    *,
+    ctx: VaeContext,
+    activation_fn: str | None = None,
+) -> GroupNorm | _VaeSpatialGroupNorm | VaeRmsNorm:
+    """Build the norm module.
+
+    ``activation_fn`` is applied after the norm; the module folds it into the fused GN op
+    when that path is used and runs it separately otherwise. Callers just call ``forward``.
+    """
     if isinstance(norm, VaeNormDescGroup):
-        # SP-active: wrap to AG H+W for correct stats; SP-inactive: plain GroupNorm.
+        # SP-active: fused DistributedGroupNorm (stats AG on one spatial axis).
         if ctx.h_factor > 1 or ctx.w_factor > 1:
             return _VaeSpatialGroupNorm(
                 num_groups=norm.num_groups,
                 num_channels=num_channels,
                 eps=norm.eps,
                 ctx=ctx,
+                activation_fn=activation_fn,
             )
         return GroupNorm(
             num_groups=norm.num_groups,
@@ -731,10 +762,11 @@ def _norm(norm: VaeNormDesc, num_channels: int, *, ctx: VaeContext) -> GroupNorm
             eps=norm.eps,
             mesh_axis=ctx.tp_axis,
             mesh_device=ctx.device,
+            activation_fn=activation_fn,
         )
     if isinstance(norm, VaeNormDescRms):
         # VaeRmsNorm normalizes per spatial position over the channel dim → SP-safe as-is.
-        return VaeRmsNorm(num_channels=num_channels, eps=norm.eps, ctx=ctx)
+        return VaeRmsNorm(num_channels=num_channels, eps=norm.eps, ctx=ctx, activation_fn=activation_fn)
 
     msg = f"invalid VaeNormDesc: {norm}"
     raise ValueError(msg)

--- a/models/tt_dit/models/vae/vae_flux2.py
+++ b/models/tt_dit/models/vae/vae_flux2.py
@@ -80,7 +80,12 @@ class Flux2VaeDecoder(Module):
             for i, (ch_in, ch_out) in enumerate(itertools.pairwise(channel_counts))
         )
 
-        self.conv_norm_out = _norm(VaeNormDescGroup(num_groups=32, eps=1e-6), num_channels=channel_counts[-1], ctx=ctx)
+        self.conv_norm_out = _norm(
+            VaeNormDescGroup(num_groups=32, eps=1e-6),
+            num_channels=channel_counts[-1],
+            ctx=ctx,
+            activation_fn="silu",
+        )
         self.conv_out = VaeConv2d(
             channel_counts[-1], out_channels, kernel_size=3, padding=1, tensor_parallel=False, ctx=ctx
         )
@@ -149,7 +154,6 @@ class Flux2VaeDecoder(Module):
             z = block.forward(z)
 
         z = self.conv_norm_out.forward(z)
-        z = ttnn.silu(z, output_tensor=z)
 
         if self._ctx.ccl_manager is not None and self._ctx.tp_axis is not None:
             z = self._ctx.ccl_manager.all_gather(z, dim=-1, mesh_axis=self._ctx.tp_axis, use_hyperparams=True)

--- a/models/tt_dit/tests/models/flux2/test_vae_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_vae_flux2.py
@@ -9,7 +9,7 @@ import torch
 
 import ttnn
 
-from ....models.vae.vae_flux2_opt import Flux2VaeDecoder
+from ....models.vae.vae_flux2 import Flux2VaeDecoder
 from ....parallel.config import Flux2VaeParallelConfig
 from ....parallel.manager import CCLManager
 from ....utils import tensor

--- a/models/tt_dit/tests/unit/test_normalization.py
+++ b/models/tt_dit/tests/unit/test_normalization.py
@@ -9,7 +9,14 @@ from loguru import logger
 
 import ttnn
 
-from ...layers.normalization import DistributedLayerNorm, DistributedRMSNorm, GroupNorm, LayerNorm, RMSNorm
+from ...layers.normalization import (
+    DistributedGroupNorm,
+    DistributedLayerNorm,
+    DistributedRMSNorm,
+    GroupNorm,
+    LayerNorm,
+    RMSNorm,
+)
 from ...parallel.manager import CCLManager
 from ...utils.check import assert_quality
 from ...utils.tensor import bf16_tensor
@@ -430,3 +437,298 @@ def test_group_norm(
     tt_torch = tt_torch.permute(0, 3, 1, 2)
 
     assert_quality(torch_output, tt_torch, pcc=0.999_300)
+
+
+@pytest.mark.parametrize(
+    "mesh_device, cluster_axis, device_params",
+    [
+        pytest.param(
+            (1, 1),
+            1,
+            {"fabric_config": None, "require_exact_physical_num_devices": False},
+            id="local_1x1",
+        ),
+        pytest.param(
+            (1, 2),
+            1,
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "require_exact_physical_num_devices": True},
+            id="sp2_axis1",
+        ),
+        pytest.param(
+            (1, 4),
+            1,
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "require_exact_physical_num_devices": True},
+            id="sp4_axis1",
+        ),
+        pytest.param(
+            (2, 1),
+            0,
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "require_exact_physical_num_devices": True},
+            id="sp2_axis0",
+        ),
+        # 8 devices: the only width that clears require_exact_physical_num_devices on a t3k, so the
+        # only config that compiles GN_DISTRIBUTED_AG there.
+        pytest.param(
+            (1, 8),
+            1,
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "require_exact_physical_num_devices": True},
+            id="sp8_axis1",
+        ),
+        pytest.param(
+            (4, 8),
+            0,
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "require_exact_physical_num_devices": True},
+            id="mesh4x8_axis0",
+        ),
+        pytest.param(
+            (4, 8),
+            1,
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "require_exact_physical_num_devices": True},
+            id="mesh4x8_axis1",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(
+    ("group_count", "input_shape"),
+    [
+        # NCHW; H must be divisible by cluster width. C % 32 == 0 for fused v1.
+        (32, (1, 128, 64, 64)),
+        (32, (1, 256, 128, 128)),
+        (8, (1, 64, 64, 64)),
+    ],
+    ids=["c128_h64", "c256_h128", "c64_g8"],
+)
+@pytest.mark.parametrize("activation_fn", [None, "silu"], ids=["no_act", "silu"])
+def test_distributed_group_norm(
+    *,
+    mesh_device: ttnn.MeshDevice,
+    cluster_axis: int,
+    input_shape: tuple[int, int, int, int],
+    group_count: int,
+    activation_fn: str | None,
+) -> None:
+    """Spatially shard H on cluster_axis; match torch GroupNorm on the full tensor."""
+    torch_dtype = torch.bfloat16
+    torch.manual_seed(0)
+
+    cluster_size = tuple(mesh_device.shape)[cluster_axis]
+    n, c, h, w = input_shape
+    assert h % cluster_size == 0, f"H={h} must be divisible by cluster_size={cluster_size}"
+
+    torch_model = torch.nn.GroupNorm(num_groups=group_count, num_channels=c)
+    torch.nn.init.normal_(torch_model.weight)
+    torch.nn.init.normal_(torch_model.bias)
+    torch_model.eval()
+
+    torch_input = torch.randn(input_shape, dtype=torch_dtype)
+    with torch.no_grad():
+        torch_output = torch_model(torch_input)
+        if activation_fn == "silu":
+            torch_output = torch.nn.functional.silu(torch_output)
+
+    ccl_manager = CCLManager(mesh_device=mesh_device, topology=ttnn.Topology.Linear)
+    tt_model = DistributedGroupNorm.from_torch(
+        torch_ref=torch_model,
+        mesh_device=mesh_device,
+        cluster_axis=cluster_axis,
+        mesh_axis=None,
+        ccl_manager=ccl_manager,
+        activation_fn=activation_fn,
+    )
+
+    # NHWC, shard height (dim 1) across cluster_axis.
+    nhwc = torch_input.permute(0, 2, 3, 1).contiguous()
+    tt_input = bf16_tensor(nhwc, device=mesh_device, mesh_axis=cluster_axis, shard_dim=1)
+
+    tt_output = tt_model(tt_input)
+
+    tt_torch = _gather_group_norm_output(tt_output, mesh_device, cluster_axis, torch_output.shape[0])
+
+    assert_quality(torch_output, tt_torch, pcc=0.999_300)
+
+
+def _gather_group_norm_output(
+    tt_output: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    cluster_axis: int,
+    batch: int,
+) -> torch.Tensor:
+    """Gather the H-sharded NHWC output back to a torch NCHW tensor."""
+    shard_dims = [None, None]
+    shard_dims[cluster_axis] = 1  # gather H
+    shard_dims[1 - cluster_axis] = 0
+    tt_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=tuple(mesh_device.shape)),
+    )
+    # ConcatMesh2dToTensor may introduce a leading mesh-replica dim when the other axis is used as batch.
+    if tt_torch.ndim == 5:
+        tt_torch = tt_torch[0]
+    # The non-cluster mesh axis holds identical replicas of the (replicated) input; keep one so the
+    # batch matches torch's. The meaningful distributed comparison (H gathered over cluster_axis)
+    # is preserved by the retained replica.
+    if tt_torch.shape[0] != batch:
+        tt_torch = tt_torch[:batch]
+    return tt_torch.permute(0, 3, 1, 2)
+
+
+@pytest.mark.parametrize(
+    "mesh_device, cluster_axis, device_params",
+    [
+        pytest.param(
+            (4, 8),
+            1,
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "require_exact_physical_num_devices": True},
+            id="mesh4x8_axis1",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_distributed_group_norm_fused_vs_unfused_silu(
+    *,
+    mesh_device: ttnn.MeshDevice,
+    cluster_axis: int,
+) -> None:
+    """Fused SiLU vs unfused GroupNorm + ``ttnn.silu``, both in one session.
+
+    Two things under test:
+      1. Both paths match the torch golden. The fused path applies SiLU to the fp32 DEST value
+         while the unfused path applies it to the bf16-rounded GroupNorm output, so the two are
+         NOT bit-exact — fused is expected to score equal or better against torch. Only a PCC
+         bound is asserted between them.
+      2. The program cache distinguishes them: identical shapes/tensors with the activation as
+         the only differing attribute, launched in the same session. If ``activation_fn``
+         were missing from ``compute_program_hash``, the second launch would reuse the first
+         one's compiled program and one of the golden checks would fail.
+    """
+    torch_dtype = torch.bfloat16
+    torch.manual_seed(0)
+
+    input_shape = (1, 128, 64, 64)
+    group_count = 32
+    n, c = input_shape[0], input_shape[1]
+
+    torch_model = torch.nn.GroupNorm(num_groups=group_count, num_channels=c)
+    torch.nn.init.normal_(torch_model.weight)
+    torch.nn.init.normal_(torch_model.bias)
+    torch_model.eval()
+
+    torch_input = torch.randn(input_shape, dtype=torch_dtype)
+    with torch.no_grad():
+        torch_gn = torch_model(torch_input)
+        torch_silu = torch.nn.functional.silu(torch_gn)
+
+    ccl_manager = CCLManager(mesh_device=mesh_device, topology=ttnn.Topology.Linear)
+    nhwc = torch_input.permute(0, 2, 3, 1).contiguous()
+
+    def build(activation_fn: str | None) -> DistributedGroupNorm:
+        return DistributedGroupNorm.from_torch(
+            torch_ref=torch_model,
+            mesh_device=mesh_device,
+            cluster_axis=cluster_axis,
+            mesh_axis=None,
+            ccl_manager=ccl_manager,
+            activation_fn=activation_fn,
+        )
+
+    # Unfused: GroupNorm, then a separate ttnn.silu (what the model did before fusion).
+    tt_input = bf16_tensor(nhwc, device=mesh_device, mesh_axis=cluster_axis, shard_dim=1)
+    unfused_out = build(None)(tt_input)
+    unfused_out = ttnn.silu(unfused_out, output_tensor=unfused_out)
+    unfused = _gather_group_norm_output(unfused_out, mesh_device, cluster_axis, n)
+
+    # Fused: same shapes, activation is the only differing op attribute.
+    tt_input = bf16_tensor(nhwc, device=mesh_device, mesh_axis=cluster_axis, shard_dim=1)
+    fused = _gather_group_norm_output(build("silu")(tt_input), mesh_device, cluster_axis, n)
+
+    logger.info("unfused vs torch:")
+    assert_quality(torch_silu, unfused, pcc=0.999_300)
+    logger.info("fused vs torch:")
+    assert_quality(torch_silu, fused, pcc=0.999_300)
+    logger.info("fused vs unfused:")
+    assert_quality(unfused, fused, pcc=0.999_500)
+
+
+@pytest.mark.parametrize(
+    "mesh_device, cluster_axis, device_params",
+    [
+        pytest.param(
+            (1, 4),
+            1,
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "require_exact_physical_num_devices": True},
+            id="sp4_axis1",
+        ),
+        pytest.param(
+            (1, 8),
+            1,
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "require_exact_physical_num_devices": True},
+            id="sp8_axis1",
+        ),
+        pytest.param(
+            (4, 8),
+            1,
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "require_exact_physical_num_devices": True},
+            id="mesh4x8_axis1",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_distributed_group_norm_program_cache_hit(
+    *,
+    mesh_device: ttnn.MeshDevice,
+    cluster_axis: int,
+) -> None:
+    """Two launches with identical attributes but different buffers must both be correct.
+
+    The second launch hits the program cache, so it runs ``override_runtime_arguments`` instead of
+    rebuilding the program. That override patches the input/output/gamma/beta/mask/stats addresses
+    and, on the master readers, the per-core stats-DRAM arg index. Nothing else in this file
+    exercises it: ``test_distributed_group_norm`` gets a fresh device per parametrization, and the
+    fused-vs-unfused test deliberately varies the activation to force a cache miss.
+    """
+    torch_dtype = torch.bfloat16
+    torch.manual_seed(0)
+
+    input_shape = (1, 128, 64, 64)
+    group_count = 32
+    n, c = input_shape[0], input_shape[1]
+
+    torch_model = torch.nn.GroupNorm(num_groups=group_count, num_channels=c)
+    torch.nn.init.normal_(torch_model.weight)
+    torch.nn.init.normal_(torch_model.bias)
+    torch_model.eval()
+
+    ccl_manager = CCLManager(mesh_device=mesh_device, topology=ttnn.Topology.Linear)
+    tt_model = DistributedGroupNorm.from_torch(
+        torch_ref=torch_model,
+        mesh_device=mesh_device,
+        cluster_axis=cluster_axis,
+        mesh_axis=None,
+        ccl_manager=ccl_manager,
+    )
+
+    # Distinct data per launch, and the first input stays alive so the second lands at a
+    # different address -- otherwise the override could be a no-op and still look correct.
+    torch_inputs = [torch.randn(input_shape, dtype=torch_dtype) for _ in range(2)]
+    tt_inputs = [
+        bf16_tensor(t.permute(0, 2, 3, 1).contiguous(), device=mesh_device, mesh_axis=cluster_axis, shard_dim=1)
+        for t in torch_inputs
+    ]
+
+    outputs = []
+    outputs.append(_gather_group_norm_output(tt_model(tt_inputs[0]), mesh_device, cluster_axis, n))
+    entries_after_first = mesh_device.num_program_cache_entries()
+    outputs.append(_gather_group_norm_output(tt_model(tt_inputs[1]), mesh_device, cluster_axis, n))
+    entries_after_second = mesh_device.num_program_cache_entries()
+
+    logger.info(f"program cache entries: {entries_after_first} after first launch, {entries_after_second} after second")
+    assert entries_after_second == entries_after_first, (
+        f"second launch added {entries_after_second - entries_after_first} program cache entries; it must reuse "
+        "the cached program so that override_runtime_arguments is what patches the buffer addresses"
+    )
+
+    with torch.no_grad():
+        for i, (torch_input, tt_out) in enumerate(zip(torch_inputs, outputs)):
+            logger.info(f"launch {i} vs torch:")
+            assert_quality(torch_model(torch_input), tt_out, pcc=0.999_300)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ccl_experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ccl_experimental_nanobind.cpp
@@ -8,6 +8,7 @@
 
 #include "ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/dit_fused_distributed_rmsnorm_nanobind.hpp"
+#include "ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/dit_fused_distributed_groupnorm_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/all_gather_matmul_async/all_gather_matmul_async_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/minimal_matmul_strided_reduce_scatter_async/minimal_matmul_strided_reduce_scatter_async_nanobind.hpp"
@@ -46,6 +47,7 @@ namespace ttnn::operations::experimental::ccl {
 void py_module(nb::module_& mod) {
     ccl::bind_fused_rms_minimal(mod);
     ccl::bind_dit_fused_distributed_rmsnorm(mod);
+    ccl::bind_dit_fused_distributed_groupnorm(mod);
     ccl::bind_all_gather_matmul_async(mod);
     ccl::bind_strided_all_gather_minimal_matmul_async(mod);
     ccl::bind_minimal_matmul_strided_reduce_scatter_async(mod);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/device/dit_fused_distributed_groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/device/dit_fused_distributed_groupnorm_device_operation.cpp
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dit_fused_distributed_groupnorm_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+
+#include "ttnn/device.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/math.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace ttnn::experimental::prim {
+
+void DitFusedDistributedGroupnormDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    const auto& gamma = tensor_args.gamma;
+    const auto& beta = tensor_args.beta;
+
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Input must be on device");
+    TT_FATAL(input.buffer() != nullptr, "Input must be allocated");
+    TT_FATAL(input.layout() == Layout::TILE, "Input layout must be TILE, got {}", input.layout());
+    TT_FATAL(input.dtype() == DataType::BFLOAT16, "Input dtype must be BFLOAT16 for v1, got {}", input.dtype());
+    TT_FATAL(
+        input.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+        "Input memory layout must be INTERLEAVED; sharded input is not supported. Got {}.",
+        input.memory_config().memory_layout());
+    TT_FATAL(
+        args.output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+        "Output memory layout must be INTERLEAVED; sharded output is not supported. Got {}.",
+        args.output_mem_config.memory_layout());
+
+    const auto& shape = input.logical_shape();
+    TT_FATAL(shape.rank() == 4, "Input rank must be 4 ([N, 1, H*W, C]), got {}", shape.rank());
+    TT_FATAL(shape[1] == 1, "Input dim1 must be 1 (shape [N, 1, H*W, C]); got {}", shape[1]);
+    // v1 folds the spatial extent as physical_volume()/C, which spans all batches — that is the
+    // wrong statistic for N>1 (GroupNorm must reduce per (batch, group), not across batch). Hard
+    // require N==1; per-batch looping is deferred to a later version.
+    TT_FATAL(
+        shape[0] == 1,
+        "v1 supports batch N==1 only (shape [N, 1, H*W, C]); got N={}. GroupNorm stats must not fold across batch.",
+        shape[0]);
+
+    const uint32_t C = shape[3];
+    TT_FATAL(args.num_groups >= 1, "num_groups must be >= 1");
+    TT_FATAL(C % args.num_groups == 0, "C ({}) must be divisible by num_groups ({})", C, args.num_groups);
+    TT_FATAL(C % TILE_WIDTH == 0, "C ({}) must be divisible by TILE_WIDTH ({})", C, TILE_WIDTH);
+    // The welford compute accumulates every one of the 32 rows in each tile; the per-group count is
+    // derived from the (padded) HW. Require tile-aligned H*W so the padded HW equals the logical HW
+    // (padded_HW == true count) — there is no row mask.
+    TT_FATAL(
+        shape[2] % TILE_HEIGHT == 0,
+        "H*W ({}) must be divisible by TILE_HEIGHT ({}) so there are no padded rows inflating "
+        "the per-group count; got H*W={}.",
+        shape[2],
+        TILE_HEIGHT,
+        shape[2]);
+    // The reused welford GroupNorm kernels require an input_mask to zero sub-tile group padding.
+    TT_FATAL(
+        tensor_args.input_mask.has_value(),
+        "dit_fused_distributed_groupnorm requires an input_mask (welford GroupNorm). Build it with "
+        "the standard group_norm input-mask helper.");
+    {
+        const auto& mask = tensor_args.input_mask.value();
+        TT_FATAL(mask.layout() == Layout::TILE, "input_mask layout must be TILE, got {}", mask.layout());
+        TT_FATAL(mask.storage_type() == StorageType::DEVICE, "input_mask must be on device");
+        TT_FATAL(mask.buffer() != nullptr, "input_mask must be allocated");
+        TT_FATAL(input.device() == mask.device(), "input and input_mask must be on the same device");
+        TT_FATAL(
+            mask.padded_shape()[1] == args.num_groups,
+            "input_mask dim1 must equal num_groups ({}), got {}",
+            args.num_groups,
+            mask.padded_shape()[1]);
+        TT_FATAL(
+            mask.padded_shape()[2] == TILE_HEIGHT,
+            "input_mask height must equal TILE_HEIGHT ({}), got {}",
+            TILE_HEIGHT,
+            mask.padded_shape()[2]);
+        TT_FATAL(
+            mask.padded_shape()[3] % TILE_WIDTH == 0,
+            "input_mask inner dim must be divisible by TILE_WIDTH ({}), got {}",
+            TILE_WIDTH,
+            mask.padded_shape()[3]);
+    }
+
+    const auto& padded = input.padded_shape();
+    TT_FATAL(padded[3] == shape[3], "Input last logical dim ({}) must equal padded last dim ({})", shape[3], padded[3]);
+
+    // Writer is the stock RM welford GN gamma/beta kernel: DRAM-packed row-major, last dim TILE_WIDTH.
+    auto validate_affine = [&](const Tensor& t, const char* name) {
+        TT_FATAL(t.storage_type() == StorageType::DEVICE, "{} must be on device", name);
+        TT_FATAL(t.buffer() != nullptr, "{} must be allocated", name);
+        TT_FATAL(input.device() == t.device(), "{} must be on the same device as input", name);
+        TT_FATAL(
+            t.dtype() == DataType::BFLOAT16 || t.dtype() == DataType::FLOAT32,
+            "{} dtype must be BFLOAT16 or FLOAT32, got {}",
+            name,
+            t.dtype());
+        TT_FATAL(t.layout() == Layout::ROW_MAJOR, "{} layout must be ROW_MAJOR, got {}", name, t.layout());
+        TT_FATAL(
+            t.padded_shape()[3] == TILE_WIDTH,
+            "{} inner dim must equal TILE_WIDTH ({}), got {}",
+            name,
+            TILE_WIDTH,
+            t.padded_shape()[3]);
+    };
+    if (gamma.has_value()) {
+        validate_affine(*gamma, "Weight");
+    }
+    if (beta.has_value()) {
+        TT_FATAL(gamma.has_value(), "bias requires weight to also be provided");
+        validate_affine(*beta, "Bias");
+        TT_FATAL(gamma->dtype() == beta->dtype(), "Weight and bias must have the same dtype");
+        TT_FATAL(gamma->layout() == beta->layout(), "Weight and bias must have the same layout");
+    }
+
+    TT_FATAL(args.ring_size >= 1, "ring_size must be >= 1");
+    TT_FATAL(args.cluster_axis < 2, "cluster_axis must be 0 or 1");
+    if (args.ring_size > 1) {
+        TT_FATAL(
+            !args.multi_device_global_semaphore.empty(),
+            "multi_device_global_semaphore must be non-empty when ring_size > 1");
+    }
+
+    const auto sizing = compute_sizing(args, input);
+    if (!sizing.is_local) {
+        const auto expected_spec = make_stats_tensor_spec(sizing);
+        const auto& e_shape = expected_spec.logical_shape();
+        TT_FATAL(
+            tensor_args.persistent_output_buffer.has_value(),
+            "persistent_output_buffer is required for ring_size > 1. "
+            "Allocate via dit_fused_distributed_groupnorm_create_stats_buffer "
+            "(shape [1, 1, {}, {}], dtype=FLOAT32, layout=ROW_MAJOR, DRAM INTERLEAVED).",
+            e_shape[2],
+            e_shape[3]);
+        const auto& buf = tensor_args.persistent_output_buffer.value();
+        TT_FATAL(buf.storage_type() == StorageType::DEVICE, "persistent_output_buffer must be on device");
+        TT_FATAL(buf.buffer() != nullptr, "persistent_output_buffer must be allocated");
+        TT_FATAL(input.device() == buf.device(), "persistent_output_buffer must be on the same device as input");
+        TT_FATAL(
+            buf.tensor_spec() == expected_spec,
+            "persistent_output_buffer must match the spec from "
+            "dit_fused_distributed_groupnorm_create_stats_buffer: shape [1, 1, {}, {}], dtype=FLOAT32, "
+            "layout=ROW_MAJOR, DRAM INTERLEAVED. Got shape {}, dtype={}, layout={}.",
+            e_shape[2],
+            e_shape[3],
+            buf.logical_shape(),
+            buf.dtype(),
+            buf.layout());
+    }
+}
+
+DitFusedDistributedGroupnormDeviceOperation::spec_return_value_t
+DitFusedDistributedGroupnormDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    const auto& logical = input.logical_shape();
+
+    std::vector<tt::tt_metal::TensorSpec> specs;
+    specs.reserve(2);
+
+    ttnn::Shape output_shape({logical[0], logical[1], logical[2], logical[3]});
+    specs.emplace_back(output_shape, TensorLayout(input.dtype(), PageConfig(Layout::TILE), args.output_mem_config));
+
+    const auto sizing = compute_sizing(args, input);
+    if (!sizing.is_local) {
+        specs.push_back(make_stats_tensor_spec(sizing));
+    }
+    return specs;
+}
+
+DitFusedDistributedGroupnormDeviceOperation::tensor_return_value_t
+DitFusedDistributedGroupnormDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    auto specs = compute_output_specs(args, tensor_args);
+    std::vector<Tensor> tensors;
+    tensors.reserve(specs.size());
+    auto* mesh_device = tensor_args.input.device();
+    tensors.push_back(create_device_tensor(specs[0], mesh_device));
+    if (specs.size() > 1) {
+        TT_FATAL(
+            tensor_args.persistent_output_buffer.has_value(), "persistent_output_buffer is required for ring_size > 1");
+        tensors.push_back(tensor_args.persistent_output_buffer.value());
+    }
+    return tensors;
+}
+
+ttsl::hash::hash_t DitFusedDistributedGroupnormDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    log_trace(tt::LogOp, "DitFusedDistributedGroupnormDeviceOperation::compute_program_hash");
+    auto* mesh_device = tensor_args.input.device();
+    auto sd_id = args.sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
+    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
+    return tt::tt_metal::operation::hash_operation<DitFusedDistributedGroupnormDeviceOperation>(
+        args.num_groups,
+        args.eps,
+        // The activation is a compile-time define on the compute kernel, so it MUST be hashed:
+        // without it a fused and a non-fused call with identical shapes collide in the program
+        // cache and the second call silently reuses the first call's compiled program.
+        args.fused_activation,
+        args.output_mem_config,
+        args.cluster_axis,
+        args.ring_size,
+        args.topology,
+        args.compute_kernel_config,
+        subdevice_core_range_set,
+        tensor_args);
+}
+
+}  // namespace ttnn::experimental::prim
+
+namespace ttnn::prim {
+
+Tensor dit_fused_distributed_groupnorm(
+    const Tensor& input_tensor,
+    int num_groups,
+    float epsilon,
+    uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
+    ttnn::ccl::Topology topology,
+    const std::optional<Tensor>& input_mask,
+    const std::optional<Tensor>& weight,
+    const std::optional<Tensor>& bias,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<Tensor>& persistent_output_buffer,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    const std::optional<ttnn::operations::unary::UnaryWithParam>& fused_activation) {
+    using OperationType = ttnn::experimental::prim::DitFusedDistributedGroupnormDeviceOperation;
+
+    auto kernel_config_val = init_device_compute_kernel_config(
+        mesh_device.arch(), compute_kernel_config, tt::tt_metal::MathFidelity::HiFi4, false, true, false);
+
+    const auto& mesh_view = mesh_device.get_view();
+    const std::size_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
+
+    tt::tt_fabric::Topology topology_ = (num_devices > 1)
+                                            ? ::ttnn::ccl::get_usable_topology(input_tensor, topology, cluster_axis)
+                                            : tt::tt_fabric::Topology::Linear;
+
+    auto operation_attributes = OperationType::operation_attributes_t{
+        .eps = epsilon,
+        .num_groups = static_cast<uint32_t>(num_groups),
+        .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
+        .compute_kernel_config = kernel_config_val,
+        .fused_activation = fused_activation,
+        .cluster_axis = cluster_axis,
+        .ring_size = static_cast<uint32_t>(num_devices),
+        .topology = topology_,
+        .multi_device_global_semaphore = multi_device_global_semaphore,
+        .sub_device_id = subdevice_id,
+    };
+
+    auto tensor_args = OperationType::tensor_args_t{
+        .input = input_tensor,
+        .gamma = weight,
+        .beta = bias,
+        .input_mask = input_mask,
+        .persistent_output_buffer = persistent_output_buffer};
+
+    auto outputs = ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+    return outputs[0];
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/device/dit_fused_distributed_groupnorm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/device/dit_fused_distributed_groupnorm_device_operation.hpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "dit_fused_distributed_groupnorm_device_operation_types.hpp"
+#include "dit_fused_distributed_groupnorm_program_factory.hpp"
+
+namespace ttnn::experimental::prim {
+
+// Single-program fused distributed GroupNorm for spatially sharded activations:
+//   PRE per-group (sum, sumsq, count)  →  fabric AG of stats sticks on
+//   cluster_axis  →  merge  →  POST (x-μ)*rsqrt(σ²+eps)*γ+β.
+//
+// ring_size==1: local PRE+POST only (no fabric). ring_size>1: 1 worker + 1
+// forwarder, max_rounds=1, stick_bytes = num_groups * 16.
+struct DitFusedDistributedGroupnormDeviceOperation {
+    using operation_attributes_t = DitFusedDistributedGroupnormParams;
+    using tensor_args_t = DitFusedDistributedGroupnormInputs;
+    // [0] = user-visible output.
+    // [1] = persistent stats DRAM scratch (only when ring_size > 1).
+    using spec_return_value_t = std::vector<tt::tt_metal::TensorSpec>;
+    using tensor_return_value_t = std::vector<Tensor>;
+    using program_factory_t = std::variant<DitFusedDistributedGroupnormMeshWorkloadFactory>;
+    using shared_variables_t = DitFusedDistributedGroupnormMeshWorkloadFactory::shared_variables_t;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::experimental::prim
+
+namespace ttnn::prim {
+
+Tensor dit_fused_distributed_groupnorm(
+    const Tensor& input_tensor,
+    int num_groups,
+    float epsilon,
+    uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
+    ttnn::ccl::Topology topology,
+    const std::optional<Tensor>& input_mask,
+    const std::optional<Tensor>& weight,
+    const std::optional<Tensor>& bias,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<Tensor>& persistent_output_buffer,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    const std::optional<ttnn::operations::unary::UnaryWithParam>& fused_activation);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/device/dit_fused_distributed_groupnorm_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/device/dit_fused_distributed_groupnorm_device_operation_types.hpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include <tt_stl/reflection.hpp>
+
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/global_semaphore.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::experimental::prim {
+
+// Mirrors GroupNormParams, plus CCL fields for stats all-gather on cluster_axis.
+struct DitFusedDistributedGroupnormParams {
+    float eps = 0.0f;
+    uint32_t num_groups = 0;
+    tt::tt_metal::MemoryConfig output_mem_config;
+    DeviceComputeKernelConfig compute_kernel_config;
+    // Optional unary activation fused into the POST stage (applied after gamma/beta, on the
+    // output tile still in DEST). nullopt = plain GroupNorm.
+    std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation;
+
+    uint32_t cluster_axis = 0;
+    uint32_t ring_size = 1;
+    ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear;
+    std::vector<GlobalSemaphore> multi_device_global_semaphore;
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
+
+    auto attributes() const {
+        using ttsl::reflection::Attribute;
+        std::vector<std::tuple<std::string, Attribute>> attrs;
+        attrs.emplace_back("eps", eps);
+        attrs.emplace_back("num_groups", num_groups);
+        attrs.emplace_back("output_mem_config", output_mem_config);
+        attrs.emplace_back("compute_kernel_config", compute_kernel_config);
+        attrs.emplace_back("fused_activation", fused_activation);
+        attrs.emplace_back("cluster_axis", cluster_axis);
+        attrs.emplace_back("ring_size", ring_size);
+        attrs.emplace_back("topology", topology);
+        return attrs;
+    }
+};
+
+// Mirrors GroupNormInputs (gamma/beta), plus persistent stats buffer for AG.
+struct DitFusedDistributedGroupnormInputs {
+    Tensor input;
+    std::optional<Tensor> gamma;
+    std::optional<Tensor> beta;
+    std::optional<Tensor> input_mask;
+    std::optional<Tensor> persistent_output_buffer;
+};
+
+// Multi-core mcast GroupNorm layout: cores split into num_virtual_cols group-columns × spatial-row
+// stacks (exactly like the stock groupnorm_mcast layout). One mcast-group master per group-column
+// owns num_groups/num_virtual_cols groups; masters = num_virtual_cols (for N==1). The column count
+// comes from ttnn::operations::normalization::compute_num_virtual_cols so create_stats_buffer, the
+// program factory, and the host-side gamma/beta/mask packing all agree.
+
+// Stats stick: PER MASTER, bf16 [mean, var] over that master's num_groups/num_virtual_cols groups.
+// stick_bytes = round_up(num_groups_per_core * 4, 64) — a multiple of NOC_DRAM_READ_ALIGNMENT_BYTES
+// (64 on Blackhole) because each master NoC-reads its own sub-stick at DRAM offset slot*stick_bytes,
+// and non-64-aligned offsets read back as zero on BH. A single forwarder coalesces all masters'
+// sub-sticks into one packet (num_groups*4 B ≤ one fabric packet), so num_chunks_per_device = 1,
+// total_pages = ring_size, and the DRAM page = num_masters * stick_bytes.
+struct DitFusedDistributedGroupnormSizing {
+    bool is_local = false;
+    uint32_t num_groups = 0;
+    uint32_t num_masters = 1;            // mcast-group senders per device = num_virtual_cols
+    uint32_t num_groups_per_core = 0;    // groups owned by each master
+    uint32_t num_forwarders = 0;         // single coalescing forwarder (optimal for the tiny stick)
+    uint32_t num_chunks_per_device = 0;  // = num_forwarders (max_rounds == 1)
+    uint32_t stick_bytes = 0;            // per-master, 64 B-aligned
+    uint32_t total_pages = 0;            // = ring_size
+    uint32_t page_size_bytes = 0;        // = num_masters * stick_bytes
+};
+
+// Single source of truth for the stats-buffer geometry. Used by create_stats_buffer (host
+// allocation), compute_output_specs, validate, and the program factory so they cannot drift.
+DitFusedDistributedGroupnormSizing gn_make_sizing(
+    uint32_t num_groups, uint32_t ring_size, uint32_t channels, uint32_t grid_x);
+
+DitFusedDistributedGroupnormSizing compute_sizing(const DitFusedDistributedGroupnormParams& args, const Tensor& input);
+
+tt::tt_metal::TensorSpec make_stats_tensor_spec(const DitFusedDistributedGroupnormSizing& sizing);
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/device/dit_fused_distributed_groupnorm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/device/dit_fused_distributed_groupnorm_program_factory.cpp
@@ -1,0 +1,983 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dit_fused_distributed_groupnorm_program_factory.hpp"
+
+#include <algorithm>
+#include <bit>
+#include <cstring>
+#include <set>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/cb_utils.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/operations/math.hpp"
+#include "ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp"
+#include "ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp"
+#include "dit_fused_distributed_groupnorm_device_operation_types.hpp"
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace ttnn::experimental::prim {
+
+namespace {
+
+uint32_t float_to_u32(float v) {
+    uint32_t out;
+    std::memcpy(&out, &v, sizeof(float));
+    return out;
+}
+
+}  // namespace
+
+// Multi-core mcast GroupNorm across the device grid — the on-device reduction is identical to the
+// stock ttnn::group_norm mcast path (groupnorm_mcast_program_factory.cpp): cores split into
+// num_virtual_cols group-columns × spatial-row stacks; one mcast-group master per column reduces
+// its column over the spatial rows, NoC-reads its peers' partials, and Welford-combines them into
+// the device-global (mean, var). The ONLY additions for the distributed op are, on the master
+// reader: (1) after the intra-device combine and BEFORE the mcast-back, the masters coalesce their
+// per-group (mean, var) sub-sticks over one forwarder, ring all-gather every device's stats, and
+// Chan-merge them into the GLOBAL (mean, var); (2) the master then mcasts the GLOBAL stat (not the
+// device-local one) back to its column. Compute + writer run verbatim on every reduction core and
+// are agnostic to sender/receiver role and to whether the stat is device-local or global. At
+// ring_size==1 there is no fabric and the result is bit-exact with stock local GroupNorm.
+DitFusedDistributedGroupnormMeshWorkloadFactory::cached_program_t
+DitFusedDistributedGroupnormMeshWorkloadFactory::create_at(
+    const DitFusedDistributedGroupnormParams& args,
+    const ttnn::MeshCoordinate& mesh_coordinate,
+    const DitFusedDistributedGroupnormInputs& tensor_args,
+    std::vector<Tensor>& tensor_return_value) {
+    Tensor& output_tensor = tensor_return_value.at(0);
+    Tensor* stats_dram_tensor = tensor_return_value.size() > 1 ? &tensor_return_value[1] : nullptr;
+    const auto& input_tensor = tensor_args.input;
+    const auto& gamma = tensor_args.gamma;
+    const auto& beta = tensor_args.beta;
+    const auto& input_mask = tensor_args.input_mask;
+
+    Program program = CreateProgram();
+
+    IDevice* device = input_tensor.device();
+    auto* mesh_device = input_tensor.device();
+
+    const bool is_local = (args.ring_size <= 1);
+    const bool use_mux = !is_local;
+
+    TT_FATAL(input_mask.has_value(), "dit_fused_distributed_groupnorm requires an input_mask (welford GroupNorm)");
+
+    // ------------------------------------------------------------------------
+    // Shapes
+    // ------------------------------------------------------------------------
+    const uint32_t tile_h = TILE_HEIGHT;
+    const uint32_t tile_w = TILE_WIDTH;
+    const uint32_t datum_size_bytes = 2;  // bfloat16
+
+    const auto& shape = input_tensor.padded_shape();
+    const uint32_t num_batches = shape[0];
+    const uint32_t H = shape[1] * shape[2] * num_batches;  // folded spatial (per-device shard)
+    const uint32_t Ht = H / tile_h;
+    const uint32_t W = shape[3];  // channels
+    const uint32_t Wt = W / tile_w;
+    const uint32_t num_groups = args.num_groups;
+
+    TT_FATAL(num_batches == 1, "dit_fused_distributed_groupnorm currently supports N==1 (got {})", num_batches);
+    TT_FATAL(W % tile_w == 0, "channels ({}) must be divisible by {}", W, tile_w);
+    TT_FATAL(W % num_groups == 0, "channels ({}) must be divisible by num_groups ({})", W, num_groups);
+    TT_FATAL(H % tile_h == 0, "folded HW ({}) must be divisible by {}", H, tile_h);
+
+    const uint32_t num_channels_per_group = W / num_groups;
+    const uint32_t num_channels_per_group_mod_tile_w =
+        (num_channels_per_group % tile_w == 0) ? tile_w : (num_channels_per_group % tile_w);
+
+    // ------------------------------------------------------------------------
+    // Multi-core mcast grid (mirror groupnorm_mcast_program_factory.cpp:118-164)
+    // ------------------------------------------------------------------------
+    const auto grid_size = device->compute_with_storage_grid_size();
+    const CoreRange core_grid({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    const uint32_t max_cores = core_grid.size();
+
+    const uint32_t num_virtual_cols =
+        ttnn::operations::normalization::compute_num_virtual_cols(grid_size.x, static_cast<int>(num_groups), W);
+    const uint32_t col_rep_max = grid_size.x / num_virtual_cols;  // ≥ 1
+
+    // Spatial-row split. Unlike stock GroupNorm — which fills the whole grid.y and FATALs when the
+    // input is too short — the per-device shard height Ht may be small (H is sharded across the
+    // cluster). Pick the largest num_virtual_rows that (a) divides Ht, (b) factors as
+    // col_replication × num_actual_rows within the grid (col_replication ≤ grid.x/num_virtual_cols,
+    // num_actual_rows ≤ grid.y), and (c) leaves a core free for the fabric forwarder. This maximizes
+    // the reduction parallelism while keeping per_core_Mt integral. vr==1 is always feasible.
+    const uint32_t reduction_core_budget = max_cores - (use_mux ? 1u : 0u);
+    uint32_t num_virtual_rows = 1, num_actual_rows = 1, col_replication = 1;
+    for (uint32_t cr = 1; cr <= col_rep_max; ++cr) {
+        for (uint32_t nr = 1; nr <= grid_size.y; ++nr) {
+            const uint32_t vr = cr * nr;
+            if (vr <= Ht && (Ht % vr) == 0 && (num_virtual_cols * vr) <= reduction_core_budget &&
+                vr > num_virtual_rows) {
+                num_virtual_rows = vr;
+                num_actual_rows = nr;
+                col_replication = cr;
+            }
+        }
+    }
+    const uint32_t num_actual_cols = num_virtual_cols * col_replication;
+    const uint32_t num_reduction_cores = num_actual_cols * num_actual_rows;
+    TT_FATAL(Ht % num_virtual_rows == 0, "internal: num_virtual_rows ({}) must divide Ht ({})", num_virtual_rows, Ht);
+
+    const uint32_t per_core_Mt = Ht / num_virtual_rows;
+    const uint32_t per_core_M = per_core_Mt * tile_h;
+    const uint32_t per_core_N = W / num_virtual_cols;
+    const uint32_t per_core_Nt = (per_core_N + tile_w - 1) / tile_w;
+    const uint32_t num_shards_c = W / per_core_N;  // == num_virtual_cols
+    const uint32_t num_groups_per_core = (num_groups > num_shards_c) ? (num_groups / num_shards_c) : 1u;
+    const uint32_t num_batches_per_core = 1;         // N == 1
+    const uint32_t num_rows_per_group = per_core_M;  // per-core rows per group (N == 1, one batch)
+
+    auto [block_wt, num_groups_per_reset] = ttnn::prim::find_max_tile_span(per_core_N, num_channels_per_group);
+    const uint32_t block_ht = per_core_Mt;  // num_batches_per_core == 1
+    const uint32_t block_wt_last = (per_core_Nt + num_groups_per_core - 1) / num_groups_per_core;
+    const uint32_t input_mask_num_tiles_per_core = block_wt * num_groups_per_core;
+    const uint32_t per_core_N_bytes_padded =
+        tt::round_up(per_core_N * datum_size_bytes, output_tensor.buffer()->alignment());
+
+    // num_out_blocks: L1 safety net that splits the (now per-core) block height so height-scaled CBs
+    // fit L1. With the multi-core split per_core_M is small, so this is typically 1. The stock
+    // heuristic is keyed on the whole-tensor volume divided across cores; pass the per-core
+    // footprint with a core count of 1 for the same result, then clamp to the block height.
+    const uint32_t num_out_blocks =
+        std::min(ttnn::prim::groupnorm_heuristic_num_out_blocks(per_core_M * per_core_N, 1u), block_ht);
+    TT_FATAL(
+        num_out_blocks >= 1 && num_out_blocks <= block_ht,
+        "num_out_blocks ({}) must be in [1, block_ht ({})]",
+        num_out_blocks,
+        block_ht);
+
+    TT_FATAL(num_groups_per_core <= 16, "num_groups_per_core ({}) must be <= 16 for welford", num_groups_per_core);
+    TT_FATAL(
+        input_mask->padded_shape()[3] == block_wt * tile_w,
+        "input mask width ({}) must equal block_wt * TILE_WIDTH ({})",
+        input_mask->padded_shape()[3],
+        block_wt * tile_w);
+
+    // ------------------------------------------------------------------------
+    // Data formats
+    // ------------------------------------------------------------------------
+    const tt::DataFormat in_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    const tt::DataFormat out_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
+    // Pinned to bf16: the cross-device gather packs each group's [mean, var] as a bf16 pair
+    // (stick_bytes = num_groups_per_core * 4), so fp32 stats would need a different stick layout.
+    const tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;
+    const tt::DataFormat fp32_df = tt::DataFormat::Float32;
+    tt::DataFormat gamma_beta_cb_data_format = tt::DataFormat::Float16_b;
+    if (gamma.has_value()) {
+        gamma_beta_cb_data_format = datatype_to_dataformat_converter(gamma->dtype());
+    } else if (beta.has_value()) {
+        gamma_beta_cb_data_format = datatype_to_dataformat_converter(beta->dtype());
+    }
+    const tt::DataFormat in_mask_cb_data_format = datatype_to_dataformat_converter(input_mask->dtype());
+
+    const uint32_t in_single_tile_size = tt::tile_size(in_data_format);
+    const uint32_t out_single_tile_size = tt::tile_size(out_data_format);
+    const uint32_t single_tile_size = tt::tile_size(cb_data_format);
+    const uint32_t gamma_beta_single_tile_size = tt::tile_size(gamma_beta_cb_data_format);
+    const uint32_t in_mask_single_tile_size = tt::tile_size(in_mask_cb_data_format);
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), args.compute_kernel_config);
+    TT_FATAL(fp32_dest_acc_en, "dit_fused_distributed_groupnorm requires fp32_dest_acc_en=true");
+
+    const bool welford_unpack_fp32_active = (in_data_format == tt::DataFormat::Float32) && fp32_dest_acc_en;
+    const bool welford_fp32_alias = welford_unpack_fp32_active;  // tilize_in == false
+    const uint32_t cb_in0_welford_index =
+        welford_fp32_alias ? static_cast<uint32_t>(tt::CBIndex::c_19) : static_cast<uint32_t>(tt::CBIndex::c_0);
+
+    const bool has_gamma = gamma.has_value();
+    const bool has_beta = beta.has_value();
+    const uint32_t groupnorm_mode = static_cast<uint32_t>(ttnn::prim::GroupNormMode::WELFORD_NATIVE);
+
+    // ------------------------------------------------------------------------
+    // Ring topology (unchanged from CCL scaffold)
+    // ------------------------------------------------------------------------
+    std::optional<ttnn::MeshCoordinate> forward_coord = std::nullopt;
+    std::optional<ttnn::MeshCoordinate> backward_coord = std::nullopt;
+    std::optional<tt::tt_fabric::FabricNodeId> forward_fabric_node_id = std::nullopt;
+    std::optional<tt::tt_fabric::FabricNodeId> backward_fabric_node_id = std::nullopt;
+    uint32_t device_index = 0;
+    if (use_mux) {
+        forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            input_tensor, mesh_coordinate, /*offset=*/1, args.topology, args.cluster_axis);
+        backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            input_tensor, mesh_coordinate, /*offset=*/-1, args.topology, args.cluster_axis);
+        device_index =
+            ttnn::ccl::get_linearized_index_from_physical_coord(input_tensor, mesh_coordinate, args.cluster_axis);
+        if (forward_coord.has_value()) {
+            forward_fabric_node_id = mesh_device->get_fabric_node_id(forward_coord.value());
+        }
+        if (backward_coord.has_value()) {
+            backward_fabric_node_id = mesh_device->get_fabric_node_id(backward_coord.value());
+        }
+    }
+
+    uint32_t num_targets_forward = 0;
+    uint32_t num_targets_backward = 0;
+    if (use_mux) {
+        std::tie(num_targets_forward, num_targets_backward) = ttnn::ccl::get_forward_backward_line_mcast_distance(
+            args.ring_size, device_index, args.topology, /*static_alternate=*/true);
+    }
+
+    // ------------------------------------------------------------------------
+    // Cores: reduction grid (num_actual_cols × num_actual_rows) + 1 forwarder when distributed.
+    // ------------------------------------------------------------------------
+    const std::vector<CoreCoord> core_coords =
+        grid_to_cores(num_reduction_cores, num_actual_cols, num_actual_rows, /*row_wise=*/false);
+    const std::vector<CoreCoord> virtual_core_coords =
+        grid_to_cores(num_reduction_cores, num_virtual_cols, num_virtual_rows, /*row_wise=*/false);
+
+    std::set<CoreRange> reduction_core_ranges;
+    for (const auto& c : core_coords) {
+        reduction_core_ranges.insert(CoreRange(c));
+    }
+    const CoreRangeSet all_reduction_cores(reduction_core_ranges);
+
+    // Forwarder: one spare core outside the reduction grid. When the reduction layout leaves a
+    // spare column/row (num_virtual_cols not dividing grid.x, the common case), it is free; if the
+    // reduction grid exactly fills the device this shape can't host a forwarder → clear FATAL.
+    const uint32_t num_forwarders = use_mux ? 1u : 0u;
+    std::vector<CoreCoord> forwarder_cores;
+    if (use_mux) {
+        std::unordered_set<uint32_t> reduction_lookup;
+        for (const auto& c : core_coords) {
+            reduction_lookup.insert(c.y * grid_size.x + c.x);
+        }
+        const auto grid_cores = corerange_to_cores(core_grid, max_cores, /*row_wise=*/true);
+        for (const auto& c : grid_cores) {
+            if (!reduction_lookup.contains(c.y * grid_size.x + c.x)) {
+                forwarder_cores.push_back(c);
+                break;
+            }
+        }
+        TT_FATAL(
+            !forwarder_cores.empty(),
+            "distributed dit_fused_distributed_groupnorm needs a spare core for the fabric forwarder, but the "
+            "reduction grid ({}x{}={}) fills the whole device ({} cores).",
+            num_actual_cols,
+            num_actual_rows,
+            num_reduction_cores,
+            max_cores);
+    }
+
+    CoreRangeSet forwarder_core_set;
+    for (const auto& c : forwarder_cores) {
+        forwarder_core_set = forwarder_core_set.merge(CoreRangeSet({CoreRange(c, c)}));
+    }
+
+    // ------------------------------------------------------------------------
+    // Mcast groups (mirror groupnorm_mcast_program_factory.cpp:324-364). For N==1 the senders are
+    // core_coords[0], [num_virtual_rows], [2*num_virtual_rows], … — one master per group-column.
+    // ------------------------------------------------------------------------
+    const uint32_t num_cores_per_batch = num_virtual_rows;  // N == 1
+    const uint32_t sender_stride = num_virtual_rows;
+    std::set<CoreRange> mcast_sender_core_ranges;
+    {
+        uint32_t core_index = 0;
+        for (uint32_t j = 0; j < num_groups / num_groups_per_core; ++j) {
+            mcast_sender_core_ranges.insert(CoreRange(core_coords[core_index]));
+            core_index += sender_stride;
+        }
+    }
+    (void)num_cores_per_batch;
+
+    std::vector<std::vector<CoreCoord>> mcast_groups;
+    std::vector<std::vector<CoreCoord>> mcast_virtual_groups;
+    int group_index = -1;
+    for (size_t i = 0; i < core_coords.size(); ++i) {
+        if (mcast_sender_core_ranges.contains(CoreRange(core_coords[i]))) {
+            group_index += 1;
+        }
+        if (group_index >= static_cast<int>(mcast_groups.size())) {
+            mcast_groups.emplace_back();
+            mcast_virtual_groups.emplace_back();
+        }
+        mcast_groups[group_index].push_back(core_coords[i]);
+        mcast_virtual_groups[group_index].push_back(virtual_core_coords[i]);
+    }
+    const uint32_t num_cores_per_mcast_group = mcast_groups[0].size();
+    const uint32_t num_masters = static_cast<uint32_t>(mcast_groups.size());
+
+    std::set<CoreRange> mcast_receiver_core_ranges;
+    for (const auto& c : core_coords) {
+        if (!mcast_sender_core_ranges.contains(CoreRange(c))) {
+            mcast_receiver_core_ranges.insert(CoreRange(c));
+        }
+    }
+    const CoreRangeSet mcast_sender_cores(mcast_sender_core_ranges);
+    const CoreRangeSet mcast_receiver_cores(mcast_receiver_core_ranges);
+    const bool has_receivers = !mcast_receiver_core_ranges.empty();
+
+    // ------------------------------------------------------------------------
+    // Fabric geometry (single source of truth shared with create_stats_buffer / validate).
+    // ------------------------------------------------------------------------
+    const auto sizing = compute_sizing(args, input_tensor);
+    TT_FATAL(
+        !use_mux || sizing.num_masters == num_masters,
+        "internal: sizing masters ({}) != program masters ({})",
+        sizing.num_masters,
+        num_masters);
+    const uint32_t stick_bytes = sizing.stick_bytes;  // per-master, 64 B-aligned
+    const uint32_t num_chunks_per_device = sizing.num_chunks_per_device;
+    constexpr uint32_t max_rounds = 1u;
+
+    TT_FATAL(
+        !use_mux || stats_dram_tensor != nullptr,
+        "create_at requires stats DRAM scratch at tensor_return_value[1] when ring_size > 1");
+    tt::tt_metal::Buffer* stats_dram_buffer = use_mux ? stats_dram_tensor->buffer() : nullptr;
+
+    if (use_mux) {
+        const uint32_t max_payload = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
+        TT_FATAL(
+            num_masters * stick_bytes <= max_payload,
+            "coalesced GN stats packet ({} masters × {} B = {} B) exceeds fabric max payload ({} B)",
+            num_masters,
+            stick_bytes,
+            num_masters * stick_bytes,
+            max_payload);
+    }
+
+    // ------------------------------------------------------------------------
+    // Circular buffers
+    // ------------------------------------------------------------------------
+    const uint32_t in0_block_tiles = block_ht / num_out_blocks * block_wt;
+    const uint32_t interm_block_tiles = in0_block_tiles;
+
+    // c_0 input (+ c_19 alias on fp32 path)
+    if (welford_fp32_alias) {
+        const uint32_t in0_cbs[] = {static_cast<uint32_t>(tt::CBIndex::c_0), static_cast<uint32_t>(tt::CBIndex::c_19)};
+        create_cb(in0_cbs, program, all_reduction_cores, in_single_tile_size, in0_block_tiles, in_data_format);
+    } else {
+        create_cb(tt::CBIndex::c_0, program, all_reduction_cores, in_single_tile_size, in0_block_tiles, in_data_format);
+    }
+    create_cb(tt::CBIndex::c_16, program, all_reduction_cores, out_single_tile_size, in0_block_tiles, out_data_format);
+    create_cb(tt::CBIndex::c_29, program, all_reduction_cores, in_single_tile_size, in0_block_tiles, in_data_format);
+    create_cb(tt::CBIndex::c_2, program, all_reduction_cores, single_tile_size, 1, cb_data_format);
+    create_cb(tt::CBIndex::c_3, program, all_reduction_cores, single_tile_size, 1, cb_data_format);  // eps
+    create_cb(tt::CBIndex::c_4, program, all_reduction_cores, single_tile_size, 1, cb_data_format);
+    if (has_gamma) {
+        create_cb(
+            tt::CBIndex::c_5,
+            program,
+            all_reduction_cores,
+            gamma_beta_single_tile_size,
+            per_core_Nt,
+            gamma_beta_cb_data_format);
+    }
+    if (has_beta) {
+        create_cb(
+            tt::CBIndex::c_6,
+            program,
+            all_reduction_cores,
+            gamma_beta_single_tile_size,
+            per_core_Nt,
+            gamma_beta_cb_data_format);
+    }
+    create_cb(
+        tt::CBIndex::c_28,
+        program,
+        all_reduction_cores,
+        in_mask_single_tile_size,
+        input_mask_num_tiles_per_core,
+        in_mask_cb_data_format);
+    create_cb(tt::CBIndex::c_24, program, all_reduction_cores, single_tile_size, 1, cb_data_format);  // x
+    create_cb(tt::CBIndex::c_25, program, all_reduction_cores, single_tile_size, 3, cb_data_format);  // xmm
+    create_cb(
+        tt::CBIndex::c_23, program, all_reduction_cores, single_tile_size, interm_block_tiles, cb_data_format);  // xmm2
+    create_cb(
+        tt::CBIndex::c_22, program, all_reduction_cores, single_tile_size, interm_block_tiles, cb_data_format);  // xmm3
+    create_cb(tt::CBIndex::c_8, program, all_reduction_cores, single_tile_size, 2, cb_data_format);  // ex_partial
+    // ex_global: dual buffer index c_15 / c_9.
+    {
+        const uint32_t ex_global_cbs[] = {
+            static_cast<uint32_t>(tt::CBIndex::c_15), static_cast<uint32_t>(tt::CBIndex::c_9)};
+        create_cb(
+            ex_global_cbs, program, all_reduction_cores, single_tile_size, 2u * num_groups_per_core, cb_data_format);
+    }
+    create_cb(
+        tt::CBIndex::c_27,
+        program,
+        all_reduction_cores,
+        single_tile_size,
+        num_groups_per_core,
+        cb_data_format);  // ex2pe
+
+    // Fabric AG staging CBs (masters) + packet CB (grid-uniform L1 addr) + header CB (forwarder).
+    // fp32 is a byte container here; the payload is bf16 [mean, var] pairs (see stick_bytes).
+    constexpr uint32_t stats_local_cb_id = tt::CBIndex::c_1;
+    constexpr uint32_t stats_gathered_cb_id = tt::CBIndex::c_10;
+    constexpr uint32_t packet_cb_id = tt::CBIndex::c_7;
+    constexpr uint32_t reserved_packet_header_cb_id = tt::CBIndex::c_11;
+    if (use_mux) {
+        create_cb(stats_local_cb_id, program, mcast_sender_cores, stick_bytes, 2, fp32_df);
+        create_cb(stats_gathered_cb_id, program, mcast_sender_cores, stick_bytes, args.ring_size, fp32_df);
+        // One coalesced packet = num_masters sub-sticks; ping-ponged (depth 2). Created on the whole
+        // grid so masters and the forwarder see the same L1 base address.
+        const uint32_t packet_bytes = num_masters * stick_bytes;
+        create_cb(packet_cb_id, program, CoreRangeSet({core_grid}), packet_bytes, 2, fp32_df);
+        const uint32_t header_size = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
+        create_cb(reserved_packet_header_cb_id, program, forwarder_core_set, header_size, 4, tt::DataFormat::RawUInt32);
+    }
+
+    // ------------------------------------------------------------------------
+    // Semaphores: reduce_sender (id 0) + reduce_receiver (id 1); fabric arrival / go on full grid.
+    // ------------------------------------------------------------------------
+    const uint32_t reduce_sender_semaphore_id = CreateSemaphore(program, all_reduction_cores, 0u);
+    const uint32_t reduce_receiver_semaphore_id = CreateSemaphore(program, all_reduction_cores, 0u);
+    const uint32_t arrival_sem_id = use_mux ? CreateSemaphore(program, CoreRangeSet({core_grid}), 0u) : 0u;
+    const uint32_t go_sem_id = use_mux ? CreateSemaphore(program, CoreRangeSet({core_grid}), 0u) : 0u;
+
+    // Kernels are the stock welford GroupNorm kernels plus the shared fused-norm CCL forwarder. The
+    // only fused-specific behaviour lives behind GN_DISTRIBUTED_AG in the two reader kernels; the
+    // compute/writer kernels are used verbatim. At ring_size == 1 the define is not set, so the
+    // fused op compiles the exact stock kernel text.
+    const std::string gn_kernel_base = "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/";
+    const std::string ccl_kernel_base = "ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_norm_common/kernels/";
+
+    // Refers to the welford stats CBs (ex_partial / ex_global / ex2pe), not the fabric staging CBs.
+    const bool stats_is_fp32 = cb_data_format == tt::DataFormat::Float32;
+    // cb_reciprocals is excluded: it's fp32 here but the reconfigs never touch it.
+    const bool enable_fp32_reconfig = ttnn::prim::groupnorm_needs_fp32_reconfig(
+        {in_data_format, out_data_format, cb_data_format, gamma_beta_cb_data_format, in_mask_cb_data_format});
+
+    // ------------------------------------------------------------------------
+    // Reader compile-time args. Named args mirror the stock welford GN reader exactly; the
+    // TensorAccessor blocks stay positional. The master appends the stats-DRAM accessor after
+    // src0 (the stock reader only declares src0, so the extra block is inert unless
+    // GN_DISTRIBUTED_AG is set).
+    // ------------------------------------------------------------------------
+    const std::unordered_map<std::string, uint32_t> reader_named_ct = {
+        {"reduce_receiver_semaphore_id", reduce_receiver_semaphore_id},
+        {"reduce_sender_semaphore_id", reduce_sender_semaphore_id},
+        {"num_cores_per_mcast_group", num_cores_per_mcast_group},
+        {"num_batch_group", num_groups_per_core * num_batches_per_core},
+        {"num_batches", num_batches_per_core},
+        {"per_core_N", per_core_Nt},
+        {"per_core_N_bytes", per_core_N_bytes_padded},
+        {"per_core_N_bytes_with_stride", per_core_Nt * tile_w * datum_size_bytes},
+        {"datum_size_bytes", datum_size_bytes},
+        {"per_core_M", per_core_Mt},
+        {"TILE_HEIGHT", tile_h},
+        {"TILE_WIDTH", tile_w},
+        {"block_h", block_ht},
+        {"block_w", block_wt},
+        {"block_hw", block_ht * block_wt},
+        {"num_cols_per_group", num_channels_per_group_mod_tile_w},
+        {"num_tiles_per_batch", per_core_Mt * Wt / num_batches_per_core},
+        {"block_w_last", block_wt_last},
+        {"GROUP_SIZE_IS_POWER_OF_2",
+         static_cast<uint32_t>((num_channels_per_group_mod_tile_w & (num_channels_per_group_mod_tile_w - 1)) == 0)},
+        {"GROUP_SIZE_SMALLER_THAN_TILE_W", static_cast<uint32_t>(num_channels_per_group < tile_w)},
+        {"group_row_offset", num_channels_per_group - ((block_wt - 1) * tile_w)},
+        {"num_out_blocks", num_out_blocks},
+        {"num_channels_per_group", num_channels_per_group},
+        {"num_rows_per_group", num_rows_per_group},
+        {"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)},
+        {"cb_in0_welford", cb_in0_welford_index},
+        {"stats_is_fp32", static_cast<uint32_t>(stats_is_fp32)},
+    };
+
+    std::map<std::string, std::string> reader_defines;
+    if (has_gamma) {
+        reader_defines["FUSE_GAMMA"] = "1";
+    }
+    if (has_beta) {
+        reader_defines["FUSE_BETA"] = "1";
+    }
+    // Only the cross-device path enables the fabric AG + batched handshake. ring_size == 1 leaves
+    // the stock per-group lock-step untouched, so the local path is bit-exact with ttnn.group_norm.
+    if (use_mux) {
+        reader_defines["GN_DISTRIBUTED_AG"] = "1";
+    }
+
+    // Master / sender reader (fabric AG when distributed).
+    std::unordered_map<std::string, uint32_t> sender_reader_named_ct = reader_named_ct;
+    if (use_mux) {
+        sender_reader_named_ct.emplace("ring_size", args.ring_size);
+        sender_reader_named_ct.emplace("stick_bytes", stick_bytes);
+        sender_reader_named_ct.emplace("num_chunks_per_device", num_chunks_per_device);
+        sender_reader_named_ct.emplace("fwd_arrival_sem_id", arrival_sem_id);
+        sender_reader_named_ct.emplace("go_sem_id", go_sem_id);
+        sender_reader_named_ct.emplace("packet_cb_id", packet_cb_id);
+        sender_reader_named_ct.emplace("stats_local_cb_id", stats_local_cb_id);
+        sender_reader_named_ct.emplace("stats_gathered_cb_id", stats_gathered_cb_id);
+    }
+    std::vector<uint32_t> sender_reader_ct;
+    TensorAccessorArgs(input_tensor.buffer()).append_to(sender_reader_ct);
+    TensorAccessorArgs(use_mux ? stats_dram_buffer : input_tensor.buffer()).append_to(sender_reader_ct);
+
+    KernelHandle sender_reader_kernel_id = CreateKernel(
+        program,
+        gn_kernel_base + "dataflow/welford_reader_mcast_sender_unary_gn.cpp",
+        mcast_sender_cores,
+        ReaderDataMovementConfig(sender_reader_ct, reader_defines, sender_reader_named_ct));
+
+    // Receiver reader (signal + wait; no fabric).
+    KernelHandle receiver_reader_kernel_id = 0;
+    if (has_receivers) {
+        std::vector<uint32_t> receiver_reader_ct;
+        TensorAccessorArgs(input_tensor.buffer()).append_to(receiver_reader_ct);
+        receiver_reader_kernel_id = CreateKernel(
+            program,
+            gn_kernel_base + "dataflow/welford_reader_mcast_receiver_unary_gn.cpp",
+            mcast_receiver_cores,
+            ReaderDataMovementConfig(receiver_reader_ct, reader_defines, reader_named_ct));
+    }
+
+    // ------------------------------------------------------------------------
+    // Writer (stock welford GN gamma/beta + output) — identical on every reduction core.
+    // Runtime args and CB indices already match stock, so this kernel is used unmodified.
+    // ------------------------------------------------------------------------
+    const std::unordered_map<std::string, uint32_t> writer_named_ct = {
+        {"is_mcast_sender", 1u},  // stock hardcodes 1 on all cores
+        {"fuse_gamma", static_cast<uint32_t>(has_gamma)},
+        {"fuse_beta", static_cast<uint32_t>(has_beta)},
+        {"num_cols_tile_gamma_beta", per_core_Nt},
+        {"per_core_M", per_core_Mt},
+        {"per_core_N", per_core_Nt},
+        {"per_core_N_bytes", per_core_N * datum_size_bytes},
+        {"per_core_N_bytes_with_stride", per_core_Nt * tile_w * datum_size_bytes},
+        {"num_groups_per_core", num_groups_per_core},
+        {"num_batches_per_core", num_batches_per_core},
+        {"num_cols_per_group", num_channels_per_group_mod_tile_w},
+        {"num_tiles_per_batch", per_core_Mt * Wt / num_batches_per_core},
+        {"block_w_last", block_wt_last},
+        {"GROUP_SIZE_IS_POWER_OF_2",
+         static_cast<uint32_t>((num_channels_per_group_mod_tile_w & (num_channels_per_group_mod_tile_w - 1)) == 0)},
+        {"GROUP_SIZE_SMALLER_THAN_TILE_W", static_cast<uint32_t>(num_channels_per_group < tile_w)},
+        {"group_row_offset", num_channels_per_group - ((block_wt - 1) * tile_w)},
+        {"num_out_blocks", num_out_blocks},
+        {"block_h", block_ht},
+        {"block_w", block_wt},
+        {"block_hw", block_ht * block_wt},
+        {"groupnorm_mode", groupnorm_mode},
+        {"TILE_WIDTH", tile_w},
+    };
+    std::vector<uint32_t> writer_ct;
+    TensorAccessorArgs(output_tensor.buffer()).append_to(writer_ct);
+    TensorAccessorArgs(has_gamma ? gamma->buffer() : nullptr).append_to(writer_ct);
+    TensorAccessorArgs(has_beta ? beta->buffer() : nullptr).append_to(writer_ct);
+    TensorAccessorArgs(input_mask->buffer()).append_to(writer_ct);
+
+    KernelHandle writer_kernel_id = CreateKernel(
+        program,
+        gn_kernel_base + "dataflow/welford_writer_unary_gn_rm_gb.cpp",
+        all_reduction_cores,
+        WriterDataMovementConfig(writer_ct, {}, writer_named_ct));
+
+    // ------------------------------------------------------------------------
+    // Forwarder (single fabric ring all-gather, coalescing all masters' sub-sticks).
+    // ------------------------------------------------------------------------
+    std::vector<KernelHandle> forwarder_kernel_ids(num_forwarders, 0);
+    for (uint32_t f = 0; f < num_forwarders; f++) {
+        std::vector<uint32_t> fwd_ct = {
+            packet_cb_id,
+            reserved_packet_header_cb_id,
+            args.ring_size,
+            device_index,
+            num_targets_forward,
+            num_targets_backward,
+            f,
+            num_forwarders,
+            num_masters,  // group_size (masters coalesced by this forwarder)
+            max_rounds,
+            stick_bytes,
+            num_chunks_per_device,
+            arrival_sem_id,
+            go_sem_id,
+        };
+        TensorAccessorArgs(stats_dram_buffer).append_to(fwd_ct);
+        // The coalescing forwarder is fully parameterized by these CT args (stick_bytes,
+        // max_rounds, num_chunks_per_device), so it is shared verbatim with the fused rmsnorm op.
+        forwarder_kernel_ids[f] = CreateKernel(
+            program,
+            ccl_kernel_base + "dataflow/dit_fused_norm_forwarder.cpp",
+            CoreRangeSet({CoreRange(forwarder_cores[f], forwarder_cores[f])}),
+            WriterDataMovementConfig(fwd_ct));
+    }
+
+    // ------------------------------------------------------------------------
+    // Compute (stock welford GroupNorm PRE/POST) — identical on every reduction core.
+    // ------------------------------------------------------------------------
+    const std::unordered_map<std::string, uint32_t> compute_named_ct = {
+        {"do_gamma", static_cast<uint32_t>(has_gamma)},
+        {"do_beta", static_cast<uint32_t>(has_beta)},
+        {"num_cores_per_mcast_group", num_cores_per_mcast_group},
+        {"batch", num_batches_per_core},
+        {"group", num_groups_per_core},
+        {"block_h", block_ht},
+        {"block_w", block_wt},
+        {"per_core_M", per_core_Mt},
+        {"per_core_N", per_core_Nt},
+        {"per_core_MN", per_core_Mt * per_core_Nt},
+        {"single_tile_size_bytes", single_tile_size},
+        {"num_tiles_input_mask", num_groups_per_core * block_wt},
+        {"num_out_blocks", num_out_blocks},
+        {"num_channels_per_group", num_channels_per_group},
+        {"reciprocal_size", 0u},  // welford native
+        {"TILE_WIDTH", tile_w},
+        {"cb_in0_welford", cb_in0_welford_index},
+        {"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)},
+        {"welford_unpack_fp32_active", static_cast<uint32_t>(welford_unpack_fp32_active)},
+        {"enable_fp32_reconfig", static_cast<uint32_t>(enable_fp32_reconfig)},
+    };
+    // Optional fused unary activation. "dst0" is the DEST index the final output tile lives in
+    // when the compute kernel applies the activation (see welford_groupnorm.cpp).
+    std::map<std::string, std::string> compute_defines;
+    if (args.fused_activation.has_value()) {
+        const auto& act = args.fused_activation.value();
+        for (auto& [key, val] : ttnn::operations::unary::utils::get_defines(
+                 act.op_type, act.params, "ACTIVATION", "dst0", output_tensor.dtype())) {
+            compute_defines[key] = val;
+        }
+    }
+
+    ComputeConfig compute_config{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode,
+        .defines = compute_defines,
+        .named_compile_args = compute_named_ct,
+    };
+    if (welford_unpack_fp32_active) {
+        std::vector<UnpackToDestMode> unpack_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+        if (welford_fp32_alias) {
+            unpack_mode[static_cast<uint32_t>(tt::CBIndex::c_19)] = UnpackToDestMode::UnpackToDestFp32;
+        }
+        compute_config.unpack_to_dest_mode = unpack_mode;
+    }
+    KernelHandle compute_kernel_id =
+        CreateKernel(program, gn_kernel_base + "compute/welford_groupnorm.cpp", all_reduction_cores, compute_config);
+
+    // ------------------------------------------------------------------------
+    // Runtime args
+    // ------------------------------------------------------------------------
+    const uint32_t input_addr = input_tensor.buffer()->address();
+    const uint32_t output_addr = output_tensor.buffer()->address();
+    const uint32_t gamma_addr = has_gamma ? gamma->buffer()->address() : 0u;
+    const uint32_t beta_addr = has_beta ? beta->buffer()->address() : 0u;
+    const uint32_t input_mask_addr = input_mask->buffer()->address();
+    const uint32_t stats_dram_addr = use_mux ? stats_dram_buffer->address() : 0u;
+
+    uint32_t out_ready_sem_bank_addr = 0;
+    if (use_mux) {
+        TT_FATAL(!args.multi_device_global_semaphore.empty(), "ring_size>1 requires a GlobalSemaphore");
+        out_ready_sem_bank_addr = args.multi_device_global_semaphore.at(0).address();
+    }
+
+    const tt::tt_metal::NOC reader_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    CoreCoord forwarder_virtual = {};
+    if (use_mux) {
+        forwarder_virtual = mesh_device->worker_core_from_logical_core(forwarder_cores[0]);
+    }
+
+    std::vector<size_t> stats_dram_addr_reader_arg_idx;
+    std::vector<CoreCoord> sender_cores_out;
+    std::vector<CoreCoord> receiver_cores_out;
+
+    for (size_t i = 0; i < mcast_groups.size(); ++i) {
+        std::vector<CoreCoord> group = mcast_groups[i];  // non-const: split_and_form_rectangle_grids mutates it
+        const auto& virtual_group = mcast_virtual_groups[i];
+        const bool rectangle_grid = ttnn::prim::is_rectangle_grid(group);
+
+        for (size_t j = 0; j < group.size(); ++j) {
+            const CoreCoord core = group[j];
+            const CoreCoord virtual_core = virtual_group[j];
+            const uint32_t in0_start_id = per_core_Mt * Wt * virtual_core.y + per_core_Nt * virtual_core.x;
+            const uint32_t out_tile_start_id = in0_start_id;
+
+            if (j == 0) {  // mcast-group master (sender reader + fabric)
+                sender_cores_out.push_back(core);
+                std::vector<CoreCoord> mcast_group_first;
+                std::vector<CoreCoord> mcast_group_mid(group);
+                std::vector<CoreCoord> mcast_group_last;
+                if (!rectangle_grid) {
+                    ttnn::prim::split_and_form_rectangle_grids(
+                        group, mcast_group_first, mcast_group_mid, mcast_group_last);
+                }
+
+                CoreCoord mcast_start = device->worker_core_from_logical_core(mcast_group_mid.front());
+                CoreCoord mcast_end = device->worker_core_from_logical_core(mcast_group_mid.back());
+                if (reader_noc == NOC::NOC_1) {
+                    std::swap(mcast_start, mcast_end);
+                }
+
+                std::vector<uint32_t> rt;
+                rt.push_back(input_addr);
+                rt.push_back(output_addr);
+                rt.push_back(in0_start_id);
+                rt.push_back(out_tile_start_id);
+                rt.push_back(Wt);
+                rt.push_back(static_cast<uint32_t>(!mcast_group_first.empty()));
+                rt.push_back(static_cast<uint32_t>(!mcast_group_last.empty()));
+                rt.push_back(mcast_start.x);
+                rt.push_back(mcast_start.y);
+                rt.push_back(mcast_end.x);
+                rt.push_back(mcast_end.y);
+                rt.push_back(mcast_group_first.empty() ? (mcast_group_mid.size() - 1) : mcast_group_mid.size());
+
+                if (!mcast_group_first.empty()) {
+                    CoreCoord fs = device->worker_core_from_logical_core(mcast_group_first.front());
+                    CoreCoord fe = device->worker_core_from_logical_core(mcast_group_first.back());
+                    rt.push_back(fs.x);
+                    rt.push_back(fs.y);
+                    rt.push_back(fe.x);
+                    rt.push_back(fe.y);
+                    rt.push_back(mcast_group_first.size() - 1);
+                }
+                if (!mcast_group_last.empty()) {
+                    CoreCoord ls = device->worker_core_from_logical_core(mcast_group_last.front());
+                    CoreCoord le = device->worker_core_from_logical_core(mcast_group_last.back());
+                    rt.push_back(ls.x);
+                    rt.push_back(ls.y);
+                    rt.push_back(le.x);
+                    rt.push_back(le.y);
+                    rt.push_back(mcast_group_last.size());
+                }
+
+                std::vector<uint32_t> noc_x;
+                std::vector<uint32_t> noc_y;
+                for (const auto& gcore : group) {
+                    CoreCoord vc = device->worker_core_from_logical_core(gcore);
+                    noc_x.push_back(vc.x);
+                    noc_y.push_back(vc.y);
+                }
+                rt.insert(rt.end(), noc_x.begin(), noc_x.end());
+                rt.insert(rt.end(), noc_y.begin(), noc_y.end());
+
+                if (use_mux) {
+                    // welford_reader_mcast_sender_unary_gn.cpp locates the fabric block from the
+                    // end of the noc_coord_x/y lists, whose offset depends on which optional mcast
+                    // sub-group blocks this core emitted. Keep the two layouts in agreement.
+                    const size_t kernel_noc_arg_base = (!mcast_group_first.empty() && !mcast_group_last.empty()) ? 22u
+                                                       : (!mcast_group_first.empty() || !mcast_group_last.empty())
+                                                           ? 17u
+                                                           : 12u;
+                    const size_t kernel_fabric_base = kernel_noc_arg_base + 2u * group.size();
+                    TT_FATAL(
+                        rt.size() == kernel_fabric_base,
+                        "sender reader runtime-arg layout mismatch: host writes the fabric block at index {}, "
+                        "the kernel reads it at index {}",
+                        rt.size(),
+                        kernel_fabric_base);
+                    TT_FATAL(
+                        group.size() == num_cores_per_mcast_group,
+                        "mcast group {} has {} cores but the kernel is compiled with num_cores_per_mcast_group={}",
+                        i,
+                        group.size(),
+                        num_cores_per_mcast_group);
+                    stats_dram_addr_reader_arg_idx.push_back(rt.size());
+                    rt.push_back(stats_dram_addr);
+                    rt.push_back(static_cast<uint32_t>(forwarder_virtual.x));
+                    rt.push_back(static_cast<uint32_t>(forwarder_virtual.y));
+                    rt.push_back(static_cast<uint32_t>(i));  // my_slot = master index
+                    rt.push_back(0u);                        // my_forwarder_index (single forwarder)
+                }
+                SetRuntimeArgs(program, sender_reader_kernel_id, core, rt);
+            } else {  // receiver reader
+                receiver_cores_out.push_back(core);
+                CoreCoord sender_virtual = device->worker_core_from_logical_core(group.front());
+                std::vector<uint32_t> rt = {
+                    input_addr,
+                    output_addr,
+                    in0_start_id,
+                    out_tile_start_id,
+                    Wt,
+                    static_cast<uint32_t>(sender_virtual.x),
+                    static_cast<uint32_t>(sender_virtual.y)};
+                SetRuntimeArgs(program, receiver_reader_kernel_id, core, rt);
+            }
+        }
+    }
+
+    // Writer RT args (welford GN) per reduction core, with per-column gamma/beta/mask offsets.
+    uint32_t gamma_tile_start_id = 0;
+    uint32_t beta_tile_start_id = 0;
+    uint32_t input_mask_tile_start_id = 0;
+    uint32_t curr_virtual_core_x = 0;
+    const uint32_t gamma_beta_num_cols_tile_per_core = per_core_Nt;
+    for (size_t i = 0; i < core_coords.size(); ++i) {
+        const CoreCoord core = core_coords[i];
+        const CoreCoord virtual_core = virtual_core_coords[i];
+        const uint32_t out_tile_start_id = per_core_Mt * Wt * virtual_core.y + per_core_Nt * virtual_core.x;
+
+        if (virtual_core.x > curr_virtual_core_x) {
+            curr_virtual_core_x++;
+            if (has_gamma) {
+                gamma_tile_start_id =
+                    (gamma_tile_start_id + gamma_beta_num_cols_tile_per_core) % (gamma->physical_volume() / tile_w);
+            }
+            if (has_beta) {
+                beta_tile_start_id =
+                    (beta_tile_start_id + gamma_beta_num_cols_tile_per_core) % (beta->physical_volume() / tile_w);
+            }
+            input_mask_tile_start_id = (input_mask_tile_start_id + input_mask_num_tiles_per_core) %
+                                       (input_mask->physical_volume() / (tile_h * tile_w));
+        }
+
+        std::vector<uint32_t> writer_rt = {
+            float_to_u32(args.eps),
+            output_addr,
+            gamma_addr,
+            beta_addr,
+            input_mask_addr,
+            out_tile_start_id,  // per-core output page start
+            gamma_tile_start_id,
+            beta_tile_start_id,
+            input_mask_tile_start_id,
+            Wt,
+        };
+        SetRuntimeArgs(program, writer_kernel_id, core, writer_rt);
+    }
+
+    // Forwarder RT args: gather all masters' NoC coords (slot order), present_count = num_masters.
+    if (num_forwarders > 0) {
+        const auto local_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
+        for (uint32_t f = 0; f < num_forwarders; f++) {
+            const auto& core = forwarder_cores[f];
+            std::vector<uint32_t> fwd_rt = {stats_dram_addr, out_ready_sem_bank_addr};
+            for (uint32_t m = 0; m < num_masters; m++) {
+                CoreCoord mv = device->worker_core_from_logical_core(mcast_groups[m].front());
+                fwd_rt.push_back(static_cast<uint32_t>(mv.x));
+                fwd_rt.push_back(static_cast<uint32_t>(mv.y));
+            }
+            fwd_rt.push_back(num_masters);  // present_count[0]
+            fwd_rt.push_back(forward_fabric_node_id.has_value() ? 1u : 0u);
+            if (forward_fabric_node_id.has_value()) {
+                tt::tt_fabric::append_fabric_connection_rt_args(
+                    local_node_id, forward_fabric_node_id.value(), /*link_idx=*/f, program, {core}, fwd_rt);
+            }
+            fwd_rt.push_back(backward_fabric_node_id.has_value() ? 1u : 0u);
+            if (backward_fabric_node_id.has_value()) {
+                tt::tt_fabric::append_fabric_connection_rt_args(
+                    local_node_id, backward_fabric_node_id.value(), /*link_idx=*/f, program, {core}, fwd_rt);
+            }
+            SetRuntimeArgs(program, forwarder_kernel_ids[f], core, fwd_rt);
+        }
+    }
+
+    std::vector<KernelHandle> reader_ids = {sender_reader_kernel_id};
+    if (has_receivers) {
+        reader_ids.push_back(receiver_reader_kernel_id);
+    }
+
+    return {
+        std::move(program),
+        DitFusedDistributedGroupnormSharedVariables{
+            .reader_kernel_ids = reader_ids,
+            .writer_kernel_ids = {writer_kernel_id},
+            .compute_kernel_ids = {compute_kernel_id},
+            .forwarder_kernel_ids = forwarder_kernel_ids,
+            .forwarder_cores = forwarder_cores,
+            .cores = core_coords,
+            .sender_cores = sender_cores_out,
+            .receiver_cores = receiver_cores_out,
+            .stats_dram_addr_reader_arg_idx = stats_dram_addr_reader_arg_idx,
+        }};
+}
+
+DitFusedDistributedGroupnormMeshWorkloadFactory::cached_mesh_workload_t
+DitFusedDistributedGroupnormMeshWorkloadFactory::create_mesh_workload(
+    const DitFusedDistributedGroupnormParams& operation_attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const DitFusedDistributedGroupnormInputs& tensor_args,
+    std::vector<Tensor>& tensor_return_value) {
+    tt::tt_metal::distributed::MeshWorkload workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+
+    for (const auto& range : tensor_coords.ranges()) {
+        for (const auto& coord : range) {
+            auto cached = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
+            workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached.program));
+            shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached.shared_variables));
+        }
+    }
+    return cached_mesh_workload_t{std::move(workload), std::move(shared_variables)};
+}
+
+void DitFusedDistributedGroupnormMeshWorkloadFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const DitFusedDistributedGroupnormParams& operation_attributes,
+    const DitFusedDistributedGroupnormInputs& tensor_args,
+    std::vector<Tensor>& tensor_return_value) {
+    const uint32_t input_addr = tensor_args.input.buffer()->address();
+    const uint32_t output_addr = tensor_return_value.at(0).buffer()->address();
+    const uint32_t gamma_addr = tensor_args.gamma.has_value() ? tensor_args.gamma->buffer()->address() : 0u;
+    const uint32_t beta_addr = tensor_args.beta.has_value() ? tensor_args.beta->buffer()->address() : 0u;
+    const uint32_t input_mask_addr =
+        tensor_args.input_mask.has_value() ? tensor_args.input_mask->buffer()->address() : 0u;
+    const uint32_t stats_dram_addr = tensor_return_value.size() > 1 ? tensor_return_value[1].buffer()->address() : 0u;
+    const uint32_t out_ready_sem_addr = operation_attributes.multi_device_global_semaphore.empty()
+                                            ? 0u
+                                            : operation_attributes.multi_device_global_semaphore.at(0).address();
+
+    for (auto& [range, program] : cached_workload.workload.get_programs()) {
+        const auto& shared = cached_workload.shared_variables.at(range);
+
+        // Master / sender reader: input, output, and (fabric) stats DRAM address.
+        auto& sender_args_by_core = GetRuntimeArgs(program, shared.reader_kernel_ids[0]);
+        const bool has_stats_arg = !shared.stats_dram_addr_reader_arg_idx.empty();
+        TT_FATAL(
+            !has_stats_arg || shared.stats_dram_addr_reader_arg_idx.size() == shared.sender_cores.size(),
+            "stats_dram_addr_reader_arg_idx has {} entries but there are {} sender cores",
+            shared.stats_dram_addr_reader_arg_idx.size(),
+            shared.sender_cores.size());
+        for (size_t s = 0; s < shared.sender_cores.size(); ++s) {
+            const auto& core = shared.sender_cores[s];
+            auto& a = sender_args_by_core.at(core.x).at(core.y);
+            a[0] = input_addr;
+            a[1] = output_addr;
+            if (has_stats_arg) {
+                a[shared.stats_dram_addr_reader_arg_idx[s]] = stats_dram_addr;
+            }
+        }
+
+        // Receiver reader: input, output.
+        if (shared.reader_kernel_ids.size() > 1 && !shared.receiver_cores.empty()) {
+            auto& recv_args_by_core = GetRuntimeArgs(program, shared.reader_kernel_ids[1]);
+            for (const auto& core : shared.receiver_cores) {
+                auto& a = recv_args_by_core.at(core.x).at(core.y);
+                a[0] = input_addr;
+                a[1] = output_addr;
+            }
+        }
+
+        // Writer (all reduction cores): output, gamma, beta, mask.
+        auto& writer_args_by_core = GetRuntimeArgs(program, shared.writer_kernel_ids[0]);
+        for (const auto& core : shared.cores) {
+            auto& a = writer_args_by_core.at(core.x).at(core.y);
+            a[1] = output_addr;
+            a[2] = gamma_addr;
+            a[3] = beta_addr;
+            a[4] = input_mask_addr;
+        }
+
+        for (size_t f = 0; f < shared.forwarder_kernel_ids.size(); f++) {
+            auto& fwd_args_by_core = GetRuntimeArgs(program, shared.forwarder_kernel_ids[f]);
+            const auto& fc = shared.forwarder_cores[f];
+            fwd_args_by_core.at(fc.x).at(fc.y)[0] = stats_dram_addr;
+            fwd_args_by_core.at(fc.x).at(fc.y)[1] = out_ready_sem_addr;
+        }
+    }
+}
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/device/dit_fused_distributed_groupnorm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/device/dit_fused_distributed_groupnorm_program_factory.hpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/operation.hpp"
+#include "dit_fused_distributed_groupnorm_device_operation_types.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct DitFusedDistributedGroupnormSharedVariables {
+    // reader_kernel_ids = {sender (mcast-group master), receiver}. Multi-core mcast layout:
+    // sender cores run the master reader (intra-device combine + fabric + mcast-back), receiver
+    // cores run the receiver reader (signal + wait). Compute + writer run on all cores.
+    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
+    std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
+    std::vector<tt::tt_metal::KernelHandle> compute_kernel_ids;
+    std::vector<tt::tt_metal::KernelHandle> forwarder_kernel_ids;
+    std::vector<tt::tt_metal::CoreCoord> forwarder_cores;
+    std::vector<tt::tt_metal::CoreCoord> cores;           // all reduction cores (writer/compute)
+    std::vector<tt::tt_metal::CoreCoord> sender_cores;    // mcast-group masters (sender reader)
+    std::vector<tt::tt_metal::CoreCoord> receiver_cores;  // non-master cores (receiver reader)
+    // Index of the stats DRAM scratch address inside each master reader's runtime-args vector,
+    // parallel to sender_cores. The index varies per core because the preceding mcast sub-group
+    // blocks are optional. Empty on the is_local (ring_size==1) path.
+    std::vector<size_t> stats_dram_addr_reader_arg_idx;
+};
+
+struct DitFusedDistributedGroupnormMeshWorkloadFactory {
+    using shared_variables_t = DitFusedDistributedGroupnormSharedVariables;
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+    static cached_mesh_workload_t create_mesh_workload(
+        const DitFusedDistributedGroupnormParams& operation_attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const DitFusedDistributedGroupnormInputs& tensor_args,
+        std::vector<Tensor>& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_workload,
+        const DitFusedDistributedGroupnormParams& operation_attributes,
+        const DitFusedDistributedGroupnormInputs& tensor_args,
+        std::vector<Tensor>& tensor_return_value);
+
+private:
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create_at(
+        const DitFusedDistributedGroupnormParams& args,
+        const ttnn::MeshCoordinate& mesh_coordinate,
+        const DitFusedDistributedGroupnormInputs& tensor_args,
+        std::vector<Tensor>& tensor_return_value);
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/dit_fused_distributed_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/dit_fused_distributed_groupnorm.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dit_fused_distributed_groupnorm.hpp"
+
+#include <algorithm>
+
+#include <tt-metalium/constants.hpp>
+
+#include "device/dit_fused_distributed_groupnorm_device_operation.hpp"
+#include "device/dit_fused_distributed_groupnorm_device_operation_types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+
+using namespace tt::constants;
+
+namespace ttnn::experimental {
+
+namespace {
+
+uint32_t cluster_width(const MeshDevice& mesh_device, uint32_t cluster_axis) {
+    const auto& mesh_view = mesh_device.get_view();
+    return static_cast<uint32_t>((cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols());
+}
+
+}  // namespace
+
+ttnn::Tensor dit_fused_distributed_groupnorm(
+    const ttnn::Tensor& input_tensor,
+    int num_groups,
+    float epsilon,
+    uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
+    ttnn::ccl::Topology topology,
+    const std::optional<Tensor>& input_mask,
+    const std::optional<Tensor>& weight,
+    const std::optional<Tensor>& bias,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<ttnn::Tensor>& persistent_output_buffer,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    const std::optional<ttnn::operations::unary::UnaryWithParam>& fused_activation) {
+    // Always launch the fused device op. Width-1 runs local PRE+POST (no fabric);
+    // width>1 runs PRE → fabric AG → POST. Packed RM γ/β + input_mask (same as ttnn.group_norm).
+    return ttnn::prim::dit_fused_distributed_groupnorm(
+        input_tensor,
+        num_groups,
+        epsilon,
+        cluster_axis,
+        mesh_device,
+        multi_device_global_semaphore,
+        topology,
+        input_mask,
+        weight,
+        bias,
+        memory_config,
+        compute_kernel_config,
+        persistent_output_buffer,
+        subdevice_id,
+        fused_activation);
+}
+
+std::optional<ttnn::Tensor> dit_fused_distributed_groupnorm_create_stats_buffer(
+    const ttnn::Tensor& input_tensor,
+    const uint32_t num_groups,
+    const uint32_t cluster_axis,
+    const MeshDevice& mesh_device) {
+    TT_FATAL(num_groups >= 1, "num_groups must be >= 1, got {}", num_groups);
+    TT_FATAL(cluster_axis < 2, "cluster_axis must be 0 or 1, got {}", cluster_axis);
+    const auto& in_shape = input_tensor.logical_shape();
+    TT_FATAL(in_shape.rank() == 4, "input rank must be 4 ([N, 1, H*W, C]), got {}", in_shape.rank());
+    const uint32_t channels = in_shape[3];
+    TT_FATAL(channels % TILE_WIDTH == 0, "C ({}) must be divisible by TILE_WIDTH ({})", channels, TILE_WIDTH);
+    TT_FATAL(channels % num_groups == 0, "C ({}) must be divisible by num_groups ({})", channels, num_groups);
+    const uint32_t ring_size = cluster_width(mesh_device, cluster_axis);
+    const uint32_t grid_x = mesh_device.compute_with_storage_grid_size().x;
+    auto sizing = ttnn::experimental::prim::gn_make_sizing(num_groups, ring_size, channels, grid_x);
+    if (sizing.is_local) {
+        return std::nullopt;
+    }
+
+    return ttnn::create_device_tensor(
+        ttnn::experimental::prim::make_stats_tensor_spec(sizing), &const_cast<MeshDevice&>(mesh_device));
+}
+
+}  // namespace ttnn::experimental
+
+namespace ttnn::experimental::prim {
+
+DitFusedDistributedGroupnormSizing gn_make_sizing(
+    uint32_t num_groups, uint32_t ring_size, uint32_t channels, uint32_t grid_x) {
+    DitFusedDistributedGroupnormSizing s;
+    s.num_groups = num_groups;
+    s.is_local = (ring_size <= 1);
+    // Multi-core mcast layout: masters = num_virtual_cols; each owns num_groups/cols groups.
+    s.num_masters =
+        ttnn::operations::normalization::compute_num_virtual_cols(grid_x, static_cast<int>(num_groups), channels);
+    s.num_groups_per_core = num_groups / s.num_masters;
+    // Per-master stick: bf16 [mean, var] over its groups (num_groups_per_core * 4 B), rounded up to
+    // NOC_DRAM_READ_ALIGNMENT_BYTES (64 on Blackhole). Each master NoC-reads its own sub-stick at
+    // DRAM offset slot*stick_bytes; a non-64-aligned offset reads back as zero on BH (which halved
+    // the variance → √2 output scale). Rounding keeps every sub-stick offset 64-aligned.
+    s.stick_bytes = ((s.num_groups_per_core * 4u + 63u) / 64u) * 64u;
+    // A single forwarder coalesces all masters' sub-sticks into one packet (whole device stat is
+    // num_groups*4 B ≤ one fabric packet), so there is one DRAM chunk per device.
+    s.num_forwarders = s.is_local ? 0u : 1u;
+    s.num_chunks_per_device = s.num_forwarders;  // max_rounds == 1
+    s.total_pages = s.is_local ? 0u : ring_size;
+    s.page_size_bytes = s.num_masters * s.stick_bytes;
+    return s;
+}
+
+DitFusedDistributedGroupnormSizing compute_sizing(const DitFusedDistributedGroupnormParams& args, const Tensor& input) {
+    const uint32_t channels = input.logical_shape()[3];
+    const uint32_t grid_x = input.device()->compute_with_storage_grid_size().x;
+    return gn_make_sizing(args.num_groups, args.ring_size, channels, grid_x);
+}
+
+tt::tt_metal::TensorSpec make_stats_tensor_spec(const DitFusedDistributedGroupnormSizing& sizing) {
+    // One ROW_MAJOR fp32 page per device; each page holds all masters' 64 B-aligned sub-sticks.
+    const uint32_t floats_per_page = sizing.page_size_bytes / sizeof(float);
+    ttnn::Shape stats_shape({1u, 1u, sizing.total_pages, floats_per_page});
+    tt::tt_metal::MemoryConfig stats_mem{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    return tt::tt_metal::TensorSpec(
+        stats_shape,
+        tt::tt_metal::TensorLayout(DataType::FLOAT32, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), stats_mem));
+}
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/dit_fused_distributed_groupnorm.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/dit_fused_distributed_groupnorm.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "ttnn/global_semaphore.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::experimental {
+
+// Fused distributed GroupNorm: same contract as ``ttnn.group_norm``, plus fabric
+// all-gather of per-group stats on ``cluster_axis`` (PRE → AG → POST).
+// Width-1 on ``cluster_axis`` runs local PRE+POST with no fabric.
+// ``fused_activation`` optionally applies a unary activation (e.g. SiLU) to the output tile
+// while it is still in DEST, removing the separate activation op's DRAM round-trip.
+ttnn::Tensor dit_fused_distributed_groupnorm(
+    const ttnn::Tensor& input_tensor,
+    int num_groups,
+    float epsilon,
+    uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
+    ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
+    const std::optional<Tensor>& input_mask = std::nullopt,
+    const std::optional<Tensor>& weight = std::nullopt,
+    const std::optional<Tensor>& bias = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    const std::optional<ttnn::Tensor>& persistent_output_buffer = std::nullopt,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
+    const std::optional<ttnn::operations::unary::UnaryWithParam>& fused_activation = std::nullopt);
+
+// Persistent DRAM scratch for the stats all-gather. Returns nullopt when
+// cluster width is 1 (no AG). Always sized for a single fabric link.
+std::optional<ttnn::Tensor> dit_fused_distributed_groupnorm_create_stats_buffer(
+    const ttnn::Tensor& input_tensor, uint32_t num_groups, uint32_t cluster_axis, const MeshDevice& mesh_device);
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/dit_fused_distributed_groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/dit_fused_distributed_groupnorm_nanobind.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dit_fused_distributed_groupnorm_nanobind.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/dit_fused_distributed_groupnorm.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+// Accepts the activation as a string ("silu", "gelu", ...) like dit_rms_norm_unary_fused does,
+// so the model layer does not have to construct a UnaryWithParam.
+ttnn::Tensor dit_fused_distributed_groupnorm_wrapper(
+    const ttnn::Tensor& input_tensor,
+    int num_groups,
+    float epsilon,
+    uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
+    ttnn::ccl::Topology topology,
+    const std::optional<ttnn::Tensor>& input_mask,
+    const std::optional<ttnn::Tensor>& weight,
+    const std::optional<ttnn::Tensor>& bias,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<ttnn::Tensor>& persistent_output_buffer,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    const std::optional<std::string>& activation) {
+    std::optional<ttnn::operations::unary::UnaryWithParam> act_param = std::nullopt;
+    if (activation.has_value()) {
+        act_param = ttnn::operations::unary::utils::string_to_unary_with_param(activation.value());
+    }
+    return ttnn::experimental::dit_fused_distributed_groupnorm(
+        input_tensor,
+        num_groups,
+        epsilon,
+        cluster_axis,
+        mesh_device,
+        multi_device_global_semaphore,
+        topology,
+        input_mask,
+        weight,
+        bias,
+        memory_config,
+        compute_kernel_config,
+        persistent_output_buffer,
+        subdevice_id,
+        act_param);
+}
+
+void bind_dit_fused_distributed_groupnorm(nb::module_& mod) {
+    ttnn::bind_function<"dit_fused_distributed_groupnorm", "ttnn.experimental.">(
+        mod,
+        R"doc(
+            Fused distributed GroupNorm for spatially sharded activations.
+
+            Same contract as ``ttnn.group_norm`` (Welford, DRAM-packed RM γ/β +
+            ``input_mask``), plus fabric all-gather of per-group stats on
+            ``cluster_axis`` (PRE → AG → POST). When mesh width on that axis is
+            1, runs local PRE+POST with no fabric. The all-gather always uses a
+            single fabric link.
+
+            ``activation`` optionally fuses a unary activation (e.g. ``"silu"``)
+            into the output stage, equivalent to
+            ``ttnn.<activation>(dit_fused_distributed_groupnorm(x, ...))`` but
+            without the extra full-tensor DRAM read/write. The activation
+            consumes the fp32 DEST value (after gamma/beta), so it is applied
+            before the output is rounded to the output dtype.
+        )doc",
+        &dit_fused_distributed_groupnorm_wrapper,
+        nb::arg("input_tensor"),
+        nb::kw_only(),
+        nb::arg("num_groups"),
+        nb::arg("epsilon") = 1e-5,
+        nb::arg("cluster_axis"),
+        nb::arg("mesh_device"),
+        nb::arg("multi_device_global_semaphore"),
+        nb::arg("topology") = ttnn::ccl::Topology::Ring,
+        nb::arg("input_mask") = nb::none(),
+        nb::arg("weight") = nb::none(),
+        nb::arg("bias") = nb::none(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("persistent_output_buffer") = nb::none(),
+        nb::arg("subdevice_id") = nb::none(),
+        nb::arg("activation") = nb::none());
+
+    ttnn::bind_function<"dit_fused_distributed_groupnorm_create_stats_buffer", "ttnn.experimental.">(
+        mod,
+        R"doc(
+            Allocate the persistent DRAM stats scratch buffer for
+            `dit_fused_distributed_groupnorm`'s all-gather path (cluster width > 1).
+
+            Returns None when cluster width is 1 (no AG). The caller must hold the
+            tensor across launches and pass it via `persistent_output_buffer`.
+            Always sized for a single fabric link.
+        )doc",
+        &ttnn::experimental::dit_fused_distributed_groupnorm_create_stats_buffer,
+        nb::arg("input_tensor"),
+        nb::arg("num_groups"),
+        nb::arg("cluster_axis"),
+        nb::arg("mesh_device"));
+}
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/dit_fused_distributed_groupnorm_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/dit_fused_distributed_groupnorm_nanobind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+namespace nb = nanobind;
+void bind_dit_fused_distributed_groupnorm(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_program_factory.cpp
@@ -1251,8 +1251,8 @@ for (uint32_t f = 0; f < num_forwarders; f++) {
         TensorAccessorArgs(stats_dram_buffer).append_to(fwd_ct);
         forwarder_kernel_ids[f] = CreateKernel(
             program,
-            "ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/dataflow/"
-            "dit_rmsnorm_fused_forwarder.cpp",
+            "ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_norm_common/kernels/dataflow/"
+            "dit_fused_norm_forwarder.cpp",
             CoreRangeSet({CoreRange(forwarder_cores[f], forwarder_cores[f])}),
             WriterDataMovementConfig(fwd_ct));
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_norm_common/kernels/dataflow/dit_fused_norm_forwarder.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_norm_common/kernels/dataflow/dit_fused_norm_forwarder.cpp
@@ -3,7 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Coalescing fabric forwarder for the fused Wan2.2 distributed RMSNorm AG.
+ * Coalescing fabric forwarder for the fused distributed norm stats all-gather.
+ *
+ * Consumers (both must be updated together if the compile-time or runtime arg
+ * layout below changes):
+ *   - ttnn::experimental::prim::DitFusedDistributedRmsnormMeshWorkloadFactory
+ *   - ttnn::experimental::prim::DitFusedDistributedGroupnormMeshWorkloadFactory
+ *
+ * The description below is written in terms of the RMSNorm caller (128 B
+ * sticks, one forwarder per link); GroupNorm uses the same protocol with its
+ * own stick_bytes and a single forwarder.
  *
  * One forwarder core per fabric link (num_forwarders = min(num_links,
  * num_workers)). It owns a contiguous GROUP of worker cores on this chip and

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/sources.cmake
@@ -150,6 +150,7 @@ set(TTNN_OP_EXPERIMENTAL_CCL_NANOBIND_SRCS
     all_reduce_async/all_reduce_async_nanobind.cpp
     rms_allgather/rms_allgather_nanobind.cpp
     dit_fused_distributed_rmsnorm/dit_fused_distributed_rmsnorm_nanobind.cpp
+    dit_fused_distributed_groupnorm/dit_fused_distributed_groupnorm_nanobind.cpp
     llama_reduce_scatter/llama_reduce_scatter_nanobind.cpp
     llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads_nanobind.cpp
     all_to_all_async/all_to_all_async_nanobind.cpp

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -10,6 +10,8 @@
 #include "api/compute/reduce.h"
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/layernorm.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/tilize.h"
@@ -20,6 +22,14 @@
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
 #include "ttnn/operations/normalization/kernel_util/compute/memory.h"
 #include "api/dataflow/dataflow_buffer.h"
+
+// The optional fused activation is applied to the final output tile in DEST, right before it is
+// packed into dfb_out (see "Write out the final output" below). The UNTILIZE_OUT branch routes the
+// output through a different CB chain (dfb_untilize_in_id), so that insertion point would not be
+// the last touch of the data — fail the build rather than fuse into the wrong place.
+#if defined(UNTILIZE_OUT) && defined(SFPU_OP_INIT_ACTIVATION)
+#error "fused activation + UNTILIZE_OUT not wired: untilize consumes dfb_untilize_in, not dfb_out"
+#endif
 
 void kernel_main() {
     /*
@@ -620,6 +630,16 @@ void kernel_main() {
                     dfb_x.wait_front(1);
                     tile_regs_acquire();
                     copy_tile(dfb_x_id, 0, dst0);
+#ifdef SFPU_OP_INIT_ACTIVATION
+                    // Optional fused unary activation (e.g. SiLU). Applied here, after gamma and
+                    // beta and on the final output tile still in DEST, so the result equals
+                    // <act>(group_norm(x)) with the activation consuming the fp32 DEST value rather
+                    // than the rounded output a standalone activation op would read back.
+                    // Safe w.r.t. welford's SFPU replay state: this is the POST stage, all welford
+                    // accumulation for the batch is already finished.
+                    SFPU_OP_INIT_ACTIVATION
+                    SFPU_OP_FUNC_ACTIVATION
+#endif
                     tile_regs_commit();
                     dfb_x.pop_front(1);
                     dfb_out.reserve_back(1);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
@@ -183,18 +183,30 @@ void kernel_main() {
             p_global_means[0] = local_result.mean;
             p_global_vars[0] = local_result.variance;
 
+#ifndef GN_DISTRIBUTED_AG
             // Signal to sender that our partial data is ready
             reduce_receiver_sem.up(noc, mcast_sender_noc_x, mcast_sender_noc_y, 1);
 
             // Wait for sender to signal that it has sent the global data
             reduce_sender_sem.wait(VALID);
             reduce_sender_sem.set(INVALID);
+#endif
 
             local_means_ptr += local_stride_per_group;
             local_vars_ptr += local_stride_per_group;
             global_means_ptr += 2 * single_tile_size_bytes;
             global_vars_ptr += 2 * single_tile_size_bytes;
         }
+
+#ifdef GN_DISTRIBUTED_AG
+        // Batched handshake: signal the master ONCE that all groups' partials are ready, then wait
+        // ONCE for its single batched mcast-back of the GLOBAL (mean, var) for every group. The
+        // master defers its mcast-back until after the cross-device fabric exchange, so the
+        // per-group lock-step above would deadlock that single exchange.
+        reduce_receiver_sem.up(noc, mcast_sender_noc_x, mcast_sender_noc_y, 1);
+        reduce_sender_sem.wait(VALID);
+        reduce_sender_sem.set(INVALID);
+#endif
 
         dfb_ex_partial.pop_front(2);
         dfb_ex_global.push_back(2 * num_groups);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
@@ -42,6 +42,29 @@ void kernel_main() {
 
     constexpr auto src0_args = TensorAccessorArgs<0>();
 
+#ifdef GN_DISTRIBUTED_AG
+    // Fabric all-gather (cross-device Chan merge over cluster_axis). ring_size == 1 never sets
+    // GN_DISTRIBUTED_AG, so the fused op's local path compiles this file's stock text verbatim.
+    constexpr uint32_t ring_size = get_named_compile_time_arg_val("ring_size");
+    constexpr uint32_t stick_bytes = get_named_compile_time_arg_val("stick_bytes");
+    constexpr uint32_t num_chunks_per_device = get_named_compile_time_arg_val("num_chunks_per_device");
+    constexpr uint32_t fwd_arrival_sem_id = get_named_compile_time_arg_val("fwd_arrival_sem_id");
+    constexpr uint32_t go_sem_id = get_named_compile_time_arg_val("go_sem_id");
+    constexpr uint32_t packet_cb_id = get_named_compile_time_arg_val("packet_cb_id");
+    constexpr uint32_t stats_local_cb_id = get_named_compile_time_arg_val("stats_local_cb_id");
+    constexpr uint32_t stats_gathered_cb_id = get_named_compile_time_arg_val("stats_gathered_cb_id");
+    // Per-device element count per group, the per-subgroup COUNT_PER_VALUE for the cross-device
+    // combine. num_rows_per_group is PER CORE, so scale by the mcast-group core count.
+    constexpr uint32_t count_per_device = num_channels_per_group * num_rows_per_group * num_mcast_cores;
+    // The gathered stats sticks are bf16 [mean, var] pairs; an fp32 stats CB would need a different
+    // stick layout and stride. Fail the build rather than silently misread the gather.
+    static_assert(
+        get_named_compile_time_arg_val("stats_is_fp32") == 0,
+        "GN_DISTRIBUTED_AG requires bf16 stats CBs (stats_is_fp32 == 0)");
+    // Appended after src0's positional accessor block.
+    constexpr auto stats_dram_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
+#endif
+
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t start_id = get_arg_val<uint32_t>(2);
     const uint32_t num_channels_tiles = get_arg_val<uint32_t>(4);
@@ -69,6 +92,7 @@ void kernel_main() {
 
     tt_l1_ptr uint32_t* noc_coord_x;
     tt_l1_ptr uint32_t* noc_coord_y;
+    uint32_t noc_arg_base;
 
     // number of cores in mcast groups
     uint32_t num_mcast_cores_first_group;
@@ -89,8 +113,7 @@ void kernel_main() {
         mcast_last_group_dest_noc_end_y = get_arg_val<uint32_t>(20);
         num_mcast_cores_last_group = get_arg_val<uint32_t>(21);
 
-        noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(22));
-        noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(22 + num_mcast_cores));
+        noc_arg_base = 22;
 
     } else if (has_mcast_first_group and not has_mcast_last_group) {
         mcast_first_group_dest_noc_start_x = get_arg_val<uint32_t>(12);
@@ -99,8 +122,7 @@ void kernel_main() {
         mcast_first_group_dest_noc_end_y = get_arg_val<uint32_t>(15);
         num_mcast_cores_first_group = get_arg_val<uint32_t>(16);
 
-        noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(17));
-        noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(17 + num_mcast_cores));
+        noc_arg_base = 17;
 
     } else if (not has_mcast_first_group and has_mcast_last_group) {
         mcast_last_group_dest_noc_start_x = get_arg_val<uint32_t>(12);
@@ -109,13 +131,14 @@ void kernel_main() {
         mcast_last_group_dest_noc_end_y = get_arg_val<uint32_t>(15);
         num_mcast_cores_last_group = get_arg_val<uint32_t>(16);
 
-        noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(17));
-        noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(17 + num_mcast_cores));
+        noc_arg_base = 17;
 
     } else {
-        noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(12));
-        noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(12 + num_mcast_cores));
+        noc_arg_base = 12;
     }
+
+    noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(noc_arg_base));
+    noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(noc_arg_base + num_mcast_cores));
 
     Noc noc;
     Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
@@ -162,6 +185,24 @@ void kernel_main() {
     constexpr uint32_t local_stride_per_group = local_stride * single_row_size_bytes;
 
     const auto src_a = TensorAccessor(src0_args, src_addr);
+
+#ifdef GN_DISTRIBUTED_AG
+    // ---- Fabric all-gather setup ----
+    const uint32_t fabric_base = noc_arg_base + 2u * num_mcast_cores;
+    const uint32_t stats_dram_addr = get_arg_val<uint32_t>(fabric_base + 0);
+    const uint32_t fwd_x = get_arg_val<uint32_t>(fabric_base + 1);
+    const uint32_t fwd_y = get_arg_val<uint32_t>(fabric_base + 2);
+    const uint32_t my_slot = get_arg_val<uint32_t>(fabric_base + 3);
+    const uint32_t my_forwarder_index = get_arg_val<uint32_t>(fabric_base + 4);
+    DataflowBuffer dfb_packet(packet_cb_id);
+    DataflowBuffer dfb_stats_local(stats_local_cb_id);
+    DataflowBuffer dfb_stats_gathered(stats_gathered_cb_id);
+    Semaphore<> fwd_arrival_sem(fwd_arrival_sem_id);
+    Semaphore<> go_sem(go_sem_id);
+    // The packet CB is created on the whole grid, so the forwarder's copy is at this same address.
+    const uint32_t fwd_packet_buf_addr = dfb_packet.get_write_ptr();
+    const auto stats_dram = TensorAccessor(stats_dram_args, stats_dram_addr);
+#endif
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = dfb_in0.get_read_ptr();
@@ -238,8 +279,26 @@ void kernel_main() {
         auto local_vars_ptr = local_means_ptr + single_tile_size_bytes;
 
         dfb_ex_global.reserve_back(2 * num_groups);
-        auto global_means_ptr = dfb_ex_global.get_write_ptr();
+        const auto global_base_ptr = dfb_ex_global.get_write_ptr();
+        auto global_means_ptr = global_base_ptr;
         auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
+
+#ifdef GN_DISTRIBUTED_AG
+        // Per-device stats stick (bf16 [mean, var] per group), staged for the fabric AG.
+        dfb_stats_local.reserve_back(1);
+        volatile tt_l1_ptr uint16_t* stick_u16 =
+            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(dfb_stats_local.get_write_ptr());
+
+        // Batched intra-device handshake: wait ONCE for every receiver to have published ALL of its
+        // groups' partials (each receiver signals once, after its per-group loop). The mcast-back is
+        // deferred to a single batched broadcast after the fabric exchange, so the per-group
+        // signal/wait lock-step below (which would deadlock a single exchange) is batched here and
+        // in the receiver. Sync granularity only: the arithmetic and the mcast'd bytes are identical.
+        if constexpr (num_mcast_cores > 1) {
+            reduce_receiver_sem.wait(num_mcast_cores - 1);
+            reduce_receiver_sem.set(0);
+        }
+#endif
 
         for (uint32_t m = 0; m < num_groups; ++m) {
             // Read mean and variance arrays from dfb_ex_partial, then combine using Welford
@@ -258,9 +317,12 @@ void kernel_main() {
             p_global_vars[0] = local_result.variance;
 
             if constexpr (num_mcast_cores > 1) {
-                // Wait until all other cores have signaled that their partial data is ready
+#ifndef GN_DISTRIBUTED_AG
+                // Wait until all other cores have signaled that their partial data is ready.
+                // (GN_DISTRIBUTED_AG hoists this to a single batched wait before the loop.)
                 reduce_receiver_sem.wait(num_mcast_cores - 1);
                 reduce_receiver_sem.set(0);
+#endif
 
                 for (uint32_t i = 1; i < num_mcast_cores; ++i) {
                     UnicastEndpoint remote_ep;
@@ -292,6 +354,14 @@ void kernel_main() {
             p_global_means[0] = global_result.mean;
             p_global_vars[0] = global_result.variance;
 
+#ifdef GN_DISTRIBUTED_AG
+            // Stage the DEVICE-GLOBAL stat (post intra-device combine) for the fabric AG — not the
+            // per-core local, so the cross-device Chan merge sees full per-device statistics.
+            stick_u16[m * 2 + 0] = global_result.mean;
+            stick_u16[m * 2 + 1] = global_result.variance;
+#endif
+
+#ifndef GN_DISTRIBUTED_AG
             if constexpr (num_mcast_cores > 1) {
                 // mcast to other cores
                 MulticastEndpoint mcast_dst;
@@ -365,12 +435,144 @@ void kernel_main() {
                 }
                 noc.async_write_barrier();
             }
+#endif
 
             local_means_ptr += local_stride_per_group;
             local_vars_ptr += local_stride_per_group;
             global_means_ptr += 2 * single_tile_size_bytes;
             global_vars_ptr += 2 * single_tile_size_bytes;
         }
+
+#ifdef GN_DISTRIBUTED_AG
+        // ---- Cross-device all-gather + Welford (Chan) merge over cluster_axis ----
+        // dfb_ex_global holds this device's per-group DEVICE-GLOBAL (mean, var). Publish this
+        // master's sub-stick, ring-gather every device's, and Chan-merge into the GLOBAL stat.
+
+        // 1. Publish this master's sub-stick to the forwarder packet buffer + signal arrival.
+        dfb_stats_local.push_back(1);
+        dfb_stats_local.wait_front(1);
+        UnicastEndpoint fwd_ep;
+        noc.async_write(
+            CoreLocalMem<uint32_t>(dfb_stats_local.get_read_ptr()),
+            fwd_ep,
+            stick_bytes,
+            {},
+            {.noc_x = fwd_x, .noc_y = fwd_y, .addr = fwd_packet_buf_addr + my_slot * stick_bytes});
+        noc.async_write_barrier();
+        fwd_arrival_sem.up(noc, fwd_x, fwd_y, 1);
+        dfb_stats_local.pop_front(1);
+
+        // 2. Wait for the ring gather to land in DRAM (forwarder increments our go-sem).
+        go_sem.wait_min(1);
+        go_sem.set(0);
+
+        // 3. Read the ring_size sub-sticks (our slot) from DRAM into the gathered CB.
+        dfb_stats_gathered.reserve_back(ring_size);
+        const uint32_t gbase = dfb_stats_gathered.get_write_ptr();
+        for (uint32_t d = 0; d < ring_size; d++) {
+            const uint32_t page_idx = d * num_chunks_per_device + my_forwarder_index;
+            noc.async_read(
+                stats_dram,
+                CoreLocalMem<uint32_t>(gbase + d * stick_bytes),
+                stick_bytes,
+                {.page_id = page_idx, .offset_bytes = my_slot * stick_bytes},
+                {});
+        }
+        noc.async_read_barrier();
+        dfb_stats_gathered.push_back(ring_size);
+
+        // 4. Chan-merge the ring_size per-device stats per group; overwrite dfb_ex_global.
+        dfb_stats_gathered.wait_front(ring_size);
+        auto gathered_u16 = reinterpret_cast<volatile uint16_t*>(gbase);
+        constexpr uint32_t stick_stride_u16 = stick_bytes / 2;  // uint16 elements per device stick
+        auto out_ptr = global_base_ptr;
+        for (uint32_t m = 0; m < num_groups; ++m) {
+            auto merged = combine_welford_stats<ring_size, count_per_device, stick_stride_u16>(
+                gathered_u16 + m * 2, gathered_u16 + m * 2 + 1);
+            auto p_out_means = reinterpret_cast<volatile uint16_t*>(out_ptr);
+            auto p_out_vars = reinterpret_cast<volatile uint16_t*>(out_ptr + single_tile_size_bytes);
+            p_out_means[0] = merged.mean;
+            p_out_vars[0] = merged.variance;
+            out_ptr += 2 * single_tile_size_bytes;
+        }
+        dfb_stats_gathered.pop_front(ring_size);
+
+        // Batched mcast-back: broadcast the whole dfb_ex_global region (the GLOBAL stat for every
+        // group) to the receiver cores in one shot, then release them with one semaphore multicast.
+        if constexpr (num_mcast_cores > 1) {
+            constexpr uint32_t mcast_bytes = 2 * num_groups * single_tile_size_bytes;
+            MulticastEndpoint mcast_dst;
+            noc.async_write_multicast(
+                CoreLocalMem<uint32_t>(global_base_ptr),
+                mcast_dst,
+                mcast_bytes,
+                num_mcast_cores_mid_group,
+                {},
+                {.noc_x_start = mcast_dest_noc_start_x,
+                 .noc_y_start = mcast_dest_noc_start_y,
+                 .noc_x_end = mcast_dest_noc_end_x,
+                 .noc_y_end = mcast_dest_noc_end_y,
+                 .addr = global_base_ptr},
+                true);
+            reduce_sender_sem.set_multicast(
+                noc,
+                mcast_dest_noc_start_x,
+                mcast_dest_noc_start_y,
+                mcast_dest_noc_end_x,
+                mcast_dest_noc_end_y,
+                num_mcast_cores_mid_group,
+                false);
+
+            if (has_mcast_first_group) {
+                MulticastEndpoint mcast_first_group_dst;
+                noc.async_write_multicast(
+                    CoreLocalMem<uint32_t>(global_base_ptr),
+                    mcast_first_group_dst,
+                    mcast_bytes,
+                    num_mcast_cores_first_group,
+                    {},
+                    {.noc_x_start = mcast_first_group_dest_noc_start_x,
+                     .noc_y_start = mcast_first_group_dest_noc_start_y,
+                     .noc_x_end = mcast_first_group_dest_noc_end_x,
+                     .noc_y_end = mcast_first_group_dest_noc_end_y,
+                     .addr = global_base_ptr},
+                    true);
+                reduce_sender_sem.set_multicast(
+                    noc,
+                    mcast_first_group_dest_noc_start_x,
+                    mcast_first_group_dest_noc_start_y,
+                    mcast_first_group_dest_noc_end_x,
+                    mcast_first_group_dest_noc_end_y,
+                    num_mcast_cores_first_group,
+                    false);
+            }
+
+            if (has_mcast_last_group) {
+                MulticastEndpoint mcast_last_group_dst;
+                noc.async_write_multicast(
+                    CoreLocalMem<uint32_t>(global_base_ptr),
+                    mcast_last_group_dst,
+                    mcast_bytes,
+                    num_mcast_cores_last_group,
+                    {},
+                    {.noc_x_start = mcast_last_group_dest_noc_start_x,
+                     .noc_y_start = mcast_last_group_dest_noc_start_y,
+                     .noc_x_end = mcast_last_group_dest_noc_end_x,
+                     .noc_y_end = mcast_last_group_dest_noc_end_y,
+                     .addr = global_base_ptr},
+                    true);
+                reduce_sender_sem.set_multicast(
+                    noc,
+                    mcast_last_group_dest_noc_start_x,
+                    mcast_last_group_dest_noc_start_y,
+                    mcast_last_group_dest_noc_end_x,
+                    mcast_last_group_dest_noc_end_y,
+                    num_mcast_cores_last_group,
+                    false);
+            }
+            noc.async_write_barrier();
+        }
+#endif
 
         dfb_ex_partial.pop_front(2);
         dfb_ex_global.push_back(2 * num_groups);

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -74,6 +74,9 @@ set(TTNNCPP_SRCS
     cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/dit_fused_distributed_rmsnorm.cpp
     cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_device_operation.cpp
     cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_program_factory.cpp
+    cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/dit_fused_distributed_groupnorm.cpp
+    cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/device/dit_fused_distributed_groupnorm_device_operation.cpp
+    cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_groupnorm/device/dit_fused_distributed_groupnorm_program_factory.cpp
     cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
     cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.cpp
     cpp/ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn_common.cpp


### PR DESCRIPTION
### PR Category
Feature

### Summary
This PR adds fused spatiality distributed group-norm so tensors stay sharded without the need to gather and re_partition 
     To link an issue: Closes #50143 

### Notes for reviewers
Only integrated in DiT models (specifically incoming Flux2). This implementation had been separated from existing groupnorm op to reduce the chance of breaking any model that uses the current groupnorm. It basically applies the chan's parallel algoritm over the current wellford's  They can be merged in the future.

### Relevant tests
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t1-unit-tests.yaml/badge.svg?branch=sadesoye/fused_silu_distributed_GN)](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t1-unit-tests.yaml?query=branch:sadesoye/fused_silu_distributed_GN) — `model=dit-common` runs `models/tt_dit/tests/unit/`, which covers the fused
  distributed GroupNorm on N150 (local) and BH QuietBox (4-device, exercises the fabric all-gather).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sadesoye/fused_silu_distributed_GN)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sadesoye/fused_silu_distributed_GN)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sadesoye/fused_silu_distributed_GN)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sadesoye/fused_silu_distributed_GN)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/fused_silu_distributed_GN)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/fused_silu_distributed_GN)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sadesoye/fused_silu_distributed_GN)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sadesoye/fused_silu_distributed_GN)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sadesoye/fused_silu_distributed_GN)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sadesoye/fused_silu_distributed_GN)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/fused_silu_distributed_GN)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/fused_silu_distributed_GN)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sadesoye/fused_silu_distributed_GN)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sadesoye/fused_silu_distributed_GN)
