### PR TITLE
[Feature] Add support for per core allocator on socket buffers

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -2048,6 +2048,7 @@ void verify_socket_configs_match(const SocketConfig& config_a, const SocketConfi
     EXPECT_EQ(config_a.socket_mem_config.fifo_size, config_b.socket_mem_config.fifo_size);
     EXPECT_EQ(config_a.socket_mem_config.sender_sub_device, config_b.socket_mem_config.sender_sub_device);
     EXPECT_EQ(config_a.socket_mem_config.receiver_sub_device, config_b.socket_mem_config.receiver_sub_device);
+    EXPECT_EQ(config_a.socket_mem_config.per_core_allocation, config_b.socket_mem_config.per_core_allocation);
     EXPECT_EQ(config_a.sender_mesh_id, config_b.sender_mesh_id);
     EXPECT_EQ(config_a.receiver_mesh_id, config_b.receiver_mesh_id);
     EXPECT_EQ(config_a.sender_rank, config_b.sender_rank);
@@ -2272,6 +2273,74 @@ TEST(SocketSerializationTest, PeerDesc) {
     EXPECT_EQ(deserialized_recv_socket_desc.config_buffer_address, recv_socket_peer_desc_l1.config_buffer_address);
     EXPECT_EQ(deserialized_send_socket_desc.data_buffer_address, send_socket_peer_desc_l1.data_buffer_address);
     EXPECT_EQ(deserialized_recv_socket_desc.data_buffer_address, recv_socket_peer_desc_l1.data_buffer_address);
+}
+
+// Verify that the per_core_allocation flag survives serialization round-trip and is a distinguishing attribute
+// (feeds the handshake equality check in validate_remote_desc).
+TEST(SocketSerializationTest, PeerDescPerCoreAllocation) {
+    std::size_t socket_fifo_size = 2048;
+    SocketConnection socket_connection(
+        MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(0, 0)), MeshCoreCoord(MeshCoordinate(1, 0), CoreCoord(0, 1)));
+
+    for (bool per_core : {false, true}) {
+        SocketMemoryConfig socket_mem_config(
+            BufferType::L1,
+            socket_fifo_size,
+            /*sender_sub_device=*/std::nullopt,
+            /*receiver_sub_device=*/std::nullopt,
+            /*per_core_allocation=*/per_core);
+        EXPECT_EQ(socket_mem_config.per_core_allocation, per_core);
+
+        SocketConfig socket_config({socket_connection}, socket_mem_config, tt_fabric::MeshId{0}, tt_fabric::MeshId{1});
+        SocketPeerDescriptor recv_desc = SocketPeerDescriptor{
+            .config = socket_config,
+            .config_buffer_address = 1 << 21,
+            .data_buffer_address = 1 << 22,
+        };
+
+        auto serialized = serialize_to_bytes(recv_desc);
+        SocketPeerDescriptor deserialized = deserialize_from_bytes(serialized);
+        EXPECT_EQ(deserialized.config.socket_mem_config.per_core_allocation, per_core);
+        verify_socket_configs_match(deserialized.config, recv_desc.config);
+    }
+}
+
+// ================== Per-Core Allocation Guardrail (Negative) Tests ==================
+// These run on the default LOCKSTEP fixture. The config-only guardrails (storage type + single receiver core)
+// are checked before the HYBRID-mode requirement, so they fire regardless of allocator mode; the HYBRID-mode
+// guardrail itself fires because this fixture opens the device in LOCKSTEP mode.
+
+TEST_F(MeshSocketTest, PerCoreAllocationRequiresHybridMode) {
+    auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
+    SocketConnection connection(
+        MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(0, 0)), MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(0, 1)));
+    SocketMemoryConfig mem_config(BufferType::L1, 1024, std::nullopt, std::nullopt, /*per_core_allocation=*/true);
+    SocketConfig socket_config({connection}, mem_config);
+    // Device opened in LOCKSTEP mode => per-core allocation must fail fast.
+    EXPECT_THROW(MeshSocket::create_socket_pair(md0, md0, socket_config), std::exception);
+}
+
+TEST_F(MeshSocketTest, PerCoreAllocationRejectsDramStorage) {
+    auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
+    SocketConnection connection(
+        MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(0, 0)), MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(0, 1)));
+    SocketMemoryConfig mem_config(BufferType::DRAM, 1024, std::nullopt, std::nullopt, /*per_core_allocation=*/true);
+    SocketConfig socket_config({connection}, mem_config);
+    EXPECT_THROW(MeshSocket::create_socket_pair(md0, md0, socket_config), std::exception);
+}
+
+TEST_F(MeshSocketTest, PerCoreAllocationRejectsMultipleReceiverCores) {
+    auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
+    // Two connections targeting two distinct receiver cores => v1 per-core restriction violated.
+    std::vector<SocketConnection> connections = {
+        SocketConnection(
+            MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(0, 0)), MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(0, 2))),
+        SocketConnection(
+            MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(1, 0)), MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(1, 2))),
+    };
+    SocketMemoryConfig mem_config(BufferType::L1, 1024, std::nullopt, std::nullopt, /*per_core_allocation=*/true);
+    SocketConfig socket_config(connections, mem_config);
+    EXPECT_THROW(MeshSocket::create_socket_pair(md0, md0, socket_config), std::exception);
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tests/tt_metal/tt_metal/api/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/api/CMakeLists.txt
@@ -87,6 +87,7 @@ target_include_directories(
     PRIVATE
         ${PROJECT_SOURCE_DIR}/tests
         ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+        ${PROJECT_SOURCE_DIR}
 )
 target_link_libraries(unit_tests_per_core_allocation PRIVATE test_metal_common_libs)
 target_precompile_headers(unit_tests_per_core_allocation REUSE_FROM metal_common_pch)

--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
@@ -6,12 +6,19 @@
 // These tests require a real device (slow dispatch).
 
 #include <cstdlib>
+#include <cstring>
+#include <utility>
+#include <vector>
 #include <gtest/gtest.h>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp>
+#include <tt-metalium/experimental/sockets/mesh_socket.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include "tests/tt_metal/tt_metal/common/device_fixture.hpp"
+#include "tt_metal/hw/inc/hostdev/socket.h"
 
 namespace tt::tt_metal {
 
@@ -152,6 +159,112 @@ TEST_F(PerCoreAllocationTest, DeallocationFreesPerCoreSpace) {
     auto buf2 = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
     EXPECT_TRUE(per_core::is_per_core_allocation(*buf2));
     EXPECT_TRUE(buf2->is_allocated());
+}
+
+// ================== Per-core socket data-buffer allocation (Phase B) ==================
+// Exercises SocketMemoryConfig{..., per_core_allocation=true}: the receiver FIFO should be allocated with the
+// per-core allocator (only on the receiver connection core) instead of lockstep across every worker core, and
+// the handshake metadata should carry that per-core address.
+
+namespace {
+
+// Builds a single-connection, single-device (md == md) per-core socket on the fixture's first unit mesh.
+std::pair<distributed::MeshSocket, distributed::MeshSocket> make_per_core_socket(
+    const std::shared_ptr<distributed::MeshDevice>& md,
+    const CoreCoord& sender_core,
+    const CoreCoord& receiver_core,
+    uint32_t fifo_size) {
+    distributed::SocketConnection connection(
+        distributed::MeshCoreCoord(distributed::MeshCoordinate(0, 0), sender_core),
+        distributed::MeshCoreCoord(distributed::MeshCoordinate(0, 0), receiver_core));
+    distributed::SocketMemoryConfig mem_config(
+        BufferType::L1,
+        fifo_size,
+        /*sender_sub_device=*/std::nullopt,
+        /*receiver_sub_device=*/std::nullopt,
+        /*per_core_allocation=*/true);
+    distributed::SocketConfig socket_config({connection}, mem_config);
+    return distributed::MeshSocket::create_socket_pair(md, md, socket_config);
+}
+
+}  // namespace
+
+TEST_F(PerCoreAllocationTest, PerCoreSocketDataBufferPlacement) {
+    auto md = this->devices_[0];
+    auto* device = md->get_devices()[0];
+
+    const CoreCoord sender_core(0, 0);
+    const CoreCoord receiver_core(0, 1);
+    const uint32_t fifo_size = 2048;
+
+    auto [send_socket, recv_socket] = make_per_core_socket(md, sender_core, receiver_core, fifo_size);
+
+    auto data_buffer = recv_socket.get_data_buffer();
+    ASSERT_TRUE(per_core::is_per_core_allocation(*data_buffer));
+
+    // The FIFO occupies L1 only on the receiver core, at a valid per-core address.
+    auto pc_addr = per_core::get_per_core_address(*data_buffer, receiver_core);
+    EXPECT_GT(pc_addr, 0u) << "Receiver per-core address should be above the L1 base";
+    EXPECT_LT(pc_addr, device->l1_size_per_core()) << "Receiver per-core address exceeds L1 size";
+
+    // A per-core buffer has no single lockstep address.
+    EXPECT_EQ(data_buffer->address(), 0u);
+}
+
+TEST_F(PerCoreAllocationTest, PerCoreSocketCoexistsWithLockstep) {
+    auto md = this->devices_[0];
+    auto* device = md->get_devices()[0];
+
+    const CoreCoord sender_core(0, 0);
+    const CoreCoord receiver_core(0, 1);
+    const uint32_t fifo_size = 2048;
+
+    auto [send_socket, recv_socket] = make_per_core_socket(md, sender_core, receiver_core, fifo_size);
+    auto pc_addr = per_core::get_per_core_address(*recv_socket.get_data_buffer(), receiver_core);
+
+    // A subsequent lockstep L1 buffer spanning the receiver core must not alias the per-core socket FIFO.
+    CoreRange grid(CoreCoord(0, 0), CoreCoord(1, 0));
+    ShardSpecBuffer shard_spec(CoreRangeSet(grid), {32, 32}, ShardOrientation::ROW_MAJOR, {32, 32}, {2, 1});
+    auto lockstep_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
+    auto lockstep_buf = Buffer::create(device, 2 * PAGE_SIZE, PAGE_SIZE, BufferType::L1, lockstep_args);
+    EXPECT_TRUE(lockstep_buf->is_allocated());
+    EXPECT_NE(lockstep_buf->address(), pc_addr) << "Lockstep buffer aliases the per-core socket FIFO";
+}
+
+TEST_F(PerCoreAllocationTest, PerCoreSocketConfigMetadataUsesPerCoreAddress) {
+    auto md = this->devices_[0];
+
+    const CoreCoord sender_core(0, 0);
+    const CoreCoord receiver_core(0, 1);
+    const uint32_t fifo_size = 2048;
+
+    auto [send_socket, recv_socket] = make_per_core_socket(md, sender_core, receiver_core, fifo_size);
+    auto pc_addr = per_core::get_per_core_address(*recv_socket.get_data_buffer(), receiver_core);
+
+    // The receiver's on-device config must point read_ptr/fifo_addr at the receiver core's per-core address.
+    std::vector<receiver_socket_md> recv_config_readback;
+    distributed::ReadShard(
+        md->mesh_command_queue(),
+        recv_config_readback,
+        recv_socket.get_config_buffer(),
+        distributed::MeshCoordinate(0, 0));
+    ASSERT_EQ(recv_config_readback.size(), 1u);
+    EXPECT_EQ(recv_config_readback[0].fifo_addr, pc_addr);
+    EXPECT_EQ(recv_config_readback[0].read_ptr, pc_addr);
+    EXPECT_EQ(recv_config_readback[0].fifo_total_size, fifo_size);
+
+    // The sender's downstream_fifo_addr must match the same per-core address.
+    std::vector<uint8_t> sender_config_bytes;
+    distributed::ReadShard(
+        md->mesh_command_queue(),
+        sender_config_bytes,
+        send_socket.get_config_buffer(),
+        distributed::MeshCoordinate(0, 0));
+    ASSERT_GE(sender_config_bytes.size(), sizeof(sender_socket_md));
+    sender_socket_md sender_md{};
+    std::memcpy(&sender_md, sender_config_bytes.data(), sizeof(sender_socket_md));
+    EXPECT_EQ(sender_md.downstream_fifo_addr, pc_addr);
+    EXPECT_EQ(sender_md.downstream_fifo_total_size, fifo_size);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
@@ -203,7 +203,7 @@ TEST_F(PerCoreAllocationTest, PerCoreSocketDataBufferPlacement) {
     ASSERT_TRUE(per_core::is_per_core_allocation(*data_buffer));
 
     // The FIFO occupies L1 only on the receiver core, at a valid per-core address.
-    auto pc_addr = per_core::get_per_core_address(*data_buffer, receiver_core);
+    auto pc_addr = per_core::get_per_core_address(*data_buffer, distributed::MeshCoordinate(0, 0), receiver_core);
     EXPECT_GT(pc_addr, 0u) << "Receiver per-core address should be above the L1 base";
     EXPECT_LT(pc_addr, device->l1_size_per_core()) << "Receiver per-core address exceeds L1 size";
 
@@ -220,7 +220,8 @@ TEST_F(PerCoreAllocationTest, PerCoreSocketCoexistsWithLockstep) {
     const uint32_t fifo_size = 2048;
 
     auto [send_socket, recv_socket] = make_per_core_socket(md, sender_core, receiver_core, fifo_size);
-    auto pc_addr = per_core::get_per_core_address(*recv_socket.get_data_buffer(), receiver_core);
+    auto pc_addr = per_core::get_per_core_address(
+        *recv_socket.get_data_buffer(), distributed::MeshCoordinate(0, 0), receiver_core);
 
     // A subsequent lockstep L1 buffer spanning the receiver core must not alias the per-core socket FIFO.
     CoreRange grid(CoreCoord(0, 0), CoreCoord(1, 0));
@@ -239,7 +240,8 @@ TEST_F(PerCoreAllocationTest, PerCoreSocketConfigMetadataUsesPerCoreAddress) {
     const uint32_t fifo_size = 2048;
 
     auto [send_socket, recv_socket] = make_per_core_socket(md, sender_core, receiver_core, fifo_size);
-    auto pc_addr = per_core::get_per_core_address(*recv_socket.get_data_buffer(), receiver_core);
+    auto pc_addr = per_core::get_per_core_address(
+        *recv_socket.get_data_buffer(), distributed::MeshCoordinate(0, 0), receiver_core);
 
     // The receiver's on-device config must point read_ptr/fifo_addr at the receiver core's per-core address.
     std::vector<receiver_socket_md> recv_config_readback;

--- a/tt_metal/api/tt-metalium/experimental/sockets/mesh_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/mesh_socket.hpp
@@ -60,6 +60,9 @@ struct SocketMemoryConfig {
     // TODO: Should data cores be on a different sub device?
     std::optional<SubDeviceId> sender_sub_device = std::nullopt;
     std::optional<SubDeviceId> receiver_sub_device = std::nullopt;
+    // TT_METAL_ALLOCATOR_MODE_HYBRID=1 must be set to enable per-core allocation on socket data buffer.
+    // so data buffers are allocated only on the receiver connection cores instead of every worker core.
+    bool per_core_allocation = false;
 
     // User-provided constructor to make this non-aggregate (prevents ambiguity with Reflectable concept)
     SocketMemoryConfig() = default;
@@ -67,16 +70,19 @@ struct SocketMemoryConfig {
         BufferType socket_storage_type,
         uint32_t fifo_size,
         std::optional<SubDeviceId> sender_sub_device = std::nullopt,
-        std::optional<SubDeviceId> receiver_sub_device = std::nullopt) :
+        std::optional<SubDeviceId> receiver_sub_device = std::nullopt,
+        bool per_core_allocation = false) :
         socket_storage_type(socket_storage_type),
         fifo_size(fifo_size),
         sender_sub_device(sender_sub_device),
-        receiver_sub_device(receiver_sub_device) {}
+        receiver_sub_device(receiver_sub_device),
+        per_core_allocation(per_core_allocation) {}
 
-    static constexpr auto attribute_names =
-        std::forward_as_tuple("socket_storage_type", "fifo_size", "sender_sub_device", "receiver_sub_device");
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "socket_storage_type", "fifo_size", "sender_sub_device", "receiver_sub_device", "per_core_allocation");
     auto attribute_values() const {
-        return std::forward_as_tuple(socket_storage_type, fifo_size, sender_sub_device, receiver_sub_device);
+        return std::forward_as_tuple(
+            socket_storage_type, fifo_size, sender_sub_device, receiver_sub_device, per_core_allocation);
     }
 };
 

--- a/tt_metal/distributed/flatbuffer/socket_peer_descriptor.fbs
+++ b/tt_metal/distributed/flatbuffer/socket_peer_descriptor.fbs
@@ -22,6 +22,7 @@ table SocketMemoryConfig {
     fifo_size: uint32;
     sender_sub_device: uint32 = null;
     receiver_sub_device: uint32 = null;
+    per_core_allocation: bool = false;
 }
 
 table SocketConfig {

--- a/tt_metal/distributed/mesh_socket_serialization.cpp
+++ b/tt_metal/distributed/mesh_socket_serialization.cpp
@@ -61,7 +61,8 @@ flatbuffers::Offset<distributed::flatbuffer::SocketMemoryConfig> to_flatbuffer(
         static_cast<uint32_t>(socket_mem_config.socket_storage_type),
         socket_mem_config.fifo_size,
         sender_sub_device,
-        receiver_sub_device);
+        receiver_sub_device,
+        socket_mem_config.per_core_allocation);
 }
 
 CoreCoord from_flatbuffer(const distributed::flatbuffer::CoreCoord* fb_core_coord) {
@@ -122,6 +123,7 @@ SocketMemoryConfig from_flatbuffer(const distributed::flatbuffer::SocketMemoryCo
         if (fb_socket_mem_config->receiver_sub_device().has_value()) {
             socket_mem_config.receiver_sub_device = SubDeviceId(fb_socket_mem_config->receiver_sub_device().value());
         }
+        socket_mem_config.per_core_allocation = fb_socket_mem_config->per_core_allocation();
     }
     return socket_mem_config;
 }

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -275,14 +275,15 @@ std::shared_ptr<MeshBuffer> create_socket_data_buffer(
             socket_mem_config.socket_storage_type == BufferType::L1,
             "Per-core socket allocation is only supported for L1 storage (got {}).",
             socket_mem_config.socket_storage_type);
-        std::set<CoreCoord> receiver_cores;
+        std::unordered_set<MeshCoreCoord> receiver_cores;
         for (const auto& connection : config.socket_connection_config) {
-            receiver_cores.insert(connection.receiver_core.core_coord);
+            receiver_cores.insert(connection.receiver_core);
         }
         TT_FATAL(
             receiver_cores.size() == 1,
-            "Per-core socket allocation (v1) supports exactly one distinct receiver core per socket, but the "
-            "connection config resolves to {} distinct receiver cores.",
+            "Per-core socket allocation (v1) supports exactly one distinct receiver core (device + core) per "
+            "socket, but the connection config resolves to {} distinct (device, core) receivers. A per-core "
+            "socket may not span multiple receiver cores or devices.",
             receiver_cores.size());
 
         TT_FATAL(
@@ -290,7 +291,7 @@ std::shared_ptr<MeshBuffer> create_socket_data_buffer(
             "Per-core socket allocation requires the device to be opened with AllocatorMode::HYBRID "
             "(set TT_METAL_ALLOCATOR_MODE_HYBRID=1 before opening the device).");
 
-        shard_grid = CoreRangeSet(*receiver_cores.begin());
+        shard_grid = CoreRangeSet(receiver_cores.begin()->core_coord);
         num_data_cores = 1;
     } else if (socket_mem_config.socket_storage_type == BufferType::DRAM) {
         // Allocate DRAM Sharded Buffer
@@ -492,8 +493,9 @@ DeviceAddr get_receiver_data_buffer_address(const MeshSocket& receiver_socket) {
     TT_FATAL(
         !config.socket_connection_config.empty(),
         "Per-core socket has no connections; cannot resolve receiver data buffer address.");
-    const auto& receiver_core = config.socket_connection_config.front().receiver_core.core_coord;
-    return experimental::per_core_allocation::get_per_core_address(data_buffer, receiver_core);
+    const auto& receiver_core = config.socket_connection_config.front().receiver_core;
+    return experimental::per_core_allocation::get_per_core_address(
+        data_buffer, receiver_core.device_coord, receiver_core.core_coord);
 }
 
 SocketPeerDescriptor generate_local_endpoint_descriptor(

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -6,6 +6,9 @@
 #include "tt_metal/distributed/mesh_socket_utils.hpp"
 #include "tt_metal/distributed/mesh_socket_serialization.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp>
+#include <tt-metalium/experimental/per_core_allocation/allocator_mode.hpp>
 #include <tt-metalium/distributed_context.hpp>
 #include <tt-metalium/system_mesh.hpp>
 
@@ -160,6 +163,11 @@ void validate_remote_desc(
         local_desc.config.socket_mem_config.receiver_sub_device ==
             remote_desc.config.socket_mem_config.receiver_sub_device,
         "Mismatch in receiver sub-device during handshake.");
+
+    TT_FATAL(
+        local_desc.config.socket_mem_config.per_core_allocation ==
+            remote_desc.config.socket_mem_config.per_core_allocation,
+        "Mismatch in socket per-core allocation flag during handshake.");
     if (validate_buffer_addresses) {
         TT_FATAL(
             local_desc.config_buffer_address == remote_desc.config_buffer_address,
@@ -261,7 +269,30 @@ std::shared_ptr<MeshBuffer> create_socket_data_buffer(
 
     uint32_t num_data_cores = 0;
     CoreRangeSet shard_grid;
-    if (socket_mem_config.socket_storage_type == BufferType::DRAM) {
+    bool per_core = socket_mem_config.per_core_allocation;
+    if (per_core) {
+        TT_FATAL(
+            socket_mem_config.socket_storage_type == BufferType::L1,
+            "Per-core socket allocation is only supported for L1 storage (got {}).",
+            socket_mem_config.socket_storage_type);
+        std::set<CoreCoord> receiver_cores;
+        for (const auto& connection : config.socket_connection_config) {
+            receiver_cores.insert(connection.receiver_core.core_coord);
+        }
+        TT_FATAL(
+            receiver_cores.size() == 1,
+            "Per-core socket allocation (v1) supports exactly one distinct receiver core per socket, but the "
+            "connection config resolves to {} distinct receiver cores.",
+            receiver_cores.size());
+
+        TT_FATAL(
+            tt::tt_metal::MetalContext::instance().rtoptions().get_allocator_mode_hybrid(),
+            "Per-core socket allocation requires the device to be opened with AllocatorMode::HYBRID "
+            "(set TT_METAL_ALLOCATOR_MODE_HYBRID=1 before opening the device).");
+
+        shard_grid = CoreRangeSet(*receiver_cores.begin());
+        num_data_cores = 1;
+    } else if (socket_mem_config.socket_storage_type == BufferType::DRAM) {
         // Allocate DRAM Sharded Buffer
         shard_grid =
             CoreRange(CoreCoord(0, 0), CoreCoord(receiver->dram_grid_size().x - 1, receiver->dram_grid_size().y - 1));
@@ -274,12 +305,16 @@ std::shared_ptr<MeshBuffer> create_socket_data_buffer(
     }
     // Allocate a shard of size fifo_size on each data core. User decides how these data-cores must be used
     const auto total_data_buffer_size = num_data_cores * socket_mem_config.fifo_size;
+    auto sharding_args = BufferShardingArgs(
+        ShardSpecBuffer(shard_grid, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_data_cores, 1}),
+        TensorMemoryLayout::HEIGHT_SHARDED);
+    if (per_core) {
+        experimental::per_core_allocation::set_per_core_allocation(sharding_args, true);
+    }
     DeviceLocalBufferConfig socket_data_buffer_specs = {
         .page_size = socket_mem_config.fifo_size,
         .buffer_type = socket_mem_config.socket_storage_type,
-        .sharding_args = BufferShardingArgs(
-            ShardSpecBuffer(shard_grid, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_data_cores, 1}),
-            TensorMemoryLayout::HEIGHT_SHARDED),
+        .sharding_args = sharding_args,
         .bottom_up = std::nullopt,
         .sub_device_id = socket_mem_config.socket_storage_type == BufferType::DRAM
                              ? std::nullopt
@@ -448,6 +483,19 @@ void write_socket_configs(
     }
 }
 
+DeviceAddr get_receiver_data_buffer_address(const MeshSocket& receiver_socket) {
+    const auto& config = receiver_socket.get_config();
+    const auto& data_buffer = *receiver_socket.get_data_buffer();
+    if (!config.socket_mem_config.per_core_allocation) {
+        return data_buffer.address();
+    }
+    TT_FATAL(
+        !config.socket_connection_config.empty(),
+        "Per-core socket has no connections; cannot resolve receiver data buffer address.");
+    const auto& receiver_core = config.socket_connection_config.front().receiver_core.core_coord;
+    return experimental::per_core_allocation::get_per_core_address(data_buffer, receiver_core);
+}
+
 SocketPeerDescriptor generate_local_endpoint_descriptor(
     const MeshSocket& socket_endpoint, std::optional<DistributedContextId> context_id) {
     const auto& config = socket_endpoint.get_config();
@@ -464,7 +512,7 @@ SocketPeerDescriptor generate_local_endpoint_descriptor(
     SocketPeerDescriptor local_endpoint_desc = {
         .config = config,
         .config_buffer_address = socket_endpoint.get_config_buffer()->address(),
-        .data_buffer_address = is_sender ? 0 : socket_endpoint.get_data_buffer()->address(),
+        .data_buffer_address = is_sender ? 0 : get_receiver_data_buffer_address(socket_endpoint),
         .exchange_tag = tag};
     return local_endpoint_desc;
 }

--- a/ttnn/cpp/ttnn-nanobind/mesh_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/mesh_socket.cpp
@@ -74,11 +74,13 @@ void py_module_types(nb::module_& mod) {
                 tt::tt_metal::BufferType,
                 uint32_t,
                 std::optional<tt::tt_metal::SubDeviceId>,
-                std::optional<tt::tt_metal::SubDeviceId>>(),
+                std::optional<tt::tt_metal::SubDeviceId>,
+                bool>(),
             nb::arg("socket_storage_type"),
             nb::arg("fifo_size"),
             nb::arg("sender_sub_device") = nb::none(),
             nb::arg("receiver_sub_device") = nb::none(),
+            nb::arg("per_core_allocation") = false,
             R"doc(
                 Initialize a SocketMemoryConfig with socket storage type, fifo size, sender sub device and receiver sub device.
 
@@ -87,7 +89,20 @@ void py_module_types(nb::module_& mod) {
                     fifo_size (int): The size of the fifo
                     sender_sub_device (SubDeviceId, optional): The sub device of the sender
                     receiver_sub_device (SubDeviceId, optional): The sub device of the receiver
-            )doc");
+                    per_core_allocation (bool, optional): When True and socket_storage_type is L1, allocate the
+                        receiver data (FIFO) buffer with the per-core (HYBRID) allocator so it only occupies L1 on
+                        the receiver connection core instead of every worker core. Requires the device to be opened
+                        with TT_METAL_ALLOCATOR_MODE_HYBRID=1. Defaults to False (no behavior change).
+            )doc")
+        .def_rw(
+            "per_core_allocation",
+            &tt::tt_metal::distributed::SocketMemoryConfig::per_core_allocation,
+            "Whether the receiver data buffer uses per-core (HYBRID) allocation")
+        .def_rw(
+            "socket_storage_type",
+            &tt::tt_metal::distributed::SocketMemoryConfig::socket_storage_type,
+            "The buffer type used for the socket data buffer")
+        .def_rw("fifo_size", &tt::tt_metal::distributed::SocketMemoryConfig::fifo_size, "The size of the socket FIFO");
     nb::class_<tt::tt_metal::distributed::SocketConfig>(mod, "SocketConfig")
         .def(
             "__init__",


### PR DESCRIPTION
### PR Category
Feature

### Summary
Currently the data buffer of mesh sockets are lock step allocated, this means that the data buffer needs to be allocated even on all worker cores, which could be an issue for L1 space critical use cases. This PR adds support for per core allocation on socket buffers.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
APC/Sanity tests: https://github.com/tenstorrent/tt-metal/actions/runs/31519721116