### PR TITLE
Fix silent clang-tidy PR-comment drop for violations with no auto-fix

### DIFF
--- a/.github/scripts/clang_tidy_report.py
+++ b/.github/scripts/clang_tidy_report.py
@@ -83,10 +83,19 @@ def _build_suggestion(file_path: str, replacements: list) -> Suggestion | None:
     violation has a Replacement at all: compiler-diagnostic-class findings
     (clang-diagnostic-error and friends) have none, since clang can't auto-fix
     "no such member" the way it can auto-fix a stylistic clang-tidy check.
+
+    A Replacement carries its own FilePath, which is not always the diagnostic's
+    file (e.g. a fix in a macro/header pulled in by the diagnostic file). rdjson
+    suggestions have no path of their own — they inherit the diagnostic's — so a
+    replacement targeting a different file can't be represented as a suggestion;
+    doing so anyway would convert its offset against the wrong file's bytes and
+    could publish a corrupting one-click "fix".
     """
     if len(replacements) != 1 or not file_path:
         return None
     rep = replacements[0]
+    if rep.get("FilePath") != file_path:
+        return None
     offset, length = rep.get("Offset"), rep.get("Length")
     if not isinstance(offset, int) or not isinstance(length, int):
         return None
@@ -358,6 +367,40 @@ Diagnostics:
             self.assertEqual(v.suggestion.text, "long")
             self.assertEqual((v.suggestion.start_line, v.suggestion.start_col), (1, 1))
             self.assertEqual((v.suggestion.end_line, v.suggestion.end_col), (1, 4))
+
+    def test_replacement_targeting_another_file_does_not_become_a_suggestion(self):
+        # Regression (caught by Copilot review on the live demo PR): a Replacement's
+        # own FilePath can differ from the diagnostic's file (e.g. a fix inside a
+        # header pulled in by the diagnostic file). Converting its offset against
+        # the diagnostic file's bytes would compute a bogus line/col and could
+        # publish a corrupting one-click suggestion.
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            src = self._write(tmp, "foo.cpp", "int x = 1;\nint y = 2;\n")
+            other = self._write(tmp, "foo.hpp", "int z = 3;\n")
+            self._write(
+                tmp,
+                "foo.cpp-abc.yaml",
+                f"""---
+MainSourceFile: '{src}'
+Diagnostics:
+  - DiagnosticName: modernize-use-nullptr
+    DiagnosticMessage:
+      Message: 'use nullptr'
+      FilePath: '{src}'
+      FileOffset: 0
+      Replacements:
+        - FilePath: '{other}'
+          Offset: 0
+          Length: 3
+          ReplacementText: 'long'
+    Level: Warning
+...
+""",
+            )
+            v = parse_fixes_dir(tmp)[0]
+            self.assertIsNone(v.suggestion)
 
     def test_multiple_replacements_do_not_become_a_suggestion(self):
         import tempfile

--- a/.github/scripts/clang_tidy_report.py
+++ b/.github/scripts/clang_tidy_report.py
@@ -19,6 +19,7 @@ Usage:
     clang_tidy_report.py <fixes-dir> --format list
     clang_tidy_report.py <fixes-dir> --format summary-md
     clang_tidy_report.py <fixes-dir> --format annotations [--max-annotations N]
+    clang_tidy_report.py <fixes-dir> --format rdjson
     clang_tidy_report.py --self-test
 """
 
@@ -26,11 +27,29 @@ from __future__ import annotations
 
 import argparse
 import glob as _glob
+import json
 import sys
 import unittest
 from dataclasses import dataclass
 
 import yaml
+
+
+@dataclass
+class Suggestion:
+    """A single-span replacement, suitable for a GitHub "suggested change" block.
+
+    Only built when a diagnostic has exactly one Replacement — GitHub suggestions
+    replace one contiguous range, so multiple disjoint replacements for the same
+    diagnostic can't be represented as a single suggestion without guessing how
+    to merge them.
+    """
+
+    start_line: int
+    start_col: int
+    end_line: int
+    end_col: int
+    text: str
 
 
 @dataclass
@@ -40,6 +59,7 @@ class Violation:
     file_path: str
     line: int | None
     col: int | None
+    suggestion: Suggestion | None = None
 
 
 def _offset_to_line_col(file_path: str, offset: int) -> tuple[int | None, int | None]:
@@ -53,6 +73,28 @@ def _offset_to_line_col(file_path: str, offset: int) -> tuple[int | None, int | 
     last_newline = data.rfind(b"\n")
     col = offset - last_newline
     return line, col
+
+
+def _build_suggestion(file_path: str, replacements: list) -> Suggestion | None:
+    """Build a Suggestion from a diagnostic's Replacements, or None if not representable.
+
+    Only diagnostics with exactly one Replacement produce a suggestion — see the
+    Suggestion docstring for why more than one can't be merged safely. Not every
+    violation has a Replacement at all: compiler-diagnostic-class findings
+    (clang-diagnostic-error and friends) have none, since clang can't auto-fix
+    "no such member" the way it can auto-fix a stylistic clang-tidy check.
+    """
+    if len(replacements) != 1 or not file_path:
+        return None
+    rep = replacements[0]
+    offset, length = rep.get("Offset"), rep.get("Length")
+    if not isinstance(offset, int) or not isinstance(length, int):
+        return None
+    start_line, start_col = _offset_to_line_col(file_path, offset)
+    end_line, end_col = _offset_to_line_col(file_path, offset + length)
+    if start_line is None or end_line is None:
+        return None
+    return Suggestion(start_line, start_col, end_line, end_col, rep.get("ReplacementText", ""))
 
 
 def parse_fixes_dir(fixes_dir: str, repo_root: str | None = None) -> list[Violation]:
@@ -86,6 +128,7 @@ def parse_fixes_dir(fixes_dir: str, repo_root: str | None = None) -> list[Violat
             if repo_root and file_path.startswith(repo_root):
                 display_path = file_path[len(repo_root) :].lstrip("/")
             message = (msg.get("Message") or "").strip().splitlines()[0] if msg.get("Message") else ""
+            suggestion = _build_suggestion(file_path, msg.get("Replacements") or [])
             violations.append(
                 Violation(
                     check=diag.get("DiagnosticName", "unknown-check"),
@@ -93,6 +136,7 @@ def parse_fixes_dir(fixes_dir: str, repo_root: str | None = None) -> list[Violat
                     file_path=display_path,
                     line=line,
                     col=col,
+                    suggestion=suggestion,
                 )
             )
     violations.sort(key=lambda v: (v.file_path, v.line or 0, v.col or 0))
@@ -156,10 +200,47 @@ def format_annotations(violations: list[Violation], max_annotations: int) -> str
     return "\n".join(lines)
 
 
+def format_rdjson(violations: list[Violation]) -> str:
+    """Emit reviewdog's rdjson diagnostic format, for `reviewdog -f=rdjson`.
+
+    Unlike posting a `git diff` (post-`clang-apply-replacements`) through reviewdog's
+    diff reporter, this reports every violation directly from the parsed YAML —
+    including violations with no machine-applicable fix, which a fix-diff can never
+    represent because there's nothing to diff. Violations with a single Replacement
+    get a suggested-change block; everything else gets a plain review comment.
+    """
+    diagnostics = []
+    for v in violations:
+        location: dict = {"path": v.file_path}
+        if v.line:
+            location["range"] = {
+                "start": {"line": v.line, "column": v.col or 1},
+                "end": {"line": v.line, "column": v.col or 1},
+            }
+        diagnostic = {
+            "message": v.message or f"clang-tidy: {v.check}",
+            "location": location,
+            "severity": "ERROR" if v.check == "clang-diagnostic-error" else "WARNING",
+            "code": {"value": v.check},
+        }
+        if v.suggestion:
+            diagnostic["suggestions"] = [
+                {
+                    "range": {
+                        "start": {"line": v.suggestion.start_line, "column": v.suggestion.start_col},
+                        "end": {"line": v.suggestion.end_line, "column": v.suggestion.end_col},
+                    },
+                    "text": v.suggestion.text,
+                }
+            ]
+        diagnostics.append(diagnostic)
+    return json.dumps({"source": {"name": "clang-tidy"}, "diagnostics": diagnostics})
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("fixes_dir", nargs="?", help="Directory containing clang-tidy --export-fixes *.yaml files")
-    parser.add_argument("--format", choices=["count", "list", "summary-md", "annotations"], default="list")
+    parser.add_argument("--format", choices=["count", "list", "summary-md", "annotations", "rdjson"], default="list")
     parser.add_argument("--repo-root", default=None, help="Strip this prefix from absolute file paths")
     parser.add_argument("--max-annotations", type=int, default=50)
     parser.add_argument("--self-test", action="store_true", help="Run unit tests and exit")
@@ -183,6 +264,8 @@ def main(argv: list[str]) -> int:
         out = format_annotations(violations, args.max_annotations)
         if out:
             print(out)
+    elif args.format == "rdjson":
+        print(format_rdjson(violations))
     return 0
 
 
@@ -243,6 +326,70 @@ Diagnostics:
             self.assertEqual(v.check, "bugprone-integer-division")
             self.assertEqual(v.line, 2)
             self.assertIn("truncated", v.message)
+            self.assertIsNone(v.suggestion)
+
+    def test_single_replacement_becomes_a_suggestion(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            src = self._write(tmp, "foo.cpp", "int x = 1;\nint y = 2;\n")
+            self._write(
+                tmp,
+                "foo.cpp-abc.yaml",
+                f"""---
+MainSourceFile: '{src}'
+Diagnostics:
+  - DiagnosticName: modernize-use-nullptr
+    DiagnosticMessage:
+      Message: 'use nullptr'
+      FilePath: '{src}'
+      FileOffset: 0
+      Replacements:
+        - FilePath: '{src}'
+          Offset: 0
+          Length: 3
+          ReplacementText: 'long'
+    Level: Warning
+...
+""",
+            )
+            v = parse_fixes_dir(tmp)[0]
+            self.assertIsNotNone(v.suggestion)
+            self.assertEqual(v.suggestion.text, "long")
+            self.assertEqual((v.suggestion.start_line, v.suggestion.start_col), (1, 1))
+            self.assertEqual((v.suggestion.end_line, v.suggestion.end_col), (1, 4))
+
+    def test_multiple_replacements_do_not_become_a_suggestion(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            src = self._write(tmp, "foo.cpp", "int x = 1;\nint y = 2;\n")
+            self._write(
+                tmp,
+                "foo.cpp-abc.yaml",
+                f"""---
+MainSourceFile: '{src}'
+Diagnostics:
+  - DiagnosticName: readability-two-part-fix
+    DiagnosticMessage:
+      Message: 'needs two edits'
+      FilePath: '{src}'
+      FileOffset: 0
+      Replacements:
+        - FilePath: '{src}'
+          Offset: 0
+          Length: 3
+          ReplacementText: 'long'
+        - FilePath: '{src}'
+          Offset: 11
+          Length: 3
+          ReplacementText: 'long'
+    Level: Warning
+...
+""",
+            )
+            v = parse_fixes_dir(tmp)[0]
+            self.assertIsNone(v.suggestion)
 
     def test_skips_unparseable_file_without_crashing(self):
         import tempfile
@@ -293,6 +440,43 @@ class TestFormatters(unittest.TestCase):
         vs = [Violation(check="c", message="a | b", file_path="x.cpp", line=1, col=1)]
         md = format_summary_md(vs)
         self.assertIn("a \\| b", md)
+
+    def test_format_rdjson_reports_violation_with_no_fix(self):
+        # The exact case that silently dropped comments: a clang-diagnostic-error
+        # has no Replacements, so a post-fix `git diff` would be empty for it.
+        vs = [
+            Violation(check="clang-diagnostic-error", message="no member named 'X'", file_path="a.cpp", line=5, col=3)
+        ]
+        doc = json.loads(format_rdjson(vs))
+        self.assertEqual(len(doc["diagnostics"]), 1)
+        diag = doc["diagnostics"][0]
+        self.assertEqual(diag["severity"], "ERROR")
+        self.assertEqual(diag["location"]["path"], "a.cpp")
+        self.assertEqual(diag["location"]["range"]["start"], {"line": 5, "column": 3})
+        self.assertNotIn("suggestions", diag)
+
+    def test_format_rdjson_includes_suggestion_when_present(self):
+        suggestion = Suggestion(start_line=1, start_col=1, end_line=1, end_col=4, text="long")
+        vs = [
+            Violation(
+                check="modernize-use-nullptr",
+                message="use nullptr",
+                file_path="a.cpp",
+                line=1,
+                col=1,
+                suggestion=suggestion,
+            )
+        ]
+        doc = json.loads(format_rdjson(vs))
+        diag = doc["diagnostics"][0]
+        self.assertEqual(diag["severity"], "WARNING")
+        self.assertEqual(
+            diag["suggestions"],
+            [{"range": {"start": {"line": 1, "column": 1}, "end": {"line": 1, "column": 4}}, "text": "long"}],
+        )
+
+    def test_format_rdjson_empty_violations(self):
+        self.assertEqual(json.loads(format_rdjson([]))["diagnostics"], [])
 
 
 if __name__ == "__main__":

--- a/.github/workflows/clang-tidy-reusable.yaml
+++ b/.github/workflows/clang-tidy-reusable.yaml
@@ -334,22 +334,15 @@ jobs:
           python3 "$REPORT" "$FIXES_DIR" --format list --repo-root "$(pwd)"
           python3 "$REPORT" "$FIXES_DIR" --format summary-md --repo-root "$(pwd)" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Apply clang-tidy fixes to working tree
-        # success() so a genuine build failure (partial YAMLs) doesn't post misleading fixes.
-        if: ${{ inputs.post-pr-suggestions && github.event_name == 'pull_request' && success() }}
-        run: |
-          FIXES_DIR=".build/clang-tidy/fixes"
-          if ls "$FIXES_DIR"/*.yaml 2>/dev/null | grep -q .; then
-            if command -v clang-apply-replacements-20 &>/dev/null; then
-              clang-apply-replacements-20 "$FIXES_DIR"
-            else
-              clang-apply-replacements "$FIXES_DIR"
-            fi
-          else
-            echo "No fix files found in $FIXES_DIR — nothing to suggest"
-          fi
-
       - name: Post inline clang-tidy suggestions on PR
+        # success() so a genuine build failure (partial YAMLs) doesn't post misleading comments.
+        # Reports every violation straight from the export-fixes YAML via rdjson, not a
+        # `clang-apply-replacements` + `git diff` round-trip: a violation with no
+        # machine-applicable fix (e.g. clang-diagnostic-error compile errors, which carry no
+        # Replacements) produces an empty diff, so the old diff-based reviewdog reporter had
+        # nothing to parse and silently posted zero PR comments even though the job failed
+        # correctly. rdjson reports the diagnostic regardless, and still renders a one-click
+        # "suggested change" for violations that do have a single unambiguous Replacement.
         if: ${{ inputs.post-pr-suggestions && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && success() }}
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
@@ -357,14 +350,15 @@ jobs:
           # /tmp is noexec (--tmpfs /tmp). Install reviewdog to /usr/local/bin instead.
           curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
             | sh -s -- -b /usr/local/bin v0.21.0
-          git diff | reviewdog \
-            -f diff \
-            -name clang-tidy \
-            -reporter github-pr-review \
-            -filter-mode diff_context \
-            -level warning \
-            -fail-level none \
-            -fail-on-error false
+          uv pip install --quiet PyYAML
+          python3 .github/scripts/clang_tidy_report.py ".build/clang-tidy/fixes" --format rdjson --repo-root "$(pwd)" \
+            | reviewdog \
+              -f=rdjson \
+              -name clang-tidy \
+              -reporter github-pr-review \
+              -filter-mode diff_context \
+              -level warning \
+              -fail-level none
 
       - name: Fail on clang-tidy violations
         # !cancelled() so it still gates when posting steps are skipped (non-PR runs).


### PR DESCRIPTION
## Problem

`code-analysis.yaml`'s "Post inline clang-tidy suggestions on PR" step is supposed to comment on the PR when clang-tidy finds violations, but on #52425 it silently posted nothing even though the job correctly failed with 3 violations.

## Root cause

The step ran `clang-apply-replacements` against the exported fixes, then piped `git diff` through reviewdog's diff reporter. All 3 violations on #52425 are `clang-diagnostic-error` — real compile errors surfaced through clang-tidy (`no member named 'TensorAccessorArgs' in namespace 'tt::tt_metal'`), not stylistic clang-tidy-check violations. Compiler-diagnostic-class findings carry no `Replacements` in the exported YAML (clang can't auto-fix "no such member"), so `clang-apply-replacements` correctly changes nothing, `git diff` is empty, and reviewdog parses zero findings from an empty diff — silently posting 0 comments. Meanwhile the separate "Fail on clang-tidy violations" step still failed the job correctly from its own YAML-based count, so nothing about the run *looked* broken.

This is a design gap, not a flake: any violation without a machine-applicable fix (every compile-error-class finding, plus many stylistic clang-tidy checks) silently produced zero PR comments.

## Fix

- Added `clang_tidy_report.py --format rdjson`, which reports every parsed violation directly from the export-fixes YAML — not a post-fix working-tree diff. Violations with exactly one `Replacement` still render as a one-click GitHub "suggested change"; everything else (including `clang-diagnostic-error`) gets a plain review comment instead of nothing.
- Rewired "Post inline clang-tidy suggestions on PR" to pipe that rdjson output into `reviewdog -f=rdjson` instead of `git diff | reviewdog -f diff`.
- Dropped the now-dead "Apply clang-tidy fixes to working tree" step.
- A Replacement carries its own `FilePath`, which isn't always the diagnostic's file (e.g. a fix inside a header). Caught by Copilot's review on the validation PR: only build a suggestion when the replacement's file matches the diagnostic's, so a cross-file replacement can't be converted against the wrong file's bytes and published as a corrupting suggestion.

18 unit tests cover the parser and both formatters (rdjson message-only, rdjson with a suggestion, single- vs multi- vs cross-file replacement handling).

## Validation

Opened a throwaway `DO NOT MERGE` PR (#52548, now closed) combining #52425's real branch (unmodified) with this fix, so the exact same 3 `TensorAccessorArgs` violations would run through a real `pull_request`-triggered job. Confirmed: all 3 posted as review comments on lines 143/144/165 via `github-actions[bot]`/reviewdog, where #52425's own run posted none.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=afuller/fix-clang-tidy-notifications)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:afuller/fix-clang-tidy-notifications)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=afuller/fix-clang-tidy-notifications)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:afuller/fix-clang-tidy-notifications)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=afuller/fix-clang-tidy-notifications)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:afuller/fix-clang-tidy-notifications)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=afuller/fix-clang-tidy-notifications)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:afuller/fix-clang-tidy-notifications)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=afuller/fix-clang-tidy-notifications)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:afuller/fix-clang-tidy-notifications)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=afuller/fix-clang-tidy-notifications)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:afuller/fix-clang-tidy-notifications)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=afuller/fix-clang-tidy-notifications)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:afuller/fix-clang-tidy-notifications)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=afuller/fix-clang-tidy-notifications)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:afuller/fix-clang-tidy-notifications)