### PR TITLE
[moe_compute] Remove expert-count-dependent TRISC2 stack allocation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -288,13 +288,6 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* num_tokens_per_expert_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_w2c_md_read_ptr[0]);
 
-    // Precompute NUM_CHUNKS_PER_EXPERT
-    uint32_t NUM_CHUNKS_PER_EXPERT[num_experts];
-    for (uint32_t expert_id = 0; expert_id < num_experts; ++expert_id) {
-        uint32_t num_tokens = num_tokens_per_expert_ptr[expert_id];
-        NUM_CHUNKS_PER_EXPERT[expert_id] = (num_tokens + tokens_per_chunk - 1) / tokens_per_chunk;
-    }
-
     // Value we wait on that indicates the next chunk of tiles have arrived from the tilize cores
     uint32_t matmul_chunk_ready_semaphore_wait_value = 1;
     uint32_t matmul_chunk_ready_semaphore_addr = cb_w2c_md_read_ptr[1];
@@ -309,7 +302,8 @@ void kernel_main() {
     // This decides which half of the buffer will have the valid data sent by tilize cores
     bool use_second_half_buffer = false;
     for (uint32_t expert_id = 0; expert_id < num_experts; ++expert_id) {
-        uint32_t num_expert_chunks = NUM_CHUNKS_PER_EXPERT[expert_id];
+        const uint32_t num_tokens = num_tokens_per_expert_ptr[expert_id];
+        const uint32_t num_expert_chunks = (num_tokens + tokens_per_chunk - 1) / tokens_per_chunk;
         for (uint32_t chunk = 0; chunk < num_expert_chunks; ++chunk) {
             // GELU re-inits its SFPU LUT inside pack_compute_activation on every iteration (the
             // trailing MUL there clobbers it), so it's its own initializer — skip the per-chunk


### PR DESCRIPTION
Closes #52374

## Summary

Remove the expert-count-sized stack allocation from the `moe_compute` compute kernel. This eliminates expert-count-dependent TRISC2 stack growth on Wormhole.

## Background

`compute.cpp` currently precomputes each expert's chunk count into a `uint32_t[num_experts]` stack array. E192 leaves only 64 bytes in the conservative call chain, and the E256 kernel uses 1168 bytes against the 976-byte effective TRISC2 stack.

Each value is consumed only once, at the start of its expert iteration. `tokens_per_chunk` is compile-time constant in the validated configuration, so the replacement chunk-count expression lowers to a load, add, and right shift; it does not emit a divide/remainder instruction or helper call.

## Changes

- Remove the per-expert chunk-count array and its initialization loop.
- Load the current expert's token count and compute its chunk count directly in the expert loop, reducing this storage from O(experts) to O(1).

## Testing

Validated at commit `3e61a4708e49f7ef7ce2b05462daf701dd4b5848` on Wormhole B0 n150 L with Watcher enabled:

- E128 ComputeOnly passed operation execution, host readback, and all numerical checks.
- E192 ComputeOnly completed the device operation, then timed out at the first host readback. Watcher reported no kernel exception.
- On a clean N150 board, E256 ComputeOnly completed the device operation, then Watcher reported a separate `dm1.cpp` BRISC stack overflow with 0 bytes free. The first host readback subsequently timed out, so numerical checks and the non-Watcher control were not run.

Post-change E128, E192, and E256 TRISC2 ELFs have identical stack frames: 128 bytes conservative use, leaving 848 bytes against the 976-byte effective budget. E256 Watcher runtime reported 776 bytes free for `compute.cpp` TRISC2.

The change removes expert-count-dependent TRISC2 stack growth through E256. Current production `moe_compute` configurations use at most 9 local experts and checked-in single-card tests use at most 16. Synthetic E256 is accepted without a capability guard, but separate expert-scaled allocations exceed the effective stack in `dm1.cpp` and both tilize data-movement kernels. Those limits are outside this PR's scope and prevent claiming full E256 runtime support.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjett/52374-wh-trisc2-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjett/52374-wh-trisc2-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sjett/52374-wh-trisc2-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sjett/52374-wh-trisc2-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sjett/52374-wh-trisc2-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sjett/52374-wh-trisc2-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjett/52374-wh-trisc2-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjett/52374-wh-trisc2-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjett/52374-wh-trisc2-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjett/52374-wh-trisc2-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sjett/52374-wh-trisc2-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sjett/52374-wh-trisc2-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sjett/52374-wh-trisc2-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sjett/52374-wh-trisc2-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sjett/52374-wh-trisc2-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sjett/52374-wh-trisc2-stack)
