### PR TITLE
cast supplied env variable I2V_ENCODE_FRAMES to int

### DIFF
--- a/models/tt_dit/pipelines/wan/pipeline_wan_i2v.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan_i2v.py
@@ -41,7 +41,7 @@ _ENCODER_T_CHUNK_BY_MESH = {
 
 # Truncated VAE encode: encode only the first I2V_ENCODE_FRAMES pixel frames and
 # replicate the last latent to fill the remaining slots.
-_I2V_ENCODE_FRAMES = os.environ.get("I2V_ENCODE_FRAMES", 81)
+_I2V_ENCODE_FRAMES = int(os.environ.get("I2V_ENCODE_FRAMES", 81))
 
 
 def _resolve_checkpoint(repo_id: str) -> str:


### PR DESCRIPTION
### PR Category
Bug fix

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sadesoye/fix_i2v_encode_env)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sadesoye/fix_i2v_encode_env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sadesoye/fix_i2v_encode_env)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sadesoye/fix_i2v_encode_env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sadesoye/fix_i2v_encode_env)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sadesoye/fix_i2v_encode_env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/fix_i2v_encode_env)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/fix_i2v_encode_env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sadesoye/fix_i2v_encode_env)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sadesoye/fix_i2v_encode_env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sadesoye/fix_i2v_encode_env)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sadesoye/fix_i2v_encode_env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/fix_i2v_encode_env)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/fix_i2v_encode_env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sadesoye/fix_i2v_encode_env)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sadesoye/fix_i2v_encode_env)