### PR TITLE
[Feature] Freeze Metal 1.0 matmul factories for the Python fusion framework

### DIFF
--- a/models/experimental/ops/descriptors/matmul.py
+++ b/models/experimental/ops/descriptors/matmul.py
@@ -63,8 +63,7 @@ def matmul(
     """
     device = input_a.device()
 
-    # Detect gather_in0 early — the factory it selects (MeshWorkload) has no
-    # Python binding, so matmul_select_program_factory_for_python would raise a TypeError.
+    # Detect gather_in0 early — the selector TT_FATALs on it, so raise a clearer error here.
     if getattr(program_config, "gather_in0", False):
         raise ValueError(
             "MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory (gather_in0) "

--- a/models/experimental/ops/descriptors/matmul.py
+++ b/models/experimental/ops/descriptors/matmul.py
@@ -64,7 +64,7 @@ def matmul(
     device = input_a.device()
 
     # Detect gather_in0 early — the factory it selects (MeshWorkload) has no
-    # Python binding, so matmul_select_program_factory would raise a TypeError.
+    # Python binding, so matmul_select_program_factory_for_python would raise a TypeError.
     if getattr(program_config, "gather_in0", False):
         raise ValueError(
             "MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory (gather_in0) "
@@ -94,7 +94,7 @@ def matmul(
     tensor_args.optional_input_tensors = [None]
 
     # Select the program factory based on program_config type
-    factory = ttnn.matmul_select_program_factory(operation_params, tensor_args)
+    factory = ttnn.matmul_select_program_factory_for_python(operation_params, tensor_args)
     if _UNSUPPORTED_FACTORY is not None and isinstance(factory, _UNSUPPORTED_FACTORY):
         raise ValueError(
             "MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory (gather_in0) "

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -25,7 +25,7 @@ import torch
 import ttnn
 
 
-from models.common.utility_functions import comp_pcc, skip_with_llk_assert, skip_with_watcher
+from models.common.utility_functions import comp_pcc, is_blackhole, skip_with_llk_assert, skip_with_watcher
 
 
 def stress_test_program_cache(fn):
@@ -2679,6 +2679,11 @@ class TestMatmulFactories:
       - MatmulMultiCoreReuseMcast2DProgramFactory (via MatmulMultiCoreReuseMultiCastProgramConfig)
       - MatmulMultiCoreReuseMcast1DProgramFactory, mcast_in0=True (in0 broadcast, N split)
       - MatmulMultiCoreReuseMcast1DProgramFactory, mcast_in0=False (in1 broadcast, M split)
+      - MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory (in1 sharded across DRAM banks)
+
+    Not reachable from here: MatmulMultiCoreProgramFactory (its MatmulMultiCoreProgramConfig has no
+    Python binding) and MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory (requires a worker set
+    matching the DRAM bank count and ordering).
       - Batched matmul (batch > 1) via reuse_optimized and fuse_batch=True mcast_1d
       - Complex topologies mixing different factories with normalization ops
     """
@@ -2723,6 +2728,89 @@ class TestMatmulFactories:
         )
         mm.launch()
         check_pcc(torch_a @ torch_b, mm.output_tensors[0], pcc=0.99, label="reuse_optimized")
+
+    def _dram_sharded_inputs(self, device, B, M, K, N, grid_x):
+        """in0 width-sharded in L1, in1 width-sharded across DRAM banks — what the
+        DRAM-sharded factories require. Returns (torch_a, torch_b, tt_a, tt_b, in0_block_w)."""
+        num_banks = device.dram_grid_size().x if is_blackhole() else 12
+        assert N % (grid_x * 32) == 0, "N must tile-divide across the worker row"
+        assert N % (num_banks * 32) == 0, "N must tile-divide across the DRAM banks"
+        assert K % (grid_x * 32) == 0, "K must tile-divide across the worker row"
+        in0_block_w = K // grid_x // 32
+
+        torch_a = torch.randn(B, 1, M, K, dtype=torch.bfloat16)
+        torch_b = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+
+        in0_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, 0))})
+        in0_cfg = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(in0_grid, [B * M, in0_block_w * 32], ttnn.ShardOrientation.ROW_MAJOR),
+        )
+        dram_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_banks - 1, 0))})
+        in1_cfg = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.DRAM,
+            ttnn.ShardSpec(dram_grid, [K, N // num_banks], ttnn.ShardOrientation.ROW_MAJOR),
+        )
+        tt_a = ttnn.from_torch(
+            torch_a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in0_cfg
+        )
+        tt_b = ttnn.from_torch(
+            torch_b, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in1_cfg
+        )
+        out_cfg = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(in0_grid, [B * M, N // grid_x], ttnn.ShardOrientation.ROW_MAJOR),
+        )
+        return torch_a, torch_b, tt_a, tt_b, in0_block_w, out_cfg
+
+    def _assert_selects(self, tt_a, tt_b, program_config, out_cfg, expected_factory):
+        """The frozen selector routes purely on program_config type; pin that mapping so a
+        config change cannot silently re-route a frozen factory."""
+        params = ttnn.MatmulParams()
+        params.program_config = program_config
+        params.output_mem_config = out_cfg
+        attrs = ttnn.create_matmul_attributes(tt_a, tt_b, params, [])
+        inputs = ttnn.MatmulInputs()
+        inputs.input_tensors = [tt_a, tt_b]
+        inputs.optional_input_tensors = [None]
+        factory = ttnn.matmul_select_program_factory_for_python(attrs, inputs)
+        assert isinstance(factory, expected_factory), f"selector returned {type(factory).__name__}"
+
+    @stress_test_program_cache
+    def test_dram_sharded_factory(self, device):
+        """MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory via the DRAM-sharded config."""
+        from models.experimental.ops.descriptors.matmul import matmul as matmul_desc
+
+        torch.manual_seed(42)
+        M, K, N, grid_x = 32, 1024, 768, 8
+        torch_a, torch_b, tt_a, tt_b, in0_block_w, out_cfg = self._dram_sharded_inputs(device, 1, M, K, N, grid_x)
+
+        cr = cores(0, 0, grid_x - 1, 0)
+        config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+            in0_block_w=in0_block_w // 4,
+            per_core_M=M // 32,
+            per_core_N=N // grid_x // 32,
+        )
+        self._assert_selects(
+            tt_a,
+            tt_b,
+            config,
+            out_cfg,
+            ttnn._ttnn.operations.matmul.MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactoryForPython,
+        )
+        mm = matmul_desc(
+            tt_a,
+            tt_b,
+            core_range_set=cr,
+            program_config=config,
+            compute_kernel_config=self._compute(),
+            output_mem_config=out_cfg,
+        )
+        mm.launch()
+        check_pcc(torch_a @ torch_b, mm.output_tensors[0], pcc=0.99, label="dram_sharded")
 
     @stress_test_program_cache
     def test_mcast_2d_factory(self, device):

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_program_factory.cpp
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/matmul/for_python/matmul_multicore_program_factory.hpp"
+#include <map>
+#include <string>
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt;
+using namespace tt::constants;
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+using tt::tt_metal::ReaderConfigDescriptor;
+using tt::tt_metal::WriterConfigDescriptor;
+
+using namespace ttnn::prim;
+
+namespace ttnn::for_python {
+
+ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
+    const ttnn::prim::MatmulParams& operation_attributes,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    if (!tensor_args.optional_input_tensors.empty()) {
+        TT_FATAL(!tensor_args.optional_input_tensors[0].has_value(), "Bias is not supported for matmul multi core");
+    }
+
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
+
+    TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
+    bool bcast_batch = operation_attributes.bcast_batch.value();
+
+    const auto& ashape = a.padded_shape();
+    const auto& bshape = b.padded_shape();
+
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+    uint32_t in0_single_tile_size = tt::tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = tt::tile_size(in1_data_format);
+    uint32_t output_single_tile_size = tt::tile_size(output_data_format);
+
+    tt::tt_metal::IDevice* device = &a.mutable_device();
+    TT_FATAL(operation_attributes.compute_kernel_config.has_value(), "Compute kernel config should have been provided");
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());
+    (void)packer_l1_acc;
+
+    const auto& cshape = output.padded_shape();  // C=A*B, N1MK*11KN->N1MN
+
+    TT_FATAL(
+        operation_attributes.program_config.has_value(),
+        "program_config must be provided for MatmulMultiCoreProgramFactory");
+    auto pc = std::get<operations::matmul::MatmulMultiCoreProgramConfig>(operation_attributes.program_config.value());
+    if (!pc.allowed_worker_cores.has_value()) {
+        log_warning(
+            tt::LogOp,
+            "MatmulMultiCoreProgramFactory: program_config.allowed_worker_cores not populated; auto-populating "
+            "from device compute_with_storage_grid_size. Callers that bypass ttnn::prim::matmul() should invoke "
+            "ttnn::operations::matmul::normalize_program_config() on the program config first. This will become "
+            "a hard error in a future release.");
+        auto device_grid = device->compute_with_storage_grid_size();
+        pc.allowed_worker_cores =
+            CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(device_grid.x - 1, device_grid.y - 1)));
+    }
+    auto compute_with_storage_grid_size = pc.allowed_worker_cores.value().bounding_box().grid_size();
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t c_batch_size = get_batch_size(cshape);
+    auto num_output_tiles_total = c_batch_size * cshape[-2] * cshape[-1] / TILE_HW;
+    auto
+        [num_cores,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_output_tiles_per_core_group_1,
+         num_output_tiles_per_core_group_2] =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles_total);
+
+    // C = A*B*...
+    // MN = MK*KN
+    uint32_t B = get_batch_size(ashape);
+    uint32_t Mt = ashape[-2] / TILE_HEIGHT;
+    uint32_t Kt = ashape[-1] / TILE_WIDTH;
+    uint32_t Nt = bshape[-1] / TILE_WIDTH;
+    uint32_t KtNt = Kt * Nt;
+    uint32_t MtKt = Mt * Kt;
+    uint32_t MtNt = Mt * Nt;
+
+    ProgramDescriptor desc;
+
+    // Circular buffers
+    uint32_t num_input_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * in0_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = 0,
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * in1_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = 1,
+            .data_format = in1_data_format,
+            .page_size = in1_single_tile_size,
+        }}},
+    });
+    uint32_t output_cb_index = tt::CBIndex::c_16;
+    uint32_t num_output_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+
+    // Reader kernel
+    uint32_t last_ktile_w = a.logical_shape()[-1] % TILE_WIDTH;
+    uint32_t last_ktile_h = 0;
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)last_ktile_w, (uint32_t)last_ktile_h};
+    tt::tt_metal::TensorAccessorArgs(a).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(b).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = reader_compile_time_args;
+    reader_desc.named_compile_time_args = {{"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}};
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // Writer kernel
+    std::vector<uint32_t> writer_compile_time_args = {};
+    tt::tt_metal::TensorAccessorArgs(output).append_to(writer_compile_time_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = writer_compile_time_args;
+    writer_desc.named_compile_time_args = {{"cb_out", output_cb_index}};
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Per-core runtime args for reader and writer
+    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_output_tiles_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_output_tiles_per_core = num_output_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_output_tiles_per_core = num_output_tiles_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges");
+        }
+        reader_desc.emplace_runtime_args(
+            core,
+            {a,
+             b,
+             Mt,
+             Kt,
+             Nt,
+             MtKt,
+             KtNt,
+             B,
+             uint32_t(bcast_batch),
+             num_tiles_written,
+             num_output_tiles_per_core,
+             MtNt});
+        writer_desc.emplace_runtime_args(core, {output, num_output_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_output_tiles_per_core;
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    const auto throttle_level = ttnn::get_throttle_level(operation_attributes.compute_kernel_config);
+    std::map<std::string, std::string> mm_kernel_defines;
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    // Compute kernel(s) — one per core group with different tile counts
+    // bmm compute kernel: B, Mt, Nt are just 3 for loops that act as 1 large loop,
+    // so only set Nt for simplicity
+    std::vector<uint32_t> compute_args_group_1 = {1, 1, Kt, num_output_tiles_per_core_group_1};
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = compute_args_group_1;
+    compute_desc_1.named_compile_time_args = {
+        {"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}, {"cb_out", tt::CBIndex::c_16}};
+    compute_desc_1.defines = {mm_kernel_defines.begin(), mm_kernel_defines.end()};
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode};
+    desc.kernels.push_back(std::move(compute_desc_1));
+
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_args_group_2 = {1, 1, Kt, num_output_tiles_per_core_group_2};
+
+        KernelDescriptor compute_desc_2;
+        compute_desc_2.kernel_source = "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = compute_args_group_2;
+        compute_desc_2.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}, {"cb_out", tt::CBIndex::c_16}};
+        compute_desc_2.defines = {mm_kernel_defines.begin(), mm_kernel_defines.end()};
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode};
+        desc.kernels.push_back(std::move(compute_desc_2));
+    }
+
+    return desc;
+}
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_program_factory.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::for_python {
+
+// Metal 1.0 copy of the production factory, frozen for the Python fusion framework.
+// Not part of MatmulDeviceOperation and not on any dispatch path — do not port it to Metal 2.0.
+
+struct MatmulMultiCoreProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::MatmulParams& operation_attributes,
+        const ttnn::prim::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+};
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -1,0 +1,721 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/matmul/for_python/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp"
+#include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
+#include "ttnn/operations/matmul/device/config/matmul_program_config.hpp"
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <utility>
+
+#include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/operations/matmul/shared_with_host/activation_type.hpp"
+
+using namespace tt;
+
+using ttnn::operations::unary::UnaryOpType;
+using ttnn::operations::unary::UnaryWithParam;
+
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::DataMovementConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+
+using namespace ttnn::prim;
+
+namespace ttnn::for_python {
+namespace reuse_batched_hs_dram_sharded_optimized_helpers {
+
+using dram_sharded_helpers::get_max_page_size_and_num_pages;
+using dram_sharded_helpers::get_optimal_dram_bank_to_reader_assignment;
+
+// Batch-sharded DRAM matmul
+// For batched matmul: [1, B, M, K] x [1, B, K, N] = [1, B, M, N]
+// Sharded by batch dimension - each worker handles B/num_workers complete matmuls
+// ProgramDescriptor variant: translates the same logic as create_program_batch_sharded
+// into a lightweight ProgramDescriptor (no Program object created).
+static ProgramDescriptor create_program_batch_sharded_descriptor(
+    tt::tt_metal::IDevice* device,
+    const CoreRangeSet& input_all_storage_cores,
+    const CoreRangeSet& output_all_storage_cores,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    bool dst_full_sync_en,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t B,
+    uint32_t /* M */,
+    uint32_t K,
+    uint32_t /* N */,
+    uint32_t in0_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    std::optional<UnaryWithParam> fused_activation,
+    const tt_metal::MeshTensor& in0_tensor,
+    const tt_metal::MeshTensor& in1_tensor,
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_tensor,
+    const tt_metal::MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool untilize_out,
+    bool skip_compute,
+    bool skip_write_back) {
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    std::vector<CoreCoord> all_worker_cores_ordered;
+    CoreRangeSet all_worker_cores;
+    get_optimal_dram_bank_to_reader_assignment(device, all_worker_cores_ordered, all_worker_cores, in1_noc);
+
+    // Input / output storage core ordering
+    std::vector<CoreCoord> input_storage_cores_ordered =
+        corerange_to_cores(input_all_storage_cores, std::nullopt, true);
+    std::vector<CoreCoord> output_storage_cores_ordered =
+        corerange_to_cores(output_all_storage_cores, std::nullopt, true);
+
+    uint32_t num_workers = all_worker_cores_ordered.size();
+    TT_FATAL(
+        input_storage_cores_ordered.size() == num_workers,
+        "Input storage cores ({}) must match number of workers/DRAM banks ({})",
+        input_storage_cores_ordered.size(),
+        num_workers);
+    TT_FATAL(
+        output_storage_cores_ordered.size() == num_workers,
+        "Output storage cores ({}) must match number of workers/DRAM banks ({})",
+        output_storage_cores_ordered.size(),
+        num_workers);
+    for (uint32_t i = 0; i < num_workers; ++i) {
+        TT_FATAL(
+            input_storage_cores_ordered[i] == all_worker_cores_ordered[i],
+            "Input storage core ordering mismatch at index {}",
+            i);
+        TT_FATAL(
+            output_storage_cores_ordered[i] == all_worker_cores_ordered[i],
+            "Output storage core ordering mismatch at index {}",
+            i);
+    }
+
+    // NOC coordinate vectors for storage cores
+    std::vector<uint32_t> input_storage_noc_x, input_storage_noc_y;
+    std::vector<uint32_t> output_storage_noc_x, output_storage_noc_y;
+    for (const auto& core : input_storage_cores_ordered) {
+        auto phys_core = device->worker_core_from_logical_core(core);
+        input_storage_noc_x.push_back(phys_core.x);
+        input_storage_noc_y.push_back(phys_core.y);
+    }
+    for (const auto& core : output_storage_cores_ordered) {
+        auto phys_core = device->worker_core_from_logical_core(core);
+        output_storage_noc_x.push_back(phys_core.x);
+        output_storage_noc_y.push_back(phys_core.y);
+    }
+
+    // Bounding box of all cores (workers + storage)
+    std::set<CoreRange> all_cores_set;
+    for (const auto& core : all_worker_cores_ordered) {
+        all_cores_set.insert(CoreRange(core));
+    }
+    for (const auto& core : input_storage_cores_ordered) {
+        all_cores_set.insert(CoreRange(core));
+    }
+    for (const auto& core : output_storage_cores_ordered) {
+        all_cores_set.insert(CoreRange(core));
+    }
+    CoreRangeSet all_cores(all_cores_set);
+    CoreRange bounding_box = all_cores.bounding_box();
+    CoreRangeSet all_cores_in_rect_grid({bounding_box});
+
+    uint32_t num_cores = num_workers;
+    uint32_t num_dram_banks = device->num_dram_channels();
+    uint32_t batches_per_core = (B + num_cores - 1) / num_cores;
+
+    TT_FATAL(
+        num_cores <= num_dram_banks,
+        "Number of worker cores ({}) cannot exceed number of DRAM banks ({})",
+        num_cores,
+        num_dram_banks);
+
+    // Subblock parameters
+    auto subblock_hw = operations::matmul::bmm_op_utils::get_matmul_subblock_params(
+        per_core_M, per_core_N, false, false, fp32_dest_acc_en);
+    auto out_subblock_h = std::get<0>(subblock_hw);
+    auto out_subblock_w = std::get<1>(subblock_hw);
+
+    uint32_t num_blocks = K / in0_block_w;
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    // Tile sizes
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    // CB sizes
+    uint32_t in0_block_tiles = per_core_M * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles * 2;
+    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
+
+    uint32_t in1_block_tiles = in0_block_w * per_core_N;
+    uint32_t in1_CB_tiles = in1_block_tiles * 3;
+    uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
+
+    uint32_t out_block_tiles = per_core_M * per_core_N;
+    uint32_t interm0_CB_size = out_block_tiles * interm0_single_tile_size;
+
+    uint32_t in0_shard_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_tile_shape()[0] *
+                               in0_tensor.shard_spec()->shape[1] / in0_tile.get_tile_shape()[1];
+    uint32_t in2_CB_size = in0_shard_tiles * in0_single_tile_size;
+
+    uint32_t in3_block_tiles = per_core_N;
+    uint32_t in3_CB_size = in3_block_tiles * bias_single_tile_size;
+
+    uint32_t out_shard_tiles = out_tensor.shard_spec()->shape[0] / output_tile.get_tile_shape()[0] *
+                               out_tensor.shard_spec()->shape[1] / output_tile.get_tile_shape()[1];
+    uint32_t out_reshard_CB_size = out_shard_tiles * output_single_tile_size;
+
+    // Page sizes for DRAM reads
+    uint32_t in1_buffer_page_size, in1_buffer_num_pages;
+    get_max_page_size_and_num_pages(
+        device, in1_block_tiles, in1_single_tile_size, in1_buffer_page_size, in1_buffer_num_pages);
+
+    uint32_t bias_buffer_page_size, bias_buffer_num_pages;
+    get_max_page_size_and_num_pages(
+        device, in3_block_tiles, bias_single_tile_size, bias_buffer_page_size, bias_buffer_num_pages);
+
+    // Tensor stride calculations
+    uint32_t in0_batch_stride_bytes = per_core_M * K * in0_single_tile_size;
+    uint32_t in1_batch_stride_bytes = K * per_core_N * in1_single_tile_size;
+    uint32_t out_batch_stride_bytes = per_core_M * per_core_N * output_single_tile_size;
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build CBDescriptors
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor desc;
+
+    tt::tt_metal::TileDescriptor in0_tile_desc{in0_tile};
+    tt::tt_metal::TileDescriptor in1_tile_desc{in1_tile};
+    tt::tt_metal::TileDescriptor bias_tile_desc{bias_tile};
+    tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+
+    // CB 0: in0 (activations) - on all cores in bounding box
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_0,
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size,
+            .tile = in0_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 1: in1 (weights) - on all cores in bounding box
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in1_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_1,
+            .data_format = in1_data_format,
+            .page_size = in1_single_tile_size,
+            .tile = in1_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 2: sharded in0 buffer - on INPUT storage cores, backed by in0_buffer
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in2_CB_size;
+        cb_desc.core_ranges = input_all_storage_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_2,
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size,
+            .tile = in0_tile_desc});
+        cb_desc.tensor = &in0_tensor;
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 3: bias (if fused) - on all cores in bounding box
+    if (bias_tensor.has_value()) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in3_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_3,
+            .data_format = bias_data_format,
+            .page_size = bias_single_tile_size,
+            .tile = bias_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 4 & 5: output and intermediate - on worker cores
+    uint32_t output_cb_index = tt::CBIndex::c_4;
+    uint32_t interm0_cb_index = tt::CBIndex::c_5;
+    if (interm0_data_format != output_data_format) {
+        // Separate CBs for output and intermediate
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = out_reshard_CB_size;
+            cb_desc.core_ranges = all_worker_cores;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = output_cb_index,
+                .data_format = output_data_format,
+                .page_size = output_single_tile_size,
+                .tile = output_tile_desc});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = interm0_CB_size;
+            cb_desc.core_ranges = all_worker_cores;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = interm0_cb_index,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    } else {
+        // Output and intermediate share the same buffer
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_reshard_CB_size;
+        cb_desc.core_ranges = all_worker_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = interm0_cb_index,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 6: output reshard buffer - on OUTPUT storage cores, backed by out_buffer
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_reshard_CB_size;
+        cb_desc.core_ranges = output_all_storage_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_6,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.tensor = &out_tensor;
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Kernel defines
+    ////////////////////////////////////////////////////////////////////////////
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> reader_defines;
+    std::map<std::string, std::string> writer_defines;
+
+    if (bias_tensor.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (skip_compute) {
+        mm_kernel_defines["SKIP_COMPUTE"] = "1";
+    }
+    if (skip_write_back) {
+        writer_defines["SKIP_WRITE_BACK"] = "1";
+    }
+    mm_kernel_defines["MATMUL_DRAM_SHARDED"] = "1";
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    // Helper to convert std::map defines to KernelDescriptor::Defines
+    auto map_to_defines = [](const std::map<std::string, std::string>& m) -> KernelDescriptor::Defines {
+        KernelDescriptor::Defines result;
+        result.reserve(m.size());
+        for (const auto& [k, v] : m) {
+            result.emplace_back(k, v);
+        }
+        return result;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Compile-time args
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> in0_reader_compile_args = {
+        (uint32_t)in0_block_tiles,
+        (uint32_t)in0_block_tiles * in0_single_tile_size,
+        (uint32_t)num_blocks,
+        (uint32_t)batches_per_core,
+        (uint32_t)in0_batch_stride_bytes,
+        (uint32_t)in2_CB_size,
+    };
+
+    std::vector<uint32_t> in1_writer_compile_args = {
+        (uint32_t)in1_buffer_page_size,
+        (uint32_t)in1_buffer_num_pages,
+        (uint32_t)per_core_N,
+        (uint32_t)in1_block_tiles,
+        (uint32_t)num_blocks,
+        (uint32_t)out_block_tiles,
+        (uint32_t)batches_per_core,
+        (uint32_t)in1_batch_stride_bytes,
+        (uint32_t)out_batch_stride_bytes,
+        (uint32_t)out_reshard_CB_size,
+    };
+    if (bias_tensor.has_value()) {
+        in1_writer_compile_args.push_back(bias_buffer_page_size);
+        in1_writer_compile_args.push_back(bias_buffer_num_pages);
+        in1_writer_compile_args.push_back(in3_block_tiles);
+    }
+
+    uint32_t in0_num_subblocks = per_core_M / out_subblock_h;
+    uint32_t in1_num_subblocks = per_core_N / out_subblock_w;
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,
+        in0_num_subblocks,
+        in0_block_tiles,
+        in0_subblock_num_tiles,
+        in1_num_subblocks,
+        in1_block_tiles,
+        per_core_N,
+        num_blocks,
+        1,
+        1,
+        out_subblock_h,
+        out_subblock_w,
+        out_subblock_num_tiles,
+        batches_per_core,
+        out_block_tiles,
+        untilize_out ? 1u : 0u,
+        0u,
+        0u,
+    };
+    if (bias_tensor.has_value()) {
+        compute_kernel_args.push_back(1u);  // row_broadcast_bias: DRAM sharded always uses row broadcast
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build Kernel Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+
+    writer_defines["OUT_SHARDED"] = "1";
+
+    // in0 reader kernel
+    KernelDescriptor in0_reader_kernel_desc;
+    in0_reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp";
+    in0_reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in0_reader_kernel_desc.core_ranges = all_cores_in_rect_grid;
+    in0_reader_kernel_desc.compile_time_args = in0_reader_compile_args;
+    in0_reader_kernel_desc.defines = map_to_defines(reader_defines);
+    in0_reader_kernel_desc.named_compile_time_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+    };
+    in0_reader_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+
+    // in1 writer kernel
+    KernelDescriptor in1_writer_kernel_desc;
+    in1_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp";
+    in1_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in1_writer_kernel_desc.core_ranges = all_cores_in_rect_grid;
+    in1_writer_kernel_desc.compile_time_args = in1_writer_compile_args;
+    in1_writer_kernel_desc.defines = map_to_defines(writer_defines);
+    in1_writer_kernel_desc.named_compile_time_args = {
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+    };
+    in1_writer_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+
+    // compute kernel
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores_in_rect_grid;
+    compute_kernel_desc.compile_time_args = compute_kernel_args;
+    compute_kernel_desc.defines = map_to_defines(mm_kernel_defines);
+    {
+        KernelDescriptor::NamedCompileTimeArgs named_compile_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+            {"cb_intermed0", tt::CBIndex::c_5},
+            {"cb_in0_intermediate", tt::CBIndex::c_8},
+            {"cb_in1_intermediate", tt::CBIndex::c_9},
+            {"cb_in0_transposed", tt::CBIndex::c_10},
+            {"bias_ntiles", per_core_N},
+            // This factory does not pad per_core_N_compute beyond per_core_N_in1_sender, so the
+            // last subblock is always fully valid. Pass out_subblock_w so the compute kernel takes
+            // its original full-width path (last_subblock_padded == false).
+            {"last_subblock_w_valid", out_subblock_w},
+        };
+        if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+            using ttnn::operations::matmul::utilities::get_activation_params;
+            const auto params = get_activation_params(fused_activation.value());
+            named_compile_args.push_back({"activation_type", static_cast<uint32_t>(params.type)});
+            named_compile_args.push_back({"activation_param0", params.param0});
+            named_compile_args.push_back({"activation_param1", params.param1});
+            named_compile_args.push_back({"activation_param2", params.param2});
+        }
+        compute_kernel_desc.named_compile_time_args = std::move(named_compile_args);
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Runtime Args (per-core loop)
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<CoreCoord> all_cores_in_rect_grid_vec = corerange_to_cores(all_cores_in_rect_grid);
+    std::set<CoreCoord> worker_cores_set(all_worker_cores_ordered.begin(), all_worker_cores_ordered.end());
+
+    std::vector<uint32_t> bank_ids;
+
+    // Idle cores in the bounding box
+    for (const auto& core : all_cores_in_rect_grid_vec) {
+        bool is_worker = worker_cores_set.contains(core);
+
+        if (!is_worker) {
+            std::vector<uint32_t> in0_idle_args = {0u};
+            in0_reader_kernel_desc.runtime_args.emplace_back(core, in0_idle_args);
+
+            std::vector<uint32_t> in1_idle_args = {0u};
+            in1_writer_kernel_desc.runtime_args.emplace_back(core, in1_idle_args);
+
+            std::vector<uint32_t> compute_idle_args = {0u};
+            compute_kernel_desc.runtime_args.emplace_back(core, compute_idle_args);
+        }
+    }
+
+    // Worker cores
+    for (uint32_t worker_idx = 0; worker_idx < all_worker_cores_ordered.size(); ++worker_idx) {
+        auto core = all_worker_cores_ordered[worker_idx];
+
+        uint32_t bank_id = worker_idx;
+        uint32_t vc = bank_id & 0x3;
+        bank_ids.push_back(bank_id);
+        for (uint32_t j = 0; j < worker_idx; ++j) {
+            auto core_prev = all_worker_cores_ordered[j];
+            if (core_prev.y == core.y && ((bank_id & 0x3) == (bank_ids[j] & 0x3))) {
+                vc = (vc + 1) & 0x3;
+                break;
+            }
+        }
+
+        // in0 reader runtime args
+        KernelDescriptor::RTArgList in0_reader_args;
+        in0_reader_args.push_back(uint32_t{1u});
+        in0_reader_args.push_back(uint32_t{input_storage_noc_x[worker_idx]});
+        in0_reader_args.push_back(uint32_t{input_storage_noc_y[worker_idx]});
+        in0_reader_args.push_back(in0_tensor);
+        in0_reader_kernel_desc.emplace_runtime_args(core, in0_reader_args);
+
+        // in1 writer runtime args
+        KernelDescriptor::RTArgList in1_writer_args;
+        in1_writer_args.push_back(uint32_t{1u});
+        in1_writer_args.push_back(in1_tensor);
+        if (bias_tensor.has_value()) {
+            in1_writer_args.push_back(*bias_tensor);
+        } else {
+            in1_writer_args.push_back(uint32_t{0u});
+        }
+        in1_writer_args.push_back(uint32_t{bank_id});
+        in1_writer_args.push_back(uint32_t{vc});
+        in1_writer_args.push_back(uint32_t{output_storage_noc_x[worker_idx]});
+        in1_writer_args.push_back(uint32_t{output_storage_noc_y[worker_idx]});
+        in1_writer_args.push_back(out_tensor);
+        in1_writer_kernel_desc.emplace_runtime_args(core, in1_writer_args);
+
+        // Compute runtime args
+        std::vector<uint32_t> compute_runtime_args = {
+            1u,
+        };
+        compute_kernel_desc.runtime_args.emplace_back(core, compute_runtime_args);
+    }
+
+    // Push all kernel descriptors
+    desc.kernels.push_back(std::move(in0_reader_kernel_desc));
+    desc.kernels.push_back(std::move(in1_writer_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+
+    return desc;
+}
+
+}  // namespace reuse_batched_hs_dram_sharded_optimized_helpers
+
+ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create_descriptor(
+    const ttnn::prim::MatmulParams& operation_attributes,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
+    const auto& output_tensors = tensor_return_value;
+
+    const auto& a = input_tensors.at(0).mesh_tensor();
+    const auto& b = input_tensors.at(1).mesh_tensor();
+    auto bias = ttnn::as_optional_mesh_tensor(optional_input_tensors.at(0));
+    const auto& output = output_tensors.at(0).mesh_tensor();
+    const auto& ashape = a.padded_shape();
+    const auto& bshape = b.padded_shape();
+    auto in0_tile = a.tensor_spec().tile();
+    auto in1_tile = b.tensor_spec().tile();
+    auto in0_tile_shape = in0_tile.get_tile_shape();
+    auto in1_tile_shape = in1_tile.get_tile_shape();
+    auto output_tile = tt::tt_metal::Tile({in0_tile.get_tile_shape()[0], in1_tile.get_tile_shape()[1]});
+
+    // CB dataformats
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        TT_FATAL(&a.device() == &c.device(), "Operands to matmul need to be on the same device!");
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    tt::tt_metal::IDevice* device = &a.mutable_device();
+
+    TT_FATAL(
+        a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");
+    CoreRangeSet input_all_cores_storage = a.shard_spec().value().grid;
+    CoreRangeSet output_all_cores_storage = output.shard_spec().value().grid;
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(tt_metal::datatype_to_dataformat_converter(a.dtype()));
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(tt_metal::datatype_to_dataformat_converter(b.dtype()));
+
+    TT_FATAL(
+        a.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        a.mesh_buffer().device_local_size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        b.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        b.mesh_buffer().device_local_size(),
+        in1_single_tile_size);
+
+    TT_FATAL(
+        ashape[-1] == bshape[-2],
+        "Dimension K (A.shape[-1] = {}, B.shape[-2] = {}) must match for matmul",
+        ashape[-1],
+        bshape[-2]);
+    TT_FATAL(ashape[-2] % in0_tile_shape[0] == 0, "A.shape[-2] must be divisible by tile shape[0]");
+    TT_FATAL(ashape[-1] % in0_tile_shape[1] == 0, "A.shape[-1] must be divisible by tile shape[1]");
+    TT_FATAL(bshape[-2] % in1_tile_shape[0] == 0, "B.shape[-2] must be divisible by tile shape[0]");
+    TT_FATAL(bshape[-1] % in1_tile_shape[1] == 0, "B.shape[-1] must be divisible by tile shape[1]");
+
+    const auto& compute_kernel_config = operation_attributes.compute_kernel_config.value();
+    const auto& program_config =
+        std::get<operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>(
+            operation_attributes.program_config.value());
+    const auto& in0_block_w = program_config.in0_block_w;
+    const auto& per_core_M = program_config.per_core_M;
+    const auto& per_core_N = program_config.per_core_N;
+    const auto& fused_activation = program_config.fused_activation;
+    const auto& untilize_out = operation_attributes.untilize_out;
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    uint32_t B = ashape[1];
+    uint32_t M = ashape[-2] / in0_tile_shape[0];
+    uint32_t K = ashape[-1] / in0_tile_shape[1];
+    uint32_t N = bshape[-1] / in1_tile_shape[1];
+
+    TT_FATAL(per_core_M == M, "For batch sharding, per_core_M ({}) must equal M ({})", per_core_M, M);
+    TT_FATAL(per_core_N == N, "For batch sharding, per_core_N ({}) must equal N ({})", per_core_N, N);
+    TT_FATAL(K % in0_block_w == 0, "K ({}) must be divisible by in0_block_w ({})", K, in0_block_w);
+
+    return reuse_batched_hs_dram_sharded_optimized_helpers::create_program_batch_sharded_descriptor(
+        device,
+        input_all_cores_storage,
+        output_all_cores_storage,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        dst_full_sync_en,
+        ttnn::get_throttle_level(operation_attributes.compute_kernel_config),
+        B,
+        M,
+        K,
+        N,
+        in0_block_w,
+        per_core_M,
+        per_core_N,
+        fused_activation,
+        a,
+        b,
+        bias,
+        output,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        untilize_out,
+        false,   // skip_compute
+        false);  // skip_write_back
+}
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::for_python {
+
+// Metal 1.0 copy of the production factory, frozen for the Python fusion framework.
+// Not part of MatmulDeviceOperation and not on any dispatch path — do not port it to Metal 2.0.
+
+struct MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::MatmulParams& operation_attributes,
+        const ttnn::prim::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+};
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -1,0 +1,5731 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_1d_program_factory.hpp"
+#include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
+#include <algorithm>
+#include <utility>
+
+#include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
+
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/operations/matmul/shared_with_host/activation_type.hpp"
+
+using namespace tt;
+
+using ttnn::operations::unary::UnaryOpType;
+using ttnn::operations::unary::UnaryWithParam;
+
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::DataMovementConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::MeshTensor;
+using tt::tt_metal::ProgramDescriptor;
+
+using namespace ttnn::prim;
+
+namespace ttnn::for_python {
+
+namespace reuse_mcast_1d_optimized_helpers {
+
+uint32_t get_preferred_noc(
+    const ttnn::CoreCoord src,
+    const ttnn::CoreCoord dst,
+    const tt_metal::IDevice* device,
+    const bool use_dedicated_noc = false) {
+    /*
+        NOC0: Preferred +x -> +y
+        NOC1: Preferred -y -> -x
+    */
+
+    uint32_t src_x = src.x, src_y = src.y;
+    uint32_t dst_x = dst.x, dst_y = dst.y;
+
+    uint32_t MAX_X = device->grid_size().x;
+    uint32_t MAX_Y = device->grid_size().y;
+
+    // Get the wrapped distances
+    uint32_t dist_right = src_x <= dst_x ? dst_x - src_x : MAX_X - src_x + dst_x;
+    uint32_t dist_left = src_x < dst_x ? src_x + MAX_X - dst_x : src_x - dst_x;
+
+    uint32_t dist_bottom = src_y <= dst_y ? dst_y - src_y : MAX_Y - src_y + dst_y;
+    uint32_t dist_top = src_y < dst_y ? src_y + MAX_Y - dst_y : src_y - dst_y;
+
+    uint32_t dist_noc_0 = dist_right + dist_bottom;
+    uint32_t dist_noc_1 = dist_top + dist_left;
+
+    uint32_t noc = dist_noc_0 < dist_noc_1 ? 0 : 1;
+
+    // Debug print if needed
+    // std::cout << "src: (" << src_x << ", " << src_y << "), dst: (" << dst_x << ", " << dst_y << "), noc: " << noc <<
+    // std::endl;
+
+    return use_dedicated_noc ? 1 : noc;
+}
+
+MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_program_and_create_override_variables(
+    tt_metal::Program& program,
+    const ttnn::Tensor& a,
+    tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    CoreCoord compute_with_storage_grid_size,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t B,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    std::optional<UnaryWithParam> fused_activation,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    ttsl::optional_reference<const MeshTensor> bias_tensor,
+    const MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool in0_is_sharded,
+    bool in1_is_sharded,
+    bool bias_is_sharded,
+    bool output_is_sharded,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    bool row_broadcast_bias = true,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
+
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = fused_op_signaler.has_value();
+
+    uint32_t num_blocks = K / in0_block_w;
+    // Only enable packer l1 accumulation when there are spills, otherwise
+    // unnecessary overhead for reconfigs are added
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = in0_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (B * num_blocks > 1) {
+        in0_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
+    // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
+    // the padded stride, so the in0/in1/bias CBs must hold pages at the aligned stride and the
+    // reader/unpacker walk tiles at the same stride. No-op when already aligned (all bf16 tiles,
+    // 32-wide bfp8, Wormhole). Replaces the staging-CB workaround. Sharded CBs are backed by the
+    // tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size =
+        in1_is_sharded ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
+    // Bias CB pages must be padded to the DRAM alignment so the reader's L1 write stride
+    // matches the DRAM page stride (e.g. 64B on Blackhole for a 32B (1,16) bf16 bias tile).
+    // Mirrors in0/in1 above. Sharded bias is backed by the L1 tensor buffer and keeps its
+    // natural page size. No-op on Wormhole and for tiles already >= dram_alignment.
+    uint32_t bias_aligned_tile_size =
+        bias_is_sharded ? bias_single_tile_size : tt::align(bias_single_tile_size, dram_alignment);
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+
+    uint32_t in2_block_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    uint32_t in0_shard_height_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+    }
+    uint32_t in2_CB_tiles = in2_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (B * num_blocks > 1) {
+        in1_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    if (in1_is_sharded) {
+        uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
+        in1_CB_tiles = per_core_N * in1_shard_height_in_tiles;
+    }
+
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_aligned_tile_size;
+
+    CoreCoord start_core = sub_device_start_core;
+    uint32_t start_core_x = start_core.x;
+    uint32_t start_core_y = start_core.y;
+    uint32_t num_cores_c = compute_with_storage_grid_size.x;
+
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. Callers must ensure this rectangle lies entirely
+    // within the active sub-device's worker cores (validated upstream). Using a
+    // CoreRangeSet here lets num_cores_to_corerangeset_in_subcoregrids honour the
+    // start offset when the sub-device is not anchored at (0, 0).
+    CoreRangeSet matmul_core_rect(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core_x + compute_with_storage_grid_size.x - 1, start_core_y + compute_with_storage_grid_size.y - 1)));
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+    uint32_t num_cores_with_work = num_blocks_total;
+
+    // mcast_in0 broadcasts a single M-block across all cores; only the start_core gets in0 sender
+    // runtime args (with output_idx_y == 0), so M must fit within per_core_M.
+    TT_FATAL(
+        num_blocks_y == 1,
+        "matmul_multicore_reuse_mcast_1d requires num_blocks_y == 1 (M <= per_core_M) for mcast_in0. "
+        "Got M={}, per_core_M={}, num_blocks_y={}.",
+        M,
+        per_core_M,
+        num_blocks_y);
+
+    uint32_t in0_sender_num_cores = in0_is_sharded ? a.shard_spec().value().grid.num_cores() : 1;
+    uint32_t num_cores = in0_is_sharded ? std::max(num_cores_with_work, in0_sender_num_cores) : num_cores_with_work;
+
+    constexpr bool row_major = true;
+    CoreRangeSet all_cores =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
+
+    CoreRangeSet in0_mcast_sender_cores =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, matmul_core_rect, row_major);
+    CoreCoord in0_mcast_sender_cores_grid = in0_mcast_sender_cores.bounding_box().grid_size();
+
+    CoreRangeSet all_cores_with_work =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, matmul_core_rect, row_major);
+    CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
+    uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
+    uint32_t in0_mcast_receiver_num_dests = std::min(
+        in0_mcast_receiver_num_cores,
+        num_cores);  // should always be number of cores in receiver grid up to number of active cores
+
+    CoreRangeSet in0_mcast_cores_with_work_and_in_receiver_grid;
+    CoreRangeSet in0_mcast_cores_without_work_and_in_receiver_grid;
+    CoreRangeSet in0_mcast_cores_without_work_and_not_in_receiver_grid;
+    CoreRangeSet in0_mcast_receivers;
+    std::vector<uint32_t> in0_mcast_noc_x;
+    std::vector<uint32_t> in0_mcast_noc_y;
+    if (in0_is_sharded) {
+        in0_mcast_cores_with_work_and_in_receiver_grid = all_cores_with_work;
+
+        if (in0_mcast_receiver_num_dests > num_cores_with_work) {
+            const uint32_t in0_mcast_cores_without_work_and_in_receiver_grid_num_cores =
+                in0_mcast_receiver_num_dests - num_cores_with_work;
+            uint32_t core_idx_x = num_cores_with_work % num_cores_c;
+            uint32_t core_idx_y = num_cores_with_work / num_cores_c;
+            CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
+            in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
+                start_core, in0_mcast_cores_without_work_and_in_receiver_grid_num_cores, matmul_core_rect, row_major);
+        }
+
+        if (in0_sender_num_cores > in0_mcast_receiver_num_dests) {
+            const uint32_t in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores =
+                in0_sender_num_cores - in0_mcast_receiver_num_dests;
+            uint32_t core_idx_x = in0_mcast_receiver_num_dests % num_cores_c;
+            uint32_t core_idx_y = in0_mcast_receiver_num_dests / num_cores_c;
+            CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
+            in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
+                start_core,
+                in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores,
+                matmul_core_rect,
+                row_major);
+        }
+
+        in0_mcast_noc_x.reserve(in0_mcast_sender_cores_grid.x);
+        in0_mcast_noc_y.reserve(in0_mcast_sender_cores_grid.y);
+        for (uint32_t core_idx_x = 0; core_idx_x < in0_mcast_sender_cores_grid.x; ++core_idx_x) {
+            in0_mcast_noc_x.push_back(
+                device->worker_core_from_logical_core({start_core_x + core_idx_x, start_core_y}).x);
+        }
+        for (uint32_t core_idx_y = 0; core_idx_y < in0_mcast_sender_cores_grid.y; ++core_idx_y) {
+            in0_mcast_noc_y.push_back(
+                device->worker_core_from_logical_core({start_core_x, start_core_y + core_idx_y}).y);
+        }
+    } else {
+        in0_mcast_cores_with_work_and_in_receiver_grid = CoreRangeSet({CoreRange(start_core, start_core)});
+        if (in0_mcast_receiver_num_cores > 1) {
+            // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+            // sub-devices anchored away from (0, 0) wrap correctly.
+            auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                            : CoreCoord{start_core.x, start_core.y + 1};
+            in0_mcast_receivers = num_cores_to_corerangeset_in_subcoregrids(
+                receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
+        }
+    }
+
+    // Mcast args
+    auto in0_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in0_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+    CoreCoord top_left_core = in0_mcast_receiver_cores_bounding_box.start_coord;
+    CoreCoord bottom_right_core = in0_mcast_receiver_cores_bounding_box.end_coord;
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    const auto& a_shape_logical = operations::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    // When transpose_a is true, the K dimension maps to the row dimension of the raw tile,
+    // which is already zero-padded during tile layout conversion. pad_last_ktile operates on
+    // columns, so applying it would incorrectly zero valid data that becomes output rows
+    // after the compute kernel transposes the tile.
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    const auto& a_padded_shape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    std::vector<uint32_t> in0_sender_compile_time_args;
+    if (in0_is_sharded) {
+        in0_sender_compile_time_args = {
+            (std::uint32_t)1,  // core_has_output_block_work
+            (std::uint32_t)1,  // core_in_in0_receiver_mcast_grid
+
+            (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+            (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,        // num_blocks
+            (std::uint32_t)out_num_blocks_x,  // num_blocks_x
+            (std::uint32_t)out_num_blocks_y,  // num_blocks_y
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_num_dests,  // in0_mcast_num_dests
+            (std::uint32_t)in0_mcast_receiver_num_cores,  // in0_mcast_num_cores
+            (std::uint32_t)(in0_mcast_sender_cores_grid.x),
+            (std::uint32_t)(in0_mcast_sender_cores_grid.y),
+            (std::uint32_t)(false),
+            (std::uint32_t)(in0_shard_width_in_tiles),
+            (std::uint32_t)(in0_shard_height_in_tiles),
+            (std::uint32_t)(in0_block_w),
+            (std::uint32_t)in0_block_h,  // in0_block_h
+
+            // batch args
+            (std::uint32_t)B  // batch
+        };
+    } else {
+        in0_sender_compile_time_args = {
+            // in0 tensor args
+            (std::uint32_t)in0_tensor_stride_w,
+            (std::uint32_t)in0_tensor_stride_h,
+            (std::uint32_t)in0_tensor_next_block_stride,
+            (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+            // in0 block args
+            (std::uint32_t)in0_block_w,          // in0_block_w
+            (std::uint32_t)in0_block_h,          // in0_block_h
+            (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+            (std::uint32_t)false,  // extract_shard_sub_blocks (not used for interleaved)
+            (std::uint32_t)0,      // shard_width_in_tiles (not used for interleaved)
+            (std::uint32_t)0,      // shard_height_in_tiles (not used for interleaved)
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,        // num_blocks
+            (std::uint32_t)out_num_blocks_x,  // num_blocks_x
+            (std::uint32_t)out_num_blocks_y,  // num_blocks_y
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)num_cores - 1,                     // in0_mcast_num_dests
+            (std::uint32_t)in0_mcast_receiver_num_cores - 1,  // in0_mcast_num_cores
+            // batch args
+            (std::uint32_t)M * K,  // MtKt
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)false,  // reuse_in0_in_CB
+            // sparsity args
+            (std::uint32_t)0,     // batchB
+            (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)true,  // bcast_A
+            (std::uint32_t)false  // get_batch_from_reader
+        };
+    }
+    in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+    in0_sender_compile_time_args.push_back((std::uint32_t)0);  // num_batch_compute (unused, sparsity disabled)
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)0,
+        (std::uint32_t)0,
+        (std::uint32_t)0,  // in1_mcast_num_dests
+        (std::uint32_t)0,  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,        // KtNt
+        (std::uint32_t)B,            // batch
+        (std::uint32_t)bcast_batch,  // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_tensor.has_value()) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    std::vector<uint32_t> in0_receiver_compile_time_args = {
+        // in0 block args
+        (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)B,     // batch
+        (std::uint32_t)false  // get_batch_from_reader
+    };
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    if (bias_tensor.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    if (in1_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
+    }
+
+    if (bias_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["BIAS_SHARDED"] = "1";
+    }
+
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+    }
+
+    // TODO: SKIP_MCAST flag isn't used for the sharded reader kernel because internal mcast logic already works without
+    // skipping We can use this flag to turn off unnecessary mcast overhead if necessary
+    if (in0_mcast_receiver_num_cores == 1) {
+        mm_kernel_in0_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+
+    mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    if (fuse_op && fused_op_signaler->is_all_gather()) {
+        // Create semaphores
+        fused_op_signaler->init_fused_op(
+            program,
+            device,
+            in0_mcast_sender_cores,
+            in0_is_sharded ? ttnn::experimental::ccl::FusedOpSignalerMode::SINGLE
+                           : ttnn::experimental::ccl::FusedOpSignalerMode::MULTI);
+    }
+
+    auto mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id = tt_metal::CreateKernel(
+        program,
+        in0_is_sharded
+            ? "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+              "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp"
+            : "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp",
+        in0_mcast_cores_with_work_and_in_receiver_grid,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = in0_noc,
+            .compile_args = in0_sender_compile_time_args,
+            .defines = mm_kernel_in0_sender_writer_defines,
+            .named_compile_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in0_sharded", tt::CBIndex::c_2},
+                {"cb_l1_array", tt::CBIndex::c_6},
+                {"cb_sparsity", tt::CBIndex::c_6},
+            }});
+
+    tt::tt_metal::KernelHandle mm_kernel_in0_mcast_cores_without_work_and_in_receiver_grid_id = 0;
+    tt::tt_metal::KernelHandle mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = 0;
+    if (in0_is_sharded) {
+        if (in0_mcast_cores_without_work_and_in_receiver_grid.num_cores() > 0) {
+            in0_sender_compile_time_args[0] = 0;  // core_has_output_block_work
+            in0_sender_compile_time_args[1] = 1;  // core_in_in0_receiver_mcast_grid
+            mm_kernel_in0_mcast_cores_without_work_and_in_receiver_grid_id = tt_metal::CreateKernel(
+                program,
+                "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp",
+                in0_mcast_cores_without_work_and_in_receiver_grid,
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = in0_noc,
+                    .compile_args = in0_sender_compile_time_args,
+                    .defines = mm_kernel_in0_sender_writer_defines,
+                    .named_compile_args = {
+                        {"cb_in0", tt::CBIndex::c_0},
+                        {"cb_in0_sharded", tt::CBIndex::c_2},
+                        {"cb_l1_array", tt::CBIndex::c_6},
+                    }});
+        }
+        if (in0_mcast_cores_without_work_and_not_in_receiver_grid.num_cores() > 0) {
+            in0_sender_compile_time_args[0] = 0;  // core_has_output_block_work
+            in0_sender_compile_time_args[1] = 0;  // core_in_in0_receiver_mcast_grid
+            mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = tt_metal::CreateKernel(
+                program,
+                "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp",
+                in0_mcast_cores_without_work_and_not_in_receiver_grid,
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = in0_noc,
+                    .compile_args = in0_sender_compile_time_args,
+                    .defines = mm_kernel_in0_sender_writer_defines,
+                    .named_compile_args = {
+                        {"cb_in0", tt::CBIndex::c_0},
+                        {"cb_in0_sharded", tt::CBIndex::c_2},
+                        {"cb_l1_array", tt::CBIndex::c_6},
+                    }});
+        }
+    }
+
+    tt::tt_metal::KernelHandle mm_kernel_in0_receiver_id = 0;
+    if (!in0_is_sharded and in0_mcast_receivers.num_cores() > 0) {
+        mm_kernel_in0_receiver_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp",
+            in0_mcast_receivers,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_receiver_compile_time_args,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                }});
+    }
+
+    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
+        all_cores_with_work,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_kernel_in1_sender_writer_defines,
+            .named_compile_args = {
+                {"cb_in1", tt::CBIndex::c_1},
+                {"cb_bias", tt::CBIndex::c_3},
+                {"cb_out", tt::CBIndex::c_4},
+                {"cb_sparsity", tt::CBIndex::c_7},
+            }});
+
+    // Compute kernel compile time args
+
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,        // num_blocks
+        out_num_blocks_x,  // out_num_blocks_x
+        out_num_blocks_y,  // out_num_blocks_y
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B,                       // batch
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias_tensor.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    constexpr auto cb_intermed0 = tt::CBIndex::c_5;
+    std::unordered_map<std::string, uint32_t> compute_named_compile_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_intermed0", cb_intermed0},
+        {"cb_in0_transposed", tt::CBIndex::c_10},
+        {"bias_ntiles", in1_per_core_w},
+    };
+
+    if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+        using ttnn::operations::matmul::utilities::get_activation_params;
+        const auto& activation = fused_activation.value();
+        const auto params = get_activation_params(activation);
+        compute_named_compile_args["activation_type"] = static_cast<uint32_t>(params.type);
+        compute_named_compile_args["activation_param0"] = params.param0;
+        compute_named_compile_args["activation_param1"] = params.param1;
+        compute_named_compile_args["activation_param2"] = params.param2;
+    }
+
+    // The fused bias add reads the partials CB as an FPU operand (SrcA), so UnpackToDestFp32 cannot be
+    // set on cb_intermed0 directly when bias is present. In that case the cross-block reload instead
+    // copies through cb_intermed0_alias, a second buffer index over the same SRAM carrying
+    // UnpackToDestFp32, while the bias add keeps reading cb_intermed0 via SrcA. The alias index is
+    // handed to the compute kernel through the MM_PARTIALS_RELOAD_ALIAS_CB define, which selects the
+    // alias reload path there. Without bias the reload reads cb_intermed0 and the flag is set on it.
+    constexpr auto cb_intermed0_alias = tt::CBIndex::c_7;
+    const bool bias_reload_alias =
+        fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32 && bias_tensor.has_value();
+    if (bias_reload_alias) {
+        mm_kernel_defines["MM_PARTIALS_RELOAD_ALIAS_CB"] = std::to_string(static_cast<uint32_t>(cb_intermed0_alias));
+    }
+    // When accumulating in fp32 (fp32_dest_acc_en) with the K reduction split across blocks,
+    // the intermediate partials CB (cb_intermed0) holds Float32 and is reloaded into DEST
+    // between blocks by copy_block_matmul_partials. Unless the reload's CB view is marked
+    // UnpackToDestFp32, that reload is routed through SrcA and rounded to TF32 (10 mantissa bits),
+    // so the fp32 partial loses precision on every block boundary. The flag is set on the alias
+    // when bias forces a separate SrcA view of cb_intermed0 (see above), else on cb_intermed0 itself.
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32) {
+        const uint32_t cb_to_mark =
+            bias_reload_alias ? static_cast<uint32_t>(cb_intermed0_alias) : static_cast<uint32_t>(cb_intermed0);
+        unpack_to_dest_mode[cb_to_mark] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    // Create compute kernel
+    // bool fp32_dest_acc_en = false;
+    // Gelu currently has better accuracy when run in approx mode
+    // bool math_approx_mode = false;
+    tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp",
+        all_cores_with_work,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines,
+            .named_compile_args = compute_named_compile_args});
+
+    // Create circular buffers
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_aligned_tile_size)
+            .set_tile_dims(src0_cb_index, in0_tile);
+    tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src0_cb_index,
+        in0_single_tile_size,
+        in0_CB_size / in0_single_tile_size,
+        in0_CB_size);
+
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_aligned_tile_size)
+            .set_tile_dims(src1_cb_index, in1_tile);
+
+    if (in1_is_sharded) {
+        src1_cb_config = src1_cb_config.set_globally_allocated_address(in1_tensor);
+    }
+
+    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src1_cb_index,
+        in1_single_tile_size,
+        in1_CB_size / in1_single_tile_size,
+        in1_CB_size);
+
+    uint32_t src2_cb_index = tt::CBIndex::c_2;
+    tt::tt_metal::CBHandle cb_src2 = 0;
+    if (in0_is_sharded) {
+        tt_metal::CircularBufferConfig src2_cb_config =
+            tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
+                .set_page_size(src2_cb_index, in0_single_tile_size)
+                .set_globally_allocated_address(in0_tensor)
+                .set_tile_dims(src2_cb_index, in0_tile);
+        cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src2_cb_index,
+            in0_single_tile_size,
+            in2_CB_size / in0_single_tile_size,
+            in2_CB_size);
+
+        // Local L1 to store temp vars
+        uint32_t l1_cb_index = tt::CBIndex::c_6;
+        tt::tt_metal::CircularBufferConfig cb_for_l1_array_config =
+            tt::tt_metal::CircularBufferConfig(32 * 2, {{l1_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(l1_cb_index, 32 * 2);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
+    }
+
+    uint32_t output_cb_index = tt::CBIndex::c_4;
+    uint32_t interm0_cb_index = tt::CBIndex::c_5;
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // output
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format},
+        };
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile);
+        // interm0
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
+            {interm0_cb_index, interm0_data_format},
+        };
+        // Alias over the same SRAM, marked UnpackToDestFp32, for the bias reload (see above).
+        if (bias_reload_alias) {
+            interm0_cb_data_format_spec[static_cast<uint8_t>(cb_intermed0_alias)] = interm0_data_format;
+        }
+        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                .set_tile_dims(interm0_cb_index, output_tile);
+        if (bias_reload_alias) {
+            interm0_cb_config =
+                interm0_cb_config.set_page_size(static_cast<uint8_t>(cb_intermed0_alias), interm0_single_tile_size)
+                    .set_tile_dims(static_cast<uint8_t>(cb_intermed0_alias), output_tile);
+        }
+
+        tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), interm0_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            interm0_cb_index,
+            interm0_single_tile_size,
+            interm0_CB_size / interm0_single_tile_size,
+            interm0_CB_size);
+    } else {
+        // share buffer
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
+        // Alias over the same SRAM, marked UnpackToDestFp32, for the bias reload (see above).
+        if (bias_reload_alias) {
+            output_cb_data_format_spec[static_cast<uint8_t>(cb_intermed0_alias)] = interm0_data_format;
+        }
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile)
+                               .set_tile_dims(interm0_cb_index, output_tile);
+        if (bias_reload_alias) {
+            output_cb_config =
+                output_cb_config.set_page_size(static_cast<uint8_t>(cb_intermed0_alias), interm0_single_tile_size)
+                    .set_tile_dims(static_cast<uint8_t>(cb_intermed0_alias), output_tile);
+        }
+    }
+
+    if (output_is_sharded) {
+        output_cb_config = output_cb_config.set_globally_allocated_address(out_tensor);
+    }
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        output_cb_index,
+        output_single_tile_size,
+        out_CB_size / output_single_tile_size,
+        out_CB_size);
+
+    tt_metal::CBHandle cb_src3 = 0;
+    if (bias_tensor.has_value()) {
+        uint32_t src3_cb_index = tt::CBIndex::c_3;
+        tt_metal::CircularBufferConfig cb_src3_config =
+            tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
+                .set_page_size(src3_cb_index, bias_aligned_tile_size)
+                .set_tile_dims(src3_cb_index, bias_tile);
+
+        if (bias_is_sharded) {
+            cb_src3_config = cb_src3_config.set_globally_allocated_address(*bias_tensor);
+        }
+
+        cb_src3 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src3_cb_index,
+            bias_aligned_tile_size,
+            in3_CB_size / bias_aligned_tile_size,
+            in3_CB_size);
+    }
+
+    // Intermediate CB read
+
+    // Transpose CB for input0
+    if (in0_transpose_tile) {
+        const uint32_t in0_transpose_cb_index = tt::CBIndex::c_10;
+        auto in0_transpose_cb_config =
+            tt_metal::CircularBufferConfig(in0_CB_size, {{in0_transpose_cb_index, in0_data_format}})
+                .set_page_size(in0_transpose_cb_index, in0_aligned_tile_size)
+                .set_tile_dims(in0_transpose_cb_index, in0_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, in0_transpose_cb_config);
+    }
+
+    // Parameters for last row, col, or block. mcast_in0 replicates M across all cores
+    // (num_blocks_y == 1), so any M-direction padding lives entirely within a single h-block.
+    uint32_t last_per_core_N = N % per_core_N == 0 ? per_core_N : N % per_core_N;
+    uint32_t last_out_block_w = last_per_core_N % out_block_w == 0 ? out_block_w : last_per_core_N % out_block_w;
+    uint32_t last_out_num_blocks_w = ((last_per_core_N - 1) / out_block_w) + 1;
+    uint32_t last_block_num_nonzero_subblocks_w = ((last_out_block_w - 1) / out_subblock_w) + 1;
+    uint32_t last_subblock_of_last_block_w =
+        last_out_block_w % out_subblock_w == 0 ? out_subblock_w : last_out_block_w % out_subblock_w;
+    uint32_t last_block_padded_subblock_tiles_addr_skip =
+        output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
+    uint32_t last_block_padded_block_tiles_w_skip =
+        (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
+
+    // M-direction padding when M < per_core_M. With num_blocks_y == 1 the last (only) h-block
+    // holds last_out_block_h valid tile rows out of out_block_h.
+    uint32_t in0_last_per_core_M = M < per_core_M ? M : per_core_M;
+    uint32_t in0_last_out_block_h =
+        in0_last_per_core_M % out_block_h == 0 ? out_block_h : in0_last_per_core_M % out_block_h;
+    uint32_t in0_last_block_num_nonzero_subblocks_h = ((in0_last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t in0_last_subblock_of_last_block_h =
+        in0_last_out_block_h % out_subblock_h == 0 ? out_subblock_h : in0_last_out_block_h % out_subblock_h;
+    uint32_t in0_last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - in0_last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    CoreCoord start_core_noc = top_left_core_physical;
+    CoreCoord end_core_noc = bottom_right_core_physical;
+    if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+        std::swap(start_core_noc, end_core_noc);
+    }
+
+    const auto& cores = corerange_to_cores(all_cores, std::nullopt, row_major);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const auto& core = cores[i];
+        uint32_t output_idx_x = i % num_blocks_x;
+        uint32_t output_idx_y = i / num_blocks_x;
+
+        if (in0_is_sharded) {
+            std::vector<uint32_t> mm_in0_sender_args;
+            mm_in0_sender_args.reserve(5 + in0_mcast_noc_x.size() + in0_mcast_noc_y.size());
+            mm_in0_sender_args.push_back(i);
+            mm_in0_sender_args.push_back(start_core_noc.x);
+            mm_in0_sender_args.push_back(start_core_noc.y);
+            mm_in0_sender_args.push_back(end_core_noc.x);
+            mm_in0_sender_args.push_back(end_core_noc.y);
+            mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_x.begin(), in0_mcast_noc_x.end());
+            mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_y.begin(), in0_mcast_noc_y.end());
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            if (i < num_cores_with_work) {
+                tt_metal::SetRuntimeArgs(
+                    program,
+                    mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id,
+                    core,
+                    mm_in0_sender_args);  // RISCV_0_default
+            } else if (i < in0_mcast_receiver_num_dests) {
+                tt_metal::SetRuntimeArgs(
+                    program,
+                    mm_kernel_in0_mcast_cores_without_work_and_in_receiver_grid_id,
+                    core,
+                    mm_in0_sender_args);  // RISCV_0_default
+            } else {
+                tt_metal::SetRuntimeArgs(
+                    program,
+                    mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id,
+                    core,
+                    mm_in0_sender_args);  // RISCV_0_default
+            }
+        }
+        // in0 sender and in1 sender
+        else if (core == start_core) {
+            std::vector<uint32_t> mm_in0_sender_args = {
+                // in0 tensor args
+                (std::uint32_t)in0_tensor.address(),
+                (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
+                // in0 mcast args
+                (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
+                (std::uint32_t)start_core_noc.y,  // in0_mcast_dest_noc_start_y
+                (std::uint32_t)end_core_noc.x,    // in0_mcast_dest_noc_end_x
+                (std::uint32_t)end_core_noc.y,    // in0_mcast_dest_noc_end_y
+
+                // padding args
+                (std::uint32_t)in0_last_out_block_h,  // last_block_h
+
+                // sparsity args
+                (std::uint32_t)0,  // sparsity_addr
+            };
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            tt_metal::SetRuntimeArgs(
+                program,
+                mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id,
+                core,
+                mm_in0_sender_args);  // RISCV_0_default
+        }
+        // in0 receiver and in 1 sender
+        else {
+            std::vector<uint32_t> mm_in0_receiver_args = {
+                // in0 mcast args
+                (std::uint32_t)top_left_core_physical.x,  // in0_mcast_sender_noc_x
+                (std::uint32_t)top_left_core_physical.y   // in0_mcast_sender_noc_y
+            };
+            tt_metal::SetRuntimeArgs(
+                program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args);  // RISCV_1_default
+        }
+        if (i < num_cores_with_work) {
+            std::vector<uint32_t> mm_in1_sender_writer_args = {
+                // READER
+                // in1 tensor args
+                (std::uint32_t)in1_tensor.address(),
+                (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
+                // in1 mcast args
+                (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
+                (std::uint32_t)0,  // in1_mcast_dest_noc_start_y
+                (std::uint32_t)0,  // in1_mcast_dest_noc_end_x
+                (std::uint32_t)0,  // in1_mcast_dest_noc_end_y
+
+                // sparsity args
+                (std::uint32_t)0,  // sparsity_addr
+
+                // WRITER
+                // out tensor args
+                (std::uint32_t)out_tensor.address(),
+                ((std::uint32_t)output_idx_x * per_core_N) +
+                    (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
+            };
+
+            if (output_idx_x == num_blocks_x - 1) {
+                // padding args (READER)
+                mm_in1_sender_writer_args.push_back(last_out_block_w);
+
+                // padding args (WRITER)
+                mm_in1_sender_writer_args.push_back(in0_last_block_num_nonzero_subblocks_h);
+                mm_in1_sender_writer_args.push_back(in0_last_subblock_of_last_block_h);
+                mm_in1_sender_writer_args.push_back(in0_last_block_padded_block_tiles_h_skip);
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
+                mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
+                mm_in1_sender_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                mm_in1_sender_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+            } else {
+                // padding args (READER)
+                mm_in1_sender_writer_args.push_back(out_block_w);
+
+                // padding args (WRITER)
+                mm_in1_sender_writer_args.push_back(in0_last_block_num_nonzero_subblocks_h);
+                mm_in1_sender_writer_args.push_back(in0_last_subblock_of_last_block_h);
+                mm_in1_sender_writer_args.push_back(in0_last_block_padded_block_tiles_h_skip);
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_sender_writer_args.push_back(out_subblock_w);
+                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(0);
+            }
+
+            // Bias base address; patched on program-cache hit by override_mcast_in0_program_parameters (idx 18).
+            mm_in1_sender_writer_args.push_back(
+                bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);  // smuggled-rta-ok
+            mm_in1_sender_writer_args.push_back(
+                bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
+            if (!output_is_sharded) {
+                if (output_idx_x == num_blocks_x - 1) {
+                    mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
+                } else {
+                    mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+                }
+            }
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, true);
+            }
+
+            tt_metal::SetRuntimeArgs(
+                program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args);  // RISCV_0_default
+        }
+    }
+
+    return MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t{
+        {mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id, mm_kernel_in1_sender_writer_id},
+        {cb_src1, cb_src2, cb_src3, cb_output},
+        false,
+        start_core,
+        cores,
+        num_cores_with_work,
+        ttnn::prim::Matmul1DType::MCAST_IN0};
+}
+
+MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_program_and_create_override_variables(
+    tt_metal::Program& program,
+    const ttnn::Tensor& a,
+    tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    CoreCoord compute_with_storage_grid_size,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_B,
+    uint32_t in1_B,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    std::optional<UnaryWithParam> fused_activation,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    ttsl::optional_reference<const MeshTensor> bias_tensor,
+    const MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool in0_is_sharded,
+    bool output_is_sharded,
+    bool untilize_out,
+    bool row_broadcast_bias = true,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = false;
+
+    uint32_t num_blocks = K / in0_block_w;
+    // Only enable packer l1 accumulation when there are num_blocks > 2, otherwise
+    // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+    // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+    // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_tensor.has_value()) && num_blocks > 1) || (num_blocks > 2));
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = in0_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+
+    bool reuse_in0_in_CB =
+        ((in0_B == 1 && in1_B > 1) && !in0_is_sharded && !output_is_sharded && !bcast_batch &&
+         !fused_activation.has_value());
+
+    if (reuse_in0_in_CB) {
+        in0_CB_tiles = per_core_M * num_blocks * in0_block_w;
+    } else if (in0_is_sharded) {
+        in0_CB_tiles = num_blocks * per_core_M * in0_block_w * in0_B;
+    } else if (in0_B * num_blocks > 1) {
+        in0_CB_tiles = in0_CB_tiles * 2;  // double buffer
+    }
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
+    // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
+    // the padded stride, so the in0/in1/bias CBs must hold pages at the aligned stride and the
+    // reader/unpacker walk tiles at the same stride. No-op when already aligned (all bf16 tiles,
+    // 32-wide bfp8, Wormhole). Replaces the staging-CB workaround. Sharded CBs are backed by the
+    // tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size = tt::align(in1_single_tile_size, dram_alignment);
+    // Bias CB pages must be padded to the DRAM alignment so the reader's L1 write stride
+    // matches the DRAM page stride (e.g. 64B on Blackhole for a 32B (1,16) bf16 bias tile).
+    // Mirrors in0/in1 above and the dram_sharded factory. No-op on Wormhole and for
+    // tiles already >= dram_alignment.
+    uint32_t bias_aligned_tile_size = tt::align(bias_single_tile_size, dram_alignment);
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+
+    const auto& a_shape_logical = operations::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    // When transpose_a is true, the K dimension maps to the row dimension of the raw tile,
+    // which is already zero-padded during tile layout conversion. pad_last_ktile operates on
+    // columns, so applying it would incorrectly zero valid data that becomes output rows
+    // after the compute kernel transposes the tile.
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    bool extract_shard_sub_blocks = false;
+    uint32_t in0_shard_height_in_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        // NOTE: Criteria for extract_shard_sub_blocks is different from mcast in0
+        // In the reader kernel, always need to copy to cb0 even for height=1 shards since we may not always do mcast
+        // In mcast in0 sharded reader kernel, this is handled by mcast with loopback src
+        // For mcast in1, if we don't need to extract_shard_sub_blocks, set the sharded in0 cb to cb0
+        // For mcast in0, sharded in0 cb is always cb2
+        if (in0_shard_width_in_tiles / in0_block_w > 1) {
+            extract_shard_sub_blocks = true;
+        }
+    }
+    uint32_t in2_CB_tiles = in0_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (in1_B * num_blocks > 1) {
+        in1_CB_tiles = in1_CB_tiles * 2;  // double buffer
+    }
+
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_aligned_tile_size;
+
+    CoreCoord start_core = sub_device_start_core;
+
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. Callers must ensure this rectangle lies entirely
+    // within the active sub-device's worker cores (validated upstream).
+    CoreRangeSet matmul_core_rect(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core.x + compute_with_storage_grid_size.x - 1, start_core.y + compute_with_storage_grid_size.y - 1)));
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+    uint32_t num_cores = num_blocks_total;
+
+    constexpr bool row_major = true;
+    CoreRangeSet all_cores =
+        tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
+    CoreRange in1_mcast_receiver_cores_bounding_box = all_cores.bounding_box();
+    uint32_t in1_mcast_receiver_num_cores = in1_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
+
+    CoreRange in1_mcast_sender(start_core, start_core);
+    CoreRangeSet in1_mcast_receivers;
+    if (in1_mcast_receiver_num_cores > 1) {
+        // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+        // sub-devices anchored away from (0, 0) wrap correctly.
+        auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                        : CoreCoord{start_core.x, start_core.y + 1};
+        in1_mcast_receivers = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+            receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
+    }
+
+    // Mcast args
+    auto in1_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+    CoreCoord top_left_core = in1_mcast_receiver_cores_bounding_box.start_coord;
+    CoreCoord bottom_right_core = in1_mcast_receiver_cores_bounding_box.end_coord;
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    const auto& a_padded_shape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    std::vector<uint32_t> in0_sender_compile_time_args = {
+        // in0 tensor args
+        (std::uint32_t)in0_tensor_stride_w,
+        (std::uint32_t)in0_tensor_stride_h,
+        (std::uint32_t)in0_tensor_next_block_stride,
+        (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+        // in0 block args
+        (std::uint32_t)in0_block_w,                // in0_block_w
+        (std::uint32_t)in0_block_h,                // in0_block_h
+        (std::uint32_t)in0_block_w * in0_block_h,  // in0_block_num_tiles
+        (std::uint32_t)in0_last_ktile_w,
+        (std::uint32_t)in0_last_ktile_h,
+
+        (std::uint32_t)extract_shard_sub_blocks,
+        (std::uint32_t)in0_shard_width_in_tiles,
+        (std::uint32_t)in0_shard_height_in_tiles,
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in0 mcast args
+        (std::uint32_t)0,
+        (std::uint32_t)0,
+        (std::uint32_t)0,  // in0_mcast_num_dests
+        (std::uint32_t)0,  // in0_mcast_num_cores
+        // batch args
+        (std::uint32_t)M * K,            // MtKt
+        (std::uint32_t)in0_B,            // batch
+        (std::uint32_t)in1_B,            // batch
+        (std::uint32_t)reuse_in0_in_CB,  // reuse_in0_in_CB
+        // sparsity args
+        (std::uint32_t)0,     // batchB
+        (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)
+        (std::uint32_t)true,  // bcast_A
+        (std::uint32_t)false  // get_batch_from_reader
+    };
+    in0_sender_compile_time_args.push_back((std::uint32_t)fuse_op);
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+    in0_sender_compile_time_args.push_back((std::uint32_t)0);  // num_batch_compute (unused, sparsity disabled)
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        (std::uint32_t)num_cores - 1,                     // in1_mcast_num_dests
+        (std::uint32_t)in1_mcast_receiver_num_cores - 1,  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,                              // KtNt
+        (std::uint32_t)(reuse_in0_in_CB ? in1_B : in0_B),  // batch
+        (std::uint32_t)bcast_batch,                        // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+
+    if (bias_tensor.has_value()) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
+        // READER
+        // in1 block args
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)(reuse_in0_in_CB ? in1_B : in0_B),  // batch
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+
+    if (bias_tensor.has_value()) {
+        in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
+    } else {
+        in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+    in1_receiver_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_receiver_writer_compile_time_args);
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
+    if (bias_tensor.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    if (in0_is_sharded) {
+        mm_kernel_in0_sender_defines["IN0_SHARDED"] = "1";
+    }
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_defines["OUT_SHARDED"] = "1";
+    }
+
+    mm_kernel_in0_sender_defines["SKIP_MCAST"] = "1";
+
+    if (in1_mcast_receiver_num_cores == 1) {
+        mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    auto mm_kernel_in0_sender_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp",
+        all_cores,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = in0_noc,
+            .compile_args = in0_sender_compile_time_args,
+            .defines = mm_kernel_in0_sender_defines,
+            .named_compile_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in0_sharded", tt::CBIndex::c_2},
+                {"cb_sparsity", tt::CBIndex::c_6},
+            }});
+
+    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
+        in1_mcast_sender,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_kernel_in1_sender_writer_defines,
+            .named_compile_args = {
+                {"cb_in1", tt::CBIndex::c_1},
+                {"cb_bias", tt::CBIndex::c_3},
+                {"cb_out", tt::CBIndex::c_4},
+                {"cb_sparsity", tt::CBIndex::c_7},
+            }});
+
+    tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_id = 0;
+    if (in1_mcast_receivers.num_cores() > 0) {
+        mm_kernel_in1_receiver_writer_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp",
+            in1_mcast_receivers,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = in1_noc,
+                .compile_args = in1_receiver_writer_compile_time_args,
+                .defines = mm_kernel_in1_receiver_writer_defines,
+                .named_compile_args = {
+                    {"cb_in1", tt::CBIndex::c_1},
+                    {"cb_bias", tt::CBIndex::c_3},
+                    {"cb_out", tt::CBIndex::c_4},
+                }});
+    }
+
+    // Compute kernel compile time args
+
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,        // num_blocks
+        out_num_blocks_x,  // out_num_blocks_x
+        out_num_blocks_y,  // out_num_blocks_y
+
+        out_subblock_h,                     // out_subblock_h
+        out_subblock_w,                     // out_subblock_w
+        out_subblock_num_tiles,             // out_subblock_num_tiles
+        (reuse_in0_in_CB ? in1_B : in0_B),  // batch
+        out_block_tiles,                    // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias_tensor.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    // Setup named compile args
+    std::unordered_map<std::string, uint32_t> compute_named_compile_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_intermed0", tt::CBIndex::c_5},
+        {"cb_in0_transposed", tt::CBIndex::c_10},
+        {"bias_ntiles", in1_per_core_w},
+    };
+
+    // Add activation type if needed
+    if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+        using ttnn::operations::matmul::utilities::get_activation_params;
+        const auto& activation = fused_activation.value();
+        const auto params = get_activation_params(activation);
+        compute_named_compile_args["activation_type"] = static_cast<uint32_t>(params.type);
+        compute_named_compile_args["activation_param0"] = params.param0;
+        compute_named_compile_args["activation_param1"] = params.param1;
+        compute_named_compile_args["activation_param2"] = params.param2;
+    }
+
+    // The fused bias add reads the partials CB as an FPU operand (SrcA), so UnpackToDestFp32 cannot be
+    // set on cb_intermed0 directly when bias is present. In that case the cross-block reload instead
+    // copies through cb_intermed0_alias, a second buffer index over the same SRAM carrying
+    // UnpackToDestFp32, while the bias add keeps reading cb_intermed0 via SrcA. The alias index is
+    // handed to the compute kernel through the MM_PARTIALS_RELOAD_ALIAS_CB define, which selects the
+    // alias reload path there. Without bias the reload reads cb_intermed0 and the flag is set on it.
+    constexpr auto cb_intermed0 = tt::CBIndex::c_5;
+    constexpr auto cb_intermed0_alias = tt::CBIndex::c_7;
+    const bool bias_reload_alias =
+        fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32 && bias_tensor.has_value();
+    if (bias_reload_alias) {
+        mm_kernel_defines["MM_PARTIALS_RELOAD_ALIAS_CB"] = std::to_string(static_cast<uint32_t>(cb_intermed0_alias));
+    }
+    // When accumulating in fp32 (fp32_dest_acc_en) with the K reduction split across blocks, the
+    // intermediate partials CB (cb_intermed0) holds Float32 and is reloaded into DEST between blocks
+    // by copy_block_matmul_partials. Unless the reload's CB view is marked UnpackToDestFp32, that
+    // reload is routed through SrcA and rounded to TF32 (10 mantissa bits), so the fp32 partial loses
+    // precision on every block boundary. The flag is set on the alias when bias forces a separate SrcA
+    // view of cb_intermed0 (see above), else on cb_intermed0 itself.
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32) {
+        const uint32_t cb_to_mark =
+            bias_reload_alias ? static_cast<uint32_t>(cb_intermed0_alias) : static_cast<uint32_t>(cb_intermed0);
+        unpack_to_dest_mode[cb_to_mark] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    // Create compute kernel
+    // bool fp32_dest_acc_en = false;
+    // Gelu currently has better accuracy when run in approx mode
+    // bool math_approx_mode = false;
+    tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp",
+        all_cores,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines,
+            .named_compile_args = compute_named_compile_args});
+
+    // Create circular buffers
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_aligned_tile_size)
+            .set_tile_dims(src0_cb_index, in0_tile);
+    if (in0_is_sharded and not extract_shard_sub_blocks) {
+        src0_cb_config = src0_cb_config.set_globally_allocated_address(in0_tensor);
+    }
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src0_cb_index,
+        in0_single_tile_size,
+        in0_CB_size / in0_single_tile_size,
+        in0_CB_size);
+
+    uint32_t src2_cb_index = tt::CBIndex::c_2;
+    tt::tt_metal::CBHandle cb_src2 = 0;
+    if (in0_is_sharded and extract_shard_sub_blocks) {  // in0_is_sharded is technically redundant
+        tt_metal::CircularBufferConfig src2_cb_config =
+            tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
+                .set_page_size(src2_cb_index, in0_single_tile_size)
+                .set_globally_allocated_address(in0_tensor)
+                .set_tile_dims(src2_cb_index, in0_tile);
+        cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src2_cb_index,
+            in0_single_tile_size,
+            in2_CB_size / in0_single_tile_size,
+            in2_CB_size);
+    }
+
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_aligned_tile_size)
+            .set_tile_dims(src1_cb_index, in1_tile);
+    tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src1_cb_index,
+        in1_single_tile_size,
+        in1_CB_size / in1_single_tile_size,
+        in1_CB_size);
+
+    uint32_t output_cb_index = tt::CBIndex::c_4;
+    uint32_t interm0_cb_index = tt::CBIndex::c_5;
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // output
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format},
+        };
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile);
+        // interm0
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
+            {interm0_cb_index, interm0_data_format},
+        };
+        // Alias over the same SRAM, marked UnpackToDestFp32, for the bias reload (see above).
+        if (bias_reload_alias) {
+            interm0_cb_data_format_spec[static_cast<uint8_t>(cb_intermed0_alias)] = interm0_data_format;
+        }
+        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                .set_tile_dims(interm0_cb_index, output_tile);
+        if (bias_reload_alias) {
+            interm0_cb_config =
+                interm0_cb_config.set_page_size(static_cast<uint8_t>(cb_intermed0_alias), interm0_single_tile_size)
+                    .set_tile_dims(static_cast<uint8_t>(cb_intermed0_alias), output_tile);
+        }
+
+        tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), interm0_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            interm0_cb_index,
+            interm0_single_tile_size,
+            interm0_CB_size / interm0_single_tile_size,
+            interm0_CB_size);
+    } else {
+        // share buffer
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
+        // Alias over the same SRAM, marked UnpackToDestFp32, for the bias reload (see above).
+        if (bias_reload_alias) {
+            output_cb_data_format_spec[static_cast<uint8_t>(cb_intermed0_alias)] = interm0_data_format;
+        }
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile)
+                               .set_tile_dims(interm0_cb_index, output_tile);
+        if (bias_reload_alias) {
+            output_cb_config =
+                output_cb_config.set_page_size(static_cast<uint8_t>(cb_intermed0_alias), interm0_single_tile_size)
+                    .set_tile_dims(static_cast<uint8_t>(cb_intermed0_alias), output_tile);
+        }
+    }
+
+    if (output_is_sharded) {
+        output_cb_config = output_cb_config.set_globally_allocated_address(out_tensor);
+    }
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        output_cb_index,
+        output_single_tile_size,
+        out_CB_size / output_single_tile_size,
+        out_CB_size);
+
+    if (bias_tensor.has_value()) {
+        uint32_t src3_cb_index = tt::CBIndex::c_3;
+        tt_metal::CircularBufferConfig cb_src3_config =
+            tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
+                .set_page_size(src3_cb_index, bias_aligned_tile_size)
+                .set_tile_dims(src3_cb_index, bias_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src3_cb_index,
+            bias_aligned_tile_size,
+            in3_CB_size / bias_aligned_tile_size,
+            in3_CB_size);
+    }
+
+    // Intermediate CB read
+
+    if (in0_transpose_tile) {
+        const uint32_t in0_transpose_cb_index = tt::CBIndex::c_10;
+        auto in0_transpose_cb_config =
+            tt_metal::CircularBufferConfig(in0_CB_size, {{in0_transpose_cb_index, in0_data_format}})
+                .set_page_size(in0_transpose_cb_index, in0_aligned_tile_size)
+                .set_tile_dims(in0_transpose_cb_index, in0_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, in0_transpose_cb_config);
+    }
+
+    // Parameters for last row, col, or block
+    uint32_t last_per_core_M = M % per_core_M == 0 ? per_core_M : M % per_core_M;
+    uint32_t last_out_block_h = last_per_core_M % out_block_h == 0 ? out_block_h : last_per_core_M % out_block_h;
+    uint32_t last_out_num_blocks_h = ((last_per_core_M - 1) / out_block_h) + 1;
+    uint32_t last_block_num_nonzero_subblocks_h = ((last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t last_subblock_of_last_block_h =
+        last_out_block_h % out_subblock_h == 0 ? out_subblock_h : last_out_block_h % out_subblock_h;
+    uint32_t last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    CoreCoord start_core_noc = bottom_right_core_physical;
+    CoreCoord end_core_noc = top_left_core_physical;
+    if (in1_noc == tt::tt_metal::NOC::NOC_0) {
+        std::swap(start_core_noc, end_core_noc);
+    }
+
+    const auto& cores = corerange_to_cores(all_cores, std::nullopt, row_major);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const auto& core = cores[i];
+        uint32_t output_idx_x = i / num_blocks_y;
+        uint32_t output_idx_y = i % num_blocks_y;
+
+        // in0 sender and in1 sender
+        if (core == start_core) {
+            std::vector<uint32_t> mm_in1_sender_writer_args = {
+                // READER
+                // in1 tensor args
+                (std::uint32_t)in1_tensor.address(),
+                (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
+                // in1 mcast args
+                (std::uint32_t)start_core_noc.x,  // in1_mcast_dest_noc_start_x
+                (std::uint32_t)start_core_noc.y,  // in1_mcast_dest_noc_start_y
+                (std::uint32_t)end_core_noc.x,    // in1_mcast_dest_noc_end_x
+                (std::uint32_t)end_core_noc.y,    // in1_mcast_dest_noc_end_y
+
+                // sparsity args
+                (std::uint32_t)0,  // sparsity_addr
+
+                // WRITER
+                // out tensor args
+                (std::uint32_t)out_tensor.address(),
+                ((std::uint32_t)output_idx_x * per_core_N) +
+                    (output_idx_y * per_core_M * N),  // out_tensor_start_tile_id
+
+                // padding args (READER)
+                (std::uint32_t)out_block_w,  // last_block_w
+                // padding args (WRITER)
+                (std::uint32_t)out_block_h / out_subblock_h,
+                (std::uint32_t)out_subblock_h,
+                (std::uint32_t)0,
+                (std::uint32_t)out_block_w / out_subblock_w,
+                (std::uint32_t)out_block_w / out_subblock_w,
+                (std::uint32_t)out_subblock_w,
+                (std::uint32_t)0,
+                (std::uint32_t)0};
+
+            if (bias_tensor.has_value()) {
+                // Bias base address; patched on program-cache hit by override_mcast_in1_program_parameters (idx 18).
+                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_tensor->address());  // smuggled-rta-ok
+                mm_in1_sender_writer_args.push_back(
+                    (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
+            } else {
+                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(0);
+            }
+            if (!output_is_sharded) {
+                mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+            }
+
+            tt_metal::SetRuntimeArgs(
+                program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args);  // RISCV_1_default
+        }
+        // in0 sender and in1 receiver
+        else {
+            std::vector<uint32_t> mm_in1_receiver_writer_args = {
+                // READER
+                // in1 mcast args
+                (std::uint32_t)top_left_core_physical.x,  // in1_mcast_sender_noc_x
+                (std::uint32_t)top_left_core_physical.y,  // in1_mcast_sender_noc_y
+
+                // WRITER
+                // out tensor args
+                (std::uint32_t)out_tensor.address(),  // out_tensor_addr
+                ((std::uint32_t)output_idx_x * per_core_N) +
+                    (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
+            };
+
+            if (output_idx_y == num_blocks_y - 1) {
+                // padding args (WRITER)
+                mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(0);
+                mm_in1_receiver_writer_args.push_back(0);
+            } else {
+                // padding args (WRITER)
+                mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(0);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(0);
+                mm_in1_receiver_writer_args.push_back(0);
+            }
+            if (!output_is_sharded) {
+                if (output_idx_y == num_blocks_y - 1) {
+                    mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                    mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                } else {
+                    mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                    mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                }
+            }
+
+            tt_metal::SetRuntimeArgs(
+                program,
+                mm_kernel_in1_receiver_writer_id,
+                core,
+                mm_in1_receiver_writer_args);  // RISCV_0_default
+        }
+        std::vector<uint32_t> mm_in0_sender_args = {
+            // in0 tensor args
+            (std::uint32_t)in0_tensor.address(),
+            (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
+            // in0 mcast args
+            (std::uint32_t)0,  // in0_mcast_dest_noc_start_x
+            (std::uint32_t)0,  // in0_mcast_dest_noc_start_y
+            (std::uint32_t)0,  // in0_mcast_dest_noc_end_x
+            (std::uint32_t)0,  // in0_mcast_dest_noc_end_y
+
+            // padding args
+            (std::uint32_t)per_core_M,  // last_block_h
+
+            // sparsity args
+            (std::uint32_t)0,  // sparsity_addr
+        };
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_sender_args);  // RISCV_1_default
+    }
+    return MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t{
+        {mm_kernel_in0_sender_id, mm_kernel_in1_sender_writer_id, mm_kernel_in1_receiver_writer_id},
+        {cb_src0, cb_src2, cb_output},
+        extract_shard_sub_blocks,
+        start_core,
+        cores,
+        0,
+        ttnn::prim::Matmul1DType::MCAST_IN1};
+}
+
+enum class CORE_TYPE : uint32_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
+
+MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0_program_and_create_override_variables(
+    tt_metal::Program& program,
+    const ttnn::Tensor& a,
+    const std::vector<ttnn::Tensor>& b_tensors,
+    tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    bool dst_full_sync_en,
+    CoreCoord /*compute_with_storage_grid_size*/,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t base_cb_index,
+    uint32_t /*B*/,
+    uint32_t /*M*/,
+    uint32_t /*N*/,
+    uint32_t K,
+    bool /*bcast_batch*/,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    std::optional<UnaryWithParam> fused_activation,
+    const CoreRangeSet& hop_cores,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> out_buffers,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat output_data_format,
+    bool untilize_out,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    uint32_t num_global_cb_receivers,
+    bool stream_in1,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    std::optional<CoreRangeSet> restricted_cores,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler) {
+    const auto& b = b_tensors[0];
+    const auto num_output_cb = out_buffers.size();
+    const auto batch = b_tensors.size();
+    const bool in1_is_dram_interleaved = in1_tensor.memory_config().is_dram() && !b.is_sharded();
+    const bool in1_is_dram_sharded =
+        in1_tensor.memory_config().is_dram() && b.is_sharded() && !global_cb.has_value();  // read from DRAM directly
+
+    /* Core setup */
+    constexpr bool row_major = true;
+    CoreRangeSet all_worker_cores = a.shard_spec().value().grid;
+    CoreRangeSet non_idle_cores = all_worker_cores.merge(hop_cores);
+    CoreRangeSet all_cores = non_idle_cores;
+    std::vector<CoreRange> non_idle_cores_vec;
+    auto subdevice_cores = device->worker_cores(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX,
+        sub_device_id.has_value() ? *sub_device_id : device->get_sub_device_ids().at(0));
+    if (restricted_cores.has_value()) {
+        subdevice_cores = subdevice_cores.subtract(restricted_cores.value());
+    }
+    for (const auto& cr : subdevice_cores.ranges()) {
+        auto intersection = non_idle_cores.intersection(cr);
+        if (intersection.empty()) {
+            continue;
+        }
+        bool is_rectangular = cr.end_coord.x > cr.start_coord.x && cr.end_coord.y > cr.start_coord.y;
+        if (is_rectangular) {
+            non_idle_cores_vec.push_back(intersection.bounding_box());
+        } else {
+            for (const auto& ir : intersection.ranges()) {
+                non_idle_cores_vec.push_back(ir);
+            }
+        }
+    }
+    all_cores = CoreRangeSet(non_idle_cores_vec);
+    std::vector<CoreRange> ring_list = all_worker_cores.ranges();
+    std::vector<CoreRange> hop_list = hop_cores.ranges();
+    ring_list.insert(ring_list.end(), hop_list.begin(), hop_list.end());
+
+    CoreRangeSet ring_cores = CoreRangeSet(ring_list);
+    const uint32_t num_cores = all_worker_cores.num_cores();
+    const uint32_t ring_size = num_cores;
+
+    uint32_t num_hop_cores = hop_cores.num_cores();
+    bool use_hop_cores = num_hop_cores > 0;
+
+    /* Inner dim padding */
+    const uint32_t Kt_pad = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width() * num_cores;
+    in0_block_w = Kt_pad / num_cores;
+
+    uint32_t num_blocks = Kt_pad / in0_block_w;
+    // Only enable packer l1 accumulation when there are spills, otherwise
+    // unnecessary overhead for reconfigs are added
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+
+    bool use_global_cb = global_cb.has_value();
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    /* in0 */
+    uint32_t in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+    uint32_t in0_CB_tiles = per_core_M * in0_shard_width_in_tiles;
+    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
+
+    /* in1 */
+    uint32_t in1_shard_height_in_tiles = 0;
+    uint32_t in1_shard_width_in_tiles = 0;
+    uint32_t in1_CB_tiles = 0;
+
+    const auto& bshape = operations::matmul::utilities::get_matmul_tensor_padded_shape(b, /*transpose=*/false);
+    uint32_t in1_tensor_width_in_tiles = bshape[-1] / in1_tile.get_width();
+
+    if (in1_is_dram_sharded || in1_is_dram_interleaved) {
+        in1_CB_tiles = 2 * in0_shard_width_in_tiles * per_core_N;  // Double buffered
+    } else if (use_global_cb) {
+        // in1 is fed via the remote GCB CB (created from global_cb->size() below), so this
+        // local in1_CB_size is dead. Skip reading the weight's legacy shard_spec — a
+        // receiver-contiguous weight is allocated with an NdShardSpec (no legacy shard_spec),
+        // and the per-receiver block geometry is fully described by per_core_N / the GCB page.
+        in1_shard_height_in_tiles = in0_block_w;
+        in1_shard_width_in_tiles = per_core_N;
+        in1_CB_tiles = in1_shard_height_in_tiles * in1_shard_width_in_tiles;
+    } else {
+        in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
+        in1_shard_width_in_tiles = in1_tensor.shard_spec()->shape[1] / in1_tile.get_width() / num_global_cb_receivers;
+        in1_CB_tiles = in1_shard_height_in_tiles * in1_shard_width_in_tiles;
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
+
+    // get the max page size based on num tiles
+    uint32_t per_core_N_size_bytes = per_core_N * in1_single_tile_size;
+    uint32_t max_packet_size = 8192;
+    uint32_t in1_block_page_size = per_core_N_size_bytes > max_packet_size ? max_packet_size : per_core_N_size_bytes;
+    uint32_t in1_block_page_size_last =
+        per_core_N_size_bytes > max_packet_size ? per_core_N_size_bytes % max_packet_size : per_core_N_size_bytes;
+    uint32_t in1_block_width_num_pages = (per_core_N_size_bytes + in1_block_page_size - 1) / in1_block_page_size;
+    uint32_t in1_shard_width_in_dram = 0;
+    if (in1_is_dram_sharded) {
+        in1_shard_width_in_dram = in1_tensor.shard_spec()->shape[1] / in1_tile.get_width();
+    }
+
+    /* in2 */
+    uint32_t in2_single_tile_size = in0_single_tile_size;
+    uint32_t in2_CB_tiles = (ring_size - 1) * in0_CB_tiles;  // All shards except local
+    uint32_t in2_CB_size = std::max(in2_CB_tiles, 1u) * in2_single_tile_size;
+
+    /* out */
+    uint32_t out_block_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_size = out_CB_tiles * interm0_single_tile_size;
+
+    uint32_t K_ = K;
+    std::vector<uint32_t> unpadded_in0_shard_widths_in_tiles(num_cores, 0);
+    for (uint32_t i = 0; i < num_cores && K_ > 0; ++i) {
+        unpadded_in0_shard_widths_in_tiles[i] = std::min(K_, in0_shard_width_in_tiles);
+        K_ -= unpadded_in0_shard_widths_in_tiles[i];
+    }
+
+    /* semaphores */
+    auto in0_signal_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+    uint32_t in0_num_subblocks = (per_core_M / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+    uint32_t in1_num_subblocks = per_core_N / out_subblock_w;
+    uint32_t in1_block_height_in_tiles = in0_block_w;
+    uint32_t in1_block_num_tiles = out_subblock_w * in1_block_height_in_tiles * in1_num_subblocks;
+    uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size;
+    uint32_t in1_tensor_size_bytes = in1_block_num_tiles * num_blocks * in1_single_tile_size;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    /* Create circular buffers */
+    uint32_t src0_cb_index = base_cb_index;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_single_tile_size)
+            .set_tile_dims(src0_cb_index, in0_tile)
+            .set_globally_allocated_address(in0_tensor);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+
+    uint32_t src1_cb_index = base_cb_index + 1;
+    tt::tt_metal::CBHandle cb_src1;
+    uint32_t remote_cb_index = tt::CBIndex::c_31;
+    if (use_global_cb) {
+        uint32_t in1_block_size_bytes = in1_single_tile_size * in1_block_num_tiles;
+        tt_metal::CircularBufferConfig remote_cb_config =
+            tt_metal::CircularBufferConfig((global_cb->size() / in1_block_size_bytes) * in1_block_size_bytes);
+        remote_cb_config.remote_index(remote_cb_index)
+            .set_page_size(in1_block_size_bytes)
+            .set_data_format(in1_data_format);
+        remote_cb_config.index(src1_cb_index).set_page_size(in1_single_tile_size).set_data_format(in1_data_format);
+        cb_src1 = tt_metal::experimental::CreateCircularBuffer(program, all_cores, remote_cb_config, *global_cb);
+    } else {
+        tt_metal::CircularBufferConfig src1_cb_config =
+            tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+                .set_page_size(src1_cb_index, in1_single_tile_size)
+                .set_tile_dims(src1_cb_index, in1_tile);
+        if (!in1_is_dram_interleaved && !in1_is_dram_sharded) {
+            src1_cb_config = src1_cb_config.set_globally_allocated_address(in1_tensor);
+        }
+        cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    }
+
+    uint32_t src2_cb_index = base_cb_index + 2;
+    tt_metal::CircularBufferConfig src2_cb_config =
+        tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
+            .set_page_size(src2_cb_index, in2_single_tile_size)
+            .set_tile_dims(src2_cb_index, in0_tile);
+    tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
+
+    // Streaming pipelines one block ahead (lookahead 1), so up to this many blocks are in flight at
+    // once: the GCB must hold this many blocks/receiver (checked below) and the reader's cumulative
+    // remote_cb_wait_front peaks at this count. Bumping it would also require generalizing the
+    // reader's one-behind ack loop. (The reader recycles GCB slots off the in1 CB's engine-accurate
+    // consumer ack, so streaming needs no separate compute-done credit CB.)
+    constexpr uint32_t kStreamingInFlightBlocks = 2;
+
+    uint32_t sync_cb_index = base_cb_index + 3;
+    // Compute->reader release signal: one 16 B page (one credit). Only the batched global-CB path
+    // uses it (signals once per layer); streaming recycles GCB slots off the in1 CB's own consumer
+    // ack and needs no credit here.
+    constexpr uint32_t sync_cb_page_bytes = 16;
+    uint32_t sync_cb_size_bytes = sync_cb_page_bytes;
+    tt_metal::CircularBufferConfig sync_cb_config =
+        tt_metal::CircularBufferConfig(sync_cb_size_bytes, {{sync_cb_index, DataFormat::UInt16}})
+            .set_page_size(sync_cb_index, sync_cb_page_bytes);
+    tt_metal::CreateCircularBuffer(program, all_cores, sync_cb_config);
+
+    uint32_t sync_cb2_index = base_cb_index + 4;
+    uint32_t sync_cb2_size_bytes = 16;
+    tt_metal::CircularBufferConfig sync_cb2_config =
+        tt_metal::CircularBufferConfig(sync_cb2_size_bytes, {{sync_cb2_index, DataFormat::UInt16}})
+            .set_page_size(sync_cb2_index, sync_cb2_size_bytes);
+    tt_metal::CreateCircularBuffer(program, all_cores, sync_cb2_config);
+
+    uint32_t output_cb_index = base_cb_index + 5;  // output operands start at index 16
+    uint32_t interm0_cb_index = base_cb_index + 6;
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+    std::vector<tt::tt_metal::CBHandle> cb_outputs;
+    std::vector<tt::tt_metal::CBHandle> output_cb_indices;
+    std::vector<tt::tt_metal::CBHandle> interm_cb_indices;
+
+    if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
+        // interm0
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
+            {interm0_cb_index, interm0_data_format},
+        };
+        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                .set_tile_dims(interm0_cb_index, output_tile);
+
+        tt_metal::CreateCircularBuffer(program, all_cores, interm0_cb_config);
+
+        for (uint32_t i = 0; i < out_buffers.size(); ++i) {
+            const auto& out_buffer = out_buffers[i];
+            output_cb_index += i * 2;  // 5, 7, 9...
+            TT_FATAL(
+                output_cb_index <= tt::CBIndex::c_31,
+                "Output circular buffer index {} exceeds maximum value {}",
+                output_cb_index,
+                tt::CBIndex::c_31);
+            // output
+            std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+                {output_cb_index, output_data_format},
+            };
+            output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                                   .set_page_size(output_cb_index, output_single_tile_size)
+                                   .set_tile_dims(output_cb_index, output_tile)
+                                   .set_globally_allocated_address(out_buffer);
+            auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+            cb_outputs.push_back(cb_output);
+            output_cb_indices.push_back(output_cb_index);
+            interm_cb_indices.push_back(interm0_cb_index);
+        }
+    } else {
+        for (uint32_t i = 0; i < out_buffers.size(); ++i) {
+            const auto& out_buffer = out_buffers[i];
+            output_cb_index += i * 2;   // 5, 7, 9...
+            interm0_cb_index += i * 2;  // 6, 8, 10...
+            TT_FATAL(
+                output_cb_index <= tt::CBIndex::c_31,
+                "Output circular buffer index {} exceeds maximum value {}",
+                output_cb_index,
+                tt::CBIndex::c_31);
+            TT_FATAL(
+                interm0_cb_index <= tt::CBIndex::c_31,
+                "Interm circular buffer index {} exceeds maximum value {}",
+                interm0_cb_index,
+                tt::CBIndex::c_31);
+            // share buffer
+            std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+                {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
+            output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                                   .set_page_size(output_cb_index, output_single_tile_size)
+                                   .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                   .set_tile_dims(output_cb_index, output_tile)
+                                   .set_tile_dims(interm0_cb_index, output_tile)
+                                   .set_globally_allocated_address(out_buffer);
+            auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+            cb_outputs.push_back(cb_output);
+            output_cb_indices.push_back(output_cb_index);
+            interm_cb_indices.push_back(interm0_cb_index);
+        }
+    }
+
+    /* Compile time args */
+    std::vector<uint32_t> in0_sender_compile_time_args = {
+        (std::uint32_t)in0_shard_width_in_tiles,
+        (std::uint32_t)per_core_M,  // in0_shard_height_in_tiles
+        (std::uint32_t)batch,       // batch
+        (std::uint32_t)ring_size,   // ring_size
+        (std::uint32_t)in0_signal_semaphore_id,
+    };
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        (std::uint32_t)in1_is_dram_interleaved,    // in1_is_dram_interleaved
+        (std::uint32_t)in1_is_dram_sharded,        // in1_is_dram_sharded
+        (std::uint32_t)in1_block_height_in_tiles,  // in1_block_height_in_tiles
+        (std::uint32_t)per_core_N,                 // in1_block_width_in_tiles
+        (std::uint32_t)in1_tensor_width_in_tiles,  // in1_tensor_width_in_tiles
+        (std::uint32_t)num_blocks,                 // num_blocks
+        (std::uint32_t)batch,                      // batch
+        (std::uint32_t)in1_block_page_size,
+        (std::uint32_t)in1_block_page_size_last,
+        (std::uint32_t)in1_block_width_num_pages,
+        (std::uint32_t)in1_shard_width_in_dram,
+        (std::uint32_t)fused_op_signaler.has_value(),
+    };
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+
+    /* compute kernel args */
+    const uint32_t out_block_num_subblocks = out_block_tiles / out_subblock_num_tiles;
+    TT_FATAL(
+        out_block_num_subblocks == 1 || !untilize_out,
+        "untilize_out is not supported for cases that out_block_num_subblocks > 1");
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,      // in1_num_subblocks
+        in1_block_num_tiles,    // in1_block_num_tiles
+        in1_block_size_bytes,   // in1_block_size_bytes
+        in1_tensor_size_bytes,  // in1_tensor_size_bytes
+        in1_per_core_w,         // in1_per_core_w
+
+        num_blocks,  // num_blocks
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        batch,                   // batch
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,             // untilize_out
+        in1_is_dram_interleaved,  // in1_is_dram_interleaved
+        in1_is_dram_sharded,      // in1_is_dram_sharded
+    };
+    std::unordered_map<std::string, uint32_t> compute_named_compile_args = {
+        {"cb_in0", src0_cb_index},
+        {"cb_in1", src1_cb_index},
+        {"cb_in2", src2_cb_index},
+        {"cb_sync", sync_cb_index},
+        {"cb_sync2", sync_cb2_index},
+    };
+    for (uint32_t i = 0; i < num_output_cb; ++i) {
+        compute_named_compile_args["cb_mm_out_" + std::to_string(i)] = output_cb_indices[i];
+    }
+    for (uint32_t i = 0; i < num_output_cb; ++i) {
+        compute_named_compile_args["cb_mm_partials_" + std::to_string(i)] = interm_cb_indices[i];
+    }
+
+    /* Kernel defines */
+    std::map<std::string, std::string> mm_in1_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_defines;
+
+    if (use_global_cb) {
+        mm_in1_kernel_defines["ENABLE_GLOBAL_CB"] = "1";
+        mm_kernel_defines["ENABLE_GLOBAL_CB"] = "1";
+        if (stream_in1) {
+            // Consume in1 blocks in ring-rotated FIFO order as they arrive (matching a
+            // streaming prefetcher) instead of waiting for the whole tensor. The reader pipelines
+            // one block ahead, so two blocks are in flight at once; the GCB must hold at least 2
+            // blocks/receiver or the reader deadlocks waiting for the prefetcher to deliver a
+            // block whose slot only frees after a later ack.
+            const uint32_t resident_blocks = global_cb->size() / (in1_block_num_tiles * in1_single_tile_size);
+            TT_FATAL(
+                resident_blocks >= kStreamingInFlightBlocks,
+                "stream_in1 pipelines {} in1 blocks per receiver in flight, so the global circular buffer must "
+                "hold at least that many blocks/receiver, but it holds only {}; increase the GCB window.",
+                kStreamingInFlightBlocks,
+                resident_blocks);
+            mm_in1_kernel_defines["STREAMING_IN1"] = "1";
+            mm_kernel_defines["STREAMING_IN1"] = "1";
+        }
+    } else {
+        TT_FATAL(!stream_in1, "stream_in1 requires a DRAM-sender global circular buffer (use_global_cb)");
+    }
+
+    if (fused_activation.has_value()) {
+        const auto& activation = fused_activation.value();
+        const auto& op_type = activation.op_type;
+        if (op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+            using ttnn::operations::matmul::utilities::get_activation_params;
+            const auto params = get_activation_params(activation);
+            compute_named_compile_args["activation_type"] = static_cast<uint32_t>(params.type);
+            compute_named_compile_args["activation_param0"] = params.param0;
+            compute_named_compile_args["activation_param1"] = params.param1;
+            compute_named_compile_args["activation_param2"] = params.param2;
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    bool use_dedicated_noc = true;
+    tt_metal::NOC_MODE noc_mode =
+        use_dedicated_noc ? tt_metal::NOC_MODE::DM_DEDICATED_NOC : tt_metal::NOC_MODE::DM_DYNAMIC_NOC;
+
+    // Init the signaler
+    if (fused_op_signaler.has_value()) {
+        ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
+        signaler.init_llama_rs_cores_mm(all_cores, program, device, 0);
+    }
+    /* Create the kernels */
+    auto mm_kernel_in0_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_ring_all_gather.cpp",
+        all_cores,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = in0_noc,
+            .noc_mode = noc_mode,
+            .compile_args = in0_sender_compile_time_args,
+            .named_compile_args = {{"cb_in0", src0_cb_index}, {"cb_in2", src2_cb_index}}});
+    // Each core needs to signal to all RS cores, need to get a count of how many cores are in all_cores
+    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp",
+        all_cores,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .noc_mode = noc_mode,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_in1_kernel_defines,
+            .named_compile_args = {
+                {"cb_in1", src1_cb_index},
+                {"cb_sync", sync_cb_index},
+                {"cb_sync2", sync_cb2_index},
+                {"cb_remote", remote_cb_index}}});
+
+    // fp32 K-partials (interm0_cb_index) are reloaded into DEST between blocks via
+    // copy_block_matmul_partials; mark the CB UnpackToDestFp32 so the reload goes directly to
+    // DEST instead of through SrcA (which would truncate the fp32 partial to TF32).
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32) {
+        unpack_to_dest_mode[interm0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    auto mm_kernel = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp",
+        all_cores,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines,
+            .named_compile_args = compute_named_compile_args});
+
+    // for all the cores in the rect grid, we send one rt arg to determine if they are worker core
+    auto all_cores_vec = corerange_to_cores(all_cores, std::nullopt, row_major);
+    auto worker_cores_vec = corerange_to_cores(all_worker_cores, std::nullopt, row_major);
+    auto hop_cores_vec = corerange_to_cores(hop_cores, std::nullopt, row_major);
+    for (auto core : all_cores_vec) {
+        auto all_worker_cores_iter = std::find(worker_cores_vec.begin(), worker_cores_vec.end(), core);
+        auto hop_cores_iter = std::find(hop_cores_vec.begin(), hop_cores_vec.end(), core);
+        bool core_is_in_all_worker_cores = all_worker_cores_iter != worker_cores_vec.end();
+        bool core_is_in_hop_cores = hop_cores_iter != hop_cores_vec.end();
+        if (!use_hop_cores) {
+            core_is_in_hop_cores = false;
+        }
+
+        if (!core_is_in_all_worker_cores && !core_is_in_hop_cores) {  // not worker core and not hop core
+            auto core_type = CORE_TYPE::IDLE_CORE;                    // idle core
+            // in0
+            std::vector<uint32_t> mm_kernel_in0_args;
+            mm_kernel_in0_args.push_back((std::uint32_t)core_type);
+            tt_metal::SetRuntimeArgs(program, mm_kernel_in0_id, core, mm_kernel_in0_args);
+
+            // in1
+            std::vector<uint32_t> mm_kernel_in1_sender_writer_args;
+            mm_kernel_in1_sender_writer_args.push_back((std::uint32_t)core_type);
+            if (fused_op_signaler.has_value()) {
+                ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
+                signaler.push_llama_rs_rt_args_for_mm(mm_kernel_in1_sender_writer_args, core, in1_noc, device);
+            }
+
+            tt_metal::SetRuntimeArgs(program, mm_kernel_in1_sender_writer_id, core, mm_kernel_in1_sender_writer_args);
+
+            // compute
+            std::vector<uint32_t> mm_kernel_args;
+            mm_kernel_args.push_back((std::uint32_t)core_type);
+            tt_metal::SetRuntimeArgs(program, mm_kernel, core, mm_kernel_args);
+        }
+    }
+
+    /* Runtime args */
+    // Mapping from worker core y-coordinate (and column group) to DRAM bank IDs.
+    // The DRAM banks are split into two column groups (left and right halves of the chip).
+    // On Wormhole: hardcoded mapping; banks 0-3 left column (x <= 3), banks 4-11 right column.
+    // On Blackhole: dynamically derived from optimal DRAM bank API; banks split at x <= 6.
+    std::map<uint32_t, uint32_t> worker_y_to_dram_bank_first_col;
+    std::map<uint32_t, uint32_t> worker_y_to_dram_bank_second_col;
+    uint32_t first_col_max_x = device->arch() == tt::ARCH::WORMHOLE_B0 ? 3 : 7;
+    uint32_t num_receiver_cores_per_dram = 2;  // default to 2 for wormhole b0 and blackhole
+    if (in1_is_dram_sharded) {
+        num_receiver_cores_per_dram = ring_size / in1_tensor.shard_spec()->grid.num_cores();
+        if (device->arch() == tt::ARCH::WORMHOLE_B0) {
+            worker_y_to_dram_bank_first_col[0] = 1;
+            worker_y_to_dram_bank_first_col[4] = 2;
+            worker_y_to_dram_bank_first_col[5] = 3;
+            worker_y_to_dram_bank_first_col[9] = 0;
+
+            worker_y_to_dram_bank_second_col[0] = 4;
+            worker_y_to_dram_bank_second_col[1] = 6;
+            worker_y_to_dram_bank_second_col[2] = 9;
+            worker_y_to_dram_bank_second_col[4] = 10;
+            worker_y_to_dram_bank_second_col[5] = 11;
+            worker_y_to_dram_bank_second_col[6] = 8;
+            worker_y_to_dram_bank_second_col[7] = 7;
+            worker_y_to_dram_bank_second_col[9] = 5;
+        } else {
+            // Dynamically derive mapping from optimal DRAM bank API
+            auto optimal_dram_workers = device->get_optimal_dram_bank_to_logical_worker_assignment(in1_noc);
+            uint32_t num_banks = optimal_dram_workers.size();
+            uint32_t banks_in_first_col = num_banks / 2;
+
+            std::vector<std::pair<uint32_t, uint32_t>> first_col_anchors;   // (y, bank_id)
+            std::vector<std::pair<uint32_t, uint32_t>> second_col_anchors;  // (y, bank_id)
+
+            for (uint32_t bank = 0; bank < num_banks; ++bank) {
+                const auto& core = optimal_dram_workers[bank];
+                if (bank < banks_in_first_col) {
+                    first_col_anchors.push_back({core.y, bank});
+                } else {
+                    second_col_anchors.push_back({core.y, bank});
+                }
+            }
+
+            // Sort anchors by y-coordinate for nearest-neighbor lookup
+            auto sort_by_y = [](const auto& a, const auto& b) { return a.first < b.first; };
+            std::sort(first_col_anchors.begin(), first_col_anchors.end(), sort_by_y);
+            std::sort(second_col_anchors.begin(), second_col_anchors.end(), sort_by_y);
+
+            // Helper to find nearest bank for a given y-coordinate
+            auto find_nearest_bank = [](uint32_t y,
+                                        const std::vector<std::pair<uint32_t, uint32_t>>& anchors) -> uint32_t {
+                if (anchors.empty()) {
+                    return 0;  // Fallback
+                }
+                uint32_t best_bank = anchors[0].second;
+                uint32_t best_dist = std::abs((int)y - (int)anchors[0].first);
+                for (const auto& [anchor_y, bank] : anchors) {
+                    uint32_t dist = std::abs((int)y - (int)anchor_y);
+                    if (dist < best_dist) {
+                        best_dist = dist;
+                        best_bank = bank;
+                    }
+                }
+                return best_bank;
+            };
+
+            // Build complete maps for all possible y-coordinates (0 to max worker y)
+            auto compute_grid = device->compute_with_storage_grid_size();
+            for (uint32_t y = 0; y < compute_grid.y; ++y) {
+                if (!first_col_anchors.empty()) {
+                    worker_y_to_dram_bank_first_col[y] = find_nearest_bank(y, first_col_anchors);
+                }
+                if (!second_col_anchors.empty()) {
+                    worker_y_to_dram_bank_second_col[y] = find_nearest_bank(y, second_col_anchors);
+                }
+            }
+        }
+    }
+
+    uint32_t bank_id = 0;
+    std::vector<uint32_t> bank_ids;
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        bool send_to_hop_core = i == 0 && use_hop_cores;
+        const auto& core = worker_cores_vec[i];
+        const auto& core_noc = device->worker_core_from_logical_core(core);
+
+        /* in0 */
+        auto core_type = CORE_TYPE::WORKER_CORE;  // worker core
+        CoreCoord next_core;
+        if (send_to_hop_core) {
+            next_core = hop_cores_vec[0];  // Send to first hop core
+        } else {
+            uint32_t next_i = i == 0 ? num_cores - 1 : i - 1;
+            next_core = worker_cores_vec[next_i % num_cores];
+        }
+        const auto& next_core_noc = device->worker_core_from_logical_core(next_core);
+        uint32_t noc = get_preferred_noc(core_noc, next_core_noc, device, use_dedicated_noc);
+
+        std::vector<uint32_t> mm_in0_args = {
+            (std::uint32_t)core_type,
+            i,                // ring_index
+            next_core_noc.x,  // next_core_noc_x
+            next_core_noc.y,  // next_core_noc_y
+            noc,
+            (std::uint32_t)false,  // end_of_hop
+        };
+
+        mm_in0_args.insert(
+            mm_in0_args.end(), unpadded_in0_shard_widths_in_tiles.begin(), unpadded_in0_shard_widths_in_tiles.end());
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in0_id, core, mm_in0_args);
+
+        /* in1 */
+        std::vector<uint32_t> mm_in1_args = {
+            (std::uint32_t)core_type,
+            in1_tensor.address(),  // in1_tensor_addr
+            i,                     // ring_idx
+        };
+        if (in1_is_dram_sharded) {
+            // Look up bank_id based on core.y and which column group core.x belongs to
+            if (core.x <= first_col_max_x) {
+                auto it = worker_y_to_dram_bank_first_col.find(core.y);
+                if (it == worker_y_to_dram_bank_first_col.end()) {
+                    log_info(
+                        tt::LogOp,
+                        "ERROR: Worker core ({}, {}) y={} NOT FOUND in first-col map! Available y values:",
+                        core.x,
+                        core.y,
+                        core.y);
+                    for (const auto& [y, bank] : worker_y_to_dram_bank_first_col) {
+                        log_info(tt::LogOp, "  y={}", y);
+                    }
+                }
+                bank_id = it->second;
+            } else {
+                auto it = worker_y_to_dram_bank_second_col.find(core.y);
+                if (it == worker_y_to_dram_bank_second_col.end()) {
+                    log_info(
+                        tt::LogOp,
+                        "ERROR: Worker core ({}, {}) y={} NOT FOUND in second-col map! Available y values:",
+                        core.x,
+                        core.y,
+                        core.y);
+                    for (const auto& [y, bank] : worker_y_to_dram_bank_second_col) {
+                        log_info(tt::LogOp, "  y={}", y);
+                    }
+                }
+                bank_id = it->second;
+            }
+
+            uint32_t dram_read_offset = 0;
+            /* TODO: This is a temporary solution to handle the dram read offset for the wormhole b0. */
+            /* TODO: The dram read offset is x coordinate dependent for wormhole because all usage on wormhole assumes
+             * input core range is column major, whereas blackhole usage is row major*/
+            /* TODO: The correct behaviour is that first core next to dram bank always has offset 0 and then offset
+             * increases by 1 for each core in the same row*/
+            /* TODO: This logic should be removed once all usage of ring matmul asserts that the input core ranges are
+             * arranged in row major order*/
+            if (device->arch() == tt::ARCH::WORMHOLE_B0) {
+                if (core.x % 2 == 0) {
+                    dram_read_offset = 1;
+                }
+            } else {
+                // For iterating through ring matmul cores in row major order
+                dram_read_offset = i % num_receiver_cores_per_dram;
+            }
+
+            bank_ids.push_back(bank_id);
+            uint32_t vc = 0;
+            for (uint32_t j = 0; j < i; ++j) {
+                auto core_prev = worker_cores_vec[j];
+                if (core_prev.y == core.y) {
+                    vc = (vc + 1) & 0x3;
+                }
+            }
+            mm_in1_args.push_back((std::uint32_t)bank_id);
+            mm_in1_args.push_back((std::uint32_t)vc);
+            mm_in1_args.push_back((std::uint32_t)dram_read_offset);
+        }
+        if (fused_op_signaler.has_value()) {
+            ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
+            signaler.push_llama_rs_rt_args_for_mm(mm_in1_args, core, in1_noc, device);
+        }
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in1_sender_writer_id, core, mm_in1_args);
+
+        /* compute */
+        std::vector<uint32_t> mm_kernel_compute_args = {
+            (std::uint32_t)core_type,
+            i,  // ring_idx
+        };
+        mm_kernel_compute_args.insert(
+            mm_kernel_compute_args.end(),
+            unpadded_in0_shard_widths_in_tiles.begin(),
+            unpadded_in0_shard_widths_in_tiles.end());
+
+        tt_metal::SetRuntimeArgs(program, mm_kernel, core, mm_kernel_compute_args);
+    }
+
+    // Runtime args for hop cores
+    for (uint32_t i = 0; i < num_hop_cores; ++i) {
+        bool end_of_hop = i == num_hop_cores - 1;
+
+        auto core_type = CORE_TYPE::HOP_CORE;  // hop core
+        const auto& core = hop_cores_vec[i];
+        const auto& core_noc = device->worker_core_from_logical_core(core);
+
+        /* in0 */
+        CoreCoord next_core = end_of_hop ? worker_cores_vec[num_cores - 1] : hop_cores_vec[i + 1];
+        const auto& next_core_noc = device->worker_core_from_logical_core(next_core);
+        uint32_t noc = get_preferred_noc(core_noc, next_core_noc, device, use_dedicated_noc);
+
+        std::vector<uint32_t> mm_in0_args = {
+            (std::uint32_t)core_type,
+            0,                // ring_index
+            next_core_noc.x,  // next_core_noc_x
+            next_core_noc.y,  // next_core_noc_y
+            noc,
+            (std::uint32_t)end_of_hop,  // end_of_hop
+        };
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in0_id, core, mm_in0_args);
+
+        // in1
+        std::vector<uint32_t> mm_kernel_in1_sender_writer_args;
+        mm_kernel_in1_sender_writer_args.push_back((std::uint32_t)core_type);
+        if (fused_op_signaler.has_value()) {
+            ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
+            signaler.push_llama_rs_rt_args_for_mm(mm_kernel_in1_sender_writer_args, core, in1_noc, device);
+        }
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in1_sender_writer_id, core, mm_kernel_in1_sender_writer_args);
+
+        // compute
+        std::vector<uint32_t> mm_kernel_args;
+        mm_kernel_args.push_back((std::uint32_t)core_type);
+        tt_metal::SetRuntimeArgs(program, mm_kernel, core, mm_kernel_args);
+    }
+    std::vector<tt::tt_metal::CBHandle> shared_cbs = {cb_src0, cb_src1};
+    shared_cbs.insert(shared_cbs.end(), cb_outputs.begin(), cb_outputs.end());
+
+    return MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t{
+        {mm_kernel_in1_sender_writer_id},
+        shared_cbs,
+        false,
+        CoreCoord{0, 0},
+        worker_cores_vec,
+        0,
+        ttnn::prim::Matmul1DType::GATHER_IN0};
+}
+
+inline void override_mcast_in1_program_parameters(
+    tt_metal::Program& program,
+    const MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t& override_variables,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    const std::vector<ttnn::Tensor>& output_tensors) {
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
+
+    TT_FATAL(
+        input_tensors.size() + optional_input_tensors.size() == 3,
+        "mcast in1 requires 3 input tensors, {} + {} = {} provided",
+        input_tensors.size(),
+        optional_input_tensors.size(),
+        optional_input_tensors.size() + input_tensors.size());
+    TT_FATAL(
+        output_tensors.size() == 1, "matmul mcast in1 requires 1 output tensor, {} provided", output_tensors.size());
+
+    const MeshTensor& src_a_tensor = input_tensors.at(0).mesh_tensor();
+    const MeshTensor& src_b_tensor = input_tensors.at(1).mesh_tensor();
+    const auto& bias_tensor = optional_input_tensors.at(0);
+
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
+    if (bias_tensor.has_value()) {
+        bias_mesh_tensor = bias_tensor.value().mesh_tensor();
+    }
+
+    const MeshTensor& dst_tensor = output_tensors.at(0).mesh_tensor();
+
+    bool src0_sharded = input_tensors[0].is_sharded();
+    bool out_sharded = output_tensors[0].is_sharded();
+
+    auto& reader_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(0));
+
+    // Manually unroll sender core
+    {
+        // in0 sender
+        auto& reader_runtime_args =
+            reader_runtime_args_by_core[override_variables.start_core.x][override_variables.start_core.y];
+        reader_runtime_args[0] = src_a_tensor.address();
+
+        // in1 sender
+        auto& sender_writer_runtime_args =
+            GetRuntimeArgs(program, override_variables.kernels.at(1), override_variables.start_core);
+        sender_writer_runtime_args[0] = src_b_tensor.address();
+        sender_writer_runtime_args[7] = dst_tensor.address();
+        if (bias_tensor.has_value()) {
+            sender_writer_runtime_args[18] = bias_mesh_tensor->address();
+        }
+    }
+
+    auto& receiver_writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(2));
+
+    for (uint32_t i = 1; i < override_variables.cores.size(); ++i) {
+        const CoreCoord& core = override_variables.cores[i];
+
+        auto& reader_runtime_args = reader_runtime_args_by_core[core.x][core.y];
+
+        auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
+
+        // in0 sender
+        reader_runtime_args[0] = src_a_tensor.address();
+        // in1 receiver
+        writer_runtime_args[2] = dst_tensor.address();
+    }
+
+    if (src0_sharded) {
+        if (override_variables.extract_shard_sub_blocks) {
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(1), src_a_tensor);
+        } else {
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), src_a_tensor);
+        }
+    }
+
+    if (out_sharded) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(2), dst_tensor);
+    }
+}
+
+static void override_mcast_in0_program_parameters(
+    tt_metal::Program& program,
+    const MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t& override_variables,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    const std::vector<ttnn::Tensor>& output_tensors) {
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
+
+    TT_FATAL(
+        input_tensors.size() + optional_input_tensors.size() == 3,
+        "mcast in0 requires 3 input tensors, {} + {} = {} provided",
+        input_tensors.size(),
+        optional_input_tensors.size(),
+        optional_input_tensors.size() + input_tensors.size());
+    TT_FATAL(
+        output_tensors.size() == 1, "matmul mcast in0 requires 1 output tensor, {} provided", output_tensors.size());
+
+    const MeshTensor& src_a_tensor = input_tensors.at(0).mesh_tensor();
+    const MeshTensor& src_b_tensor = input_tensors.at(1).mesh_tensor();
+    const auto& bias_tensor = optional_input_tensors.at(0);
+
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
+    if (bias_tensor.has_value()) {
+        bias_mesh_tensor = bias_tensor.value().mesh_tensor();
+    }
+
+    const MeshTensor& dst_tensor = output_tensors.at(0).mesh_tensor();
+
+    bool src0_sharded = input_tensors[0].is_sharded();
+    bool src1_sharded = input_tensors[1].is_sharded();
+    bool out_sharded = output_tensors[0].is_sharded();
+
+    // Manually unroll sender core
+    if (src0_sharded) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(1), src_a_tensor);
+    } else {
+        // in0 sender
+        auto& reader_sender_runtime_args =
+            GetRuntimeArgs(program, override_variables.kernels.at(0), override_variables.start_core);
+        reader_sender_runtime_args[0] = src_a_tensor.address();
+    }
+
+    if (src1_sharded) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), src_b_tensor);
+    }
+
+    if (bias_tensor.has_value() && bias_tensor.value().is_sharded()) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(2), *bias_mesh_tensor);
+    }
+
+    auto& writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(1));
+
+    for (uint32_t i = 0; i < override_variables.num_cores_with_work; ++i) {
+        const auto& core = override_variables.cores[i];
+
+        auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
+
+        // in1 sender
+        writer_runtime_args[0] = src_b_tensor.address();
+        writer_runtime_args[7] = dst_tensor.address();
+        if (bias_tensor.has_value()) {
+            writer_runtime_args[18] = bias_mesh_tensor->address();
+        }
+    }
+
+    if (out_sharded) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(3), dst_tensor);
+    }
+}
+
+inline void override_gather_in0_program_parameters(
+    tt_metal::Program& program,
+    const MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t& override_variables,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    const std::vector<ttnn::Tensor>& output_tensors) {
+    const auto& input_tensors = tensor_args.input_tensors;
+
+    const MeshTensor& src_a_tensor = input_tensors[0].mesh_tensor();
+    const MeshTensor& src_b_tensor = input_tensors[1].mesh_tensor();
+
+    bool src0_sharded = input_tensors[0].is_sharded();
+    bool src1_sharded = input_tensors[1].is_sharded();
+    bool out_sharded = output_tensors[0].is_sharded();
+
+    // Manually unroll sender core
+    if (src0_sharded) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs[0], src_a_tensor);
+    }
+    if (src1_sharded) {
+        if (!global_cb.has_value() && !src_b_tensor.memory_config().is_dram()) {
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs[1], src_b_tensor);
+        }
+    }
+    if (out_sharded) {
+        for (uint32_t i = 0; i < override_variables.cbs.size() - 2; ++i) {
+            // cbs 0 and 1 contain cb_src0 and cb_src1
+            // the rest contains the actual output cbs
+            const auto& cb_output = override_variables.cbs[i + 2];
+            const MeshTensor& out_tensor = output_tensors[i].mesh_tensor();
+            UpdateDynamicCircularBufferAddress(program, cb_output, out_tensor);
+        }
+    }
+
+    // Update in1 tensor address for all worker cores.
+    // Note: override_variables.cores only contains worker cores (not hop/idle cores),
+    // so it's safe to unconditionally update index [1] which holds in1_tensor_addr.
+    auto& writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(0));
+    for (const auto& core : override_variables.cores) {
+        auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
+
+        /* in1 */
+        writer_runtime_args[1] = src_b_tensor.address();
+    }
+}
+
+void override_program_parameters(
+    const MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t& override_variables,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    Program& program,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    const std::vector<ttnn::Tensor>& tensor_return_value) {
+    switch (override_variables.type) {
+        case ttnn::prim::Matmul1DType::MCAST_IN0:
+            override_mcast_in0_program_parameters(program, override_variables, tensor_args, tensor_return_value);
+            break;
+        case ttnn::prim::Matmul1DType::GATHER_IN0: {
+            override_gather_in0_program_parameters(
+                program, override_variables, global_cb, tensor_args, tensor_return_value);
+            break;
+        }
+        case ttnn::prim::Matmul1DType::MCAST_IN1:
+            override_mcast_in1_program_parameters(program, override_variables, tensor_args, tensor_return_value);
+            break;
+    }
+}
+
+static ProgramDescriptor create_program_mcast_in0_descriptor(
+    const ttnn::Tensor& a,
+    tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    CoreCoord compute_with_storage_grid_size,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_B,
+    uint32_t in1_B,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    std::optional<UnaryWithParam> fused_activation,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    ttsl::optional_reference<const MeshTensor> bias_tensor,
+    const MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool in0_is_sharded,
+    bool in1_is_sharded,
+    bool bias_is_sharded,
+    bool output_is_sharded,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    bool row_broadcast_bias = true,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
+
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = fused_op_signaler.has_value();
+
+    uint32_t num_blocks = K / in0_block_w;
+    // Only enable packer l1 accumulation when there are spills, otherwise
+    // unnecessary overhead for reconfigs are added
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
+    // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
+    // the padded stride, so the in0/in1/bias CBs must hold pages at the aligned stride and the
+    // reader/unpacker walk tiles at the same stride. No-op when already aligned (all bf16 tiles,
+    // 32-wide bfp8, Wormhole). Replaces the staging-CB workaround. Sharded CBs are backed by the
+    // tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size =
+        in1_is_sharded ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
+    // Bias CB pages must be padded to the DRAM alignment so the reader's L1 write stride
+    // matches the DRAM page stride (e.g. 64B on Blackhole for a 32B (1,16) bf16 bias tile).
+    // Mirrors in0/in1 above. Sharded bias is backed by the L1 tensor buffer and keeps its
+    // natural page size. No-op on Wormhole and for tiles already >= dram_alignment.
+    uint32_t bias_aligned_tile_size =
+        bias_is_sharded ? bias_single_tile_size : tt::align(bias_single_tile_size, dram_alignment);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = in0_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (in0_B * num_blocks > 1) {
+        in0_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+
+    uint32_t in2_block_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    uint32_t in0_shard_height_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+    }
+    uint32_t in2_CB_tiles = in2_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (in1_B * num_blocks > 1) {
+        in1_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    if (in1_is_sharded) {
+        uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
+        in1_CB_tiles = per_core_N * in1_shard_height_in_tiles;
+    }
+
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_aligned_tile_size;
+
+    CoreCoord start_core = sub_device_start_core;
+    uint32_t start_core_x = start_core.x;
+    uint32_t start_core_y = start_core.y;
+    uint32_t num_cores_c = compute_with_storage_grid_size.x;
+
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. Callers must ensure this rectangle lies entirely
+    // within the active sub-device's worker cores (validated upstream).
+    CoreRangeSet matmul_core_rect(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core_x + compute_with_storage_grid_size.x - 1, start_core_y + compute_with_storage_grid_size.y - 1)));
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+    uint32_t num_cores_with_work = num_blocks_total;
+
+    // mcast_in0 broadcasts a single M-block across all cores; only the start_core gets in0 sender
+    // runtime args (with output_idx_y == 0), so M must fit within per_core_M.
+    TT_FATAL(
+        num_blocks_y == 1,
+        "matmul_multicore_reuse_mcast_1d requires num_blocks_y == 1 (M <= per_core_M) for mcast_in0. "
+        "Got M={}, per_core_M={}, num_blocks_y={}.",
+        M,
+        per_core_M,
+        num_blocks_y);
+
+    uint32_t in0_sender_num_cores = in0_is_sharded ? a.shard_spec().value().grid.num_cores() : 1;
+    uint32_t num_cores = in0_is_sharded ? std::max(num_cores_with_work, in0_sender_num_cores) : num_cores_with_work;
+
+    constexpr bool row_major = true;
+    CoreRangeSet all_cores =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
+
+    CoreRangeSet in0_mcast_sender_cores =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, matmul_core_rect, row_major);
+    CoreCoord in0_mcast_sender_cores_grid = in0_mcast_sender_cores.bounding_box().grid_size();
+
+    CoreRangeSet all_cores_with_work =
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, matmul_core_rect, row_major);
+    CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
+    uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
+    uint32_t in0_mcast_receiver_num_dests = std::min(
+        in0_mcast_receiver_num_cores,
+        num_cores);  // should always be number of cores in receiver grid up to number of active cores
+
+    CoreRangeSet in0_mcast_cores_with_work_and_in_receiver_grid;
+    CoreRangeSet in0_mcast_cores_without_work_and_in_receiver_grid;
+    CoreRangeSet in0_mcast_cores_without_work_and_not_in_receiver_grid;
+    CoreRangeSet in0_mcast_receivers;
+    std::vector<uint32_t> in0_mcast_noc_x;
+    std::vector<uint32_t> in0_mcast_noc_y;
+    if (in0_is_sharded) {
+        in0_mcast_cores_with_work_and_in_receiver_grid = all_cores_with_work;
+
+        if (in0_mcast_receiver_num_dests > num_cores_with_work) {
+            const uint32_t in0_mcast_cores_without_work_and_in_receiver_grid_num_cores =
+                in0_mcast_receiver_num_dests - num_cores_with_work;
+            uint32_t core_idx_x = num_cores_with_work % num_cores_c;
+            uint32_t core_idx_y = num_cores_with_work / num_cores_c;
+            CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
+            in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
+                start_core, in0_mcast_cores_without_work_and_in_receiver_grid_num_cores, matmul_core_rect, row_major);
+        }
+
+        if (in0_sender_num_cores > in0_mcast_receiver_num_dests) {
+            const uint32_t in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores =
+                in0_sender_num_cores - in0_mcast_receiver_num_dests;
+            uint32_t core_idx_x = in0_mcast_receiver_num_dests % num_cores_c;
+            uint32_t core_idx_y = in0_mcast_receiver_num_dests / num_cores_c;
+            CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
+            in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
+                start_core,
+                in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores,
+                matmul_core_rect,
+                row_major);
+        }
+
+        in0_mcast_noc_x.reserve(in0_mcast_sender_cores_grid.x);
+        in0_mcast_noc_y.reserve(in0_mcast_sender_cores_grid.y);
+        for (uint32_t core_idx_x = 0; core_idx_x < in0_mcast_sender_cores_grid.x; ++core_idx_x) {
+            in0_mcast_noc_x.push_back(
+                device->worker_core_from_logical_core({start_core_x + core_idx_x, start_core_y}).x);
+        }
+        for (uint32_t core_idx_y = 0; core_idx_y < in0_mcast_sender_cores_grid.y; ++core_idx_y) {
+            in0_mcast_noc_y.push_back(
+                device->worker_core_from_logical_core({start_core_x, start_core_y + core_idx_y}).y);
+        }
+    } else {
+        in0_mcast_cores_with_work_and_in_receiver_grid = CoreRangeSet({CoreRange(start_core, start_core)});
+        if (in0_mcast_receiver_num_cores > 1) {
+            // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+            // sub-devices anchored away from (0, 0) wrap correctly.
+            auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                            : CoreCoord{start_core.x, start_core.y + 1};
+            in0_mcast_receivers = num_cores_to_corerangeset_in_subcoregrids(
+                receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
+        }
+    }
+
+    // Mcast args — semaphore IDs assigned sequentially (0, 1)
+    uint32_t in0_mcast_sender_semaphore_id = 0;
+    uint32_t in0_mcast_receiver_semaphore_id = 1;
+
+    CoreCoord top_left_core = in0_mcast_receiver_cores_bounding_box.start_coord;
+    CoreCoord bottom_right_core = in0_mcast_receiver_cores_bounding_box.end_coord;
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    const auto& a_shape_logical = operations::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    // When transpose_a is true, the K dimension maps to the row dimension of the raw tile,
+    // which is already zero-padded during tile layout conversion. pad_last_ktile operates on
+    // columns, so applying it would incorrectly zero valid data that becomes output rows
+    // after the compute kernel transposes the tile.
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    const auto& a_padded_shape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    std::vector<uint32_t> in0_sender_compile_time_args;
+    if (in0_is_sharded) {
+        in0_sender_compile_time_args = {
+            (std::uint32_t)1,  // core_has_output_block_work
+            (std::uint32_t)1,  // core_in_in0_receiver_mcast_grid
+
+            (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+            (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,        // num_blocks
+            (std::uint32_t)out_num_blocks_x,  // num_blocks_x
+            (std::uint32_t)out_num_blocks_y,  // num_blocks_y
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_num_dests,  // in0_mcast_num_dests
+            (std::uint32_t)in0_mcast_receiver_num_cores,  // in0_mcast_num_cores
+            (std::uint32_t)(in0_mcast_sender_cores_grid.x),
+            (std::uint32_t)(in0_mcast_sender_cores_grid.y),
+            (std::uint32_t)(false),
+            (std::uint32_t)(in0_shard_width_in_tiles),
+            (std::uint32_t)(in0_shard_height_in_tiles),
+            (std::uint32_t)(in0_block_w),
+            (std::uint32_t)in0_block_h,  // in0_block_h
+
+            // batch args
+            (std::uint32_t)in0_B  // batch
+        };
+    } else {
+        in0_sender_compile_time_args = {
+            // in0 tensor args
+            (std::uint32_t)in0_tensor_stride_w,
+            (std::uint32_t)in0_tensor_stride_h,
+            (std::uint32_t)in0_tensor_next_block_stride,
+            (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+            // in0 block args
+            (std::uint32_t)in0_block_w,          // in0_block_w
+            (std::uint32_t)in0_block_h,          // in0_block_h
+            (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+            (std::uint32_t)false,  // extract_shard_sub_blocks (not used for interleaved)
+            (std::uint32_t)0,      // shard_width_in_tiles (not used for interleaved)
+            (std::uint32_t)0,      // shard_height_in_tiles (not used for interleaved)
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,        // num_blocks
+            (std::uint32_t)out_num_blocks_x,  // num_blocks_x
+            (std::uint32_t)out_num_blocks_y,  // num_blocks_y
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)num_cores - 1,                     // in0_mcast_num_dests
+            (std::uint32_t)in0_mcast_receiver_num_cores - 1,  // in0_mcast_num_cores
+            // batch args
+            (std::uint32_t)M * K,  // MtKt
+            (std::uint32_t)in0_B,  // batch
+            (std::uint32_t)in1_B,  // batch
+            (std::uint32_t)false,  // reuse_in0_in_CB
+            // sparsity args
+            (std::uint32_t)0,     // batchB
+            (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)true,  // bcast_A
+            (std::uint32_t)false  // get_batch_from_reader
+        };
+    }
+    in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+    in0_sender_compile_time_args.push_back((std::uint32_t)0);  // num_batch_compute (unused, sparsity disabled)
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)0,
+        (std::uint32_t)0,
+        (std::uint32_t)0,  // in1_mcast_num_dests
+        (std::uint32_t)0,  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,        // KtNt
+        (std::uint32_t)in0_B,        // batch
+        (std::uint32_t)bcast_batch,  // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_tensor.has_value()) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    std::vector<uint32_t> in0_receiver_compile_time_args = {
+        // in0 block args
+        (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)in0_B,  // batch
+        (std::uint32_t)false   // get_batch_from_reader
+    };
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    if (bias_tensor.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    if (in1_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
+    }
+
+    if (bias_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["BIAS_SHARDED"] = "1";
+    }
+
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+    }
+
+    // TODO: SKIP_MCAST flag isn't used for the sharded reader kernel because internal mcast logic already works without
+    // skipping We can use this flag to turn off unnecessary mcast overhead if necessary
+    if (in0_mcast_receiver_num_cores == 1) {
+        mm_kernel_in0_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+
+    mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+
+    // Intermediate CB read
+
+    // Helper to convert std::map defines to KernelDescriptor::Defines (vector of pairs)
+    auto map_to_defines = [](const std::map<std::string, std::string>& m) -> KernelDescriptor::Defines {
+        KernelDescriptor::Defines result;
+        result.reserve(m.size());
+        for (const auto& [k, v] : m) {
+            result.emplace_back(k, v);
+        }
+        return result;
+    };
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build Kernel Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    KernelDescriptor in0_sender_kernel_desc;
+    KernelDescriptor in0_no_work_in_receiver_kernel_desc;
+    bool has_in0_no_work_in_receiver_kernel = false;
+    KernelDescriptor in0_no_work_not_in_receiver_kernel_desc;
+    bool has_in0_no_work_not_in_receiver_kernel = false;
+    KernelDescriptor in0_receiver_kernel_desc;
+    bool has_in0_receiver_kernel = false;
+    KernelDescriptor in1_sender_writer_kernel_desc;
+    KernelDescriptor compute_kernel_desc;
+
+    in0_sender_kernel_desc.kernel_source =
+        in0_is_sharded
+            ? "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+              "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp"
+            : "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp";
+    in0_sender_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in0_sender_kernel_desc.core_ranges = in0_mcast_cores_with_work_and_in_receiver_grid;
+    in0_sender_kernel_desc.compile_time_args = in0_sender_compile_time_args;
+    in0_sender_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_writer_defines);
+    if (in0_is_sharded) {
+        in0_sender_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in0_sharded", tt::CBIndex::c_2},
+            {"cb_l1_array", tt::CBIndex::c_6},
+            {"cb_sparsity", tt::CBIndex::c_6},
+        };
+    } else {
+        in0_sender_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in0_sharded", tt::CBIndex::c_2},
+            {"cb_sparsity", tt::CBIndex::c_6},
+        };
+    }
+    in0_sender_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+
+    if (in0_is_sharded) {
+        if (in0_mcast_cores_without_work_and_in_receiver_grid.num_cores() > 0) {
+            has_in0_no_work_in_receiver_kernel = true;
+            auto no_work_ct_args = in0_sender_compile_time_args;
+            no_work_ct_args[0] = 0;  // core_has_output_block_work
+            no_work_ct_args[1] = 1;  // core_in_in0_receiver_mcast_grid
+            in0_no_work_in_receiver_kernel_desc.kernel_source =
+                "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp";
+            in0_no_work_in_receiver_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+            in0_no_work_in_receiver_kernel_desc.core_ranges = in0_mcast_cores_without_work_and_in_receiver_grid;
+            in0_no_work_in_receiver_kernel_desc.compile_time_args = no_work_ct_args;
+            in0_no_work_in_receiver_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_writer_defines);
+            in0_no_work_in_receiver_kernel_desc.named_compile_time_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in0_sharded", tt::CBIndex::c_2},
+                {"cb_l1_array", tt::CBIndex::c_6},
+            };
+            in0_no_work_in_receiver_kernel_desc.config =
+                DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+        }
+        if (in0_mcast_cores_without_work_and_not_in_receiver_grid.num_cores() > 0) {
+            has_in0_no_work_not_in_receiver_kernel = true;
+            auto no_work_ct_args = in0_sender_compile_time_args;
+            no_work_ct_args[0] = 0;  // core_has_output_block_work
+            no_work_ct_args[1] = 0;  // core_in_in0_receiver_mcast_grid
+            in0_no_work_not_in_receiver_kernel_desc.kernel_source =
+                "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp";
+            in0_no_work_not_in_receiver_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+            in0_no_work_not_in_receiver_kernel_desc.core_ranges = in0_mcast_cores_without_work_and_not_in_receiver_grid;
+            in0_no_work_not_in_receiver_kernel_desc.compile_time_args = no_work_ct_args;
+            in0_no_work_not_in_receiver_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_writer_defines);
+            in0_no_work_not_in_receiver_kernel_desc.named_compile_time_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in0_sharded", tt::CBIndex::c_2},
+                {"cb_l1_array", tt::CBIndex::c_6},
+            };
+            in0_no_work_not_in_receiver_kernel_desc.config =
+                DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+        }
+    }
+
+    if (!in0_is_sharded && in0_mcast_receivers.num_cores() > 0) {
+        has_in0_receiver_kernel = true;
+        in0_receiver_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp";
+        in0_receiver_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in0_receiver_kernel_desc.core_ranges = in0_mcast_receivers;
+        in0_receiver_kernel_desc.compile_time_args = in0_receiver_compile_time_args;
+        in0_receiver_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+        };
+        in0_receiver_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+    }
+
+    in1_sender_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp";
+    in1_sender_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in1_sender_writer_kernel_desc.core_ranges = all_cores_with_work;
+    in1_sender_writer_kernel_desc.compile_time_args = in1_sender_writer_compile_time_args;
+    in1_sender_writer_kernel_desc.defines = map_to_defines(mm_kernel_in1_sender_writer_defines);
+    in1_sender_writer_kernel_desc.named_compile_time_args = {
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_sparsity", tt::CBIndex::c_7},
+    };
+    in1_sender_writer_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+
+    // Compute kernel compile time args
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,        // num_blocks
+        out_num_blocks_x,  // out_num_blocks_x
+        out_num_blocks_y,  // out_num_blocks_y
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        in0_B,                   // batch
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias_tensor.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores_with_work;
+    compute_kernel_desc.compile_time_args = compute_kernel_args;
+    constexpr auto cb_intermed0 = tt::CBIndex::c_5;
+    // The fused bias add reads the partials CB as an FPU operand (SrcA), so UnpackToDestFp32 cannot be
+    // set on cb_intermed0 directly when bias is present. In that case the cross-block reload instead
+    // copies through cb_intermed0_alias, a second buffer index over the same SRAM carrying
+    // UnpackToDestFp32, while the bias add keeps reading cb_intermed0 via SrcA. The alias index is
+    // handed to the compute kernel through the MM_PARTIALS_RELOAD_ALIAS_CB define, which selects the
+    // alias reload path there. Without bias the reload reads cb_intermed0 and the flag is set on it.
+    constexpr auto cb_intermed0_alias = tt::CBIndex::c_7;
+    const bool bias_reload_alias =
+        fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32 && bias_tensor.has_value();
+    if (bias_reload_alias) {
+        mm_kernel_defines["MM_PARTIALS_RELOAD_ALIAS_CB"] = std::to_string(static_cast<uint32_t>(cb_intermed0_alias));
+    }
+    compute_kernel_desc.defines = map_to_defines(mm_kernel_defines);
+    {
+        KernelDescriptor::NamedCompileTimeArgs named_compile_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+            {"cb_intermed0", cb_intermed0},
+            {"cb_in0_transposed", tt::CBIndex::c_10},
+            {"bias_ntiles", in1_per_core_w},
+        };
+        if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+            using ttnn::operations::matmul::utilities::get_activation_params;
+            const auto params = get_activation_params(fused_activation.value());
+            named_compile_args.push_back({"activation_type", static_cast<uint32_t>(params.type)});
+            named_compile_args.push_back({"activation_param0", params.param0});
+            named_compile_args.push_back({"activation_param1", params.param1});
+            named_compile_args.push_back({"activation_param2", params.param2});
+        }
+        compute_kernel_desc.named_compile_time_args = std::move(named_compile_args);
+    }
+    // When accumulating in fp32 with the K reduction split across blocks, the intermediate
+    // partials CB holds Float32 and is reloaded into DEST between blocks by copy_block_matmul_partials.
+    // Unless the reload's CB view is marked UnpackToDestFp32, that reload is routed through SrcA and
+    // rounded to TF32 (10 mantissa bits), so the fp32 partial loses precision on every block boundary
+    // and accuracy degrades as the number of K-blocks grows. The flag is set on the alias when bias
+    // forces a separate SrcA view of cb_intermed0 (see above), else on cb_intermed0 itself.
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32) {
+        const uint32_t cb_to_mark =
+            bias_reload_alias ? static_cast<uint32_t>(cb_intermed0_alias) : static_cast<uint32_t>(cb_intermed0);
+        unpack_to_dest_mode[cb_to_mark] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        .math_approx_mode = math_approx_mode};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build CBDescriptors
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor desc;
+
+    tt::tt_metal::TileDescriptor in0_tile_desc{in0_tile};
+    tt::tt_metal::TileDescriptor in1_tile_desc{in1_tile};
+    tt::tt_metal::TileDescriptor bias_tile_desc{bias_tile};
+    tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+
+    // CB 0: in0
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_0,
+            .data_format = in0_data_format,
+            .page_size = in0_aligned_tile_size,
+            .tile = in0_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 1: in1
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in1_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_1,
+            .data_format = in1_data_format,
+            .page_size = in1_aligned_tile_size,
+            .tile = in1_tile_desc});
+        if (in1_is_sharded) {
+            cb_desc.tensor = &in1_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 2: in0 sharded
+    if (in0_is_sharded) {
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = in2_CB_size;
+            cb_desc.core_ranges = all_cores;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_2,
+                .data_format = in0_data_format,
+                .page_size = in0_single_tile_size,
+                .tile = in0_tile_desc});
+            cb_desc.tensor = &in0_tensor;
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+
+        // Local L1 to store temp vars
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = 32 * 2;
+            cb_desc.core_ranges = all_cores;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_6, .data_format = tt::DataFormat::Float16_b, .page_size = 32 * 2});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    }
+
+    // CB 4 and CB 5: output and intermediate
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // Separate output and intermediate CBs
+        // output
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = out_CB_size;
+            cb_desc.core_ranges = all_cores;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_4,
+                .data_format = output_data_format,
+                .page_size = output_single_tile_size,
+                .tile = output_tile_desc});
+            if (output_is_sharded) {
+                cb_desc.tensor = &out_tensor;
+            }
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+        // interm0
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = interm0_CB_size;
+            cb_desc.core_ranges = CoreRangeSet({all_cores});
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_5,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+            // Alias over the same SRAM, marked UnpackToDestFp32, for the bias reload (see above).
+            if (bias_reload_alias) {
+                cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                    .buffer_index = cb_intermed0_alias,
+                    .data_format = interm0_data_format,
+                    .page_size = interm0_single_tile_size,
+                    .tile = output_tile_desc});
+            }
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    } else {
+        // share buffer
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_4,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_5,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        // Alias over the same SRAM, marked UnpackToDestFp32, for the bias reload (see above).
+        if (bias_reload_alias) {
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = cb_intermed0_alias,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+        }
+        if (output_is_sharded) {
+            cb_desc.tensor = &out_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB for bias
+    if (bias_tensor.has_value()) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in3_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_3,
+            .data_format = bias_data_format,
+            .page_size = bias_aligned_tile_size,
+            .tile = bias_tile_desc});
+        if (bias_is_sharded) {
+            cb_desc.tensor = &*bias_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // Intermediate CB read
+
+    // Transpose CB for input0
+    if (in0_transpose_tile) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_10,
+            .data_format = in0_data_format,
+            .page_size = in0_aligned_tile_size,
+            .tile = in0_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Semaphore Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_sender_semaphore_id, .core_ranges = all_cores, .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_receiver_semaphore_id, .core_ranges = all_cores, .initial_value = INVALID});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Runtime Args (per-core loop)
+    ////////////////////////////////////////////////////////////////////////////
+    // Parameters for last row, col, or block. mcast_in0 replicates M across all cores
+    // (num_blocks_y == 1), so any M-direction padding lives entirely within a single h-block.
+    uint32_t last_per_core_N = N % per_core_N == 0 ? per_core_N : N % per_core_N;
+    uint32_t last_out_block_w = last_per_core_N % out_block_w == 0 ? out_block_w : last_per_core_N % out_block_w;
+    uint32_t last_out_num_blocks_w = ((last_per_core_N - 1) / out_block_w) + 1;
+    uint32_t last_block_num_nonzero_subblocks_w = ((last_out_block_w - 1) / out_subblock_w) + 1;
+    uint32_t last_subblock_of_last_block_w =
+        last_out_block_w % out_subblock_w == 0 ? out_subblock_w : last_out_block_w % out_subblock_w;
+    uint32_t last_block_padded_subblock_tiles_addr_skip =
+        output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
+    uint32_t last_block_padded_block_tiles_w_skip =
+        (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
+
+    // M-direction padding when M < per_core_M. With num_blocks_y == 1 the last (only) h-block
+    // holds last_out_block_h valid tile rows out of out_block_h.
+    uint32_t in0_last_per_core_M = M < per_core_M ? M : per_core_M;
+    uint32_t in0_last_out_block_h =
+        in0_last_per_core_M % out_block_h == 0 ? out_block_h : in0_last_per_core_M % out_block_h;
+    uint32_t in0_last_block_num_nonzero_subblocks_h = ((in0_last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t in0_last_subblock_of_last_block_h =
+        in0_last_out_block_h % out_subblock_h == 0 ? out_subblock_h : in0_last_out_block_h % out_subblock_h;
+    uint32_t in0_last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - in0_last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    CoreCoord start_core_noc = top_left_core_physical;
+    CoreCoord end_core_noc = bottom_right_core_physical;
+    if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+        std::swap(start_core_noc, end_core_noc);
+    }
+
+    const auto& cores = corerange_to_cores(all_cores, std::nullopt, row_major);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const auto& core = cores[i];
+        uint32_t output_idx_x = i % num_blocks_x;
+        uint32_t output_idx_y = i / num_blocks_x;
+
+        if (in0_is_sharded) {
+            std::vector<uint32_t> mm_in0_sender_args;
+            mm_in0_sender_args.reserve(5 + in0_mcast_noc_x.size() + in0_mcast_noc_y.size());
+            mm_in0_sender_args.push_back(i);
+            mm_in0_sender_args.push_back(start_core_noc.x);
+            mm_in0_sender_args.push_back(start_core_noc.y);
+            mm_in0_sender_args.push_back(end_core_noc.x);
+            mm_in0_sender_args.push_back(end_core_noc.y);
+            mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_x.begin(), in0_mcast_noc_x.end());
+            mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_y.begin(), in0_mcast_noc_y.end());
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            if (i < num_cores_with_work) {
+                in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+            } else if (i < in0_mcast_receiver_num_dests) {
+                in0_no_work_in_receiver_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+            } else {
+                in0_no_work_not_in_receiver_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+            }
+        }
+        // in0 sender and in1 sender
+        else if (core == start_core) {
+            std::vector<uint32_t> mm_in0_sender_args = {
+                // in0 tensor args
+                (std::uint32_t)in0_tensor.address(),
+                (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
+                // in0 mcast args
+                (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
+                (std::uint32_t)start_core_noc.y,  // in0_mcast_dest_noc_start_y
+                (std::uint32_t)end_core_noc.x,    // in0_mcast_dest_noc_end_x
+                (std::uint32_t)end_core_noc.y,    // in0_mcast_dest_noc_end_y
+
+                // padding args
+                (std::uint32_t)in0_last_out_block_h,  // last_block_h
+
+                // sparsity args
+                (std::uint32_t)0,  // sparsity_addr
+            };
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            {
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in0_sender_variant(
+                    mm_in0_sender_args.begin(), mm_in0_sender_args.end());
+                in0_sender_variant[0] = in0_tensor;
+                in0_sender_kernel_desc.emplace_runtime_args(core, in0_sender_variant);
+            }
+        }
+        // in0 receiver and in 1 sender
+        else {
+            std::vector<uint32_t> mm_in0_receiver_args = {
+                // in0 mcast args
+                (std::uint32_t)top_left_core_physical.x,  // in0_mcast_sender_noc_x
+                (std::uint32_t)top_left_core_physical.y   // in0_mcast_sender_noc_y
+            };
+            in0_receiver_kernel_desc.runtime_args.emplace_back(core, mm_in0_receiver_args);
+        }
+        if (i < num_cores_with_work) {
+            std::vector<uint32_t> mm_in1_sender_writer_args = {
+                // READER
+                // in1 tensor args
+                (std::uint32_t)in1_tensor.address(),
+                (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
+                // in1 mcast args
+                (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
+                (std::uint32_t)0,  // in1_mcast_dest_noc_start_y
+                (std::uint32_t)0,  // in1_mcast_dest_noc_end_x
+                (std::uint32_t)0,  // in1_mcast_dest_noc_end_y
+
+                // sparsity args
+                (std::uint32_t)0,  // sparsity_addr
+
+                // WRITER
+                // out tensor args
+                (std::uint32_t)out_tensor.address(),
+                ((std::uint32_t)output_idx_x * per_core_N) +
+                    (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
+            };
+
+            if (output_idx_x == num_blocks_x - 1) {
+                // padding args (READER)
+                mm_in1_sender_writer_args.push_back(last_out_block_w);
+
+                // padding args (WRITER)
+                mm_in1_sender_writer_args.push_back(in0_last_block_num_nonzero_subblocks_h);
+                mm_in1_sender_writer_args.push_back(in0_last_subblock_of_last_block_h);
+                mm_in1_sender_writer_args.push_back(in0_last_block_padded_block_tiles_h_skip);
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
+                mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
+                mm_in1_sender_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                mm_in1_sender_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+            } else {
+                // padding args (READER)
+                mm_in1_sender_writer_args.push_back(out_block_w);
+
+                // padding args (WRITER)
+                mm_in1_sender_writer_args.push_back(in0_last_block_num_nonzero_subblocks_h);
+                mm_in1_sender_writer_args.push_back(in0_last_subblock_of_last_block_h);
+                mm_in1_sender_writer_args.push_back(in0_last_block_padded_block_tiles_h_skip);
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
+                mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_sender_writer_args.push_back(out_subblock_w);
+                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(0);
+            }
+
+            // Bias base address placeholder; rebound to a tensor binding via in1_sender_variant[18] below.
+            mm_in1_sender_writer_args.push_back(
+                bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);  // smuggled-rta-ok
+            mm_in1_sender_writer_args.push_back(
+                bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
+            if (!output_is_sharded) {
+                if (output_idx_x == num_blocks_x - 1) {
+                    mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
+                } else {
+                    mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+                }
+            }
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, true);
+            }
+
+            {
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in1_sender_variant(
+                    mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
+                in1_sender_variant[0] = in1_tensor;
+                in1_sender_variant[7] = out_tensor;
+                if (bias_tensor.has_value()) {
+                    in1_sender_variant[18] = *bias_tensor;
+                }
+                in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Push kernels to descriptor
+    ////////////////////////////////////////////////////////////////////////////
+    desc.kernels.push_back(std::move(in0_sender_kernel_desc));
+    if (has_in0_no_work_in_receiver_kernel) {
+        desc.kernels.push_back(std::move(in0_no_work_in_receiver_kernel_desc));
+    }
+    if (has_in0_no_work_not_in_receiver_kernel) {
+        desc.kernels.push_back(std::move(in0_no_work_not_in_receiver_kernel_desc));
+    }
+    if (has_in0_receiver_kernel) {
+        desc.kernels.push_back(std::move(in0_receiver_kernel_desc));
+    }
+    desc.kernels.push_back(std::move(in1_sender_writer_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+
+    return desc;
+}
+
+static ProgramDescriptor create_program_mcast_in1_descriptor(
+    const ttnn::Tensor& a,
+    tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    CoreCoord compute_with_storage_grid_size,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_B,
+    uint32_t in1_B,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    std::optional<UnaryWithParam> fused_activation,
+    const MeshTensor& in0_tensor,
+    const MeshTensor& in1_tensor,
+    ttsl::optional_reference<const MeshTensor> bias_tensor,
+    const MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool in0_is_sharded,
+    bool output_is_sharded,
+    bool untilize_out,
+    bool row_broadcast_bias = true,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = false;
+
+    uint32_t num_blocks = K / in0_block_w;
+    // Only enable packer l1 accumulation when there are num_blocks > 2, otherwise
+    // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+    // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+    // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_tensor.has_value()) && num_blocks > 1) || (num_blocks > 2));
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
+    // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
+    // the padded stride, so the in0/in1/bias CBs must hold pages at the aligned stride and the
+    // reader/unpacker walk tiles at the same stride. No-op when already aligned (all bf16 tiles,
+    // 32-wide bfp8, Wormhole). Replaces the staging-CB workaround. Sharded CBs are backed by the
+    // tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size = tt::align(in1_single_tile_size, dram_alignment);
+    // Bias CB pages must be padded to the DRAM alignment so the reader's L1 write stride
+    // matches the DRAM page stride (e.g. 64B on Blackhole for a 32B (1,16) bf16 bias tile).
+    // Mirrors in0/in1 above and the dram_sharded factory. No-op on Wormhole and for
+    // tiles already >= dram_alignment.
+    uint32_t bias_aligned_tile_size = tt::align(bias_single_tile_size, dram_alignment);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = in0_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+
+    if (in0_B == 1 && in1_B > 1) {
+        in0_CB_tiles = per_core_M * num_blocks * in0_block_w;
+    } else if (in0_is_sharded) {
+        in0_CB_tiles = num_blocks * per_core_M * in0_block_w * in0_B;
+    } else if (in0_B * num_blocks > 1) {
+        in0_CB_tiles = in0_CB_tiles * 2;  // double buffer
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+
+    const auto& a_shape_logical = operations::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    bool extract_shard_sub_blocks = false;
+    uint32_t in0_shard_height_in_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        // Do a real per-block copy (not point cb_in0 at L1) when K needs splitting, or when there's more
+        // than 1 row-block AND col-block: a row-block's data is needed twice, but advancing lands on the wrong one.
+        if (in0_shard_width_in_tiles / in0_block_w > 1 || (in0_num_blocks_y > 1 && in1_num_blocks_x > 1)) {
+            extract_shard_sub_blocks = true;
+        }
+    }
+    uint32_t in2_CB_tiles = in0_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (in1_B * num_blocks > 1) {
+        in1_CB_tiles = in1_CB_tiles * 2;  // double buffer
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_aligned_tile_size;
+
+    CoreCoord start_core = sub_device_start_core;
+
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. Callers must ensure this rectangle lies entirely
+    // within the active sub-device's worker cores (validated upstream).
+    CoreRangeSet matmul_core_rect(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core.x + compute_with_storage_grid_size.x - 1, start_core.y + compute_with_storage_grid_size.y - 1)));
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+    uint32_t num_cores = num_blocks_total;
+
+    constexpr bool row_major = true;
+    CoreRangeSet all_cores =
+        tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
+    CoreRange in1_mcast_receiver_cores_bounding_box = all_cores.bounding_box();
+    uint32_t in1_mcast_receiver_num_cores = in1_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
+
+    CoreRange in1_mcast_sender(start_core, start_core);
+    CoreRangeSet in1_mcast_receivers;
+    if (in1_mcast_receiver_num_cores > 1) {
+        // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+        // sub-devices anchored away from (0, 0) wrap correctly.
+        auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                        : CoreCoord{start_core.x, start_core.y + 1};
+        in1_mcast_receivers = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+            receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
+    }
+
+    // Mcast args — semaphore IDs assigned sequentially (0, 1)
+    uint32_t in1_mcast_sender_semaphore_id = 0;
+    uint32_t in1_mcast_receiver_semaphore_id = 1;
+
+    CoreCoord top_left_core = in1_mcast_receiver_cores_bounding_box.start_coord;
+    CoreCoord bottom_right_core = in1_mcast_receiver_cores_bounding_box.end_coord;
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    const auto& a_padded_shape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    const bool reuse_in0_in_CB = (in0_B == 1 && in1_B > 1) && !in0_is_sharded && !output_is_sharded && !bcast_batch &&
+                                 !fused_activation.has_value();
+
+    std::vector<uint32_t> in0_sender_compile_time_args = {
+        // in0 tensor args
+        (std::uint32_t)in0_tensor_stride_w,
+        (std::uint32_t)in0_tensor_stride_h,
+        (std::uint32_t)in0_tensor_next_block_stride,
+        (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+        // in0 block args
+        (std::uint32_t)in0_block_w,                // in0_block_w
+        (std::uint32_t)in0_block_h,                // in0_block_h
+        (std::uint32_t)in0_block_w * in0_block_h,  // in0_block_num_tiles
+        (std::uint32_t)in0_last_ktile_w,
+        (std::uint32_t)in0_last_ktile_h,
+
+        (std::uint32_t)extract_shard_sub_blocks,
+        (std::uint32_t)in0_shard_width_in_tiles,
+        (std::uint32_t)in0_shard_height_in_tiles,
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in0 mcast args
+        (std::uint32_t)0,
+        (std::uint32_t)0,
+        (std::uint32_t)0,  // in0_mcast_num_dests
+        (std::uint32_t)0,  // in0_mcast_num_cores
+        // batch args
+        (std::uint32_t)M * K,            // MtKt
+        (std::uint32_t)in0_B,            // batch
+        (std::uint32_t)in1_B,            // batch
+        (std::uint32_t)reuse_in0_in_CB,  // reuse_in0_in_CB
+
+        // sparsity args
+        (std::uint32_t)0,     // batchB
+        (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)
+        (std::uint32_t)true,  // bcast_A
+        (std::uint32_t)false  // get_batch_from_reader
+    };
+    in0_sender_compile_time_args.push_back((std::uint32_t)fuse_op);
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+    in0_sender_compile_time_args.push_back((std::uint32_t)0);  // num_batch_compute (unused, sparsity disabled)
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        (std::uint32_t)num_cores - 1,                     // in1_mcast_num_dests
+        (std::uint32_t)in1_mcast_receiver_num_cores - 1,  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,                              // KtNt
+        (std::uint32_t)(reuse_in0_in_CB ? in1_B : in0_B),  // batch
+        (std::uint32_t)bcast_batch,                        // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+
+    if (bias_tensor.has_value()) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_tensor).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
+        // READER
+        // in1 block args
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,        // num_blocks
+        (std::uint32_t)out_num_blocks_x,  // out_num_blocks_x
+        (std::uint32_t)out_num_blocks_y,  // out_num_blocks_y
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)(reuse_in0_in_CB ? in1_B : in0_B),  // batch (must match in1 sender)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+
+    if (bias_tensor.has_value()) {
+        in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
+    } else {
+        in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+    in1_receiver_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_receiver_writer_compile_time_args);
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
+    if (bias_tensor.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
+    if (in0_is_sharded) {
+        mm_kernel_in0_sender_defines["IN0_SHARDED"] = "1";
+    }
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_defines["OUT_SHARDED"] = "1";
+    }
+
+    mm_kernel_in0_sender_defines["SKIP_MCAST"] = "1";
+
+    if (in1_mcast_receiver_num_cores == 1) {
+        mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+
+    // Intermediate CB read
+
+    // Helper to convert std::map defines to KernelDescriptor::Defines (vector of pairs)
+    auto map_to_defines = [](const std::map<std::string, std::string>& m) -> KernelDescriptor::Defines {
+        KernelDescriptor::Defines result;
+        result.reserve(m.size());
+        for (const auto& [k, v] : m) {
+            result.emplace_back(k, v);
+        }
+        return result;
+    };
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build Kernel Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    KernelDescriptor in0_sender_kernel_desc;
+    KernelDescriptor in1_sender_writer_kernel_desc;
+    KernelDescriptor in1_receiver_writer_kernel_desc;
+    bool has_in1_receiver_writer_kernel = false;
+    KernelDescriptor compute_kernel_desc;
+
+    in0_sender_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp";
+    in0_sender_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in0_sender_kernel_desc.core_ranges = all_cores;
+    in0_sender_kernel_desc.compile_time_args = in0_sender_compile_time_args;
+    in0_sender_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_defines);
+    in0_sender_kernel_desc.named_compile_time_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in0_sharded", tt::CBIndex::c_2},
+        {"cb_sparsity", tt::CBIndex::c_6},
+    };
+    in0_sender_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+
+    in1_sender_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp";
+    in1_sender_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in1_sender_writer_kernel_desc.core_ranges = CoreRangeSet(in1_mcast_sender);
+    in1_sender_writer_kernel_desc.compile_time_args = in1_sender_writer_compile_time_args;
+    in1_sender_writer_kernel_desc.defines = map_to_defines(mm_kernel_in1_sender_writer_defines);
+    in1_sender_writer_kernel_desc.named_compile_time_args = {
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_sparsity", tt::CBIndex::c_7},
+    };
+    in1_sender_writer_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+
+    if (in1_mcast_receivers.num_cores() > 0) {
+        has_in1_receiver_writer_kernel = true;
+        in1_receiver_writer_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp";
+        in1_receiver_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in1_receiver_writer_kernel_desc.core_ranges = in1_mcast_receivers;
+        in1_receiver_writer_kernel_desc.compile_time_args = in1_receiver_writer_compile_time_args;
+        in1_receiver_writer_kernel_desc.defines = map_to_defines(mm_kernel_in1_receiver_writer_defines);
+        in1_receiver_writer_kernel_desc.named_compile_time_args = {
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+        };
+        in1_receiver_writer_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+    }
+
+    // Compute kernel compile time args
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,        // num_blocks
+        out_num_blocks_x,  // out_num_blocks_x
+        out_num_blocks_y,  // out_num_blocks_y
+
+        out_subblock_h,                   // out_subblock_h
+        out_subblock_w,                   // out_subblock_w
+        out_subblock_num_tiles,           // out_subblock_num_tiles
+        reuse_in0_in_CB ? in1_B : in0_B,  // batch
+        out_block_tiles,                  // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias_tensor.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores;
+    compute_kernel_desc.compile_time_args = compute_kernel_args;
+    constexpr auto cb_intermed0 = tt::CBIndex::c_5;
+    // See create_program_mcast_in0_descriptor: the fused bias add reads the partials CB via SrcA, so
+    // when bias is present the reload copies through cb_intermed0_alias (an UnpackToDestFp32 view of
+    // the same SRAM) while the bias add keeps reading cb_intermed0. The alias index reaches the compute
+    // kernel via the MM_PARTIALS_RELOAD_ALIAS_CB define, which selects the alias reload path there.
+    constexpr auto cb_intermed0_alias = tt::CBIndex::c_7;
+    const bool bias_reload_alias =
+        fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32 && bias_tensor.has_value();
+    if (bias_reload_alias) {
+        mm_kernel_defines["MM_PARTIALS_RELOAD_ALIAS_CB"] = std::to_string(static_cast<uint32_t>(cb_intermed0_alias));
+    }
+    compute_kernel_desc.defines = map_to_defines(mm_kernel_defines);
+    {
+        KernelDescriptor::NamedCompileTimeArgs named_compile_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+            {"cb_intermed0", cb_intermed0},
+            {"cb_in0_transposed", tt::CBIndex::c_10},
+            {"bias_ntiles", in1_per_core_w},
+        };
+        if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+            using ttnn::operations::matmul::utilities::get_activation_params;
+            const auto params = get_activation_params(fused_activation.value());
+            named_compile_args.push_back({"activation_type", static_cast<uint32_t>(params.type)});
+            named_compile_args.push_back({"activation_param0", params.param0});
+            named_compile_args.push_back({"activation_param1", params.param1});
+            named_compile_args.push_back({"activation_param2", params.param2});
+        }
+        compute_kernel_desc.named_compile_time_args = std::move(named_compile_args);
+    }
+    // When accumulating in fp32 with the K reduction split across blocks, the intermediate
+    // partials CB holds Float32 and is reloaded into DEST between blocks by copy_block_matmul_partials.
+    // Unless the reload's CB view is marked UnpackToDestFp32, that reload is routed through SrcA and
+    // rounded to TF32 (10 mantissa bits), so the fp32 partial loses precision on every block boundary
+    // and accuracy degrades as the number of K-blocks grows. The flag is set on the alias when bias
+    // forces a separate SrcA view of cb_intermed0 (see above), else on cb_intermed0 itself.
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32) {
+        const uint32_t cb_to_mark =
+            bias_reload_alias ? static_cast<uint32_t>(cb_intermed0_alias) : static_cast<uint32_t>(cb_intermed0);
+        unpack_to_dest_mode[cb_to_mark] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        .math_approx_mode = math_approx_mode};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build CBDescriptors
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor desc;
+
+    tt::tt_metal::TileDescriptor in0_tile_desc{in0_tile};
+    tt::tt_metal::TileDescriptor in1_tile_desc{in1_tile};
+    tt::tt_metal::TileDescriptor bias_tile_desc{bias_tile};
+    tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+
+    // CB 0: in0
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_0,
+            .data_format = in0_data_format,
+            .page_size = in0_aligned_tile_size,
+            .tile = in0_tile_desc});
+        if (in0_is_sharded && !extract_shard_sub_blocks) {
+            cb_desc.tensor = &in0_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 2: in0 sharded (only for extract_shard_sub_blocks)
+    if (in0_is_sharded && extract_shard_sub_blocks) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in2_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_2,
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size,
+            .tile = in0_tile_desc});
+        cb_desc.tensor = &in0_tensor;
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 1: in1
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in1_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_1,
+            .data_format = in1_data_format,
+            .page_size = in1_aligned_tile_size,
+            .tile = in1_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 4 and CB 5: output and intermediate
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // Separate output and intermediate CBs
+        // output
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = out_CB_size;
+            cb_desc.core_ranges = all_cores;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_4,
+                .data_format = output_data_format,
+                .page_size = output_single_tile_size,
+                .tile = output_tile_desc});
+            if (output_is_sharded) {
+                cb_desc.tensor = &out_tensor;
+            }
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+        // interm0
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = interm0_CB_size;
+            cb_desc.core_ranges = CoreRangeSet({all_cores});
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_5,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+            // Alias over the same SRAM, marked UnpackToDestFp32, for the bias reload (see above).
+            if (bias_reload_alias) {
+                cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                    .buffer_index = cb_intermed0_alias,
+                    .data_format = interm0_data_format,
+                    .page_size = interm0_single_tile_size,
+                    .tile = output_tile_desc});
+            }
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    } else {
+        // share buffer
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_4,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_5,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        // Alias over the same SRAM, marked UnpackToDestFp32, for the bias reload (see above).
+        if (bias_reload_alias) {
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = cb_intermed0_alias,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+        }
+        if (output_is_sharded) {
+            cb_desc.tensor = &out_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB for bias
+    if (bias_tensor.has_value()) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in3_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_3,
+            .data_format = bias_data_format,
+            .page_size = bias_aligned_tile_size,
+            .tile = bias_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // Intermediate CB read
+
+    if (in0_transpose_tile) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = all_cores;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_10,
+            .data_format = in0_data_format,
+            .page_size = in0_aligned_tile_size,
+            .tile = in0_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Semaphore Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in1_mcast_sender_semaphore_id, .core_ranges = all_cores, .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in1_mcast_receiver_semaphore_id, .core_ranges = all_cores, .initial_value = INVALID});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Runtime Args (per-core loop)
+    ////////////////////////////////////////////////////////////////////////////
+    // Parameters for last row, col, or block
+    uint32_t last_per_core_M = M % per_core_M == 0 ? per_core_M : M % per_core_M;
+    uint32_t last_out_block_h = last_per_core_M % out_block_h == 0 ? out_block_h : last_per_core_M % out_block_h;
+    uint32_t last_out_num_blocks_h = ((last_per_core_M - 1) / out_block_h) + 1;
+    uint32_t last_block_num_nonzero_subblocks_h = ((last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t last_subblock_of_last_block_h =
+        last_out_block_h % out_subblock_h == 0 ? out_subblock_h : last_out_block_h % out_subblock_h;
+    uint32_t last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    CoreCoord start_core_noc = bottom_right_core_physical;
+    CoreCoord end_core_noc = top_left_core_physical;
+    if (in1_noc == tt::tt_metal::NOC::NOC_0) {
+        std::swap(start_core_noc, end_core_noc);
+    }
+
+    const auto& cores = corerange_to_cores(all_cores, std::nullopt, row_major);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const auto& core = cores[i];
+        uint32_t output_idx_x = i / num_blocks_y;
+        uint32_t output_idx_y = i % num_blocks_y;
+
+        // in0 sender and in1 sender
+        if (core == start_core) {
+            std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> mm_in1_sender_writer_args = {
+                // READER
+                // in1 tensor args
+                in1_tensor,
+                (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
+                // in1 mcast args
+                (std::uint32_t)start_core_noc.x,  // in1_mcast_dest_noc_start_x
+                (std::uint32_t)start_core_noc.y,  // in1_mcast_dest_noc_start_y
+                (std::uint32_t)end_core_noc.x,    // in1_mcast_dest_noc_end_x
+                (std::uint32_t)end_core_noc.y,    // in1_mcast_dest_noc_end_y
+
+                // sparsity args
+                (std::uint32_t)0,  // sparsity_addr
+
+                // WRITER
+                // out tensor args
+                out_tensor,
+                ((std::uint32_t)output_idx_x * per_core_N) +
+                    (output_idx_y * per_core_M * N),  // out_tensor_start_tile_id
+
+                // padding args (READER)
+                (std::uint32_t)out_block_w,  // last_block_w
+                // padding args (WRITER)
+                (std::uint32_t)out_block_h / out_subblock_h,
+                (std::uint32_t)out_subblock_h,
+                (std::uint32_t)0,
+                (std::uint32_t)out_block_w / out_subblock_w,
+                (std::uint32_t)out_block_w / out_subblock_w,
+                (std::uint32_t)out_subblock_w,
+                (std::uint32_t)0,
+                (std::uint32_t)0};
+
+            if (bias_tensor.has_value()) {
+                mm_in1_sender_writer_args.push_back(*bias_tensor);
+                mm_in1_sender_writer_args.push_back(
+                    (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
+            } else {
+                mm_in1_sender_writer_args.push_back(0u);
+                mm_in1_sender_writer_args.push_back(0u);
+            }
+            if (!output_is_sharded) {
+                mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+            }
+
+            {
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in1_sender_variant(
+                    mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
+                in1_sender_variant[0] = in1_tensor;
+                in1_sender_variant[7] = out_tensor;
+                if (bias_tensor.has_value()) {
+                    in1_sender_variant[18] = *bias_tensor;
+                }
+                in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
+            }
+        }
+        // in0 sender and in1 receiver
+        else {
+            std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> mm_in1_receiver_writer_args =
+                {
+                    // READER
+                    // in1 mcast args
+                    (std::uint32_t)top_left_core_physical.x,  // in1_mcast_sender_noc_x
+                    (std::uint32_t)top_left_core_physical.y,  // in1_mcast_sender_noc_y
+
+                    // WRITER
+                    // out tensor args
+                    out_tensor,  // out_tensor_addr
+                    ((std::uint32_t)output_idx_x * per_core_N) +
+                        (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
+                };
+
+            if (output_idx_y == num_blocks_y - 1) {
+                // padding args (WRITER)
+                mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(0u);
+                mm_in1_receiver_writer_args.push_back(0u);
+            } else {
+                // padding args (WRITER)
+                mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                mm_in1_receiver_writer_args.push_back(0u);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                mm_in1_receiver_writer_args.push_back(0u);
+                mm_in1_receiver_writer_args.push_back(0u);
+            }
+            if (!output_is_sharded) {
+                if (output_idx_y == num_blocks_y - 1) {
+                    mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                    mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                } else {
+                    mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                    mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                }
+            }
+
+            {
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in1_recv_variant(
+                    mm_in1_receiver_writer_args.begin(), mm_in1_receiver_writer_args.end());
+                in1_recv_variant[2] = out_tensor;
+                in1_receiver_writer_kernel_desc.emplace_runtime_args(core, in1_recv_variant);
+            }
+        }
+        std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> mm_in0_sender_args = {
+            // in0 tensor args
+            in0_tensor,
+            (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
+            // in0 mcast args
+            (std::uint32_t)0,  // in0_mcast_dest_noc_start_x
+            (std::uint32_t)0,  // in0_mcast_dest_noc_start_y
+            (std::uint32_t)0,  // in0_mcast_dest_noc_end_x
+            (std::uint32_t)0,  // in0_mcast_dest_noc_end_y
+
+            // padding args
+            (std::uint32_t)per_core_M,  // last_block_h
+
+            // sparsity args
+            (std::uint32_t)0,  // sparsity_addr
+        };
+        {
+            std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> in0_sender_variant(
+                mm_in0_sender_args.begin(), mm_in0_sender_args.end());
+            in0_sender_variant[0] = in0_tensor;
+            in0_sender_kernel_desc.emplace_runtime_args(core, in0_sender_variant);
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Push kernels to descriptor
+    ////////////////////////////////////////////////////////////////////////////
+    desc.kernels.push_back(std::move(in0_sender_kernel_desc));
+    desc.kernels.push_back(std::move(in1_sender_writer_kernel_desc));
+    if (has_in1_receiver_writer_kernel) {
+        desc.kernels.push_back(std::move(in1_receiver_writer_kernel_desc));
+    }
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+
+    return desc;
+}
+
+}  // namespace reuse_mcast_1d_optimized_helpers
+
+MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_reuse_mcast_1d_optimized_(
+    tt_metal::Program& program,
+    const Tensor& a,
+    const std::vector<Tensor>& b_tensors,
+    const std::optional<const Tensor>& bias,
+    const std::vector<Tensor>& output_tensors,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    CoreCoord compute_with_storage_grid_size,
+    DeviceComputeKernelConfig compute_kernel_config,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    bool fuse_batch,
+    const std::optional<UnaryWithParam>& fused_activation,
+    bool mcast_in0,
+    bool gather_in0,
+    const CoreRangeSet& hop_cores,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    uint32_t num_global_cb_receivers,
+    bool stream_in1,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    uint32_t start_cb_index,
+    std::optional<CoreRangeSet> restricted_cores) {
+    const auto& b = b_tensors[0];
+    const auto& output = output_tensors[0].mesh_tensor();
+
+    TT_FATAL(output_tensors.size() == b_tensors.size(), "number of outputs must match number of inputs b");
+
+    const auto& ashape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const auto& bshape = operations::matmul::utilities::get_matmul_tensor_padded_shape(b, transpose_b);
+    auto in0_tile = operations::matmul::utilities::get_matmul_tile(a, transpose_a);
+    auto in1_tile = operations::matmul::utilities::get_matmul_tile(b, transpose_b);
+    // cannot use the output tensor tile directly as that might be changed by user override
+    auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+
+    // CB dataformats
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());  // in0
+    const MeshTensor& in1_tensor = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());  // in1
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());   // output
+
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        TT_FATAL(
+            c.storage_type() == StorageType::DEVICE,
+            "Bias tensor must be on device, got storage type: {}",
+            c.storage_type());
+        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
+
+        bias_mesh_tensor = c.mesh_tensor();
+
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    tt_metal::IDevice* device = a.device();
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    const MeshTensor& in0_tensor = a.mesh_tensor();
+    TT_FATAL(
+        in0_tensor.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        in0_tensor.mesh_buffer().device_local_size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        in1_tensor.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        in1_tensor.mesh_buffer().device_local_size(),
+        in1_single_tile_size);
+
+    TT_FATAL(
+        ashape[-1] == bshape[-2],
+        "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
+    TT_FATAL(
+        ashape[-2] % in0_tile.get_height() == 0,
+        "A.shape[-2] ({}) must be divisible by tile height ({})",
+        ashape[-2],
+        in0_tile.get_height());
+    TT_FATAL(
+        ashape[-1] % in0_tile.get_width() == 0,
+        "A.shape[-1] ({}) must be divisible by tile width ({})",
+        ashape[-1],
+        in0_tile.get_width());
+    TT_FATAL(
+        bshape[-2] % in1_tile.get_height() == 0,
+        "B.shape[-2] ({}) must be divisible by tile height ({})",
+        bshape[-2],
+        in1_tile.get_height());
+    TT_FATAL(
+        bshape[-1] % in1_tile.get_width() == 0,
+        "B.shape[-1] ({}) must be divisible by tile width ({})",
+        bshape[-1],
+        in1_tile.get_width());
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Matmul Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    // NOTE: Pads matmul input dims to 512 x 512 multiples (ie. multiples of 16*32 x 16*32)
+    // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
+    const auto in0_B = fuse_batch ? 1 : get_batch_size(ashape);
+    const auto in1_B = fuse_batch ? 1 : get_batch_size(bshape);
+    const auto Mt = operations::matmul::utilities::get_M_dim(ashape, in0_tile, fuse_batch);
+    const auto Kt = operations::matmul::utilities::get_K_dim(ashape, in0_tile);
+    const auto Nt = operations::matmul::utilities::get_N_dim(bshape, in1_tile);
+
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
+
+    // This should allocate a DRAM buffer on the device
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores = num_cores_x * num_cores_y;
+
+    // Calculate number of blocks along x and y; tensor dims are padded up to 512
+    uint32_t num_blocks_y = ((Mt - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((Nt - 1) / per_core_N) + 1;
+    uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
+
+    // TODO: Max used grid can actually exceed mcast receiver grid if in0 is sharded
+    // TODO: Move these validates to op validate and properly check for this
+    TT_FATAL(
+        num_blocks_total <= num_cores,
+        "Number of blocks exceeds number of cores: {} blocks > {} cores",
+        num_blocks_total,
+        num_cores);
+
+    if (!gather_in0) {
+        TT_FATAL(hop_cores.empty(), "Hop cores are not supported for any mode besides gather_in0.");
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Grayskull Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+
+    if (gather_in0) {
+        TT_FATAL(
+            !transpose_a,
+            "Transpose A is ({}) not supported for gather_in0, please use a different program configuration",
+            transpose_a);
+        TT_FATAL(
+            !transpose_b,
+            "Transpose B is ({}) not supported for gather_in0, please use a different program configuration",
+            transpose_b);
+        std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> out_buffers;
+        out_buffers.reserve(output_tensors.size());
+        for (const auto& output_tensor : output_tensors) {
+            out_buffers.push_back(output_tensor.mesh_tensor());
+        }
+        return reuse_mcast_1d_optimized_helpers::process_gather_in0_program_and_create_override_variables(
+            program,
+            a,
+            b_tensors,
+            device,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode,
+            packer_l1_acc,
+            dst_full_sync_en,
+            compute_with_storage_grid_size,
+            throttle_level,
+            start_cb_index,
+            in0_B,
+            Mt,
+            Nt,
+            Kt,
+            bcast_batch,
+            in0_block_w,
+            out_subblock_h,
+            out_subblock_w,
+            per_core_M,
+            per_core_N,
+            fused_activation,
+            hop_cores,
+            in0_tensor,
+            in1_tensor,
+            out_buffers,
+            in0_tile,
+            in1_tile,
+            output_tile,
+            in0_data_format,
+            in1_data_format,
+            output_data_format,
+            untilize_out,
+            global_cb,
+            num_global_cb_receivers,
+            stream_in1,
+            sub_device_id,
+            std::move(restricted_cores),
+            fused_op_signaler);
+    }
+    TT_FATAL(start_cb_index == tt::CBIndex::c_0, "mcast does not support a non-zero start cb index");
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Sub-device start core
+    ////////////////////////////////////////////////////////////////////////////
+    // The 1D mcast matmul only supports rectangular sub-device worker grids, because the in0/in1
+    // multicast targets a single bounding-box rectangle and the per-core index math assumes a
+    // contiguous row-major rectangle of width `compute_with_storage_grid_size.x`.
+    CoreCoord sub_device_start_core = {0, 0};
+    if (sub_device_id.has_value()) {
+        auto sd_worker_cores =
+            device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value());
+        auto bbox = sd_worker_cores.bounding_box();
+        TT_FATAL(
+            sd_worker_cores.num_cores() == bbox.size(),
+            "matmul_multicore_reuse_mcast_1d only supports rectangular sub-device worker grids. "
+            "Got sub-device worker cores: {} (bounding box: {})",
+            sd_worker_cores,
+            bbox);
+        TT_FATAL(
+            bbox.start_coord.x + compute_with_storage_grid_size.x - 1 <= bbox.end_coord.x &&
+                bbox.start_coord.y + compute_with_storage_grid_size.y - 1 <= bbox.end_coord.y,
+            "matmul_multicore_reuse_mcast_1d compute_with_storage_grid_size {} anchored at sub-device start {} "
+            "extends past the sub-device's worker bounding box {}",
+            compute_with_storage_grid_size,
+            bbox.start_coord,
+            bbox);
+        sub_device_start_core = bbox.start_coord;
+    }
+
+    if (mcast_in0) {
+        return reuse_mcast_1d_optimized_helpers::process_mcast_in0_program_and_create_override_variables(
+            program,
+            a,
+            device,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode,
+            packer_l1_acc,
+            compute_with_storage_grid_size,
+            throttle_level,
+            in0_B,
+            Mt,
+            Nt,
+            Kt,
+            bcast_batch,
+            transpose_a,
+            transpose_b,
+            in0_block_w,
+            out_subblock_h,
+            out_subblock_w,
+            out_block_h,
+            out_block_w,
+            per_core_M,
+            per_core_N,
+            fused_activation,
+            in0_tensor,
+            in1_tensor,
+            bias_mesh_tensor,
+            output,
+            in0_tile,
+            in1_tile,
+            bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+            output_tile,
+            in0_data_format,
+            in1_data_format,
+            bias_data_format,
+            output_data_format,
+            a.memory_config().is_sharded(),
+            in1_tensor.memory_config().is_sharded(),
+            bias.has_value() ? bias->memory_config().is_sharded() : false,
+            output.memory_config().is_sharded(),
+            untilize_out,
+            fused_op_signaler,
+            operations::matmul::utilities::fused_matmul_bias_row_broadcastable(bias),
+            sub_device_start_core);
+    }
+    return reuse_mcast_1d_optimized_helpers::process_mcast_in1_program_and_create_override_variables(
+        program,
+        a,
+        device,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        compute_with_storage_grid_size,
+        throttle_level,
+        in0_B,
+        in1_B,
+        Mt,
+        Nt,
+        Kt,
+        bcast_batch,
+        transpose_a,
+        transpose_b,
+        in0_block_w,
+        out_subblock_h,
+        out_subblock_w,
+        out_block_h,
+        out_block_w,
+        per_core_M,
+        per_core_N,
+        fused_activation,
+        in0_tensor,
+        in1_tensor,
+        bias_mesh_tensor,
+        output,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        a.memory_config().is_sharded(),
+        output.memory_config().is_sharded(),
+        untilize_out,
+        operations::matmul::utilities::fused_matmul_bias_row_broadcastable(bias),
+        sub_device_start_core);
+}
+
+void MatmulMultiCoreReuseMcast1DProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const shared_variables_t& shared_variables,
+    const ttnn::prim::MatmulParams& operation_attributes,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    reuse_mcast_1d_optimized_helpers::override_program_parameters(
+        shared_variables, operation_attributes.global_cb, program, tensor_args, tensor_return_value);
+}
+
+ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
+    const ttnn::prim::MatmulParams& operation_attributes,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    using namespace tt;
+    using namespace operations::matmul::utilities;
+
+    const auto& a = tensor_args.input_tensors.at(0);
+    const auto& b = tensor_args.input_tensors.at(1);
+    const auto& bias = tensor_args.optional_input_tensors.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
+
+    TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
+    TT_FATAL(operation_attributes.program_config.has_value(), "Error: program_config field should have been populated");
+    bool bcast_batch = operation_attributes.bcast_batch.value();
+    bool transpose_a = operation_attributes.transpose_a;
+    bool transpose_b = operation_attributes.transpose_b;
+
+    auto program_config = std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+        operation_attributes.program_config.value());
+
+    auto fuse_batch = program_config.fuse_batch;
+    auto in0_block_w = program_config.in0_block_w;
+    auto out_subblock_h = program_config.out_subblock_h;
+    auto out_subblock_w = program_config.out_subblock_w;
+    auto out_block_h = program_config.out_block_h;
+    auto out_block_w = program_config.out_block_w;
+    auto per_core_M = program_config.per_core_M;
+    auto per_core_N = program_config.per_core_N;
+    auto mcast_in0 = program_config.mcast_in0;
+    auto gather_in0 = program_config.gather_in0;
+
+    TT_FATAL(!gather_in0, "create_descriptor does not support gather_in0 mode");
+
+    TT_FATAL(
+        operation_attributes.compute_kernel_config.has_value(),
+        "Error: compute_kernel_config field should have been populated");
+    auto compute_kernel_config = operation_attributes.compute_kernel_config.value();
+    auto untilize_out = operation_attributes.untilize_out;
+
+    const auto& a_shape_padded = get_matmul_tensor_padded_shape(a, transpose_a);
+    const auto& b_shape_padded = get_matmul_tensor_padded_shape(b, transpose_b);
+    const auto in0_tile = get_matmul_tile(a, transpose_a);
+    const auto in1_tile = get_matmul_tile(b, transpose_b);
+
+    // cannot use the output tensor tile directly as that might be changed by user override
+    const auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+
+    // CB dataformats
+    const MeshTensor& in0_tensor = a.mesh_tensor();
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(in0_tensor.dtype());
+    const MeshTensor& in1_tensor = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        bias_mesh_tensor = c.mesh_tensor();
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    tt_metal::IDevice* device = &in0_tensor.mutable_device();
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    const auto in0_B = fuse_batch ? 1 : get_batch_size(a_shape_padded);
+    const auto in1_B = fuse_batch ? 1 : get_batch_size(b_shape_padded);
+    const auto Mt = get_M_dim(a_shape_padded, in0_tile, fuse_batch);
+    const auto Kt = get_K_dim(a_shape_padded, in0_tile);
+    const auto Nt = get_N_dim(b_shape_padded, in1_tile);
+
+    // The 1D mcast matmul only supports rectangular sub-device worker grids, because the in0/in1
+    // multicast targets a single bounding-box rectangle and the per-core index math assumes a
+    // contiguous row-major rectangle of width `grid_size.x`.
+    if (!program_config.allowed_worker_cores.has_value()) {
+        log_warning(
+            tt::LogOp,
+            "MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor: program_config.allowed_worker_cores not "
+            "populated; auto-populating from compute_with_storage_grid_size. Callers that bypass "
+            "ttnn::prim::matmul() should invoke ttnn::operations::matmul::normalize_program_config() on the "
+            "program config first. This will become a hard error in a future release.");
+        program_config.allowed_worker_cores = CoreRangeSet(CoreRange(
+            CoreCoord(0, 0),
+            CoreCoord(
+                program_config.compute_with_storage_grid_size.x - 1,
+                program_config.compute_with_storage_grid_size.y - 1)));
+    }
+    auto grid_size = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+
+    // When a sub-device is present use its bounding-box start; otherwise fall
+    // back to allowed_worker_cores start so non-(0,0) placements work correctly.
+    CoreCoord sub_device_start_core = program_config.allowed_worker_cores.value().bounding_box().start_coord;
+    if (operation_attributes.sub_device_id.has_value()) {
+        auto sd_worker_cores = device->worker_cores(
+            tt::tt_metal::HalProgrammableCoreType::TENSIX, operation_attributes.sub_device_id.value());
+        auto bbox = sd_worker_cores.bounding_box();
+        TT_FATAL(
+            sd_worker_cores.num_cores() == bbox.size(),
+            "matmul_multicore_reuse_mcast_1d only supports rectangular sub-device worker grids. "
+            "Got sub-device worker cores: {} (bounding box: {})",
+            sd_worker_cores,
+            bbox);
+        TT_FATAL(
+            bbox.start_coord.x + grid_size.x - 1 <= bbox.end_coord.x &&
+                bbox.start_coord.y + grid_size.y - 1 <= bbox.end_coord.y,
+            "matmul_multicore_reuse_mcast_1d grid_size {} anchored at sub-device start {} "
+            "extends past the sub-device's worker bounding box {}",
+            grid_size,
+            bbox.start_coord,
+            bbox);
+        sub_device_start_core = bbox.start_coord;
+    }
+
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> fused_op_signaler = std::nullopt;
+
+    if (mcast_in0) {
+        return reuse_mcast_1d_optimized_helpers::create_program_mcast_in0_descriptor(
+            a,
+            device,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode,
+            packer_l1_acc,
+            grid_size,
+            ttnn::get_throttle_level(compute_kernel_config),
+            in0_B,
+            in1_B,
+            Mt,
+            Nt,
+            Kt,
+            bcast_batch,
+            transpose_a,
+            transpose_b,
+            in0_block_w,
+            out_subblock_h,
+            out_subblock_w,
+            out_block_h,
+            out_block_w,
+            per_core_M,
+            per_core_N,
+            program_config.fused_activation,
+            in0_tensor,
+            in1_tensor,
+            bias_mesh_tensor,
+            output,
+            in0_tile,
+            in1_tile,
+            bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+            output_tile,
+            in0_data_format,
+            in1_data_format,
+            bias_data_format,
+            output_data_format,
+            in0_tensor.memory_config().is_sharded(),
+            in1_tensor.memory_config().is_sharded(),
+            bias.has_value() ? bias->memory_config().is_sharded() : false,
+            output.memory_config().is_sharded(),
+            untilize_out,
+            fused_op_signaler,
+            fused_matmul_bias_row_broadcastable(bias),
+            sub_device_start_core);
+    }
+    return reuse_mcast_1d_optimized_helpers::create_program_mcast_in1_descriptor(
+        a,
+        device,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        grid_size,
+        ttnn::get_throttle_level(compute_kernel_config),
+        in0_B,
+        in1_B,
+        Mt,
+        Nt,
+        Kt,
+        bcast_batch,
+        transpose_a,
+        transpose_b,
+        in0_block_w,
+        out_subblock_h,
+        out_subblock_w,
+        out_block_h,
+        out_block_w,
+        per_core_M,
+        per_core_N,
+        program_config.fused_activation,
+        in0_tensor,
+        in1_tensor,
+        bias_mesh_tensor,
+        output,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        in0_tensor.memory_config().is_sharded(),
+        output.memory_config().is_sharded(),
+        untilize_out,
+        fused_matmul_bias_row_broadcastable(bias),
+        sub_device_start_core);
+}
+
+MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_reuse_mcast_1d_optimized_helper(
+    tt_metal::Program& program,
+    const Tensor& a,
+    const std::vector<Tensor>& b_tensors,
+    const std::optional<const Tensor>& bias,
+    const std::vector<Tensor>& output_tensors,
+    bool broadcast_batch,
+    DeviceComputeKernelConfig compute_kernel_config,
+    const operations::matmul::MatmulProgramConfig& program_config,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    uint32_t start_cb_index,
+    std::optional<CoreRangeSet> restricted_cores) {
+    auto config = std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(program_config);
+
+    if (!config.allowed_worker_cores.has_value()) {
+        log_warning(
+            tt::LogOp,
+            "matmul_multi_core_reuse_mcast_1d_optimized_helper: program_config.allowed_worker_cores not populated; "
+            "auto-populating from compute_with_storage_grid_size. Callers that bypass ttnn::prim::matmul() (e.g. "
+            "CCL fused ops) should invoke ttnn::operations::matmul::normalize_program_config() on the program "
+            "config first. This will become a hard error in a future release.");
+        config.allowed_worker_cores = CoreRangeSet(CoreRange(
+            CoreCoord(0, 0),
+            CoreCoord(config.compute_with_storage_grid_size.x - 1, config.compute_with_storage_grid_size.y - 1)));
+    }
+    auto resolved_grid = config.allowed_worker_cores.value().bounding_box().grid_size();
+
+    return matmul_multi_core_reuse_mcast_1d_optimized_(
+        program,
+        a,
+        b_tensors,
+        bias,
+        output_tensors,
+        broadcast_batch,
+        /*transpose_a=*/false,
+        /*transpose_b=*/false,
+        resolved_grid,
+        compute_kernel_config,
+        ttnn::get_throttle_level(compute_kernel_config),
+        config.in0_block_w,
+        config.out_subblock_h,
+        config.out_subblock_w,
+        config.out_block_h,
+        config.out_block_w,
+        config.per_core_M,
+        config.per_core_N,
+        config.fuse_batch,
+        config.fused_activation,
+        config.mcast_in0,
+        config.gather_in0,
+        config.hop_cores,
+        untilize_out,
+        fused_op_signaler,
+        global_cb,
+        config.num_global_cb_receivers,
+        config.stream_in1,
+        sub_device_id,
+        start_cb_index,
+        std::move(restricted_cores));
+}
+
+MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory::cached_mesh_workload_t
+MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory::create_mesh_workload(
+    const ttnn::prim::MatmulParams& attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    tt::tt_metal::distributed::MeshWorkload workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
+        for (const auto& mesh_coord : mesh_coord_range) {
+            const ttnn::MeshCoordinateRange mesh_coord_range{mesh_coord, mesh_coord};
+            auto pc = std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+                attributes.program_config.value());
+            if (!pc.allowed_worker_cores.has_value()) {
+                log_warning(
+                    tt::LogOp,
+                    "MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory::create_mesh_workload: "
+                    "program_config.allowed_worker_cores not populated; auto-populating from "
+                    "compute_with_storage_grid_size. Callers that bypass ttnn::prim::matmul() should invoke "
+                    "ttnn::operations::matmul::normalize_program_config() on the program config first. This will "
+                    "become a hard error in a future release.");
+                pc.allowed_worker_cores = CoreRangeSet(CoreRange(
+                    CoreCoord(0, 0),
+                    CoreCoord(pc.compute_with_storage_grid_size.x - 1, pc.compute_with_storage_grid_size.y - 1)));
+            }
+            auto mesh_grid = pc.allowed_worker_cores.value().bounding_box().grid_size();
+            DeviceComputeKernelConfig ckc = attributes.compute_kernel_config.value();
+            tt_metal::Program program{};
+            std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> empty_signaler = std::nullopt;
+            auto b_tensors =
+                std::vector<Tensor>{tensor_args.input_tensors.begin() + 1, tensor_args.input_tensors.end()};
+            auto shared_vars = matmul_multi_core_reuse_mcast_1d_optimized_(
+                program,
+                tensor_args.input_tensors.at(0),
+                b_tensors,
+                tensor_args.optional_input_tensors.at(0),
+                tensor_return_value,
+                attributes.bcast_batch.value_or(false),
+                attributes.transpose_a,
+                attributes.transpose_b,
+                mesh_grid,
+                ckc,
+                ttnn::get_throttle_level(ckc),
+                pc.in0_block_w,
+                pc.out_subblock_h,
+                pc.out_subblock_w,
+                pc.out_block_h,
+                pc.out_block_w,
+                pc.per_core_M,
+                pc.per_core_N,
+                pc.fuse_batch,
+                pc.fused_activation,
+                pc.mcast_in0,
+                pc.gather_in0,
+                pc.hop_cores,
+                attributes.untilize_out,
+                empty_signaler,
+                attributes.global_cb,
+                pc.num_global_cb_receivers,
+                pc.stream_in1,
+                attributes.sub_device_id,
+                tt::CBIndex::c_0,
+                std::nullopt);
+            shared_variables[mesh_coord_range] = std::move(shared_vars);
+            workload.add_program(mesh_coord_range, std::move(program));
+        }
+    }
+    return {std::move(workload), std::move(shared_variables)};
+}
+
+void MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const ttnn::prim::MatmulParams& attributes,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    for (auto& [mesh_coord_range, program] : cached_workload.workload.get_programs()) {
+        MatmulMultiCoreReuseMcast1DProgramFactory::override_runtime_arguments(
+            program,
+            cached_workload.shared_variables.at(mesh_coord_range),
+            attributes,
+            tensor_args,
+            tensor_return_value);
+    }
+}
+
+ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t>
+matmul_multi_core_reuse_mcast_1d_optimized_helper(
+    tt_metal::Program& program,
+    const Tensor& a,
+    const std::vector<Tensor>& b_tensors,
+    const std::optional<const Tensor>& bias,
+    const std::vector<Tensor>& output_tensors,
+    bool broadcast_batch,
+    DeviceComputeKernelConfig compute_kernel_config,
+    const operations::matmul::MatmulProgramConfig& program_config,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t shared_vars =
+        matmul_multi_core_reuse_mcast_1d_optimized_helper(
+            program,
+            a,
+            b_tensors,
+            bias,
+            output_tensors,
+            broadcast_batch,
+            compute_kernel_config,
+            program_config,
+            untilize_out,
+            fused_op_signaler,
+            global_cb,
+            sub_device_id,
+            tt::CBIndex::c_0,
+            std::nullopt);
+
+    return {std::move(program), std::move(shared_vars)};
+}
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_1d_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_1d_program_factory.hpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+#include "ttnn/operations/matmul/device/matmul_1d_type.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::for_python {
+
+// Metal 1.0 copy of the production factory, frozen for the Python fusion framework.
+// Not part of MatmulDeviceOperation and not on any dispatch path — do not port it to Metal 2.0.
+
+struct matmul_mcast_1d_common_override_variables_t {
+    std::vector<tt::tt_metal::KernelHandle> kernels;
+    std::vector<tt::tt_metal::CBHandle> cbs;
+    bool extract_shard_sub_blocks{};
+    CoreCoord start_core;
+    std::vector<CoreCoord> cores;
+    uint32_t num_cores_with_work{};
+    ttnn::prim::Matmul1DType type{};
+};
+
+struct MatmulMultiCoreReuseMcast1DProgramFactory {
+    using shared_variables_t = matmul_mcast_1d_common_override_variables_t;
+
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const shared_variables_t& shared_variables,
+        const ttnn::prim::MatmulParams& operation_attributes,
+        const ttnn::prim::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value);
+
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::MatmulParams& operation_attributes,
+        const ttnn::prim::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+};
+
+struct MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory {
+    using shared_variables_t = MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t;
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+    static cached_mesh_workload_t create_mesh_workload(
+        const ttnn::prim::MatmulParams& operation_attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const ttnn::prim::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_workload,
+        const ttnn::prim::MatmulParams& operation_attributes,
+        const ttnn::prim::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value);
+};
+
+MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_reuse_mcast_1d_optimized_helper(
+    tt::tt_metal::Program& program,
+    const Tensor& a,
+    const std::vector<Tensor>& b_tensors,
+    const std::optional<const Tensor>& bias,
+    const std::vector<Tensor>& output_tensors,
+    bool broadcast_batch,
+    DeviceComputeKernelConfig compute_kernel_config,
+    const operations::matmul::MatmulProgramConfig& program_config,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    uint32_t start_cb_index,
+    std::optional<CoreRangeSet> restricted_cores);
+
+ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t>
+matmul_multi_core_reuse_mcast_1d_optimized_helper(
+    tt::tt_metal::Program& program,
+    const Tensor& a,
+    const std::vector<Tensor>& b_tensors,
+    const std::optional<const Tensor>& bias,
+    const std::vector<Tensor>& output_tensors,
+    bool broadcast_batch,
+    DeviceComputeKernelConfig compute_kernel_config,
+    const operations::matmul::MatmulProgramConfig& program_config,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id);
+
+namespace reuse_mcast_1d_optimized_helpers {
+void override_program_parameters(
+    const MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t& override_variables,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    Program& program,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    const std::vector<ttnn::Tensor>& tensor_return_value);
+}  // namespace reuse_mcast_1d_optimized_helpers
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -1,0 +1,3546 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_2d_program_factory.hpp"
+#include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include "tt-metalium/buffer_types.hpp"
+
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/operations/matmul/shared_with_host/activation_type.hpp"
+
+using ttnn::operations::unary::UnaryOpType;
+using ttnn::operations::unary::UnaryWithParam;
+
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::DataMovementConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+
+using namespace ttnn::prim;
+
+namespace ttnn::for_python {
+
+namespace reuse_mcast_optimized_helpers {
+
+static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
+    tt::tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    bool dst_full_sync_en,
+    uint32_t B,
+    uint32_t M,
+    uint32_t M_per_batch,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_block_w,
+    uint32_t in0_last_ktile_w,
+    uint32_t in0_last_ktile_h,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    bool transpose_mcast,
+    std::optional<UnaryWithParam> fused_activation,
+    const tt::tt_metal::MeshTensor& in0_tensor,
+    const tt::tt_metal::MeshTensor& in1_tensor,
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_tensor,
+    const tt::tt_metal::MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    bool row_broadcast_bias = true,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    using namespace tt;
+    using tt::tt_metal::TensorMemoryLayout;
+
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_mesh;
+    if (bias_tensor.has_value()) {
+        bias_mesh = *bias_tensor;
+    }
+
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = fused_op_signaler.has_value();
+
+    TensorMemoryLayout in0_memory_layout = in0_tensor.memory_config().memory_layout();
+
+    uint32_t num_blocks = K / in0_block_w;
+
+    // Only enable packer l1 accumulation when there are num_blocks > 2, otherwise
+    // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+    // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+    // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_mesh.has_value()) && num_blocks > 1) || (num_blocks > 2));
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    const bool in0_block_sharded = in0_memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool in0_height_sharded = in0_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in0_is_sharded = in0_block_sharded || in0_height_sharded;
+    const bool in1_is_width_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+    const bool in1_is_height_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
+    const bool output_is_sharded = out_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
+    // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
+    // the padded stride, so the in0/in1/bias CBs must hold pages at the aligned stride and the
+    // reader/unpacker walk tiles at the same stride. No-op when already aligned (all bf16 tiles,
+    // 32-wide bfp8, Wormhole). Replaces the staging-CB workaround. Sharded CBs are backed by the
+    // tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size =
+        in1_is_sharded ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
+    // Bias is DRAM-interleaved; its CB pages must be padded to the DRAM alignment so the
+    // reader's L1 write stride matches the DRAM page stride (e.g. 64B on Blackhole for a
+    // 32B (1,16) bf16 bias tile). Without this, L1 dst and DRAM src alignment offsets
+    // disagree and the NOC rejects the transaction. Mirrors in0/in1 above and the
+    // dram_sharded factory. No-op on Wormhole and for tiles already >= dram_alignment.
+    uint32_t bias_aligned_tile_size = tt::align(bias_single_tile_size, dram_alignment);
+
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = out_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (B * num_blocks > 1) {
+        in0_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (B * num_blocks > 1) {
+        in1_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in2_block_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    uint32_t in0_shard_height_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+    }
+
+    uint32_t in2_CB_tiles = in2_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_aligned_tile_size;
+
+    uint32_t start_core_x = sub_device_start_core.x;
+    uint32_t start_core_y = sub_device_start_core.y;
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_cores_with_work_c = num_blocks_x;
+    uint32_t num_cores_with_work_r = num_blocks_y;
+    if (transpose_mcast) {
+        std::swap(num_cores_with_work_c, num_cores_with_work_r);
+    }
+
+    CoreRange all_cores_with_work(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y + num_cores_with_work_r - 1});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      IN0 SHARDED SENDER/RECEIVER
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t num_cores_c = num_cores_with_work_c;
+    uint32_t num_cores_r = num_cores_with_work_r;
+    uint32_t in0_mcast_receiver_grid_diff_coord_start;
+    uint32_t in0_mcast_receiver_grid_diff_coord_end;
+    std::vector<uint32_t> in0_mcast_noc_x;
+    std::vector<uint32_t> in0_mcast_noc_y;
+    uint32_t in0_sender_num_cores_along_width = 0;
+
+    // Only used for in0 block sharded
+    std::optional<CoreRange> in0_mcast_cores_without_work_and_not_in_receiver_grid;
+    if (in0_block_sharded) {
+        CoreCoord in0_shard_grid = in0_tensor.shard_spec()->grid.bounding_box().grid_size();
+        // in0 shard grid already accounts for transpose_mcast
+        // ie. If transpose_mcast, in0 width is along y
+        in0_sender_num_cores_along_width = transpose_mcast ? in0_shard_grid.y : in0_shard_grid.x;
+        if (in0_sender_num_cores_along_width > num_blocks_x) {
+            in0_mcast_cores_without_work_and_not_in_receiver_grid =
+                transpose_mcast ? CoreRange(
+                                      {(std::size_t)start_core_x, (std::size_t)start_core_y + num_blocks_x},
+                                      {(std::size_t)start_core_x + num_blocks_y - 1,
+                                       (std::size_t)start_core_y + in0_sender_num_cores_along_width - 1})
+                                : CoreRange(
+                                      {(std::size_t)start_core_x + num_blocks_x, (std::size_t)start_core_y},
+                                      {(std::size_t)start_core_x + in0_sender_num_cores_along_width - 1,
+                                       (std::size_t)start_core_y + num_blocks_y - 1});
+        }
+
+        if (transpose_mcast) {
+            in0_mcast_receiver_grid_diff_coord_start =
+                device->worker_core_from_logical_core({start_core_x, start_core_y}).y;
+            in0_mcast_receiver_grid_diff_coord_end =
+                device->worker_core_from_logical_core({start_core_x, start_core_y + num_blocks_x - 1}).y;
+            in0_mcast_noc_y.reserve(in0_sender_num_cores_along_width);
+            for (uint32_t core_idx_y = 0; core_idx_y < in0_sender_num_cores_along_width; ++core_idx_y) {
+                in0_mcast_noc_y.push_back(
+                    device->worker_core_from_logical_core({start_core_x, start_core_y + core_idx_y}).y);
+            }
+        } else {
+            in0_mcast_receiver_grid_diff_coord_start =
+                device->worker_core_from_logical_core({start_core_x, start_core_y}).x;
+            in0_mcast_receiver_grid_diff_coord_end =
+                device->worker_core_from_logical_core({start_core_x + num_blocks_x - 1, start_core_y}).x;
+            in0_mcast_noc_x.reserve(in0_sender_num_cores_along_width);
+            for (uint32_t core_idx_x = 0; core_idx_x < in0_sender_num_cores_along_width; ++core_idx_x) {
+                in0_mcast_noc_x.push_back(
+                    device->worker_core_from_logical_core({start_core_x + core_idx_x, start_core_y}).x);
+            }
+        }
+
+        // Set in0 sender/receiver cores to be maximum
+        if (transpose_mcast) {
+            num_cores_r = std::max(num_cores_r, in0_sender_num_cores_along_width);
+        } else {
+            num_cores_c = std::max(num_cores_c, in0_sender_num_cores_along_width);
+        }
+    }
+
+    // Used for setting up CBs and semaphores by both in0 interleaved or sharded
+    CoreRange all_cores(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_c - 1, (std::size_t)start_core_y + num_cores_r - 1});
+    const auto& cores = grid_to_cores(all_cores.start_coord, all_cores.end_coord, true);
+    //////////////////////////////////////////////////////////////////////////////////////////
+    //       IN0 SENDER (interleaved only) and IN1 SENDER (both interleaved and sharded)
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // Left column
+    CoreRange in0_sender_interleaved(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1});
+
+    // Top row
+    CoreRange in1_sender(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y});
+
+    // Left column except corner
+    std::optional<CoreRange> in0_sender_in1_receiver;
+    if (num_cores_with_work_r > 1) {
+        in0_sender_in1_receiver = {
+            {(std::size_t)start_core_x, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    // Top row except corner
+    std::optional<CoreRange> in0_receiver_in1_sender;
+    if (num_cores_with_work_c > 1) {
+        in0_receiver_in1_sender = {
+            {(std::size_t)start_core_x + 1, (std::size_t)start_core_y},
+            {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y}};
+    }
+
+    if (transpose_mcast) {
+        std::swap(in0_sender_interleaved, in1_sender);
+        std::swap(in0_sender_in1_receiver, in0_receiver_in1_sender);
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    //       IN0 RECEIVER (interleaved only) and IN1 RECEIVER (both interleaved and sharded)
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // Not exactly half-half; this seems to get slightly better perf for fused qkv and selfout
+    // TODO: Experiment with different splits?
+    bool split_half = num_cores_with_work_c > 2 && num_cores_with_work_r > 1 && !in0_is_sharded;
+    uint32_t half_core = split_half ? (num_cores_with_work_c) / 2 : num_cores_with_work_c - 1;
+
+    std::optional<CoreRange> in0_receiver_in1_receiver_left_half;
+    if (num_cores_with_work_c > 1 and num_cores_with_work_r > 1) {
+        in0_receiver_in1_receiver_left_half = {
+            {(std::size_t)start_core_x + 1, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x + half_core, (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    std::set<CoreRange> in0_receiver_interleaved_set;
+    std::set<CoreRange> in1_receiver_set;
+    if (in0_receiver_in1_sender.has_value()) {
+        in0_receiver_interleaved_set.insert(in0_receiver_in1_sender.value());
+    }
+    if (in0_sender_in1_receiver.has_value()) {
+        in1_receiver_set.insert(in0_sender_in1_receiver.value());
+    }
+    if (in0_receiver_in1_receiver_left_half.has_value()) {
+        in0_receiver_interleaved_set.insert(in0_receiver_in1_receiver_left_half.value());
+        in1_receiver_set.insert(in0_receiver_in1_receiver_left_half.value());
+    }
+    CoreRangeSet in0_receiver_interleaved(in0_receiver_interleaved_set);
+    CoreRangeSet in1_receiver(in1_receiver_set);
+
+    std::optional<CoreRange> in0_receiver_in1_receiver_interleaved_other_cores;
+    if (split_half) {
+        in0_receiver_in1_receiver_interleaved_other_cores = {
+            {(std::size_t)start_core_x + half_core + 1, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x + num_cores_with_work_c - 1,
+             (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    // Mcast args — semaphore IDs assigned sequentially (0, 1, 2, 3)
+    uint32_t in0_mcast_sender_semaphore_id = 0;
+    uint32_t in0_mcast_receiver_semaphore_id = 1;
+    uint32_t in1_mcast_sender_semaphore_id = 2;
+    uint32_t in1_mcast_receiver_semaphore_id = 3;
+
+    bool in1_is_dram = in1_tensor.mesh_buffer().device_local_config().buffer_type == tt_metal::BufferType::DRAM;
+
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+
+    TT_FATAL(
+        out_block_h % out_subblock_h == 0 and out_block_h >= out_subblock_h,
+        "out_block_h must be multiple of out_subblock_h");
+    TT_FATAL(
+        out_block_w % out_subblock_w == 0 and out_block_w >= out_subblock_w,
+        "out_block_w must be multiple of out_subblock_w");
+
+    std::vector<uint32_t> in0_sender_compile_time_args;
+
+    uint32_t num_dram_banks = 0;
+    uint32_t per_core_N_storage = 0;
+    uint32_t batches_per_bank = 0;
+    if (in1_is_sharded and in1_is_dram) {
+        num_dram_banks = device->num_dram_channels();
+        if (in1_is_width_sharded) {
+            per_core_N_storage = (N + num_dram_banks - 1) / num_dram_banks;
+        } else {
+            // Height sharded: batches are distributed across DRAM banks
+            uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
+            batches_per_bank = in1_shard_height_in_tiles / K;
+        }
+    }
+
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    if (in0_block_sharded) {
+        uint32_t num_x = in0_sender_num_cores_along_width;
+        uint32_t num_y = 1;
+        if (transpose_mcast) {
+            std::swap(num_x, num_y);
+        }
+
+        in0_sender_compile_time_args = {
+            (std::uint32_t)1,  // core_has_output_block_work
+            (std::uint32_t)1,  // core_in_in0_receiver_mcast_grid
+
+            (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+            (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,  // num_blocks
+            (std::uint32_t)out_num_blocks_x,
+            (std::uint32_t)out_num_blocks_y,
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)num_blocks_x,  // in0_mcast_num_dests
+            (std::uint32_t)num_blocks_x,  // in0_mcast_num_cores
+            (std::uint32_t)num_x,
+            (std::uint32_t)num_y,
+            (std::uint32_t)transpose_mcast,
+            (std::uint32_t)in0_shard_width_in_tiles,
+            (std::uint32_t)in0_shard_height_in_tiles,
+            (std::uint32_t)in0_block_w,
+            (std::uint32_t)in0_block_h,
+            // batch args
+            (std::uint32_t)B  // batch
+        };
+    } else {
+        in0_sender_compile_time_args = {
+            // in0 tensor args
+            (std::uint32_t)in0_tensor_stride_w,
+            (std::uint32_t)in0_tensor_stride_h,
+            (std::uint32_t)in0_tensor_next_block_stride,
+            (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+            // in0 block args
+            (std::uint32_t)in0_block_w,          // in0_block_w
+            (std::uint32_t)in0_block_h,          // in0_block_h
+            (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            (std::uint32_t)false,                      // extract_shard_sub_blocks (not used for interleaved)
+            (std::uint32_t)in0_shard_width_in_tiles,   // shard_width_in_tiles (not used for interleaved)
+            (std::uint32_t)in0_shard_height_in_tiles,  // shard_height_in_tiles (not used for interleaved)
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,  // num_blocks
+            (std::uint32_t)out_num_blocks_x,
+            (std::uint32_t)out_num_blocks_y,
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)(num_blocks_x - 1),  // in0_mcast_num_dests
+            (std::uint32_t)(num_blocks_x - 1),  // in0_mcast_num_cores
+            // batch args
+            (std::uint32_t)M * K,  // MtKt
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)false,  // reuse_in0_in_CB
+
+            // sparsity args
+            (std::uint32_t)0,      // batchB
+            (std::uint32_t)0,      // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)true,   // bcast_A
+            (std::uint32_t)false,  // get_batch_from_reader
+        };
+    }
+    in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+    in0_sender_compile_time_args.push_back((std::uint32_t)0);  // num_batch_compute (unused, sparsity disabled)
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        (std::uint32_t)(num_blocks_y - 1),  // in1_mcast_num_dests
+        (std::uint32_t)(num_blocks_y - 1),  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,        // KtNt
+        (std::uint32_t)B,            // batch
+        (std::uint32_t)bcast_batch,  // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_mesh.has_value()) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_mesh.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_mesh).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    if (in1_is_sharded and in1_is_dram) {
+        if (in1_is_width_sharded) {
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in0_block_w);
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in1_single_tile_size);
+        } else {
+            // Height sharded: pass tiles per batch and batches per bank
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)(K * N));  // KtNt per batch (tiles)
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)batches_per_bank);
+        }
+    }
+    std::vector<uint32_t> in0_receiver_compile_time_args = {
+        // in0 block args
+        (std::uint32_t)in0_block_w * in0_block_h,  // in0_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)B,     // batch
+        (std::uint32_t)false  // get_batch_from_reader
+    };
+    std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
+        // READER
+        // in1 block args
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)B,  // batch
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_mesh.has_value()) {
+        in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
+    } else {
+        in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+    in1_receiver_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_receiver_writer_compile_time_args);
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_sharded_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_interleaved_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_other_noc_setup_defines;
+    if (bias_mesh.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_other_noc_setup_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), cores.size(), mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), cores.size(), mm_kernel_defines, throttle_level);
+
+    if (in0_receiver_interleaved.num_cores() == 0) {
+        mm_kernel_in0_sender_interleaved_defines["SKIP_MCAST"] = "1";
+    }
+    if (in0_height_sharded) {
+        mm_kernel_in0_sender_interleaved_defines["IN0_SHARDED"] = "1";
+    }
+
+    if (in1_receiver.num_cores() == 0) {
+        mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+    if (in1_is_sharded) {
+        if (in1_is_dram) {
+            if (in1_is_width_sharded) {
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_WIDTH_SHARDED"] = "1";
+            } else {
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_HEIGHT_SHARDED"] = "1";
+            }
+        } else {
+            mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
+        }
+    }
+
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_other_noc_setup_defines["OUT_SHARDED"] = "1";
+    }
+
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+
+    // Helper to convert std::map defines to KernelDescriptor::Defines (vector of pairs)
+    auto map_to_defines = [](const std::map<std::string, std::string>& m) -> KernelDescriptor::Defines {
+        KernelDescriptor::Defines result;
+        result.reserve(m.size());
+        for (const auto& [k, v] : m) {
+            result.emplace_back(k, v);
+        }
+        return result;
+    };
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    tt_metal::NOC in0_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    tt_metal::NOC in1_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build Kernel Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    // We build kernel descriptors as local variables, populate their runtime_args
+    // in the per-core loop, then push them all to desc.kernels at the end.
+    // The order they are pushed determines the kernel handle index.
+
+    // Kernel index tracking:
+    // Index 0: mm_kernel_in0_sender (block sharded or interleaved)
+    // Index 1: mm_kernel_in0_mcast_cores_without_work (only if in0_block_sharded && extra cores exist)
+    //   OR: (not created if not needed)
+    // Then: mm_kernel_in1_sender_writer
+    // Then: mm_kernel_in1_receiver_writer (if in1_receiver.num_cores() > 0)
+    // Then: mm_kernel_in0_receiver (if !in0_block_sharded && in0_receiver_interleaved.num_cores() > 0)
+    // Then: mm_kernel_in1_receiver_writer_other_noc_setup (if split_half other cores exist)
+    // Then: mm_kernel_in0_receiver_other_noc_setup (if split_half other cores exist)
+    // Then: compute kernel
+
+    KernelDescriptor in0_sender_kernel_desc;
+    KernelDescriptor in0_mcast_no_work_kernel_desc;
+    bool has_in0_mcast_no_work_kernel = false;
+    KernelDescriptor in1_sender_writer_kernel_desc;
+    KernelDescriptor in1_receiver_writer_kernel_desc;
+    bool has_in1_receiver_writer_kernel = false;
+    KernelDescriptor in0_receiver_kernel_desc;
+    bool has_in0_receiver_kernel = false;
+    KernelDescriptor in1_receiver_writer_other_kernel_desc;
+    bool has_in1_receiver_writer_other_kernel = false;
+    KernelDescriptor in0_receiver_other_kernel_desc;
+    bool has_in0_receiver_other_kernel = false;
+
+    if (in0_block_sharded) {
+        in0_sender_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp";
+        in0_sender_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in0_sender_kernel_desc.core_ranges = CoreRangeSet(all_cores_with_work);
+        in0_sender_kernel_desc.compile_time_args = in0_sender_compile_time_args;
+        in0_sender_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_sharded_defines);
+        in0_sender_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in0_sharded", tt::CBIndex::c_2},
+            {"cb_l1_array", tt::CBIndex::c_6},
+        };
+        in0_sender_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+
+        if (in0_mcast_cores_without_work_and_not_in_receiver_grid.has_value()) {
+            has_in0_mcast_no_work_kernel = true;
+            auto no_work_ct_args = in0_sender_compile_time_args;
+            no_work_ct_args[0] = 0;  // core_has_output_block_work
+            no_work_ct_args[1] = 0;  // core_in_in0_receiver_mcast_grid
+            in0_mcast_no_work_kernel_desc.kernel_source =
+                "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp";
+            in0_mcast_no_work_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+            in0_mcast_no_work_kernel_desc.core_ranges =
+                CoreRangeSet(in0_mcast_cores_without_work_and_not_in_receiver_grid.value());
+            in0_mcast_no_work_kernel_desc.compile_time_args = no_work_ct_args;
+            in0_mcast_no_work_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_sharded_defines);
+            in0_mcast_no_work_kernel_desc.named_compile_time_args = {
+                {"cb_in0", tt::CBIndex::c_0},
+                {"cb_in0_sharded", tt::CBIndex::c_2},
+                {"cb_l1_array", tt::CBIndex::c_6},
+            };
+            in0_mcast_no_work_kernel_desc.config =
+                DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+        }
+    } else {
+        // NOTE: fused_op_signaler init_fused_op() calls are NOT translated to the descriptor
+        // because they modify the Program directly. These are handled when the Program is
+        // constructed from the descriptor in create_program_mcast_in0_in1().
+
+        in0_sender_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp";
+        in0_sender_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in0_sender_kernel_desc.core_ranges = CoreRangeSet(in0_sender_interleaved);
+        in0_sender_kernel_desc.compile_time_args = in0_sender_compile_time_args;
+        in0_sender_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_interleaved_defines);
+        in0_sender_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in0_sharded", tt::CBIndex::c_2},
+            {"cb_sparsity", tt::CBIndex::c_6},
+        };
+        in0_sender_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+    }
+
+    in1_sender_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp";
+    in1_sender_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in1_sender_writer_kernel_desc.core_ranges = CoreRangeSet(in1_sender);
+    in1_sender_writer_kernel_desc.compile_time_args = in1_sender_writer_compile_time_args;
+    in1_sender_writer_kernel_desc.defines = map_to_defines(mm_kernel_in1_sender_writer_defines);
+    in1_sender_writer_kernel_desc.named_compile_time_args = {
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_sparsity", tt::CBIndex::c_7},
+    };
+    in1_sender_writer_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+
+    if (in1_receiver.num_cores() > 0) {
+        has_in1_receiver_writer_kernel = true;
+        in1_receiver_writer_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp";
+        in1_receiver_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in1_receiver_writer_kernel_desc.core_ranges = in1_receiver;
+        in1_receiver_writer_kernel_desc.compile_time_args = in1_receiver_writer_compile_time_args;
+        in1_receiver_writer_kernel_desc.defines = map_to_defines(mm_kernel_in1_receiver_writer_defines);
+        in1_receiver_writer_kernel_desc.named_compile_time_args = {
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+        };
+        in1_receiver_writer_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+    }
+
+    if (!in0_block_sharded and in0_receiver_interleaved.num_cores() > 0) {
+        has_in0_receiver_kernel = true;
+        in0_receiver_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp";
+        in0_receiver_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in0_receiver_kernel_desc.core_ranges = in0_receiver_interleaved;
+        in0_receiver_kernel_desc.compile_time_args = in0_receiver_compile_time_args;
+        in0_receiver_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+        };
+        in0_receiver_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+    }
+
+    if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
+        has_in1_receiver_writer_other_kernel = true;
+        in1_receiver_writer_other_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp";
+        in1_receiver_writer_other_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in1_receiver_writer_other_kernel_desc.core_ranges =
+            CoreRangeSet(in0_receiver_in1_receiver_interleaved_other_cores.value());
+        in1_receiver_writer_other_kernel_desc.compile_time_args = in1_receiver_writer_compile_time_args;
+        in1_receiver_writer_other_kernel_desc.defines =
+            map_to_defines(mm_kernel_in1_receiver_writer_other_noc_setup_defines);
+        in1_receiver_writer_other_kernel_desc.named_compile_time_args = {
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+        };
+        in1_receiver_writer_other_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_split_noc};
+
+        has_in0_receiver_other_kernel = true;
+        in0_receiver_other_kernel_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp";
+        in0_receiver_other_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        in0_receiver_other_kernel_desc.core_ranges =
+            CoreRangeSet(in0_receiver_in1_receiver_interleaved_other_cores.value());
+        in0_receiver_other_kernel_desc.compile_time_args = in0_receiver_compile_time_args;
+        in0_receiver_other_kernel_desc.named_compile_time_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+        };
+        in0_receiver_other_kernel_desc.config =
+            DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_split_noc};
+    }
+
+    // Compute kernel compile time args
+
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,  // num_blocks
+        out_num_blocks_x,
+        out_num_blocks_y,
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B,                       // batch,
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias_mesh.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    // Create compute kernel descriptor
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = CoreRangeSet(all_cores_with_work);
+    compute_kernel_desc.compile_time_args = compute_kernel_args;
+    constexpr auto cb_intermed0 = tt::CBIndex::c_5;
+    // The fused bias add reads the partials CB as an FPU operand (SrcA), so UnpackToDestFp32 cannot be
+    // set on cb_intermed0 directly when bias is present. In that case the cross-block reload instead
+    // copies through cb_intermed0_alias, a second buffer index over the same SRAM carrying
+    // UnpackToDestFp32, while the bias add keeps reading cb_intermed0 via SrcA. The alias index is
+    // handed to the compute kernel through the MM_PARTIALS_RELOAD_ALIAS_CB define, which selects the
+    // alias reload path there. Without bias the reload reads cb_intermed0 and the flag is set on it.
+    constexpr auto cb_intermed0_alias = tt::CBIndex::c_7;
+    const bool bias_reload_alias =
+        fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32 && bias_tensor.has_value();
+    if (bias_reload_alias) {
+        mm_kernel_defines["MM_PARTIALS_RELOAD_ALIAS_CB"] = std::to_string(static_cast<uint32_t>(cb_intermed0_alias));
+    }
+    compute_kernel_desc.defines = map_to_defines(mm_kernel_defines);
+    {
+        KernelDescriptor::NamedCompileTimeArgs named_compile_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+            {"cb_intermed0", cb_intermed0},
+            {"cb_in0_transposed", tt::CBIndex::c_10},
+            {"bias_ntiles", in1_per_core_w},
+        };
+        if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+            using ttnn::operations::matmul::utilities::get_activation_params;
+            const auto params = get_activation_params(fused_activation.value());
+            named_compile_args.push_back({"activation_type", static_cast<uint32_t>(params.type)});
+            named_compile_args.push_back({"activation_param0", params.param0});
+            named_compile_args.push_back({"activation_param1", params.param1});
+            named_compile_args.push_back({"activation_param2", params.param2});
+        }
+        compute_kernel_desc.named_compile_time_args = std::move(named_compile_args);
+    }
+    // When accumulating in fp32 with the K reduction split across blocks, the intermediate
+    // partials CB holds Float32 and is reloaded into DEST between blocks by copy_block_matmul_partials.
+    // Unless the reload's CB view is marked UnpackToDestFp32, that reload is routed through SrcA and
+    // rounded to TF32 (10 mantissa bits), so the fp32 partial loses precision on every block boundary
+    // and accuracy degrades as the number of K-blocks grows. The flag is set on the alias when bias
+    // forces a separate SrcA view of cb_intermed0 (see above), else on cb_intermed0 itself.
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32) {
+        const uint32_t cb_to_mark =
+            bias_reload_alias ? static_cast<uint32_t>(cb_intermed0_alias) : static_cast<uint32_t>(cb_intermed0);
+        unpack_to_dest_mode[cb_to_mark] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        .math_approx_mode = math_approx_mode};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build CBDescriptors
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor desc;
+
+    tt::tt_metal::TileDescriptor in0_tile_desc{in0_tile};
+    tt::tt_metal::TileDescriptor in1_tile_desc{in1_tile};
+    tt::tt_metal::TileDescriptor bias_tile_desc{bias_tile};
+    tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+
+    // CB 0: in0
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = CoreRangeSet(all_cores);
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_0,
+            .data_format = in0_data_format,
+            .page_size = in0_aligned_tile_size,
+            .tile = in0_tile_desc});
+        if (in0_height_sharded) {
+            cb_desc.tensor = &in0_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 1: in1
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in1_CB_size;
+        cb_desc.core_ranges = CoreRangeSet(all_cores);
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_1,
+            .data_format = in1_data_format,
+            .page_size = in1_aligned_tile_size,
+            .tile = in1_tile_desc});
+        if (in1_is_sharded and not in1_is_dram) {
+            cb_desc.tensor = &in1_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 2: in0 sharded (only for block sharded)
+    if (in0_block_sharded) {
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = in2_CB_size;
+            cb_desc.core_ranges = CoreRangeSet(all_cores);
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_2,
+                .data_format = in0_data_format,
+                .page_size = in0_single_tile_size,
+                .tile = in0_tile_desc});
+            cb_desc.tensor = &in0_tensor;
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+
+        // Local L1 to store temp vars
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = 32 * 2;
+            cb_desc.core_ranges = CoreRangeSet(all_cores);
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_6, .data_format = tt::DataFormat::Float16_b, .page_size = 32 * 2});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    }
+
+    // CB 4 and CB 5: output and intermediate
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // Separate output and intermediate CBs
+        // output
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = out_CB_size;
+            cb_desc.core_ranges = CoreRangeSet({all_cores});
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_4,
+                .data_format = output_data_format,
+                .page_size = output_single_tile_size,
+                .tile = output_tile_desc});
+            if (output_is_sharded) {
+                cb_desc.tensor = &out_tensor;
+            }
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+        // interm0
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = interm0_CB_size;
+            cb_desc.core_ranges = CoreRangeSet({all_cores});
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_5,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+            // Alias over the same SRAM, marked UnpackToDestFp32, for the bias reload (see above).
+            if (bias_reload_alias) {
+                cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                    .buffer_index = cb_intermed0_alias,
+                    .data_format = interm0_data_format,
+                    .page_size = interm0_single_tile_size,
+                    .tile = output_tile_desc});
+            }
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    } else {
+        // share buffer
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_CB_size;
+        cb_desc.core_ranges = CoreRangeSet({all_cores});
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_4,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_5,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        // Alias over the same SRAM, marked UnpackToDestFp32, for the bias reload (see above).
+        if (bias_reload_alias) {
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = cb_intermed0_alias,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+        }
+        if (output_is_sharded) {
+            cb_desc.tensor = &out_tensor;
+        }
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB for bias
+    if (bias_mesh.has_value()) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in3_CB_size;
+        cb_desc.core_ranges = CoreRangeSet(all_cores);
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_3,
+            .data_format = bias_data_format,
+            .page_size = bias_aligned_tile_size,
+            .tile = bias_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // Intermediate CB read
+
+    if (in0_transpose_tile) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = CoreRangeSet(all_cores);
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_10,
+            .data_format = in0_data_format,
+            .page_size = in0_aligned_tile_size,
+            .tile = in0_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Semaphore Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_sender_semaphore_id, .core_ranges = CoreRangeSet(all_cores), .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_receiver_semaphore_id, .core_ranges = CoreRangeSet(all_cores), .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in1_mcast_sender_semaphore_id, .core_ranges = CoreRangeSet(all_cores), .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in1_mcast_receiver_semaphore_id, .core_ranges = CoreRangeSet(all_cores), .initial_value = INVALID});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Runtime Args (per-core loop)
+    ////////////////////////////////////////////////////////////////////////////
+    // Parameters for last row, col, or block
+    uint32_t last_per_core_M = M % per_core_M == 0 ? per_core_M : M % per_core_M;
+    uint32_t last_per_core_N = N % per_core_N == 0 ? per_core_N : N % per_core_N;
+    uint32_t last_out_block_h = last_per_core_M % out_block_h == 0 ? out_block_h : last_per_core_M % out_block_h;
+    uint32_t last_out_block_w = last_per_core_N % out_block_w == 0 ? out_block_w : last_per_core_N % out_block_w;
+    uint32_t last_out_num_blocks_h = ((last_per_core_M - 1) / out_block_h) + 1;
+    uint32_t last_out_num_blocks_w = ((last_per_core_N - 1) / out_block_w) + 1;
+    uint32_t last_block_num_nonzero_subblocks_h = ((last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t last_block_num_nonzero_subblocks_w = ((last_out_block_w - 1) / out_subblock_w) + 1;
+    uint32_t last_subblock_of_last_block_h =
+        last_out_block_h % out_subblock_h == 0 ? out_subblock_h : last_out_block_h % out_subblock_h;
+    uint32_t last_subblock_of_last_block_w =
+        last_out_block_w % out_subblock_w == 0 ? out_subblock_w : last_out_block_w % out_subblock_w;
+    uint32_t last_block_padded_subblock_tiles_addr_skip =
+        output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
+    uint32_t last_block_padded_block_tiles_w_skip =
+        (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
+    uint32_t last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    if (in0_block_sharded) {
+        if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+            std::swap(in0_mcast_receiver_grid_diff_coord_start, in0_mcast_receiver_grid_diff_coord_end);
+        }
+    }
+
+    // dram sharded weights stride params
+    uint32_t worker_core_stride = 0;   // stride in the worker core
+    uint32_t storage_core_stride = 0;  // stride in the dram bank
+    uint32_t curr_worker_core = 0;     // current worker core
+    uint32_t curr_storage_core = 0;    // current read dram bank
+    uint32_t vc = 0;
+
+    uint32_t in0_end_idx = num_blocks_y - 1;
+    uint32_t in1_end_idx = num_blocks_x - 1;
+
+    for (const auto& core : cores) {
+        CoreCoord left_core = {(std::size_t)start_core_x, (std::size_t)core.y};
+        CoreCoord left_core_plus_one = {(std::size_t)start_core_x + 1, (std::size_t)core.y};
+        CoreCoord right_core = {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)core.y};
+        CoreCoord top_core = {(std::size_t)core.x, (std::size_t)start_core_y};
+        CoreCoord top_core_plus_one = {(std::size_t)core.x, (std::size_t)start_core_y + 1};
+        CoreCoord bottom_core = {(std::size_t)core.x, (std::size_t)start_core_y + num_cores_with_work_r - 1};
+
+        auto left_core_physical = device->worker_core_from_logical_core(left_core);
+        auto left_core_plus_one_physical = device->worker_core_from_logical_core(left_core_plus_one);
+        auto right_core_physical = device->worker_core_from_logical_core(right_core);
+        auto top_core_physical = device->worker_core_from_logical_core(top_core);
+        auto top_core_plus_one_physical = device->worker_core_from_logical_core(top_core_plus_one);
+        auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
+        uint32_t in0_idx = core.y - start_core_y;
+        uint32_t in1_idx = core.x - start_core_x;
+
+        auto in0_mcast_sender = left_core_physical;
+        auto in1_mcast_sender = top_core_physical;
+
+        // Assuming in0 is NOC0
+        auto in0_mcast_start = left_core_plus_one_physical;
+        auto in0_mcast_end = right_core_physical;
+        if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+            std::swap(in0_mcast_start, in0_mcast_end);
+        }
+
+        // Assuming in1 is NOC1
+        auto in1_mcast_start = bottom_core_physical;
+        auto in1_mcast_end = top_core_plus_one_physical;
+        if (in1_noc == tt::tt_metal::NOC::NOC_0) {
+            std::swap(in1_mcast_start, in1_mcast_end);
+        }
+
+        if (transpose_mcast) {
+            std::swap(in0_idx, in1_idx);
+            std::swap(in0_mcast_sender, in1_mcast_sender);
+            std::swap(in0_mcast_start, in1_mcast_end);
+            std::swap(in0_mcast_end, in1_mcast_start);
+        }
+
+        // in0 sender
+        if (in0_block_sharded) {
+            uint32_t in0_mcast_receiver_grid_same_coord;
+            std::vector<uint32_t> mm_in0_sender_args;
+            if (transpose_mcast) {
+                in0_mcast_receiver_grid_same_coord = device->worker_core_from_logical_core(core).x;
+                mm_in0_sender_args.push_back(core.y);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_start);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_end);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_y.begin(), in0_mcast_noc_y.end());
+            } else {
+                in0_mcast_receiver_grid_same_coord = device->worker_core_from_logical_core(core).y;
+                mm_in0_sender_args.push_back(core.x);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_start);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_end);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_x.begin(), in0_mcast_noc_x.end());
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+            }
+            if (in1_idx < num_blocks_x) {
+                in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+            } else {
+                in0_mcast_no_work_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+            }
+        } else if (in1_idx == 0) {
+            std::vector<uint32_t> mm_in0_sender_args = {
+                // in0 tensor args
+                (std::uint32_t)in0_tensor.address(),
+                (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
+                // in0 mcast args
+                (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
+                (std::uint32_t)in0_mcast_start.y,  // in0_mcast_dest_noc_start_y
+                (std::uint32_t)in0_mcast_end.x,    // in0_mcast_dest_noc_end_x
+                (std::uint32_t)in0_mcast_end.y,    // in0_mcast_dest_noc_end_y
+            };
+            if (in0_idx == in0_end_idx) {
+                // padding args (READER)
+                mm_in0_sender_args.push_back(last_out_block_h);  // last_out_block_h
+            } else {
+                mm_in0_sender_args.push_back(out_block_h);
+            }
+
+            // sparsity args
+            mm_in0_sender_args.push_back(0);  // sparsity_addr
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            {
+                std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>> in0_args(
+                    mm_in0_sender_args.begin(), mm_in0_sender_args.end());
+                in0_args[0] = in0_tensor;
+                in0_sender_kernel_desc.emplace_runtime_args(core, in0_args);
+            }
+
+            // in0 receiver
+        } else {
+            std::vector<uint32_t> mm_in0_receiver_args = {
+                // in0 mcast args
+                (std::uint32_t)in0_mcast_sender.x,  // in0_mcast_sender_noc_x
+                (std::uint32_t)in0_mcast_sender.y   // in0_mcast_sender_noc_y
+            };
+            // left half
+            if ((core.x - start_core_x) <= half_core || (!transpose_mcast and core.y == start_core_y)) {
+                in0_receiver_kernel_desc.runtime_args.emplace_back(core, mm_in0_receiver_args);
+            }
+            // right half
+            else {
+                in0_receiver_other_kernel_desc.runtime_args.emplace_back(core, mm_in0_receiver_args);
+            }
+        }
+
+        if (in0_idx < num_blocks_y and in1_idx < num_blocks_x) {
+            // in1 sender
+            if (in0_idx == 0) {
+                std::vector<uint32_t> mm_in1_sender_writer_args = {
+                    // READER
+                    // in1 tensor args
+                    (std::uint32_t)in1_tensor.address(),
+                    (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
+                    // in1 mcast args
+                    (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
+                    (std::uint32_t)in1_mcast_start.y,  // in1_mcast_dest_noc_start_y
+                    (std::uint32_t)in1_mcast_end.x,    // in1_mcast_dest_noc_end_x
+                    (std::uint32_t)in1_mcast_end.y,    // in1_mcast_dest_noc_end_y
+
+                    // sparsity args
+                    (std::uint32_t)0,  // sparsity_addr
+
+                    // WRITER
+                    // out tensor args
+                    (std::uint32_t)out_tensor.address(),
+                    ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
+                };
+
+                if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
+                    // padding args (READER)
+                    mm_in1_sender_writer_args.push_back(last_out_block_w);
+
+                    // padding args (WRITER)
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_sender_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_sender_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else {
+                    // padding args (READER)
+                    mm_in1_sender_writer_args.push_back(out_block_w);
+
+                    // padding args (WRITER)
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(0);
+                }
+
+                // in3 (bias) tensor address slot: placeholder only. The real address is provided as a
+                // tracked buffer binding (in1_sender_variant[18] = *bias_mesh below) before
+                // emplace_runtime_args, so the descriptor framework patches it on program-cache hits and
+                // the value pushed here is overwritten. Left at 0 when there is no bias.
+                mm_in1_sender_writer_args.push_back(0u);
+                mm_in1_sender_writer_args.push_back(
+                    bias_mesh.has_value() ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
+                if (!output_is_sharded) {
+                    if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
+                        mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
+                    } else {
+                        mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+                    }
+                }
+
+                if (in1_is_sharded and in1_is_dram) {  // in1 is dram sharded
+                    if (in1_is_width_sharded) {
+                        uint32_t num_iter_index = mm_in1_sender_writer_args.size() + 1;
+                        vc = vc == 3 ? 0 : vc + 1;
+                        mm_in1_sender_writer_args.push_back(vc);
+
+                        uint32_t num_iter = 0;  // iterate how many banks, till fill the current worker block
+
+                        if (curr_storage_core < num_dram_banks) {
+                            num_iter++;
+
+                            worker_core_stride = per_core_N_storage - storage_core_stride;
+
+                            mm_in1_sender_writer_args.push_back(
+                                storage_core_stride * in1_single_tile_size);  // dram_tensor_start_offset
+                            mm_in1_sender_writer_args.push_back(
+                                worker_core_stride * in1_single_tile_size);          // per_core_N_dram_bytes
+                            mm_in1_sender_writer_args.push_back(curr_storage_core);  // current_dram_bank_id
+
+                            log_debug(
+                                tt::LogOp,
+                                "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
+                                curr_worker_core,
+                                worker_core_stride,
+                                curr_storage_core,
+                                storage_core_stride);
+
+                            curr_storage_core += (storage_core_stride + worker_core_stride) / per_core_N_storage;
+                            storage_core_stride = (storage_core_stride + worker_core_stride) % per_core_N_storage;
+
+                            uint32_t curr_worker_core_old = curr_worker_core;
+                            if (worker_core_stride >= per_core_N) {
+                                curr_worker_core += 1;
+                            }
+
+                            while (curr_worker_core <= curr_worker_core_old and curr_storage_core < num_dram_banks) {
+                                num_iter++;
+
+                                uint32_t stride = worker_core_stride + per_core_N_storage;
+                                stride = std::min(stride, per_core_N);
+
+                                mm_in1_sender_writer_args.push_back(
+                                    (stride - worker_core_stride) * in1_single_tile_size);  // per_core_N_dram_bytes
+                                mm_in1_sender_writer_args.push_back(curr_storage_core);     // current_dram_bank_id
+
+                                log_debug(
+                                    tt::LogOp,
+                                    "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
+                                    curr_worker_core,
+                                    (stride - worker_core_stride),
+                                    curr_storage_core,
+                                    storage_core_stride);
+
+                                if (stride >= per_core_N) {
+                                    curr_worker_core += 1;
+                                }
+                                storage_core_stride = (stride - worker_core_stride) % per_core_N_storage;
+                                curr_storage_core += (stride - worker_core_stride) / per_core_N_storage;
+                                worker_core_stride = stride;
+                            }
+                        }
+                        mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + num_iter_index, num_iter);
+                    } else {
+                        // Height sharded: no additional runtime args needed
+                        // (bank/offset computed from compile-time args + batch index)
+                    }
+                }
+                if (fuse_op) {
+                    if (fused_op_signaler->is_all_gather()) {
+                        fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, true);
+                    } else if (fused_op_signaler->is_reduce_scatter()) {
+                        fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, in0_idx, in1_idx);
+                    } else {
+                        TT_FATAL(false, "Fused operation must be either all_gather or reduce_scatter.");
+                    }
+                }
+                {
+                    std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>>
+                        in1_sender_variant(mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
+                    in1_sender_variant[0] = in1_tensor;
+                    in1_sender_variant[7] = out_tensor;
+                    if (bias_mesh.has_value()) {
+                        in1_sender_variant[18] = *bias_mesh;
+                    }
+                    in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_sender_variant);
+                }
+
+                // in1 receiver
+            } else {
+                std::vector<uint32_t> mm_in1_receiver_writer_args = {
+                    // READER
+                    // in1 mcast args
+                    (std::uint32_t)in1_mcast_sender.x,  // in1_mcast_sender_noc_x
+                    (std::uint32_t)in1_mcast_sender.y,  // in1_mcast_sender_noc_y
+
+                    // WRITER
+                    // out tensor args
+                    (std::uint32_t)out_tensor.address(),                                // out_tensor_addr
+                    ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
+                };
+
+                if (in1_idx == in1_end_idx and in0_idx == in0_end_idx) {  // bottom-right core when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else if (in0_idx == in0_end_idx) {  // bottom cores except bottom-right when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(0);
+                } else if (in1_idx == in1_end_idx) {  // right cores except bottom when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else {
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(0);
+                }
+                if (!output_is_sharded) {
+                    if (in1_idx == in1_end_idx and
+                        in0_idx == in0_end_idx) {  // bottom-right core when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_w);
+                    } else if (in0_idx == in0_end_idx) {  // bottom cores except bottom-right when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                    } else if (in1_idx == in1_end_idx) {  // right cores except bottom when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_w);
+                    } else {
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                    }
+                }
+
+                if (fuse_op && fused_op_signaler->is_reduce_scatter()) {
+                    fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_receiver_writer_args, in0_idx, in1_idx);
+                }
+
+                {
+                    std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>>
+                        in1_recv_variant(mm_in1_receiver_writer_args.begin(), mm_in1_receiver_writer_args.end());
+                    in1_recv_variant[2] = out_tensor;
+                    // left half
+                    if ((core.x - start_core_x) <= half_core || (transpose_mcast and core.y == start_core_y)) {
+                        in1_receiver_writer_kernel_desc.emplace_runtime_args(core, in1_recv_variant);
+                    }
+                    // right half
+                    else {
+                        in1_receiver_writer_other_kernel_desc.emplace_runtime_args(core, in1_recv_variant);
+                    }
+                }
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Push Kernels to Descriptor
+    ////////////////////////////////////////////////////////////////////////////
+    // Order matters — determines kernel handle indices
+    desc.kernels.push_back(std::move(in0_sender_kernel_desc));
+    if (has_in0_mcast_no_work_kernel) {
+        desc.kernels.push_back(std::move(in0_mcast_no_work_kernel_desc));
+    }
+    desc.kernels.push_back(std::move(in1_sender_writer_kernel_desc));
+    if (has_in1_receiver_writer_kernel) {
+        desc.kernels.push_back(std::move(in1_receiver_writer_kernel_desc));
+    }
+    if (has_in0_receiver_kernel) {
+        desc.kernels.push_back(std::move(in0_receiver_kernel_desc));
+    }
+    if (has_in1_receiver_writer_other_kernel) {
+        desc.kernels.push_back(std::move(in1_receiver_writer_other_kernel_desc));
+    }
+    if (has_in0_receiver_other_kernel) {
+        desc.kernels.push_back(std::move(in0_receiver_other_kernel_desc));
+    }
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+
+    return desc;
+}
+
+ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t>
+create_program_mcast_in0_in1(
+    tt::tt_metal::Program& program,
+    tt::tt_metal::IDevice* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    bool dst_full_sync_en,
+    uint32_t B,
+    uint32_t M,
+    uint32_t M_per_batch,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    bool transpose_a,
+    bool transpose_b,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t in0_block_w,
+    uint32_t in0_last_ktile_w,
+    uint32_t in0_last_ktile_h,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t out_block_h,
+    uint32_t out_block_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    bool transpose_mcast,
+    std::optional<UnaryWithParam> fused_activation,
+    const tt::tt_metal::MeshTensor& in0_tensor,
+    const tt::tt_metal::MeshTensor& in1_tensor,
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_tensor,
+    const tt::tt_metal::MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    bool row_broadcast_bias = true,
+    CoreCoord sub_device_start_core = {0, 0}) {
+    using namespace tt;
+    using tt::tt_metal::TensorMemoryLayout;
+
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_mesh;
+    if (bias_tensor.has_value()) {
+        bias_mesh = *bias_tensor;
+    }
+
+    // currently only support transpose of the full tile
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    bool fuse_op = fused_op_signaler.has_value();
+
+    TensorMemoryLayout in0_memory_layout = in0_tensor.memory_config().memory_layout();
+
+    uint32_t num_blocks = K / in0_block_w;
+
+    // Only enable packer l1 accumulation when there are num_blocks > 2, otherwise
+    // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+    // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+    // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+    bool packer_l1_acc_en = packer_l1_acc && (((bias_mesh.has_value()) && num_blocks > 1) || (num_blocks > 2));
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    const bool in0_block_sharded = in0_memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool in0_height_sharded = in0_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in0_is_sharded = in0_block_sharded || in0_height_sharded;
+    const bool in1_is_width_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+    const bool in1_is_height_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
+    const bool output_is_sharded = out_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+
+    TT_FATAL(
+        !(output_is_sharded && B > 1),
+        "Block-sharded output is incompatible with batch > 1 (B={}). The output CB is backed by the shard buffer "
+        "which only holds per_core_M * per_core_N = {} tiles, but the kernel would produce B * per_core_M * per_core_N "
+        "= {} tiles without draining. Use fuse_batch=True.",
+        B,
+        per_core_M * per_core_N,
+        B * per_core_M * per_core_N);
+    bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
+
+    uint32_t in0_block_h = out_block_h;
+    uint32_t in1_block_w = out_block_w;
+    uint32_t in0_num_blocks_y = per_core_M / out_block_h;
+    uint32_t in1_num_blocks_x = per_core_N / out_block_w;
+    uint32_t out_num_blocks_x = in1_num_blocks_x;
+    uint32_t out_num_blocks_y = in0_num_blocks_y;
+
+    uint32_t in0_block_tiles = out_block_h * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (B * num_blocks > 1) {
+        in0_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
+    // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
+    // the padded stride, so the in0/in1/bias CBs must hold pages at the aligned stride and the
+    // reader/unpacker walk tiles at the same stride. No-op when already aligned (all bf16 tiles,
+    // 32-wide bfp8, Wormhole). Replaces the staging-CB workaround. Sharded CBs are backed by the
+    // tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size =
+        in1_is_sharded ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
+    // Bias CB pages must be padded to the DRAM alignment so the reader's L1 write stride
+    // matches the DRAM page stride (e.g. 64B on Blackhole for a 32B (1,16) bf16 bias tile).
+    // Mirrors in0/in1 above and the dram_sharded factory. No-op on Wormhole and for
+    // tiles already >= dram_alignment.
+    uint32_t bias_aligned_tile_size = tt::align(bias_single_tile_size, dram_alignment);
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+    uint32_t in1_block_tiles = out_block_w * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (B * num_blocks > 1) {
+        in1_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = out_block_h * out_block_w;
+    uint32_t out_shard_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    if (output_is_sharded) {
+        out_CB_tiles = out_shard_tiles;
+    }
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t interm0_CB_size = interm0_CB_tiles * interm0_single_tile_size;
+
+    uint32_t in2_block_tiles = 0;
+    uint32_t in0_shard_width_in_tiles = 0;
+    uint32_t in0_shard_height_in_tiles = 0;
+    if (in0_is_sharded) {
+        in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
+        in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+    }
+
+    uint32_t in2_CB_tiles = in2_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in3_block_tiles = out_block_w;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_aligned_tile_size;
+
+    uint32_t start_core_x = sub_device_start_core.x;
+    uint32_t start_core_y = sub_device_start_core.y;
+
+    uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+    uint32_t num_cores_with_work_c = num_blocks_x;
+    uint32_t num_cores_with_work_r = num_blocks_y;
+    if (transpose_mcast) {
+        std::swap(num_cores_with_work_c, num_cores_with_work_r);
+    }
+
+    CoreRange all_cores_with_work(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y + num_cores_with_work_r - 1});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      IN0 SHARDED SENDER/RECEIVER
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t num_cores_c = num_cores_with_work_c;
+    uint32_t num_cores_r = num_cores_with_work_r;
+    uint32_t in0_mcast_receiver_grid_diff_coord_start;
+    uint32_t in0_mcast_receiver_grid_diff_coord_end;
+    std::vector<uint32_t> in0_mcast_noc_x;
+    std::vector<uint32_t> in0_mcast_noc_y;
+    uint32_t in0_sender_num_cores_along_width = 0;
+
+    // Only used for in0 block sharded
+    std::optional<CoreRange> in0_mcast_cores_without_work_and_not_in_receiver_grid;
+    if (in0_block_sharded) {
+        CoreCoord in0_shard_grid = in0_tensor.shard_spec()->grid.bounding_box().grid_size();
+        // in0 shard grid already accounts for transpose_mcast
+        // ie. If transpose_mcast, in0 width is along y
+        in0_sender_num_cores_along_width = transpose_mcast ? in0_shard_grid.y : in0_shard_grid.x;
+        if (in0_sender_num_cores_along_width > num_blocks_x) {
+            in0_mcast_cores_without_work_and_not_in_receiver_grid =
+                transpose_mcast ? CoreRange(
+                                      {(std::size_t)start_core_x, (std::size_t)start_core_y + num_blocks_x},
+                                      {(std::size_t)start_core_x + num_blocks_y - 1,
+                                       (std::size_t)start_core_y + in0_sender_num_cores_along_width - 1})
+                                : CoreRange(
+                                      {(std::size_t)start_core_x + num_blocks_x, (std::size_t)start_core_y},
+                                      {(std::size_t)start_core_x + in0_sender_num_cores_along_width - 1,
+                                       (std::size_t)start_core_y + num_blocks_y - 1});
+        }
+
+        if (transpose_mcast) {
+            in0_mcast_receiver_grid_diff_coord_start =
+                device->worker_core_from_logical_core({start_core_x, start_core_y}).y;
+            in0_mcast_receiver_grid_diff_coord_end =
+                device->worker_core_from_logical_core({start_core_x, start_core_y + num_blocks_x - 1}).y;
+            in0_mcast_noc_y.reserve(in0_sender_num_cores_along_width);
+            for (uint32_t core_idx_y = 0; core_idx_y < in0_sender_num_cores_along_width; ++core_idx_y) {
+                in0_mcast_noc_y.push_back(
+                    device->worker_core_from_logical_core({start_core_x, start_core_y + core_idx_y}).y);
+            }
+        } else {
+            in0_mcast_receiver_grid_diff_coord_start =
+                device->worker_core_from_logical_core({start_core_x, start_core_y}).x;
+            in0_mcast_receiver_grid_diff_coord_end =
+                device->worker_core_from_logical_core({start_core_x + num_blocks_x - 1, start_core_y}).x;
+            in0_mcast_noc_x.reserve(in0_sender_num_cores_along_width);
+            for (uint32_t core_idx_x = 0; core_idx_x < in0_sender_num_cores_along_width; ++core_idx_x) {
+                in0_mcast_noc_x.push_back(
+                    device->worker_core_from_logical_core({start_core_x + core_idx_x, start_core_y}).x);
+            }
+        }
+
+        // Set in0 sender/receiver cores to be maximum
+        if (transpose_mcast) {
+            num_cores_r = std::max(num_cores_r, in0_sender_num_cores_along_width);
+        } else {
+            num_cores_c = std::max(num_cores_c, in0_sender_num_cores_along_width);
+        }
+    }
+
+    // Used for setting up CBs and semaphores by both in0 interleaved or sharded
+    CoreRange all_cores(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_c - 1, (std::size_t)start_core_y + num_cores_r - 1});
+    const auto& cores = grid_to_cores(all_cores.start_coord, all_cores.end_coord, true);
+    //////////////////////////////////////////////////////////////////////////////////////////
+    //       IN0 SENDER (interleaved only) and IN1 SENDER (both interleaved and sharded)
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // Left column
+    CoreRange in0_sender_interleaved(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1});
+
+    // Top row
+    CoreRange in1_sender(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y});
+
+    // Left column except corner
+    std::optional<CoreRange> in0_sender_in1_receiver;
+    if (num_cores_with_work_r > 1) {
+        in0_sender_in1_receiver = {
+            {(std::size_t)start_core_x, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    // Top row except corner
+    std::optional<CoreRange> in0_receiver_in1_sender;
+    if (num_cores_with_work_c > 1) {
+        in0_receiver_in1_sender = {
+            {(std::size_t)start_core_x + 1, (std::size_t)start_core_y},
+            {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y}};
+    }
+
+    if (transpose_mcast) {
+        std::swap(in0_sender_interleaved, in1_sender);
+        std::swap(in0_sender_in1_receiver, in0_receiver_in1_sender);
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    //       IN0 RECEIVER (interleaved only) and IN1 RECEIVER (both interleaved and sharded)
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // Not exactly half-half; this seems to get slightly better perf for fused qkv and selfout
+    // TODO: Experiment with different splits?
+    bool split_half = num_cores_with_work_c > 2 && num_cores_with_work_r > 1 && !in0_is_sharded;
+    uint32_t half_core = split_half ? (num_cores_with_work_c) / 2 : num_cores_with_work_c - 1;
+
+    std::optional<CoreRange> in0_receiver_in1_receiver_left_half;
+    if (num_cores_with_work_c > 1 and num_cores_with_work_r > 1) {
+        in0_receiver_in1_receiver_left_half = {
+            {(std::size_t)start_core_x + 1, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x + half_core, (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    std::set<CoreRange> in0_receiver_interleaved_set;
+    std::set<CoreRange> in1_receiver_set;
+    if (in0_receiver_in1_sender.has_value()) {
+        in0_receiver_interleaved_set.insert(in0_receiver_in1_sender.value());
+    }
+    if (in0_sender_in1_receiver.has_value()) {
+        in1_receiver_set.insert(in0_sender_in1_receiver.value());
+    }
+    if (in0_receiver_in1_receiver_left_half.has_value()) {
+        in0_receiver_interleaved_set.insert(in0_receiver_in1_receiver_left_half.value());
+        in1_receiver_set.insert(in0_receiver_in1_receiver_left_half.value());
+    }
+    CoreRangeSet in0_receiver_interleaved(in0_receiver_interleaved_set);
+    CoreRangeSet in1_receiver(in1_receiver_set);
+
+    std::optional<CoreRange> in0_receiver_in1_receiver_interleaved_other_cores;
+    if (split_half) {
+        in0_receiver_in1_receiver_interleaved_other_cores = {
+            {(std::size_t)start_core_x + half_core + 1, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x + num_cores_with_work_c - 1,
+             (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    // Mcast args
+    auto in0_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in0_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+    bool in1_is_dram = in1_tensor.mesh_buffer().device_local_config().buffer_type == tt_metal::BufferType::DRAM;
+
+    uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+
+    TT_FATAL(
+        out_block_h % out_subblock_h == 0 and out_block_h >= out_subblock_h,
+        "out_block_h must be multiple of out_subblock_h");
+    TT_FATAL(
+        out_block_w % out_subblock_w == 0 and out_block_w >= out_subblock_w,
+        "out_block_w must be multiple of out_subblock_w");
+
+    std::vector<uint32_t> in0_sender_compile_time_args;
+
+    uint32_t num_dram_banks = 0;
+    uint32_t per_core_N_storage = 0;
+    uint32_t batches_per_bank = 0;
+    if (in1_is_sharded and in1_is_dram) {
+        num_dram_banks = device->num_dram_channels();
+        if (in1_is_width_sharded) {
+            per_core_N_storage = (N + num_dram_banks - 1) / num_dram_banks;
+        } else {
+            // Height sharded: batches are distributed across DRAM banks
+            uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
+            batches_per_bank = in1_shard_height_in_tiles / K;
+        }
+    }
+
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
+    const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
+
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+    const auto in1_tensor_next_w_dim_block_stride = in1_block_w * in1_tensor_stride_w;
+    const auto in1_tensor_start_tile_id_stride = per_core_N * in1_tensor_stride_w;
+
+    if (in0_block_sharded) {
+        uint32_t num_x = in0_sender_num_cores_along_width;
+        uint32_t num_y = 1;
+        if (transpose_mcast) {
+            std::swap(num_x, num_y);
+        }
+
+        in0_sender_compile_time_args = {
+            (std::uint32_t)1,  // core_has_output_block_work
+            (std::uint32_t)1,  // core_in_in0_receiver_mcast_grid
+
+            (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+            (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,  // num_blocks
+            (std::uint32_t)out_num_blocks_x,
+            (std::uint32_t)out_num_blocks_y,
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)num_blocks_x,  // in0_mcast_num_dests
+            (std::uint32_t)num_blocks_x,  // in0_mcast_num_cores
+            (std::uint32_t)num_x,
+            (std::uint32_t)num_y,
+            (std::uint32_t)transpose_mcast,
+            (std::uint32_t)in0_shard_width_in_tiles,
+            (std::uint32_t)in0_shard_height_in_tiles,
+            (std::uint32_t)in0_block_w,
+            (std::uint32_t)in0_block_h,
+            // batch args
+            (std::uint32_t)B  // batch
+        };
+    } else {
+        in0_sender_compile_time_args = {
+            // in0 tensor args
+            (std::uint32_t)in0_tensor_stride_w,
+            (std::uint32_t)in0_tensor_stride_h,
+            (std::uint32_t)in0_tensor_next_block_stride,
+            (std::uint32_t)in0_tensor_next_h_dim_block_stride,
+            // in0 block args
+            (std::uint32_t)in0_block_w,          // in0_block_w
+            (std::uint32_t)in0_block_h,          // in0_block_h
+            (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)in0_last_ktile_h,
+
+            (std::uint32_t)false,                      // extract_shard_sub_blocks (not used for interleaved)
+            (std::uint32_t)in0_shard_width_in_tiles,   // shard_width_in_tiles (not used for interleaved)
+            (std::uint32_t)in0_shard_height_in_tiles,  // shard_height_in_tiles (not used for interleaved)
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,  // num_blocks
+            (std::uint32_t)out_num_blocks_x,
+            (std::uint32_t)out_num_blocks_y,
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
+            (std::uint32_t)(num_blocks_x - 1),  // in0_mcast_num_dests
+            (std::uint32_t)(num_blocks_x - 1),  // in0_mcast_num_cores
+            // batch args
+            (std::uint32_t)M * K,  // MtKt
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)B,      // batch
+            (std::uint32_t)false,  // reuse_in0_in_CB
+
+            // sparsity args
+            (std::uint32_t)0,      // batchB
+            (std::uint32_t)0,      // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)true,   // bcast_A
+            (std::uint32_t)false,  // get_batch_from_reader
+        };
+    }
+    in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    tt::tt_metal::TensorAccessorArgs(in0_tensor).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
+    in0_sender_compile_time_args.push_back((std::uint32_t)0);  // num_batch_compute (unused, sparsity disabled)
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        // READER
+        // in1 tensor args
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)in1_tensor_next_w_dim_block_stride,
+        // in1 block args
+        (std::uint32_t)in1_block_w,                // in1_block_w
+        (std::uint32_t)in0_block_w,                // in1_block_h
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        (std::uint32_t)(num_blocks_y - 1),  // in1_mcast_num_dests
+        (std::uint32_t)(num_blocks_y - 1),  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,        // KtNt
+        (std::uint32_t)B,            // batch
+        (std::uint32_t)bcast_batch,  // bcast_B
+        // sparsity args
+        (std::uint32_t)0,  // batchB
+        (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_mesh.has_value()) {
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
+    } else {
+        in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+
+    // Append TensorAccessorArgs
+    tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_mesh.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(*bias_mesh).append_to(in1_sender_writer_compile_time_args);
+    }
+
+    if (in1_is_sharded and in1_is_dram) {
+        if (in1_is_width_sharded) {
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in0_block_w);
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in1_single_tile_size);
+        } else {
+            // Height sharded: pass tiles per batch and batches per bank
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)(K * N));  // KtNt per batch (tiles)
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)batches_per_bank);
+        }
+    }
+    std::vector<uint32_t> in0_receiver_compile_time_args = {
+        // in0 block args
+        (std::uint32_t)in0_block_w * in0_block_h,  // in0_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)B,     // batch
+        (std::uint32_t)false  // get_batch_from_reader
+    };
+    std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
+        // READER
+        // in1 block args
+        (std::uint32_t)in1_block_w * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        (std::uint32_t)out_num_blocks_x,
+        (std::uint32_t)out_num_blocks_y,
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
+        // batch args
+        (std::uint32_t)B,  // batch
+
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        (std::uint32_t)out_block_w,         // out_tensor_next_w_dim_block_stride
+        (std::uint32_t)out_block_h * N,     // out_tensor_next_h_dim_block_stride
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
+    };
+    if (bias_mesh.has_value()) {
+        in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
+    } else {
+        in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
+    }
+    in1_receiver_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+    tt::tt_metal::TensorAccessorArgs(out_tensor).append_to(in1_receiver_writer_compile_time_args);
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_sharded_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_interleaved_defines;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
+    std::map<std::string, std::string> mm_kernel_in1_receiver_writer_other_noc_setup_defines;
+    if (bias_mesh.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_receiver_writer_other_noc_setup_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), cores.size(), mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), cores.size(), mm_kernel_defines, throttle_level);
+
+    if (in0_receiver_interleaved.num_cores() == 0) {
+        mm_kernel_in0_sender_interleaved_defines["SKIP_MCAST"] = "1";
+    }
+    if (in0_height_sharded) {
+        mm_kernel_in0_sender_interleaved_defines["IN0_SHARDED"] = "1";
+    }
+
+    if (in1_receiver.num_cores() == 0) {
+        mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+    if (in1_is_sharded) {
+        if (in1_is_dram) {
+            if (in1_is_width_sharded) {
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_WIDTH_SHARDED"] = "1";
+            } else {
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_HEIGHT_SHARDED"] = "1";
+            }
+        } else {
+            mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
+        }
+    }
+
+    if (output_is_sharded) {
+        mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_defines["OUT_SHARDED"] = "1";
+        mm_kernel_in1_receiver_writer_other_noc_setup_defines["OUT_SHARDED"] = "1";
+    }
+
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    tt_metal::NOC in0_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    tt_metal::NOC in1_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+
+    tt::tt_metal::KernelHandle mm_kernel_in0_sender_id = 0;
+    tt::tt_metal::KernelHandle mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = 0;
+    if (in0_block_sharded) {
+        mm_kernel_in0_sender_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp",
+            all_cores_with_work,  // in0_mcast_cores_with_work_and_in_receiver_grid
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_sender_compile_time_args,
+                .defines = mm_kernel_in0_sender_sharded_defines,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                    {"cb_in0_sharded", tt::CBIndex::c_2},
+                    {"cb_l1_array", tt::CBIndex::c_6},
+                }});
+        if (in0_mcast_cores_without_work_and_not_in_receiver_grid.has_value()) {
+            in0_sender_compile_time_args[0] = 0;  // core_has_output_block_work
+            in0_sender_compile_time_args[1] = 0;  // core_in_in0_receiver_mcast_grid
+            mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = tt_metal::CreateKernel(
+                program,
+                "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp",
+                in0_mcast_cores_without_work_and_not_in_receiver_grid.value(),
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = in0_noc,
+                    .compile_args = in0_sender_compile_time_args,
+                    .defines = mm_kernel_in0_sender_sharded_defines,
+                    .named_compile_args = {
+                        {"cb_in0", tt::CBIndex::c_0},
+                        {"cb_in0_sharded", tt::CBIndex::c_2},
+                        {"cb_l1_array", tt::CBIndex::c_6},
+                    }});
+        }
+    } else {
+        if (fuse_op) {
+            if (fused_op_signaler->is_all_gather()) {
+                // Create semaphores
+                fused_op_signaler->init_fused_op(program, device, in0_sender_interleaved);
+            } else if (fused_op_signaler->is_reduce_scatter()) {
+                fused_op_signaler->init_fused_op(program, device, all_cores, cores);
+            } else {
+                TT_FATAL(false, "Fused operation must be either all_gather or reduce_scatter.");
+            }
+        }
+
+        mm_kernel_in0_sender_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp",
+            in0_sender_interleaved,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_sender_compile_time_args,
+                .defines = mm_kernel_in0_sender_interleaved_defines,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                    {"cb_in0_sharded", tt::CBIndex::c_2},
+                    {"cb_sparsity", tt::CBIndex::c_6},
+                }});
+    }
+
+    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
+        in1_sender,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_kernel_in1_sender_writer_defines,
+            .named_compile_args = {
+                {"cb_in1", tt::CBIndex::c_1},
+                {"cb_bias", tt::CBIndex::c_3},
+                {"cb_out", tt::CBIndex::c_4},
+                {"cb_sparsity", tt::CBIndex::c_7},
+            }});
+
+    tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_id = 0;
+    if (in1_receiver.num_cores() > 0) {
+        mm_kernel_in1_receiver_writer_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp",
+            /* in0_sender_in1_receiver, // If not using half-half noc setup */
+            in1_receiver,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = in1_noc,
+                .compile_args = in1_receiver_writer_compile_time_args,
+                .defines = mm_kernel_in1_receiver_writer_defines,
+                .named_compile_args = {
+                    {"cb_in1", tt::CBIndex::c_1},
+                    {"cb_bias", tt::CBIndex::c_3},
+                    {"cb_out", tt::CBIndex::c_4},
+                }});
+    }
+
+    tt::tt_metal::KernelHandle mm_kernel_in0_receiver_id = 0;
+    if (!in0_block_sharded and in0_receiver_interleaved.num_cores() > 0) {
+        mm_kernel_in0_receiver_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp",
+            /* in0_receiver_in1_sender, // If not using half-half noc setup */
+            in0_receiver_interleaved,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_receiver_compile_time_args,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                }});
+    }
+
+    tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_other_noc_setup_id = mm_kernel_in1_receiver_writer_id;
+    tt::tt_metal::KernelHandle mm_kernel_in0_receiver_other_noc_setup_id = mm_kernel_in0_receiver_id;
+
+    if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
+        mm_kernel_in1_receiver_writer_other_noc_setup_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+            "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp",
+            in0_receiver_in1_receiver_interleaved_other_cores.value(),
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = in1_split_noc,
+                .compile_args = in1_receiver_writer_compile_time_args,
+                .defines = mm_kernel_in1_receiver_writer_other_noc_setup_defines,
+                .named_compile_args = {
+                    {"cb_in1", tt::CBIndex::c_1},
+                    {"cb_bias", tt::CBIndex::c_3},
+                    {"cb_out", tt::CBIndex::c_4},
+                }});
+
+        mm_kernel_in0_receiver_other_noc_setup_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp",
+            in0_receiver_in1_receiver_interleaved_other_cores.value(),
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_split_noc,
+                .compile_args = in0_receiver_compile_time_args,
+                .named_compile_args = {
+                    {"cb_in0", tt::CBIndex::c_0},
+                }});
+    }
+
+    // Compute kernel compile time args
+
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (out_block_w / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,  // num_blocks
+        out_num_blocks_x,
+        out_num_blocks_y,
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B,                       // batch,
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias_mesh.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    constexpr auto cb_intermed0 = tt::CBIndex::c_5;
+    std::unordered_map<std::string, uint32_t> compute_named_compile_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_intermed0", cb_intermed0},
+        {"cb_in0_transposed", tt::CBIndex::c_10},
+        {"bias_ntiles", in1_per_core_w},
+    };
+
+    if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+        using ttnn::operations::matmul::utilities::get_activation_params;
+        const auto& activation = fused_activation.value();
+        const auto params = get_activation_params(activation);
+        compute_named_compile_args["activation_type"] = static_cast<uint32_t>(params.type);
+        compute_named_compile_args["activation_param0"] = params.param0;
+        compute_named_compile_args["activation_param1"] = params.param1;
+        compute_named_compile_args["activation_param2"] = params.param2;
+    }
+
+    // The fused bias add reads the partials CB as an FPU operand (SrcA), so UnpackToDestFp32 cannot be
+    // set on cb_intermed0 directly when bias is present. In that case the cross-block reload instead
+    // copies through cb_intermed0_alias, a second buffer index over the same SRAM carrying
+    // UnpackToDestFp32, while the bias add keeps reading cb_intermed0 via SrcA. The alias index is
+    // handed to the compute kernel through the MM_PARTIALS_RELOAD_ALIAS_CB define, which selects the
+    // alias reload path there. Without bias the reload reads cb_intermed0 and the flag is set on it.
+    constexpr auto cb_intermed0_alias = tt::CBIndex::c_7;
+    const bool bias_reload_alias =
+        fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32 && bias_mesh.has_value();
+    if (bias_reload_alias) {
+        mm_kernel_defines["MM_PARTIALS_RELOAD_ALIAS_CB"] = std::to_string(static_cast<uint32_t>(cb_intermed0_alias));
+    }
+    // When accumulating in fp32 with the K reduction split across blocks, the intermediate
+    // partials CB holds Float32 and is reloaded into DEST between blocks by copy_block_matmul_partials.
+    // Unless the reload's CB view is marked UnpackToDestFp32, that reload is routed through SrcA and
+    // rounded to TF32 (10 mantissa bits), so the fp32 partial loses precision on every block boundary
+    // and accuracy degrades as the number of K-blocks grows. The flag is set on the alias when bias
+    // forces a separate SrcA view of cb_intermed0 (see above), else on cb_intermed0 itself.
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (fp32_dest_acc_en && interm0_data_format == tt::DataFormat::Float32) {
+        const uint32_t cb_to_mark =
+            bias_reload_alias ? static_cast<uint32_t>(cb_intermed0_alias) : static_cast<uint32_t>(cb_intermed0);
+        unpack_to_dest_mode[cb_to_mark] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    // Create compute kernel
+    // bool fp32_dest_acc_en = true;
+    // Gelu currently has better accuracy when run in approx mode
+    // bool math_approx_mode = false;
+    tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp",
+        all_cores_with_work,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines,
+            .named_compile_args = compute_named_compile_args});
+
+    // Create circular buffers
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_aligned_tile_size)
+            .set_tile_dims(src0_cb_index, in0_tile);
+    if (in0_height_sharded) {
+        src0_cb_config.set_globally_allocated_address(in0_tensor);
+    }
+    tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src0_cb_index,
+        in0_single_tile_size,
+        in0_CB_size / in0_single_tile_size,
+        in0_CB_size);
+
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_aligned_tile_size)
+            .set_tile_dims(src1_cb_index, in1_tile);
+    if (in1_is_sharded and not in1_is_dram) {
+        src1_cb_config.set_globally_allocated_address(in1_tensor);
+    }
+    tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src1_cb_index,
+        in1_single_tile_size,
+        in1_CB_size / in1_single_tile_size,
+        in1_CB_size);
+
+    uint32_t src2_cb_index = tt::CBIndex::c_2;
+    tt::tt_metal::CBHandle cb_src2 = 0;
+    if (in0_block_sharded) {
+        tt_metal::CircularBufferConfig src2_cb_config =
+            tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
+                .set_page_size(src2_cb_index, in0_single_tile_size)
+                .set_globally_allocated_address(in0_tensor)
+                .set_tile_dims(src2_cb_index, in0_tile);
+        cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src2_cb_index,
+            in0_single_tile_size,
+            in2_CB_size / in0_single_tile_size,
+            in2_CB_size);
+
+        // Local L1 to store temp vars
+        uint32_t l1_cb_index = tt::CBIndex::c_6;
+        tt::tt_metal::CircularBufferConfig cb_for_l1_array_config =
+            tt::tt_metal::CircularBufferConfig(32 * 2, {{l1_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(l1_cb_index, 32 * 2);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
+    }
+
+    uint32_t output_cb_index = tt::CBIndex::c_4;
+    uint32_t interm0_cb_index = tt::CBIndex::c_5;
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+
+    if (do_not_inplace_interm0_out_CB || (interm0_data_format != output_data_format) ||
+        (untilize_out && (in1_num_subblocks > 1))) {
+        // output
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format},
+        };
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile);
+        // interm0
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
+            {interm0_cb_index, interm0_data_format},
+        };
+        // Alias over the same SRAM, marked UnpackToDestFp32, for the bias reload (see above).
+        if (bias_reload_alias) {
+            interm0_cb_data_format_spec[static_cast<uint8_t>(cb_intermed0_alias)] = interm0_data_format;
+        }
+        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                .set_tile_dims(interm0_cb_index, output_tile);
+        if (bias_reload_alias) {
+            interm0_cb_config =
+                interm0_cb_config.set_page_size(static_cast<uint8_t>(cb_intermed0_alias), interm0_single_tile_size)
+                    .set_tile_dims(static_cast<uint8_t>(cb_intermed0_alias), output_tile);
+        }
+
+        tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), interm0_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            interm0_cb_index,
+            interm0_single_tile_size,
+            interm0_CB_size / interm0_single_tile_size,
+            interm0_CB_size);
+    } else {
+        // share buffer
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
+        // Alias over the same SRAM, marked UnpackToDestFp32, for the bias reload (see above).
+        if (bias_reload_alias) {
+            output_cb_data_format_spec[static_cast<uint8_t>(cb_intermed0_alias)] = interm0_data_format;
+        }
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile)
+                               .set_tile_dims(interm0_cb_index, output_tile);
+        if (bias_reload_alias) {
+            output_cb_config =
+                output_cb_config.set_page_size(static_cast<uint8_t>(cb_intermed0_alias), interm0_single_tile_size)
+                    .set_tile_dims(static_cast<uint8_t>(cb_intermed0_alias), output_tile);
+        }
+    }
+
+    if (output_is_sharded) {
+        output_cb_config = output_cb_config.set_globally_allocated_address(out_tensor);
+    }
+    auto cb_output = tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), output_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        output_cb_index,
+        output_single_tile_size,
+        out_CB_size / output_single_tile_size,
+        out_CB_size);
+
+    // CB for bias
+    if (bias_mesh.has_value()) {
+        uint32_t src3_cb_index = tt::CBIndex::c_3;
+        tt_metal::CircularBufferConfig cb_src3_config =
+            tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
+                .set_page_size(src3_cb_index, bias_aligned_tile_size)
+                .set_tile_dims(src3_cb_index, bias_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src3_cb_index,
+            bias_aligned_tile_size,
+            in3_CB_size / bias_aligned_tile_size,
+            in3_CB_size);
+    }
+    // Intermediate CB read
+
+    if (in0_transpose_tile) {
+        uint32_t in0_transpose_cb_index = tt::CBIndex::c_10;
+        auto in0_transpose_cb_config =
+            tt_metal::CircularBufferConfig(in0_CB_size, {{in0_transpose_cb_index, in0_data_format}})
+                .set_page_size(in0_transpose_cb_index, in0_aligned_tile_size)
+                .set_tile_dims(in0_transpose_cb_index, in0_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, in0_transpose_cb_config);
+    }
+
+    // Parameters for last row, col, or block
+    uint32_t last_per_core_M = M % per_core_M == 0 ? per_core_M : M % per_core_M;
+    uint32_t last_per_core_N = N % per_core_N == 0 ? per_core_N : N % per_core_N;
+    uint32_t last_out_block_h = last_per_core_M % out_block_h == 0 ? out_block_h : last_per_core_M % out_block_h;
+    uint32_t last_out_block_w = last_per_core_N % out_block_w == 0 ? out_block_w : last_per_core_N % out_block_w;
+    uint32_t last_out_num_blocks_h = ((last_per_core_M - 1) / out_block_h) + 1;
+    uint32_t last_out_num_blocks_w = ((last_per_core_N - 1) / out_block_w) + 1;
+    uint32_t last_block_num_nonzero_subblocks_h = ((last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t last_block_num_nonzero_subblocks_w = ((last_out_block_w - 1) / out_subblock_w) + 1;
+    uint32_t last_subblock_of_last_block_h =
+        last_out_block_h % out_subblock_h == 0 ? out_subblock_h : last_out_block_h % out_subblock_h;
+    uint32_t last_subblock_of_last_block_w =
+        last_out_block_w % out_subblock_w == 0 ? out_subblock_w : last_out_block_w % out_subblock_w;
+    uint32_t last_block_padded_subblock_tiles_addr_skip =
+        output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
+    uint32_t last_block_padded_block_tiles_w_skip =
+        (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
+    uint32_t last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
+
+    if (in0_block_sharded) {
+        if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+            std::swap(in0_mcast_receiver_grid_diff_coord_start, in0_mcast_receiver_grid_diff_coord_end);
+        }
+    }
+
+    // dram sharded weights stride params
+    uint32_t worker_core_stride = 0;   // stride in the worker core
+    uint32_t storage_core_stride = 0;  // stride in the dram bank
+    uint32_t curr_worker_core = 0;     // current worker core
+    uint32_t curr_storage_core = 0;    // current read dram bank
+    uint32_t vc = 0;
+
+    uint32_t in0_end_idx = num_blocks_y - 1;
+    uint32_t in1_end_idx = num_blocks_x - 1;
+    const auto& in0_sender_interleaved_cores = grid_to_cores(
+        in0_sender_interleaved.start_coord, in0_sender_interleaved.end_coord, true);  // Only used for interleaved in0
+    const auto& in1_sender_cores = grid_to_cores(in1_sender.start_coord, in1_sender.end_coord, true);
+    const auto& in1_receiver_cores = corerange_to_cores(in1_receiver, std::nullopt, true);
+    std::vector<CoreCoord> in1_receiver_other_cores;
+    if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
+        in1_receiver_other_cores = grid_to_cores(
+            in0_receiver_in1_receiver_interleaved_other_cores.value().start_coord,
+            in0_receiver_in1_receiver_interleaved_other_cores.value().end_coord,
+            true);
+    }
+
+    for (const auto& core : cores) {
+        CoreCoord left_core = {(std::size_t)start_core_x, (std::size_t)core.y};
+        CoreCoord left_core_plus_one = {(std::size_t)start_core_x + 1, (std::size_t)core.y};
+        CoreCoord right_core = {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)core.y};
+        CoreCoord top_core = {(std::size_t)core.x, (std::size_t)start_core_y};
+        CoreCoord top_core_plus_one = {(std::size_t)core.x, (std::size_t)start_core_y + 1};
+        CoreCoord bottom_core = {(std::size_t)core.x, (std::size_t)start_core_y + num_cores_with_work_r - 1};
+
+        auto left_core_physical = device->worker_core_from_logical_core(left_core);
+        auto left_core_plus_one_physical = device->worker_core_from_logical_core(left_core_plus_one);
+        auto right_core_physical = device->worker_core_from_logical_core(right_core);
+        auto top_core_physical = device->worker_core_from_logical_core(top_core);
+        auto top_core_plus_one_physical = device->worker_core_from_logical_core(top_core_plus_one);
+        auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
+        uint32_t in0_idx = core.y - start_core_y;
+        uint32_t in1_idx = core.x - start_core_x;
+
+        auto in0_mcast_sender = left_core_physical;
+        auto in1_mcast_sender = top_core_physical;
+
+        // Assuming in0 is NOC0
+        auto in0_mcast_start = left_core_plus_one_physical;
+        auto in0_mcast_end = right_core_physical;
+        if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+            std::swap(in0_mcast_start, in0_mcast_end);
+        }
+
+        // Assuming in1 is NOC1
+        auto in1_mcast_start = bottom_core_physical;
+        auto in1_mcast_end = top_core_plus_one_physical;
+        if (in1_noc == tt::tt_metal::NOC::NOC_0) {
+            std::swap(in1_mcast_start, in1_mcast_end);
+        }
+
+        if (transpose_mcast) {
+            std::swap(in0_idx, in1_idx);
+            std::swap(in0_mcast_sender, in1_mcast_sender);
+            std::swap(in0_mcast_start, in1_mcast_end);
+            std::swap(in0_mcast_end, in1_mcast_start);
+        }
+
+        // in0 sender
+        if (in0_block_sharded) {
+            uint32_t in0_mcast_receiver_grid_same_coord;
+            std::vector<uint32_t> mm_in0_sender_args;
+            if (transpose_mcast) {
+                in0_mcast_receiver_grid_same_coord = device->worker_core_from_logical_core(core).x;
+                mm_in0_sender_args.push_back(core.y);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_start);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_end);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_y.begin(), in0_mcast_noc_y.end());
+            } else {
+                in0_mcast_receiver_grid_same_coord = device->worker_core_from_logical_core(core).y;
+                mm_in0_sender_args.push_back(core.x);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_start);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_end);
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+                mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_x.begin(), in0_mcast_noc_x.end());
+                mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
+            }
+            if (in1_idx < num_blocks_x) {
+                tt_metal::SetRuntimeArgs(
+                    program, mm_kernel_in0_sender_id, core, mm_in0_sender_args);  // RISCV_0_default
+            } else {
+                tt_metal::SetRuntimeArgs(
+                    program,
+                    mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id,
+                    core,
+                    mm_in0_sender_args);  // RISCV_0_default
+            }
+        } else if (in1_idx == 0) {
+            std::vector<uint32_t> mm_in0_sender_args = {
+                // in0 tensor args
+                (std::uint32_t)in0_tensor.address(),
+                (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
+                // in0 mcast args
+                (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
+                (std::uint32_t)in0_mcast_start.y,  // in0_mcast_dest_noc_start_y
+                (std::uint32_t)in0_mcast_end.x,    // in0_mcast_dest_noc_end_x
+                (std::uint32_t)in0_mcast_end.y,    // in0_mcast_dest_noc_end_y
+            };
+            if (in0_idx == in0_end_idx) {
+                // padding args (READER)
+                mm_in0_sender_args.push_back(last_out_block_h);  // last_out_block_h
+            } else {
+                mm_in0_sender_args.push_back(out_block_h);
+            }
+
+            // sparsity args
+            mm_in0_sender_args.push_back(0);  // sparsity_addr
+
+            if (fuse_op && fused_op_signaler->is_all_gather()) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
+            tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_sender_args);  // RISCV_0_default
+
+            // in0 receiver
+        } else {
+            std::vector<uint32_t> mm_in0_receiver_args = {
+                // in0 mcast args
+                (std::uint32_t)in0_mcast_sender.x,  // in0_mcast_sender_noc_x
+                (std::uint32_t)in0_mcast_sender.y   // in0_mcast_sender_noc_y
+            };
+            // left half
+            if ((core.x - start_core_x) <= half_core || (!transpose_mcast and core.y == start_core_y)) {
+                tt_metal::SetRuntimeArgs(program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args);
+            }
+            // right half
+            else {
+                tt_metal::SetRuntimeArgs(
+                    program, mm_kernel_in0_receiver_other_noc_setup_id, core, mm_in0_receiver_args);
+            }
+        }
+
+        if (in0_idx < num_blocks_y and in1_idx < num_blocks_x) {
+            // in1 sender
+            if (in0_idx == 0) {
+                std::vector<uint32_t> mm_in1_sender_writer_args = {
+                    // READER
+                    // in1 tensor args
+                    (std::uint32_t)in1_tensor.address(),
+                    (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
+                    // in1 mcast args
+                    (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
+                    (std::uint32_t)in1_mcast_start.y,  // in1_mcast_dest_noc_start_y
+                    (std::uint32_t)in1_mcast_end.x,    // in1_mcast_dest_noc_end_x
+                    (std::uint32_t)in1_mcast_end.y,    // in1_mcast_dest_noc_end_y
+
+                    // sparsity args
+                    (std::uint32_t)0,  // sparsity_addr
+
+                    // WRITER
+                    // out tensor args
+                    (std::uint32_t)out_tensor.address(),
+                    ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
+                };
+
+                if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
+                    // padding args (READER)
+                    mm_in1_sender_writer_args.push_back(last_out_block_w);
+
+                    // padding args (WRITER)
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_sender_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_sender_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else {
+                    // padding args (READER)
+                    mm_in1_sender_writer_args.push_back(out_block_w);
+
+                    // padding args (WRITER)
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(out_subblock_w);
+                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(0);
+                }
+
+                mm_in1_sender_writer_args.push_back(bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);
+                mm_in1_sender_writer_args.push_back(
+                    bias_mesh.has_value() ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
+                if (!output_is_sharded) {
+                    if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
+                        mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
+                    } else {
+                        mm_in1_sender_writer_args.push_back(out_num_blocks_x);
+                    }
+                }
+
+                if (fuse_op) {
+                    if (fused_op_signaler->is_all_gather()) {
+                        fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, true);
+                    } else if (fused_op_signaler->is_reduce_scatter()) {
+                        fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, in0_idx, in1_idx);
+                    } else {
+                        TT_FATAL(false, "Fused operation must be either all_gather or reduce_scatter.");
+                    }
+                }
+                if (in1_is_sharded and in1_is_dram) {  // in1 is dram sharded
+                    if (in1_is_width_sharded) {
+                        uint32_t num_iter_index = mm_in1_sender_writer_args.size() + 1;
+                        vc = vc == 3 ? 0 : vc + 1;
+                        mm_in1_sender_writer_args.push_back(vc);
+
+                        uint32_t num_iter = 0;  // iterate how many banks, till fill the current worker block
+
+                        if (curr_storage_core < num_dram_banks) {
+                            num_iter++;
+
+                            worker_core_stride = per_core_N_storage - storage_core_stride;
+
+                            mm_in1_sender_writer_args.push_back(
+                                storage_core_stride * in1_single_tile_size);  // dram_tensor_start_offset
+                            mm_in1_sender_writer_args.push_back(
+                                worker_core_stride * in1_single_tile_size);          // per_core_N_dram_bytes
+                            mm_in1_sender_writer_args.push_back(curr_storage_core);  // current_dram_bank_id
+
+                            log_debug(
+                                tt::LogOp,
+                                "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
+                                curr_worker_core,
+                                worker_core_stride,
+                                curr_storage_core,
+                                storage_core_stride);
+
+                            curr_storage_core += (storage_core_stride + worker_core_stride) / per_core_N_storage;
+                            storage_core_stride = (storage_core_stride + worker_core_stride) % per_core_N_storage;
+
+                            uint32_t curr_worker_core_old = curr_worker_core;
+                            if (worker_core_stride >= per_core_N) {
+                                curr_worker_core += 1;
+                            }
+
+                            while (curr_worker_core <= curr_worker_core_old and curr_storage_core < num_dram_banks) {
+                                num_iter++;
+
+                                uint32_t stride = worker_core_stride + per_core_N_storage;
+                                stride = std::min(stride, per_core_N);
+
+                                mm_in1_sender_writer_args.push_back(
+                                    (stride - worker_core_stride) * in1_single_tile_size);  // per_core_N_dram_bytes
+                                mm_in1_sender_writer_args.push_back(curr_storage_core);     // current_dram_bank_id
+
+                                log_debug(
+                                    tt::LogOp,
+                                    "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
+                                    curr_worker_core,
+                                    (stride - worker_core_stride),
+                                    curr_storage_core,
+                                    storage_core_stride);
+
+                                if (stride >= per_core_N) {
+                                    curr_worker_core += 1;
+                                }
+                                storage_core_stride = (stride - worker_core_stride) % per_core_N_storage;
+                                curr_storage_core += (stride - worker_core_stride) / per_core_N_storage;
+                                worker_core_stride = stride;
+                            }
+                        }
+                        mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + num_iter_index, num_iter);
+                    } else {
+                        // Height sharded: no additional runtime args needed
+                        // (bank/offset computed from compile-time args + batch index)
+                    }
+                }
+                tt_metal::SetRuntimeArgs(
+                    program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args);  // RISCV_1_default
+
+                // in1 receiver
+            } else {
+                std::vector<uint32_t> mm_in1_receiver_writer_args = {
+                    // READER
+                    // in1 mcast args
+                    (std::uint32_t)in1_mcast_sender.x,  // in1_mcast_sender_noc_x
+                    (std::uint32_t)in1_mcast_sender.y,  // in1_mcast_sender_noc_y
+
+                    // WRITER
+                    // out tensor args
+                    (std::uint32_t)out_tensor.address(),                                // out_tensor_addr
+                    ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
+                };
+
+                if (in1_idx == in1_end_idx and in0_idx == in0_end_idx) {  // bottom-right core when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else if (in0_idx == in0_end_idx) {  // bottom cores except bottom-right when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_h);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_h);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_h_skip);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(0);
+                } else if (in1_idx == in1_end_idx) {  // right cores except bottom when no transpose_mcast
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                    mm_in1_receiver_writer_args.push_back(last_subblock_of_last_block_w);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                    mm_in1_receiver_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+                } else {
+                    // padding args (WRITER)
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_h);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_block_w / out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(out_subblock_w);
+                    mm_in1_receiver_writer_args.push_back(0);
+                    mm_in1_receiver_writer_args.push_back(0);
+                }
+                if (!output_is_sharded) {
+                    if (in1_idx == in1_end_idx and
+                        in0_idx == in0_end_idx) {  // bottom-right core when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_w);
+                    } else if (in0_idx == in0_end_idx) {  // bottom cores except bottom-right when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_h);
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                    } else if (in1_idx == in1_end_idx) {  // right cores except bottom when no transpose_mcast
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                        mm_in1_receiver_writer_args.push_back(last_out_num_blocks_w);
+                    } else {
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_y);
+                        mm_in1_receiver_writer_args.push_back(out_num_blocks_x);
+                    }
+                }
+
+                if (fuse_op && fused_op_signaler->is_reduce_scatter()) {
+                    fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_receiver_writer_args, in0_idx, in1_idx);
+                }
+
+                // left half
+                if ((core.x - start_core_x) <= half_core || (transpose_mcast and core.y == start_core_y)) {
+                    tt_metal::SetRuntimeArgs(
+                        program, mm_kernel_in1_receiver_writer_id, core, mm_in1_receiver_writer_args);
+                }
+                // right half
+                else {
+                    tt_metal::SetRuntimeArgs(
+                        program, mm_kernel_in1_receiver_writer_other_noc_setup_id, core, mm_in1_receiver_writer_args);
+                }
+            }
+        }
+    }
+
+    return {
+        std::move(program),
+        {mm_kernel_in0_sender_id,
+         in0_sender_interleaved_cores,
+         mm_kernel_in1_sender_writer_id,
+         in1_sender_cores,
+         mm_kernel_in1_receiver_writer_id,
+         in1_receiver_cores,
+         mm_kernel_in1_receiver_writer_other_noc_setup_id,
+         in1_receiver_other_cores,
+         cb_src2,
+         cb_output,
+         num_cores_with_work_r,
+         num_cores_with_work_c,
+         start_core_x,
+         start_core_y,
+         transpose_mcast,
+         cores}};
+}
+
+void override_runtime_arguments_impl(
+    const MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t& shared_variables,
+    tt::tt_metal::Program& program,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& output_tensors) {
+    auto mm_kernel_in0_sender_id = shared_variables.mm_kernel_in0_sender_id;
+    auto in0_sender_interleaved_cores = shared_variables.in0_sender_interleaved_cores;
+    auto mm_kernel_in1_sender_writer_id = shared_variables.mm_kernel_in1_sender_writer_id;
+    auto in1_sender_cores = shared_variables.in1_sender_cores;
+    auto mm_kernel_in1_receiver_writer_id = shared_variables.mm_kernel_in1_receiver_writer_id;
+    auto in1_receiver_cores = shared_variables.in1_receiver_cores;
+    auto mm_kernel_in1_receiver_writer_other_noc_setup_id =
+        shared_variables.mm_kernel_in1_receiver_writer_other_noc_setup_id;
+    auto in1_receiver_other_cores = shared_variables.in1_receiver_other_cores;
+    auto cb_src2 = shared_variables.cb_src2;
+    auto cb_output = shared_variables.cb_output;
+    auto cores = shared_variables.cores;
+
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
+
+    TT_FATAL(
+        input_tensors.size() + optional_input_tensors.size() == 3,
+        "Total number of input tensors (required + optional) must be 3, but got {} + {} = {}",
+        input_tensors.size(),
+        optional_input_tensors.size(),
+        input_tensors.size() + optional_input_tensors.size());
+    TT_FATAL(output_tensors.size() == 1, "Number of output tensors must be 1, but got {}", output_tensors.size());
+
+    const auto& in0 = input_tensors.at(0).mesh_tensor();
+    const auto& in1 = input_tensors.at(1).mesh_tensor();
+    const auto& bias_tensor = optional_input_tensors.at(0);
+
+    const auto& out = output_tensors.at(0).mesh_tensor();
+
+    bool src0_sharded = input_tensors[0].memory_config().is_sharded();
+    bool out_sharded = output_tensors[0].memory_config().is_sharded();
+
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_mesh;
+    if (bias_tensor.has_value()) {
+        bias_mesh = bias_tensor.value().mesh_tensor();
+    }
+
+    // in0 sender
+    if (src0_sharded) {
+        UpdateDynamicCircularBufferAddress(program, cb_src2, in0);
+    } else {
+        auto& reader_sender_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in0_sender_id);
+        for (const auto& core : in0_sender_interleaved_cores) {
+            auto& reader_runtime_args = reader_sender_runtime_args_by_core[core.x][core.y];
+            reader_runtime_args[0] = in0.address();
+        }
+    }
+
+    // in1 sender
+    auto& sender_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_sender_writer_id);
+    for (const auto& core : in1_sender_cores) {
+        auto& writer_runtime_args = sender_writer_runtime_args_by_core[core.x][core.y];
+        writer_runtime_args[0] = in1.address();
+        writer_runtime_args[7] = out.address();
+        if (bias_tensor.has_value()) {
+            writer_runtime_args[18] = bias_mesh->address();
+        }
+    }
+
+    // in1 receiver
+    auto& receiver_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_id);
+    for (const auto& core : in1_receiver_cores) {
+        auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
+        writer_runtime_args[2] = out.address();
+    }
+    if (mm_kernel_in1_receiver_writer_id != mm_kernel_in1_receiver_writer_other_noc_setup_id) {
+        auto& receiver_writer_runtime_args_by_core =
+            GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_other_noc_setup_id);
+        for (const auto& core : in1_receiver_other_cores) {
+            auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
+            writer_runtime_args[2] = out.address();
+        }
+    }
+
+    if (out_sharded) {
+        UpdateDynamicCircularBufferAddress(program, cb_output, out);
+    }
+}
+}  // namespace reuse_mcast_optimized_helpers
+
+static ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t>
+matmul_multi_core_reuse_mcast_2d_optimized_(
+    tt::tt_metal::Program& program,
+    const ttnn::prim::MatmulParams& operation_attributes,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler) {
+    using namespace tt;
+    using namespace operations::matmul::utilities;
+
+    const auto& a = tensor_args.input_tensors.at(0);
+    const auto& b = tensor_args.input_tensors.at(1);
+    const auto& bias = tensor_args.optional_input_tensors.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
+
+    TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
+    TT_FATAL(operation_attributes.program_config.has_value(), "Error: program_config field should have been populated");
+    bool bcast_batch = operation_attributes.bcast_batch.value();
+    bool transpose_a = operation_attributes.transpose_a;
+    bool transpose_b = operation_attributes.transpose_b;
+
+    auto program_config = std::get<operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>(
+        operation_attributes.program_config.value());
+
+    if (!program_config.allowed_worker_cores.has_value()) {
+        log_warning(
+            tt::LogOp,
+            "matmul_multi_core_reuse_mcast_2d_optimized_helper: program_config.allowed_worker_cores not populated; "
+            "auto-populating from compute_with_storage_grid_size. Callers that bypass ttnn::prim::matmul() (e.g. "
+            "CCL fused ops) should invoke ttnn::operations::matmul::normalize_program_config() on the program "
+            "config first. This will become a hard error in a future release.");
+        program_config.allowed_worker_cores = CoreRangeSet(CoreRange(
+            CoreCoord(0, 0),
+            CoreCoord(
+                program_config.compute_with_storage_grid_size.x - 1,
+                program_config.compute_with_storage_grid_size.y - 1)));
+    }
+
+    auto fuse_batch = program_config.fuse_batch;
+    auto in0_block_w = program_config.in0_block_w;
+    auto compute_with_storage_grid_size = program_config.allowed_worker_cores.value().bounding_box().grid_size();
+    auto out_subblock_h = program_config.out_subblock_h;
+    auto out_subblock_w = program_config.out_subblock_w;
+    auto out_block_h = program_config.out_block_h;
+    auto out_block_w = program_config.out_block_w;
+    auto per_core_M = program_config.per_core_M;
+    auto per_core_N = program_config.per_core_N;
+    auto transpose_mcast = program_config.transpose_mcast;
+
+    TT_FATAL(
+        operation_attributes.compute_kernel_config.has_value(),
+        "Error: compute_kernel_config field should have been populated");
+    auto compute_kernel_config = operation_attributes.compute_kernel_config.value();
+    auto untilize_out = operation_attributes.untilize_out;
+    // auto fused_op_signaler = std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>();
+
+    const auto& a_shape_padded = get_matmul_tensor_padded_shape(a, transpose_a);
+    const auto& b_shape_padded = get_matmul_tensor_padded_shape(b, transpose_b);
+    const auto in0_tile = get_matmul_tile(a, transpose_a);
+    const auto in1_tile = get_matmul_tile(b, transpose_b);
+
+    // cannot use the output tensor tile directly as that might be changed by user override
+    const auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+
+    // CB dataformats
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());  // in0
+    const auto& in1_tensor = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());  // in1
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());   // output
+
+    const auto& a_shape_logical = get_matmul_tensor_logical_shape(a, transpose_a);
+    // When transpose_a is true, the K dimension maps to the row dimension of the raw tile,
+    // which is already zero-padded during tile layout conversion. pad_last_ktile operates on
+    // columns, so applying it would incorrectly zero valid data that becomes output rows
+    // after the compute kernel transposes the tile.
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_mesh;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        TT_FATAL(
+            c.storage_type() == StorageType::DEVICE,
+            "Bias tensor must be on device, got storage type: {}",
+            c.storage_type());
+        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
+        TT_FATAL(c.is_allocated(), "Operands to matmul need to be allocated in buffers on device!");
+
+        bias_mesh = c.mesh_tensor();
+
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    tt_metal::IDevice* device = a.device();
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    const auto& in0_tensor = a.mesh_tensor();
+    TT_FATAL(
+        in0_tensor.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        in0_tensor.mesh_buffer().device_local_size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        in1_tensor.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        in1_tensor.mesh_buffer().device_local_size(),
+        in1_single_tile_size);
+
+    TT_FATAL(
+        a_shape_padded[-1] == b_shape_padded[-2],
+        "Dimension K (A.shape[-1] = {}, B.shape[-2] = {}) must match for matmul",
+        a_shape_padded[-1],
+        b_shape_padded[-2]);
+    TT_FATAL(
+        a_shape_padded[-2] % in0_tile.get_height() == 0,
+        "A.shape[-2] ({}) must be divisible by tile shape[0] ({})",
+        a_shape_padded[-2],
+        in0_tile.get_height());
+    TT_FATAL(
+        a_shape_padded[-1] % in0_tile.get_width() == 0,
+        "A.shape[-1] ({}) must be divisible by tile shape[1] ({})",
+        a_shape_padded[-1],
+        in0_tile.get_width());
+    TT_FATAL(
+        b_shape_padded[-2] % in1_tile.get_height() == 0,
+        "B.shape[-2] ({}) must be divisible by tile shape[0] ({})",
+        b_shape_padded[-2],
+        in1_tile.get_height());
+    TT_FATAL(
+        b_shape_padded[-1] % in1_tile.get_width() == 0,
+        "B.shape[-1] ({}) must be divisible by tile shape[1] ({})",
+        b_shape_padded[-1],
+        in1_tile.get_width());
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Matmul Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    // NOTE: Pads matmul input dims to 512 x 512 multiples (ie. multiples of 16*32 x 16*32)
+    // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
+    const auto B = fuse_batch ? 1 : get_batch_size(a_shape_padded);
+    const auto Mt = get_M_dim(a_shape_padded, in0_tile, fuse_batch);
+    const auto Mt_per_batch = get_M_dim(a_shape_padded, in0_tile, false);
+    const auto Kt = get_K_dim(a_shape_padded, in0_tile);
+    const auto Nt = get_N_dim(b_shape_padded, in1_tile);
+
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
+
+    // This should allocate a DRAM buffer on the device
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    // Calculate number of blocks along x and y; tensor dims are padded up to 512
+    uint32_t num_blocks_y = ((Mt - 1) / per_core_M) + 1;
+    uint32_t num_blocks_x = ((Nt - 1) / per_core_N) + 1;
+    if (transpose_mcast) {
+        std::swap(num_blocks_x, num_blocks_y);
+    }
+
+    // TODO: Max used grid can actually exceed mcast receiver grid if in0 is sharded
+    // TODO: Move these validates to op validate and properly check for this
+    TT_FATAL(
+        num_blocks_x <= num_cores_x,
+        "Num output blocks along x ({}) must be smaller than or equal to the number of columns in compute grid ({})!",
+        num_blocks_x,
+        num_cores_x);
+    TT_FATAL(
+        num_blocks_y <= num_cores_y,
+        "Num output blocks along y ({}) must be smaller than or equal to the number of rows in compute grid ({})!",
+        num_blocks_y,
+        num_cores_y);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Sub-device start core
+    ////////////////////////////////////////////////////////////////////////////
+    CoreCoord sub_device_start_core = {0, 0};
+    if (operation_attributes.sub_device_id.has_value()) {
+        auto sub_device_cores = device->worker_cores(
+            tt::tt_metal::HalProgrammableCoreType::TENSIX, operation_attributes.sub_device_id.value());
+        auto bbox = sub_device_cores.bounding_box();
+        sub_device_start_core = bbox.start_coord;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    return reuse_mcast_optimized_helpers::create_program_mcast_in0_in1(
+        program,
+        device,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        dst_full_sync_en,
+        B,
+        Mt,
+        Mt_per_batch,
+        Nt,
+        Kt,
+        bcast_batch,
+        transpose_a,
+        transpose_b,
+        ttnn::get_throttle_level(compute_kernel_config),
+        in0_block_w,
+        in0_last_ktile_w,
+        in0_last_ktile_h,
+        out_subblock_h,
+        out_subblock_w,
+        out_block_h,
+        out_block_w,
+        per_core_M,
+        per_core_N,
+        transpose_mcast,
+        program_config.fused_activation,
+        in0_tensor,
+        in1_tensor,
+        bias_mesh,
+        output,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        untilize_out,
+        fused_op_signaler,
+        fused_matmul_bias_row_broadcastable(bias),
+        sub_device_start_core);
+}
+
+void MatmulMultiCoreReuseMcast2DProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const shared_variables_t& shared_variables,
+    const ttnn::prim::MatmulParams& /*operation_attributes*/,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    reuse_mcast_optimized_helpers::override_runtime_arguments_impl(
+        shared_variables, program, tensor_args, tensor_return_value);
+}
+
+ProgramDescriptor MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
+    const ttnn::prim::MatmulParams& operation_attributes,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    using namespace tt;
+    using namespace operations::matmul::utilities;
+
+    const auto& a = tensor_args.input_tensors.at(0);
+    const auto& b = tensor_args.input_tensors.at(1);
+    const auto& bias = tensor_args.optional_input_tensors.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
+
+    TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
+    TT_FATAL(operation_attributes.program_config.has_value(), "Error: program_config field should have been populated");
+    bool bcast_batch = operation_attributes.bcast_batch.value();
+    bool transpose_a = operation_attributes.transpose_a;
+    bool transpose_b = operation_attributes.transpose_b;
+
+    auto program_config = std::get<operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>(
+        operation_attributes.program_config.value());
+
+    auto fuse_batch = program_config.fuse_batch;
+    auto in0_block_w = program_config.in0_block_w;
+    auto out_subblock_h = program_config.out_subblock_h;
+    auto out_subblock_w = program_config.out_subblock_w;
+    auto out_block_h = program_config.out_block_h;
+    auto out_block_w = program_config.out_block_w;
+    auto per_core_M = program_config.per_core_M;
+    auto per_core_N = program_config.per_core_N;
+    auto transpose_mcast = program_config.transpose_mcast;
+
+    TT_FATAL(
+        operation_attributes.compute_kernel_config.has_value(),
+        "Error: compute_kernel_config field should have been populated");
+    auto compute_kernel_config = operation_attributes.compute_kernel_config.value();
+    auto untilize_out = operation_attributes.untilize_out;
+
+    const auto& a_shape_padded = get_matmul_tensor_padded_shape(a, transpose_a);
+    const auto& b_shape_padded = get_matmul_tensor_padded_shape(b, transpose_b);
+    const auto in0_tile = get_matmul_tile(a, transpose_a);
+    const auto in1_tile = get_matmul_tile(b, transpose_b);
+
+    // cannot use the output tensor tile directly as that might be changed by user override
+    const auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+
+    // CB dataformats
+    const auto& in0_tensor = a.mesh_tensor();
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(in0_tensor.dtype());
+    const auto& in1_tensor = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    const auto& a_shape_logical = get_matmul_tensor_logical_shape(a, transpose_a);
+    const auto in0_last_ktile_w = transpose_a ? 0 : a_shape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? a_shape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    ttsl::optional_reference<const tt_metal::MeshTensor> bias_mesh;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        bias_mesh = c.mesh_tensor();
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    tt_metal::IDevice* device = &in0_tensor.mutable_device();
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    const auto B = fuse_batch ? 1 : get_batch_size(a_shape_padded);
+    const auto Mt = get_M_dim(a_shape_padded, in0_tile, fuse_batch);
+    const auto Mt_per_batch = get_M_dim(a_shape_padded, in0_tile, false);
+    const auto Kt = get_K_dim(a_shape_padded, in0_tile);
+    const auto Nt = get_N_dim(b_shape_padded, in1_tile);
+
+    // When a sub-device is present use its bounding-box start; otherwise fall
+    // back to allowed_worker_cores start so non-(0,0) placements work correctly.
+    CoreCoord sub_device_start_core = program_config.allowed_worker_cores.has_value()
+                                          ? program_config.allowed_worker_cores.value().bounding_box().start_coord
+                                          : CoreCoord{0, 0};
+    if (operation_attributes.sub_device_id.has_value()) {
+        auto sub_device_cores = device->worker_cores(
+            tt::tt_metal::HalProgrammableCoreType::TENSIX, operation_attributes.sub_device_id.value());
+        auto bbox = sub_device_cores.bounding_box();
+        sub_device_start_core = bbox.start_coord;
+    }
+
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> fused_op_signaler = std::nullopt;
+    return reuse_mcast_optimized_helpers::create_program_mcast_in0_in1_descriptor(
+        device,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        dst_full_sync_en,
+        B,
+        Mt,
+        Mt_per_batch,
+        Nt,
+        Kt,
+        bcast_batch,
+        transpose_a,
+        transpose_b,
+        ttnn::get_throttle_level(compute_kernel_config),
+        in0_block_w,
+        in0_last_ktile_w,
+        in0_last_ktile_h,
+        out_subblock_h,
+        out_subblock_w,
+        out_block_h,
+        out_block_w,
+        per_core_M,
+        per_core_N,
+        transpose_mcast,
+        program_config.fused_activation,
+        in0_tensor,
+        in1_tensor,
+        bias_mesh,
+        output,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        untilize_out,
+        fused_op_signaler,
+        fused_matmul_bias_row_broadcastable(bias),
+        sub_device_start_core);
+}
+
+ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t>
+matmul_multi_core_reuse_mcast_2d_optimized_helper(
+    tt::tt_metal::Program& program, /* Take programa as input by reference */
+    const Tensor& a,
+    const Tensor& b,
+    const std::optional<const Tensor>& bias,
+    Tensor& output_tensor,
+    bool broadcast_batch,
+    DeviceComputeKernelConfig compute_kernel_config,
+    const operations::matmul::MatmulProgramConfig& program_config,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler) {
+    auto attributes = ttnn::prim::MatmulParams{.program_config = program_config, .bcast_batch = broadcast_batch};
+    attributes.compute_kernel_config = compute_kernel_config;
+    attributes.untilize_out = untilize_out;
+
+    auto output_tensors = std::vector<ttnn::Tensor>{output_tensor};
+    return matmul_multi_core_reuse_mcast_2d_optimized_(
+        program, attributes, ttnn::prim::MatmulInputs{{a, b}, {bias}, {}}, output_tensors, fused_op_signaler);
+}
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_2d_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_2d_program_factory.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::for_python {
+
+// Metal 1.0 copy of the production factory, frozen for the Python fusion framework.
+// Not part of MatmulDeviceOperation and not on any dispatch path — do not port it to Metal 2.0.
+
+struct MatmulMultiCoreReuseMcast2DProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle mm_kernel_in0_sender_id{};
+        std::vector<CoreCoord> in0_sender_interleaved_cores;
+        tt::tt_metal::KernelHandle mm_kernel_in1_sender_writer_id{};
+        std::vector<CoreCoord> in1_sender_cores;
+        tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_id{};
+        std::vector<CoreCoord> in1_receiver_cores;
+        tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_other_noc_setup_id{};
+        std::vector<CoreCoord> in1_receiver_other_cores;
+        tt::tt_metal::CBHandle cb_src2{};
+        tt::tt_metal::CBHandle cb_output{};
+        uint32_t num_cores_with_work_r{};
+        uint32_t num_cores_with_work_c{};
+        uint32_t start_core_x{};
+        uint32_t start_core_y{};
+        bool transpose_mcast{};
+        std::vector<CoreCoord> cores;
+    };
+
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const shared_variables_t& shared_variables,
+        const ttnn::prim::MatmulParams& operation_attributes,
+        const ttnn::prim::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value);
+
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::MatmulParams& operation_attributes,
+        const ttnn::prim::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+};
+
+ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t>
+matmul_multi_core_reuse_mcast_2d_optimized_helper(
+    tt::tt_metal::Program& program, /* Take programa as input by reference */
+    const Tensor& a,
+    const Tensor& b,
+    const std::optional<const Tensor>& bias,
+    Tensor& output_tensor,
+    bool broadcast_batch,
+    DeviceComputeKernelConfig compute_kernel_config,
+    const operations::matmul::MatmulProgramConfig& program_config,
+    bool untilize_out,
+    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler);
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -1,0 +1,1056 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_dram_sharded_program_factory.hpp"
+#include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
+#include "ttnn/operations/matmul/device/config/matmul_program_config.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/operations/matmul/shared_with_host/activation_type.hpp"
+
+using namespace tt;
+
+using ttnn::operations::unary::UnaryOpType;
+using ttnn::operations::unary::UnaryWithParam;
+
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::DataMovementConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+
+using namespace ttnn::prim;
+
+namespace ttnn::for_python {
+namespace reuse_dram_sharded_optimized_helpers {
+
+using dram_sharded_helpers::get_max_page_size_and_num_pages;
+using dram_sharded_helpers::get_optimal_dram_bank_to_reader_assignment;
+using dram_sharded_helpers::move_common_entries;
+
+static ProgramDescriptor create_program_dram_sharded_descriptor(
+    tt::tt_metal::IDevice* device,
+    const CoreRangeSet& input_all_storage_cores,
+    const CoreRangeSet& output_all_storage_cores,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    bool dst_full_sync_en,
+    ttnn::operations::compute_throttle_utils::ThrottleLevel throttle_level,
+    uint32_t B,
+    uint32_t /* M */,
+    uint32_t N,
+    uint32_t K,
+    uint32_t in0_block_w,
+    uint32_t in0_last_ktile_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N_storage,
+    std::optional<UnaryWithParam> fused_activation,
+    const tt::tt_metal::MeshTensor& in0_tensor,
+    const tt::tt_metal::MeshTensor& in1_tensor,
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_tensor,
+    const tt::tt_metal::MeshTensor& out_tensor,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool untilize_out,
+    bool skip_compute,
+    bool skip_in0_mcast,
+    bool skip_write_back,
+    bool row_broadcast_bias) {
+    using namespace tt;
+
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias;
+    if (bias_tensor.has_value()) {
+        bias = *bias_tensor;
+    }
+
+    // currently only support transpose of the full tile
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+    TT_FATAL(
+        in1_tensor.shard_spec()->orientation == ShardOrientation::ROW_MAJOR, "Only ROW_MAJOR sharding is supported");
+
+    uint32_t start_core_x = 0;
+    uint32_t start_core_y = 0;
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_mcast_cores = compute_with_storage_grid_size.x * compute_with_storage_grid_size.y;
+
+    CoreCoord top_left_core = {(std::size_t)start_core_x, (std::size_t)start_core_y};
+    CoreCoord bottom_right_core = {
+        (std::size_t)start_core_x + compute_with_storage_grid_size.x - 1,
+        (std::size_t)start_core_y + compute_with_storage_grid_size.y - 1};
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    CoreCoord start_core_noc = top_left_core_physical;
+    CoreCoord end_core_noc = bottom_right_core_physical;
+    if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+        std::swap(start_core_noc, end_core_noc);
+    }
+
+    // get the dram readers
+    std::vector<CoreCoord> all_worker_cores_ordered;
+    CoreRangeSet all_worker_cores;
+    get_optimal_dram_bank_to_reader_assignment(device, all_worker_cores_ordered, all_worker_cores, in1_noc);
+
+    // dram banks
+    uint32_t num_dram_banks = all_worker_cores_ordered.size();
+
+    // Remove cores assigned to padding-only DRAM banks from the workers category
+    uint32_t in1_shard_width_tiles = in1_tensor.shard_spec()->shape[1] / in1_tile.get_tile_shape()[1];
+    uint32_t in1_tensor_padded_width_tiles = in1_shard_width_tiles * num_dram_banks;
+
+    if (in1_tensor_padded_width_tiles > N) {
+        uint32_t padding_width_tiles = in1_tensor_padded_width_tiles - N;
+        uint32_t only_padding_banks = padding_width_tiles / in1_shard_width_tiles;
+        TT_FATAL(
+            only_padding_banks < all_worker_cores_ordered.size(),
+            "Padding banks count {} must be less than workers count {}",
+            only_padding_banks,
+            all_worker_cores_ordered.size());
+        for (uint32_t i = 0; i < only_padding_banks; ++i) {
+            all_worker_cores_ordered.pop_back();
+        }
+        std::set<CoreRange> new_workers_set;
+        for (const auto& worker_core : all_worker_cores_ordered) {
+            new_workers_set.insert(CoreRange(worker_core));
+        }
+        all_worker_cores = CoreRangeSet(new_workers_set);
+        num_dram_banks = all_worker_cores_ordered.size();
+    }
+
+    uint32_t per_core_N_compute = div_up(N, num_dram_banks);
+    uint32_t per_core_N_in1_sender = per_core_N_compute;
+
+    auto subblock_hw = operations::matmul::bmm_op_utils::get_matmul_subblock_params(
+        per_core_M, per_core_N_compute, false, false, fp32_dest_acc_en);
+    auto out_subblock_h = std::get<0>(subblock_hw);
+    auto out_subblock_w = std::get<1>(subblock_hw);
+
+    uint32_t max_subblock_w = fp32_dest_acc_en ? 4 : 8;
+    if (out_subblock_h == 1 and out_subblock_w < max_subblock_w) {
+        uint32_t num_subblock_w_per_core_N = per_core_N_compute / out_subblock_w;
+        uint32_t num_iter = max_subblock_w - out_subblock_w;
+        uint32_t new_out_subblock_w = out_subblock_w;
+        uint32_t preferred_out_subblock_w = out_subblock_w;
+
+        for (uint32_t i = 0; i < num_iter; ++i) {
+            new_out_subblock_w += 1;
+            uint32_t new_num_subblock_w_per_core_N = (per_core_N_compute + new_out_subblock_w - 1) / new_out_subblock_w;
+
+            if (new_num_subblock_w_per_core_N < num_subblock_w_per_core_N) {
+                num_subblock_w_per_core_N = new_num_subblock_w_per_core_N;
+                preferred_out_subblock_w = new_out_subblock_w;
+            }
+        }
+        out_subblock_w = preferred_out_subblock_w;
+        per_core_N_compute = out_subblock_w * num_subblock_w_per_core_N;
+    }
+
+    // Number of in1 columns in the last subblock that are actually backed by reader-pushed tiles.
+    // When the subblock-width optimization above pads per_core_N_compute beyond per_core_N_in1_sender,
+    // the last subblock has out_subblock_w lanes total but only this many lanes correspond to in1
+    // tiles the reader pushed into cb_in1; the rest are padded columns that the output writer drops.
+    // The compute kernel uses this to narrow the matmul_block call for the last subblock so it never
+    // reads cb_in1 tile indices that were not produced for the current block.
+    // When no padding occurs (per_core_N_compute == per_core_N_in1_sender) this equals out_subblock_w.
+    uint32_t last_subblock_w_valid = out_subblock_w - (per_core_N_compute - per_core_N_in1_sender);
+
+    uint32_t num_blocks = K / in0_block_w;
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    // in1/bias are DRAM sharded with one tile per page; the allocator pads each page to the DRAM
+    // alignment (e.g. bfp8 32x16 tile = 544B padded to 576B on Blackhole's 64B alignment). The
+    // reader copies blocks contiguously from DRAM, so the CB must hold tiles at the padded stride.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in1_aligned_tile_size = tt::align(in1_single_tile_size, dram_alignment);
+    uint32_t bias_aligned_tile_size = tt::align(bias_single_tile_size, dram_alignment);
+
+    uint32_t in0_block_tiles = per_core_M * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (B * num_blocks > 1) {
+        in0_CB_tiles = in0_CB_tiles * 2;  // double buffer
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
+    uint32_t in1_block_tiles = per_core_N_in1_sender * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (B * num_blocks > 1) {
+        in1_CB_tiles = in1_CB_tiles * 3;  // triple buffer
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+
+    uint32_t out_block_tiles = per_core_M * per_core_N_compute;
+    uint32_t out_CB_tiles = out_block_tiles;
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_size = out_CB_tiles * interm0_single_tile_size;
+
+    uint32_t out_reshard_block_tiles = per_core_M * per_core_N_storage;
+    uint32_t out_reshard_CB_tiles = out_reshard_block_tiles;
+    uint32_t out_reshard_CB_size = out_reshard_CB_tiles * output_single_tile_size;
+
+    uint32_t in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_tile_shape()[1];
+    uint32_t in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+    uint32_t in2_CB_tiles = in2_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in3_CB_tiles = per_core_N_compute;
+    uint32_t in3_CB_size = in3_CB_tiles * bias_aligned_tile_size;
+
+    // get the max page size based on num tiles
+    uint32_t in1_buffer_page_size, in1_buffer_num_pages;
+    get_max_page_size_and_num_pages(
+        device, in1_block_tiles, in1_aligned_tile_size, in1_buffer_page_size, in1_buffer_num_pages);
+
+    uint32_t bias_buffer_page_size, bias_buffer_num_pages;
+    get_max_page_size_and_num_pages(
+        device, per_core_N_in1_sender, bias_aligned_tile_size, bias_buffer_page_size, bias_buffer_num_pages);
+
+    uint32_t num_worker_cores = num_dram_banks;
+
+    // move conflict coord from mcast receiver to mcast sender
+    std::vector<CoreCoord> input_all_storage_cores_vec = corerange_to_cores(input_all_storage_cores);
+    std::vector<CoreCoord> all_worker_cores_vec = corerange_to_cores(all_worker_cores);
+    std::vector<CoreCoord> storage_worker_common;
+    move_common_entries(input_all_storage_cores_vec, all_worker_cores_vec, storage_worker_common);
+
+    std::vector<CoreRange> input_all_storage_cores_range;
+    input_all_storage_cores_range.reserve(input_all_storage_cores_vec.size());
+    std::transform(
+        input_all_storage_cores_vec.begin(),
+        input_all_storage_cores_vec.end(),
+        std::back_inserter(input_all_storage_cores_range),
+        [](const CoreCoord& coord) { return CoreRange(coord); });
+
+    std::vector<CoreRange> all_worker_cores_range;
+    all_worker_cores_range.reserve(all_worker_cores_vec.size());
+    std::transform(
+        all_worker_cores_vec.begin(),
+        all_worker_cores_vec.end(),
+        std::back_inserter(all_worker_cores_range),
+        [](const CoreCoord& coord) { return CoreRange(coord); });
+
+    std::set<CoreRange> input_all_storage_cores_set(
+        input_all_storage_cores_range.begin(), input_all_storage_cores_range.end());
+    std::set<CoreRange> all_worker_cores_set(all_worker_cores_range.begin(), all_worker_cores_range.end());
+    CoreRangeSet mcast_senders = CoreRangeSet(input_all_storage_cores_set);
+    CoreRangeSet mcast_receivers = CoreRangeSet(all_worker_cores_set);
+
+    // all cores
+    std::set<CoreRange> all_cores_set;
+    all_cores_set.insert(mcast_senders.ranges().begin(), mcast_senders.ranges().end());
+    all_cores_set.insert(mcast_receivers.ranges().begin(), mcast_receivers.ranges().end());
+    CoreRangeSet all_cores = CoreRangeSet(all_cores_set);
+
+    // grid bounding box
+    CoreRange bounding_box = all_cores.bounding_box();
+    std::set<CoreRange> bounding_box_set;
+    bounding_box_set.insert(bounding_box);
+    CoreRangeSet all_cores_in_rect_grid(bounding_box_set);
+    std::vector<CoreCoord> all_cores_in_rect_grid_vec = corerange_to_cores(all_cores_in_rect_grid);
+
+    // Semaphore IDs (manually assigned, matching CreateSemaphore sequential allocation)
+    uint32_t in0_mcast_sender_semaphore_id = 0;
+    uint32_t in0_mcast_receiver_semaphore_id = 1;
+    uint32_t in0_mcast_sender_valid_semaphore_id = 2;
+
+    uint32_t in0_num_subblocks = (per_core_M / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+
+    uint32_t num_blocks_per_shard = num_blocks / input_all_storage_cores_vec.size();
+    if (per_core_M > 1) {
+        TT_FATAL(
+            num_blocks_per_shard == 1,
+            "currently not support per_core_M larger than 1, while split one shard into multiple blocks (per_core_M "
+            "{}, num_blocks_per_shard {})",
+            per_core_M,
+            num_blocks_per_shard);
+    }
+
+    std::vector<uint32_t> in0_sender_compile_time_args = {
+        (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+        (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+        (std::uint32_t)in0_last_ktile_w,                            // in0_last_ktile_w
+        (std::uint32_t)0,                                           // in0_last_ktile_h (transpose not supported)
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        (std::uint32_t)num_worker_cores,  // in0_mcast_num_dests
+        (std::uint32_t)num_mcast_cores,   // in0_mcast_num_cores
+        // block
+        (std::uint32_t)num_blocks,
+        // mcast noc coords
+        (std::uint32_t)start_core_noc.x,
+        (std::uint32_t)start_core_noc.y,
+        (std::uint32_t)end_core_noc.x,
+        (std::uint32_t)end_core_noc.y,
+        // semaphore valid
+        (std::uint32_t)in0_mcast_sender_valid_semaphore_id,
+        //
+        (std::uint32_t)num_blocks_per_shard,
+        (std::uint32_t)in0_block_w};
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        (std::uint32_t)in1_buffer_page_size,
+        (std::uint32_t)in1_buffer_num_pages,
+        // in1 block args
+        (std::uint32_t)per_core_N_compute,                   // in1_block_w (padded, used only for bias CB)
+        (std::uint32_t)per_core_N_in1_sender * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,                                    // num_blocks
+        (std::uint32_t)out_block_tiles,                               // out_block_num_tiles
+        (std::uint32_t)per_core_N_compute * output_single_tile_size,  // out_tensor_stride_w_bytes
+        (std::uint32_t)per_core_N_storage * output_single_tile_size,  // out_reshard_tensor_stride_w_bytes
+        (std::uint32_t)per_core_M};
+    if (bias.has_value()) {
+        in1_sender_writer_compile_time_args.push_back(bias_buffer_page_size);
+        in1_sender_writer_compile_time_args.push_back(bias_buffer_num_pages);
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);
+    }
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_define;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    if (bias.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+    mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+
+    if (skip_compute) {
+        mm_kernel_defines["SKIP_COMPUTE"] = "1";
+    }
+    if (skip_in0_mcast) {
+        mm_kernel_in0_sender_define["SKIP_MCAST"] = "1";
+    }
+    if (skip_write_back) {
+        mm_kernel_in1_sender_writer_defines["SKIP_WRITE_BACK"] = "1";
+    }
+    mm_kernel_defines["MATMUL_DRAM_SHARDED"] = "1";
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    const uint32_t num_compute_cores = all_cores_in_rect_grid.num_cores();
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_compute_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_compute_cores, mm_kernel_defines, throttle_level);
+
+    // Helper to convert std::map defines to KernelDescriptor::Defines (vector of pairs)
+    auto map_to_defines = [](const std::map<std::string, std::string>& m) -> KernelDescriptor::Defines {
+        KernelDescriptor::Defines result;
+        result.reserve(m.size());
+        for (const auto& [k, v] : m) {
+            result.emplace_back(k, v);
+        }
+        return result;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build Kernel Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+
+    // in0 sender kernel (reader - RISCV_1)
+    KernelDescriptor in0_sender_kernel_desc;
+    in0_sender_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp";
+    in0_sender_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in0_sender_kernel_desc.core_ranges = all_cores_in_rect_grid;
+    in0_sender_kernel_desc.compile_time_args = in0_sender_compile_time_args;
+    in0_sender_kernel_desc.defines = map_to_defines(mm_kernel_in0_sender_define);
+    in0_sender_kernel_desc.named_compile_time_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in0_sharded", tt::CBIndex::c_2},
+    };
+    in0_sender_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+
+    // in1 sender/writer kernel (writer - RISCV_0)
+    KernelDescriptor in1_sender_writer_kernel_desc;
+    in1_sender_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_sender_dram_sharded.cpp";
+    in1_sender_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    in1_sender_writer_kernel_desc.core_ranges = all_cores_in_rect_grid;
+    in1_sender_writer_kernel_desc.compile_time_args = in1_sender_writer_compile_time_args;
+    in1_sender_writer_kernel_desc.defines = map_to_defines(mm_kernel_in1_sender_writer_defines);
+    in1_sender_writer_kernel_desc.named_compile_time_args = {
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_out_reshard", tt::CBIndex::c_6},
+    };
+    in1_sender_writer_kernel_desc.config =
+        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
+
+    // Compute kernel
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+    uint32_t in1_num_subblocks = (per_core_N_compute / out_subblock_w);
+    uint32_t in1_per_core_w = per_core_N_in1_sender;
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,  // in1_num_subblocks
+        in1_block_tiles,    // in1_block_num_tiles
+        in1_per_core_w,     // in1_per_core_w
+
+        num_blocks,  // num_blocks
+        1,           // out_num_blocks_x
+        1,           // out_num_blocks_y
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B,                       // batch
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        false,         // in0_transpose_tile
+    };
+    if (bias.has_value()) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
+
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores_in_rect_grid;
+    compute_kernel_desc.compile_time_args = compute_kernel_args;
+    compute_kernel_desc.defines = map_to_defines(mm_kernel_defines);
+    {
+        KernelDescriptor::NamedCompileTimeArgs named_compile_args = {
+            {"cb_in0", tt::CBIndex::c_0},
+            {"cb_in1", tt::CBIndex::c_1},
+            {"cb_bias", tt::CBIndex::c_3},
+            {"cb_out", tt::CBIndex::c_4},
+            {"cb_intermed0", tt::CBIndex::c_5},
+            {"cb_in0_intermediate", tt::CBIndex::c_8},
+            {"cb_in1_intermediate", tt::CBIndex::c_9},
+            {"cb_in0_transposed", tt::CBIndex::c_10},
+            {"bias_ntiles", per_core_N_compute},
+            {"last_subblock_w_valid", last_subblock_w_valid},
+        };
+        if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+            using ttnn::operations::matmul::utilities::get_activation_params;
+            const auto params = get_activation_params(fused_activation.value());
+            named_compile_args.push_back({"activation_type", static_cast<uint32_t>(params.type)});
+            named_compile_args.push_back({"activation_param0", params.param0});
+            named_compile_args.push_back({"activation_param1", params.param1});
+            named_compile_args.push_back({"activation_param2", params.param2});
+        }
+        compute_kernel_desc.named_compile_time_args = std::move(named_compile_args);
+    }
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build CBDescriptors
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor desc;
+
+    tt::tt_metal::TileDescriptor in0_tile_desc{in0_tile};
+    tt::tt_metal::TileDescriptor in1_tile_desc{in1_tile};
+    tt::tt_metal::TileDescriptor bias_tile_desc{bias_tile};
+    tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+
+    // CB 0: in0
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in0_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_0,
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size,
+            .tile = in0_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 1: in1
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in1_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_1,
+            .data_format = in1_data_format,
+            .page_size = in1_aligned_tile_size,
+            .tile = in1_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 2: in0 sharded (backed by in0_buffer)
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in2_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_2,
+            .data_format = in0_data_format,
+            .page_size = in0_single_tile_size,
+            .tile = in0_tile_desc});
+        cb_desc.tensor = &in0_tensor;
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 4 and CB 5: output and intermediate
+    if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
+        // Separate output and intermediate CBs
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = out_CB_size;
+            cb_desc.core_ranges = all_cores_in_rect_grid;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_4,
+                .data_format = output_data_format,
+                .page_size = output_single_tile_size,
+                .tile = output_tile_desc});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+        {
+            CBDescriptor cb_desc;
+            cb_desc.total_size = interm0_CB_size;
+            cb_desc.core_ranges = all_cores_in_rect_grid;
+            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_5,
+                .data_format = interm0_data_format,
+                .page_size = interm0_single_tile_size,
+                .tile = output_tile_desc});
+            desc.cbs.push_back(std::move(cb_desc));
+        }
+    } else {
+        // share buffer
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_4,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_5,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 6: resharded output (backed by out_buffer)
+    {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = out_reshard_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_6,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        cb_desc.tensor = &out_tensor;
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 3: bias
+    if (bias.has_value()) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = in3_CB_size;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_3,
+            .data_format = bias_data_format,
+            .page_size = bias_aligned_tile_size,
+            .tile = bias_tile_desc});
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Semaphore Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_sender_semaphore_id, .core_ranges = all_cores_in_rect_grid, .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_receiver_semaphore_id, .core_ranges = all_cores_in_rect_grid, .initial_value = INVALID});
+    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+        .id = in0_mcast_sender_valid_semaphore_id, .core_ranges = all_cores_in_rect_grid, .initial_value = VALID});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Runtime Args (per-core loop)
+    ////////////////////////////////////////////////////////////////////////////
+
+    std::vector<uint32_t> in0_mcast_sender_noc_x;
+    std::vector<uint32_t> in0_mcast_sender_noc_y;
+    std::vector<CoreCoord> mcast_senders_coords = corerange_to_cores(mcast_senders);
+    std::sort(mcast_senders_coords.begin(), mcast_senders_coords.end(), [](const CoreCoord& a, const CoreCoord& b) {
+        if (a.y != b.y) {
+            return a.y < b.y;
+        }
+        return a.x < b.x;
+    });
+    in0_mcast_sender_noc_x.reserve(mcast_senders_coords.size());
+    for (auto core : mcast_senders_coords) {
+        in0_mcast_sender_noc_x.push_back((std::uint32_t)device->worker_core_from_logical_core(core).x);
+    }
+    in0_mcast_sender_noc_y.reserve(mcast_senders_coords.size());
+    for (auto core : mcast_senders_coords) {
+        in0_mcast_sender_noc_y.push_back((std::uint32_t)device->worker_core_from_logical_core(core).y);
+    }
+
+    // in0 sender runtime args (mcast senders)
+    uint32_t sender_id = 0;
+    for (auto core : mcast_senders_coords) {
+        std::vector<uint32_t> mm_in0_sender_args;
+
+        uint32_t worker_core_type;
+        if (find(storage_worker_common.begin(), storage_worker_common.end(), core) != storage_worker_common.end()) {
+            worker_core_type = 2;
+        } else {
+            worker_core_type = 1;
+        }
+
+        mm_in0_sender_args.push_back((std::uint32_t)worker_core_type);
+        mm_in0_sender_args.push_back((std::uint32_t)sender_id);
+        mm_in0_sender_args.push_back(
+            (std::uint32_t)((core == input_all_storage_cores_vec.back()) and (in0_last_ktile_w > 0)));
+        mm_in0_sender_args.insert(
+            mm_in0_sender_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
+        mm_in0_sender_args.insert(
+            mm_in0_sender_args.end(), in0_mcast_sender_noc_y.begin(), in0_mcast_sender_noc_y.end());
+
+        in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_sender_args);
+        sender_id++;
+    }
+
+    // in0 sender runtime args (mcast receivers)
+    std::vector<CoreCoord> mcast_receiver_coords = corerange_to_cores(mcast_receivers);
+    for (auto core : mcast_receiver_coords) {
+        std::vector<uint32_t> mm_in0_receiver_args;
+        uint32_t worker_core_type = 3;
+        mm_in0_receiver_args.push_back((std::uint32_t)worker_core_type);
+        mm_in0_receiver_args.push_back((std::uint32_t)0);
+        mm_in0_receiver_args.push_back((std::uint32_t)0);  // in0_last_ktile_w
+        mm_in0_receiver_args.insert(
+            mm_in0_receiver_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
+        mm_in0_receiver_args.insert(
+            mm_in0_receiver_args.end(), in0_mcast_sender_noc_y.begin(), in0_mcast_sender_noc_y.end());
+
+        in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_receiver_args);
+    }
+
+    // in0 sender runtime args (idle cores in rect grid)
+    for (auto core : all_cores_in_rect_grid_vec) {
+        if (std::find(mcast_senders_coords.begin(), mcast_senders_coords.end(), core) == mcast_senders_coords.end() and
+            std::find(mcast_receiver_coords.begin(), mcast_receiver_coords.end(), core) ==
+                mcast_receiver_coords.end()) {
+            std::vector<uint32_t> mm_in0_idle_args;
+            uint32_t worker_core_type = 0;
+            mm_in0_idle_args.push_back((std::uint32_t)worker_core_type);
+
+            in0_sender_kernel_desc.runtime_args.emplace_back(core, mm_in0_idle_args);
+        }
+    }
+
+    // Compute and in1 sender/writer runtime args
+    uint32_t bank_id = 0;
+    std::vector<uint32_t> bank_ids;
+    uint32_t curr_storage_core_idx = 0;
+    uint32_t per_core_N_storage_curr_stride = 0;
+
+    uint32_t worker_core_stride = 0;
+    uint32_t storage_core_stride = 0;
+    uint32_t curr_worker_core = 0;
+    uint32_t curr_storage_core = 0;
+
+    std::vector<uint32_t> output_noc_x;
+    std::vector<uint32_t> output_noc_y;
+    std::vector<CoreCoord> output_coords = corerange_to_cores(output_all_storage_cores, std::nullopt, true);
+    output_noc_x.reserve(output_coords.size());
+    for (auto core : output_coords) {
+        output_noc_x.push_back((std::uint32_t)device->worker_core_from_logical_core(core).x);
+    }
+    output_noc_y.reserve(output_coords.size());
+    for (auto core : output_coords) {
+        output_noc_y.push_back((std::uint32_t)device->worker_core_from_logical_core(core).y);
+    }
+
+    uint32_t num_cores_written_back = (N + per_core_N_storage - 1) / per_core_N_storage;
+    uint32_t expected_max_total_width = num_cores_written_back * per_core_N_storage;
+    uint32_t total_tensor_width_written_back = 0;
+
+    // For all cores in the rect grid, set compute and in1 rt args for non-worker cores
+    for (auto core : all_cores_in_rect_grid_vec) {
+        if (std::find(all_worker_cores.ranges().begin(), all_worker_cores.ranges().end(), core) ==
+            all_worker_cores.ranges().end()) {  // not worker
+            bool is_worker_core = false;
+            std::vector<uint32_t> mm_in1_sender_writer_args;
+            mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);
+            in1_sender_writer_kernel_desc.runtime_args.emplace_back(core, mm_in1_sender_writer_args);
+
+            std::vector<uint32_t> mm_compute_args;
+            mm_compute_args.push_back((std::uint32_t)is_worker_core);
+            compute_kernel_desc.runtime_args.emplace_back(core, mm_compute_args);
+        } else {
+            bool is_worker_core = true;
+            std::vector<uint32_t> mm_compute_args;
+            mm_compute_args.push_back((std::uint32_t)is_worker_core);
+            compute_kernel_desc.runtime_args.emplace_back(core, mm_compute_args);
+        }
+    }
+
+    // Worker cores: in1 sender/writer runtime args
+    for (uint32_t i = 0; i < all_worker_cores_ordered.size(); ++i) {
+        auto core = all_worker_cores_ordered[i];
+
+        bool is_worker_core = true;
+        std::vector<uint32_t> mm_in1_sender_writer_args;
+        mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);
+        mm_in1_sender_writer_args.push_back(in1_tensor.address());  // [1]: will be replaced by Buffer*
+        mm_in1_sender_writer_args.push_back(bias.has_value() ? bias->address() : 0u);  // [2]: may be replaced
+
+        uint32_t vc = bank_id & 0x3;
+        bank_ids.push_back(bank_id);
+        for (uint32_t j = 0; j < i; ++j) {
+            auto core_prev = all_worker_cores_ordered[j];
+
+            if (core_prev.y == core.y and ((bank_id & 0x3) == (bank_ids[j] & 0x3))) {
+                vc = (vc + 1) & 0x3;
+                break;
+            }
+        }
+        mm_in1_sender_writer_args.push_back((std::uint32_t)bank_id);
+        mm_in1_sender_writer_args.push_back((std::uint32_t)vc);
+
+        bank_id = (bank_id + 1) % num_dram_banks;
+
+        if (per_core_N_in1_sender < per_core_N_storage) {
+            TT_FATAL(curr_storage_core_idx < num_cores_written_back, "Worker {} has no storage area assigned", core);
+
+            uint32_t remaining_per_core_N_storage = (per_core_N_storage - per_core_N_storage_curr_stride);
+            uint32_t per_core_N_reshard_1 = (remaining_per_core_N_storage > per_core_N_in1_sender)
+                                                ? per_core_N_in1_sender
+                                                : remaining_per_core_N_storage;
+            uint32_t per_core_N_reshard_2 = per_core_N_in1_sender - per_core_N_reshard_1;
+
+            if (per_core_N_reshard_2 != 0 and (curr_storage_core_idx + 1) < num_cores_written_back) {
+                mm_in1_sender_writer_args.push_back(2);
+            } else {
+                mm_in1_sender_writer_args.push_back(1);
+            }
+
+            mm_in1_sender_writer_args.push_back(
+                per_core_N_storage_curr_stride * output_single_tile_size);  // reshard_tensor_start_offset
+            mm_in1_sender_writer_args.push_back(
+                per_core_N_reshard_1 * output_single_tile_size);                       // per_core_N_reshard_bytes_1
+            mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core_idx]);  // output_noc_x
+            mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core_idx]);  // output_noc_y
+
+            total_tensor_width_written_back += per_core_N_reshard_1;
+
+            if (per_core_N_reshard_2 != 0 and (curr_storage_core_idx + 1) < num_cores_written_back) {
+                mm_in1_sender_writer_args.push_back(
+                    per_core_N_reshard_2 * output_single_tile_size);  // per_core_N_reshard_bytes_2
+                mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core_idx + 1]);  // output_noc_x
+                mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core_idx + 1]);  // output_noc_y
+
+                total_tensor_width_written_back += per_core_N_reshard_2;
+            }
+
+            curr_storage_core_idx += (per_core_N_storage_curr_stride + per_core_N_in1_sender) / per_core_N_storage;
+            per_core_N_storage_curr_stride =
+                (per_core_N_storage_curr_stride + per_core_N_in1_sender) % per_core_N_storage;
+        } else {
+            uint32_t num_cores_write_back = 0;
+
+            if (curr_storage_core < num_cores_written_back) {
+                num_cores_write_back++;
+
+                worker_core_stride = per_core_N_storage - storage_core_stride;
+
+                mm_in1_sender_writer_args.push_back(
+                    storage_core_stride * output_single_tile_size);  // reshard_tensor_start_offset
+                mm_in1_sender_writer_args.push_back(
+                    worker_core_stride * output_single_tile_size);                     // per_core_N_reshard
+                mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core]);  // output_noc_x
+                mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core]);  // output_noc_y
+
+                curr_storage_core += (storage_core_stride + worker_core_stride) / per_core_N_storage;
+                storage_core_stride = (storage_core_stride + worker_core_stride) % per_core_N_storage;
+
+                if (worker_core_stride >= per_core_N_in1_sender) {
+                    curr_worker_core += 1;
+                }
+
+                total_tensor_width_written_back += worker_core_stride;
+
+                while (curr_worker_core <= i and curr_storage_core < num_cores_written_back) {
+                    num_cores_write_back++;
+
+                    bool increment_worker_core = (worker_core_stride + per_core_N_storage) >= per_core_N_in1_sender;
+                    uint32_t current_worker_stride_total =
+                        increment_worker_core ? per_core_N_in1_sender : worker_core_stride + per_core_N_storage;
+                    uint32_t current_worker_write_back_tiles = current_worker_stride_total - worker_core_stride;
+
+                    if (increment_worker_core) {
+                        curr_worker_core += 1;
+                    }
+
+                    mm_in1_sender_writer_args.push_back(
+                        current_worker_write_back_tiles * output_single_tile_size);        // per_core_N_reshard
+                    mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core]);  // output_noc_x
+                    mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core]);  // output_noc_y
+
+                    total_tensor_width_written_back += current_worker_write_back_tiles;
+
+                    storage_core_stride = current_worker_write_back_tiles % per_core_N_storage;
+                    curr_storage_core += current_worker_write_back_tiles / per_core_N_storage;
+                    worker_core_stride = current_worker_stride_total;
+                }
+            }
+
+            mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + 5, num_cores_write_back);
+        }
+
+        // Build variant args: positions [1] and [2] are buffer addresses
+        std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>> in1_writer_args(
+            mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
+        in1_writer_args[1] = in1_tensor;
+        if (bias.has_value()) {
+            in1_writer_args[2] = *bias;
+        }
+        in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_writer_args);
+        TT_FATAL(
+            mm_in1_sender_writer_args.size() >= 10,
+            "Kernel requires at least 10 runtime args, got {}",
+            mm_in1_sender_writer_args.size());
+    }
+
+    TT_FATAL(
+        total_tensor_width_written_back <= expected_max_total_width,
+        "more datums written back to sharded tensor, L1 corruption, expected: {}, actual: {}",
+        expected_max_total_width,
+        total_tensor_width_written_back);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Push Kernel Descriptors
+    ////////////////////////////////////////////////////////////////////////////
+    desc.kernels.push_back(std::move(in0_sender_kernel_desc));
+    desc.kernels.push_back(std::move(in1_sender_writer_kernel_desc));
+    desc.kernels.push_back(std::move(compute_kernel_desc));
+
+    return desc;
+}
+
+}  // namespace reuse_dram_sharded_optimized_helpers
+
+ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create_descriptor(
+    const ttnn::prim::MatmulParams& operation_attributes,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
+    const auto& output_tensors = tensor_return_value;
+
+    const auto& a = input_tensors.at(0);
+    const auto& b = input_tensors.at(1).mesh_tensor();
+    const auto& bias = optional_input_tensors.at(0);
+    const auto& output = output_tensors.at(0);
+    const auto& ashape = a.padded_shape();
+    const auto& bshape = b.padded_shape();
+    auto in0_tile = a.tensor_spec().tile();
+    auto in1_tile = b.tensor_spec().tile();
+    auto in0_tile_shape = in0_tile.get_tile_shape();
+    auto in1_tile_shape = in1_tile.get_tile_shape();
+    auto output_tile = tt::tt_metal::Tile({in0_tile.get_tile_shape()[0], in1_tile.get_tile_shape()[1]});
+
+    // CB dataformats
+    tt::DataFormat in0_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat in1_data_format = tt::tt_metal::datatype_to_dataformat_converter(b.dtype());
+    tt::DataFormat output_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias_mesh;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        TT_FATAL(
+            c.storage_type() == StorageType::DEVICE,
+            "Bias tensor must be on device, got storage type: {}",
+            c.storage_type());
+        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
+
+        bias_mesh = c.mesh_tensor();
+        bias_data_format = tt::tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    const bool row_broadcast_bias = operations::matmul::utilities::fused_matmul_bias_row_broadcastable(bias);
+
+    tt::tt_metal::IDevice* device = a.device();
+
+    TT_FATAL(
+        a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");
+    CoreRangeSet input_all_cores_storage = a.shard_spec().value().grid;
+    CoreRangeSet output_all_cores_storage = output.shard_spec().value().grid;
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    const auto& a_mesh = a.mesh_tensor();
+    TT_FATAL(
+        a_mesh.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        a_mesh.mesh_buffer().device_local_size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        b.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        b.mesh_buffer().device_local_size(),
+        in1_single_tile_size);
+
+    TT_FATAL(
+        ashape[-1] == bshape[-2],
+        "Dimension K (A.shape[-1] = {}, B.shape[-2] = {}) must match for matmul",
+        ashape[-1],
+        bshape[-2]);
+    TT_FATAL(
+        ashape[-2] % in0_tile_shape[0] == 0,
+        "A.shape[-2] ({}) must be divisible by tile shape[0] ({})",
+        ashape[-2],
+        in0_tile_shape[0]);
+    TT_FATAL(
+        ashape[-1] % in0_tile_shape[1] == 0,
+        "A.shape[-1] ({}) must be divisible by tile shape[1] ({})",
+        ashape[-1],
+        in0_tile_shape[1]);
+    TT_FATAL(
+        bshape[-2] % in1_tile_shape[0] == 0,
+        "B.shape[-2] ({}) must be divisible by tile shape[0] ({})",
+        bshape[-2],
+        in1_tile_shape[0]);
+    TT_FATAL(
+        bshape[-1] % in1_tile_shape[1] == 0,
+        "B.shape[-1] ({}) must be divisible by tile shape[1] ({})",
+        bshape[-1],
+        in1_tile_shape[1]);
+
+    const auto& compute_kernel_config = operation_attributes.compute_kernel_config.value();
+    const auto& program_config = std::get<operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>(
+        operation_attributes.program_config.value());
+    const auto& in0_block_w = program_config.in0_block_w;
+    const auto& per_core_M = program_config.per_core_M;
+    const auto& per_core_N = program_config.per_core_N;
+    const auto& fused_activation = program_config.fused_activation;
+
+    const auto& untilize_out = operation_attributes.untilize_out;
+    const bool skip_compute = false;
+    const bool skip_in0_mcast = false;
+    const bool skip_write_back = false;
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    uint32_t B = 1;
+    uint32_t Mt = get_batch_size(ashape) * ashape[-2] / in0_tile_shape[0];
+    uint32_t Kt = ashape[-1] / in0_tile_shape[1];
+    uint32_t Nt = bshape[-1] / in1_tile_shape[1];
+    uint32_t in0_last_ktile_w = a.logical_shape()[-1] % in0_tile_shape[1];
+
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
+
+    const auto& output_mesh = output.mesh_tensor();
+
+    return reuse_dram_sharded_optimized_helpers::create_program_dram_sharded_descriptor(
+        device,
+        input_all_cores_storage,
+        output_all_cores_storage,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        dst_full_sync_en,
+        ttnn::get_throttle_level(operation_attributes.compute_kernel_config),
+        B,
+        Mt,
+        Nt,
+        Kt,
+        in0_block_w,
+        in0_last_ktile_w,
+        per_core_M,
+        per_core_N,
+        fused_activation,
+        a_mesh,
+        b,
+        bias_mesh,
+        output_mesh,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        untilize_out,
+        skip_compute,
+        skip_in0_mcast,
+        skip_write_back,
+        row_broadcast_bias);
+}
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_dram_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_dram_sharded_program_factory.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::for_python {
+
+// Metal 1.0 copy of the production factory, frozen for the Python fusion framework.
+// Not part of MatmulDeviceOperation and not on any dispatch path — do not port it to Metal 2.0.
+
+struct MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::MatmulParams& operation_attributes,
+        const ttnn::prim::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+};
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -1,0 +1,639 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "ttnn/operations/matmul/for_python/matmul_multicore_reuse_optimized_program_factory.hpp"
+
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
+
+#include <map>
+#include <string>
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+
+using namespace tt;
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::ComputeConfigDescriptor;
+using tt::tt_metal::KernelDescriptor;
+using tt::tt_metal::ProgramDescriptor;
+using tt::tt_metal::ReaderConfigDescriptor;
+using tt::tt_metal::WriterConfigDescriptor;
+
+using namespace ttnn::prim;
+
+namespace ttnn::for_python {
+
+CoreRangeSet MatmulMultiCoreReuseOptimizedProgramFactory::default_core_range(IDevice* device) {
+    auto grid_size = device->compute_with_storage_grid_size();
+    return CoreRangeSet({CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1})});
+}
+
+tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::create_descriptor(
+    const ttnn::prim::MatmulParams& operation_attributes,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const std::optional<CoreRangeSet>& core_range_set) {
+    TT_FATAL(operation_attributes.program_config.has_value(), "program_config must be provided for create_descriptor");
+    const auto& program_config =
+        std::get<operations::matmul::MatmulMultiCoreReuseProgramConfig>(operation_attributes.program_config.value());
+
+    TT_FATAL(operation_attributes.output_dtype.has_value(), "Output dtype should have been provided");
+    TT_FATAL(operation_attributes.compute_kernel_config.has_value(), "Compute kernel config should have been provided");
+    TT_FATAL(operation_attributes.bcast_batch.has_value(), "Bcast batch should have been provided");
+
+    const auto& a = tensor_args.input_tensors.at(0);
+    const auto& b = tensor_args.input_tensors.at(1);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
+
+    bool bcast_batch = operation_attributes.bcast_batch.value();
+    bool transpose_a = operation_attributes.transpose_a;
+    bool transpose_b = operation_attributes.transpose_b;
+    bool untilize_out = operation_attributes.untilize_out;
+
+    uint32_t in0_block_w = program_config.in0_block_w;
+    uint32_t out_subblock_h = program_config.out_subblock_h;
+    uint32_t out_subblock_w = program_config.out_subblock_w;
+    uint32_t per_core_M = program_config.per_core_M;
+    uint32_t per_core_N = program_config.per_core_N;
+
+    const auto& ashape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const auto& bshape = operations::matmul::utilities::get_matmul_tensor_padded_shape(b, transpose_b);
+    auto in0_tile = operations::matmul::utilities::get_matmul_tile(a, transpose_a);
+    auto in1_tile = operations::matmul::utilities::get_matmul_tile(b, transpose_b);
+
+    const auto& in0_buffer = a.mesh_tensor();
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(in0_buffer.dtype());
+    const auto& in1_buffer = b.mesh_tensor();
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_buffer.dtype());
+    tt::DataFormat output_data_format =
+        tt_metal::datatype_to_dataformat_converter(operation_attributes.output_dtype.value());
+
+    tt_metal::IDevice* device = &in0_buffer.mutable_device();
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());
+
+    if (fp32_dest_acc_en) {
+        TT_FATAL(
+            out_subblock_h * out_subblock_w <= 4,
+            "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
+    }
+
+    uint32_t B = get_batch_size(ashape);
+    uint32_t Mt = operations::matmul::utilities::get_M_dim(ashape, in0_tile, false);
+    uint32_t Kt = operations::matmul::utilities::get_K_dim(ashape, in0_tile);
+    uint32_t Nt = operations::matmul::utilities::get_N_dim(bshape, in1_tile);
+    uint32_t M = Mt;
+    uint32_t N = Nt;
+    uint32_t K = Kt;
+
+    const auto ashape_logical = operations::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    // When transpose_a is true, the K dimension maps to the row dimension of the raw tile,
+    // which is already zero-padded during tile layout conversion. pad_last_ktile operates on
+    // columns, so applying it would incorrectly zero valid data that becomes output rows
+    // after the compute kernel transposes the tile.
+    const auto in0_last_ktile_w = transpose_a ? 0 : ashape_logical[-1] % in0_tile.get_width();
+    const auto in0_last_ktile_h = transpose_a ? ashape_logical[-1] % in0_tile.get_width() : 0;
+    TT_FATAL(
+        in0_last_ktile_w == 0 || in0_last_ktile_h == 0,
+        "At most one of in0_last_ktile_w ({}) and in0_last_ktile_h ({}) can be non-zero",
+        in0_last_ktile_w,
+        in0_last_ktile_h);
+
+    // Derived parameters
+    uint32_t batch_scale_factor = per_core_M > M ? per_core_M / M : 1;
+    uint32_t per_core_M_per_batch = per_core_M > M ? M : per_core_M;
+    uint32_t num_blocks = (K / in0_block_w);
+    bool packer_l1_acc_en = packer_l1_acc && (num_blocks > 2);
+
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    bool in0_is_sharded = in0_buffer.is_sharded();
+    bool in1_is_sharded = in1_buffer.is_sharded();
+    bool output_is_sharded = output.is_sharded();
+
+    // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on Blackhole's
+    // 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at that padded
+    // stride, so the in0/in1 CBs must hold pages at the aligned stride and the reader/unpacker walk
+    // tiles at the same stride. This is a no-op when the tile is already aligned (all bf16 tiles,
+    // 32-wide bfp8, and everything on Wormhole's 32B alignment) and replaces the staging-CB workaround.
+    // Sharded CBs are backed by the tensor buffer and keep their natural page size.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t in0_aligned_tile_size =
+        in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size =
+        in1_is_sharded ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
+
+    // CB sizes
+    uint32_t in0_block_num_tiles = per_core_M_per_batch * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_num_tiles;
+    if (in0_is_sharded) {
+        in0_CB_tiles = per_core_M * K;
+    } else {
+        in0_CB_tiles *= 2;
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_aligned_tile_size;
+    uint32_t in1_block_num_tiles = per_core_N * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_num_tiles;
+    if (in1_is_sharded) {
+        in1_CB_tiles *= num_blocks * batch_scale_factor;
+    } else {
+        in1_CB_tiles *= 2;
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_aligned_tile_size;
+    uint32_t out_block_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_size = out_CB_tiles * interm0_single_tile_size;
+
+    // Optional fused full-tile bias. The whole per-batch [M, N] bias block
+    // is loaded once and reused across the core's batch iterations.
+    const auto bias = ttnn::as_optional_mesh_tensor(tensor_args.optional_input_tensors.at(0));
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
+    tt::tt_metal::Tile bias_tile = output_tile;
+    uint32_t bias_single_tile_size = 0;
+    if (bias.has_value()) {
+        // Defence in depth: guarantees the whole [M, N] bias fits one block so the load-once and
+        // reuse-over-batch scheme is correct. Unreachable via ttnn.linear: get_post_process_bias
+        // only routes a bias here when this precondition already holds.
+        TT_FATAL(
+            N == per_core_N && per_core_M_per_batch == M,
+            "Fused bias in matmul_multicore_reuse requires each batch element's matrix to be a single "
+            "block: N ({}) == per_core_N ({}) and M ({}) == per_core_M_per_batch ({}).",
+            N,
+            per_core_N,
+            M,
+            per_core_M_per_batch);
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(bias->dtype());
+        bias_tile = bias->tensor_spec().tile();
+        bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    }
+    // Full [M, N] per-batch bias block
+    uint32_t in3_block_tiles = per_core_M_per_batch * per_core_N;
+    uint32_t in3_CB_size = in3_block_tiles * bias_single_tile_size;
+
+    // Compute kernel args
+    uint32_t in0_num_subblocks = (per_core_M_per_batch / out_subblock_h);
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+    uint32_t in1_num_subblocks = (per_core_N / out_subblock_w);
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+    uint32_t out_num_subblocks_h = per_core_M_per_batch / out_subblock_h;
+    uint32_t out_num_subblocks_w = in1_num_subblocks;
+    uint32_t num_output_blocks_total = (B * M / per_core_M) * (N / per_core_N);
+
+    std::optional<tt::tt_metal::ShardSpec> shard_spec = std::nullopt;
+    if (in0_is_sharded) {
+        shard_spec = in0_buffer.shard_spec().value();
+    } else if (in1_is_sharded) {
+        shard_spec = in1_buffer.shard_spec().value();
+    } else if (output_is_sharded) {
+        shard_spec = output.shard_spec().value();
+    }
+
+    // Core splitting
+    uint32_t num_cores = 0, num_blocks_per_core_group_1 = 0, num_blocks_per_core_group_2 = 0;
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+
+    if (shard_spec.has_value()) {
+        all_cores = shard_spec.value().grid;
+        num_cores = all_cores.num_cores();
+        core_group_1 = all_cores;
+        num_blocks_per_core_group_1 = num_output_blocks_total / num_cores * batch_scale_factor;
+    } else if (core_range_set.has_value()) {
+        std::tie(
+            num_cores,
+            all_cores,
+            core_group_1,
+            core_group_2,
+            num_blocks_per_core_group_1,
+            num_blocks_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(core_range_set.value(), num_output_blocks_total);
+        num_blocks_per_core_group_1 *= batch_scale_factor;
+        num_blocks_per_core_group_2 *= batch_scale_factor;
+    } else {
+        if (!program_config.allowed_worker_cores.has_value()) {
+            log_warning(
+                tt::LogOp,
+                "MatmulMultiCoreReuseOptimizedProgramFactory: program_config.allowed_worker_cores not populated; "
+                "falling back to compute_with_storage_grid_size. Callers that bypass ttnn::prim::matmul() should "
+                "invoke ttnn::operations::matmul::normalize_program_config() on the program config first. This "
+                "will become a hard error in a future release.");
+        }
+        // Use the CoreRangeSet overload so the output core ranges carry the actual
+        // absolute coordinates (e.g. (4,0)-(7,0)) rather than always starting at (0,0).
+        if (program_config.allowed_worker_cores.has_value()) {
+            std::tie(
+                num_cores,
+                all_cores,
+                core_group_1,
+                core_group_2,
+                num_blocks_per_core_group_1,
+                num_blocks_per_core_group_2) =
+                tt::tt_metal::split_work_to_cores(program_config.allowed_worker_cores.value(), num_output_blocks_total);
+        } else {
+            CoreCoord grid = program_config.compute_with_storage_grid_size;
+            std::tie(
+                num_cores,
+                all_cores,
+                core_group_1,
+                core_group_2,
+                num_blocks_per_core_group_1,
+                num_blocks_per_core_group_2) = tt::tt_metal::split_work_to_cores(grid, num_output_blocks_total);
+        }
+        num_blocks_per_core_group_1 *= batch_scale_factor;
+        num_blocks_per_core_group_2 *= batch_scale_factor;
+    }
+    uint32_t g1_numcores = core_group_1.num_cores();
+    uint32_t num_evenly_divided_output_blocks = num_output_blocks_total / num_cores;
+    TT_FATAL(num_evenly_divided_output_blocks > 0, "Not all cores from core_range was used!");
+
+    const auto in0_tensor_stride_w = transpose_a ? M : 1;
+    const auto in0_tensor_stride_h = transpose_a ? 1 : K;
+    const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
+    const auto in1_tensor_stride_w = transpose_b ? K : 1;
+    const auto in1_tensor_stride_h = transpose_b ? 1 : N;
+    const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
+
+    // Compile time args for reader
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t)in0_tensor_stride_w,
+        (std::uint32_t)in0_tensor_stride_h,
+        (std::uint32_t)in0_tensor_next_block_stride,
+        (std::uint32_t)in0_block_w,
+        (std::uint32_t)per_core_M_per_batch,
+        (std::uint32_t)in0_block_num_tiles,
+        (std::uint32_t)in0_last_ktile_w,
+        (std::uint32_t)in0_last_ktile_h,
+        (std::uint32_t)num_blocks,
+        (std::uint32_t)bcast_batch,
+        (std::uint32_t)M * K,
+    };
+    tt::tt_metal::TensorAccessorArgs(in0_buffer).append_to(reader_compile_time_args);
+
+    // Compile time args for reader/writer
+    std::vector<uint32_t> reader_writer_compile_time_args = {
+        (std::uint32_t)in1_tensor_stride_w,
+        (std::uint32_t)in1_tensor_stride_h,
+        (std::uint32_t)in1_tensor_next_block_stride,
+        (std::uint32_t)per_core_N,
+        (std::uint32_t)in0_block_w,
+        (std::uint32_t)in1_block_num_tiles,
+        (std::uint32_t)num_blocks,
+        (std::uint32_t)bcast_batch,
+        (std::uint32_t)K * N,
+        (std::uint32_t)1,
+        (std::uint32_t)N,
+        (std::uint32_t)out_subblock_w,
+        (std::uint32_t)out_subblock_h * N,
+        (std::uint32_t)out_subblock_w,
+        (std::uint32_t)out_subblock_h,
+        (std::uint32_t)(out_subblock_w * out_subblock_h),
+        (std::uint32_t)out_num_subblocks_w,
+        (std::uint32_t)out_num_subblocks_h,
+        (std::uint32_t)M * N,
+    };
+    tt::tt_metal::TensorAccessorArgs(in1_buffer).append_to(reader_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output).append_to(reader_writer_compile_time_args);
+    if (bias.has_value()) {
+        // Bias accessor CT args follow the output accessor
+        tt::tt_metal::TensorAccessorArgs(bias.value()).append_to(reader_writer_compile_time_args);
+    }
+
+    // Reader defines
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines reader_writer_defines;
+    if (in0_is_sharded) {
+        reader_defines.emplace_back("IN0_SHARDED", "1");
+    }
+    if (in1_is_sharded) {
+        reader_writer_defines.emplace_back("IN1_SHARDED", "1");
+    }
+    if (output_is_sharded) {
+        reader_writer_defines.emplace_back("OUT_SHARDED", "1");
+    }
+    if (bias.has_value()) {
+        reader_writer_defines.emplace_back("FUSE_BIAS", "1");
+    }
+
+    // Named compile-time args for CB indices (enables fusion/chaining)
+    KernelDescriptor::NamedCompileTimeArgs cb_named_args = {
+        {"cb_in0", tt::CBIndex::c_0},
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_intermed0", tt::CBIndex::c_5},
+        {"cb_in0_transposed", tt::CBIndex::c_10},
+    };
+
+    KernelDescriptor::NamedCompileTimeArgs compute_named_args = cb_named_args;
+    if (bias.has_value()) {
+        compute_named_args.push_back({"bias_ntiles", per_core_M_per_batch * per_core_N});
+    }
+
+    // Compute kernel compile time args (group 1)
+    std::vector<uint32_t> compute_kernel_args_group_1 = {
+        in0_block_w,
+        in0_num_subblocks,
+        in0_block_num_tiles,
+        in0_subblock_num_tiles,
+        in1_num_subblocks,
+        in1_block_num_tiles,
+        in1_per_core_w,
+        num_blocks,
+        1,  // out_num_blocks_x
+        1,  // out_num_blocks_y
+        out_subblock_h,
+        out_subblock_w,
+        out_subblock_num_tiles,
+        num_blocks_per_core_group_1,
+        out_block_tiles,
+        untilize_out,
+        false,  // get_batch_from_reader
+        in0_transpose_tile,
+    };
+    if (bias.has_value()) {
+        compute_kernel_args_group_1.push_back(0u);  // arg 18: row_broadcast_bias=false (full-tile bias)
+    }
+
+    // Compute defines
+    std::map<std::string, std::string> mm_kernel_defines;
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+    if (bias.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        // This factory loads the whole per-batch [M, N] bias block, so the compute indexes the bias
+        // by (M-tile-row, N-tile). Other callers of this shared kernel load a single bias row.
+        mm_kernel_defines["BIAS_FULL_BLOCK"] = "1";
+    }
+    const auto throttle_level = ttnn::get_throttle_level(operation_attributes.compute_kernel_config);
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+    KernelDescriptor::Defines compute_defines{mm_kernel_defines.begin(), mm_kernel_defines.end()};
+
+    // Build per-core runtime args
+    bool row_major = false;
+    if (shard_spec.has_value()) {
+        row_major = shard_spec.value().orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR;
+    }
+    const auto cores = corerange_to_cores(all_cores, num_cores, row_major);
+
+    uint32_t m_blocks_per_batch = M / per_core_M_per_batch;
+    uint32_t n_blocks_per_batch = N / per_core_N;
+    uint32_t blocks_per_batch = m_blocks_per_batch * n_blocks_per_batch;
+    uint32_t in0_batch_stride = M * K;
+    uint32_t in1_batch_stride = K * N;
+    uint32_t in0_m_block_stride = per_core_M_per_batch * (transpose_a ? 1 : K);
+    uint32_t in1_n_block_stride = per_core_N * (transpose_b ? K : 1);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build ProgramDescriptor
+    ////////////////////////////////////////////////////////////////////////////
+    ProgramDescriptor program_descriptor;
+
+    // Reader kernel descriptor (created before loop so emplace_runtime_args can be called in loop)
+    KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp";
+    reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = all_cores;
+    reader_kernel_desc.compile_time_args = reader_compile_time_args;
+    reader_kernel_desc.named_compile_time_args = cb_named_args;
+    reader_kernel_desc.defines = reader_defines;
+    reader_kernel_desc.config = ReaderConfigDescriptor{};
+
+    // Reader/Writer kernel descriptor (reads in1, writes output)
+    KernelDescriptor reader_writer_kernel_desc;
+    reader_writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp";
+    reader_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_writer_kernel_desc.core_ranges = all_cores;
+    reader_writer_kernel_desc.compile_time_args = reader_writer_compile_time_args;
+    reader_writer_kernel_desc.named_compile_time_args = cb_named_args;
+    reader_writer_kernel_desc.defines = reader_writer_defines;
+    reader_writer_kernel_desc.config = WriterConfigDescriptor{};
+
+    KernelDescriptor::RuntimeArgs compute_runtime_args_g1;
+    KernelDescriptor::RuntimeArgs compute_runtime_args_g2;
+    compute_runtime_args_g1.reserve(g1_numcores);
+
+    for (uint32_t i = 0, num_blocks_written = 0; i < cores.size(); ++i) {
+        const CoreCoord& core = cores[i];
+        uint32_t num_output_blocks_per_core =
+            i < g1_numcores ? num_blocks_per_core_group_1 : num_blocks_per_core_group_2;
+
+        uint32_t start_batch = num_blocks_written / blocks_per_batch;
+        uint32_t block_within_batch = num_blocks_written % blocks_per_batch;
+        uint32_t start_m_block = block_within_batch / n_blocks_per_batch;
+        uint32_t start_n_block = block_within_batch % n_blocks_per_batch;
+
+        uint32_t in0_start_tile_id = (start_batch * in0_batch_stride) + (start_m_block * in0_m_block_stride);
+        uint32_t in1_start_tile_id =
+            (bcast_batch ? 0 : (start_batch * in1_batch_stride)) + (start_n_block * in1_n_block_stride);
+
+        reader_kernel_desc.emplace_runtime_args(core, {in0_buffer, in0_start_tile_id, num_output_blocks_per_core});
+
+        uint32_t out_start_tile_id =
+            (start_batch * M * N) + (start_m_block * per_core_M_per_batch * N) + (start_n_block * per_core_N);
+        KernelDescriptor::RTArgList rw_args;
+        rw_args.push_back(in1_buffer);
+        rw_args.push_back(in1_start_tile_id);
+        rw_args.push_back(num_output_blocks_per_core);
+        rw_args.push_back(output);
+        rw_args.push_back(out_start_tile_id);
+        if (bias.has_value()) {
+            rw_args.push_back(*bias);
+            // Broadcast over batch, single block per element (start_m_block == start_n_block == 0
+            // under the bias FATAL): the whole [M, N] bias starts at tile 0.
+            rw_args.push_back(0u);  // bias_start_tile_id
+        }
+        reader_writer_kernel_desc.emplace_runtime_args(core, rw_args);
+
+        // Compute kernels have no per-core runtime args
+        if (i < g1_numcores) {
+            compute_runtime_args_g1.emplace_back(core, std::vector<uint32_t>{});
+        } else {
+            compute_runtime_args_g2.emplace_back(core, std::vector<uint32_t>{});
+        }
+
+        num_blocks_written += num_output_blocks_per_core;
+    }
+
+    program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
+    program_descriptor.kernels.push_back(std::move(reader_writer_kernel_desc));
+
+    // Compute kernel descriptor (core group 1)
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp";
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = core_group_1;
+    compute_kernel_desc.compile_time_args = compute_kernel_args_group_1;
+    compute_kernel_desc.named_compile_time_args = compute_named_args;
+    compute_kernel_desc.defines = compute_defines;
+    compute_kernel_desc.runtime_args = std::move(compute_runtime_args_g1);
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode};
+    program_descriptor.kernels.push_back(std::move(compute_kernel_desc));
+
+    // Core group 2 compute kernel (if needed)
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_kernel_args_group_2 = {
+            in0_block_w,
+            in0_num_subblocks,
+            in0_block_num_tiles,
+            in0_subblock_num_tiles,
+            in1_num_subblocks,
+            in1_block_num_tiles,
+            in1_per_core_w,
+            num_blocks,
+            1,  // out_num_blocks_x
+            1,  // out_num_blocks_y
+            out_subblock_h,
+            out_subblock_w,
+            out_subblock_num_tiles,
+            num_blocks_per_core_group_2,
+            out_block_tiles,
+            untilize_out,
+            false,  // get_batch_from_reader
+            in0_transpose_tile,
+        };
+        if (bias.has_value()) {
+            compute_kernel_args_group_2.push_back(0u);  // arg 18: row_broadcast_bias=false
+        }
+
+        KernelDescriptor compute_kernel_desc_g2;
+        compute_kernel_desc_g2.kernel_source =
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/"
+            "bmm_large_block_zm_fused_bias_activation.cpp";
+        compute_kernel_desc_g2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_kernel_desc_g2.core_ranges = core_group_2;
+        compute_kernel_desc_g2.compile_time_args = compute_kernel_args_group_2;
+        compute_kernel_desc_g2.named_compile_time_args = compute_named_args;
+        compute_kernel_desc_g2.defines = compute_defines;
+        compute_kernel_desc_g2.runtime_args = std::move(compute_runtime_args_g2);
+        compute_kernel_desc_g2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode};
+        program_descriptor.kernels.push_back(std::move(compute_kernel_desc_g2));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Build CBDescriptors
+    ////////////////////////////////////////////////////////////////////////////
+    auto make_cb_descriptor = [&all_cores](
+                                  uint32_t total_size,
+                                  uint8_t buffer_index,
+                                  tt::DataFormat data_format,
+                                  uint32_t page_size,
+                                  const tt::tt_metal::Tile& tile,
+                                  const tt_metal::MeshTensor* tensor = nullptr) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = total_size;
+        cb_desc.core_ranges = all_cores;
+        tt::tt_metal::TileDescriptor tile_desc{tile};
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = buffer_index, .data_format = data_format, .page_size = page_size, .tile = tile_desc});
+        cb_desc.tensor = tensor;
+        return cb_desc;
+    };
+
+    // CB 0: Input A
+    program_descriptor.cbs.push_back(make_cb_descriptor(
+        in0_CB_size,
+        tt::CBIndex::c_0,
+        in0_data_format,
+        in0_aligned_tile_size,
+        in0_tile,
+        in0_is_sharded ? &in0_buffer : nullptr));
+
+    // CB 1: Input B
+    program_descriptor.cbs.push_back(make_cb_descriptor(
+        in1_CB_size,
+        tt::CBIndex::c_1,
+        in1_data_format,
+        in1_aligned_tile_size,
+        in1_tile,
+        in1_is_sharded ? &in1_buffer : nullptr));
+
+    // CB 3: Bias (fused elementwise, optional)
+    if (bias.has_value()) {
+        program_descriptor.cbs.push_back(
+            make_cb_descriptor(in3_CB_size, tt::CBIndex::c_3, bias_data_format, bias_single_tile_size, bias_tile));
+    }
+
+    // CB 4 and CB 5: Output and intermediate accumulator
+    if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
+        // Separate output and intermediate CBs
+        program_descriptor.cbs.push_back(make_cb_descriptor(
+
+            out_CB_size,
+            tt::CBIndex::c_4,
+            output_data_format,
+            output_single_tile_size,
+            output_tile,
+            output_is_sharded ? &output : nullptr));
+        program_descriptor.cbs.push_back(make_cb_descriptor(
+            interm0_CB_size, tt::CBIndex::c_5, interm0_data_format, interm0_single_tile_size, output_tile));
+    } else {
+        // Shared output+intermediate CB
+        CBDescriptor output_cb_desc;
+        output_cb_desc.total_size = out_CB_size;
+        output_cb_desc.core_ranges = all_cores;
+        tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+        output_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_4,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        output_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_5,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        output_cb_desc.tensor = output_is_sharded ? &output : nullptr;
+        program_descriptor.cbs.push_back(std::move(output_cb_desc));
+    }
+
+    // Optional transpose CB
+    if (in0_transpose_tile) {
+        program_descriptor.cbs.push_back(
+            make_cb_descriptor(in0_CB_size, tt::CBIndex::c_10, in0_data_format, in0_aligned_tile_size, in0_tile));
+    }
+
+    return program_descriptor;
+}
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_optimized_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_multicore_reuse_optimized_program_factory.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
+namespace ttnn::for_python {
+
+// Metal 1.0 copy of the production factory, frozen for the Python fusion framework.
+// Not part of MatmulDeviceOperation and not on any dispatch path — do not port it to Metal 2.0.
+
+struct MatmulMultiCoreReuseOptimizedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ttnn::prim::MatmulParams& operation_attributes,
+        const ttnn::prim::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value,
+        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+
+    static CoreRangeSet default_core_range(IDevice* device);
+};
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_program_factory_for_python.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_program_factory_for_python.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/matmul/for_python/matmul_program_factory_for_python.hpp"
+
+#include "ttnn/operations/matmul/device/config/matmul_program_config.hpp"
+
+namespace ttnn::for_python {
+
+MatmulProgramFactory select_matmul_program_factory(
+    const ttnn::prim::MatmulParams& operation_attributes, const ttnn::prim::MatmulInputs& /*tensor_args*/) {
+    const auto& config = operation_attributes.program_config.value();
+
+    return std::visit(
+        [](const auto& c) -> MatmulProgramFactory {
+            using T = std::decay_t<decltype(c)>;
+            if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreProgramConfig>) {
+                return MatmulMultiCoreProgramFactory{};
+            } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                return MatmulMultiCoreReuseOptimizedProgramFactory{};
+            } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
+                return MatmulMultiCoreReuseMcast2DProgramFactory{};
+            } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                TT_FATAL(!c.gather_in0, "gather_in0 is not supported in the descriptor interface");
+                return MatmulMultiCoreReuseMcast1DProgramFactory{};
+            } else if constexpr (std::is_same_v<
+                                     T,
+                                     operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
+                return MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory{};
+            } else if constexpr (
+                std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+                return MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory{};
+            } else {
+                TT_THROW("Unknown program config type");
+            }
+        },
+        config);
+}
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_program_factory_for_python.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/for_python/matmul_program_factory_for_python.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <variant>
+
+#include "ttnn/operations/matmul/for_python/matmul_multicore_program_factory.hpp"
+#include "ttnn/operations/matmul/for_python/matmul_multicore_reuse_optimized_program_factory.hpp"
+#include "ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_1d_program_factory.hpp"
+#include "ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_2d_program_factory.hpp"
+#include "ttnn/operations/matmul/for_python/matmul_multicore_reuse_mcast_dram_sharded_program_factory.hpp"
+#include "ttnn/operations/matmul/for_python/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp"
+
+namespace ttnn::for_python {
+
+using MatmulProgramFactory = std::variant<
+    MatmulMultiCoreProgramFactory,
+    MatmulMultiCoreReuseOptimizedProgramFactory,
+    MatmulMultiCoreReuseMcast1DProgramFactory,
+    MatmulMultiCoreReuseMcast2DProgramFactory,
+    MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory,
+    MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory>;
+
+// gather_in0 selects a MeshWorkload factory that never had a create_descriptor entry point,
+// so it is rejected here instead of being returned.
+MatmulProgramFactory select_matmul_program_factory(
+    const ttnn::prim::MatmulParams& operation_attributes, const ttnn::prim::MatmulInputs& tensor_args);
+
+}  // namespace ttnn::for_python

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -18,7 +18,7 @@
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include "ttnn/operations/matmul/device/config/matmul_program_config.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation.hpp"
-#include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.hpp"
+#include "ttnn/operations/matmul/for_python/matmul_program_factory_for_python.hpp"
 #include "ttnn-nanobind/bind_function.hpp"
 #include "ttnn-nanobind/json_class.hpp"
 #include "ttnn/operations/matmul/matmul.hpp"
@@ -1222,15 +1222,15 @@ void py_module(nb::module_& mod) {
             nb::arg("tensor_args"));
 
     // Bind MatmulMultiCoreReuseOptimizedProgramFactory for descriptor creation
-    nb::class_<ttnn::prim::MatmulMultiCoreReuseOptimizedProgramFactory>(
-        mod, "MatmulMultiCoreReuseOptimizedProgramFactory")
+    nb::class_<ttnn::for_python::MatmulMultiCoreReuseOptimizedProgramFactory>(
+        mod, "MatmulMultiCoreReuseOptimizedProgramFactoryForPython")
         .def_static(
             "create_descriptor",
             [](const ttnn::prim::MatmulParams& operation_attributes,
                const ttnn::prim::MatmulInputs& tensor_args,
                std::vector<ttnn::Tensor>& tensor_return_value,
                const std::optional<CoreRangeSet>& core_range_set) {
-                return ttnn::prim::MatmulMultiCoreReuseOptimizedProgramFactory::create_descriptor(
+                return ttnn::for_python::MatmulMultiCoreReuseOptimizedProgramFactory::create_descriptor(
                     operation_attributes, tensor_args, tensor_return_value, core_range_set);
             },
             nb::arg("operation_attributes"),
@@ -1239,18 +1239,18 @@ void py_module(nb::module_& mod) {
             nb::arg("core_range_set") = std::nullopt)
         .def_static(
             "default_core_range",
-            &ttnn::prim::MatmulMultiCoreReuseOptimizedProgramFactory::default_core_range,
+            &ttnn::for_python::MatmulMultiCoreReuseOptimizedProgramFactory::default_core_range,
             nb::arg("device"));
 
     // Bind MatmulMultiCoreProgramFactory for descriptor creation
-    nb::class_<ttnn::prim::MatmulMultiCoreProgramFactory>(mod, "MatmulMultiCoreProgramFactory")
+    nb::class_<ttnn::for_python::MatmulMultiCoreProgramFactory>(mod, "MatmulMultiCoreProgramFactoryForPython")
         .def_static(
             "create_descriptor",
             [](const ttnn::prim::MatmulParams& operation_attributes,
                const ttnn::prim::MatmulInputs& tensor_args,
                std::vector<ttnn::Tensor>& tensor_return_value,
                const std::optional<CoreRangeSet>& core_range_set) {
-                return ttnn::prim::MatmulMultiCoreProgramFactory::create_descriptor(
+                return ttnn::for_python::MatmulMultiCoreProgramFactory::create_descriptor(
                     operation_attributes, tensor_args, tensor_return_value, core_range_set);
             },
             nb::arg("operation_attributes"),
@@ -1259,14 +1259,15 @@ void py_module(nb::module_& mod) {
             nb::arg("core_range_set") = std::nullopt);
 
     // Bind MatmulMultiCoreReuseMcast1DProgramFactory for descriptor creation
-    nb::class_<ttnn::prim::MatmulMultiCoreReuseMcast1DProgramFactory>(mod, "MatmulMultiCoreReuseMcast1DProgramFactory")
+    nb::class_<ttnn::for_python::MatmulMultiCoreReuseMcast1DProgramFactory>(
+        mod, "MatmulMultiCoreReuseMcast1DProgramFactoryForPython")
         .def_static(
             "create_descriptor",
             [](const ttnn::prim::MatmulParams& operation_attributes,
                const ttnn::prim::MatmulInputs& tensor_args,
                std::vector<ttnn::Tensor>& tensor_return_value,
                const std::optional<CoreRangeSet>& core_range_set) {
-                return ttnn::prim::MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
+                return ttnn::for_python::MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
                     operation_attributes, tensor_args, tensor_return_value, core_range_set);
             },
             nb::arg("operation_attributes"),
@@ -1275,14 +1276,15 @@ void py_module(nb::module_& mod) {
             nb::arg("core_range_set") = std::nullopt);
 
     // Bind MatmulMultiCoreReuseMcast2DProgramFactory for descriptor creation
-    nb::class_<ttnn::prim::MatmulMultiCoreReuseMcast2DProgramFactory>(mod, "MatmulMultiCoreReuseMcast2DProgramFactory")
+    nb::class_<ttnn::for_python::MatmulMultiCoreReuseMcast2DProgramFactory>(
+        mod, "MatmulMultiCoreReuseMcast2DProgramFactoryForPython")
         .def_static(
             "create_descriptor",
             [](const ttnn::prim::MatmulParams& operation_attributes,
                const ttnn::prim::MatmulInputs& tensor_args,
                std::vector<ttnn::Tensor>& tensor_return_value,
                const std::optional<CoreRangeSet>& core_range_set) {
-                return ttnn::prim::MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
+                return ttnn::for_python::MatmulMultiCoreReuseMcast2DProgramFactory::create_descriptor(
                     operation_attributes, tensor_args, tensor_return_value, core_range_set);
             },
             nb::arg("operation_attributes"),
@@ -1291,15 +1293,15 @@ void py_module(nb::module_& mod) {
             nb::arg("core_range_set") = std::nullopt);
 
     // Bind MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory for descriptor creation
-    nb::class_<ttnn::prim::MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory>(
-        mod, "MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory")
+    nb::class_<ttnn::for_python::MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory>(
+        mod, "MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactoryForPython")
         .def_static(
             "create_descriptor",
             [](const ttnn::prim::MatmulParams& operation_attributes,
                const ttnn::prim::MatmulInputs& tensor_args,
                std::vector<ttnn::Tensor>& tensor_return_value,
                const std::optional<CoreRangeSet>& core_range_set) {
-                return ttnn::prim::MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create_descriptor(
+                return ttnn::for_python::MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create_descriptor(
                     operation_attributes, tensor_args, tensor_return_value, core_range_set);
             },
             nb::arg("operation_attributes"),
@@ -1308,15 +1310,15 @@ void py_module(nb::module_& mod) {
             nb::arg("core_range_set") = std::nullopt);
 
     // Bind MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory for descriptor creation
-    nb::class_<ttnn::prim::MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory>(
-        mod, "MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory")
+    nb::class_<ttnn::for_python::MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory>(
+        mod, "MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactoryForPython")
         .def_static(
             "create_descriptor",
             [](const ttnn::prim::MatmulParams& operation_attributes,
                const ttnn::prim::MatmulInputs& tensor_args,
                std::vector<ttnn::Tensor>& tensor_return_value,
                const std::optional<CoreRangeSet>& core_range_set) {
-                return ttnn::prim::MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create_descriptor(
+                return ttnn::for_python::MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create_descriptor(
                     operation_attributes, tensor_args, tensor_return_value, core_range_set);
             },
             nb::arg("operation_attributes"),
@@ -1326,8 +1328,8 @@ void py_module(nb::module_& mod) {
 
     // Bind select_program_factory for Python-side factory dispatch
     mod.def(
-        "matmul_select_program_factory",
-        &ttnn::prim::MatmulDeviceOperation::select_program_factory,
+        "matmul_select_program_factory_for_python",
+        &ttnn::for_python::select_matmul_program_factory,
         nb::arg("operation_attributes"),
         nb::arg("tensor_args"));
 

--- a/ttnn/cpp/ttnn/operations/matmul/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/matmul/sources.cmake
@@ -30,7 +30,6 @@ set(TTNN_OP_MATMUL_API_HEADERS
     device/config/matmul_program_config.hpp
     device/config/matmul_program_config_types.hpp
     shared_with_host/activation_type.hpp
-    for_python/matmul_program_factory_for_python.hpp
 )
 
 # Registered on the shared `ttnn` Python module target from

--- a/ttnn/cpp/ttnn/operations/matmul/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/matmul/sources.cmake
@@ -12,6 +12,13 @@ set(TTNN_OP_MATMUL_SRCS
     device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
     device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
     device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+    for_python/matmul_multicore_program_factory.cpp
+    for_python/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+    for_python/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+    for_python/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+    for_python/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+    for_python/matmul_multicore_reuse_optimized_program_factory.cpp
+    for_python/matmul_program_factory_for_python.cpp
     device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
     device/sparse/sparse_matmul_device_operation.cpp
 )
@@ -23,6 +30,7 @@ set(TTNN_OP_MATMUL_API_HEADERS
     device/config/matmul_program_config.hpp
     device/config/matmul_program_config_types.hpp
     shared_with_host/activation_type.hpp
+    for_python/matmul_program_factory_for_python.hpp
 )
 
 # Registered on the shared `ttnn` Python module target from

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -485,9 +485,9 @@ from ttnn.operations.matmul import (
     MatmulParams,
     MatmulInputs,
     MatmulDeviceOperation,
-    MatmulMultiCoreReuseOptimizedProgramFactory,
+    MatmulMultiCoreReuseOptimizedProgramFactoryForPython,
     create_matmul_attributes,
-    matmul_select_program_factory,
+    matmul_select_program_factory_for_python,
 )
 
 from ttnn.operations.normalization import (

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -22,9 +22,11 @@ MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig = (
 MatmulParams = ttnn._ttnn.operations.matmul.MatmulParams
 MatmulInputs = ttnn._ttnn.operations.matmul.MatmulInputs
 MatmulDeviceOperation = ttnn._ttnn.operations.matmul.MatmulDeviceOperation
-MatmulMultiCoreReuseOptimizedProgramFactory = ttnn._ttnn.operations.matmul.MatmulMultiCoreReuseOptimizedProgramFactory
+MatmulMultiCoreReuseOptimizedProgramFactoryForPython = (
+    ttnn._ttnn.operations.matmul.MatmulMultiCoreReuseOptimizedProgramFactoryForPython
+)
 create_matmul_attributes = ttnn._ttnn.operations.matmul.create_matmul_attributes
-matmul_select_program_factory = ttnn._ttnn.operations.matmul.matmul_select_program_factory
+matmul_select_program_factory_for_python = ttnn._ttnn.operations.matmul.matmul_select_program_factory_for_python
 
 
 def _golden_function(


### PR DESCRIPTION
### Problem

`models/experimental/ops/descriptors/` (the experimental fusion framework) is the only Python consumer of the descriptor pybinds. It calls `<Factory>.create_descriptor(...)` to get a `ProgramDescriptor` and runs it through `generic_op`.

`generic_op` accepts only `ProgramDescriptor`/`MeshProgramDescriptor`. A Metal 2.0 factory produces `ProgramArtifacts` via `create_program_artifacts`, and no `ProgramArtifacts -> ProgramDescriptor` lowering exists. So porting a factory silently removes it from the fusion framework.

This already happened here: the three ported `quasar/matmul` factories carry comments saying their `create_descriptor` entry point was dropped, and `experimental/quasar/slice` (fully MetalV2) no longer binds any factory at all.

### Change

Adds frozen Metal 1.0 copies of all six bound matmul factories under `ttnn::for_python`, in `ttnn/cpp/ttnn/operations/matmul/for_python/`:

- `MatmulMultiCoreProgramFactory`
- `MatmulMultiCoreReuseOptimizedProgramFactory` (+ `default_core_range`)
- `MatmulMultiCoreReuseMcast1DProgramFactory`
- `MatmulMultiCoreReuseMcast2DProgramFactory`
- `MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory`
- `MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory`

Because each production file is wrapped in a single `namespace ttnn::prim { ... }`, rewriting the outer namespace carried the nested `reuse_*_optimized_helpers` namespaces along, so the copies own their own helpers. Nothing in them links back to production descriptor-building code, and there is no ODR overlap.

The `ttnn::prim` factories are now free to be ported to Metal 2.0 without breaking Python. The copies carry "do not port" comments.

`select_program_factory` had to be forked too: it returns the factory *variant*, so keeping the production binding would hand Python post-migration types with no `create_descriptor`. `ttnn.matmul_select_program_factory` becomes `ttnn.matmul_select_program_factory_for_python`. The `gather_in0` case now raises directly instead of returning the MeshWorkload factory, which never had a `create_descriptor` entry point — the Python caller already rejected it explicitly.

Python-visible factory names gain a `ForPython` suffix so a caller can tell they are on the frozen path.

### Scope notes

This is the largest of the three PRs by line count (~12k), because the mcast 1D/2D helper namespaces are large and are the code that actually builds the descriptors. It is a mechanical copy — no logic was changed.

- `MatmulParams` / `MatmulInputs` / `create_output_tensors` / `compute_output_specs` stay bound to production — they survive the port.
- `compute_program_hash` also stays on production. Spec-as-key does delete it, so this is the remaining exposure, but freezing a hash is a keying decision and is deliberately left out of this PR.
- The copies still call `matmul::utilities` (`get_M_dim`, `get_matmul_tile`, ...). Those are pure shape/config helpers and do not encode the execution model, so forking them would buy no migration safety and only create drift.

### Testing

Built with `build_metal.sh`. 258 fusion tests pass locally on hardware (`tests/ttnn/unit_tests/operations/fused/parallel_sequential/`), covering all four matmul factory routes exercised by the framework.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/for-python-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/for-python-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/for-python-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/for-python-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/for-python-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/for-python-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/for-python-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/for-python-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/for-python-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/for-python-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/for-python-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/for-python-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/for-python-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/for-python-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/for-python-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/for-python-matmul)