### PR TITLE
fix(eltwise): drop the stale input-domain guard from sinh_bw and cosh_bw (6 and 8 fewer ops per call)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_hyperbolic_range.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_hyperbolic_range.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+
+# sinh_bw and cosh_bw used to guard on the input domain at |input| > 88.5, which is
+# log(FLT_MAX) -- where exp saturates. Both gradients are hyperbolic functions, which
+# are (e^x +/- e^-x)/2 and do not overflow until log(2*FLT_MAX) = 89.4159862, so the
+# guard fired a full 0.916 early and returned +/-inf for arguments the forward op
+# still computes finitely. With grad = 0 it returned sign(0) * inf = NaN, where torch
+# returns 0.
+#
+# Below 88.5 and above 89.4159862 nothing changes: the first is untouched by the
+# guard and the second genuinely overflows, so inf is the right answer there. Those
+# are the two controls.
+#
+# bfloat16 note: at this magnitude bfloat16 steps by 0.5, so 88.6 rounds to 88.5 --
+# not past the old bound -- and 89.4 rounds to 89.5, which overflows for real. In
+# that dtype only +/-89.0 lands inside the window, and the other points act as extra
+# controls. They are kept rather than skipped because a test that silently ran fewer
+# cases in one dtype would be worse than one that says why.
+INPUTS = (88.0, 88.6, 89.0, 89.4, -89.0, 100.0)
+INPUT_IDS = ["88.0_below", "88.6", "89.0", "89.4", "-89.0", "100.0_overflows"]
+
+# grad = 0 is not padding: it is the case the guard turned into NaN.
+GRADS = (1.0, 0.0)
+GRAD_IDS = ["grad_1", "grad_0"]
+
+DTYPES = ((torch.float32, ttnn.float32), (torch.bfloat16, ttnn.bfloat16))
+DTYPE_IDS = ("float32", "bfloat16")
+
+SHAPE = torch.Size([1, 1, 32, 32])
+
+
+def _to_device(pt, ttnn_dtype, device):
+    return ttnn.from_torch(pt.detach(), dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+
+@pytest.mark.parametrize("torch_dtype, ttnn_dtype", DTYPES, ids=DTYPE_IDS)
+@pytest.mark.parametrize("grad_value", GRADS, ids=GRAD_IDS)
+@pytest.mark.parametrize("input_value", INPUTS, ids=INPUT_IDS)
+@pytest.mark.parametrize("ttnn_op", (ttnn.sinh_bw, ttnn.cosh_bw), ids=("sinh_bw", "cosh_bw"))
+def test_bw_hyperbolic_upper_range(input_value, grad_value, torch_dtype, ttnn_dtype, ttnn_op, device):
+    in_data = torch.full(SHAPE, input_value, dtype=torch_dtype).requires_grad_(True)
+    grad_data = torch.full(SHAPE, grad_value, dtype=torch_dtype)
+
+    tt_out = ttnn_op(_to_device(grad_data, ttnn_dtype, device), _to_device(in_data, ttnn_dtype, device))
+    golden = ttnn.get_golden_function(ttnn_op)(grad_data, in_data)[0]
+
+    got = ttnn.to_torch(tt_out[0]).float()
+    want = golden.float()
+
+    finite_ref = torch.isfinite(want)
+    lost = int((finite_ref & ~torch.isfinite(got)).sum())
+    assert lost == 0, (
+        f"{ttnn_op.__name__}(grad={grad_value:g}, input={input_value:g}) [{torch_dtype}]: "
+        f"{lost} of {got.numel()} gradients came back non-finite where the reference is "
+        f"{float(want.flatten()[0]):g}"
+    )
+    torch.testing.assert_close(got, want, rtol=2e-2, atol=0.0, equal_nan=True)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1062,18 +1062,17 @@ std::vector<Tensor> sin_bw(
 std::vector<Tensor> sinh_bw(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor t_inf = ttnn::multiply(
-        ttnn::sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config);
-    Tensor grad_a = where(
-        ttnn::gt(input, 88.5f, std::nullopt, output_mem_config),
-        t_inf,
-        where(
-            ttnn::lt(input, -88.5f, std::nullopt, output_mem_config),
-            t_inf,
-            ttnn::multiply(grad, ttnn::cosh(input, output_mem_config), std::nullopt, output_mem_config),
-            output_mem_config),
-        output_mem_config);
-    t_inf.deallocate();
+    // An input-domain guard used to sit here, returning +/-inf once |input| passed 88.5. That
+    // bound is log(FLT_MAX), the point where exp saturates -- but cosh is (e^x + e^-x)/2 and does
+    // not overflow until log(2*FLT_MAX) = 89.4159862. Over that window the guard discarded a
+    // value the forward op computes correctly and finitely, and with grad = 0 it produced
+    // sign(0) * inf = NaN where torch returns 0.
+    //
+    // It was also redundant. The magnitude clamp immediately below already returns inf exactly
+    // when the result overflows and the finite value when it does not, which is the decision the
+    // guard was trying to make, made on the right quantity. Removing it takes six element-wise
+    // operations and one intermediate tensor off every call.
+    Tensor grad_a = ttnn::multiply(grad, ttnn::cosh(input, output_mem_config), std::nullopt, output_mem_config);
     grad_a = where(
         ttnn::ge(grad_a, 3.4e+38f, std::nullopt, output_mem_config),
         std::numeric_limits<float>::infinity(),
@@ -1180,21 +1179,11 @@ std::vector<Tensor> softsign_bw(
 std::vector<Tensor> cosh_bw(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor t_inf = ttnn::multiply(
-        ttnn::sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config);
-    Tensor t_neg_inf = ttnn::multiply(
-        ttnn::sign(grad, output_mem_config), -std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config);
-    Tensor grad_a = where(
-        ttnn::gt(input, 88.50f, std::nullopt, output_mem_config),
-        t_inf,
-        where(
-            ttnn::lt(input, -88.50f, std::nullopt, output_mem_config),
-            t_neg_inf,
-            ttnn::multiply(grad, ttnn::sinh(input, output_mem_config), std::nullopt, output_mem_config),
-            output_mem_config),
-        output_mem_config);
-    t_neg_inf.deallocate();
-    t_inf.deallocate();
+    // The same stale guard as in sinh_bw, and eight element-wise operations here rather than six,
+    // because the negative branch builds a second infinity tensor. sinh overflows at the same
+    // log(2*FLT_MAX) = 89.4159862, so the window above the old bound was being thrown away, and
+    // the magnitude clamp below already decides the genuine overflow correctly.
+    Tensor grad_a = ttnn::multiply(grad, ttnn::sinh(input, output_mem_config), std::nullopt, output_mem_config);
     grad_a = where(
         ttnn::ge(grad_a, 3.4e+38f, std::nullopt, output_mem_config),
         std::numeric_limits<float>::infinity(),


### PR DESCRIPTION
### Ticket

Fixes #52612.

### What's wrong

`sinh_bw` and `cosh_bw` guard on the input domain at `|input| > 88.5`, which is `log(FLT_MAX)` —
the point where `exp` saturates. Their gradients are `cosh` and `sinh`, which are `(eˣ ± e⁻ˣ)/2`
and do not overflow until `log(2·FLT_MAX) = 89.4159862`, so the guard fires 0.916 early and
returns `±inf` for arguments the forward op still computes finitely.

```
ttnn.cosh(89.0)          -> 2.24481e38      correct, finite, representable
ttnn.sinh_bw(1.0, 89.0)  -> inf             exact answer: 2.24481e38
```

With `grad = 0` inside that window the guard computes `sign(0) · inf = NaN`, where torch returns
`0`.

### What changed

The guard is deleted. Nothing replaces it, because both functions already end with a clamp on the
**magnitude of the result**:

```cpp
grad_a = where(ttnn::ge(grad_a, 3.4e+38f, ...), inf,
          where(ttnn::le(grad_a, -3.4e+38f, ...), -inf, grad_a, ...), ...);
```

That clamp returns `inf` exactly when the result overflows and the finite value when it does not —
the decision the input-domain guard was trying to make, made on the right quantity.

**This removes work rather than adding it:**

| | element-wise ops dropped | intermediate tensors dropped |
|---|---|---|
| `sinh_bw` | `sign` `multiply` `gt` `lt` `where` `where` = **6** | 1 |
| `cosh_bw` | the same plus a second `sign`/`multiply` for `t_neg_inf` = **8** | 2 |

The file gets shorter by 11 lines even with the explanation added.

### What does not change

- `|input| ≤ 88.5`: the guard never fired, so those values are bit-identical.
- `|input| > 89.4159862`: `cosh` and `sinh` genuinely overflow, the forward op returns `inf`, and
  the magnitude clamp keeps returning `inf`. Measured at `input = 100` in both dtypes.
- `grad = 0` with `|input| > 89.4159862`: still `NaN`, because `0 · inf` is `NaN` and that is what
  torch gives too.

### Why 88.5 was there

It is `log(FLT_MAX)` rounded down, correct for `exp` and inherited by functions that are not `exp`.
Since #45552 the SFPU computes `cosh` as `q + q` with `q = exp(a)/4`, which is why `cosh(89)` comes
back finite on the device while the backward pass was still refusing to look at it.

### Measured

ttsim 1.9.7, `Arch.BLACKHOLE`, `float32`, `grad = 1`:

| input | `sinh_bw` today | exact (`grad · cosh x`) | `ttnn.cosh(input)` |
|---|---|---|---|
| 88.4 | 1.23198e38 | 1.23198e38 | 1.23198e38 (ok) |
| **88.6** | **inf** | 1.50474e38 | **1.50474e38** |
| **89.0** | **inf** | 2.24481e38 | **2.24481e38** |
| **89.4** | **inf** | 3.34886e38 | **3.34886e38** |
| −89.0 | **inf** | 2.24481e38 | 2.24481e38 |
| 89.42 | inf | not representable | inf (ok) |

The third column is the point: the device computes the right number and the backward pass throws
it away.

### Test

`tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_hyperbolic_range.py` —
both ops, six input magnitudes, `grad ∈ {1, 0}`, both dtypes. `88.0` and `100.0` are controls on
either side of the window.

In `bfloat16` the spacing at this magnitude is `0.5`, so `88.6` rounds to `88.5` — not past the old
bound — and `89.4` rounds to `89.5`, which overflows for real. Only `±89.0` lands inside the window
in that dtype; the other points become extra controls there. They are kept rather than skipped,
and the file says why, because a test that silently ran fewer cases in one dtype would be worse
than one that explains itself.

The existing coverage draws `input` from `data_gen_with_range(input_shapes, -9, 9, ...)`, an order
of magnitude away from the window, which is why nothing caught this.
