### PR TITLE
ttnn.pow: propagate NaN base/exponent instead of returning a finite value

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
@@ -2,8 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
 import pytest
+import torch
 import ttnn
 from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range, compare_pcc
 from tests.ttnn.utils_for_testing import (
@@ -439,3 +439,66 @@ def test_pow_arange_masking_fp32(exponent, device):
     golden = flush_subnormal_values_to_zero(golden)
 
     assert_allclose(golden, result, atol=5e-4, rtol=8e-7)
+
+
+# Regression for https://github.com/tenstorrent/tt-metal/issues/52593
+# ttnn.pow must propagate IEEE-754 NaN instead of silently producing a finite value.
+#   pow(NaN,  0.0) = 1.0
+#   pow(NaN, -0.0) = 1.0
+#   pow(NaN,  y  ) = NaN       for y != +-0
+#   pow(1.0,  NaN) = 1.0
+#   pow(x,    NaN) = NaN       for x != 1.0
+@pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
+@pytest.mark.parametrize("shape", [[1, 1, 32, 32], [2, 32, 320]])
+def test_binary_sfpu_pow_nan_propagation(shape, dtype, device):
+    torch.manual_seed(0)
+    torch_dtype = getattr(torch, dtype)
+    ttnn_dtype = getattr(ttnn, dtype)
+    nan = float("nan")
+
+    # Finite values: base in [1, 2], exponent in [0, 1] so every normal lane is
+    # finite and in [1, 2] and tolerates the bf16 approximation well.
+    base = torch.rand(shape, dtype=torch_dtype) + 1.0
+    exp = torch.rand(shape, dtype=torch_dtype) * 0.5
+
+    b = base.flatten()
+    e = exp.flatten()
+
+    # Fully deterministic injected lanes (no random-value dependence).
+    # pow(NaN, y) = NaN for y != +-0
+    b[0] = nan
+    e[0] = 2.0
+    b[1] = nan
+    e[1] = 0.5
+    # pow(NaN, +-0) = 1 (idempotency exception)
+    b[2] = nan
+    e[2] = 0.0
+    b[3] = nan
+    e[3] = -0.0
+    # pow(x, NaN) = NaN for x != 1
+    b[4] = 2.0
+    e[4] = nan
+    b[5] = 4.0
+    e[5] = nan
+    # pow(1, NaN) = 1 (idempotency exception)
+    b[6] = 1.0
+    e[6] = nan
+
+    base = b.reshape(shape)
+    exp = e.reshape(shape)
+
+    # torch.pow implements IEEE-754 pow() semantics.
+    golden = torch.pow(base, exp)
+
+    in_base = ttnn.from_torch(base, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    in_exp = ttnn.from_torch(exp, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    out = ttnn.pow(in_base, in_exp)
+    out = ttnn.to_torch(out)
+
+    # NaN handling: it must match IEEE (NaN in -> NaN out, with the x^0 and 1^x
+    # idempotency exceptions). Finite lanes must also match within tolerance.
+    if dtype == "bfloat16":
+        assert_allclose(out, golden, atol=2.5e-2, rtol=5e-3)
+    else:
+        assert_allclose(out, golden, atol=1e-5, rtol=1e-4)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -283,16 +283,34 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow);
 
+// IEEE-754 NaN propagation guard for pow (see #52593).
+// pow(NaN, y) = NaN unless y == +/- 0 (-> 1);
+// pow(x, NaN) = NaN unless x == 1.0   (-> 1).
+sfpi_inline sfpi::vFloat _sfpu_binary_power_nan_guard_(sfpi::vFloat base, sfpi::vFloat pow, sfpi::vFloat y) {
+    v_if(sfpi::is_nan(base)) {
+        v_if(pow == 0.0f) { y = 1.0f; }
+        v_else { y = std::numeric_limits<float>::quiet_NaN(); }
+        v_endif;
+    }
+    v_elseif(sfpi::is_nan(pow)) {
+        v_if(base == 1.0f) { y = 1.0f; }
+        v_else { y = std::numeric_limits<float>::quiet_NaN(); }
+        v_endif;
+    }
+    v_endif;
+    return y;
+}
+
 // is_fp32_dest_acc_en == false
 template <>
 sfpi_inline sfpi::vFloat _sfpu_binary_power_<false>(sfpi::vFloat base, sfpi::vFloat pow) {
-    return _sfpu_binary_power_21f_<false>(base, pow);
+    return _sfpu_binary_power_nan_guard_(base, pow, _sfpu_binary_power_21f_<false>(base, pow));
 }
 
 // is_fp32_dest_acc_en == true
 template <>
 sfpi_inline sfpi::vFloat _sfpu_binary_power_<true>(sfpi::vFloat base, sfpi::vFloat pow) {
-    return _sfpu_binary_power_f32_(base, pow);
+    return _sfpu_binary_power_nan_guard_(base, pow, _sfpu_binary_power_f32_(base, pow));
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -283,16 +283,34 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow);
 
+// IEEE-754 NaN propagation guard for pow (see #52593).
+// pow(NaN, y) = NaN unless y == +/- 0 (-> 1);
+// pow(x, NaN) = NaN unless x == 1.0   (-> 1).
+sfpi_inline sfpi::vFloat _sfpu_binary_power_nan_guard_(sfpi::vFloat base, sfpi::vFloat pow, sfpi::vFloat y) {
+    v_if(sfpi::is_nan(base)) {
+        v_if(pow == 0.0f) { y = 1.0f; }
+        v_else { y = std::numeric_limits<float>::quiet_NaN(); }
+        v_endif;
+    }
+    v_elseif(sfpi::is_nan(pow)) {
+        v_if(base == 1.0f) { y = 1.0f; }
+        v_else { y = std::numeric_limits<float>::quiet_NaN(); }
+        v_endif;
+    }
+    v_endif;
+    return y;
+}
+
 // is_fp32_dest_acc_en == false
 template <>
 sfpi_inline sfpi::vFloat _sfpu_binary_power_<false>(sfpi::vFloat base, sfpi::vFloat pow) {
-    return _sfpu_binary_power_21f_<false>(base, pow);
+    return _sfpu_binary_power_nan_guard_(base, pow, _sfpu_binary_power_21f_<false>(base, pow));
 }
 
 // is_fp32_dest_acc_en == true
 template <>
 sfpi_inline sfpi::vFloat _sfpu_binary_power_<true>(sfpi::vFloat base, sfpi::vFloat pow) {
-    return _sfpu_binary_power_f32_(base, pow);
+    return _sfpu_binary_power_nan_guard_(base, pow, _sfpu_binary_power_f32_(base, pow));
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>


### PR DESCRIPTION
**PR Category**
Bug fix

**Summary**
`ttnn.pow` silently turns a NaN base or exponent into a finite number.

Root cause: the SFPU power fast path normalizes the base with
`setexp(abs_base, 127)` before the log2 polynomial. `setexp(NaN, 127)`
rewrites the exponent field while keeping the non-zero mantissa, so the NaN
bit pattern is destroyed before the result is produced, and there is no
`is_nan` guard anywhere in the power path to recover it.

Change: add a representation-neutral NaN guard in the binary power dispatcher
so both the bf16 (21f) and fp32 (f32) paths, on Wormhole and Blackhole, follow
IEEE-754 `pow()` semantics:
- `pow(NaN, y) = NaN` unless `y == +-0` (-> 1)
- `pow(x, NaN) = NaN` unless `x == 1.0` (-> 1)
The guard uses the existing `sfpi::is_nan()` primitive. The existing zero-base,
negative-base, and overflow/underflow handling is unchanged.

**Notes for reviewers**
- The idempotency exceptions are preserved on purpose: a blanket "any NaN ->
  NaN" would wrongly turn `pow(NaN, 0)` and `pow(1, NaN)` into NaN.
- Validation: host IEEE/numpy model (the 11-case matrix in #52593) matches
  numpy golden after the fix; a PyTorch regression in
  `tests/ttnn/unit_tests/operations/eltwise/test_pow.py` asserts the NaN cases
  against `torch.pow`. Device runtime accuracy of finite lanes is out of scope;
  this change is limited to NaN propagation semantics.

**Fixes** #52593
