### PR TITLE
Sparse MLA: move gathers to high-bandwidth all-gather

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -412,6 +412,7 @@ def run_sparse_mla_chunked_case(
         sp_axis=sp_axis,
         tp_axis=tp_axis,
         is_chunked=True,
+        active_seq_len=chunk,
         slot_num=num_users,
         layer_num=1,
         sparse_kv_cache_format=cache_format,
@@ -524,6 +525,7 @@ def run_sparse_mla_kv_only_case(variant, config, mesh_device, seq_len, chunk, ds
         sp_axis=sp_axis,
         tp_axis=tp_axis,
         is_chunked=True,
+        active_seq_len=chunk,
         layer_num=1,
         sparse_kv_cache_format=cache_format,
         kv_only=True,
@@ -622,6 +624,7 @@ def run_sparse_mla_rotated_case(
         sp_axis=sp_axis,
         tp_axis=tp_axis,
         is_chunked=True,
+        active_seq_len=chunk_size_global,
         slot_num=1,
         layer_num=1,
     )

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_ccl_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_ccl_perf.py
@@ -4,9 +4,13 @@
 
 """Galaxy CCL microbenchmarks and LoudBox proxies for GLM sparse-MLA tensor shapes and placements.
 
-Each collective sparse MLA runs in production (``tt/mla/mla.py``) is expressed as one ``CollectivePath``
-value; the tests turn each into a build -> profile -> (verify) -> report cycle under the real-time
-profiler. Adding a fourth collective is a single ``CollectivePath`` literal — no new driver code.
+Each collective shape and placement that sparse MLA uses in production (``tt/mla/mla.py``) is expressed
+as one ``CollectivePath`` value; the tests turn each into a build -> profile -> (verify) -> report cycle
+under the real-time profiler. Adding a fourth collective is a single ``CollectivePath`` literal — no
+new driver code.
+
+The KVPE-prefix benchmark evaluates ``high_bw_all_gather``. The GLM head/sequence redistribution
+benchmarks continue to measure the production ``all_to_all_async_generic`` paths.
 """
 
 import math
@@ -23,7 +27,6 @@ from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import glm_hf_config
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_mesh import detect_num_devices
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.test_sparse_mla_perf import CHUNK_TOKENS, GALAXY_SP, SCENARIOS
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
-from models.demos.deepseek_v3_d_p.tt.tt_ccl import create_global_semaphores
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
 
@@ -117,33 +120,33 @@ class CollectivePath:
     """One production sparse-MLA collective, described declaratively.
 
     ``collective_axis`` unifies three things: which mesh axis the op runs over (SP/TP), the ``cluster_axis``
-    of its collective, and which axis supplies the roofline ``participants`` count. ``out_dim is None``
-    marks a pure all-gather; otherwise the op is an all-to-all reshard. Shapes are
-    ``(workload, mesh_shape) -> list`` builders so a proxy and Galaxy share one source.
+    of its collective, and which axis supplies the roofline ``participants`` count. ``partition_dim is None``
+    marks a pure all-gather; otherwise the op is an all-to-all reshard. Shapes are ``(workload, mesh_shape)
+    -> list`` builders so a proxy and Galaxy share one source.
     """
 
     name: str
     mla_ref: str  # the production source this mirrors, e.g. "mla.py:1468"
     collective_axis: int
-    in_dim: int
+    gather_dim: int
     input_placements: tuple
     layout: object
     logical_shape: Callable
     local_input_shape: Callable
     output_placements: tuple  # tensor placements after the collective (asserted post-op)
-    out_dim: Optional[int] = None
+    partition_dim: Optional[int] = None
     expected_output_shape: Optional[Callable] = None
     verify_reshard: bool = False
 
     def __post_init__(self):
-        if self.out_dim is not None:
+        # A reshard needs an expected output shape to assert, and its reconstruct/recompose use placement
+        # .dim, so every reshard placement must be a shard (a Replicate has no dim).
+        if self.partition_dim is not None:
             assert self.expected_output_shape is not None, f"{self.name}: reshard path needs expected_output_shape"
             assert all(
                 isinstance(placement, ttnn.PlacementShard)
                 for placement in self.input_placements + self.output_placements
             ), f"{self.name}: reshard placements must all be PlacementShard"
-            assert self.input_placements[self.collective_axis].dim == self.in_dim
-            assert self.output_placements[self.collective_axis].dim == self.out_dim
 
 
 # --------------------------------------------------------------------------------------------------
@@ -201,9 +204,9 @@ def _sequence_to_head_output_shape(w: Workload, mesh_shape) -> list:
 # The three production collectives, as data.
 KVPE_ALL_GATHER = CollectivePath(
     name="kvpe_all_gather",
-    mla_ref="mla.py:1534 (_gather_kvpe_prefix)",
+    mla_ref="mla.py:1543 (_gather_kvpe_prefix)",
     collective_axis=SP_AXIS,
-    in_dim=2,
+    gather_dim=2,
     input_placements=(ttnn.PlacementShard(2), ttnn.PlacementReplicate()),  # SP shards tokens; TP replicates.
     output_placements=(ttnn.PlacementReplicate(), ttnn.PlacementReplicate()),  # gathered over SP -> fully replicated.
     layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -213,10 +216,10 @@ KVPE_ALL_GATHER = CollectivePath(
 
 GLM_HEAD_TO_SEQUENCE = CollectivePath(
     name="glm_head_to_sequence_reshard",
-    mla_ref="mla.py:1423 (_sparse_mla thin-head transpose)",
+    mla_ref="mla.py:1481-1489 (_sparse_mla thin-head transpose)",
     collective_axis=TP_AXIS,
-    in_dim=1,
-    out_dim=2,
+    gather_dim=1,
+    partition_dim=2,
     input_placements=(ttnn.PlacementShard(2), ttnn.PlacementShard(1)),  # SP shards Q, TP shards H.
     output_placements=(ttnn.PlacementShard(2), ttnn.PlacementShard(2)),  # SP shards Q, TP also shards Q.
     layout=ttnn.TILE_LAYOUT,
@@ -228,10 +231,10 @@ GLM_HEAD_TO_SEQUENCE = CollectivePath(
 
 GLM_SEQUENCE_TO_HEAD = CollectivePath(
     name="glm_sequence_to_head_reshard",
-    mla_ref="mla.py:1471 (_sparse_mla transpose inverse)",
+    mla_ref="mla.py:1528-1538 (_sparse_mla transpose inverse)",
     collective_axis=TP_AXIS,
-    in_dim=2,
-    out_dim=1,
+    gather_dim=2,
+    partition_dim=1,
     input_placements=(ttnn.PlacementShard(2), ttnn.PlacementShard(2)),  # SP shards Q, TP also shards Q.
     output_placements=(ttnn.PlacementShard(2), ttnn.PlacementShard(1)),  # SP shards Q, TP shards H.
     layout=ttnn.TILE_LAYOUT,
@@ -292,39 +295,30 @@ def resolve_runtime_system(mesh_device, path: CollectivePath, topology=ttnn.Topo
 
 
 # --------------------------------------------------------------------------------------------------
-# Profiling + semaphores
+# Profiling
 # --------------------------------------------------------------------------------------------------
-def _global_semaphores(mesh_device):
-    compute_grid = mesh_device.compute_with_storage_grid_size()
-    cores = ttnn.CoreRangeSet(
-        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid.x - 1, compute_grid.y - 1))}
-    )
-    gather_semaphores = create_global_semaphores(mesh_device, cores, 0)
-    barrier_semaphore = ttnn.create_global_semaphore(mesh_device, cores, 0)
-    return gather_semaphores, barrier_semaphore
-
-
-def _profile_programs(mesh_device, run_fn, latest_program_only=False):
+def _profile_programs(mesh_device, run_fn, expected_programs):
     if not ttnn.device.IsProgramRealtimeProfilerActive():
         pytest.fail("Real-time profiler must be active for sparse MLA CCL perf checks")
 
     # Drain setup programs before registering the callback so only run_fn contributes records.
     ttnn.synchronize_device(mesh_device)
     result, records = profile_realtime_program(mesh_device, run_fn, collect_all=True)
-    # Receiver delivery is asynchronous: a setup program completed before callback registration can arrive
-    # after it and appear in records. A2A dispatches exactly one measured program, so select the newest
-    # monotonic runtime ID there. All-gather retains all IDs because it may dispatch multiple programs.
-    if latest_program_only:
-        measured_runtime_id = max(record["runtime_id"] for record in records)
-        records = tuple(record for record in records if record["runtime_id"] == measured_runtime_id)
-
-    measured_records = tuple(record for record in records if record["runtime_id"])
+    # The receiver can deliver already-completed setup records after the callback is registered. Runtime
+    # IDs are monotonic, so retain exactly the programs dispatched by run_fn at the end of the capture.
+    runtime_ids = sorted({record["runtime_id"] for record in records if record["runtime_id"]})
+    assert len(runtime_ids) >= expected_programs
+    measured_runtime_ids = set(runtime_ids[-expected_programs:])
+    records = [record for record in records if record["runtime_id"] in measured_runtime_ids]
     program_durations_ns = {}
-    for record in measured_records:
+    for record in records:
         runtime_id = record["runtime_id"]
-        program_durations_ns[runtime_id] = max(program_durations_ns.get(runtime_id, 0.0), float(record["duration_ns"]))
+        if runtime_id:
+            program_durations_ns[runtime_id] = max(
+                program_durations_ns.get(runtime_id, 0.0), float(record["duration_ns"])
+            )
     assert program_durations_ns, "real-time profiler returned no valid program durations"
-    return result, measured_records, program_durations_ns
+    return result, tuple(records), program_durations_ns
 
 
 def _tensor_description(tensor):
@@ -337,9 +331,43 @@ def _tensor_description(tensor):
 # --------------------------------------------------------------------------------------------------
 def run_collective(mesh_device, path: CollectivePath, workload: Workload, system: RuntimeSystem) -> Measurement:
     """Build the input, profile the collective, and (for reshards) prove it moved data losslessly."""
-    if path.out_dim is None:
+    if path.partition_dim is None:
         return _run_all_gather(mesh_device, path, workload, system)
     return _run_reshard(mesh_device, path, workload, system)
+
+
+def _gathered_placements(input_placements, gather_dim, cluster_axis):
+    placements = list(input_placements)
+    collective_placement = placements[cluster_axis]
+    assert isinstance(collective_placement, ttnn.PlacementShard)
+    assert collective_placement.dim == gather_dim
+    placements[cluster_axis] = ttnn.PlacementReplicate()
+    return tuple(placements)
+
+
+def _placement_signature(placements):
+    return tuple(placement.dim if isinstance(placement, ttnn.PlacementShard) else None for placement in placements)
+
+
+def _allocate_gather_output(mesh_device, global_shape, layout, placements):
+    return ttnn.rand(
+        global_shape,
+        mesh_device,
+        layout=layout,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.MeshMapperConfig(list(placements), mesh_device.shape),
+    )
+
+
+def _high_bw_all_gather(tt_input, output_tensor, gather_dim, cluster_axis, num_links):
+    return ttnn.experimental.high_bw_all_gather(
+        tt_input,
+        dim=gather_dim,
+        output_tensor=output_tensor,
+        cluster_axis=cluster_axis,
+        num_links=num_links,
+    )
 
 
 def _run_all_gather(mesh_device, path, workload, system) -> Measurement:
@@ -354,22 +382,23 @@ def _run_all_gather(mesh_device, path, workload, system) -> Measurement:
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         mesh_mapper=mesh_mapper,
     )
-    gather_semaphores, barrier_semaphore = _global_semaphores(mesh_device)
-    tt_output, records, program_durations_ns = _profile_programs(
+    usable_topology = ttnn.get_usable_topology(tt_input, system.topology, path.collective_axis)
+    assert usable_topology == system.topology, (
+        f"{path.name}: requested {system.topology} on cluster_axis={path.collective_axis}, "
+        f"but Fabric resolved {usable_topology}"
+    )
+    gathered_placements = _gathered_placements(path.input_placements, path.gather_dim, path.collective_axis)
+    assert _placement_signature(gathered_placements) == _placement_signature(path.output_placements)
+    tt_output = _allocate_gather_output(mesh_device, global_shape, path.layout, gathered_placements)
+    _, records, program_durations_ns = _profile_programs(
         mesh_device,
-        lambda: ttnn.experimental.all_gather_async(
-            tt_input,
-            dim=path.in_dim,
-            multi_device_global_semaphore=gather_semaphores,
-            barrier_semaphore=barrier_semaphore,
-            num_links=system.num_links,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=system.topology,
-            cluster_axis=path.collective_axis,
-        ),
+        lambda: _high_bw_all_gather(tt_input, tt_output, path.gather_dim, path.collective_axis, system.num_links),
+        expected_programs=1,
     )
     assert list(tt_output.shape) == global_shape
-    assert tt_output.tensor_topology().placements() == list(path.output_placements)
+    assert _placement_signature(tt_output.tensor_topology().placements()) == _placement_signature(
+        path.output_placements
+    )
     measurement = Measurement(
         records, program_durations_ns, _tensor_description(tt_input), _tensor_description(tt_output)
     )
@@ -378,12 +407,13 @@ def _run_all_gather(mesh_device, path, workload, system) -> Measurement:
     return measurement
 
 
-def _reshard(tt_input, path, system):
-    """Run the single all-to-all used by sparse MLA to exchange sharded tensor dimensions."""
+def _reshard(tt_input, output_buffer, path, system):
+    """Run the all-to-all used by sparse MLA to exchange sharded tensor dimensions."""
     return ttnn.experimental.all_to_all_async_generic(
         tt_input,
-        in_dim=path.in_dim,
-        out_dim=path.out_dim,
+        in_dim=path.gather_dim,
+        out_dim=path.partition_dim,
+        persistent_output_buffer=output_buffer,
         num_links=system.num_links,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         topology=system.topology,
@@ -424,12 +454,12 @@ def _build_reshard_input(mesh_device, path, torch_input, system):
     )
     tt_input = ttnn.experimental.all_to_all_async_generic(
         source,
-        in_dim=path.out_dim,
-        out_dim=path.in_dim,
+        in_dim=path.output_placements[cax].dim,
+        out_dim=path.input_placements[cax].dim,
         num_links=system.num_links,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        topology=system.topology,
         cluster_axis=cax,
+        topology=system.topology,
     )
     ttnn.synchronize_device(mesh_device)
     ttnn.deallocate(source)
@@ -455,11 +485,18 @@ def _run_reshard(mesh_device, path, workload, system) -> Measurement:
     tt_input = _build_reshard_input(mesh_device, path, torch_input, system)
     # Input shape is shared with the traffic roofline; output shape remains an explicit reshard assertion.
     assert list(ttnn.get_device_tensors(tt_input)[0].shape) == path.local_input_shape(workload, mesh_shape)
-
+    # Match MLA: preallocate the exact per-device output once, outside the profiled collective.
+    output_buffer = ttnn.empty(
+        path.expected_output_shape(workload, mesh_shape),
+        device=mesh_device,
+        layout=path.layout,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
     tt_output, records, program_durations_ns = _profile_programs(
         mesh_device,
-        lambda: _reshard(tt_input, path, system),
-        latest_program_only=True,
+        lambda: _reshard(tt_input, output_buffer, path, system),
+        expected_programs=1,
     )
     assert list(ttnn.get_device_tensors(tt_output)[0].shape) == path.expected_output_shape(workload, mesh_shape)
     if path.verify_reshard:
@@ -482,7 +519,7 @@ def collective_roofline(path: CollectivePath, workload: Workload, mesh_device, s
     local_input_bytes = math.prod(path.local_input_shape(workload, mesh_shape)) * torch.bfloat16.itemsize
     participants = mesh_shape[path.collective_axis]
     num_devices = math.prod(mesh_shape)
-    if path.out_dim is None:
+    if path.partition_dim is None:
         critical_path_bytes = local_input_bytes * (participants - 1)
         total_network_bytes = critical_path_bytes * num_devices
         sustained_directions = 2 if system.topology == ttnn.Topology.Ring else 1
@@ -512,7 +549,7 @@ def report(path: CollectivePath, scenario: str, mesh_device, measurement: Measur
     sp, tp = mesh_device.shape
 
     logger.info(
-        f"{path.name}/{scenario} [{traffic.topology}, SP{sp}xTP{tp}]: {measurement.input_description} -> {measurement.output_description}"
+        f"{path.name}/{scenario} [SP{sp}xTP{tp}]: {measurement.input_description} -> {measurement.output_description}"
     )
     logger.info(
         f"theoretical fabric roofline: {traffic.link_gigabits_per_second_per_direction:.1f} "
@@ -523,7 +560,7 @@ def report(path: CollectivePath, scenario: str, mesh_device, measurement: Measur
         f"total-mesh={traffic.total_network_bytes / 1e6:.3f} MB, "
         f"theoretical={traffic.theoretical_ns / 1e3:.3f} us"
     )
-    measured_ops = "all_to_all" if path.out_dim is not None else "all_gather"
+    measured_ops = "all_to_all" if path.partition_dim is not None else "all_gather"
     logger.info(
         f"real-time profiler measured: {measured_ns / 1e3:.3f} us ({measured_ops}), "
         f"achieved ethernet bandwidth={measured_gigabytes_per_second:.3f} / "

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -690,6 +690,7 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, kv_cache_fo
         sp_axis=sp_axis,
         tp_axis=tp_axis,
         is_chunked=True,
+        active_seq_len=chunk,
         layer_num=1,
         has_indexer=has_indexer,  # sparse: DSA indexer + sparse_sdpa; dense: NullIndexer + ring MLA
         sparse_kv_cache_format=kv_cache_format if has_indexer else MlaKvCacheFormat.BF16_RM,

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -510,6 +510,7 @@ def test_glm_kv_cache_table(
         sp_axis=sp_axis,
         tp_axis=tp_axis,
         is_chunked=True,
+        active_seq_len=chunk_size_global,
         slot_num=1,
         layer_num=1,
     )
@@ -724,6 +725,7 @@ def test_glm52_kv_cache_table(
         sp_axis=sp_axis,
         tp_axis=tp_axis,
         is_chunked=True,
+        active_seq_len=chunk_size_global,
         slot_num=1,
         layer_num=1,
     )

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -674,6 +674,7 @@ def _run_chunked_prefill(
         is_balanced=False,
         topology=topology,
         is_chunked=True,
+        active_seq_len=chunk_size_global,
         slot_num=num_users,
         layer_num=1,
     )

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block_chunked.py
@@ -1152,7 +1152,8 @@ def run_chunked_block_glm_indexer(
                 "fabric_config": ttnn.FabricConfig.FABRIC_2D,
                 "fabric_router_config": create_fabric_router_config(max_payload_size=GLM52Config.FABRIC_PAYLOAD_SIZE),
                 "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-                "l1_small_size": 512,
+                # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores.
+                "l1_small_size": 768,
             },
             2,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -970,7 +970,7 @@ _PADDED_MODES = ["notrace", "traced"]
                 # semaphores there (use_l1_small_for_semaphores) instead of pinning the main-L1 floor.
                 # Kept minimal: L1_SMALL is carved from the top of L1, so a large value would shift the
                 # main-L1 buffer floor down and could re-introduce the clash.
-                "l1_small_size": 512,
+                "l1_small_size": 768,
                 # Needed only by mode="traced"; device_params is a separate parametrize axis so it
                 # cannot be conditioned on `mode`. Reserving it for every mode costs DRAM headroom the
                 # non-traced modes do not use — harmless here (the traced L61/full55k case, which has
@@ -991,7 +991,7 @@ _PADDED_MODES = ["notrace", "traced"]
                 "fabric_config": ttnn.FabricConfig.FABRIC_2D,
                 "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
                 "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-                "l1_small_size": 512,
+                "l1_small_size": 768,
                 "trace_region_size": 256 * 1024 * 1024,
             },
             2,
@@ -1063,9 +1063,8 @@ def test_kimi_prefill_transformer_chunked_padded(
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
                 "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
-                # Small L1_SMALL region for the MoE routing all-gather's global semaphores
-                # (use_l1_small_for_semaphores); see the Kimi chunked test for the rationale.
-                "l1_small_size": 512,
+                # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores.
+                "l1_small_size": 768,
             },
             2,
             ttnn.Topology.Linear,
@@ -1711,7 +1710,7 @@ def run_chunked_transformer_updated(
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
                 "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
                 # L1_SMALL region for the MoE routing all-gather's semaphores (see TtMoERoutingSetup).
-                "l1_small_size": 512,
+                "l1_small_size": 768,
                 # Required by mode="traced": without it conftest logs "No trace region size" and the
                 # captured trace buffers come out of general DRAM instead of a reserved region —
                 # unbounded, and trace_bytes() then reports 0.00 MB because the TRACE pool is empty.
@@ -1807,7 +1806,7 @@ def test_kimi_prefill_transformer_chunked_perf(
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
                 "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
                 # L1_SMALL region for the MoE routing all-gather's semaphores (see TtMoERoutingSetup).
-                "l1_small_size": 512,
+                "l1_small_size": 768,
                 # Required by mode="traced": without it conftest logs "No trace region size" and the
                 # captured trace buffers come out of general DRAM instead of a reserved region —
                 # unbounded, and trace_bytes() then reports 0.00 MB because the TRACE pool is empty.
@@ -1965,9 +1964,8 @@ def test_ds_prefill_transformer_chunked_no_pcc(
                 "fabric_config": ttnn.FabricConfig.FABRIC_2D,
                 "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
                 "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-                # Small L1_SMALL region for the MoE routing all-gather's global semaphores
-                # (use_l1_small_for_semaphores); see test_glm_prefill_transformer_chunked.
-                "l1_small_size": 512,
+                # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores.
+                "l1_small_size": 768,
             },
             2,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -256,6 +256,7 @@ class TtIndexer:
         sp_ccl_topology,
         tp_ccl_topology,
         seq_len: int = 1024,
+        active_seq_len: int | None = None,
         slot_num: int = 1,
         layer_num: int = 1,
     ):
@@ -306,6 +307,22 @@ class TtIndexer:
             index_rope_interleave=config.index_rope_interleave,
         )
         self.seq_len = seq_len
+        # Keep the index tensor width fixed at the configured maximum, except on small-cache test /
+        # deployment configurations where the cache itself cannot contain that many entries.  This
+        # width is static for the model lifetime; early prefixes fill the unused suffix with the
+        # sparse-SDPA sentinel through topk_large_indices(valid_length=...).
+        self.index_topk_capacity = min(self.index_args.index_topk, self.seq_len)
+        assert 16 <= self.index_topk_capacity <= 2048 and self.index_topk_capacity % 16 == 0, (
+            "indexer top-k capacity must be in [16, 2048] and a multiple of 16; " f"got {self.index_topk_capacity}"
+        )
+        # Chunked sparse MLA has a fixed active prefill chunk.  The TP gathers below are activation
+        # collectives, so their maximum output is this chunk (not the growing key-cache length).  Keep
+        # the optional default for direct TtIndexer users that predate the explicit active-sequence arg.
+        self.active_seq_len = active_seq_len if active_seq_len is not None else seq_len
+        assert (
+            self.active_seq_len % self.sp_factor == 0
+        ), f"active_seq_len ({self.active_seq_len}) must divide SP factor ({self.sp_factor})"
+        self.active_seq_len_local = self.active_seq_len // self.sp_factor
         # Block-cyclic key-cache path: mirrors the MLA KVPE cache — a persistent, per-user/layer,
         # block-cyclic ND-sharded key cache written by update_padded_kv_cache and scored by
         # indexer_score_dsa's block-cyclic reader. The rope is always the interleaved on-device INDEXED op
@@ -329,6 +346,42 @@ class TtIndexer:
         self._is_index_compact = self._num_index_layers is not None
         self._index_layer_idx = full_indexer_rank(config, layer_idx) if self._is_index_compact else layer_idx
         self._index_cache_layers = self._num_index_layers if self._is_index_compact else self.layer_num
+        # Stable, worst-case TP gather outputs.  Indexer layers execute serially, so TT_CCL shares each
+        # buffer across them.  This keeps the high-bandwidth gathers allocation-free and their output
+        # address fixed on the hot forward path.
+        self._k_all_gather_output = None
+        self._weights_all_gather_output = None
+        self._topk_indices_all_gather_output = None
+        if self.tp_factor > 1:
+            assert (
+                self.active_seq_len_local % self.tp_factor == 0
+            ), f"local active_seq_len ({self.active_seq_len_local}) must divide TP factor ({self.tp_factor})"
+            assert (self.active_seq_len_local // self.tp_factor) % ttnn.TILE_SIZE == 0, (
+                "the TP-local active sequence length must be tile aligned for high_bw_all_gather; "
+                f"got {self.active_seq_len_local // self.tp_factor}"
+            )
+            assert self.index_args.index_head_dim % (self.tp_factor * ttnn.TILE_SIZE) == 0, (
+                "the TP-local index head dimension must be tile aligned for high_bw_all_gather; "
+                f"got {self.index_args.index_head_dim // self.tp_factor}"
+            )
+            self._k_all_gather_output = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
+                name="indexer_k_all_reduce",
+                shape=[1, 1, self.active_seq_len_local, self.index_args.index_head_dim],
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+            )
+            self._weights_all_gather_output = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
+                name="indexer_weights_all_reduce",
+                shape=[1, self.tp_factor, self.active_seq_len_local, self.index_args.index_n_heads],
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+            )
+            self._topk_indices_all_gather_output = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
+                name="indexer_topk_indices",
+                shape=[1, 1, self.active_seq_len_local, self.index_topk_capacity],
+                dtype=ttnn.uint32,
+                layout=ttnn.TILE_LAYOUT,
+            )
         self._upload_weights(idx_host)
         # DS block-cyclic uses the interleaved rotary_embedding_indexed op, but DS weights emit the
         # half-split (rotate_half) rope arrangement. Permute the rope half (half-split -> interleaved) so
@@ -366,14 +419,13 @@ class TtIndexer:
         )
         if rs_only:
             return t
-        return ttnn.experimental.all_gather_async(
+        assert self._k_all_gather_output is not None
+        assert tuple(t.shape) == (1, 1, self.active_seq_len_local, self.index_args.index_head_dim // self.tp_factor)
+        return ttnn.experimental.high_bw_all_gather(
             t,
             dim=3,
-            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
-            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+            output_tensor=self._k_all_gather_output,
             num_links=self.ccl_num_links,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=self.tp_ccl_topology,
             cluster_axis=self.tp_axis,
         )
 
@@ -388,14 +440,13 @@ class TtIndexer:
         917-929), measured cheaper even on an 18x-wider tensor than wts."""
         if self.tp_factor == 1:
             return t
-        t = ttnn.experimental.all_gather_async(
+        assert self._weights_all_gather_output is not None
+        assert tuple(t.shape) == (1, 1, self.active_seq_len_local, self.index_args.index_n_heads)
+        t = ttnn.experimental.high_bw_all_gather(
             t,
             dim=1,
-            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
-            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+            output_tensor=self._weights_all_gather_output,
             num_links=self.ccl_num_links,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=self.tp_ccl_topology,
             cluster_axis=self.tp_axis,
         )
         return ttnn.experimental.fast_reduce_nc(
@@ -408,14 +459,19 @@ class TtIndexer:
         indices that were computed on TP-seq-sharded query rows back to the [1,1,S/sp,k] contract.)"""
         if self.tp_factor == 1:
             return t
-        return ttnn.experimental.all_gather_async(
+        assert dim == 2, "TtIndexer only regathers TP-split sequence rows"
+        assert self._topk_indices_all_gather_output is not None
+        assert tuple(t.shape) == (
+            1,
+            1,
+            self.active_seq_len_local // self.tp_factor,
+            self.index_topk_capacity,
+        )
+        return ttnn.experimental.high_bw_all_gather(
             t,
             dim=dim,
-            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
-            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+            output_tensor=self._topk_indices_all_gather_output,
             num_links=self.ccl_num_links,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=self.tp_ccl_topology,
             cluster_axis=self.tp_axis,
         )
 
@@ -672,16 +728,13 @@ class TtIndexer:
         # partial-logit all-reduce over tp. This is the win: the removed step was a 2-CCL (RS+AG) all-reduce
         # spanning the full end_pos-wide logit (+ a TILE<->ROW_MAJOR round-trip), the indexer's dominant cost.
         # Top-k key indices [1,1,S/sp,k] (ROW_MAJOR uint32). Future/pad -inf columns surface as the
-        # 0xFFFFFFFF sentinel that sparse_mla drops. topk_large_indices: 16 <= k <= 2048, multiple of 16.
-        # index_topk is a multiple of 16, so k is too iff end_pos is — assert it at the caller contract
-        # (current chunk sizing guarantees tile alignment) rather than failing deep inside the op.
-        assert end_pos % 16 == 0, f"indexer top-k requires a tile-aligned key count; got end_pos={end_pos}"
+        # 0xFFFFFFFF sentinel that sparse_mla drops. The indexer score/cache contract requires a
+        # 16-element-aligned key prefix; this is independent of fixed top-k capacity.
+        assert end_pos % 16 == 0, f"indexer cache prefix must be 16-element aligned; got end_pos={end_pos}"
         # Block-cyclic logits are the full preallocated width T with a stale [end_pos, T) tail (kv_len only
         # wrote the real prefix); valid_length bounds top-k to that prefix so the tail is never read or ranked.
         topk_valid_length = end_pos
-        idx = ttnn.experimental.topk_large_indices(
-            logits, k=min(self.index_args.index_topk, end_pos), valid_length=topk_valid_length
-        )
+        idx = ttnn.experimental.topk_large_indices(logits, k=self.index_topk_capacity, valid_length=topk_valid_length)
         # TP×SP: topk ran on the TP-seq-sharded rows ([1,1,S/(sp·tp),k]); regather over TP back to the
         # [1,1,S/sp,k] contract so sparse_sdpa/mla.py are unchanged. (Redundant TP-round-trip for GLM's
         # head→seq reshard, which re-splits it; correct regardless. tp=1: no-op.)
@@ -700,7 +753,8 @@ class TtIndexer:
             idx = ttnn.to_layout(idx_gathered, ttnn.ROW_MAJOR_LAYOUT)
             ttnn.deallocate(idx_local)
             ttnn.deallocate(idx_tiled)
-            ttnn.deallocate(idx_gathered)
+            # high_bw_all_gather returns a fresh wrapper around model-owned scratch; do not
+            # deallocate its backing buffer on the hot path.
         return idx
 
 

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -265,6 +265,7 @@ class ttMLA:
         kv_only: bool = False,
         has_indexer: bool | None = None,
         sparse_kv_cache_format: MlaKvCacheFormat = MlaKvCacheFormat.BF16_RM,
+        active_seq_len: Optional[int] = None,
     ):
         # DSA indexer weights (v3.2 / GLM): extract NON-mutating, so the caller's state_dict survives
         # repeated construction / cache build+load (the old pop() emptied it on the first pass). Dense
@@ -279,6 +280,17 @@ class ttMLA:
         self.is_balanced = is_balanced
         self.weight_cache_path = weight_cache_path
         self.is_chunked = is_chunked
+        self.max_seq_len = seq_len
+        # In chunked mode ``seq_len`` is the KV-cache capacity, while ``active_seq_len`` is the fixed
+        # physical activation slab.  Logical ISL may be shorter, but callers zero-pad it in this slab;
+        # keeping that shape fixed is what permits init-time high-BW-gather scratch allocation and
+        # program-cache reuse across rotated/partial chunks.
+        if is_chunked:
+            assert active_seq_len is not None, "chunked ttMLA requires the fixed physical active_seq_len"
+        self.active_seq_len = active_seq_len if active_seq_len is not None else seq_len
+        assert (
+            self.active_seq_len <= self.max_seq_len
+        ), f"active_seq_len ({self.active_seq_len}) exceeds max_seq_len ({self.max_seq_len})"
         self.slot_num = slot_num
         self.layer_num = layer_num
         self.sparse_kv_cache_format = MlaKvCacheFormat(sparse_kv_cache_format or MlaKvCacheFormat.BF16_RM)
@@ -360,8 +372,33 @@ class ttMLA:
         self.tt_ccl = get_tt_ccl(mesh_device)
         self.tp_factor = mesh_device.shape[self.tp_axis]
         self.sp_factor = mesh_device.shape[self.sp_axis]
+        assert (
+            self.active_seq_len % self.sp_factor == 0
+        ), f"active_seq_len ({self.active_seq_len}) must divide SP factor ({self.sp_factor})"
+        self.active_seq_len_local = self.active_seq_len // self.sp_factor
 
         self.ccl_num_links = 2 if is_blackhole() else 1  # Blackhole trains 2 fabric routing planes, others 1
+
+        # The TP high-bandwidth all-gathers operate on the fixed prefill chunk, never on the full
+        # growing KV-cache. Allocate their worst-case outputs once at construction and share them
+        # across serial MLA layers through TT_CCL; forward only reuses these stable addresses.
+        self._q_a_latent_gather_output = None
+        self._kv_stem_gather_output = None
+        if self.tp_factor > 1:
+            if not self.kv_only:
+                self._q_a_latent_gather_output = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
+                    name="q_a_latent",
+                    shape=[1, 1, self.active_seq_len_local, self.q_lora_rank],
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.TILE_LAYOUT,
+                )
+            self._kv_stem_gather_output = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
+                name="kv_stem",
+                shape=[1, self.tp_factor, self.active_seq_len_local, self.kv_lora_rank + self.qk_rope_head_dim],
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+            )
+
         # Per-axis CCL topology, named symmetrically by axis. The q/kv/wo collectives run on the TP
         # axis (cluster_axis=tp_axis) and use tp_ccl_topology; the ring-attention SDPA (ring_mla /
         # ring_joint_sdpa) runs on the SP axis (cluster_axis=sp_axis) and MUST use sp_ccl_topology.
@@ -453,6 +490,14 @@ class ttMLA:
         # the attention dense (has_indexer=False). Dense-path tuning gates that must tell V3.1 from a
         # dense-run V3.2 key on this, not _has_indexer (see _get_sdpa_program_config).
         self._is_dsa_family = TtIndexer.matches_config(config)
+        self._sparse_kv_gather_buffer = None
+        if self._has_indexer and not self.kv_only and self.sp_factor > 1:
+            self._sparse_kv_gather_buffer = self.tt_ccl.get_mla_sparse_kv_gather_buffer(
+                seq_len=seq_len,
+                row_width=self.sparse_kv_cache_format.storage_width(self.kv_cache_geometry),
+                dtype=self.sparse_kv_cache_format.storage_dtype,
+                layout=self.sparse_kv_cache_format.storage_layout,
+            )
         # GLM-5.2 indexer reuse: a "shared" layer is sparse but owns no indexer weights — it reuses the
         # most recent "full" layer's top-k indices, injected at forward, and binds a weight-less
         # ReuseIndexer (never computes). Absent indexer_types (v3.1 / v3.2 / GLM-5.1) every layer is
@@ -484,6 +529,7 @@ class ttMLA:
                     sp_ccl_topology=self.sp_ccl_topology,
                     tp_ccl_topology=self.tp_ccl_topology,
                     seq_len=seq_len,
+                    active_seq_len=self.active_seq_len,
                     slot_num=slot_num,
                     layer_num=self.layer_num,
                 )
@@ -860,15 +906,16 @@ class ttMLA:
                 topology=self.tp_ccl_topology,
                 cluster_axis=self.tp_axis,
             )
-            qr = ttnn.experimental.all_gather_async(
+            assert seq_len_local == self.active_seq_len_local, (
+                f"q_a latent gather was preallocated for {self.active_seq_len_local} local tokens, "
+                f"got {seq_len_local}"
+            )
+            qr = ttnn.experimental.high_bw_all_gather(
                 qr,
                 dim=3,
-                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
-                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
-                num_links=self.ccl_num_links,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                topology=self.tp_ccl_topology,
+                output_tensor=self._q_a_latent_gather_output,
                 cluster_axis=self.tp_axis,
+                num_links=self.ccl_num_links,
             )
 
         return ttnn.rms_norm(
@@ -946,24 +993,31 @@ class ttMLA:
         cache and consumed by attention without a decode/re-encode round trip.
         """
         # NOTE: input is ideally L1 for chunked, but hidden states memory config is set outside the module
+        kv_mm_kwargs = self._get_mm_kwargs("kv_a_proj_with_mqa", seq_len_local)
+        # high_bw_all_gather directly streams its source from DRAM. Kimi's 640-token
+        # matmul tune otherwise returns L1, while the fixed-slab TP path is active.
+        # Request DRAM from the producer instead of adding a forward-time conversion
+        # or falling back to the legacy all-gather.
+        if self.tp_factor > 1:
+            kv_mm_kwargs["memory_config"] = ttnn.DRAM_MEMORY_CONFIG
         tt_kv = ttnn.linear(
             hidden_states,
             self.kv_a_proj_with_mqa_weight,
             compute_kernel_config=self.default_compute_kernel_config,
-            **self._get_mm_kwargs("kv_a_proj_with_mqa", seq_len_local),
+            **kv_mm_kwargs,
         )
 
         # All reduce (skip for single-device TP)
         if self.tp_factor > 1:
-            tt_kv = ttnn.experimental.all_gather_async(
+            assert seq_len_local == self.active_seq_len_local, (
+                f"KV stem gather was preallocated for {self.active_seq_len_local} local tokens, " f"got {seq_len_local}"
+            )
+            tt_kv = ttnn.experimental.high_bw_all_gather(
                 tt_kv,
                 dim=1,
-                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
-                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
-                num_links=self.ccl_num_links,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                topology=self.tp_ccl_topology,
+                output_tensor=self._kv_stem_gather_output,
                 cluster_axis=self.tp_axis,
+                num_links=self.ccl_num_links,
             )
             tt_kv = ttnn.experimental.fast_reduce_nc(
                 tt_kv, dims=[1], output=None, compute_kernel_config=self.hifi4_fp32_compute_kernel_config
@@ -1292,12 +1346,11 @@ class ttMLA:
 
         cache_batch_idx = self._cache_batch_idx(cache_user_id, cache_layer_idx)
 
-        # Chunked: the prefix lives in the BLOCK-CYCLIC cache. Slice this (user, layer) slot out and
-        # gather ONLY that slot on device, then hand it to sparse_sdpa still block-cyclic — the op remaps
-        # the natural top-k indices to physical pages in-kernel (block_cyclic_chunk_local = per-shard
-        # chunk = seq_len_local), so no host reorder. Slicing the slot BEFORE the gather keeps the
-        # all-gather to one physical-cache slot (gathering the whole B=num_users*num_layers cache OOMs
-        # at 78 layers). The gathered kv is batch-1, so cache_batch_idx is unset (None) below.
+        # Chunked: the prefix lives in the BLOCK-CYCLIC cache. The high-bandwidth gather selects this
+        # (user, layer) slot in-device and gathers only its populated prefix into the shared batch-1
+        # worst-case buffer. sparse_sdpa receives the cache still block-cyclic and remaps natural top-k
+        # indices to physical pages in-kernel (block_cyclic_chunk_local = per-shard chunk = seq_len_local),
+        # so no host reorder or per-call output allocation is needed.
         self._update_kv_cache(
             kvpe_cache,
             tt_kvpe,
@@ -1309,7 +1362,10 @@ class ttMLA:
         # only needs that populated prefix (top-k indices never address the unwritten suffix).
         populated_global = kv_actual_isl + seq_len_local * self.sp_factor
         kvpe_dev = self._gather_kvpe_prefix(
-            kvpe_cache, cache_batch_idx, populated_global=populated_global, chunk_local=seq_len_local
+            kvpe_cache,
+            cache_batch_idx,
+            populated_global,
+            block_cyclic_chunk_local=seq_len_local,
         )
         ttnn.deallocate(tt_kvpe)
 
@@ -1318,7 +1374,12 @@ class ttMLA:
         attn_out = self._sparse_mla(
             tt_q, kvpe_dev, indices, block_cyclic_chunk_local=seq_len_local, cache_batch_idx=None
         )
-        ttnn.deallocate(kvpe_dev.storage)
+        # high_bw_all_gather returns a fresh Python wrapper for its supplied output. Do not use
+        # wrapper identity here: SP>1 always writes the model-owned persistent scratch. At SP=1,
+        # slicing a multi-slot cache creates transient storage, while slicing a single-slot cache
+        # is a no-op that aliases the caller-owned persistent cache.
+        if self.sp_factor == 1 and kvpe_cache.storage.shape[0] > 1:
+            ttnn.deallocate(kvpe_dev.storage)
         ttnn.deallocate(tt_q)
         return self._apply_wkv_b2(attn_out, seq_len_local)
 
@@ -1391,25 +1452,6 @@ class ttMLA:
     # never reaches these). The full forward above shares the dense/sparse Q/KV stem and epilogue;
     # only sparse-specific gather/attention helpers live below.
     # ----------------------------------------------------------------------------------------
-
-    def _all_gather(self, t, dim, cluster_axis):
-        """All-gather across a mesh cluster axis → replicated on that axis. factor==1: no-op.
-        cluster_axis picks SP (sequence) or TP; the guard reads the matching mesh factor."""
-        factor = self.sp_factor if cluster_axis == self.sp_axis else self.tp_factor
-        if factor == 1:
-            return t
-        # Per-axis topology: match the ring/line topology to the axis this gather rides.
-        topology = self.sp_ccl_topology if cluster_axis == self.sp_axis else self.tp_ccl_topology
-        return ttnn.experimental.all_gather_async(
-            t,
-            dim=dim,
-            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=cluster_axis),
-            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=cluster_axis),
-            num_links=self.ccl_num_links,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=topology,
-            cluster_axis=cluster_axis,
-        )
 
     @property
     def _needs_head_to_seq_reshard(self) -> bool:
@@ -1522,7 +1564,12 @@ class ttMLA:
         return ret
 
     def _gather_kvpe_prefix(
-        self, kvpe_cache: MlaKvCache, cache_batch_idx, populated_global=None, chunk_local=None
+        self,
+        kvpe_cache: MlaKvCache,
+        cache_batch_idx,
+        populated_global: int,
+        *,
+        block_cyclic_chunk_local: int,
     ) -> MlaKvCache:
         """On-device read-back of the chunked KVPE prefix for sparse attention. The cache is
         ND-sharded / block-cyclic across SP, in the op's format (BF16 or packed scaled FP8, ROW_MAJOR).
@@ -1530,49 +1577,51 @@ class ttMLA:
         natural-position indices to physical block-cyclic pages in-kernel (invP), so the buffer is
         LEFT in block-cyclic order — no host reorder.
 
-        SLOT SELECT BEFORE THE GATHER: the persistent cache's per-chip shape is [B, 1, seq_len_local,
-        row_width], B = num_users*num_layers (user-major slots), seq_len_local = seq_len_cache / sp. Slice the
-        active (user, layer) slot out of dim 0 FIRST, then all-gather only that single slot over SP (→
-        [1, 1, seq_len_cache, row_width]) — NOT the whole B-slot cache. At 78 layers the full-cache gather is
-        ~5 GB (×2 in-flight → OOM against the near-full 78-layer weights); the single-slot gather is B×
-        smaller. The gathered kv is then batch-1, so sparse_sdpa needs NO cache_batch_idx (the op
-        requires B==1 when cache_batch_idx is unset). This mirrors the dense ring_mla single-slot gather
-        (kv_cache_batch_idx → batch-1 scratch).
+        SLOT SELECT IN THE GATHER: the persistent cache's per-chip shape is [B, 1, seq_len_local,
+        row_width], B = num_users*num_layers (user-major slots), seq_len_local = seq_len_cache / sp. The
+        all-gather offsets its input pages to the active (user, layer) cache slot and packs only that slot's
+        valid prefix into the model-owned [1, 1, max_seq_len, row_width] output scratch. It never transports
+        the other B-1 slots, avoiding the ~5 GB full-cache gather at 78 layers. The gathered KV is batch-1,
+        so sparse_sdpa needs no cache_batch_idx.
 
-        POPULATED-WIDTH TRIM (``populated_global`` = written KV depth after this chunk, ``chunk_local`` =
-        per-chip slab width): trim the per-chip seq dim to only the populated SLABS BEFORE the gather
-        instead of gathering the full allocated cache width. The per-chip cache is slab-major (slab s at
-        local rows [s*chunk_local, (s+1)*chunk_local)) and ``populated_global`` can end mid-slab (padded /
-        rotated ``kv_actual_isl``). A partial boundary slab holds a NON-uniform valid-row count across
-        chips (low chips full, high chips none), and the block-cyclic index remap needs an integer slab
-        count -- so a uniform ``populated_global / sp`` width would drop valid rows on low chips AND slice
-        a fractional slab. Round the touched depth UP to a whole chunk: every valid slab is kept intact
-        and the pad tail is present but never addressed (top-k indices stay < valid). It shrinks the SP
-        all-gather (and the downstream sparse_sdpa buffer) to the populated slab count.
+        Pipeline (all on device): a selected-slot prefix SP all-gather directly from the persistent
+        ND-sharded cache into the model-owned worst-case scratch (a transient selected-slot slice at sp==1).
+        The cache is already in the op format, so there is no read-back dtype/layout or memory-layout
+        conversion. The prefix is rounded to a whole block-cyclic slab; sparse SDPA only dereferences current
+        top-k indices, so its unwritten suffix is never consumed."""
 
-        Pipeline (all on device): ND→interleaved, slot + populated-width slice (no-op for a single-slot,
-        full-width cache), SP all-gather (no-op at sp==1). The cache is already in the op format, so there
-        is NO read-back dtype/layout conversion."""
-
-        storage = ttnn.to_memory_config(kvpe_cache.storage, ttnn.DRAM_MEMORY_CONFIG)
+        storage = kvpe_cache.storage
         slot_lo = cache_batch_idx if storage.shape[0] > 1 else 0
-        seq_hi = storage.shape[2]
-        if populated_global is not None and chunk_local is not None:
-            chunk_size_global = chunk_local * self.sp_factor
-            num_slabs = -(-populated_global // chunk_size_global)
-            seq_hi = min(num_slabs * chunk_local, seq_hi)
-
-        if storage.shape[0] > 1 or seq_hi != storage.shape[2]:
-            selected = ttnn.slice(
+        if self.sp_factor == 1:
+            # The native high-bandwidth gather requires multiple devices. Preserve the single-device
+            # behavior, where sparse_sdpa still needs a batch-1 cache. For a multi-slot cache this
+            # slice creates owned transient storage that the caller releases; for a single-slot cache
+            # it is a no-op alias of the persistent cache and must not be released by the caller.
+            gathered = ttnn.slice(
                 storage,
                 [slot_lo, 0, 0, 0],
-                [slot_lo + 1, 1, seq_hi, storage.shape[3]],
+                [slot_lo + 1, 1, storage.shape[2], storage.shape[3]],
             )
-            ttnn.deallocate(storage)
-            storage = selected
-        gathered = self._all_gather(storage, dim=2, cluster_axis=self.sp_axis)
-        if self.sp_factor > 1:
-            ttnn.deallocate(storage)
+        else:
+            # Block-cyclic storage is meaningful only in complete SP slabs. The new AG writes each
+            # rank's active local prefix into its fixed worst-case slot, retaining the allocation and
+            # the natural-to-physical stride expected by sparse SDPA for the next chunk/layer.
+            slab_global = block_cyclic_chunk_local * self.sp_factor
+            gathered_dim_size = min(
+                storage.shape[2] * self.sp_factor,
+                ((populated_global + slab_global - 1) // slab_global) * slab_global,
+            )
+            assert gathered_dim_size > 0
+            assert self._sparse_kv_gather_buffer is not None
+            gathered = ttnn.experimental.high_bw_all_gather(
+                storage,
+                dim=2,
+                output_tensor=self._sparse_kv_gather_buffer,
+                num_links=self.ccl_num_links,
+                cluster_axis=self.sp_axis,
+                input_batch_index=slot_lo,
+                gathered_dim_size=gathered_dim_size,
+            )
 
         return MlaKvCache(
             format=kvpe_cache.format,

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_1.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_1.py
@@ -40,7 +40,8 @@ class GLM51Adapter(MLAPrefillAdapter):
     prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_51_code_debug_55k_vllm"
 
     # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL.
-    l1_small_size = 512
+    # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores.
+    l1_small_size = 768
     routing_use_l1_small_for_semaphores = True
 
     def load_hf_config(self):

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
@@ -40,7 +40,8 @@ class GLM52Adapter(MLAPrefillAdapter):
     prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_52_55k_vllm"
 
     # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL.
-    l1_small_size = 512
+    # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores.
+    l1_small_size = 768
     routing_use_l1_small_for_semaphores = True
 
     def load_hf_config(self):

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_6.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_6.py
@@ -32,7 +32,8 @@ class KimiK26Adapter(MLAPrefillAdapter):
     prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/kimi-26/kimi_longbook_56320"
 
     # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL.
-    l1_small_size = 512
+    # Routing consumes 512 B; leave 256 B for MLA high-bandwidth-gather semaphores.
+    l1_small_size = 768
     routing_use_l1_small_for_semaphores = True
 
     # --- test metadata (HF download coordinates + PCC thresholds) ---

--- a/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
@@ -131,6 +131,14 @@ class TT_CCL:
         # MLA, keyed by shape signature. See get_mla_chunked_kv_buffer.
         self.mla_chunked_kv_buffers: dict[tuple, "ttnn.Tensor"] = {}
 
+        # Persistent full-capacity sparse-MLA KV-prefix gather buffers shared by every layer's MLA.
+        # See get_mla_sparse_kv_gather_buffer.
+        self.mla_sparse_kv_gather_buffers: dict[tuple, "ttnn.Tensor"] = {}
+
+        # Persistent TP high-bandwidth all-gather outputs shared by MLA layers.  Their sequence
+        # capacity is the fixed prefill chunk length, not the growing KV-cache length.
+        self.mla_high_bw_all_gather_buffers: dict[tuple, "ttnn.Tensor"] = {}
+
         # Persistent ring-indexer gathered-K scratch buffers shared by every layer's DSA indexer,
         # keyed by shape signature. See get_indexer_ring_k_buffer.
         self.indexer_ring_k_buffers: dict[tuple, "ttnn.Tensor"] = {}
@@ -220,6 +228,45 @@ class TT_CCL:
                 ),
             )
         return self.mla_chunked_kv_buffers[key]
+
+    def get_mla_sparse_kv_gather_buffer(self, *, seq_len, row_width, dtype, layout):
+        """Return the full-capacity output scratch for sparse MLA's SP KV-prefix gather.
+
+        The sparse cache has a fixed maximum sequence length. Each layer gathers one selected cache slot
+        into this replicated batch-1 scratch, overwriting it before sparse SDPA consumes the selected
+        indices. Layers run serially, so one stable-address buffer per cache representation is sufficient
+        for the model and avoids per-prefix allocations.
+        """
+        import torch
+
+        key = (seq_len, row_width, dtype, layout)
+        if key not in self.mla_sparse_kv_gather_buffers:
+            self.mla_sparse_kv_gather_buffers[key] = ttnn.from_torch(
+                torch.zeros(1, 1, seq_len, row_width),
+                device=self.mesh_device,
+                layout=layout,
+                dtype=dtype,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+        return self.mla_sparse_kv_gather_buffers[key]
+
+    def get_mla_high_bw_all_gather_buffer(self, *, name, shape, dtype, layout):
+        """Return an MLA TP all-gather output allocated during model construction.
+
+        Layers execute serially, so one buffer for each fixed activation shape can be shared across the
+        model.  ``shape`` is the maximum (fixed) prefill chunk shape seen by the corresponding gather.
+        """
+        key = (name, tuple(shape), dtype, layout)
+        if key not in self.mla_high_bw_all_gather_buffers:
+            self.mla_high_bw_all_gather_buffers[key] = ttnn.empty(
+                shape,
+                dtype=dtype,
+                layout=layout,
+                device=self.mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+        return self.mla_high_bw_all_gather_buffers[key]
 
     def get_indexer_ring_k_buffer(self, *, local_k, sp_axis):
         """Return the persistent full-K output buffer for the fused ring indexer.

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -293,6 +293,7 @@ class TtPrefillBlock(LightweightModule):
             is_balanced=is_balanced,
             weight_cache_path=weight_cache_path,
             is_chunked=is_chunked,
+            active_seq_len=seq_len,
             slot_num=slot_num,
             layer_num=layer_num,
             kv_only=kv_only,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
@@ -453,10 +453,33 @@ def test_topk_large_indices_valid_length_program_cache_reuse_while_growing(devic
         device.disable_and_clear_program_cache()
 
 
+@pytest.mark.parametrize("k", [512, 1024, 2048])
+def test_topk_large_indices_short_valid_length_emits_sentinels(device, k):
+    # Sparse MLA keeps a fixed maximum top-k shape while its cache is shorter than k.  The valid
+    # prefix supplies the real indices and the remaining output slots must be the sparse-SDPA sentinel.
+    valid_length = 496
+    # Keep one full output-width of finite stale data beyond the requested top-k, so every k exercises
+    # that the runtime prefix bound—not just the sentinel padding—excludes the physical tail.
+    n = 2 * k
+    torch_input = _make_bf16_exact_input(num_rows=1, n=n)
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=valid_length)
+    _, valid_indices = torch.topk(
+        torch_input[:, :valid_length].float(), valid_length, dim=-1, largest=True, sorted=True
+    )
+    expected = torch.cat(
+        [
+            valid_indices,
+            torch.full((1, k - valid_length), 0xFFFFFFFF, dtype=torch.int64),
+        ],
+        dim=-1,
+    )
+    _assert_indices(tt_indices, expected, [1, k])
+
+
 @pytest.mark.parametrize(
     "k,n,valid_length",
     [
-        (512, 1024, 496),  # valid_length < k
+        (512, 1024, 0),  # valid_length must be positive
         (512, 1024, 2048),  # valid_length > n
     ],
 )

--- a/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
@@ -18,16 +18,16 @@ from models.common.utility_functions import run_for_blackhole
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
 
 
-def _fabric_router_config():
+def _fabric_router_config(max_packet_payload_size=14 * 1024):
     config = ttnn.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = 14 * 1024
+    config.max_packet_payload_size_bytes = max_packet_payload_size
     return config
 
 
-def _device_params(fabric_config):
+def _device_params(fabric_config, max_packet_payload_size=14 * 1024):
     return {
         "fabric_config": fabric_config,
-        "fabric_router_config": _fabric_router_config(),
+        "fabric_router_config": _fabric_router_config(max_packet_payload_size),
         "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
         "l1_small_size": 2048,
     }
@@ -83,6 +83,11 @@ _FABRIC_2D_TORUS_XY_DEVICE_PARAMS = pytest.param(
     _device_params(ttnn.FabricConfig.FABRIC_2D_TORUS_XY),
     id="fabric_2d_torus_xy",
 )
+
+_SELECTED_BATCH_PREFIX_DEVICE_PARAMS = [
+    _FABRIC_2D_LINE_DEVICE_PARAMS,
+    pytest.param(_device_params(ttnn.FabricConfig.FABRIC_1D_RING), id="fabric_1d_ring"),
+]
 
 _TEST_CASES = [
     ("bf16_1152b_rows", ttnn.bfloat16, 576, ttnn.ROW_MAJOR_LAYOUT, 1152),
@@ -286,6 +291,28 @@ def _run_high_bw_all_gather_accuracy(
     ttnn.synchronize_device(mesh_device)
 
     _assert_exact_all_gather(device_input, persistent_output, mesh_device, dtype)
+
+
+@run_for_blackhole("high_bw_all_gather requires Blackhole fabric")
+@pytest.mark.parametrize(
+    "device_params",
+    [pytest.param(_device_params(ttnn.FabricConfig.FABRIC_2D, 6144), id="fabric_2d_6k_payload")],
+    indirect=True,
+)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
+def test_high_bw_all_gather_single_page_bank_owned_packet(mesh_device):
+    """A bank-owned GLM q-latent page must use the single-page writer when only one page fits a packet."""
+    assert ttnn.get_tt_fabric_max_payload_size_bytes() == 6144
+    rank_line, cluster_axis = _rank_line_mesh(mesh_device)
+    _run_high_bw_all_gather_accuracy(
+        rank_line,
+        ttnn.bfloat16,
+        width=2048,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        expected_page_size=4096,
+        cluster_axis=cluster_axis,
+        rows_per_device=640,
+    )
 
 
 @run_for_blackhole("high_bw_all_gather requires Blackhole fabric")
@@ -727,6 +754,70 @@ def test_high_bw_all_gather_512k_fabric_2d_line(mesh_device):
     # 1x4 row submesh; both omit a wraparound edge under FABRIC_2D.
     rank_line, cluster_axis = _rank_line_mesh(mesh_device)
     _run_high_bw_all_gather_test_cases(rank_line, min_bandwidth_gbps=45.0, cluster_axis=cluster_axis)
+
+
+@pytest.mark.parametrize("device_params", _SELECTED_BATCH_PREFIX_DEVICE_PARAMS, indirect=True)
+@run_for_blackhole("high_bw_all_gather selected-cache-slot coverage requires Blackhole")
+def test_high_bw_all_gather_selected_batch_prefix(mesh_device):
+    """One maximum-size output allocation can gather either cache slot and a shorter valid prefix."""
+    rank_line, cluster_axis = _rank_line_mesh(mesh_device)
+    axis_size = rank_line.shape[cluster_axis]
+    local_rows, active_local_rows, width = 1024, 512, 576
+    torch.manual_seed(0)
+    host_input = torch.rand((2, 1, local_rows * axis_size, width), dtype=torch.bfloat16)
+    device_input = _make_tensor(
+        rank_line,
+        host_input,
+        ttnn.bfloat16,
+        ttnn.ROW_MAJOR_LAYOUT,
+        ttnn.ShardTensor2dMesh(
+            rank_line,
+            dims=(2, None) if cluster_axis == 0 else (None, 2),
+            mesh_shape=tuple(rank_line.shape),
+        ),
+    )
+    persistent_output = _make_tensor(
+        rank_line,
+        torch.zeros((1, 1, local_rows * axis_size, width), dtype=torch.bfloat16),
+        ttnn.bfloat16,
+        ttnn.ROW_MAJOR_LAYOUT,
+        ttnn.ReplicateTensorToMesh(rank_line),
+    )
+
+    cache_entries_after_first = None
+    # Start smaller and grow the logical extent. This proves the cached program is compiled for the
+    # worst-case slab rather than the first active prefix.
+    for batch_index, rows_this_call in ((0, active_local_rows // 2), (1, active_local_rows)):
+        ttnn.experimental.high_bw_all_gather(
+            device_input,
+            dim=2,
+            output_tensor=persistent_output,
+            cluster_axis=cluster_axis,
+            num_links=_NUM_LINKS,
+            input_batch_index=batch_index,
+            gathered_dim_size=rows_this_call * axis_size,
+        )
+        ttnn.synchronize_device(rank_line)
+        if cache_entries_after_first is None:
+            cache_entries_after_first = rank_line.num_program_cache_entries()
+        else:
+            assert rank_line.num_program_cache_entries() == cache_entries_after_first
+
+        # Runtime extents transfer only the valid prefix from every rank, but retain the
+        # maximum-size output's rank stride. This makes the output safe to reuse as an
+        # address-indexed cache without moving its later-rank pages on every call.
+        expected = torch.zeros((1, 1, local_rows * axis_size, width), dtype=torch.bfloat16)
+        for rank, shard in enumerate(ttnn.get_device_tensors(device_input)):
+            expected[:, :, rank * local_rows : rank * local_rows + rows_this_call, :] = ttnn.to_torch(shard)[
+                batch_index : batch_index + 1, :, :rows_this_call, :
+            ]
+        for output_shard in ttnn.get_device_tensors(persistent_output):
+            actual = ttnn.to_torch(output_shard)
+            for rank in range(axis_size):
+                start = rank * local_rows
+                assert torch.equal(
+                    actual[:, :, start : start + rows_this_call, :], expected[:, :, start : start + rows_this_call, :]
+                )
 
 
 @run_for_blackhole("high_bw_all_gather requires Blackhole fabric")

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation.cpp
@@ -100,6 +100,29 @@ std::optional<uint64_t> resolve_direct_neighbor_route_hash(
 
 using namespace CMAKE_UNIQUE_NAMESPACE;
 
+ttsl::hash::hash_t HighBwAllGatherDeviceOperation::compute_program_hash(
+    const HighBwAllGatherParams& args, const HighBwAllGatherInputs& tensor_args) {
+    // input_batch_index / gathered_dim_size alter only runtime page ranges and iterator strides;
+    // exclude their values so changing cache slot or prefix does not recompile the program.
+    return tt::tt_metal::operation::hash_operation<HighBwAllGatherDeviceOperation>(
+        args.dim,
+        args.output_mem_config,
+        args.cluster_axis,
+        args.fabric_config,
+        args.axis_topology,
+        args.axis_num_devices,
+        args.axis_num_links,
+        args.num_devices,
+        args.packet_size,
+        args.neighbor_unicast_eligible,
+        args.neighbor_route_plan_hash,
+        args.subdevice_id,
+        args.sub_core_grid,
+        args.input_batch_index.has_value(),
+        args.gathered_dim_size.has_value(),
+        tensor_args);
+}
+
 void HighBwAllGatherDeviceOperation::validate_on_program_cache_miss(
     const HighBwAllGatherParams& args, const HighBwAllGatherInputs& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
@@ -173,11 +196,49 @@ void HighBwAllGatherDeviceOperation::validate_on_program_cache_miss(
             output_shape.size() == input_padded_shape.size(),
             "Output tensor shape should have same number of dimensions as input tensor but has {}",
             output_shape.size());
+        if (args.input_batch_index.has_value()) {
+            TT_FATAL(args.dim != 0, "high_bw_all_gather input_batch_index cannot be used when gathering dim 0");
+            TT_FATAL(
+                *args.input_batch_index < input_padded_shape[0],
+                "high_bw_all_gather input_batch_index {} must be < input batch {}",
+                *args.input_batch_index,
+                input_padded_shape[0]);
+            TT_FATAL(
+                output_shape[0] == 1,
+                "high_bw_all_gather selected-batch output must have batch 1, got {}",
+                output_shape[0]);
+            // The selected cache-slot path intentionally addresses one contiguous [1, ...] tensor.
+            // Supporting arbitrary leading dimensions would make the selected page range discontinuous.
+            for (int32_t i = 1; i < args.dim; ++i) {
+                TT_FATAL(
+                    input_padded_shape[i] == 1 && output_shape[i] == 1,
+                    "high_bw_all_gather selected-batch path requires singleton dimensions between batch and dim; "
+                    "input shape {}, output shape {}, dim {}",
+                    input_padded_shape,
+                    output_shape,
+                    args.dim);
+            }
+            expected_output_shape[0] = 1;
+        }
         TT_FATAL(
             output_shape == expected_output_shape,
-            "Output tensor shape must be {}, got {}",
+            "Output tensor shape must be the worst-case gathered shape {}, got {}",
             expected_output_shape,
             output_shape);
+
+        if (args.gathered_dim_size.has_value()) {
+            const uint32_t gathered_dim_size = *args.gathered_dim_size;
+            TT_FATAL(
+                gathered_dim_size > 0 && gathered_dim_size <= expected_output_shape[args.dim],
+                "high_bw_all_gather gathered_dim_size {} must be in (0, {}]",
+                gathered_dim_size,
+                expected_output_shape[args.dim]);
+            TT_FATAL(
+                gathered_dim_size % args.num_devices == 0,
+                "high_bw_all_gather gathered_dim_size {} must divide evenly across {} devices",
+                gathered_dim_size,
+                args.num_devices);
+        }
     }
 
     TT_FATAL(
@@ -187,26 +248,41 @@ void HighBwAllGatherDeviceOperation::validate_on_program_cache_miss(
 }
 
 void HighBwAllGatherDeviceOperation::validate_on_program_cache_hit(
-    const HighBwAllGatherParams&, const HighBwAllGatherInputs& tensor_args) {
-    // Every miss-path validation input is part of the framework's canonical
-    // program-cache key, so a hit has already validated the same structure.
-    // Buffer allocation is not structural, however, and the program factory
-    // dereferences the persistent output buffer on cache hits as well.
-    TT_FATAL(tensor_args.output_tensor.buffer() != nullptr, "Output tensor must be allocated in buffers on device!");
+    const HighBwAllGatherParams& args, const HighBwAllGatherInputs& tensor_args) {
+    // The slot/prefix values are deliberately hash-excluded. Recheck only their cheap dynamic
+    // bounds here; all tensor/layout/fabric structure belongs to the program key and was proven on
+    // the miss path. This keeps a serving-loop cache hit to scalar validation plus direct RT-arg writes.
+    const auto& input_shape = tensor_args.input_tensor.padded_shape();
+    const auto& output_tensor = tensor_args.output_tensor;
+    TT_FATAL(output_tensor.buffer() != nullptr, "Output tensor must be allocated in buffers on device!");
+    if (args.input_batch_index.has_value()) {
+        TT_FATAL(args.dim != 0, "high_bw_all_gather input_batch_index cannot be used when gathering dim 0");
+        TT_FATAL(
+            *args.input_batch_index < input_shape[0],
+            "high_bw_all_gather input_batch_index {} must be < input batch {}",
+            *args.input_batch_index,
+            input_shape[0]);
+    }
+    if (args.gathered_dim_size.has_value()) {
+        const int32_t rank = static_cast<int32_t>(input_shape.rank());
+        const int32_t gather_dim = args.dim < 0 ? args.dim + rank : args.dim;
+        const uint32_t max_gathered = input_shape[gather_dim] * args.num_devices;
+        TT_FATAL(
+            *args.gathered_dim_size > 0 && *args.gathered_dim_size <= max_gathered &&
+                *args.gathered_dim_size % args.num_devices == 0,
+            "high_bw_all_gather gathered_dim_size {} must be in (0, {}] and divide evenly across {} devices",
+            *args.gathered_dim_size,
+            max_gathered,
+            args.num_devices);
+    }
 }
 
 HighBwAllGatherDeviceOperation::spec_return_value_t HighBwAllGatherDeviceOperation::compute_output_specs(
-    const HighBwAllGatherParams& args, const HighBwAllGatherInputs& tensor_args) {
-    const auto& input_tensor = tensor_args.input_tensor;
-    // The kernels gather complete device pages. A tile shard whose logical
-    // gather extent is not tile-aligned therefore exposes the gathered padded
-    // extent, matching the required preallocated output tensor.
-    auto shape = input_tensor.padded_shape();
-    shape[args.dim] *= args.num_devices;
-    return tt::tt_metal::TensorSpec(
-        shape,
-        tt::tt_metal::TensorLayout(
-            input_tensor.dtype(), input_tensor.tensor_spec().page_config(), args.output_mem_config));
+    const HighBwAllGatherParams&, const HighBwAllGatherInputs& tensor_args) {
+    // This op always writes the caller-provided persistent tensor.  In selected-batch mode its
+    // batch dimension is intentionally smaller than the source cache, so its own spec—not one
+    // re-derived from the input—is the authoritative output contract.
+    return tensor_args.output_tensor.tensor_spec();
 }
 
 HighBwAllGatherDeviceOperation::topology_return_value_t HighBwAllGatherDeviceOperation::compute_output_topologies(
@@ -231,7 +307,9 @@ std::tuple<HighBwAllGatherParams, HighBwAllGatherInputs> high_bw_all_gather_buil
     uint32_t cluster_axis,
     const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
     const std::optional<CoreRangeSet>& sub_core_grid,
-    std::optional<uint32_t> num_links) {
+    std::optional<uint32_t> num_links,
+    std::optional<uint32_t> input_batch_index,
+    std::optional<uint32_t> gathered_dim_size) {
     // Query the machine and Fabric setup info.
     // This info is also effectively part of CCL args and hence should be in the program-cache hash,
     // so we include it in HighBwAllGatherParams.
@@ -331,7 +409,9 @@ std::tuple<HighBwAllGatherParams, HighBwAllGatherInputs> high_bw_all_gather_buil
             .neighbor_unicast_eligible = neighbor_unicast_eligible,
             .neighbor_route_plan_hash = direct_neighbor_route_hash.value_or(0),
             .subdevice_id = subdevice_id,
-            .sub_core_grid = sub_core_grid},
+            .sub_core_grid = sub_core_grid,
+            .input_batch_index = input_batch_index,
+            .gathered_dim_size = gathered_dim_size},
         HighBwAllGatherInputs{.input_tensor = input_tensor, .output_tensor = output_tensor}};
 }
 
@@ -346,9 +426,19 @@ Tensor high_bw_all_gather(
     uint32_t cluster_axis,
     const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
     const std::optional<CoreRangeSet>& sub_core_grid,
-    std::optional<uint32_t> num_links) {
+    std::optional<uint32_t> num_links,
+    std::optional<uint32_t> input_batch_index,
+    std::optional<uint32_t> gathered_dim_size) {
     auto [params, inputs] = ttnn::operations::experimental::high_bw_all_gather::high_bw_all_gather_build_operation_args(
-        input_tensor, output_tensor, dim, cluster_axis, subdevice_id, sub_core_grid, num_links);
+        input_tensor,
+        output_tensor,
+        dim,
+        cluster_axis,
+        subdevice_id,
+        sub_core_grid,
+        num_links,
+        input_batch_index,
+        gathered_dim_size);
     return ttnn::device_operation::launch<
         ttnn::operations::experimental::high_bw_all_gather::HighBwAllGatherDeviceOperation>(params, inputs);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation.hpp
@@ -8,6 +8,7 @@
 #include <variant>
 #include <tt-metalium/sub_device_types.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/operation.hpp"
 #include "high_bw_all_gather_device_operation_types.hpp"
 #include "high_bw_all_gather_unicast_factory.hpp"
 
@@ -21,6 +22,9 @@ struct HighBwAllGatherDeviceOperation {
     using topology_return_value_t = std::vector<tt::tt_metal::TensorTopology>;
     using program_factory_t = std::variant<HighBwAllGatherUnicastFactory>;
 
+    // The selected batch slot and valid prefix are patched into kernel runtime arguments. Hash only
+    // their presence, so a serving loop reuses one compiled program as either value changes.
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
@@ -42,6 +46,8 @@ Tensor high_bw_all_gather(
     uint32_t cluster_axis,
     const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id = std::nullopt,
     const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
-    std::optional<uint32_t> num_links = std::nullopt);
+    std::optional<uint32_t> num_links = std::nullopt,
+    std::optional<uint32_t> input_batch_index = std::nullopt,
+    std::optional<uint32_t> gathered_dim_size = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation_types.hpp
@@ -44,6 +44,14 @@ struct HighBwAllGatherParams {
     // Worker-core selection.
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id;
     std::optional<CoreRangeSet> sub_core_grid;
+
+    // Optional runtime controls for gathering one slot of a persistent cache into a maximum-capacity
+    // output buffer. `gathered_dim_size` is the global (post-gather) valid extent along dim; each rank's
+    // local prefix occupies that rank's fixed worst-case output slot, and the allocation remains full size.
+    // Their values are hash-excluded and patch only indexed kernel runtime arguments, so slots/prefixes
+    // reuse one cached program.
+    std::optional<uint32_t> input_batch_index;
+    std::optional<uint32_t> gathered_dim_size;
 };
 
 struct HighBwAllGatherInputs {

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.cpp
@@ -27,6 +27,7 @@ struct PageGeometry {
     uint32_t num_input_pages;
     uint32_t num_output_chunks;
     uint32_t output_chunks_per_stripe;
+    uint32_t input_page_base;
 };
 
 enum class ReaderRtArg : std::size_t {
@@ -44,6 +45,7 @@ enum class ReaderRtArg : std::size_t {
     InputPageEnd,
     ReadySemaphore,
     DataValidSemaphore,
+    OutputChunksPerStripe,
     Count,
 };
 
@@ -64,8 +66,10 @@ enum class WriterRtArg : std::size_t {
     DataValidNocX,
     DataValidNocY,
     NumGranularSends,
+    DataValidGranularity,
     NeighborDeviceId,
     NeighborMeshId,
+    OutputChunksPerStripe,
     Count,
 };
 
@@ -74,7 +78,8 @@ constexpr std::size_t rt_arg_index(Enum value) {
     return static_cast<std::size_t>(value);
 }
 
-PageGeometry derive_page_geometry(const Tensor& input_tensor, const Tensor& output_tensor, int32_t gather_dim) {
+PageGeometry derive_page_geometry(
+    const Tensor& input_tensor, const Tensor& output_tensor, const HighBwAllGatherParams& operation_attributes) {
     const uint32_t input_page_size = input_tensor.buffer()->aligned_page_size();
     const uint32_t input_unaligned_page_size = input_tensor.buffer()->page_size();
     const uint32_t output_unaligned_page_size = output_tensor.buffer()->page_size();
@@ -86,33 +91,99 @@ PageGeometry derive_page_geometry(const Tensor& input_tensor, const Tensor& outp
         output_chunks_per_page == 1 || input_page_size == input_unaligned_page_size,
         "concat requires an unpadded input page");
 
-    const uint32_t num_input_pages = input_tensor.buffer()->num_pages();
-    const uint32_t num_output_chunks = num_input_pages * split_factor;
     const auto& input_shape = input_tensor.padded_shape();
     const uint32_t rank = input_shape.rank();
+    int32_t gather_dim = operation_attributes.dim;
     if (gather_dim < 0) {
         gather_dim += rank;
     }
+
+    const bool has_runtime_extent = operation_attributes.gathered_dim_size.has_value();
+    const uint32_t active_dim_size = has_runtime_extent
+                                         ? *operation_attributes.gathered_dim_size / operation_attributes.num_devices
+                                         : input_shape[gather_dim];
 
     const auto tile_spec =
         input_tensor.layout() == Layout::TILE ? input_tensor.tensor_spec().tile() : tt::tt_metal::Tile();
     uint32_t input_pages_per_stripe = 1;
     for (int32_t i = gather_dim; i < rank; i++) {
-        uint32_t extent;
+        uint32_t extent = i == gather_dim ? active_dim_size : input_shape[i];
         if (i == rank - 1) {
-            extent = input_tensor.layout() == Layout::TILE
-                         ? input_shape[i] / tile_spec.get_width()
-                         : (input_shape[i] * input_tensor.element_size()) / input_unaligned_page_size;
+            if (input_tensor.layout() == Layout::TILE) {
+                TT_FATAL(
+                    extent % tile_spec.get_width() == 0,
+                    "high_bw_all_gather active gather extent {} must be tile-width aligned ({})",
+                    extent,
+                    tile_spec.get_width());
+                extent /= tile_spec.get_width();
+            } else {
+                TT_FATAL(
+                    (static_cast<uint64_t>(extent) * input_tensor.element_size()) % input_unaligned_page_size == 0,
+                    "high_bw_all_gather active innermost gather extent {} must occupy whole input pages",
+                    extent);
+                extent = (extent * input_tensor.element_size()) / input_unaligned_page_size;
+            }
         } else if (input_tensor.layout() == Layout::TILE && i == rank - 2) {
-            extent = input_shape[i] / tile_spec.get_height();
-        } else {
-            extent = input_shape[i];
+            TT_FATAL(
+                extent % tile_spec.get_height() == 0,
+                "high_bw_all_gather active gather extent {} must be tile-height aligned ({})",
+                extent,
+                tile_spec.get_height());
+            extent /= tile_spec.get_height();
         }
         input_pages_per_stripe *= extent;
     }
 
-    const uint32_t output_chunks_per_stripe = input_pages_per_stripe * split_factor;
+    // A runtime extent controls how many source pages are transferred, not the placement stride in
+    // the preallocated output. Keeping the maximum per-rank stride leaves address-indexed caches
+    // (such as sparse MLA's block-cyclic KV cache) at their stable physical offsets.
+    uint32_t max_input_pages_per_stripe = 1;
+    for (int32_t i = gather_dim; i < rank; i++) {
+        uint32_t extent = input_shape[i];
+        if (i == rank - 1) {
+            extent = input_tensor.layout() == Layout::TILE
+                         ? extent / tile_spec.get_width()
+                         : (extent * input_tensor.element_size()) / input_unaligned_page_size;
+        } else if (input_tensor.layout() == Layout::TILE && i == rank - 2) {
+            extent /= tile_spec.get_height();
+        }
+        max_input_pages_per_stripe *= extent;
+    }
+    const uint32_t output_chunks_per_stripe = max_input_pages_per_stripe * split_factor;
     TT_FATAL(output_chunks_per_stripe > 0, "output_chunks_per_stripe must be > 0");
+    const bool selected_batch = operation_attributes.input_batch_index.has_value();
+    const bool selected_or_partial = selected_batch || has_runtime_extent;
+    uint32_t input_page_base = 0;
+    uint32_t num_input_pages = input_tensor.buffer()->num_pages();
+    if (selected_or_partial) {
+        // A partial all-gather is sourced from one contiguous batch slot. Its active pages are
+        // placed in each rank's fixed worst-case output slot, preserving stable cache offsets.
+        for (int32_t i = 1; i < gather_dim; ++i) {
+            TT_FATAL(
+                input_shape[i] == 1,
+                "high_bw_all_gather selected/partial gather requires singleton dimensions between batch and dim; "
+                "input shape {}, dim {}",
+                input_shape,
+                gather_dim);
+        }
+        if (selected_batch) {
+            TT_FATAL(
+                input_tensor.buffer()->num_pages() % input_shape[0] == 0,
+                "high_bw_all_gather input batch slots must occupy equal page ranges");
+            input_page_base =
+                *operation_attributes.input_batch_index * (input_tensor.buffer()->num_pages() / input_shape[0]);
+        } else {
+            TT_FATAL(
+                input_shape[0] == 1,
+                "high_bw_all_gather gathered_dim_size without input_batch_index requires input batch 1, got {}",
+                input_shape[0]);
+        }
+        num_input_pages = input_pages_per_stripe;
+        TT_FATAL(
+            input_page_base + num_input_pages <= input_tensor.buffer()->num_pages(),
+            "high_bw_all_gather selected range exceeds input allocation");
+    }
+    const uint32_t num_output_chunks = num_input_pages * split_factor;
     return {
         input_page_size,
         output_chunk_size,
@@ -120,7 +191,17 @@ PageGeometry derive_page_geometry(const Tensor& input_tensor, const Tensor& outp
         split_factor,
         num_input_pages,
         num_output_chunks,
-        output_chunks_per_stripe};
+        output_chunks_per_stripe,
+        input_page_base};
+}
+
+uint32_t derive_data_valid_granularity(const PageGeometry& geometry, uint32_t packet_size, uint32_t total_slices) {
+    const uint32_t pages_per_packet = std::max(1u, packet_size / geometry.input_page_size);
+    const uint32_t cb_page_size = geometry.input_page_size * pages_per_packet;
+    const uint32_t outputs_per_cb_page = std::max(1u, cb_page_size / geometry.output_chunk_size);
+    const uint32_t cb_pages_per_stripe =
+        std::max(1u, (geometry.num_output_chunks / total_slices) / outputs_per_cb_page);
+    return std::max(1u, cb_pages_per_stripe / 2u);
 }
 
 bool can_use_output_bank_owned_schedule(
@@ -274,7 +355,11 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
     // connection and multiplex traffic.
     // This is a major perf knob, below heuristic was determined from extensive test sweeps.
     const uint32_t num_links = operation_attributes.axis_num_links[axis];
-    const auto page_geometry = derive_page_geometry(input_tensor, output_tensor, operation_attributes.dim);
+    const bool has_runtime_controls =
+        operation_attributes.input_batch_index.has_value() || operation_attributes.gathered_dim_size.has_value();
+    const auto page_geometry = derive_page_geometry(input_tensor, output_tensor, operation_attributes);
+    // gathered_dim_size is deliberately cache-key-independent. Runtime controls always use the
+    // direct indexed schedule, and their page ranges are patched below from page_geometry.
     const uint32_t input_page_size = page_geometry.input_page_size;
     const uint32_t num_dram_banks = mesh_device->allocator()->get_num_banks(tt::tt_metal::BufferType::DRAM);
     TT_FATAL(num_dram_banks > 0, "high_bw_all_gather requires at least one allocator-managed DRAM bank");
@@ -283,6 +368,11 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
     const uint64_t per_link_bytes = total_output_bytes / std::max(1u, num_links);
     constexpr uint64_t bank_owned_min_link_bytes = 1500000ULL;
     constexpr uint64_t high_parallelism_min_link_bytes = 32000000ULL;
+    const auto can_use_fixed_shape_bank_owned = [&](uint32_t workers_per_direction) {
+        return !has_runtime_controls &&
+               can_use_output_bank_owned_schedule(
+                   input_tensor, output_tensor, page_geometry, num_links, workers_per_direction, num_dram_banks);
+    };
     uint32_t workers_per_dir = 1;
     if (input_tensor.device()->arch() == tt::ARCH::WORMHOLE_B0) {
         workers_per_dir = 2;
@@ -292,27 +382,22 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
         // scatter fallback. Keep two workers for small messages, where additional core/mux setup is not amortized.
         const uint32_t bank_covering_workers =
             scheduler::workers_per_direction_to_cover_banks(num_links, num_dram_banks);
-        if (per_link_bytes >= bank_owned_min_link_bytes &&
-            can_use_output_bank_owned_schedule(
-                input_tensor, output_tensor, page_geometry, num_links, bank_covering_workers, num_dram_banks)) {
+        if (per_link_bytes >= bank_owned_min_link_bytes && can_use_fixed_shape_bank_owned(bank_covering_workers)) {
             workers_per_dir = bank_covering_workers;
         }
 
         // Large messages benefit from additional in-flight DRAM reads after every bank is covered.
         const uint32_t high_parallelism_workers = std::max(8u, bank_covering_workers);
         if (per_link_bytes >= high_parallelism_min_link_bytes &&
-            can_use_output_bank_owned_schedule(
-                input_tensor, output_tensor, page_geometry, num_links, high_parallelism_workers, num_dram_banks)) {
+            can_use_fixed_shape_bank_owned(high_parallelism_workers)) {
             workers_per_dir = high_parallelism_workers;
         }
     } else if (input_tensor.device()->arch() == tt::ARCH::BLACKHOLE) {
         // Measured on Blackhole across every qualified page format and line/ring schedules. Four workers amortize
         // their mux/core overhead once a bank-owned message reaches roughly 1.5 MB/link. Eight workers do not
         // consistently pull ahead of four until roughly 32 MB/link.
-        const bool four_workers_bank_owned = can_use_output_bank_owned_schedule(
-            input_tensor, output_tensor, page_geometry, num_links, 4, num_dram_banks);
-        const bool eight_workers_bank_owned = can_use_output_bank_owned_schedule(
-            input_tensor, output_tensor, page_geometry, num_links, 8, num_dram_banks);
+        const bool four_workers_bank_owned = can_use_fixed_shape_bank_owned(4);
+        const bool eight_workers_bank_owned = can_use_fixed_shape_bank_owned(8);
 
         workers_per_dir = 2;
         if (per_link_bytes >= bank_owned_min_link_bytes && four_workers_bank_owned) {
@@ -337,8 +422,7 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
         available_worker_cores = available_worker_cores.intersection(operation_attributes.sub_core_grid.value());
     }
     const uint32_t preferred_workers_per_dir = workers_per_dir;
-    const bool preferred_schedule_is_bank_owned = can_use_output_bank_owned_schedule(
-        input_tensor, output_tensor, page_geometry, num_links, preferred_workers_per_dir, num_dram_banks);
+    const bool preferred_schedule_is_bank_owned = can_use_fixed_shape_bank_owned(preferred_workers_per_dir);
     const auto worker_count_fits = [&](uint32_t count) {
         return scheduler::worker_count_fits(
             count, num_links, static_cast<uint32_t>(available_worker_cores.num_cores()));
@@ -356,9 +440,7 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
             static_cast<uint32_t>(available_worker_cores.num_cores()),
             reduction_tiers);
     }
-    if (preferred_schedule_is_bank_owned &&
-        !can_use_output_bank_owned_schedule(
-            input_tensor, output_tensor, page_geometry, num_links, workers_per_dir, num_dram_banks)) {
+    if (preferred_schedule_is_bank_owned && !can_use_fixed_shape_bank_owned(workers_per_dir)) {
         // Do not spend almost as many cores on the scatter fallback when a restricted grid falls just short of
         // covering every bank.
         workers_per_dir = std::min(2u, workers_per_dir);
@@ -521,9 +603,13 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
     // when the input uses an ND-sharded/block-cyclic DRAM layout. Keeping the
     // destination pages bank-local lets the writer coalesce small pages into a
     // full Fabric packet instead of falling back to four-entry scatter writes.
-    const bool output_bank_owned_schedule = can_use_output_bank_owned_schedule(
-        input_tensor, output_tensor, page_geometry, num_links, workers_per_dir, num_dram_banks);
+    // Runtime-sized cache prefixes use direct indexed scheduling. A bank-owned schedule bakes a
+    // max-shape stride into the binary, so keep it for the fixed-shape fast path only.
+    const bool output_bank_owned_schedule = can_use_fixed_shape_bank_owned(workers_per_dir);
     const uint32_t slice_step = output_bank_owned_schedule ? num_dram_banks : 1;
+    // Selected-slot/prefix gathers patch this at runtime. Every fixed-shape path, including direct
+    // scheduling, can bake its stripe width so the iterator avoids dynamic div/mod.
+    const uint32_t static_output_chunks_per_stripe = has_runtime_controls ? 0 : output_chunks_per_stripe;
 
     ////////////////////////////////////////////////////////////////
     // Circular Buffer and Kernel creation
@@ -543,36 +629,33 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
     // Auto-selected to half the per-worker stripe: enough pipelining without the over-signalling that hurts
     // small-page tensors at scale. Kept as a fraction of the stripe so it self-scales with tensor size, links,
     // and workers.
-    const uint32_t outputs_per_cb_page = std::max(1u, cb_page_size / output_chunk_size);
-    const uint32_t cb_pages_per_stripe = std::max(1u, (num_output_chunks / total_slices) / outputs_per_cb_page);
-    const uint32_t data_valid_granularity = std::max(1u, cb_pages_per_stripe / 2u);
+    const uint32_t data_valid_granularity = derive_data_valid_granularity(page_geometry, packet_size, total_slices);
 
     // KERNEL CREATION
     // Reader
     std::vector<uint32_t> reader_compile_args = {
-        input_page_size,           // input tensor page size
-        output_chunk_size,         // NOC write size = min(input, output)
-        output_chunks_per_page,    // chunks per output page (1 unless concat)
-        output_chunks_per_stripe,  // stripe length in chunks
-        num_devices,               // device count (stripe indexing)
-        cb0_id,                    // cb id
-        cb_page_size,              // cb entry size
-        slice_step,                // one means contiguous slices; >1 owns one interleaved DRAM bank
+        input_page_size,         // input tensor page size
+        output_chunk_size,       // NOC write size = min(input, output)
+        output_chunks_per_page,  // chunks per output page (1 unless concat)
+        num_devices,             // device count (stripe indexing)
+        cb0_id,                  // cb id
+        cb_page_size,            // cb entry size
+        slice_step,              // one means contiguous slices; >1 owns one interleaved DRAM bank
+        static_output_chunks_per_stripe,
     };
     tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_args);
     tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(reader_compile_args);
 
     // Writer
     std::vector<uint32_t> writer_compile_args = {
-        output_chunk_size,         // NOC write size = min(input, output)
-        output_chunks_per_page,    // chunks per output page (1 unless concat)
-        output_chunks_per_stripe,  // stripe length in chunks
-        num_devices,               // device count (stripe indexing)
-        cb0_id,                    // cb id
-        cb_page_size,              // cb entry size
-        packet_size,               // packet_size
-        data_valid_granularity,    // signal data_valid once per this many CB pages
-        slice_step,                // one means scatter packets; >1 enables contiguous full packets
+        output_chunk_size,       // NOC write size = min(input, output)
+        output_chunks_per_page,  // chunks per output page (1 unless concat)
+        num_devices,             // device count (stripe indexing)
+        cb0_id,                  // cb id
+        cb_page_size,            // cb entry size
+        packet_size,             // packet_size
+        slice_step,              // one means scatter packets; >1 enables contiguous full packets
+        static_output_chunks_per_stripe,
     };
     tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_args);
 
@@ -716,10 +799,13 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
                 reader_rt_args[rt_arg_index(ReaderRtArg::SliceCount)] = num_worker_output_chunks;
                 reader_rt_args[rt_arg_index(ReaderRtArg::FinalStart)] = final_start;
                 reader_rt_args[rt_arg_index(ReaderRtArg::FinalCount)] = final_count;
-                reader_rt_args[rt_arg_index(ReaderRtArg::InputPageStart)] = input_tile_id_start;
-                reader_rt_args[rt_arg_index(ReaderRtArg::InputPageEnd)] = input_tile_id_end;
+                reader_rt_args[rt_arg_index(ReaderRtArg::InputPageStart)] =
+                    page_geometry.input_page_base + input_tile_id_start;
+                reader_rt_args[rt_arg_index(ReaderRtArg::InputPageEnd)] =
+                    page_geometry.input_page_base + input_tile_id_end;
                 reader_rt_args[rt_arg_index(ReaderRtArg::ReadySemaphore)] = ready_sem.address();
                 reader_rt_args[rt_arg_index(ReaderRtArg::DataValidSemaphore)] = data_valid_sem.address();
+                reader_rt_args[rt_arg_index(ReaderRtArg::OutputChunksPerStripe)] = output_chunks_per_stripe;
                 tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, {core}, reader_rt_args);
 
                 std::vector<uint32_t> writer_rt_args(rt_arg_index(WriterRtArg::Count));
@@ -739,10 +825,12 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
                 writer_rt_args[rt_arg_index(WriterRtArg::DataValidNocX)] = static_cast<uint32_t>(mirror_core.x);
                 writer_rt_args[rt_arg_index(WriterRtArg::DataValidNocY)] = static_cast<uint32_t>(mirror_core.y);
                 writer_rt_args[rt_arg_index(WriterRtArg::NumGranularSends)] = num_granular;
+                writer_rt_args[rt_arg_index(WriterRtArg::DataValidGranularity)] = data_valid_granularity;
                 writer_rt_args[rt_arg_index(WriterRtArg::NeighborDeviceId)] =
                     static_cast<uint32_t>(neighbor_node.chip_id);
                 writer_rt_args[rt_arg_index(WriterRtArg::NeighborMeshId)] =
                     static_cast<uint32_t>(*neighbor_node.mesh_id);
+                writer_rt_args[rt_arg_index(WriterRtArg::OutputChunksPerStripe)] = output_chunks_per_stripe;
                 if (num_iters > 0) {
                     if (use_mux) {
                         // Connect this worker to its channel (== worker index w) on the direction's mux.
@@ -784,6 +872,14 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
         .writer_kernel_id = writer_kernel_id,
         .ready_sem = ready_sem,
         .data_valid_sem = data_valid_sem,
+        .num_links = num_links,
+        .workers_per_direction = workers_per_dir,
+        .num_devices = num_devices,
+        .device_idx = device_idx,
+        .forward_iterations = fwd_iters,
+        .backward_iterations = bwd_iters,
+        .is_ring = is_ring,
+        .ring_even_split = ring_even_split,
     };
 
     return {std::move(program), std::move(shared_variables)};
@@ -791,11 +887,16 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
 
 void HighBwAllGatherUnicastFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
-    const HighBwAllGatherParams& /*operation_attributes*/,
+    const HighBwAllGatherParams& operation_attributes,
     const HighBwAllGatherInputs& tensor_args,
     Tensor& output_tensor) {
     const uint32_t input_addr = tensor_args.input_tensor.buffer()->address();
     const uint32_t output_addr = output_tensor.buffer()->address();
+    const bool has_runtime_controls =
+        operation_attributes.input_batch_index.has_value() || operation_attributes.gathered_dim_size.has_value();
+    const auto page_geometry = has_runtime_controls
+                                   ? derive_page_geometry(tensor_args.input_tensor, output_tensor, operation_attributes)
+                                   : PageGeometry{};
 
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
@@ -814,6 +915,78 @@ void HighBwAllGatherUnicastFactory::override_runtime_arguments(
             writer_args.at(rt_arg_index(WriterRtArg::OutputAddress)) = output_addr;
             writer_args.at(rt_arg_index(WriterRtArg::ReadySemaphore)) = ready_addr;
             writer_args.at(rt_arg_index(WriterRtArg::DataValidSemaphore)) = data_valid_addr;
+        }
+
+        if (!has_runtime_controls) {
+            continue;
+        }
+
+        // The selected-slot/prefix path intentionally uses the direct (non-bank-owned) schedule.
+        // Patch only scalar runtime arguments: no program rebuild, worker re-selection, allocation, or
+        // tensor view/slice is involved on a cache hit.
+        const uint32_t total_slices = shared_vars.num_links * shared_vars.workers_per_direction;
+        const uint32_t data_valid_granularity =
+            derive_data_valid_granularity(page_geometry, operation_attributes.packet_size, total_slices);
+        const uint32_t input_pages_per_slice = page_geometry.num_input_pages / total_slices;
+        const uint32_t remainder = page_geometry.num_input_pages % total_slices;
+        for (uint32_t link = 0; link < shared_vars.num_links; ++link) {
+            for (uint32_t dir = 0; dir < 2; ++dir) {
+                const bool is_forward = dir == 0;
+                // Runtime-controlled gathers are always direct scheduled, so their per-worker
+                // output slice is contiguous. Keep this distinct from the ring traversal step.
+                constexpr uint32_t slice_step = 1;
+                const uint32_t num_recv =
+                    shared_vars.is_ring
+                        ? shared_vars.num_devices / 2
+                        : (is_forward ? shared_vars.device_idx : shared_vars.num_devices - 1 - shared_vars.device_idx);
+                for (uint32_t w = 0; w < shared_vars.workers_per_direction; ++w) {
+                    const uint32_t slice_idx = link * shared_vars.workers_per_direction + w;
+                    const uint32_t input_page_start =
+                        slice_idx * input_pages_per_slice + std::min(slice_idx, remainder);
+                    const uint32_t input_page_end =
+                        (slice_idx + 1) * input_pages_per_slice + std::min(slice_idx + 1, remainder);
+                    const uint32_t local_output_start =
+                        (static_cast<uint64_t>(input_page_start) * page_geometry.num_output_chunks) /
+                        page_geometry.num_input_pages;
+                    const uint32_t local_output_end =
+                        (static_cast<uint64_t>(input_page_end) * page_geometry.num_output_chunks) /
+                        page_geometry.num_input_pages;
+                    const uint32_t slice_count = local_output_end - local_output_start;
+                    const uint32_t half = slice_count / 2;
+                    const uint32_t final_start =
+                        shared_vars.ring_even_split
+                            ? (is_forward ? local_output_start : local_output_start + half * slice_step)
+                            : local_output_start;
+                    const uint32_t final_count =
+                        shared_vars.ring_even_split ? (is_forward ? half : slice_count - half) : slice_count;
+                    const uint32_t total_chunks =
+                        num_recv * slice_count - (shared_vars.ring_even_split ? slice_count - final_count : 0);
+                    const auto& core =
+                        shared_vars.worker_cores[(link * 2 + dir) * shared_vars.workers_per_direction + w];
+
+                    auto& reader_args = reader_args_by_core[core.x][core.y];
+                    reader_args.at(rt_arg_index(ReaderRtArg::TotalChunks)) = total_chunks;
+                    reader_args.at(rt_arg_index(ReaderRtArg::SliceStart)) = local_output_start;
+                    reader_args.at(rt_arg_index(ReaderRtArg::SliceCount)) = slice_count;
+                    reader_args.at(rt_arg_index(ReaderRtArg::FinalStart)) = final_start;
+                    reader_args.at(rt_arg_index(ReaderRtArg::FinalCount)) = final_count;
+                    reader_args.at(rt_arg_index(ReaderRtArg::InputPageStart)) =
+                        page_geometry.input_page_base + input_page_start;
+                    reader_args.at(rt_arg_index(ReaderRtArg::InputPageEnd)) =
+                        page_geometry.input_page_base + input_page_end;
+                    reader_args.at(rt_arg_index(ReaderRtArg::OutputChunksPerStripe)) =
+                        page_geometry.output_chunks_per_stripe;
+
+                    auto& writer_args = writer_args_by_core[core.x][core.y];
+                    writer_args.at(rt_arg_index(WriterRtArg::SliceStart)) = local_output_start;
+                    writer_args.at(rt_arg_index(WriterRtArg::SliceCount)) = slice_count;
+                    writer_args.at(rt_arg_index(WriterRtArg::FinalStart)) = final_start;
+                    writer_args.at(rt_arg_index(WriterRtArg::FinalCount)) = final_count;
+                    writer_args.at(rt_arg_index(WriterRtArg::OutputChunksPerStripe)) =
+                        page_geometry.output_chunks_per_stripe;
+                    writer_args.at(rt_arg_index(WriterRtArg::DataValidGranularity)) = data_valid_granularity;
+                }
+            }
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.hpp
@@ -19,6 +19,14 @@ struct HighBwAllGatherUnicastFactory {
         tt::tt_metal::KernelHandle writer_kernel_id{};
         tt::tt_metal::GlobalSemaphore ready_sem;
         tt::tt_metal::GlobalSemaphore data_valid_sem;
+        uint32_t num_links{};
+        uint32_t workers_per_direction{};
+        uint32_t num_devices{};
+        uint32_t device_idx{};
+        uint32_t forward_iterations{};
+        uint32_t backward_iterations{};
+        bool is_ring{};
+        bool ring_even_split{};
     };
 
     using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_common.hpp
@@ -46,19 +46,25 @@ namespace fabric_api = tt::tt_fabric::linear::experimental;
 // relay iteration via init(). A stripe's src address on this device equals its dst address on the neighbor, so
 // reader and writer share this iterator unchanged.
 template <
-    uint32_t output_chunks_per_stripe,
     uint32_t output_chunks_per_page,
     uint32_t output_chunk_size,
     uint32_t num_devices,
-    uint32_t slice_step>
+    uint32_t slice_step,
+    uint32_t static_output_chunks_per_stripe>
 class OutputStripeIterator {
     static constexpr uint32_t output_page_size = output_chunks_per_page * output_chunk_size;
-    static constexpr uint32_t stripe_distance_chunks = num_devices * output_chunks_per_stripe;
-    static constexpr uint32_t output_pages_per_row = stripe_distance_chunks / output_chunks_per_page;
+    static_assert(slice_step == 1 || static_output_chunks_per_stripe != 0);
 
 public:
     // Point at `stripe` for the chunk range [start, start + count).
-    FORCE_INLINE void init(uint32_t stripe, uint32_t start, uint32_t count) {
+    FORCE_INLINE void init(uint32_t stripe, uint32_t start, uint32_t count, uint32_t output_chunks_per_stripe) {
+        if constexpr (static_output_chunks_per_stripe != 0) {
+            output_chunks_per_stripe_ = static_output_chunks_per_stripe;
+        } else {
+            output_chunks_per_stripe_ = output_chunks_per_stripe;
+        }
+        stripe_distance_chunks_ = num_devices * output_chunks_per_stripe_;
+        output_pages_per_row_ = stripe_distance_chunks_ / output_chunks_per_page;
         if constexpr (slice_step > 1) {
             static_assert(output_chunks_per_page == 1, "strided bank-owned schedule requires matched output pages");
             stripe_ = stripe;
@@ -67,20 +73,20 @@ public:
             count_ = count;
             return;
         }
-        const uint32_t s_start = (start / output_chunks_per_stripe) * stripe_distance_chunks +
-                                 (start % output_chunks_per_stripe) + stripe * output_chunks_per_stripe;
+        const uint32_t s_start = (start / output_chunks_per_stripe_) * stripe_distance_chunks_ +
+                                 (start % output_chunks_per_stripe_) + stripe * output_chunks_per_stripe_;
         page_id_ = s_start / output_chunks_per_page;
         byte_off_ = (s_start % output_chunks_per_page) * output_chunk_size;
         if constexpr (output_chunks_per_page == 1) {
             phase_ = 0;
-            stripe_jump_ = output_pages_per_row - (output_chunks_per_stripe - 1);
+            stripe_jump_ = output_pages_per_row_ - (output_chunks_per_stripe_ - 1);
         } else {
             // In concat mode the page phase (and hence the stripe jump) depends on the stripe.
-            const uint32_t off = (stripe * output_chunks_per_stripe) % output_chunks_per_page;
+            const uint32_t off = (stripe * output_chunks_per_stripe_) % output_chunks_per_page;
             phase_ = off * output_chunk_size;
-            stripe_jump_ = output_pages_per_row - (off + output_chunks_per_stripe - 1) / output_chunks_per_page;
+            stripe_jump_ = output_pages_per_row_ - (off + output_chunks_per_stripe_ - 1) / output_chunks_per_page;
         }
-        chunk_in_stripe_ = start % output_chunks_per_stripe;
+        chunk_in_stripe_ = start % output_chunks_per_stripe_;
         sent_ = 0;
         count_ = count;
     }
@@ -91,14 +97,14 @@ public:
     FORCE_INLINE std::pair<uint32_t, uint32_t> next() {
         if constexpr (slice_step > 1) {
             const uint32_t local_chunk = start_ + sent_ * slice_step;
-            const uint32_t stripe_group = local_chunk / output_chunks_per_stripe;
-            const uint32_t chunk_in_stripe = local_chunk % output_chunks_per_stripe;
             ++sent_;
-            return {stripe_group * stripe_distance_chunks + stripe_ * output_chunks_per_stripe + chunk_in_stripe, 0};
+            // A bank-owned worker receives a proper subset of one full stripe, so it never wraps into another
+            // stripe group. Keep this strided hot path entirely compile-time and free of divide/modulo.
+            return {stripe_ * static_output_chunks_per_stripe + local_chunk, 0};
         }
         std::pair<uint32_t, uint32_t> loc{page_id_, byte_off_};
         sent_++;
-        if (++chunk_in_stripe_ == output_chunks_per_stripe) {
+        if (++chunk_in_stripe_ == output_chunks_per_stripe_) {
             chunk_in_stripe_ = 0;
             page_id_ += stripe_jump_;
             byte_off_ = phase_;
@@ -114,6 +120,7 @@ public:
 
 private:
     uint32_t page_id_, byte_off_, chunk_in_stripe_, sent_, count_, phase_, stripe_jump_, stripe_, start_;
+    uint32_t output_chunks_per_stripe_, stripe_distance_chunks_, output_pages_per_row_;
 };
 
 // Unicasts pages one hop to the single neighbor. Handles packetization (pack several pages into one

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_reader.cpp
@@ -44,11 +44,13 @@ void kernel_main() {
     constexpr uint32_t input_page_size = get_compile_time_arg_val(0);
     constexpr uint32_t output_chunk_size = get_compile_time_arg_val(1);
     constexpr uint32_t output_chunks_per_page = get_compile_time_arg_val(2);
-    constexpr uint32_t output_chunks_per_stripe = get_compile_time_arg_val(3);
-    constexpr uint32_t num_devices = get_compile_time_arg_val(4);
-    constexpr uint32_t cb0_id = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_page_size = get_compile_time_arg_val(6);
-    constexpr uint32_t slice_step = get_compile_time_arg_val(7);
+    constexpr uint32_t num_devices = get_compile_time_arg_val(3);
+    constexpr uint32_t cb0_id = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_page_size = get_compile_time_arg_val(5);
+    constexpr uint32_t slice_step = get_compile_time_arg_val(6);
+    // Zero selects the runtime geometry used by selected-slot/prefix gathers. Fixed-shape
+    // bank-owned schedules bake their stripe width and keep the iterator arithmetic constexpr.
+    constexpr uint32_t static_output_chunks_per_stripe = get_compile_time_arg_val(7);
     constexpr auto input_tensor_args = TensorAccessorArgs<8>();
     constexpr auto output_tensor_args = TensorAccessorArgs<input_tensor_args.next_compile_time_args_offset()>();
 
@@ -73,6 +75,7 @@ void kernel_main() {
     const uint32_t input_page_id_end = get_arg_val<uint32_t>(arg_idx++);
     const address_t ready_sem_addr = get_arg_val<uint32_t>(arg_idx++);
     const address_t data_valid_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t output_chunks_per_stripe = get_arg_val<uint32_t>(arg_idx++);
 
     auto input_tensor_accessor = TensorAccessor(input_tensor_args, input_tensor_address);
     auto output_tensor_accessor = TensorAccessor(output_tensor_args, output_tensor_address);
@@ -82,7 +85,12 @@ void kernel_main() {
     const DynamicL1Semaphore ready_sem(ready_sem_addr);
     const DynamicL1Semaphore data_valid_sem(data_valid_sem_addr);
 
-    OutputStripeIterator<output_chunks_per_stripe, output_chunks_per_page, output_chunk_size, num_devices, slice_step>
+    OutputStripeIterator<
+        output_chunks_per_page,
+        output_chunk_size,
+        num_devices,
+        slice_step,
+        static_output_chunks_per_stripe>
         it;
 
     ///////////////////////////////////////////////////
@@ -129,7 +137,7 @@ void kernel_main() {
             const uint32_t start = last ? final_start : slice_start;
             const uint32_t count = last ? final_count : slice_count;
             const uint32_t base_chunk = (iter - 1) * slice_count + (start - slice_start) / slice_step;
-            it.init(stripe, start, count);
+            it.init(stripe, start, count, output_chunks_per_stripe);
             for (uint32_t chunks_read = 0; chunks_read < count;) {
                 const uint32_t batch = std::min(outputs_per_cb_page, count - chunks_read);
                 data_valid_sem.wait_min(base_chunk + chunks_read + batch);

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_writer.cpp
@@ -33,14 +33,15 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     constexpr uint32_t output_chunk_size = get_compile_time_arg_val(0);
     constexpr uint32_t output_chunks_per_page = get_compile_time_arg_val(1);
-    constexpr uint32_t output_chunks_per_stripe = get_compile_time_arg_val(2);
-    constexpr uint32_t num_devices = get_compile_time_arg_val(3);
-    constexpr uint32_t cb0_id = get_compile_time_arg_val(4);
-    constexpr uint32_t cb_page_size = get_compile_time_arg_val(5);
-    constexpr uint32_t packet_size = get_compile_time_arg_val(6);
-    constexpr uint32_t data_valid_granularity = get_compile_time_arg_val(7);
-    constexpr uint32_t slice_step = get_compile_time_arg_val(8);
-    constexpr auto output_tensor_args = TensorAccessorArgs<9>();
+    constexpr uint32_t num_devices = get_compile_time_arg_val(2);
+    constexpr uint32_t cb0_id = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_page_size = get_compile_time_arg_val(4);
+    constexpr uint32_t packet_size = get_compile_time_arg_val(5);
+    constexpr uint32_t slice_step = get_compile_time_arg_val(6);
+    // See unicast_reader.cpp: runtime-controlled gathers retain a dynamic stripe width;
+    // fixed bank-owned gathers bake it to avoid divide/modulo in the send loop.
+    constexpr uint32_t static_output_chunks_per_stripe = get_compile_time_arg_val(7);
+    constexpr auto output_tensor_args = TensorAccessorArgs<8>();
 
     // The direct-EDM/mux path and mux geometry follow the tensor-accessor arguments.
     constexpr uint32_t mux_ct_base = output_tensor_args.next_compile_time_args_offset();
@@ -73,8 +74,10 @@ void kernel_main() {
     const uint8_t data_valid_sem_noc_x = get_arg_val<uint32_t>(arg_idx++);  // mirror core (data_valid_sem target)
     const uint8_t data_valid_sem_noc_y = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_granular_sends = get_arg_val<uint32_t>(arg_idx++);  // leading sends the downstream relays
+    const uint32_t data_valid_granularity = get_arg_val<uint32_t>(arg_idx++);
     [[maybe_unused]] const uint8_t neighbor_dev_id = get_arg_val<uint32_t>(arg_idx++);
     [[maybe_unused]] const uint16_t neighbor_mesh_id = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t output_chunks_per_stripe = get_arg_val<uint32_t>(arg_idx++);
     [[maybe_unused]] size_t arg_for_fab = arg_idx;  // fabric connection args start here (non-mux path)
 
     // A direction with no neighbor (a line endpoint) relays nothing; no fabric/mux connection was appended.
@@ -125,7 +128,9 @@ void kernel_main() {
     auto run_writer = [&](auto* sender) {
         using SenderT = std::remove_pointer_t<decltype(sender)>;
 
-        FabricWriter<output_chunk_size, packet_size, (slice_step > 1), SenderT> fabric(
+        constexpr bool coalesce_contiguous_pages = slice_step > 1 && outputs_per_cb_page > 1;
+        static_assert(!coalesce_contiguous_pages || cb_page_size <= packet_size);
+        FabricWriter<output_chunk_size, packet_size, coalesce_contiguous_pages, SenderT> fabric(
             noc, sender, neighbor_dev_id, neighbor_mesh_id);
 
         // One 1-hop atomic-inc header for data_valid signals. Flush keeps each
@@ -164,11 +169,11 @@ void kernel_main() {
         ///////////////////////////////////////////////////
 
         OutputStripeIterator<
-            output_chunks_per_stripe,
             output_chunks_per_page,
             output_chunk_size,
             num_devices,
-            slice_step>
+            slice_step,
+            static_output_chunks_per_stripe>
             it;
 
         uint32_t stripe = initial_stripe;
@@ -178,7 +183,7 @@ void kernel_main() {
             const uint32_t count = last ? final_count : slice_count;
             const bool granular = (iter < num_granular_sends);  // downstream relays this stripe -> signal fine-grained
             const bool local_copy = (iter == 0) && (do_local_write != 0);
-            it.init(stripe, start, count);
+            it.init(stripe, start, count, output_chunks_per_stripe);
 
             uint32_t pending_chunks = 0, pending_pages = 0;
             for (uint32_t chunks_sent = 0; chunks_sent < count;) {
@@ -189,7 +194,7 @@ void kernel_main() {
                 cb.wait_front(1);
                 uint32_t l1_read_addr = cb.get_read_ptr();
                 bool signal_fused = false;
-                if constexpr (slice_step > 1 && outputs_per_cb_page > 1) {
+                if constexpr (coalesce_contiguous_pages) {
                     // Bank-owned logical pages are physically contiguous. Send the complete CB batch as one Fabric
                     // packet and use the same contiguous address for the optional local output copy.
                     auto [first_page_id, first_byte_off] = it.next();

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/high_bw_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/high_bw_all_gather.cpp
@@ -15,9 +15,19 @@ Tensor high_bw_all_gather(
     uint32_t cluster_axis,
     const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
     const std::optional<CoreRangeSet>& sub_core_grid,
-    std::optional<uint32_t> num_links) {
+    std::optional<uint32_t> num_links,
+    std::optional<uint32_t> input_batch_index,
+    std::optional<uint32_t> gathered_dim_size) {
     return ttnn::prim::high_bw_all_gather(
-        input_tensor, output_tensor, dim, cluster_axis, subdevice_id, sub_core_grid, num_links);
+        input_tensor,
+        output_tensor,
+        dim,
+        cluster_axis,
+        subdevice_id,
+        sub_core_grid,
+        num_links,
+        input_batch_index,
+        gathered_dim_size);
 }
 
 }  // namespace ttnn::operations::experimental::high_bw_all_gather

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/high_bw_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/high_bw_all_gather.hpp
@@ -19,7 +19,9 @@ Tensor high_bw_all_gather(
     uint32_t cluster_axis,
     const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id = std::nullopt,
     const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
-    std::optional<uint32_t> num_links = std::nullopt);
+    std::optional<uint32_t> num_links = std::nullopt,
+    std::optional<uint32_t> input_batch_index = std::nullopt,
+    std::optional<uint32_t> gathered_dim_size = std::nullopt);
 
 }  // namespace ttnn::operations::experimental::high_bw_all_gather
 

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/high_bw_all_gather_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/high_bw_all_gather_nanobind.cpp
@@ -57,6 +57,15 @@ void bind_experimental_high_bw_all_gather_operation(nb::module_& mod) {
                     Galaxy.
                 subdevice_id: Subdevice containing the worker cores.
                 sub_core_grids: Optional worker-core restriction.
+                input_batch_index: Optional batch slot selected from a persistent input cache.
+                    When set, input has shape [B, 1, ...], output has batch 1, and only that
+                    slot is transported.
+                gathered_dim_size: Optional active global gathered extent along ``dim``. The
+                    output tensor must still be allocated at its worst-case full gathered size.
+                    Each rank writes its active local prefix into that rank's fixed worst-case
+                    slot; bytes outside those prefixes are left unchanged. ``gathered_dim_size``
+                    is the total valid extent, not a contiguous output prefix: consumers must
+                    preserve the fixed per-rank stride when locating every rank's valid data.
         )doc",
         &high_bw_all_gather,
         nb::arg("input_tensor").noconvert(),
@@ -66,7 +75,9 @@ void bind_experimental_high_bw_all_gather_operation(nb::module_& mod) {
         nb::arg("cluster_axis"),
         nb::arg("subdevice_id") = nb::none(),
         nb::arg("sub_core_grids") = nb::none(),
-        nb::arg("num_links") = nb::none());
+        nb::arg("num_links") = nb::none(),
+        nb::arg("input_batch_index") = nb::none(),
+        nb::arg("gathered_dim_size") = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::high_bw_all_gather::detail

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
@@ -60,10 +60,12 @@ void validate_runtime_args(const operation_attributes_t& attrs, const tensor_arg
         input_row_bytes);
 
     // Optional bounded search width: top-k scans only the first valid_length columns of each row (the rest
-    // of the physically-wider row is ignored, not read). Must hold at least k values and fit within the row.
+    // of the physically-wider row is ignored, not read).  A short valid prefix is legal: inactive lanes
+    // are already represented as -inf by the TopK XL tail path and are materialized as 0xFFFFFFFF indices.
+    // This keeps a fixed worst-case k/output shape while a serving cache grows through its early prefixes.
     if (attrs.valid_length.has_value()) {
         const uint32_t valid_length = attrs.valid_length.value();
-        TT_FATAL(valid_length >= attrs.k, "topk_large_indices valid_length {} must be >= k {}", valid_length, attrs.k);
+        TT_FATAL(valid_length > 0, "topk_large_indices valid_length must be > 0");
         TT_FATAL(
             valid_length <= n,
             "topk_large_indices valid_length {} must be <= the input last dimension {}",


### PR DESCRIPTION
## Summary
- Migrate Sparse MLA from legacy async all-gather to experimental `high_bw_all_gather`.
- Add selected cache-slot and logical-prefix runtime controls to high-bandwidth all-gather, matching ring-indexer semantics without program-cache misses.
- Reuse model-owned worst-case output buffers and gather directly from the persistent ND-sharded KVPE cache; remove the per-forward ND-sharded-to-interleaved conversion.
- Keep the existing Fabric2D setup; ring-topology migration remains separate work.


## Performance impact

GLM-5.2 on Blackhole LoudBox, SP=2 × TP=4. Total profiler time in ms (`origin/main` → branch).

| Mode | Warm | Cold | Long |
| --- | ---: | ---: | ---: |
| Sparse BF16 | 6.498 → 5.846 (-10.0%) | 63.021 → 59.115 (-6.2%) | 15.716 → 10.459 (-33.4%) |
| Sparse FP8 | 6.169 → 5.659 (-8.3%) | 60.801 → 57.367 (-5.6%) | 15.096 → 10.138 (-32.8%) |
| Dense control | 3.674 → 3.680 (+0.2%) | 31.431 → 31.460 (+0.1%) | 19.718 → 19.590 (-0.6%) |
### Dispatched CI
_Additional manually dispatched workflows for this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pjosipovic/sparse-mla-high-bw-gather-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pjosipovic/sparse-mla-high-bw-gather-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/sparse-mla-high-bw-gather-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/sparse-mla-high-bw-gather-runtime)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse-mla-high-bw-gather-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/sparse-mla-high-bw-gather-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse-mla-high-bw-gather-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/sparse-mla-high-bw-gather-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse-mla-high-bw-gather-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/sparse-mla-high-bw-gather-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sparse-mla-high-bw-gather-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/sparse-mla-high-bw-gather-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/sparse-mla-high-bw-gather-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/sparse-mla-high-bw-gather-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/sparse-mla-high-bw-gather-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/sparse-mla-high-bw-gather-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/sparse-mla-high-bw-gather-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/sparse-mla-high-bw-gather-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/sparse-mla-high-bw-gather-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/sparse-mla-high-bw-gather-runtime)