### PR TITLE
[Bug fix] Fix high_bw_all_gather cached-launch synchronization

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.cpp
@@ -42,6 +42,7 @@ enum class ReaderRtArg : std::size_t {
     FinalCount,
     InputPageStart,
     InputPageEnd,
+    ReadySemaphore,
     DataValidSemaphore,
     Count,
 };
@@ -56,6 +57,9 @@ enum class WriterRtArg : std::size_t {
     FinalStart,
     FinalCount,
     DoLocalWrite,
+    ReadySemaphore,
+    ReadyNocX,
+    ReadyNocY,
     DataValidSemaphore,
     DataValidNocX,
     DataValidNocY,
@@ -146,7 +150,7 @@ using namespace CMAKE_UNIQUE_NAMESPACE;
 // (CB producer, no fabric) reads iteration 0 from local input and later iterations from what upstream relayed
 // into our output; the writer (CB consumer) unicasts each stripe one hop to the neighbor's output (same
 // address on every device). Direction/topology are runtime args, so both kernels compile once and run on all
-// cores. data_valid_sem gates relays and tracks completion.
+// cores. ready_sem protects destination initialization, while data_valid_sem gates relays and tracks completion.
 ////////////////////////////////////////////////////////////////
 
 HighBwAllGatherUnicastFactory::cached_mesh_workload_t HighBwAllGatherUnicastFactory::create_mesh_workload(
@@ -165,7 +169,7 @@ HighBwAllGatherUnicastFactory::cached_mesh_workload_t HighBwAllGatherUnicastFact
     }
     ttsl::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
 
-    // Keep the relay/completion semaphore in L1_SMALL when the device reserves it.
+    // Keep the startup-readiness and relay/completion semaphores in L1_SMALL when the device reserves it.
     const bool has_l1_small = mesh_device->allocator()->get_bank_size(tt::tt_metal::BufferType::L1_SMALL) > 0;
     auto sem_buffer_type = has_l1_small ? tt::tt_metal::BufferType::L1_SMALL : tt::tt_metal::BufferType::L1;
     if (sem_buffer_type != tt::tt_metal::BufferType::L1_SMALL) {
@@ -174,6 +178,7 @@ HighBwAllGatherUnicastFactory::cached_mesh_workload_t HighBwAllGatherUnicastFact
             "Allocating semaphores in L1, which may fragment L1 and reduce headroom for subsequent op "
             "allocations. Configure an L1_SMALL region to mitigate this.");
     }
+    auto ready_sem = ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
     auto data_valid_sem =
         ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
     log_debug(tt::LogOp, "Semaphores allocated and waiting for all devices to be ready");
@@ -181,7 +186,8 @@ HighBwAllGatherUnicastFactory::cached_mesh_workload_t HighBwAllGatherUnicastFact
     log_debug(tt::LogOp, "All devices are ready, starting program execution");
 
     for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, output_tensor, data_valid_sem);
+        auto cached_program =
+            create_at(operation_attributes, coord, tensor_args, output_tensor, ready_sem, data_valid_sem);
         workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
         shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
     }
@@ -194,6 +200,7 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
     const ttnn::MeshCoordinate& sender_device_coord,
     const HighBwAllGatherInputs& tensor_args,
     const Tensor& output_tensor,
+    const tt::tt_metal::GlobalSemaphore& ready_sem,
     const tt::tt_metal::GlobalSemaphore& data_valid_sem) {
     const auto& input_tensor = tensor_args.input_tensor;
     tt::tt_metal::Program program{};
@@ -654,11 +661,14 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
             const uint32_t half = num_worker_output_chunks / 2;
 
             // Both directions (dir: 0 = forward, 1 = backward). mirror_core is this core's coords, reused as the
-            // data_valid_sem target on the neighbor's mirror core.
+            // data_valid_sem target on the neighbor's mirror core; partner_core is the opposite-direction worker
+            // targeted by the startup-ready handshake.
             for (uint32_t dir = 0; dir < num_directions; ++dir) {
                 const bool is_forward = (dir == 0);
                 const CoreCoord core = worker_core(link, dir, w);
+                const CoreCoord partner = worker_core(link, 1 - dir, w);
                 const CoreCoord mirror_core = mesh_device->worker_core_from_logical_core(core);
+                const CoreCoord partner_core = mesh_device->worker_core_from_logical_core(partner);
                 const auto neighbor = dir_neighbor(dir);
                 const auto neighbor_node =
                     neighbor.has_value() ? mesh_device->get_fabric_node_id(*neighbor) : sender_fabric_node_id;
@@ -708,6 +718,7 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
                 reader_rt_args[rt_arg_index(ReaderRtArg::FinalCount)] = final_count;
                 reader_rt_args[rt_arg_index(ReaderRtArg::InputPageStart)] = input_tile_id_start;
                 reader_rt_args[rt_arg_index(ReaderRtArg::InputPageEnd)] = input_tile_id_end;
+                reader_rt_args[rt_arg_index(ReaderRtArg::ReadySemaphore)] = ready_sem.address();
                 reader_rt_args[rt_arg_index(ReaderRtArg::DataValidSemaphore)] = data_valid_sem.address();
                 tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, {core}, reader_rt_args);
 
@@ -721,6 +732,9 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
                 writer_rt_args[rt_arg_index(WriterRtArg::FinalStart)] = final_start;
                 writer_rt_args[rt_arg_index(WriterRtArg::FinalCount)] = final_count;
                 writer_rt_args[rt_arg_index(WriterRtArg::DoLocalWrite)] = do_local_write ? 1u : 0u;
+                writer_rt_args[rt_arg_index(WriterRtArg::ReadySemaphore)] = ready_sem.address();
+                writer_rt_args[rt_arg_index(WriterRtArg::ReadyNocX)] = static_cast<uint32_t>(partner_core.x);
+                writer_rt_args[rt_arg_index(WriterRtArg::ReadyNocY)] = static_cast<uint32_t>(partner_core.y);
                 writer_rt_args[rt_arg_index(WriterRtArg::DataValidSemaphore)] = data_valid_sem.address();
                 writer_rt_args[rt_arg_index(WriterRtArg::DataValidNocX)] = static_cast<uint32_t>(mirror_core.x);
                 writer_rt_args[rt_arg_index(WriterRtArg::DataValidNocY)] = static_cast<uint32_t>(mirror_core.y);
@@ -768,6 +782,7 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
         .worker_cores = worker_cores,
         .reader_kernel_id = reader_kernel_id,
         .writer_kernel_id = writer_kernel_id,
+        .ready_sem = ready_sem,
         .data_valid_sem = data_valid_sem,
     };
 
@@ -784,6 +799,7 @@ void HighBwAllGatherUnicastFactory::override_runtime_arguments(
 
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
+        const uint32_t ready_addr = shared_vars.ready_sem.address();
         const uint32_t data_valid_addr = shared_vars.data_valid_sem.address();
 
         auto& reader_args_by_core = GetRuntimeArgs(program, shared_vars.reader_kernel_id);
@@ -792,9 +808,11 @@ void HighBwAllGatherUnicastFactory::override_runtime_arguments(
             auto& reader_args = reader_args_by_core[core.x][core.y];
             reader_args.at(rt_arg_index(ReaderRtArg::InputAddress)) = input_addr;
             reader_args.at(rt_arg_index(ReaderRtArg::OutputAddress)) = output_addr;
+            reader_args.at(rt_arg_index(ReaderRtArg::ReadySemaphore)) = ready_addr;
             reader_args.at(rt_arg_index(ReaderRtArg::DataValidSemaphore)) = data_valid_addr;
             auto& writer_args = writer_args_by_core[core.x][core.y];
             writer_args.at(rt_arg_index(WriterRtArg::OutputAddress)) = output_addr;
+            writer_args.at(rt_arg_index(WriterRtArg::ReadySemaphore)) = ready_addr;
             writer_args.at(rt_arg_index(WriterRtArg::DataValidSemaphore)) = data_valid_addr;
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.hpp
@@ -17,6 +17,7 @@ struct HighBwAllGatherUnicastFactory {
         std::vector<tt::tt_metal::CoreCoord> worker_cores;
         tt::tt_metal::KernelHandle reader_kernel_id{};
         tt::tt_metal::KernelHandle writer_kernel_id{};
+        tt::tt_metal::GlobalSemaphore ready_sem;
         tt::tt_metal::GlobalSemaphore data_valid_sem;
     };
 
@@ -42,6 +43,7 @@ private:
         const ttnn::MeshCoordinate& sender_device_coord,
         const HighBwAllGatherInputs& tensor_args,
         const Tensor& output_tensor,
+        const tt::tt_metal::GlobalSemaphore& ready_sem,
         const tt::tt_metal::GlobalSemaphore& data_valid_sem);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_common.hpp
@@ -25,11 +25,11 @@ namespace fabric_api = tt::tt_fabric::linear::experimental;
 ////////////////////////////////////////////////////////////////
 // data_valid semaphore protocol
 //
-// data_valid counts the chunks upstream has relayed into our output -- cumulative over the op, reset at
-// completion. A chunk's absolute position is base_chunk + within-slice offset, with base_chunk = (iter-1) *
-// slice_count. The writer maintains the count (atomic-inc per chunks delivered); the reader waits on it with
-// noc_semaphore_wait_min at the last chunk of each batch it reads, then a final wait for total_chunks before
-// reset.
+// data_valid counts the chunks upstream has relayed into our output. The writer maintains the count (atomic-inc
+// per chunks delivered); the reader waits on it with noc_semaphore_wait_min at the last chunk of each batch it
+// reads, then waits for total_chunks and atomically subtracts exactly total_chunks at completion. Each
+// invocation consumes only its own credits, leaving any additional credits available to their owning
+// invocation. All reusable protocol state is maintained on device.
 //
 // Waiting on an absolute position (not a signal count) lets one reader path cover every case with no alignment
 // or per-topology special-casing:

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_reader.cpp
@@ -28,9 +28,7 @@ public:
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_addr_), value);
     }
 
-    void set(uint32_t value) const {
-        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_addr_), value);
-    }
+    void consume(uint32_t value) const { noc_semaphore_inc(get_noc_addr(l1_addr_), uint32_t{0} - value); }
 
 private:
     address_t l1_addr_;
@@ -73,6 +71,7 @@ void kernel_main() {
     const uint32_t final_count = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t input_page_id_start = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t input_page_id_end = get_arg_val<uint32_t>(arg_idx++);
+    const address_t ready_sem_addr = get_arg_val<uint32_t>(arg_idx++);
     const address_t data_valid_sem_addr = get_arg_val<uint32_t>(arg_idx++);
 
     auto input_tensor_accessor = TensorAccessor(input_tensor_args, input_tensor_address);
@@ -80,6 +79,7 @@ void kernel_main() {
 
     Noc noc;
     CircularBuffer cb(cb0_id);
+    const DynamicL1Semaphore ready_sem(ready_sem_addr);
     const DynamicL1Semaphore data_valid_sem(data_valid_sem_addr);
 
     OutputStripeIterator<output_chunks_per_stripe, output_chunks_per_page, output_chunk_size, num_devices, slice_step>
@@ -88,6 +88,16 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     // MAIN
     ///////////////////////////////////////////////////
+
+    // A remote writer can reach this device before this device has completed
+    // earlier input/output transfers on its own command queue. Gate the local
+    // writer's CB producer until the downstream device announces that its
+    // corresponding collective program has started. Each invocation owns and
+    // consumes one readiness credit.
+    if (num_iters > 0) {
+        ready_sem.wait_min(1);
+        ready_sem.consume(1);
+    }
 
     uint32_t stripe = initial_stripe;
     for (uint32_t iter = 0; iter < num_iters; ++iter) {
@@ -166,7 +176,9 @@ void kernel_main() {
     // CLEANUP
     ///////////////////////////////////////////////////
 
-    // Completion: wait for every chunk upstream delivers (relayed + sink), then reset for reuse.
+    // Completion: wait for every chunk upstream delivers (relayed + sink),
+    // then atomically consume this invocation's credits.
     data_valid_sem.wait_min(total_chunks);
-    data_valid_sem.set(0);
+    data_valid_sem.consume(total_chunks);
+    noc.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_writer.cpp
@@ -66,6 +66,9 @@ void kernel_main() {
     const uint32_t final_start = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t final_count = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t do_local_write = get_arg_val<uint32_t>(arg_idx++);
+    const address_t ready_sem = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t ready_sem_noc_x = get_arg_val<uint32_t>(arg_idx++);  // neighbor opposite-direction core
+    const uint8_t ready_sem_noc_y = get_arg_val<uint32_t>(arg_idx++);
     const address_t data_valid_sem = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t data_valid_sem_noc_x = get_arg_val<uint32_t>(arg_idx++);  // mirror core (data_valid_sem target)
     const uint8_t data_valid_sem_noc_y = get_arg_val<uint32_t>(arg_idx++);
@@ -145,6 +148,12 @@ void kernel_main() {
                 UnicastAtomicIncUpdateMask::DstAddr | UnicastAtomicIncUpdateMask::Val>(
                 sender, sem_packet_header, tt::tt_fabric::NocUnicastAtomicIncCommandHeader{addr, val});
         };
+
+        // Announce that this device has reached the collective program. Its
+        // earlier command-queue entries, including output initialization, are
+        // complete, so the neighbor can safely write into this output. Target
+        // the opposite-direction reader paired with the writer returning here.
+        atomic_inc(safe_get_noc_addr(ready_sem_noc_x, ready_sem_noc_y, ready_sem, 0), 1);
 
         const uint64_t downstream_data_valid_addr =
             safe_get_noc_addr(data_valid_sem_noc_x, data_valid_sem_noc_y, data_valid_sem, 0);


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fix two cross-invocation ordering holes in experimental `high_bw_all_gather` that caused nondeterministic output corruption and could lose relay progress on cached launches.

#### Root cause

`high_bw_all_gather` stores global semaphores in the cached mesh workload, so the same semaphore storage is reused across invocations while device command queues can advance independently.

First, each reader waited for the final data-valid credit and then cleared the shared counter. A faster peer could already have published credit for invocation N+1 before a slower reader completed invocation N. Clearing the counter discarded that valid credit, leaving a later relay waiting for a notification that had already arrived.

Second, cache misses happened to synchronize the mesh after allocating the global semaphores, while cache hits had no equivalent startup ordering. Callers can enqueue input and persistent-output transfers independently on each device immediately before launching the collective. A fast device could begin Fabric writes into a slow destination while that destination still had an output-initialization transfer queued. The late local transfer then overwrote valid remote stripes.

This timing window is much easier to hit under CI load than on an otherwise quiet local machine.

#### Why this operation exposes the race

Many CCLs allocate their outputs internally, and their tests do not exercise cached launches with caller-provided persistent output buffers. `high_bw_all_gather` has no such alternative: every invocation requires a preallocated output tensor. Consequently, output initialization can be queued independently on each device immediately before the collective. Device queues progressing at different rates can then allow remote Fabric writes to overtake a pending initialization on a slow destination.

This mandatory output-buffer path makes the ordering hole visible here. Similar synchronization patterns in other CCLs may remain latent without equivalent persistent-output coverage; their current tests passing does not establish that those patterns are safe under this launch model.

#### Fix

- Add a per-worker, neighbor-paired startup handshake on every invocation. A writer announces that its device has entered the collective, and the paired reader gates its local writer until the downstream program is ready.
- Treat readiness and data-valid values as consumable credits. Each reader waits for the amount owned by its invocation and atomically subtracts exactly that amount.
- Drain the final atomic subtraction before reader exit.

Atomic consumption preserves credits already posted by independently progressing peers. It keeps reusable synchronization state entirely on device, requires no destructive reset or host-maintained generation, has no rollover path, and remains correct when a cached program is captured and replayed without runtime-argument overrides.

No test-only delay, diagnostic harness, or unrelated change is included in this branch.

### Validation

- `./build_metal.sh --release`
- Clean-branch QuietBox Ring and Torus correctness/performance subset: 2 passed, including large shapes at approximately 119–121 GB/s
- Six independently dispatched Blackhole sanity runs passed the relevant QuietBox multi-device CCL job on commit `949935f1ab8`:
  - [31307860964](https://github.com/tenstorrent/tt-metal/actions/runs/31307860964/job/93232749358)
  - [31307862341](https://github.com/tenstorrent/tt-metal/actions/runs/31307862341/job/93231908786)
  - [31308824899](https://github.com/tenstorrent/tt-metal/actions/runs/31308824899/job/93234221257)
  - [31308826454](https://github.com/tenstorrent/tt-metal/actions/runs/31308826454/job/93234984087)
  - [31309748113](https://github.com/tenstorrent/tt-metal/actions/runs/31309748113/job/93237384262)
  - [31309749500](https://github.com/tenstorrent/tt-metal/actions/runs/31309749500/job/93236516116)
- Eight queued cached invocations passed for Ring and Torus
- Eighty delayed cached invocations per topology passed for Ring and Torus
- A 100-million-cycle startup skew on ranks 0 through 3 passed all Ring and Torus cases
- Trace capture followed by eight replays with changing input and sentinel-reset persistent output passed for Ring and Torus
- Sixteen delayed queued generations on Fabric1D and Fabric2D line endpoints passed

The stress and trace-replay cases were used locally to validate the protocol and are intentionally not part of this fix-only branch.

### Notes for reviewers

The startup reproducer warms the program cache, delays one rank, creates fresh input and sentinel-filled persistent output tensors, and launches the cached collective without a pre-launch tensor readback. The delayed destination local initialization can erase remote stripes unless startup is ordered.

The trace-replay case is important for the data-valid protocol: host-managed generation bases can appear to fix ordinary cached launches, but replay does not invoke the host runtime-argument override. Device-owned credit consumption covers both normal cached dispatch and replay.

#### Design provenance

The atomic credit-consumption approach follows existing Fabric credit protocols, where credits are removed using a wrapped negative NoC atomic increment followed by an atomic barrier. This avoids racing concurrent remote credit returns. Examples include the [Fabric mux sender](https://github.com/tenstorrent/tt-metal/blob/949935f1ab8212724fd65be6f7624ba1a95f5e26/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_mux_sender_client.cpp#L121) and [DeepSeek combine credit handling](https://github.com/tenstorrent/tt-metal/blob/949935f1ab8212724fd65be6f7624ba1a95f5e26/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp#L280-L286).

The startup gate is adapted from the neighbour-readiness handshake used by the [standard `all_gather` implementation](https://github.com/tenstorrent/tt-metal/blob/949935f1ab8212724fd65be6f7624ba1a95f5e26/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/unicast_reader.cpp#L71-L79). Here, readiness is also consumed atomically because the semaphore persists across cached invocations.

Investigation of [#52396](https://github.com/tenstorrent/tt-metal/pull/52396) additionally reinforced keeping reusable producer state on device and avoiding counter reconstruction or reset at rollover. That PR motivated the state-ownership review, although it is not the direct source of the atomic-consumption implementation.

Closes #52363
