### PR TITLE
[ttnn] pad: replace get_dynamic_runtime_args with a factory override_runtime_arguments

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -380,6 +380,61 @@ def test_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard
         device.set_program_cache_misses_allowed(False)
 
 
+def test_pad_rm_sharded_height_only_override_addr_change(device):
+    """Cache-hit hook (override_runtime_arguments) for the CB-bound height-sharded RM factory: buffer
+    addresses are excluded from the pad hash, so a second identical pad at DIFFERENT input AND output
+    addresses must hit the cache and still re-point both sharded CB bases instead of reading/writing
+    the first dispatch's L1 shards."""
+    torch.manual_seed(48928)
+
+    n, c, h, w = 1, 3, 224, 256
+    padded_shape = [n, c, 256, w]
+    input_tensor_start = [0, 0, 0, 0]
+    pad_value = 8.0
+
+    num_cores_x, num_cores_y = 8, 7
+    ncores = num_cores_x * num_cores_y
+    shard_grid = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1))}
+    )
+    in_cfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, (ttnn.core.divup(n * c * h, ncores), w), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    out_cfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            shard_grid,
+            (ttnn.core.divup(n * c * padded_shape[2], ncores), w),
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+
+    def _make():
+        t = torch.rand((n, c, h, w), dtype=torch.bfloat16)
+        return t, ttnn.from_torch(
+            t, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=in_cfg
+        )
+
+    def _run(tt_in):
+        return ttnn.pad(tt_in, padded_shape, input_tensor_start, pad_value, memory_config=out_cfg)
+
+    torch_a, tt_a = _make()
+    tt_out_a = _run(tt_a)
+    assert_equal(pad_reference(torch_a, padded_shape, input_tensor_start, pad_value), ttnn.to_torch(tt_out_a))
+    entries_after_first = device.num_program_cache_entries()
+
+    # Keep A alive so B's input and output both land at different L1 addresses.
+    torch_b, tt_b = _make()
+    assert tt_b.buffer_address() != tt_a.buffer_address(), "second input must land at a different address"
+    tt_out_b = _run(tt_b)
+    assert tt_out_b.buffer_address() != tt_out_a.buffer_address(), "second output must land at a different address"
+    assert device.num_program_cache_entries() == entries_after_first, "identical pad must be a cache hit"
+    assert_equal(pad_reference(torch_b, padded_shape, input_tensor_start, pad_value), ttnn.to_torch(tt_out_b))
+
+
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
 @pytest.mark.parametrize("padding,torch_padding", [(((0, 64),), (0, 64)), (((16, 16), (0, 32)), (0, 32, 0, 32))])
@@ -403,15 +458,14 @@ def test_pad(device, h, w, padding, torch_padding, value):
 @pytest.mark.parametrize("w", [64])
 @pytest.mark.parametrize("padding,torch_padding", [(((32, 32),), (32, 32))])
 @pytest.mark.parametrize("value", [0])
-def test_pad_padding_validation_front_pad_not_supported(device, h, w, padding, torch_padding, value):
+def test_pad_padding_validation_front_pad_not_supported(device, h, w, padding, torch_padding, value, expect_error):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    with pytest.raises(RuntimeError) as e:
+    with expect_error(RuntimeError, "ttnn.pad: on device tile padding does not support front padding"):
         ttnn.pad(input_tensor, padding=padding, value=value)
-    assert "ttnn.pad: on device tile padding does not support front padding" in str(e.value)
     return
 
 
@@ -419,15 +473,14 @@ def test_pad_padding_validation_front_pad_not_supported(device, h, w, padding, t
 @pytest.mark.parametrize("w", [64])
 @pytest.mark.parametrize("padding,torch_padding", [(((0, 32), (0, 32), (0, 32)), (0, 32, 0, 32, 0, 32))])
 @pytest.mark.parametrize("value", [0])
-def test_pad_padding_validation_length(device, h, w, padding, torch_padding, value):
+def test_pad_padding_validation_length(device, h, w, padding, torch_padding, value, expect_error):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    with pytest.raises(RuntimeError) as e:
+    with expect_error(RuntimeError, "ttnn.pad: padding len can't be larger than input tensor rank"):
         ttnn.pad(input_tensor, padding=padding, value=value)
-    assert "ttnn.pad: padding len can't be larger than input tensor rank" in str(e.value)
     return
 
 
@@ -487,7 +540,7 @@ def test_pad_back_to_back(device, h, w, padding, torch_padding, value):
 @pytest.mark.parametrize("w", [64])
 @pytest.mark.parametrize("padding", [((0, 32), (0, 32)), ((1, 64), (0, 96)), ((0, 64), (0, 43)), ((32, 64), (64, 96))])
 @pytest.mark.parametrize("value", [0])
-def test_pad_for_tensor_in_tile_layout(device, h, w, padding, value):
+def test_pad_for_tensor_in_tile_layout(device, h, w, padding, value, expect_error):
     torch.manual_seed(0)
     torch_padding = (padding[1][0], padding[1][1], padding[0][0], padding[0][1])
 
@@ -502,9 +555,8 @@ def test_pad_for_tensor_in_tile_layout(device, h, w, padding, value):
         or padding[1][0] % ttnn.TILE_SIZE != 0
         or padding[1][1] % ttnn.TILE_SIZE != 0
     ):
-        with pytest.raises(RuntimeError) as e:
-            output_tensor = ttnn.pad(input_tensor, padding=padding, value=value)
-        assert "must be a multiple of the tile size on height and width" in str(e.value)
+        with expect_error(RuntimeError, "must be a multiple of the tile size on height and width"):
+            ttnn.pad(input_tensor, padding=padding, value=value)
         return
     else:
         output_tensor = ttnn.pad(input_tensor, padding=padding, value=value)
@@ -1251,7 +1303,7 @@ def test_pad_nd_sharded_to_nd_sharded_front_padding_row_major(
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-def test_pad_nd_sharded_front_padding_tile_layout_not_supported(device, dtype):
+def test_pad_nd_sharded_front_padding_tile_layout_not_supported(device, dtype, expect_error):
     torch.manual_seed(42)
 
     tensor_shape = [1, 1, 32, 32]
@@ -1275,7 +1327,7 @@ def test_pad_nd_sharded_front_padding_tile_layout_not_supported(device, dtype):
         memory_config=input_memory_config,
     )
 
-    with pytest.raises(RuntimeError, match="ttnn.pad: on device tile padding does not support front padding"):
+    with expect_error(RuntimeError, "ttnn.pad: on device tile padding does not support front padding"):
         ttnn.pad(
             input_ttnn_tensor,
             padded_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
@@ -232,22 +232,6 @@ Tensor PadDeviceOperation::create_output_tensors(
     return create_device_tensor(output_spec, tensor_args.input.device());
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> PadDeviceOperation::get_dynamic_runtime_args(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Height-sharded RM factory is CB-bound (addresses ride on the sharded CBs; no Buffer* rt-arg). Re-apply
-    // writer arg0 (= output shard height, unchanged) on the first core to trip the fast-path, so the
-    // framework re-patches the sharded CB base addresses instead of rebuilding create_descriptor. (#48928)
-    if (!std::holds_alternative<PadRmShardedHeightOnlyProgramFactory>(
-            select_program_factory(operation_attributes, tensor_args))) {
-        return {};
-    }
-    const auto shard = tensor_return_value.shard_spec().value();  // writer kernel is index 1
-    return {tt::tt_metal::DynamicRuntimeArg{1, shard.grid.bounding_box().start_coord, 0, shard.shape[0]}};
-}
-
 PadDeviceOperation::tensor_return_value_t pad(
     const Tensor& input,
     const ttnn::Shape& output_logical_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.hpp
@@ -22,7 +22,6 @@
 #include "ttnn/operations/data_movement/pad/device/pad_tile_program_factory.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/distributed/types.hpp"
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::prim {
 struct PadDeviceOperation {
@@ -51,13 +50,6 @@ struct PadDeviceOperation {
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors);
-
-    // #48928: the height-sharded RM factory is pure CB-bound; opt into the descriptor fast-path on a cache hit.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t&,
-        const tensor_args_t&,
-        tensor_return_value_t&,
-        const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
 };
 }  // namespace ttnn::prim
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -409,4 +409,18 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     return desc;
 }
 
+void PadRmShardedHeightOnlyProgramFactory::override_runtime_arguments(
+    Program& program,
+    const PadParams& /*operation_attributes*/,
+    const PadInputs& tensor_args,
+    Tensor& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // create_descriptor pushes the input CB, then the output CB, then the unbound pad-value CB; mirror
+    // that order positionally so only those two base addresses are re-pointed.
+    ProgramDescriptor cb_addr_only;
+    cb_addr_only.cbs.push_back(CBDescriptor{.buffer = tensor_args.input.buffer()});
+    cb_addr_only.cbs.push_back(CBDescriptor{.buffer = tensor_return_value.buffer()});
+    apply_descriptor_runtime_args(program, cb_addr_only);  // override-rebuild-ok: cb-addr-only
+}
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.hpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
@@ -15,5 +16,14 @@ namespace ttnn::prim {
 struct PadRmShardedHeightOnlyProgramFactory {
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
+
+    // Every per-core arg is pinned by the hashed shapes and shard specs; only the two sharded CB base
+    // addresses vary per dispatch. Replaces get_dynamic_runtime_args (#48928).
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const PadParams& operation_attributes,
+        const PadInputs& tensor_args,
+        Tensor& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 }  // namespace ttnn::prim


### PR DESCRIPTION
### What changed

`ttnn.pad` no longer declares `get_dynamic_runtime_args`. The height-sharded row-major factory
(`PadRmShardedHeightOnlyProgramFactory`) now owns its cache-hit re-derivation through
`override_runtime_arguments` on the **program factory** — its natural home, next to
`create_descriptor` — so the other six pad factories are untouched and keep the behaviour they have
today.

The old hook re-applied no real value: it re-wrote writer arg 0 (the output shard height, which is
pinned by the hash) on one core purely to *trip* the framework's descriptor fast path, so that
`apply_resolved_bindings` would re-patch the sharded CB base addresses (#48928). The new hook does
that job directly.

### Why

Part of the `get_dynamic_runtime_args` elimination. `override_runtime_arguments` supersedes it and
the adapter's `static_assert` forbids declaring both, so the legacy hook is deleted in the same
change.

### What varies per dispatch

Pad has no custom `compute_program_hash`, so every per-core reader/writer arg is already pinned by
the hashed shapes, shard specs and attributes. The only per-dispatch state is the two sharded CB
base addresses — the input and output buffers ride on `cb.buffer`, not on a runtime arg. The
override re-points exactly those two through a minimal CB-only `ProgramDescriptor`: O(1), no
per-core `GetRuntimeArgs`, no `create_descriptor` rebuild on the hit path
(`scripts/detect_override_rebuild.py` passes).

### The cache-hit test

`test_pad_rm_sharded_height_only_override_addr_change` runs the same pad twice, keeping the first
input and output alive so the second pair is forced to different L1 addresses. It asserts both
address changes (so the test cannot silently go vacuous), asserts the second dispatch is a
program-cache hit, and requires bit-exact output for the second input.

Being explicit about what it does and does not prove:

- It **does** guard the new mechanism. With the CB re-pointing removed from the override body, the
  second dispatch reads the first input's shards and writes the first output's shards, and the test
  fails on the second data comparison (verified on a build with the two `cbs.push_back` lines
  removed).
- It is **not** a regression test against `main`: on unmodified `main` it passes, because the old
  `get_dynamic_runtime_args` had the framework patch the same two CB addresses. This migration is
  behaviour-preserving, so no test can fail before and pass after. The test exists to keep the new,
  explicit hook honest.

### Also in this diff

`tests/.../test_pad.py` had four pre-existing `pytest.raises` sites that the `prefer-expect-error`
pre-commit hook rejects for any commit touching the file; converted them to the `expect_error`
fixture. No behavioural change — same counts before and after.

### Testing

- `test_pad.py`: 507 passed, 63 skipped, 8 xfailed
- `test_pad_subcoregrids.py`: 58 passed
- `scripts/detect_override_rebuild.py` on the changed files: clean

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-pad-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-pad-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-pad-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-pad-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-pad-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-pad-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-pad-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-pad-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-pad-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-pad-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-pad-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-pad-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-pad-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-pad-override)