### PR TITLE
Optimize CB memory tracking for tt-smi

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -7,6 +7,7 @@ set(UNIT_TESTS_API_SOURCES
     allocator/test_overlapped_bank_manager.cpp
     allocator/test_per_core_bank_manager.cpp
     circular_buffer/test_CircularBuffer_allocation.cpp
+    circular_buffer/test_CircularBuffer_cb_tracking.cpp
     circular_buffer/test_CircularBuffer_creation.cpp
     circular_buffer/test_CircularBuffer_non_blocking.cpp
     circular_buffer/test_CircularBuffer_wrapping.cpp

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1101,21 +1101,99 @@ std::shared_ptr<distributed::MeshDevice> Device::get_mesh_device() { return mesh
 // Program tracking for accurate CB memory reporting
 void Device::register_program(detail::ProgramImpl* program) {
     std::lock_guard<std::mutex> lock(active_programs_mutex_);
-    active_programs_.insert(program);
+    bool inserted = active_programs_.insert(program).second;
+    if (!inserted) {
+        return;  // already tracked; its CB coverage is already folded in
+    }
+
+    // Snapshot this program's per-core CB L1 regions and fold them into the running total. Same
+    // source of truth as the from-scratch oracle: ProgramImpl::get_cb_l1_regions_per_core.
+    detail::ProgramImpl::CbL1RegionsPerCore prog_regions;
+    program->get_cb_l1_regions_per_core(prog_regions, this->id(), program->get_num_cb_devices());
+
+    // Copy into the device-local region-map type (it differs from CbL1RegionsPerCore only in the
+    // hash functor) so the snapshot can be stored without pulling ProgramImpl's full definition
+    // into the header.
+    CbL1Regions regions(prog_regions.begin(), prog_regions.end());
+
+    apply_cb_coverage_locked(regions, +1);
+    active_program_cb_regions_.emplace(program, std::move(regions));
 }
 
 void Device::unregister_program(detail::ProgramImpl* program) {
     std::lock_guard<std::mutex> lock(active_programs_mutex_);
-    active_programs_.erase(program);
+    if (active_programs_.erase(program) == 0) {
+        return;  // not tracked
+    }
+    // Remove exactly the intervals that were folded in at register time.
+    if (active_program_cb_regions_.count(program) != 0) {
+        apply_cb_coverage_locked(active_program_cb_regions_.at(program), -1);
+        active_program_cb_regions_.erase(program);
+    }
+}
+
+void Device::apply_cb_coverage_locked(const CbL1Regions& regions, int sign) {
+    // Fold the given per-core intervals into the per-core sweep-line, recomputing only the touched
+    // cores' union measure and adjusting the running device total accordingly.
+    for (const auto& core_entry : regions) {
+        const CoreCoord& core = core_entry.first;
+        const std::vector<std::pair<uint64_t, uint64_t>>& intervals = core_entry.second;
+
+        CbCoreCoverage& cov = cb_core_coverage_[core];
+        total_cb_allocated_ -= cov.covered_length;
+
+        for (const std::pair<uint64_t, uint64_t>& interval : intervals) {
+            uint64_t start = interval.first;
+            uint64_t end = interval.second;
+            if (start >= end) {
+                continue;  // skip empty/degenerate interval (contributes zero to the measure)
+            }
+            cov.deltas[start] += sign;
+            cov.deltas[end] -= sign;
+        }
+
+        // Recompute this core's union measure as the total length where the running coverage count
+        // is > 0 -- identical to the sort-and-merge in the from-scratch oracle. Prune zeroed keys
+        // so the map does not grow unboundedly as programs come and go.
+        uint64_t covered = 0;
+        int count = 0;
+        uint64_t prev_addr = 0;
+        std::map<uint64_t, int>::iterator delta_it = cov.deltas.begin();
+        while (delta_it != cov.deltas.end()) {
+            if (delta_it->second == 0) {
+                delta_it = cov.deltas.erase(delta_it);
+                continue;
+            }
+            if (count > 0) {
+                covered += delta_it->first - prev_addr;
+            }
+            count += delta_it->second;
+            prev_addr = delta_it->first;
+            ++delta_it;
+        }
+
+        cov.covered_length = covered;
+        total_cb_allocated_ += covered;
+        if (cov.deltas.empty()) {
+            cb_core_coverage_.erase(core);
+        }
+    }
 }
 
 uint64_t Device::get_total_cb_allocated() const {
     std::lock_guard<std::mutex> lock(active_programs_mutex_);
+    return total_cb_allocated_;
+}
 
+uint64_t Device::get_total_cb_allocated_from_scratch() const {
+    std::lock_guard<std::mutex> lock(active_programs_mutex_);
+    return compute_total_cb_allocated_from_scratch_locked();
+}
+
+uint64_t Device::compute_total_cb_allocated_from_scratch_locked() const {
     // For PHYSICAL CB tracking accounting for address reuse:
     // Collect L1 regions per core and merge overlapping addresses
     // This handles cached/traced programs that share the same physical L1 addresses on the same core
-
     detail::ProgramImpl::CbL1RegionsPerCore device_regions_per_core;
 
     for (const auto* program : active_programs_) {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1122,7 +1122,6 @@ uint64_t Device::get_total_cb_allocated() const {
         size_t num_devices = program->get_num_cb_devices();
 
         // Append this program's per-core L1 regions directly into the device-wide map
-        // (out-param avoids a per-program temp map + merge copy).
         program->get_cb_l1_regions_per_core(device_regions_per_core, this->id(), num_devices);
     }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1116,19 +1116,14 @@ uint64_t Device::get_total_cb_allocated() const {
     // Collect L1 regions per core and merge overlapping addresses
     // This handles cached/traced programs that share the same physical L1 addresses on the same core
 
-    std::map<CoreCoord, std::vector<std::pair<uint64_t, uint64_t>>> device_regions_per_core;
+    detail::ProgramImpl::CbL1RegionsPerCore device_regions_per_core;
 
     for (const auto* program : active_programs_) {
         size_t num_devices = program->get_num_cb_devices();
 
-        // Get L1 regions per core for this program on this device
-        auto program_regions = program->get_cb_l1_regions_per_core(this->id(), num_devices);
-
-        // Merge into device-wide map
-        for (const auto& [core, regions] : program_regions) {
-            auto& core_regions = device_regions_per_core[core];
-            core_regions.insert(core_regions.end(), regions.begin(), regions.end());
-        }
+        // Append this program's per-core L1 regions directly into the device-wide map
+        // (out-param avoids a per-program temp map + merge copy).
+        program->get_cb_l1_regions_per_core(device_regions_per_core, this->id(), num_devices);
     }
 
     // Merge overlapping regions per core to get actual physical usage

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -4,10 +4,15 @@
 
 #pragma once
 
+#include <cstdint>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include <tt-metalium/device.hpp>
 #include <hostdevcommon/common_values.hpp>
@@ -184,6 +189,9 @@ public:
     void register_program(detail::ProgramImpl* program);
     void unregister_program(detail::ProgramImpl* program);
     uint64_t get_total_cb_allocated() const;
+    // Reference/validation path (used by tests): recomputes the CB-allocated total from scratch
+    // using the pre-incremental O(active_programs) algorithm. Not on any hot path.
+    uint64_t get_total_cb_allocated_from_scratch() const;
 
 private:
     // Deprecated overrides for sub_device_manager_tracker
@@ -281,6 +289,38 @@ private:
     // Program tracking for CB memory reporting
     std::unordered_set<detail::ProgramImpl*> active_programs_;
     mutable std::mutex active_programs_mutex_;
+
+    // --- Incremental CB-allocated tracking (all guarded by active_programs_mutex_) -------------
+    // get_total_cb_allocated() previously rescanned every active program on each call (an
+    // O(active_programs) per-core interval merge). Instead, register_program/unregister_program
+    // fold a program's per-core CB L1 intervals into a per-core sweep-line (L1 address ->
+    // coverage-count delta); the device-wide total is the sum of each core's union measure, so the
+    // query is O(1). The original from-scratch algorithm is retained as a debug oracle.
+    struct CbCoreCoordHash {
+        size_t operator()(const CoreCoord& c) const noexcept {
+            return (static_cast<size_t>(c.x) << 32) ^ static_cast<size_t>(c.y);
+        }
+    };
+    // Per-core interval lists ([start, end) L1 regions), keyed by core. Structurally matches
+    // detail::ProgramImpl::CbL1RegionsPerCore but uses a device-local hash so this header does not
+    // need the full ProgramImpl definition.
+    using CbL1Regions = std::unordered_map<CoreCoord, std::vector<std::pair<uint64_t, uint64_t>>, CbCoreCoordHash>;
+    struct CbCoreCoverage {
+        std::map<uint64_t, int> deltas;  // L1 address -> coverage-count delta (sorted ascending)
+        uint64_t covered_length = 0;     // cached measure of the union of intervals on this core
+    };
+    std::unordered_map<CoreCoord, CbCoreCoverage, CbCoreCoordHash> cb_core_coverage_;
+    uint64_t total_cb_allocated_ = 0;  // running sum of covered_length across all cores
+    // Snapshot of each active program's per-core intervals, captured at register time so unregister
+    // removes exactly what was folded in (robust even if the program mutates while registered). The
+    // incremental total is validated against get_total_cb_allocated_from_scratch() by a unit test.
+    std::unordered_map<const detail::ProgramImpl*, CbL1Regions> active_program_cb_regions_;
+
+    // Fold per-core intervals into cb_core_coverage_ with sign +1 (add) or -1 (remove), updating
+    // total_cb_allocated_. Caller must hold active_programs_mutex_.
+    void apply_cb_coverage_locked(const CbL1Regions& regions, int sign);
+    // Debug oracle: original O(active_programs) from-scratch total. Caller must hold the mutex.
+    uint64_t compute_total_cb_allocated_from_scratch_locked() const;
 
     // Friend declaration for experimental API
     friend uint32_t experimental::Device::get_worker_noc_hop_distance(

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
@@ -157,11 +157,9 @@ public:
     // pid: Process ID for per-process tracking
     void update_from_allocator(const class Device* device, pid_t pid);
 
-    // Overload for homogeneous-mesh callers that update every sub-device in a loop.
-    // On such a mesh get_total_cb_allocated() returns the same value for every sub-device, so it is
-    // computed at most once and cached via `cached_cb_allocated` (in/out): empty on the first call
-    // (computed and stored), reused on subsequent calls. Result is identical to calling the 2-arg
-    // overload per device; a debug assertion verifies the cross-device equality.
+    // On a mesh where get_total_cb_allocated() returns the same value for every sub-device,
+    // compute it once and cache via `cached_cb_allocated` (empty on the first call then
+    // reused on subsequent calls.
     void update_from_allocator(const class Device* device, pid_t pid, std::optional<uint64_t>& cached_cb_allocated);
 
     // Get per-chip statistics (for remote device tracking)

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 #include <sys/types.h>
@@ -155,6 +156,13 @@ public:
     // device: Device to query (can be nullptr to skip update)
     // pid: Process ID for per-process tracking
     void update_from_allocator(const class Device* device, pid_t pid);
+
+    // Overload for homogeneous-mesh callers that update every sub-device in a loop.
+    // On such a mesh get_total_cb_allocated() returns the same value for every sub-device, so it is
+    // computed at most once and cached via `cached_cb_allocated` (in/out): empty on the first call
+    // (computed and stored), reused on subsequent calls. Result is identical to calling the 2-arg
+    // overload per device; a debug assertion verifies the cross-device equality.
+    void update_from_allocator(const class Device* device, pid_t pid, std::optional<uint64_t>& cached_cb_allocated);
 
     // Get per-chip statistics (for remote device tracking)
     struct ChipInfo {

--- a/tt_metal/impl/memory_tracking/update_allocator_stats.cpp
+++ b/tt_metal/impl/memory_tracking/update_allocator_stats.cpp
@@ -5,8 +5,10 @@
 #include "impl/device/device_impl.hpp"
 #include "impl/memory_tracking/memory_stats_shm.hpp"
 #include <tt-logger/tt-logger.hpp>
+#include <cassert>
 #include <chrono>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 
 namespace tt::tt_metal {
@@ -15,6 +17,13 @@ namespace tt::tt_metal {
 // Query ONLY locally-allocated CBs (device->get_total_cb_allocated() only counts local CBs)
 // Globally-allocated CBs create L1 Buffers and are already tracked in L1 column
 void SharedMemoryStatsProvider::update_from_allocator(const Device* device, pid_t pid) {
+    // Lone-caller path: no cross-device dedup, compute normally.
+    std::optional<uint64_t> uncached;
+    update_from_allocator(device, pid, uncached);
+}
+
+void SharedMemoryStatsProvider::update_from_allocator(
+    const Device* device, pid_t pid, std::optional<uint64_t>& cached_cb_allocated) {
     if (!region_ || !device) {
         return;
     }
@@ -35,8 +44,23 @@ void SharedMemoryStatsProvider::update_from_allocator(const Device* device, pid_
     }
 
     try {
-        // Query actual LOCALLY-allocated CB usage (globally-allocated CBs are in L1 already)
-        uint64_t cb_allocated = device->get_total_cb_allocated();
+        // Query actual LOCALLY-allocated CB usage (globally-allocated CBs are in L1 already).
+        // On a homogeneous mesh this value is identical across sub-devices, so a caller updating
+        // every sub-device in a loop can compute it once and pass it via cached_cb_allocated: we
+        // fill it on first computation and reuse it thereafter. In debug we recompute and verify
+        // equality, so any future per-device CB layout (which would break the assumption) is
+        // caught rather than silently reported wrong.
+        uint64_t cb_allocated;
+        if (cached_cb_allocated.has_value()) {
+            cb_allocated = *cached_cb_allocated;
+            assert(
+                cb_allocated == device->get_total_cb_allocated() &&
+                "SHM CB-allocated differs across mesh sub-devices; a per-device CB layout must not "
+                "share a cached value (see ProgramImpl::kCbL1LayoutIsDeviceIndependent)");
+        } else {
+            cb_allocated = device->get_total_cb_allocated();
+            cached_cb_allocated = cb_allocated;
+        }
 
         // Update device-wide CB total (query-based, accurate, no accumulation)
         region_->total_cb_allocated.store(cb_allocated, std::memory_order_relaxed);

--- a/tt_metal/impl/memory_tracking/update_allocator_stats.cpp
+++ b/tt_metal/impl/memory_tracking/update_allocator_stats.cpp
@@ -17,7 +17,6 @@ namespace tt::tt_metal {
 // Query ONLY locally-allocated CBs (device->get_total_cb_allocated() only counts local CBs)
 // Globally-allocated CBs create L1 Buffers and are already tracked in L1 column
 void SharedMemoryStatsProvider::update_from_allocator(const Device* device, pid_t pid) {
-    // Lone-caller path: no cross-device dedup, compute normally.
     std::optional<uint64_t> uncached;
     update_from_allocator(device, pid, uncached);
 }
@@ -46,10 +45,7 @@ void SharedMemoryStatsProvider::update_from_allocator(
     try {
         // Query actual LOCALLY-allocated CB usage (globally-allocated CBs are in L1 already).
         // On a homogeneous mesh this value is identical across sub-devices, so a caller updating
-        // every sub-device in a loop can compute it once and pass it via cached_cb_allocated: we
-        // fill it on first computation and reuse it thereafter. In debug we recompute and verify
-        // equality, so any future per-device CB layout (which would break the assumption) is
-        // caught rather than silently reported wrong.
+        // every sub-device in a loop can compute it once and pass it via cached_cb_allocated.
         uint64_t cb_allocated;
         if (cached_cb_allocated.has_value()) {
             cb_allocated = *cached_cb_allocated;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1517,6 +1517,10 @@ void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
     if (not this->local_circular_buffer_allocation_needed_) {
         // Report CB allocations for any NEW devices (using cached addresses)
         if (!new_devices.empty() && !this->circular_buffers_.empty()) {
+            // Homogeneous mesh: get_total_cb_allocated() is identical across sub-devices, so
+            // compute it once and share it across this per-sub-device update loop
+            // (guarded by kCbL1LayoutIsDeviceIndependent).
+            std::optional<uint64_t> cached_cb_total;
             for (const IDevice* dev : new_devices) {
                 for (const auto& circular_buffer : this->circular_buffers_) {
                     if (!circular_buffer->globally_allocated()) {
@@ -1534,7 +1538,11 @@ void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
                 if (device_obj) {
                     device_obj->register_program(this);
                     if (device_obj->get_shm_stats_provider()) {
-                        device_obj->get_shm_stats_provider()->update_from_allocator(device_obj, getpid());
+                        if constexpr (!kCbL1LayoutIsDeviceIndependent) {
+                            cached_cb_total.reset();  // per-device layout: force per-device recompute
+                        }
+                        device_obj->get_shm_stats_provider()->update_from_allocator(
+                            device_obj, getpid(), cached_cb_total);
                     }
                 }
             }
@@ -1593,28 +1601,38 @@ void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
         circular_buffer->set_locally_allocated_address(computed_addr);
     }
 
-    // Register program ONLY with NEW devices (prevents duplicate registration)
+    // Register program ONLY with NEW devices (prevents duplicate registration).
+    // Homogeneous mesh: get_total_cb_allocated() is identical across sub-devices, so compute it
+    // once and share it across this per-sub-device update loop (guarded by the contract flag).
+    std::optional<uint64_t> cached_cb_total;
     for (const IDevice* dev : new_devices) {
         auto* device_obj = dynamic_cast<Device*>(const_cast<IDevice*>(dev));
         if (device_obj) {
             device_obj->register_program(this);
             // Update locally-allocated CB stats via query (accurate even for cached programs)
             if (device_obj->get_shm_stats_provider()) {
-                device_obj->get_shm_stats_provider()->update_from_allocator(device_obj, getpid());
+                if constexpr (!kCbL1LayoutIsDeviceIndependent) {
+                    cached_cb_total.reset();  // per-device layout: force per-device recompute
+                }
+                device_obj->get_shm_stats_provider()->update_from_allocator(device_obj, getpid(), cached_cb_total);
             }
         }
     }
     this->local_circular_buffer_allocation_needed_ = false;
 }
 
-std::map<CoreCoord, std::vector<std::pair<uint64_t, uint64_t>>> detail::ProgramImpl::get_cb_l1_regions_per_core(
-    int device_id, size_t num_devices) const {
+void detail::ProgramImpl::get_cb_l1_regions_per_core(
+    CbL1RegionsPerCore& regions_per_core, int device_id, size_t num_devices) const {
+    // NOTE: this result is currently independent of device_id / num_devices. That independence is
+    // relied upon by Device::get_total_cb_allocated() and the "compute once per mesh" SHM update
+    // fast path. If you start using either argument here, set
+    // ProgramImpl::kCbL1LayoutIsDeviceIndependent = false (program_impl.hpp) so the fast path
+    // falls back to per-device computation.
     (void)device_id;    // TODO: Use device_id once per-device or heterogeneous mesh CB layouts are supported
     (void)num_devices;  // TODO: Use num_devices for multi-device filtering or layout partitioning when implemented
 
-    std::map<CoreCoord, std::vector<std::pair<uint64_t, uint64_t>>> regions_per_core;
-
-    // For each allocator, iterate through all cores in its CoreRange
+    // For each allocator, iterate through all cores in its CoreRange.
+    // Appends directly into the caller-provided map (no per-program temp map / return copy).
     for (const auto& cb_allocator : cb_allocators_) {
         const auto& l1_regions = cb_allocator.l1_regions;
 
@@ -1623,12 +1641,11 @@ std::map<CoreCoord, std::vector<std::pair<uint64_t, uint64_t>>> detail::ProgramI
             for (uint32_t y = cb_allocator.core_range.start_coord.y; y <= cb_allocator.core_range.end_coord.y; y++) {
                 CoreCoord core(x, y);
                 auto& core_regions = regions_per_core[core];
+                core_regions.reserve(core_regions.size() + l1_regions.size());
                 core_regions.insert(core_regions.end(), l1_regions.begin(), l1_regions.end());
             }
         }
     }
-
-    return regions_per_core;
 }
 
 void detail::ProgramImpl::deallocate_circular_buffers() {
@@ -1639,14 +1656,20 @@ void detail::ProgramImpl::deallocate_circular_buffers() {
             tt::tt_metal::GraphTracker::instance().track_deallocate_cb(idevice);
         }
 
-        // Unregister program from ALL devices (matches registration)
+        // Unregister program from ALL devices (matches registration).
+        // Homogeneous mesh: after the same program is removed from each sub-device,
+        // get_total_cb_allocated() is identical across them, so compute it once and share.
+        std::optional<uint64_t> cached_cb_total;
         for (const IDevice* idevice : this->cb_devices_) {
             auto* device = dynamic_cast<Device*>(const_cast<IDevice*>(idevice));
             if (device) {
                 device->unregister_program(this);
                 // Update locally-allocated CB stats via query (accurate after deallocation)
                 if (device->get_shm_stats_provider()) {
-                    device->get_shm_stats_provider()->update_from_allocator(device, getpid());
+                    if constexpr (!kCbL1LayoutIsDeviceIndependent) {
+                        cached_cb_total.reset();  // per-device layout: force per-device recompute
+                    }
+                    device->get_shm_stats_provider()->update_from_allocator(device, getpid(), cached_cb_total);
                 }
             }
         }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1518,8 +1518,7 @@ void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
         // Report CB allocations for any NEW devices (using cached addresses)
         if (!new_devices.empty() && !this->circular_buffers_.empty()) {
             // Homogeneous mesh: get_total_cb_allocated() is identical across sub-devices, so
-            // compute it once and share it across this per-sub-device update loop
-            // (guarded by kCbL1LayoutIsDeviceIndependent).
+            // compute it once and share it across this per-sub-device update loop.
             std::optional<uint64_t> cached_cb_total;
             for (const IDevice* dev : new_devices) {
                 for (const auto& circular_buffer : this->circular_buffers_) {
@@ -1603,7 +1602,7 @@ void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
 
     // Register program ONLY with NEW devices (prevents duplicate registration).
     // Homogeneous mesh: get_total_cb_allocated() is identical across sub-devices, so compute it
-    // once and share it across this per-sub-device update loop (guarded by the contract flag).
+    // once and share it across this per-sub-device update loop.
     std::optional<uint64_t> cached_cb_total;
     for (const IDevice* dev : new_devices) {
         auto* device_obj = dynamic_cast<Device*>(const_cast<IDevice*>(dev));
@@ -1632,7 +1631,6 @@ void detail::ProgramImpl::get_cb_l1_regions_per_core(
     (void)num_devices;  // TODO: Use num_devices for multi-device filtering or layout partitioning when implemented
 
     // For each allocator, iterate through all cores in its CoreRange.
-    // Appends directly into the caller-provided map (no per-program temp map / return copy).
     for (const auto& cb_allocator : cb_allocators_) {
         const auto& l1_regions = cb_allocator.l1_regions;
 

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -321,15 +321,6 @@ public:
     void deallocate_circular_buffers();
 
     // CB tracking for SHM memory reporting.
-    //
-    // Tier-1 perf (guaranteed identical result): the consumer
-    // (Device::get_total_cb_allocated) reduces these regions to a single sum over
-    // cores, which is independent of container type and iteration order. So we
-    //   (1) key by an unordered_map with a strong, collision-free hash instead of
-    //       a std::map (drops O(log n) + red-black node allocation per access), and
-    //   (2) append directly into the caller's map via an out-param, eliminating the
-    //       per-program temporary map and its return/merge copy.
-    // Neither change can alter the computed value.
     struct CbCoreCoordHash {
         size_t operator()(const CoreCoord& c) const noexcept {
             return (static_cast<size_t>(c.x) << 32) ^ static_cast<size_t>(c.y);
@@ -338,7 +329,7 @@ public:
     using CbL1RegionsPerCore =
         std::unordered_map<CoreCoord, std::vector<std::pair<uint64_t, uint64_t>>, CbCoreCoordHash>;
 
-    // Contract flag: true iff get_cb_l1_regions_per_core() (and therefore
+    // True iff get_cb_l1_regions_per_core() (and therefore
     // Device::get_total_cb_allocated()) is independent of device_id / num_devices.
     //
     // When true, the CB-allocated SHM stat is identical across every sub-device of a homogeneous
@@ -346,9 +337,7 @@ public:
     // once and reuse it (eliminating a redundant ~O(active_programs) rescan per sub-device).
     //
     // IMPORTANT: if you start using device_id or num_devices in get_cb_l1_regions_per_core to
-    // produce per-device / heterogeneous CB layouts, set this to false. The update loops then
-    // fall back to recomputing the stat per device. A debug assertion in
-    // SharedMemoryStatsProvider::update_from_allocator also cross-checks this invariant at runtime.
+    // produce per-device / heterogeneous CB layouts, set this to false.
     static constexpr bool kCbL1LayoutIsDeviceIndependent = true;
 
     void get_cb_l1_regions_per_core(CbL1RegionsPerCore& regions_per_core, int device_id, size_t num_devices) const;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -320,9 +320,38 @@ public:
     // Deallocate circular buffers and unregister from devices
     void deallocate_circular_buffers();
 
-    // CB tracking for SHM memory reporting
-    std::map<CoreCoord, std::vector<std::pair<uint64_t, uint64_t>>> get_cb_l1_regions_per_core(
-        int device_id, size_t num_devices) const;
+    // CB tracking for SHM memory reporting.
+    //
+    // Tier-1 perf (guaranteed identical result): the consumer
+    // (Device::get_total_cb_allocated) reduces these regions to a single sum over
+    // cores, which is independent of container type and iteration order. So we
+    //   (1) key by an unordered_map with a strong, collision-free hash instead of
+    //       a std::map (drops O(log n) + red-black node allocation per access), and
+    //   (2) append directly into the caller's map via an out-param, eliminating the
+    //       per-program temporary map and its return/merge copy.
+    // Neither change can alter the computed value.
+    struct CbCoreCoordHash {
+        size_t operator()(const CoreCoord& c) const noexcept {
+            return (static_cast<size_t>(c.x) << 32) ^ static_cast<size_t>(c.y);
+        }
+    };
+    using CbL1RegionsPerCore =
+        std::unordered_map<CoreCoord, std::vector<std::pair<uint64_t, uint64_t>>, CbCoreCoordHash>;
+
+    // Contract flag: true iff get_cb_l1_regions_per_core() (and therefore
+    // Device::get_total_cb_allocated()) is independent of device_id / num_devices.
+    //
+    // When true, the CB-allocated SHM stat is identical across every sub-device of a homogeneous
+    // mesh, so the per-sub-device update loops in allocate/deallocate_circular_buffers compute it
+    // once and reuse it (eliminating a redundant ~O(active_programs) rescan per sub-device).
+    //
+    // IMPORTANT: if you start using device_id or num_devices in get_cb_l1_regions_per_core to
+    // produce per-device / heterogeneous CB layouts, set this to false. The update loops then
+    // fall back to recomputing the stat per device. A debug assertion in
+    // SharedMemoryStatsProvider::update_from_allocator also cross-checks this invariant at runtime.
+    static constexpr bool kCbL1LayoutIsDeviceIndependent = true;
+
+    void get_cb_l1_regions_per_core(CbL1RegionsPerCore& regions_per_core, int device_id, size_t num_devices) const;
     size_t get_num_cb_devices() const { return cb_devices_.size(); }
 
     KernelHandle add_kernel(const std::shared_ptr<Kernel>& kernel, const HalProgrammableCoreType& core_type);


### PR DESCRIPTION
### Summary

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sosborne/memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sosborne/memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sosborne/memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sosborne/memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sosborne/memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sosborne/memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sosborne/memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sosborne/memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sosborne/memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sosborne/memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sosborne/memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sosborne/memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sosborne/memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sosborne/memory-tracking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sosborne/memory-tracking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sosborne/memory-tracking)