### PR TITLE
[Bug fix] Compile only the general relay_paged read loop on an erisc, unbreaking the eth prefetcher

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -296,6 +296,20 @@ static uint32_t downstream_data_ptr_s = dispatch_s_buffer_base;
 static uint32_t ringbuffer_wp = scratch_db_base;
 static uint32_t ringbuffer_offset = 0;
 
+// Whether to compile the specialized shapes of the relay_paged read loop, below. Each is specialized for a property
+// of the command that holds for its whole duration, and each costs its own copy of the loop.
+//
+// A Tensix prefetcher has room for them: its kernel text region is 1432 KB. An erisc one has 24 KB less the erisc
+// firmware's own text, which on Wormhole leaves 21424 B, and the fan-out is what took that build over the line
+// (issue #52429). So an erisc compiles the general shape alone. It keeps the bank walk, which is not part of the
+// cost -- it replaces address generation rather than adding to it -- and gives up programming the transaction
+// length once per command and folding a shared bank offset into the row address.
+#if defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_ERISC)
+constexpr bool specialize_paged_read_loop = false;
+#else
+constexpr bool specialize_paged_read_loop = true;
+#endif
+
 // Whether every interleaved bank carries the same base offset, for DRAM and for L1. That is what lets the relay_paged
 // read loop fold the offset into the row address and stop reprogramming the source address per read. The bank tables
 // are fixed once firmware init has written them, so this is scanned once in kernel_main rather than per command.
@@ -304,7 +318,10 @@ static bool l1_bank_offsets_uniform = false;
 
 template <bool is_dram>
 FORCE_INLINE bool bank_offsets_uniform() {
-    if constexpr (is_dram) {
+    if constexpr (!specialize_paged_read_loop) {
+        // The folding path is not compiled, so nothing reads the scan and kernel_main does not run it.
+        return false;
+    } else if constexpr (is_dram) {
         return dram_bank_offsets_uniform;
     } else {
         return l1_bank_offsets_uniform;
@@ -1324,10 +1341,13 @@ FORCE_INLINE uint32_t read_pages_into_scratch(
 // per chunk and each loop body is free of it.
 //
 // Deliberately out of line. Inlined, the three loops below were emitted at both call sites and for both values of
-// is_dram -- twelve read loops, half of them redundant, and 1.7 KB of dispatch code that the eth prefetcher's 22 KB
+// is_dram -- twelve read loops, half of them redundant, and 1.7 KB of dispatch code that the eth prefetcher's 21 KB
 // kernel region does not have. Out of line the loops are still inlined here, so the per-page work is unchanged, and
 // the one call per scratch buffer is amortized over every page read into it: on Blackhole a 64 MB paged read holds
 // to within 0.5% from 32 B pages up, on DRAM and on L1.
+//
+// Where specialize_paged_read_loop is false only the general loop is compiled, and both callers pass flags that are
+// constant-false, so the choice below folds away with the other two loops.
 template <bool is_dram, typename AddrGen>
 __attribute__((noinline)) uint32_t read_pages_into_scratch(
     bool single_read,
@@ -1337,13 +1357,18 @@ __attribute__((noinline)) uint32_t read_pages_into_scratch(
     uint32_t scratch_read_addr,
     uint32_t amt_to_read,
     uint32_t page_size) {
-    if (!single_read) {
+    if constexpr (specialize_paged_read_loop) {
+        if (!single_read) {
+            return read_pages_into_scratch<false, false>(addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
+        }
+        if (folded_offset) {
+            return read_pages_into_scratch<true, true>(addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
+        }
+        return read_pages_into_scratch<true, false>(addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
+    } else {
+        ASSERT(!single_read && !folded_offset);
         return read_pages_into_scratch<false, false>(addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
     }
-    if (folded_offset) {
-        return read_pages_into_scratch<true, true>(addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
-    }
-    return read_pages_into_scratch<true, false>(addr_gen, walker, scratch_read_addr, amt_to_read, page_size);
 }
 
 // This fn prefetches data from DRAM memory and writes data to the dispatch core.
@@ -1412,7 +1437,7 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
     // command buffer with is their own, since the writes to the dispatcher go out on a different one. Programming it
     // with no send is the same thing paged_read_into_cmddat_q and noc_read_64bit_any_len do, and leaves the address
     // registers to the read loop, which has to write them anyway.
-    const bool single_read = page_size <= NOC_MAX_BURST_SIZE;
+    const bool single_read = specialize_paged_read_loop && page_size <= NOC_MAX_BURST_SIZE;
     if (single_read) {
         noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sndL, CQ_NOC_send, CQ_NOC_WAIT>(
             noc_index, 0, 0, 0, page_size);
@@ -3125,8 +3150,10 @@ void kernel_main() {
     to_dev_id = get_arg_val<uint32_t>(OFFSETOF_TO_DEV_ID);
     router_direction = get_arg_val<uint32_t>(OFFSETOF_ROUTER_DIRECTION);
 
-    dram_bank_offsets_uniform = InterleavedBankWalker<true>::scan_offsets_uniform();
-    l1_bank_offsets_uniform = InterleavedBankWalker<false>::scan_offsets_uniform();
+    if constexpr (specialize_paged_read_loop) {
+        dram_bank_offsets_uniform = InterleavedBankWalker<true>::scan_offsets_uniform();
+        l1_bank_offsets_uniform = InterleavedBankWalker<false>::scan_offsets_uniform();
+    }
 
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();


### PR DESCRIPTION
### PR Category

Bug fix.

### Summary

Fixes #52429. `ttnn sweeps t3k / mesh1x1_col_1d_p5` has failed since 2026-08-06 because the prefetcher no longer fits on an idle eth core:

```
kernels/cq_prefetch/.../idle_erisc/idle_erisc.elf:
  segment[0] [0x4020,+0x566c) overflows region:0 limit of 0x53b0 bytes, reduce the size of code
```

22124 B of text against 21424 B — 700 B over. The budget is `MEM_IERISC_KERNEL_SIZE` (24 KB) less the idle-erisc firmware's own text (3152 B), emitted as a `.segments` limit by `kernel_ierisc.ld` and enforced by `ElfFile::Impl::TrimSegments`. The sweep then hangs rather than failing: the throw lands in the child process and the harness kills it on timeout as `FAIL_CRASH_HANG`.

The cause is mine — #51793, which specialized `process_relay_paged_cmd`'s read loop on two properties that hold for a whole command (whether a page fits one burst, and whether the interleaved banks share a base offset) and compiled a loop for each combination. On Tensix those are paid out of a 1432 KB kernel text region; an erisc has ~21 KB. The blame is by elimination and by measurement: the same job passed at `042afb80a26f` and failed at `d68d60cec42e`, #51793 is the only commit in that window touching `cq_prefetch.cpp` or anything it includes, and swapping the file for its parent revision and re-JITting moves a Blackhole prefetcher from 33736 B of text to 32696 B.

An erisc now compiles the general loop alone. It keeps the bank walk — that is not part of the cost, it replaces address generation rather than adding to it — and gives up programming the transaction length once per command and folding a shared bank offset into the row address. Both flags become compile-time `false` there, so the choice between loops folds away along with the two loops it would have chosen, as does the one-time uniform-offset scan in `kernel_main`.

Worker dispatch is untouched, which is where the 30–65 % relay_paged gain was measured and where every arch's default dispatch core type puts the prefetcher.

### Notes for reviewers

**The size claim, and how it was taken.** Nothing available to me builds an idle-erisc prefetcher — the p100a here has no eth cores (`No core coordinate found at location: (0, 0, ETH, LOGICAL)`), and no reachable T3K is free (the yyz LLMBoxes are all allocated, and the one that is free, `wh-lb-44`, is drained under DEVINFRA-5607 for exactly the broken inter-card links this needs; I confirmed it cannot map a t3k MGD). So the measurement is the erisc *code shape* forced on for a Blackhole Tensix build, which compiles the same source through the same removal:

| | text |
|---|---|
| before #51793 | 32696 |
| main today | 33736 |
| this PR, erisc shape | **32004** |
| this PR, Tensix | 33736 (byte-identical to main) |

1732 B recovered against a 700 B overflow, and 692 B below where the kernel sat before #51793 — the walk is a net size win over `TensorAccessor::get_noc_addr`. Different arch, different opt level and a different prefetch variant than the T3K build, so treat the margin as wide rather than exact. **The eth build itself is unverified**; the scheduled `ttnn - run sweeps model traced` job is what will confirm it.

**Correctness of the loop the erisc now always takes.** `read_pages_into_scratch<false, false>` is not new code — it is the shape pages larger than one burst already take — but until now it never ran for small pages. Both suites below were run twice, once with the erisc shape forced on so that every page went through it, and once normally, with `TT_METAL_WATCHER=1` throughout, which is what compiles in the per-page comparison of the walk's address against `addr_gen.get_noc_addr`:

- `unit_tests_dispatch --gtest_filter='UnitMeshCQSingleCard*BufferFixture*'` on a Blackhole p100a — 58/58 both ways.

**Why CI only caught this in one job.** Not the profiler: `DISPATCH_KERNEL` gates instrumentation out unless `PROFILER_OPT_DO_DISPATCH_CORES` is set, and the prefetch text is byte-identical with and without `TT_METAL_DEVICE_PROFILER=1`. It is eth dispatch. Wormhole core descriptors default to `dispatch_core_type: tensix`, and `tests/sweep_framework/sweep_utils/mesh_tensor_utils.py` opens with `prefer_eth=True` for every wormhole single-host caller, so the model-traced sweeps are effectively the only job that builds this kernel at all. The n150/n300 sweeps pass on a smaller variant, which is also why my own `TT_METAL_GTEST_ETH_DISPATCH=1` runs on an n150 for #51793 did not catch this — that check needs a T3K to mean anything.

**Left undone.** Nothing guards the ceiling. The next kilobyte of prefetch growth hits it again with the same single nightly sweeps job as the tripwire, and the failure mode is a hang, not a clean error. A T3K eth-dispatch smoke test in a per-PR pipeline would be the fix; I would rather agree that is wanted, and where it belongs, than bolt it onto this.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/eth-prefetch-read-loop-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/eth-prefetch-read-loop-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/eth-prefetch-read-loop-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/eth-prefetch-read-loop-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/eth-prefetch-read-loop-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/eth-prefetch-read-loop-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/eth-prefetch-read-loop-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/eth-prefetch-read-loop-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/eth-prefetch-read-loop-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/eth-prefetch-read-loop-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/eth-prefetch-read-loop-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/eth-prefetch-read-loop-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/eth-prefetch-read-loop-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/eth-prefetch-read-loop-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/eth-prefetch-read-loop-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/eth-prefetch-read-loop-size)
