### PR TITLE
DO NOT MERGE: CI re-repro v2 for #52290 (post-fix verification)

### DIFF
--- a/tt_metal/common/env_lib.hpp
+++ b/tt_metal/common/env_lib.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+// CI repro: no-op comment to flip the tt-metalium-changed path filter and
+// trigger runtime-examples / sdk-examples [wh_n150_civ2] for tt-metal#52290.
 #include <cstdint>
 #include <map>
 #include <vector>


### PR DESCRIPTION
**DO NOT MERGE.**

Re-run of #52346, rebased on current main. #52346's rerun hit an unrelated
submodule-checkout failure on \`asan-build\`, likely from merging a
several-days-stale fork branch against current main. This branch is synced
fresh off upstream main to avoid that.

Purpose: confirm tenstorrent/github-ci-infra#1526/#1528 (the fetch-mechanism
fix + prod rollout) actually fixes the timeout behavior from #52290 on live
external-fork PR jobs. Single no-op comment change, same as #52346.

Will close (not merge) once the `runtime sdk examples [wh_n150_civ2]` timing
is captured.