### PR TITLE
[moe_compute] Drain pending NoC atomics before ComputeOnly exit

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
@@ -462,7 +462,7 @@ void kernel_main() {
     if constexpr (compute_only) {
         // Non-posted matmul->combine writes need ACK-barrier (not just issuer-queue flush)
         // so destination L1 is committed before host reads matmul_output_tensor.
-        noc1_obj.async_write_barrier();
+        noc1_obj.async_full_barrier();
     } else {
         // wait for combine to do its final semaphore increment before resetting. Otherwise, leads to hang.
         combine_sem.wait(combine_semaphore_val);


### PR DESCRIPTION
Closes #52519

## Summary

Drain all outstanding NoC1 transactions before the `moe_compute` ComputeOnly
`dm1.cpp` kernel exits. This prevents BRISC from completing with pending
semaphore atomics on Blackhole.

## Background and changes

The ComputeOnly path issues posted NoC1 semaphore increments for ring and tilize
drain synchronization. Its exit currently calls `async_write_barrier()`, which
waits for writes but not the separate atomic transaction queue.

Change the ComputeOnly exit barrier in `dm1.cpp` from
`async_write_barrier()` to `async_full_barrier()`. The full barrier preserves
write completion and also drains the outstanding atomics before kernel
completion. No other paths or files are changed.

## Testing

Validated against current `main`
(`43b49ac51772717e16529c8199bb0ab3bb071c35`) on Blackhole p150b:

- On unmodified `main`, both the minimal `T=1`, `E=16`, `H=2048`, `N=512`
  ComputeOnly case and the existing DeepSeek-shaped `T=32`, `E=16`, `H=7168`,
  `N=2048` ComputeOnly case aborted under Watcher with the exact pending-NoC
  `dm1.cpp` diagnostic.
- Both baseline cases passed their numerical checks without Watcher.
- With only the barrier update, both Watcher cases passed without the
  pending-NoC diagnostic.
- Both patched no-Watcher controls passed their numerical checks.
- DeepSeek and GPT-OSS FullLocal controls passed under Watcher with all
  numerical outputs and cache-hit combine validation passing. Neither produced
  a pending-NoC diagnostic or kernel-completion race.

The same Watcher diagnostic was previously reproduced on Blackhole p100a.
FullCcl remains outside the single-card validation scope.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjett/52519-moe-compute-dm1-noc-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjett/52519-moe-compute-dm1-noc-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sjett/52519-moe-compute-dm1-noc-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sjett/52519-moe-compute-dm1-noc-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sjett/52519-moe-compute-dm1-noc-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sjett/52519-moe-compute-dm1-noc-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjett/52519-moe-compute-dm1-noc-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjett/52519-moe-compute-dm1-noc-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjett/52519-moe-compute-dm1-noc-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjett/52519-moe-compute-dm1-noc-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sjett/52519-moe-compute-dm1-noc-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sjett/52519-moe-compute-dm1-noc-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sjett/52519-moe-compute-dm1-noc-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sjett/52519-moe-compute-dm1-noc-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sjett/52519-moe-compute-dm1-noc-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sjett/52519-moe-compute-dm1-noc-barrier)