### PR TITLE
[Bug fix] Fix tensor prefetcher stop() deadlocking under the Tracy device profiler

### DIFF
--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -1228,8 +1228,13 @@ void TensorPrefetcherManager::stop() {
     }
 
     // Wait for kernels to drain their request loop (they exit on the sentinel).
+    // read_device_profiler_results must be false: we hold the (non-recursive) MeshDevice api
+    // lock, and the profiler read reaches enqueue_read_shard_from_core, which takes that same
+    // lock. With the device profiler off the read is a no-op, so this only deadlocks under
+    // tracy. Nothing is lost by skipping it — the read covers worker/eth cores, not the DRAM
+    // cores this program runs on, and the profiler still drains on Finish and at device close.
     for (uint32_t d = 0; d < devices_.size(); ++d) {
-        ::tt::tt_metal::detail::WaitProgramDone(devices_[d], *programs_[d]);
+        ::tt::tt_metal::detail::WaitProgramDone(devices_[d], *programs_[d], /*read_device_profiler_results=*/false);
     }
 
     sockets_.clear();


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #52515 — any code using the DRAM tensor prefetcher hangs under the Tracy profiler.

`TensorPrefetcherManager::stop()` holds the MeshDevice api lock — a plain, non-recursive
`std::mutex` — for its whole body, and inside it called `detail::WaitProgramDone()`, whose
`read_device_profiler_results` parameter defaults to `true`:

```
TensorPrefetcherManager::stop()                       <- holds api_mutex_
`- detail::WaitProgramDone(..., read_profiler = true)
   `- detail::ReadDeviceProfilerResults(device)        <- early-returns when profiler is OFF
      `- DeviceProfiler::readResults -> readControlBuffers -> readControlBufferForCore
         `- FDMeshCommandQueue::enqueue_read_shard_from_core
            `- lock_api_function_() -> MeshDeviceImpl::lock_api() -> pthread_mutex_lock  <- deadlock
```

With the device profiler off, `ReadDeviceProfilerResults` early-returns on
`getDeviceProfilerState()` and never re-enters the command queue, which is why this only
appears under Tracy / `TT_METAL_DEVICE_PROFILER=1`. It is a hard hang — pytest's signal
timeout cannot break it, because the block is inside a native call that never returns to
Python. The stack above is from a `gdb` attach to a hung run.

The fix passes the flag off explicitly. That read is whole-device (worker and active-eth
cores, from `getVirtualCoresForProfiling`, which does not include DRAM cores) and is
unrelated to the program being waited on, so no prefetcher profiling data is lost — the
profiler still drains on `Finish` and at device close.

`start()` was already safe: it passes `wait_until_cores_done=false`, which gates the same
profiler call inside `LaunchProgram`.

### Notes for reviewers

Verified on a p100a at firmware 19.12.0.0 with
`tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py`:

| | before | after |
| --- | --- | --- |
| `TT_METAL_DEVICE_PROFILER=1` | hung indefinitely | 50 passed / 3 skipped |
| full `python -m tracy -v -r -p` | not reached | 50 passed / 3 skipped, trace + ops CSV generated |
| profiler off | 50 passed / 3 skipped | 50 passed / 3 skipped |

The 3 skips are the recv-contig cases that need 8 unharvested DRAM banks; this board is a
harvested 7-bank part.

Two things worth a reviewer's eye:

- The general hazard is that any code holding the MeshDevice api lock and calling a
  `detail::` API which bottoms out in the command queue will deadlock, and it stays
  invisible until someone enables the profiler. `WaitProgramDone` and `LaunchProgram` both
  default their profiler-read/wait flags to `true`, so they are easy to trip. I chose to
  turn the flag off rather than narrow the lock, because the lock also serializes
  `queue()` / `stop()` / `enqueue_cq_signal_and_wait` ordering (see the comment in
  `enqueue_cq_signal_and_wait`) and narrowing it risks that invariant. Happy to go the
  other way if reviewers prefer.
- Separately found while investigating, **not fixed here**: with
  `TT_METAL_DEVICE_PROFILER=1 TT_METAL_PROFILER_ACCUMULATE=1` the DRISC kernel fails to
  build with `undefined reference to kernel_profiler::wIndex` / `stackSize`. `DO_ACCUMULATE`
  in `kernel_profiler.hpp` excludes ERISC/IDLE_ERISC/AERISC but not DRISC, and `drisc.cc`
  does not define the profiler globals that the other firmwares do. That is a clean build
  error rather than a hang, and belongs with the broader "profiler support on DRISC cores"
  work.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tracy-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/tensor-prefetcher-tracy-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tracy-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/tensor-prefetcher-tracy-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tracy-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/tensor-prefetcher-tracy-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tracy-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/tensor-prefetcher-tracy-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tracy-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/tensor-prefetcher-tracy-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tracy-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/tensor-prefetcher-tracy-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tracy-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/tensor-prefetcher-tracy-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tracy-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/tensor-prefetcher-tracy-deadlock)