### PR TITLE
fix(eltwise): factor the magnitude out before squaring in the variance composite

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_normalize_hw_scale.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_normalize_hw_scale.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+
+# std_hw, var_hw and normalize_hw compute the variance as the mean of (x - mean)^2, forming the
+# square as a value of its own. That square is the only part of the computation with a narrower
+# range than the answer it feeds:
+#
+#   |x - mean| < 1.0842e-19   the square falls below the smallest normal and flushes to zero, so
+#                             the standard deviation of an ordinary spread comes back an exact 0
+#                             and normalize_hw divides by it
+#   |x - mean| > 1.3043818e19 the accumulator tops out at 2^127, so the standard deviation comes
+#                             back as sqrt(2^127) -- the same number for every input above that,
+#                             which makes normalize_hw grow linearly where the answer is fixed
+#
+# The tensors below are built so the answer is exact rather than approximate: alternating columns
+# of +v and -v give a mean of exactly zero and a population standard deviation of exactly v, at
+# every magnitude. normalize_hw must therefore return the +/-1 pattern unchanged.
+#
+# That construction is the reference on purpose. torch.std in float32 forms the same square and
+# overflows at the top of this range, so it cannot referee the high end; the analytic value can.
+DEVIATIONS = (1e-25, 1e-20, 1e-19, 1e-10, 1.0, 1e10, 1e18, 1e20, 1e25)
+DEVIATION_IDS = ["1e-25", "1e-20", "1e-19", "1e-10", "1.0", "1e10", "1e18", "1e20", "1e25"]
+
+DTYPES = ((torch.float32, ttnn.float32), (torch.bfloat16, ttnn.bfloat16))
+DTYPE_IDS = ("float32", "bfloat16")
+
+SHAPE = torch.Size([1, 1, 32, 32])
+
+
+def _alternating(deviation, torch_dtype):
+    """Columns of +deviation and -deviation: mean exactly 0, population std exactly |deviation|."""
+    sign = torch.ones(SHAPE)
+    sign[..., 1::2] = -1.0
+    return sign, (sign * deviation).to(torch_dtype)
+
+
+@pytest.mark.parametrize("torch_dtype, ttnn_dtype", DTYPES, ids=DTYPE_IDS)
+@pytest.mark.parametrize("deviation", DEVIATIONS, ids=DEVIATION_IDS)
+def test_normalize_hw_is_scale_invariant(deviation, torch_dtype, ttnn_dtype, device):
+    sign, in_data = _alternating(deviation, torch_dtype)
+    tt_in = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    got = ttnn.to_torch(ttnn.normalize_hw(tt_in)).float()
+
+    n_bad = int((~torch.isfinite(got)).sum())
+    assert n_bad == 0, (
+        f"normalize_hw with deviation {deviation:g} [{torch_dtype}] returned {n_bad} non-finite "
+        f"values of {got.numel()}; every element should be +/-1"
+    )
+    torch.testing.assert_close(got, sign, rtol=2e-2, atol=0.0)
+
+
+@pytest.mark.parametrize("torch_dtype, ttnn_dtype", DTYPES, ids=DTYPE_IDS)
+@pytest.mark.parametrize("deviation", DEVIATIONS, ids=DEVIATION_IDS)
+def test_std_hw_matches_the_constructed_spread(deviation, torch_dtype, ttnn_dtype, device):
+    _, in_data = _alternating(deviation, torch_dtype)
+    tt_in = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    got = float(ttnn.to_torch(ttnn.std_hw(tt_in)).float().flatten()[0])
+    expected = float(torch.tensor([deviation], dtype=torch_dtype)[0])
+
+    assert got != 0.0, f"std_hw returned an exact 0 for a spread of {expected:g} [{torch_dtype}]"
+    assert got == got and abs(got) != float("inf"), f"std_hw returned {got} for {expected:g}"
+    assert abs(got - expected) <= 2e-2 * abs(expected), (
+        f"std_hw returned {got:g} where the spread is exactly {expected:g} [{torch_dtype}]"
+    )
+
+
+@pytest.mark.parametrize("torch_dtype, ttnn_dtype", DTYPES, ids=DTYPE_IDS)
+def test_std_hw_scales_with_its_input(torch_dtype, ttnn_dtype, device):
+    """std(k*x) == k*std(x) stated directly, across the exponent range."""
+    _, base = _alternating(1.0, torch_dtype)
+    tt_base = ttnn.from_torch(base, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    unit = float(ttnn.to_torch(ttnn.std_hw(tt_base)).float().flatten()[0])
+    assert abs(unit - 1.0) <= 2e-2, f"std_hw of the unit spread is {unit:g}, expected 1"
+
+    for k in (1e-25, 1e-19, 1e-6, 1e6, 1e19, 1e25):
+        _, scaled = _alternating(k, torch_dtype)
+        tt_scaled = ttnn.from_torch(scaled, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        got = float(ttnn.to_torch(ttnn.std_hw(tt_scaled)).float().flatten()[0])
+        want = k * unit
+        assert abs(got - want) <= 2e-2 * abs(want), (
+            f"std_hw(k*x) is {got:g} but k*std_hw(x) is {want:g}, for k = {k:g} [{torch_dtype}]"
+        )

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -28,18 +28,56 @@
 #include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
 namespace ttnn::detail {
 
+namespace {
+
+// Largest deviation in each H x W plane, used to factor the magnitude out before squaring.
+//
+// The square is the only part of this computation with a narrower range than the answer it
+// feeds. Below |d| = 1.0842e-19 -- the square root of the smallest normal float -- d^2 flushes
+// to zero, so the standard deviation of an ordinary spread comes back as an exact 0. Above
+// |d| = 1.3043818e19 the accumulator tops out at 2^127 and the standard deviation comes back as
+// sqrt(2^127), the same value for every input above that point. Neither is a tolerance
+// question: the answers themselves, 1e-20 and 1e20, are ordinary float32 numbers.
+//
+// A constant tensor has no deviation and no scale to factor out. Substituting 1 there keeps the
+// division a no-op and the variance exactly zero, as before.
+Tensor _deviation_scale(const Tensor& y_minus_mean_y, const std::optional<MemoryConfig>& output_mem_config) {
+    ttsl::SmallVector<int> dims = {2, 3};
+    Tensor m = ttnn::max(ttnn::abs(y_minus_mean_y, output_mem_config), dims, true, output_mem_config);
+    return ttnn::where(ttnn::eqz(m, output_mem_config), 1.0f, m, output_mem_config);
+}
+
+// mean((d / max|d|)^2). Every squared term lands in [0, 1], so nothing here can underflow to zero
+// or saturate the accumulator; the magnitude is restored by the callers.
+Tensor _scaled_variance_impl(
+    const Tensor& y,
+    Tensor& y_minus_mean_y,
+    const Tensor& deviation_scale,
+    const std::optional<MemoryConfig>& output_mem_config) {
+    ttsl::SmallVector<int> dims = {2, 3};
+    constexpr float correction = 0.0f;
+    auto shape_wh = y.padded_shape();
+    float scale = 1.0f / ((float)(shape_wh[3] * shape_wh[2]) - correction);
+    Tensor normalised = ttnn::bcast(
+        y_minus_mean_y,
+        ttnn::reciprocal(deviation_scale, output_mem_config),
+        ttnn::BcastOpMath::MUL,
+        ttnn::BcastOpDim::HW);
+    Tensor sqr_normalised = ttnn::square(normalised, output_mem_config);
+    return ttnn::sum(sqr_normalised, dims, true, std::nullopt, std::nullopt, scale);
+}
+
+}  // namespace
+
 // Function variance of whole tensor.
 Tensor _variance_impl(
     const Tensor& y,
     const Tensor& /*mean_y*/,
     Tensor& y_minus_mean_y,
     const std::optional<MemoryConfig>& output_mem_config) {
-    ttsl::SmallVector<int> dims = {2, 3};
-    constexpr float correction = 0.0f;
-    auto shape_wh = y.padded_shape();
-    float scale = 1.0f / ((float)(shape_wh[3] * shape_wh[2]) - correction);
-    Tensor sqr_y_minus_mean_y = ttnn::square(y_minus_mean_y, output_mem_config);
-    return ttnn::sum(sqr_y_minus_mean_y, dims, true, std::nullopt, std::nullopt, scale);
+    Tensor m = _deviation_scale(y_minus_mean_y, output_mem_config);
+    Tensor scaled = _scaled_variance_impl(y, y_minus_mean_y, m, output_mem_config);
+    return ttnn::multiply(ttnn::square(m, output_mem_config), scaled, std::nullopt, output_mem_config);
 }
 Tensor _variance_impl(const Tensor& y, const Tensor& mean_y, const std::optional<MemoryConfig>& output_mem_config) {
     Tensor y_minus_mean_y = ttnn::bcast(y, mean_y, ttnn::BcastOpMath::SUB, ttnn::BcastOpDim::HW);
@@ -47,7 +85,8 @@ Tensor _variance_impl(const Tensor& y, const Tensor& mean_y, const std::optional
 }
 
 Tensor _std(const Tensor& y, const Tensor& mean_y, const std::optional<MemoryConfig>& output_mem_config) {
-    return ttnn::sqrt(_variance_impl(y, mean_y, output_mem_config));
+    Tensor y_minus_mean_y = ttnn::bcast(y, mean_y, ttnn::BcastOpMath::SUB, ttnn::BcastOpDim::HW);
+    return _std(y, mean_y, y_minus_mean_y, output_mem_config);
 }
 
 Tensor _std(
@@ -55,7 +94,13 @@ Tensor _std(
     const Tensor& mean_y,
     Tensor& y_minus_mean_y,
     const std::optional<MemoryConfig>& output_mem_config) {
-    return ttnn::sqrt(_variance_impl(y, mean_y, y_minus_mean_y, output_mem_config));
+    // The scale is restored after the square root, not before it. Standard deviation is
+    // homogeneous of degree one -- std(k*d) = k*std(d) -- so going through the variance would
+    // demand that k^2 be representable when only k needs to be, which is exactly the range that
+    // was being lost. Routing std through the variance is what turned a 1e-20 spread into 0.
+    Tensor m = _deviation_scale(y_minus_mean_y, output_mem_config);
+    Tensor scaled = _scaled_variance_impl(y, y_minus_mean_y, m, output_mem_config);
+    return ttnn::multiply(m, ttnn::sqrt(scaled), std::nullopt, output_mem_config);
 }
 
 std::vector<Tensor> split_tensor_for_glu(


### PR DESCRIPTION
### Ticket

Fixes #52614.

### What's wrong

`std_hw`, `var_hw` and `normalize_hw` compute the variance as the mean of `(x - mean)²`, forming
the square as a value of its own. That square has a much narrower range than the answer it feeds,
and it fails at both ends:

| condition | what happens | `std_hw` |
|---|---|---|
| `\|x − mean\| < 1.0842e-19` | the square falls below the smallest normal and flushes to zero | **exactly 0** |
| `\|x − mean\| > 1.3043818e19` | the accumulator tops out at `2¹²⁷` | **`sqrt(2¹²⁷)`, the same number for every input above that** |

`1.0842e-19` is `√FLT_MIN` and `1.3043818e19` is `√2¹²⁷`; both are properties of the intermediate,
not of the answer. A spread of `1e-20` or `1e20` is an ordinary `float32`.

`normalize_hw` divides by that standard deviation, so it is non-finite at the low end and grows
linearly at the high end — where the correct answer is `±1.0` at every magnitude, by construction.

```
deviation 1e-20   ->  std_hw = 0              normalize_hw not finite
deviation 1e20    ->  std_hw = 1.30438e19     normalize_hw = 7.65
deviation 1e25    ->  std_hw = 1.30438e19     normalize_hw = 7.7e5
```

### What changed

The deviations are divided by their own largest magnitude before squaring, and the scale is
restored afterwards. Every squared term then lands in `[0, 1]`, so nothing can underflow or
saturate.

**For `std` the scale is restored after the square root, not before it.** Standard deviation is
homogeneous of degree one — `std(k·d) = k·std(d)` — so going through the variance would demand
that `k²` be representable when only `k` needs to be. That is the whole defect: `var(1e-20)` is
`1e-40` and genuinely does not exist in `float32`, while `std(1e-20) = 1e-20` does. Routing `std`
through `var` is what turned an ordinary spread into `0`.

A constant tensor has no deviation and no scale to factor out; the substituted `1` keeps the
division a no-op and the variance exactly zero, as before.

### What this costs, stated plainly

It is not free, and I would rather price it than let a reviewer find it:

| | before | after |
|---|---|---|
| element-wise passes | square | **abs**, **broadcast multiply**, square |
| reductions | sum | **max**, sum |
| on the reduced tile | — | `eqz`, `where`, `reciprocal`, one multiply (a 1×1 result, negligible) |

So one extra element-wise pass, one extra broadcast multiply, and one extra reduction — roughly
double the variance step, on top of the broadcast subtract the callers already do.

Why that seems worth paying here, when the same trade would not be worth it in an SFPU kernel:

- These are host-side composites over a reduction that already costs two passes and a reduction.
  They are not on a per-element hot path.
- The current result is not imprecise, it is a different function: an exact `0` over everything
  below `1.0842e-19`, and a fixed constant over everything above `1.3043818e19` — about nineteen
  decades of input in each direction.
- #41838 accepted a 32-file Welford rewrite of the reduction path for a related failure. This is
  the same problem in the composite the migration did not reach, and a much smaller change.

If the cost is unacceptable, the rescale can be made conditional on `max|d|` leaving the safe
band, at the price of a data-dependent branch. Happy to do that instead — I did not want to
introduce a branch without being asked.

### What this does not fix

`var_hw` itself still cannot return `var(1e-20) = 1e-40`, because that number is not a `float32`.
What changes for `var_hw` is the high end, where the variance *is* representable and used to come
back as a saturated constant. `std_hw` and `normalize_hw` are fixed at both ends, and they are the
two the range actually reaches.

### Measured

The composite reimplemented in `float32` with the device's flush-to-zero and the `2¹²⁷` ceiling
modelled, over 122 deviations spanning `1e-30` to `1e30`:

| | wrong before | wrong after |
|---|---|---|
| `std_hw` | **46 of 122** | **0** |

The model reproduces both measured boundaries exactly — the low end at `1.0842e-19` and the
ceiling at `1.3043818e19` — which is why I trust it to price the fix rather than just describe it.

On the device, ttsim 1.9.7, `Arch.BLACKHOLE`, `float32`, a `[1, 1, 32, 32]` tile of alternating
`+v` / `−v` columns:

| deviation | `std_hw` | exact | `normalize_hw` |
|---|---|---|---|
| 1e−25 | **0** | 1e−25 | not finite |
| 1e−20 | **0** | 1e−20 | not finite |
| 1e18 | 9.99759e17 | 1e18 | 1.00004 (ok) |
| 1.8e19 | **1.30438e19** | 1.8e19 | 1.376 |
| 1e20 | **1.30438e19** | 1e20 | **7.646** |
| 1e25 | **1.30438e19** | 1e25 | **764626** |

### Test

`tests/ttnn/unit_tests/operations/eltwise/test_normalize_hw_scale.py`. Alternating `+v` / `−v`
columns give a mean of exactly zero and a population standard deviation of exactly `v` at every
magnitude, so `normalize_hw` must return the `±1` pattern unchanged and `std_hw` must return `v`.
Nine magnitudes from `1e-25` to `1e25`, both dtypes, plus the scale invariance `std(k·x) = k·std(x)`
asserted directly.

That construction is the reference on purpose. `torch.std` in `float32` forms the same square and
overflows at the top of this range, so it cannot referee the high end — the analytic value can.
