### PR TITLE
[skip ci] Restrict stale-PR workflow to Monday-Thursday

### DIFF
--- a/.github/workflows/close-stale-prs.yaml
+++ b/.github/workflows/close-stale-prs.yaml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   schedule:
-    - cron: "0 5 * * *"   # Runs nightly at 05:00 UTC
+    - cron: "0 5 * * 1-4"   # Runs at 05:00 UTC, Monday through Thursday
   workflow_dispatch: # Allows manual trigger
 
 jobs:


### PR DESCRIPTION
Follow-up to #52343.

## Summary
The stale-PR closer added in #52343 ran nightly. This restricts it to **Monday through Thursday** so that there is always a working day after a run to notice and fix any issues (e.g. a PR closed that should not have been).

## Change
```diff
-    - cron: "0 5 * * *"   # Runs nightly at 05:00 UTC
+    - cron: "0 5 * * 1-4"   # Runs at 05:00 UTC, Monday through Thursday
```

Cron day-of-week `1-4` = Monday, Tuesday, Wednesday, Thursday.

## Note on manual triggering
A manual trigger was also requested, but `workflow_dispatch` was already present in #52343, so no change was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbakerTT/close-stale-prs-weekdays-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbakerTT/close-stale-prs-weekdays-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbakerTT/close-stale-prs-weekdays-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbakerTT/close-stale-prs-weekdays-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbakerTT/close-stale-prs-weekdays-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbakerTT/close-stale-prs-weekdays-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbakerTT/close-stale-prs-weekdays-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbakerTT/close-stale-prs-weekdays-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbakerTT/close-stale-prs-weekdays-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbakerTT/close-stale-prs-weekdays-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbakerTT/close-stale-prs-weekdays-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbakerTT/close-stale-prs-weekdays-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbakerTT/close-stale-prs-weekdays-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbakerTT/close-stale-prs-weekdays-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbakerTT/close-stale-prs-weekdays-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbakerTT/close-stale-prs-weekdays-only)