### PR TITLE
exp_ring_joint_sdpa: replace get_dynamic_runtime_args with a program-factory override

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
@@ -196,7 +196,7 @@ def run_exp_ring_joint_sdpa_nightly(
     per-link GlobalSemaphore addresses are hash-excluded) AND that every iteration matches the PyTorch
     reference (PCC/MSE). If a semaphore address froze on the cache-hit fast path, iterations 1+ would
     sync on iteration 0's stale semaphore and either hang or produce a wrong result. This exercises
-    ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args re-applying the addresses every dispatch.
+    ExpRingJointSDPAMeshWorkloadFactory::override_runtime_arguments re-applying the addresses every dispatch.
     """
     num_devices = detect_devices_without_opening()
     sp_size, tp_size, arch_type = calculate_mesh_config(num_devices)
@@ -492,7 +492,7 @@ def run_exp_ring_joint_sdpa_nightly(
                 logger.info(f"[cache-hit iter {i}] PCC: {out_pcc}, MSE: {mse:.2e}")
                 assert out_pass, (
                     f"Iteration {i}: PCC {out_pcc} below threshold {pcc_threshold}. On a cache HIT the "
-                    "per-link GlobalSemaphore addresses must be re-applied via get_dynamic_runtime_args; "
+                    "per-link GlobalSemaphore addresses must be re-applied via override_runtime_arguments; "
                     "a frozen (stale) address would sync on an earlier iteration's semaphore and corrupt "
                     "the output."
                 )
@@ -692,7 +692,7 @@ def test_exp_ring_joint_attention_sdpa_semaphore_realloc_cache_hit(
     The per-link GlobalSemaphore addresses are excluded from exp_ring_joint_sdpa's program-cache
     hash, so calls that differ only in which semaphores they pass still cache-hit. That makes the
     addresses DYNAMIC: the factory bakes them on the cache-miss build and
-    ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args() must re-apply them on every dispatch.
+    ExpRingJointSDPAMeshWorkloadFactory::override_runtime_arguments() must re-apply them on every dispatch.
     If an address froze on the cache-hit fast path, a later dispatch reusing the cached program with
     a freshly-allocated semaphore set would sync on the stale address and hang or produce garbage.
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.cpp
@@ -373,56 +373,6 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> ExpRingJointSDPADevi
     return operation::OpPerformanceModelGeneral<Tensors>(input_tensors, output_tensors, ideal_cycles);
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args(
-    const ExpRingJointSDPAParams& operation_attributes,
-    const ExpRingJointSDPAInputs& tensor_args,
-    ExpRingJointSDPAResult& /*tensor_return_value*/,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Re-apply the hash-excluded per-link GlobalSemaphore addresses to the cached program on every
-    // cache hit (the non-Buffer analog of the BufferBinding fast path). The factory bakes these same
-    // slots on the cache-miss build; both paths use the shared exp_ring_joint_sdpa_dynamic constants so
-    // the slot layout cannot drift. Semaphore addresses are mesh-uniform, so they are coord-independent
-    // (mesh_dispatch_coordinate is unused).
-    namespace dyn = exp_ring_joint_sdpa_dynamic;
-
-    // Recompute the SDPA worker grid exactly as build_exp_ring_joint_sdpa_program_descriptor() does.
-    auto* mesh_device = tensor_args.input_q.device();
-    const auto device_grid = mesh_device->compute_with_storage_grid_size();
-    const CoreCoord user_grid =
-        operation_attributes.program_config.has_value() ? operation_attributes.program_config->compute_with_storage_grid_size : device_grid;
-    const CoreCoord sdpa_grid = {user_grid.x - 1, user_grid.y};
-    const uint32_t num_sdpa_cores = sdpa_grid.x * sdpa_grid.y;
-
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(static_cast<std::size_t>(num_sdpa_cores) * (operation_attributes.num_links + 1));
-    for (uint32_t i = 0; i < num_sdpa_cores; ++i) {
-        const CoreCoord core = {i % sdpa_grid.x, i / sdpa_grid.x};
-
-        // Reader kernel: per-link semaphore addresses on every SDPA core.
-        for (uint32_t lnk = 0; lnk < operation_attributes.num_links; ++lnk) {
-            dynamic_args.push_back(
-                {dyn::kReaderKernelIdx,
-                 core,
-                 dyn::kReaderSemaphoreArgBase + lnk,
-                 static_cast<uint32_t>(operation_attributes.semaphore[lnk].address())});
-        }
-
-        // Fabric-writer kernel: out_ready_sem_addr on the two MUX-writer columns. num_links is
-        // TT_FATAL-fixed to 2 (see validate_on_program_cache_miss), so link_in_range always holds in the
-        // factory and out_ready_sem_addr is present on every MUX-writer core — mirror that here.
-        const bool is_mux_writer = (core.x >= sdpa_grid.x - 2);
-        if (is_mux_writer) {
-            const uint32_t link = (core.x == sdpa_grid.x - 1) ? 1u : 0u;
-            dynamic_args.push_back(
-                {dyn::kWriterFabricKernelIdx,
-                 core,
-                 dyn::kWriterFabricOutReadySemArg,
-                 static_cast<uint32_t>(operation_attributes.semaphore[link].address())});
-        }
-    }
-    return dynamic_args;
-}
-
 }  // namespace ttnn::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.hpp
@@ -21,23 +21,12 @@ struct ExpRingJointSDPADeviceOperation {
     using tensor_args_t = ExpRingJointSDPAInputs;
     using spec_return_value_t = ExpRingJointSDPAResultSpec;
     using tensor_return_value_t = ExpRingJointSDPAResult;
-    using program_factory_t = std::variant<ExpRingJointSDPAProgramFactory>;
+    using program_factory_t = std::variant<ExpRingJointSDPAMeshWorkloadFactory>;
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors);
-
-    // The per-link GlobalSemaphore addresses are excluded from the program-cache hash
-    // (ExpRingJointSDPAParams::attribute_values omits `semaphore`), so they are DYNAMIC: the factory
-    // bakes them for the cache-miss build and this method re-applies them to the cached program on
-    // every dispatch, so a cache hit with a different semaphore set cannot reuse a frozen address.
-    // Slot layout mirrors the factory via the shared exp_ring_joint_sdpa_dynamic constants.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 ExpRingJointSDPAResult exp_ring_joint_scaled_dot_product_attention(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
@@ -1553,14 +1553,14 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         // Per-link semaphore addresses for chunk-level sync. These occupy per-core reader slots
         // exp_ring_joint_sdpa_dynamic::kReaderSemaphoreArgBase .. +num_links-1. They are hash-excluded, so
         // they are baked here for the cache-miss build and re-applied every dispatch by
-        // get_dynamic_runtime_args(); if you reorder the args above, update kReaderSemaphoreArgBase (and
-        // thus the re-apply target) accordingly.
+        // ExpRingJointSDPAMeshWorkloadFactory::override_runtime_arguments(), which asserts the total
+        // per-core count: adding or removing an arg fails loudly, a count-preserving reorder does not.
         reader_args.push_back(args.num_links);
         for (uint32_t lnk = 0; lnk < args.num_links; ++lnk) {
             reader_args.push_back(static_cast<uint32_t>(
                 args.semaphore[lnk]
                     .address()));  // smuggled-rta-ok: hash-excluded global-semaphore address, re-applied every dispatch
-                                   // via ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args
+                                   // via ExpRingJointSDPAMeshWorkloadFactory::override_runtime_arguments
         }
 
         // Inject fused-op synchronization RT args: ring_size, ring_index, direction (3 values)
@@ -1641,12 +1641,13 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
                 // out_ready_sem_addr occupies per-core fabric-writer slot
                 // exp_ring_joint_sdpa_dynamic::kWriterFabricOutReadySemArg. It is a hash-excluded
                 // global-semaphore address, so it is baked here for the cache-miss build and re-applied
-                // every dispatch by get_dynamic_runtime_args(); if you reorder the args above, update
-                // kWriterFabricOutReadySemArg (and thus the re-apply target) accordingly.
+                // every dispatch by ExpRingJointSDPAMeshWorkloadFactory::override_runtime_arguments(),
+                // which asserts the per-core count: an added/removed arg fails loudly, a reorder does not.
                 const uint32_t out_ready_sem_addr = args.semaphore[link].address();
                 writer_args.push_back(
                     out_ready_sem_addr);  // smuggled-rta-ok: hash-excluded global-semaphore address, re-applied every
-                                          // dispatch via ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args
+                                          // dispatch via
+                                          // ExpRingJointSDPAMeshWorkloadFactory::override_runtime_arguments
 
                 // Find the injector core for this MUX writer's (batch, head)
                 const auto& mux_head_work = core_work.at(i).head_work;
@@ -1773,6 +1774,73 @@ tt::tt_metal::WorkloadDescriptor ExpRingJointSDPAProgramFactory::create_workload
         wd.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
     return wd;
+}
+
+ExpRingJointSDPAMeshWorkloadFactory::cached_mesh_workload_t ExpRingJointSDPAMeshWorkloadFactory::create_mesh_workload(
+    const ExpRingJointSDPAParams& operation_attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const ExpRingJointSDPAInputs& tensor_args,
+    ExpRingJointSDPAResult& tensor_return_value) {
+    return descriptor_adapter_t::create_mesh_workload(
+        operation_attributes, tensor_coords, tensor_args, tensor_return_value);
+}
+
+void ExpRingJointSDPAMeshWorkloadFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const ExpRingJointSDPAParams& operation_attributes,
+    const ExpRingJointSDPAInputs& tensor_args,
+    ExpRingJointSDPAResult& tensor_return_value) {
+    // apply_descriptor re-points the Buffer* runtime args; the hash-excluded per-link GlobalSemaphore
+    // addresses are all that is left to patch.
+    descriptor_adapter_t::apply_descriptor(cached_workload, operation_attributes, tensor_args, tensor_return_value);
+
+    namespace dyn = exp_ring_joint_sdpa_dynamic;
+    const auto& args = operation_attributes;
+
+    // Recompute the SDPA worker grid exactly as build_exp_ring_joint_sdpa_program_descriptor() does.
+    auto* mesh_device = tensor_args.input_q.device();
+    const CoreCoord user_grid = args.program_config.has_value() ? args.program_config->compute_with_storage_grid_size
+                                                                : mesh_device->compute_with_storage_grid_size();
+    const CoreCoord sdpa_grid = {user_grid.x - 1, user_grid.y};
+    const uint32_t num_sdpa_cores = sdpa_grid.x * sdpa_grid.y;
+    const uint32_t expected_reader_args = dyn::reader_arg_count(args.num_links);
+
+    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+        // Hoisted out of the per-core loop, and by reference: a copy would clone the whole arg grid.
+        auto& reader_grid = GetRuntimeArgs(program, dyn::kReaderKernelIdx);
+        auto& writer_fabric_grid = GetRuntimeArgs(program, dyn::kWriterFabricKernelIdx);
+
+        for (uint32_t i = 0; i < num_sdpa_cores; ++i) {
+            const CoreCoord core = {i % sdpa_grid.x, i / sdpa_grid.x};
+
+            auto& reader_args = reader_grid[core.x][core.y];
+            TT_FATAL(
+                reader_args.size() == expected_reader_args,
+                "Exp ring joint SDPA reader expected {} runtime args on core ({},{}), cached program has {}",
+                expected_reader_args,
+                core.x,
+                core.y,
+                reader_args.size());
+            for (uint32_t lnk = 0; lnk < args.num_links; ++lnk) {
+                reader_args[dyn::kReaderSemaphoreArgBase + lnk] = static_cast<uint32_t>(args.semaphore[lnk].address());
+            }
+
+            // out_ready_sem_addr lives only on the two MUX-writer columns. num_links is TT_FATAL-fixed
+            // to 2, so link_in_range always holds in the factory and the slot is always present.
+            if (core.x >= sdpa_grid.x - 2) {
+                const uint32_t link = (core.x == sdpa_grid.x - 1) ? 1u : 0u;
+                auto& writer_args = writer_fabric_grid[core.x][core.y];
+                TT_FATAL(
+                    writer_args.size() == dyn::kWriterFabricArgCount,
+                    "Exp ring joint SDPA fabric writer expected {} runtime args on core ({},{}), cached program has {}",
+                    dyn::kWriterFabricArgCount,
+                    core.x,
+                    core.y,
+                    writer_args.size());
+                writer_args[dyn::kWriterFabricOutReadySemArg] = static_cast<uint32_t>(args.semaphore[link].address());
+            }
+        }
+    }
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.hpp
@@ -8,10 +8,12 @@
 #include <optional>
 
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/workload_descriptor.hpp>
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/mesh_device_operation_adapter.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
@@ -26,14 +28,15 @@ namespace ttnn::prim {
 // The per-link GlobalSemaphore addresses are excluded from the program-cache key
 // (ExpRingJointSDPAParams::attribute_values omits `semaphore`), so two calls that differ only in
 // which GlobalSemaphores they pass still cache-hit. That makes the addresses dynamic: the factory
-// bakes them for the cache-miss build, and ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args()
-// re-applies them on every dispatch — otherwise a cache hit with a different semaphore set would
-// silently reuse the address frozen at the first miss (the frozen-runtime-arg bug).
+// bakes them for the cache-miss build, and
+// ExpRingJointSDPAMeshWorkloadFactory::override_runtime_arguments() re-applies them on every
+// dispatch — otherwise a cache hit with a different semaphore set would silently reuse the address
+// frozen at the first miss (the frozen-runtime-arg bug).
 //
-// The kernel indices and per-core arg slots below are the shared reference for BOTH the factory's
-// cache-miss bake (build_exp_ring_joint_sdpa_program_descriptor) and the cache-hit patch
-// (get_dynamic_runtime_args); reorder the runtime args in the factory and these constants (and thus
-// the re-apply targets) must be updated in lockstep.
+// The kernel indices, per-core arg slots and total arg counts below are the shared reference for
+// BOTH the factory's cache-miss bake (build_exp_ring_joint_sdpa_program_descriptor) and the
+// cache-hit patch. The patch asserts arg COUNTS, so adding or removing an arg fails loudly; a
+// reorder that keeps the count is not detected, so update these slots in lockstep with the bake.
 namespace exp_ring_joint_sdpa_dynamic {
 // Kernel indices — must match the desc.kernels push order (reader, writer, writer_fabric, compute[, mux]).
 inline constexpr uint32_t kReaderKernelIdx = 0;
@@ -41,9 +44,28 @@ inline constexpr uint32_t kWriterFabricKernelIdx = 2;
 // Per-core reader runtime-arg slot of the first per-link semaphore address; slots
 // kReaderSemaphoreArgBase .. +num_links-1 hold args.semaphore[lnk].address().
 inline constexpr uint32_t kReaderSemaphoreArgBase = 26;
+// Reader args after the semaphore addresses: ring_size, ring_index, direction.
+inline constexpr uint32_t kReaderTrailingArgCount = 3;
+inline constexpr uint32_t reader_arg_count(uint32_t num_links) {
+    return kReaderSemaphoreArgBase + num_links + kReaderTrailingArgCount;
+}
 // Per-core fabric-writer runtime-arg slot of out_ready_sem_addr (= args.semaphore[link].address()).
 inline constexpr uint32_t kWriterFabricOutReadySemArg = 25;
+// Fabric-writer args after out_ready_sem_addr: injector x/y, num_muxes, mux index, AG Wt/Ht,
+// gathered k/v addresses.
+inline constexpr uint32_t kWriterFabricArgCount = kWriterFabricOutReadySemArg + 9;
 }  // namespace exp_ring_joint_sdpa_dynamic
+
+namespace detail {
+
+struct ExpRingJointSDPADescriptorAdapterOperation {
+    using operation_attributes_t = ExpRingJointSDPAParams;
+    using tensor_args_t = ExpRingJointSDPAInputs;
+    using spec_return_value_t = ExpRingJointSDPAResultSpec;
+    using tensor_return_value_t = ExpRingJointSDPAResult;
+};
+
+}  // namespace detail
 
 struct ExpRingJointSDPAProgramFactory {
     static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
@@ -52,5 +74,26 @@ struct ExpRingJointSDPAProgramFactory {
         ExpRingJointSDPAResult& tensor_return_value,
         const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
+
+struct ExpRingJointSDPAMeshWorkloadFactory {
+    using descriptor_adapter_t =
+        ttnn::device_operation::MeshDeviceOperationAdapter<detail::ExpRingJointSDPADescriptorAdapterOperation>::
+            DescriptorMeshWorkloadAdapter<ExpRingJointSDPAProgramFactory>;
+    using cached_mesh_workload_t = typename descriptor_adapter_t::cached_mesh_workload_t;
+
+    static cached_mesh_workload_t create_mesh_workload(
+        const ExpRingJointSDPAParams& operation_attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const ExpRingJointSDPAInputs& tensor_args,
+        ExpRingJointSDPAResult& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_workload,
+        const ExpRingJointSDPAParams& operation_attributes,
+        const ExpRingJointSDPAInputs& tensor_args,
+        ExpRingJointSDPAResult& tensor_return_value);
+};
+
+static_assert(ttnn::device_operation::MeshWorkloadFactoryConcept<ExpRingJointSDPAMeshWorkloadFactory>);
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
### What changed

`exp_ring_joint_sdpa` no longer uses the legacy `get_dynamic_runtime_args` hook. Its cache-hit
re-application now lives on a program factory, as `ExpRingJointSDPAMeshWorkloadFactory::override_runtime_arguments`.

- `ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args` (declaration + 50-line body) is deleted.
- New `ExpRingJointSDPAMeshWorkloadFactory` wraps `DescriptorMeshWorkloadAdapter<ExpRingJointSDPAProgramFactory>`:
  `create_mesh_workload` delegates to the adapter, and `override_runtime_arguments` calls
  `apply_descriptor` (buffer addresses) and then patches the hash-excluded per-link GlobalSemaphore
  addresses in place.
- `exp_ring_joint_sdpa_dynamic` gains `reader_arg_count(num_links)` and `kWriterFabricArgCount`; the hit
  path asserts both per-core counts.

### Why the factory hook and not the plain `Program&` override

`exp_ring_joint_sdpa` is a **`WorkloadDescriptor`-variant** factory. In `mesh_device_operation_adapter.hpp`,
`apply_descriptor` takes the `if constexpr (has_workload_descriptor)` branch *before* it ever tests
`has_override_runtime_arguments()`, so a `Program&`-shaped hook on `ExpRingJointSDPAProgramFactory` would
compile, be accepted by the `static_assert`, force `get_dynamic` to be deleted — and then never be called,
silently freezing the semaphore addresses. The sibling op `ring_joint_sdpa` in the same directory already
solves this with a hand-written `MeshWorkloadFactory`; this change mirrors it exactly, so no framework
change is needed.

Buffer addresses are untouched by this PR: before and after, they ride
`resolve_bindings`/`apply_resolved_bindings` inside `apply_descriptor`. The only behavioural delta is
*where* the semaphore-address patch is invoked from.

### Hot-path discipline

- No `create_descriptor()` in the override — `scripts/detect_override_rebuild.py` reports 0 errors on all
  four changed files.
- `GetRuntimeArgs(program, kernel_idx)` results are bound **by reference** and hoisted above the per-core
  loop, so no arg-grid copy per dispatch.
- No `GetCommonRuntimeArgs` involved; this op declares no common runtime args.

### What the cache-hit test proves

`tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::test_exp_ring_joint_attention_sdpa_semaphore_realloc_cache_hit`
already exists and is the regression net for exactly this. It enables the program cache and dispatches
several iterations, each with a **freshly allocated** global-semaphore set (all sets kept alive so
addresses never collide), then asserts:

1. the program-cache entry count is stable after the first dispatch (a genuine cache hit — the addresses
   are hash-excluded), and
2. every iteration matches the PyTorch SDPA reference (PCC/MSE).

With the re-application removed, iterations 1+ reuse the address frozen at the first miss and sync on the
previous iteration's semaphore, which hangs or corrupts the output — failing (2). The count assertion in
(1) separately guarantees the test is actually exercising the hit path rather than re-missing. Its
docstrings are updated to name the new hook. It runs in CI via `tests/pipeline_reorg/blackhole_multi_card_sanity_tests.yaml`
("sdpa nightly tests (QB2 only)" runs the whole `tests/nightly/blackhole/sdpa/` directory on `bh_quietbox_2`).

### Not verified locally — please rely on CI

This is a fabric/CCL multi-device op. The dev box has a **single** device (`/dev/tenstorrent/0`), and the
test skips below 4 devices in the ring (`sp_size < 4`); ttsim cannot do fabric at all. **I did not run any
`exp_ring_joint_sdpa` test.** What was verified locally instead:

- The unity TU containing both changed `.cpp` files compiles clean (`clang++ -fsyntax-only`, exit 0), and
  the same object built as part of the real `./build_metal.sh --build-tests` run.
- Compile-time probe (same flags) confirming the wiring, all four asserts passing:
  `program_factory_t == variant<ExpRingJointSDPAMeshWorkloadFactory>`; the factory does **not** expose
  `apply_descriptor` (which `device_operation.hpp` would otherwise prefer, shadowing the override); it
  **does** expose `override_runtime_arguments`; and `get_dynamic_runtime_args` is gone.
- `detect_override_rebuild.py`, `detect_smuggled_rta.py`, `detect_legacy_device_op.py`: 0 errors.
  `git-clang-format`: clean.

Part of the `get_dynamic_runtime_args` elimination campaign.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-exp-ring-joint-sdpa-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-exp-ring-joint-sdpa-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-exp-ring-joint-sdpa-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-exp-ring-joint-sdpa-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/gd-exp-ring-joint-sdpa-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/gd-exp-ring-joint-sdpa-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-exp-ring-joint-sdpa-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-exp-ring-joint-sdpa-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-exp-ring-joint-sdpa-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-exp-ring-joint-sdpa-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-exp-ring-joint-sdpa-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-exp-ring-joint-sdpa-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-exp-ring-joint-sdpa-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-exp-ring-joint-sdpa-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-exp-ring-joint-sdpa-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-exp-ring-joint-sdpa-override)