### PR TITLE
[Feature] Freeze a Metal 1.0 slice tile factory for the Python fusion framework

### DIFF
--- a/models/experimental/ops/descriptors/data_movement/slice.py
+++ b/models/experimental/ops/descriptors/data_movement/slice.py
@@ -51,7 +51,7 @@ def slice(
 
     output_tensor = ttnn.SliceDeviceOperation.create_output_tensors(params, tensor_args)
 
-    descriptor = ttnn.SliceTileProgramFactory.create_descriptor(params, tensor_args, output_tensor)
+    descriptor = ttnn.SliceTileProgramFactoryForPython.create_descriptor(params, tensor_args, output_tensor)
 
     return OpDescriptor(
         descriptor=descriptor,

--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -244,6 +244,7 @@ target_sources(
             sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_program_factory.hpp
             # slice/
             slice/slice_nanobind.hpp
+            slice/slice_program_factory_tile_for_python.hpp
             slice/device/slice_device_operation.hpp
             slice/device/slice_device_operation_types.hpp
             slice/device/slice_program_factory_rm.hpp

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
@@ -17,7 +17,7 @@
 
 #include "slice.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
-#include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
+#include "ttnn/operations/data_movement/slice/slice_program_factory_tile_for_python.hpp"
 
 namespace ttnn::operations::data_movement::detail {
 
@@ -162,13 +162,13 @@ void bind_slice_descriptor(nb::module_& mod) {
             nb::arg("operation_attributes"),
             nb::arg("tensor_args"));
 
-    nb::class_<ttnn::prim::SliceTileProgramFactory>(mod, "SliceTileProgramFactory")
+    nb::class_<ttnn::for_python::SliceTileProgramFactory>(mod, "SliceTileProgramFactoryForPython")
         .def_static(
             "create_descriptor",
             [](const ttnn::prim::SliceParams& operation_attributes,
                const ttnn::prim::SliceInputs& tensor_args,
                Tensor& tensor_return_value) {
-                return ttnn::prim::SliceTileProgramFactory::create_descriptor(
+                return ttnn::for_python::SliceTileProgramFactory::create_descriptor(
                     operation_attributes, tensor_args, tensor_return_value);
             },
             nb::arg("operation_attributes"),

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_program_factory_tile_for_python.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_program_factory_tile_for_python.cpp
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/data_movement/slice/slice_program_factory_tile_for_python.hpp"
+
+#include <optional>
+#include <span>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::for_python {
+
+tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
+    const ttnn::prim::SliceParams& args, const ttnn::prim::SliceInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input;
+    tt::tt_metal::IDevice* device = input.device();
+
+    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+
+    tt::tt_metal::Buffer* src0_buffer = input.buffer();
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    const auto& input_shape = input.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+
+    // --- CB Descriptor ---
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = 2;
+
+    tt::tt_metal::ProgramDescriptor program_descriptor;
+
+    tt::tt_metal::CBDescriptor cb_desc;
+    cb_desc.total_size = num_input_tiles * single_tile_size;
+    cb_desc.core_ranges = all_cores;
+    cb_desc.format_descriptors.push_back(tt::tt_metal::CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(src0_cb_index),
+        .data_format = cb_data_format,
+        .page_size = single_tile_size});
+    program_descriptor.cbs.push_back(std::move(cb_desc));
+
+    // --- Reader Kernel Descriptor ---
+    // CB index via named compile-time arg (essential for fusion CB remapping).
+    std::vector<uint32_t> reader_compile_time_args = {num_dims};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+
+    // Reader common runtime args: [src_addr, num_unpadded_per_dim..., num_padded_per_dim...]
+    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
+    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
+    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
+    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    accumulated_total_per_dim[0] = num_total_Xt;
+    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+
+    // src0 buffer binding is registered separately below; this vector holds only the per-dim values.
+    std::vector<uint32_t> reader_common_dims(num_dims * 2);
+    std::span<uint32_t> reader_common_dims_view{reader_common_dims};
+    auto num_unpadded_tiles_per_dim = reader_common_dims_view.subspan(0, num_dims);
+    auto num_padded_tiles_per_dim = reader_common_dims_view.subspan(num_dims, num_dims);
+    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
+    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
+    num_padded_tiles_per_dim[0] = num_padded_Xt;
+    num_padded_tiles_per_dim[1] = num_padded_Yt;
+    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
+        num_padded_tiles_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    uint32_t start_offset = ttnn::operations::data_movement::get_tiled_start_offset(input, args.slice_start);
+
+    // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
+    tt::tt_metal::KernelDescriptor::RuntimeArgs reader_runtime_args;
+    uint32_t num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            std::vector<uint32_t> reader_args(2 + num_dims, 0);
+            reader_runtime_args.emplace_back(core, std::move(reader_args));
+            continue;
+        }
+
+        std::vector<uint32_t> reader_args(2 + num_dims);
+        // Compute per-dim indices for this core's starting position
+        reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
+        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
+        uint32_t start_id = reader_args[2] + start_offset;
+        for (uint32_t j = 1; j < num_dims; ++j) {
+            reader_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
+            start_id += reader_args[2 + j] * accumulated_total_per_dim[j - 1];
+        }
+        reader_args[0] = start_id;
+        reader_args[1] = num_tiles_per_core;
+
+        reader_runtime_args.emplace_back(core, std::move(reader_args));
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    tt::tt_metal::KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+        "reader_unary_unpad_dims_interleaved_start_id.cpp";
+    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = all_cores;
+    reader_kernel_desc.compile_time_args = reader_compile_time_args;
+    reader_kernel_desc.named_compile_time_args = {{"dfb_id_in", src0_cb_index}};
+    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
+    tt::tt_metal::KernelDescriptor::RTArgList reader_common;
+    reader_common.reserve(1 + (num_dims * 2));
+    reader_common.push_back(src0_buffer);
+    reader_common.append(reader_common_dims);
+    reader_kernel_desc.emplace_common_runtime_args(reader_common);
+    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
+    program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
+
+    // --- Writer Kernel Descriptor ---
+    // CB index via named compile-time arg (essential for fusion CB remapping).
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    tt::tt_metal::KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+        "writer_unary_interleaved_start_id.cpp";
+    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = all_cores;
+    writer_kernel_desc.compile_time_args = writer_compile_time_args;
+    writer_kernel_desc.named_compile_time_args = {{"dfb_id_out", src0_cb_index}};
+    writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
+
+    // Writer per-core runtime args: [dst_addr, num_tiles, start_id].
+    // dst_buffer is declared as a buffer binding at arg 0, so the framework patches its
+    // base address on program-cache hits instead of rebuilding the descriptor.
+    num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            writer_kernel_desc.emplace_runtime_args(core, {0u, 0u, 0u});
+            continue;
+        }
+
+        writer_kernel_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
+
+    return program_descriptor;
+}
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_program_factory_tile_for_python.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_program_factory_tile_for_python.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
+
+namespace ttnn::for_python {
+
+// Metal 1.0 copy of ttnn::prim::SliceTileProgramFactory, frozen for the Python fusion framework.
+// Not part of SliceDeviceOperation and not on any dispatch path — do not port it to Metal 2.0.
+struct SliceTileProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::SliceParams& args, const ttnn::prim::SliceInputs& tensor_args, Tensor& output);
+};
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
@@ -123,6 +123,7 @@ set(TTNN_OP_DATA_MOVEMENT_SRCS
     slice/device/slice_program_factory_tile.cpp
     slice/device/slice_program_factory_tile_tensor_args.cpp
     slice/slice.cpp
+    slice/slice_program_factory_tile_for_python.cpp
     split/device/split_device_operation.cpp
     split/device/split_program_factory.cpp
     split/split.cpp

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -608,7 +608,7 @@ from ttnn._ttnn.operations.data_movement import (
     SliceParams,
     SliceInputs,
     SliceDeviceOperation,
-    SliceTileProgramFactory,
+    SliceTileProgramFactoryForPython,
 )
 
 import pathlib

--- a/ttnn/ttnn/operations/data_movement.py
+++ b/ttnn/ttnn/operations/data_movement.py
@@ -162,6 +162,6 @@ ttnn.attach_golden_function(
 SliceParams = ttnn._ttnn.operations.data_movement.SliceParams
 SliceInputs = ttnn._ttnn.operations.data_movement.SliceInputs
 SliceDeviceOperation = ttnn._ttnn.operations.data_movement.SliceDeviceOperation
-SliceTileProgramFactory = ttnn._ttnn.operations.data_movement.SliceTileProgramFactory
+SliceTileProgramFactoryForPython = ttnn._ttnn.operations.data_movement.SliceTileProgramFactoryForPython
 
 __all__ = []


### PR DESCRIPTION
### Problem

`models/experimental/ops/descriptors/` (the experimental fusion framework) is the only Python consumer of the descriptor pybinds. It calls `<Factory>.create_descriptor(...)` to get a `ProgramDescriptor` and runs it through `generic_op`.

`generic_op` accepts only `ProgramDescriptor`/`MeshProgramDescriptor`. A Metal 2.0 factory produces `ProgramArtifacts` via `create_program_artifacts`, and no `ProgramArtifacts -> ProgramDescriptor` lowering exists. So porting a factory silently removes it from the fusion framework.

This already happened: `experimental/quasar/slice` is fully MetalV2 and its `bind_slice_descriptor` no longer binds any factory; the three ported `quasar/matmul` factories carry comments saying their `create_descriptor` entry point was dropped.

### Change

Adds `ttnn::for_python::SliceTileProgramFactory` — a Metal 1.0 copy of `ttnn::prim::SliceTileProgramFactory::create_descriptor`, frozen. It is not in `SliceDeviceOperation::program_factory_t` and is not reachable from any dispatch path; only nanobind refers to it.

`ttnn::prim::SliceTileProgramFactory` is now free to be ported to Metal 2.0 without breaking Python. The new type lives outside `device/` and carries a "do not port" comment.

Python-visible name becomes `SliceTileProgramFactoryForPython` so a caller can tell they are on the frozen path.

### Scope notes

- `SliceParams` / `SliceInputs` / `create_output_tensors` / `compute_output_specs` stay bound to production — they survive the port.
- The copy still calls the pure shape helper `get_tiled_start_offset`. That does not encode the execution model, so forking it would buy no migration safety and only create drift.

### Testing

Built with `build_metal.sh`. 258 fusion tests pass locally on hardware (`tests/ttnn/unit_tests/operations/fused/parallel_sequential/`), including the slice chains.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/for-python-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/for-python-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/for-python-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/for-python-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/for-python-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/for-python-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/for-python-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/for-python-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/for-python-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/for-python-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/for-python-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/for-python-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/for-python-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/for-python-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/for-python-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/for-python-slice)