### PR TITLE
Port transpose off get_dynamic_runtime_args onto override_runtime_arguments

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -749,6 +749,78 @@ def test_transpose_hc_sharded_cache_hit_new_input(device, n, c, h, w, grid_size)
             ), "transpose must reuse the cached program on a hit"
 
 
+def _run_transpose_sharded_override_addr_change(
+    device, dim0, dim1, n, c, h, w, grid_size, orientation, pass_output_mem_config
+):
+    """Buffer addresses are excluded from the transpose hash, so a second identical-shape transpose at
+    DIFFERENT addresses must hit the cache and still be correct (override re-patches the sharded CB bases)."""
+    torch.manual_seed(47828)
+    grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+    shard_spec = ttnn.ShardSpec(shard_grid, (n * c * h // (grid_size.x * grid_size.y), w), orientation)
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+
+    def _make():
+        torch_input = torch.rand((n, c, h, w), dtype=torch.bfloat16)
+        tt_input = ttnn.from_torch(
+            torch_input,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        return torch_input, ttnn.to_memory_config(tt_input, sharded_mem_config)
+
+    def _to_torch(tt_tensor):
+        return ttnn.to_torch(ttnn.from_device(ttnn.to_memory_config(tt_tensor, ttnn.L1_MEMORY_CONFIG)))
+
+    out_mem_config = sharded_mem_config if pass_output_mem_config else None
+
+    torch_a, tt_a = _make()
+    out_a = ttnn.transpose(tt_a, dim0, dim1, memory_config=out_mem_config)
+    assert_with_pcc(torch_a.transpose(dim0, dim1), _to_torch(out_a), 0.9999)
+
+    # Keep A alive so B is forced to a different buffer address; the second transpose must be a cache HIT.
+    torch_b, tt_b = _make()
+    assert tt_b.buffer_address() != tt_a.buffer_address(), "second input must land at a different address"
+    entries_before_second = device.num_program_cache_entries()
+    out_b = ttnn.transpose(tt_b, dim0, dim1, memory_config=out_mem_config)
+    assert device.num_program_cache_entries() == entries_before_second, "identical-shape transpose must be a cache hit"
+    assert out_b.buffer_address() != out_a.buffer_address(), "second output must land at a different address"
+    assert_with_pcc(torch_b.transpose(dim0, dim1), _to_torch(out_b), 0.9999)
+
+
+@pytest.mark.parametrize(
+    "n, c, h, w, grid_size",
+    [
+        # generic path: shard height 288 is neither a multiple nor a divisor of H=224
+        (24, 3, 224, 224, ttnn.CoreGrid(y=8, x=7)),
+        # special case path, one H block per core: shard height 224 == H
+        (16, 4, 224, 224, ttnn.CoreGrid(y=8, x=8)),
+        # special case path, multiple H blocks per core: shard height 4096 == 32 * H
+        (16, 128, 128, 16, ttnn.CoreGrid(y=8, x=8)),
+    ],
+    ids=["generic", "special_case_single_h_block", "special_case_multi_h_block"],
+)
+def test_transpose_hc_sharded_override_addr_change(device, n, c, h, w, grid_size):
+    if grid_size.y > device.core_grid.y:
+        pytest.skip("grid size not for N300")
+    _run_transpose_sharded_override_addr_change(
+        device, 1, 2, n, c, h, w, grid_size, ttnn.ShardOrientation.ROW_MAJOR, pass_output_mem_config=True
+    )
+
+
+@pytest.mark.parametrize("n, c, h, w, grid_size", [(2, 128, 128, 16, ttnn.CoreGrid(y=4, x=8))])
+def test_transpose_wh_sharded_rm_override_addr_change(device, n, c, h, w, grid_size):
+    if grid_size.y > device.core_grid.y:
+        pytest.skip("grid size not for N300")
+    _run_transpose_sharded_override_addr_change(
+        device, 2, 3, n, c, h, w, grid_size, ttnn.ShardOrientation.COL_MAJOR, pass_output_mem_config=False
+    )
+
+
 @pytest.mark.parametrize(
     "shape, swap_dims",
     [

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.hpp
@@ -18,7 +18,6 @@
 #include <variant>
 #include "ttnn/operation.hpp"
 #include "ttnn/distributed/types.hpp"
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::prim {
 
@@ -54,14 +53,6 @@ struct TransposeDeviceOperation {
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, const Tensor& output);
-
-    // #48928: opt the CB-bound height-sharded factories into the descriptor fast-path. Defined in
-    // transpose_hc_sharded_program_factory.cpp so it can reuse that factory's per-core arg builders.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t&,
-        const tensor_args_t&,
-        tensor_return_value_t&,
-        const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transpose_hc_sharded_program_factory.hpp"
-#include "ttnn/operations/data_movement/transpose/device/transpose_device_operation.hpp"
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
@@ -20,23 +19,6 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
-
-// Reader arg0 of the generic HC-sharded path. Closed form: the value is the same on every core and
-// does not depend on the per-core loop state
-inline uint32_t hc_rm_sharded_reader_arg0(const Tensor& input_tensor) {
-    return input_tensor.shard_spec().value().shape[0];  // num_sticks_per_core
-}
-
-// Reader arg0 of the special-case HC-sharded path (read_single_h_block_per_core).
-// H comes from padded_shape() to match get_runtime_args_hc_rm_sharded_special_case; the
-// hc_rm_sharded_is_special_case predicate is evaluated on logical_shape() at the call sites, and the
-// two differ for a padded shard.
-inline uint32_t hc_rm_sharded_special_case_reader_arg0(const Tensor& input_tensor) {
-    const uint32_t shard_height = input_tensor.shard_spec().value().shape[0];
-    const uint32_t H = input_tensor.padded_shape()[2];
-    const uint32_t num_H_per_core = shard_height / H > 0 ? shard_height / H : 1;
-    return static_cast<uint32_t>(num_H_per_core == 1);
-}
 
 std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime_args_hc_rm_sharded(
     const Tensor& input_tensor, uint32_t num_cores, uint32_t num_cores_x, uint32_t num_cores_y) {
@@ -75,8 +57,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
         }
         uint32_t num_sticks_per_core = shard_height;
 
-        std::vector<uint32_t> reader_runtime_args = {
-            hc_rm_sharded_reader_arg0(input_tensor), curr_sticks_read, curr_c, curr_h, curr_n};
+        std::vector<uint32_t> reader_runtime_args = {num_sticks_per_core, curr_sticks_read, curr_c, curr_h, curr_n};
         reader_runtime_args.insert(reader_runtime_args.end(), shard_grid_x_map.begin(), shard_grid_x_map.end());
         reader_runtime_args.insert(reader_runtime_args.end(), shard_grid_y_map.begin(), shard_grid_y_map.end());
 
@@ -281,7 +262,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
             }
         }
 
-        bool read_single_h_block_per_core = hc_rm_sharded_special_case_reader_arg0(input_tensor) != 0;
+        const bool read_single_h_block_per_core = num_H_per_core == 1;
 
         constexpr size_t num_reader_scalar_args = 5;
         const size_t num_non_repeat_args =
@@ -332,8 +313,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     return ret_val;
 }
 
-// Selects the special-case per-core builder. Shared by create_descriptor and get_dynamic_runtime_args
-// so the reader arg0 value they emit/re-apply cannot drift.
+// Selects the special-case per-core builder.
 inline bool hc_rm_sharded_is_special_case(uint32_t shard_height, uint32_t H, uint32_t C) {
     return (shard_height % H == 0 || H % shard_height == 0) && (shard_height % C == 0 || C % shard_height == 0) &&
            (C % H == 0 || H % C == 0) && (shard_height <= C * H);
@@ -375,8 +355,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
     uint32_t num_cores_y = grid_size.y;
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
-    // Sharded CBs bound to the input/output buffers: the framework re-applies
-    // UpdateDynamicCircularBufferAddress on cache hit via the .buffer member.
+    // Sharded CBs bound to the input/output buffers; override_runtime_arguments re-points them on a hit.
     desc.cbs.push_back(CBDescriptor{
         .total_size = shard_height * stick_size_bytes,
         .core_ranges = all_cores,
@@ -480,29 +459,18 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> TransposeDeviceOperation::get_dynamic_runtime_args(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/,
+void TransposeHCShardedProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const TransposeParams& /*operation_attributes*/,
+    const TransposeInputs& tensor_args,
+    Tensor& output_tensor,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    const auto factory = select_program_factory(operation_attributes, tensor_args);
-    const auto& input = tensor_args.input;
-    // HC sharded RM is CB-bound; re-apply reader arg0 (read by the kernel) on core 0 to trip the fast-path.
-    // The value is invariant for a cached program (shard height and shape are part of the program-cache
-    // hash)
-    if (std::holds_alternative<TransposeHCShardedProgramFactory>(factory)) {
-        const auto& shard = input.shard_spec().value();
-        const uint32_t H = input.logical_shape()[2], C = input.logical_shape()[1];
-        const bool special = hc_rm_sharded_is_special_case(shard.shape[0], H, C);
-        const uint32_t arg0 =
-            special ? hc_rm_sharded_special_case_reader_arg0(input) : hc_rm_sharded_reader_arg0(input);
-        return {tt::tt_metal::DynamicRuntimeArg{0, corerange_to_cores(shard.grid).front(), 0, arg0}};
-    }
-    // WH sharded RM emits one placeholder reader arg the kernel ignores; re-apply 0 to trip the fast-path.
-    if (std::holds_alternative<TransposeWHShardedRMProgramFactory>(factory)) {
-        return {tt::tt_metal::DynamicRuntimeArg{0, corerange_to_cores(input.shard_spec().value().grid).front(), 0, 0u}};
-    }
-    return {};
+    // No custom compute_program_hash, so shape and shard spec are keyed and every reader/writer arg is
+    // pinned; only the buffer addresses move, and both ride on the sharded CBs pushed above (src0, out).
+    ProgramDescriptor cb_addr_only;
+    cb_addr_only.cbs.push_back(CBDescriptor{.buffer = tensor_args.input.buffer()});
+    cb_addr_only.cbs.push_back(CBDescriptor{.buffer = output_tensor.buffer()});
+    apply_descriptor_runtime_args(program, cb_addr_only);  // override-rebuild-ok: cb-addr-only
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.hpp
@@ -15,6 +15,13 @@ namespace ttnn::prim {
 struct TransposeHCShardedProgramFactory {
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
+
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const TransposeParams& operation_attributes,
+        const TransposeInputs& tensor_args,
+        Tensor& output_tensor,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -243,17 +243,25 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
         .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
     };
 
-    // #48928: this reader uses compile-time args only; emit one placeholder rt-arg per core so
-    // get_dynamic_runtime_args has a slot to re-apply, opting this CB-bound factory into the fast-path.
-    for (const auto& core : corerange_to_cores(all_cores)) {
-        reader_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{0u});
-    }
-
     desc.kernels.push_back(std::move(reader_desc));
     desc.kernels.push_back(std::move(writer_desc));
     desc.kernels.push_back(std::move(compute_desc));
 
     return desc;
+}
+
+void TransposeWHShardedRMProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const TransposeParams& /*operation_attributes*/,
+    const TransposeInputs& tensor_args,
+    Tensor& output_tensor,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // All three kernels take compile-time args only, so the buffer addresses are the whole per-dispatch
+    // state. CBs are matched positionally: src0 and output are pushed first, the rest are unbound.
+    ProgramDescriptor cb_addr_only;
+    cb_addr_only.cbs.push_back(CBDescriptor{.buffer = tensor_args.input.buffer()});
+    cb_addr_only.cbs.push_back(CBDescriptor{.buffer = output_tensor.buffer()});
+    apply_descriptor_runtime_args(program, cb_addr_only);  // override-rebuild-ok: cb-addr-only
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.hpp
@@ -15,6 +15,13 @@ namespace ttnn::prim {
 struct TransposeWHShardedRMProgramFactory {
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
+
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const TransposeParams& operation_attributes,
+        const TransposeInputs& tensor_args,
+        Tensor& output_tensor,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
### What

Ports `transpose` off the legacy `get_dynamic_runtime_args` hook onto per-factory
`override_runtime_arguments`.

- `TransposeDeviceOperation::get_dynamic_runtime_args` is deleted.
- `TransposeHCShardedProgramFactory` and `TransposeWHShardedRMProgramFactory` — the two factories
  `get_dynamic` was serving — each get an `override_runtime_arguments` that re-points their two
  tensor-backed sharded CBs (input `c_0`, output `c_16`) via a CB-only `ProgramDescriptor` +
  `apply_descriptor_runtime_args`. The other six factories get no hook: they have nothing
  per-dispatch to patch and keep taking the existing rebuild path.
- Drops the two pieces of scaffolding `get_dynamic` needed and nothing else used: the per-core
  placeholder reader runtime arg the WH-sharded-RM reader ignored (it takes compile-time args only),
  and the two `hc_rm_sharded_*_reader_arg0` closed-form helpers, whose values are just locals already
  computed inside the HC arg builders.

### Why

`transpose` has no custom `compute_program_hash`, so shape, shard spec and memory config are all
keyed and every reader/writer runtime arg is pinned for a cached program. The only hash-excluded
per-dispatch state is the input/output buffer addresses, and both ride on the sharded CBs.

`get_dynamic` never re-applied anything meaningful here — it re-emitted a value that is invariant for
a cached program, purely to trip the descriptor fast path so the framework would also patch the
`.buffer` CB bindings via `resolve_bindings`. `override_runtime_arguments` states the actual
per-dispatch contract directly: the factory that built the descriptor owns re-applying it, with no
address inference and no invariant-value placeholder. A `static_assert` in
`mesh_device_operation_adapter.hpp` rejects an op declaring both hooks, so deleting `get_dynamic` is
part of the same change.

The hook is O(1) per dispatch: two `CBDescriptor`s, no `create_descriptor()` call, no per-core loop.

### Tests

New `test_transpose_hc_sharded_override_addr_change` (3 params: generic, special-case
single-H-block, special-case multi-H-block) and `test_transpose_wh_sharded_rm_override_addr_change`
in `tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py`.

Each runs the same-shape transpose twice, keeping the first input and output alive so the second pair
is forced to different L1 addresses, then asserts all three of: the addresses really did move, the
second call was a program-cache **hit** (`num_program_cache_entries()` unchanged), and the second
output matches its own fresh input.

That is exactly what the new hook is responsible for. Verified non-vacuous: with the
`apply_descriptor_runtime_args` call removed from both overrides, all four fail on PCC (the second
dispatch reads and writes the first dispatch's buffers). They also pass against the pre-change
`get_dynamic` code, which is expected — there was no pre-existing correctness bug here, `get_dynamic`
routed the CB addresses through `resolve_bindings`; the tests pin the behaviour to the new mechanism.

Full `test_transpose.py`: 456 passed, 70 skipped. `test_reshape_transpose.py` + `test_permute.py`:
1595 passed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-transpose-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-transpose-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-transpose-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-transpose-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/gd-transpose-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/gd-transpose-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-transpose-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-transpose-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-transpose-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-transpose-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-transpose-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-transpose-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-transpose-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-transpose-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-transpose-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-transpose-override)