### PR TITLE
fix flux clip regression by reversing ring attention accumulation order

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -251,9 +251,8 @@ void kernel_main() {
             continue;
         }
         // Sharded joint: one L/P shard per ring iteration — process joint K/V on every iteration.
-        // Replicated joint: Already present full joint K/V is processd after all spatial K/V is consumed.
-        const bool do_joint_kv =
-            has_gathered_joint_k ? true : is_last_active_ring_iter(active_ring_iter_mask, ring_iter);
+        // Replicated joint: All data already present process joint when ring_id == ring_size-1
+        const bool do_joint_kv = has_gathered_joint_k ? true : (ring_id == ring_size - 1);
         const uint32_t num_kv_chunks = do_joint_kv ? num_local_k_chunks + num_joint_k_chunks : num_local_k_chunks;
         const bool is_first_active_iter = !seen_active_iter;
         seen_active_iter = true;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -690,9 +690,8 @@ void kernel_main() {
         // slice is read from the local joint tensor, same as spatial). Each shard is available right
         // after its ring_id sync, so we process joint K/V on EVERY ring iteration — no need to batch
         // at the end.
-        // Replicated joint: Already present full joint K/V is processd after all spatial K/V is consumed.
-        const bool do_joint_kv =
-            has_gathered_joint_k ? true : is_last_active_ring_iter(active_ring_iter_mask, ring_iter);
+        // Replicated joint: process joint when ring_id == ring_size-1
+        const bool do_joint_kv = has_gathered_joint_k ? true : (ring_id == ring_size - 1);
         uint32_t num_kv_chunks = num_local_k_chunks;
         if constexpr (has_joint_k) {
             if (do_joint_kv) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -607,9 +607,8 @@ void kernel_main() {
             continue;
         }
         // Sharded joint: one L/P shard per ring iteration — process joint K/V on every iteration.
-        // Replicated joint: Already present full joint K/V is processd after all spatial K/V is consumed.
-        const bool do_joint_kv =
-            has_gathered_joint_k ? true : is_last_active_ring_iter(active_ring_iter_mask, ring_iter);
+        // Replicated joint: process joint when ring_id == ring_size-1.
+        const bool do_joint_kv = has_gathered_joint_k ? true : (ring_id == ring_size - 1);
         uint32_t num_kv_chunks = num_local_k_chunks;
         if constexpr (has_joint_k) {
             if (do_joint_kv) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -252,12 +252,12 @@ RingWorkPlan build_ring_work_plan(
         const uint32_t ring_id = seq.get_next_ring_id(noop_sync);
         // Sharded joint: each ring iteration delivers one L/P shard immediately, so process
         // joint K/V on every ring iteration (no need to wait for the full gather to complete).
-        // Replicated joint: Already present full joint K/V is processd after all spatial K/V is consumed.
+        // Replicated joint: process joint when ring_id == ring_size-1
         const bool has_joint_work = derivation.num_joint_k_chunks > 0 && derivation.joint_seq_len != 0;
         // Whether this ring iteration is a candidate to consume joint K/V at all (sharded: every iter;
-        // replicated: only the last, when the full gather has completed).
+        // replicated: when ring_id == ring_size-1, matching the kernel's do_joint_kv condition).
         const bool joint_iter_selected =
-            has_joint_work && (derivation.joint_is_sharded || ring_iter == derivation.ring_size - 1);
+            has_joint_work && (derivation.joint_is_sharded || ring_id == derivation.ring_size - 1);
         // Count only the joint K chunks that carry REAL tokens, mirroring the kernel's
         // kv_chunk_is_beyond_logical_l skip: a joint chunk whose global start tile
         // (ring_id * joint_local_padded_Nt + k * k_chunk_tile_count) is at/after logical_lt is pure
@@ -864,7 +864,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         - for each KV chunk in kv_local_padded_N:
             - on the first ring iteration, read from local input_tensor_k and input_tensor_v
             - otherwise, read from gathered_input_tensor_k and gathered_input_tensor_v
-            - Replicated joint: on the last ring iteration, also read from joint_tensor_k/v (full L).
+            - Replicated joint: when ring_id == ring_size-1, also read from joint_tensor_k/v (full L).
             - Sharded joint: on every ring iteration, read one L_local shard from gathered_joint_k/v
               (or from the local joint_tensor_k/v when ring_id == this device's ring_index).
             - if the KV chunk is from the non-joint input and contains the global token index (logical_n - 1),


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
To link an issue:  Fixes #52412 

### Notes for reviewers
Simply restore "arbitrary" older accumulation order of ring_id == ring_size-1

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sadesoye/revert_sdpa_replicated_strategy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sadesoye/revert_sdpa_replicated_strategy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sadesoye/revert_sdpa_replicated_strategy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sadesoye/revert_sdpa_replicated_strategy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sadesoye/revert_sdpa_replicated_strategy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sadesoye/revert_sdpa_replicated_strategy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/revert_sdpa_replicated_strategy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/revert_sdpa_replicated_strategy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sadesoye/revert_sdpa_replicated_strategy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sadesoye/revert_sdpa_replicated_strategy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sadesoye/revert_sdpa_replicated_strategy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sadesoye/revert_sdpa_replicated_strategy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/revert_sdpa_replicated_strategy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/revert_sdpa_replicated_strategy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sadesoye/revert_sdpa_replicated_strategy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sadesoye/revert_sdpa_replicated_strategy)