### PR TITLE
[Cleanup] Surface Area Reduction `host_api.hpp` & `tt_metal.hpp`

### DIFF
--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -23,13 +23,13 @@
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include "impl/buffers/semaphore.hpp"
-#include "impl/kernels/kernel.hpp"
 #include <tt_stl/span.hpp>
 #include "tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal::distributed::test::utils {
 

--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
 
 #include "hostdevcommon/fabric_common.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <hostdevcommon/common_values.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
@@ -20,6 +19,7 @@
 #include <llrt/tt_cluster.hpp>
 #include <tt-metalium/allocator.hpp>
 #include "test_host_kernel_common.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_fabric::fabric_router_tests {
 

--- a/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
+++ b/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
@@ -7,7 +7,6 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/global_semaphore.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -40,6 +39,7 @@
 #include <limits>
 
 #include <tt_metal/fabric/ccl/ccl_common.hpp>
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -140,7 +140,7 @@ static void build_and_enqueue(
         futures.emplace_back(tt::tt_metal::detail::async([&devices, &programs, i, enqueue_only]() {
             if constexpr (std::is_same_v<ProgramContainer, std::vector<Program*>>) {
                 if (!enqueue_only) {
-                    tt::tt_metal::detail::CompileProgram(devices[i]->get_devices()[0], *programs[i]);
+                    programs[i]->impl().compile(devices[i]->get_devices()[0]);
                 }
                 MeshWorkload mesh_workload;
                 MeshCoordinateRange device_range = MeshCoordinateRange({0, 0}, {0, 0});  // Single device range
@@ -148,7 +148,7 @@ static void build_and_enqueue(
                 tt::tt_metal::distributed::EnqueueMeshWorkload(devices[i]->mesh_command_queue(), mesh_workload, false);
             } else {
                 if (!enqueue_only) {
-                    tt::tt_metal::detail::CompileProgram(devices[i]->get_devices()[0], programs[i]);
+                    programs[i].impl().compile(devices[i]->get_devices()[0]);
                 }
                 MeshWorkload mesh_workload;
                 MeshCoordinateRange device_range = MeshCoordinateRange({0, 0}, {0, 0});  // Single device range

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -37,12 +37,12 @@
 #include <tt_stl/span.hpp>
 #include <tt_stl/fmt.hpp>
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "test_host_kernel_common.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_fabric::fabric_router_tests {
 

--- a/tests/tt_metal/tt_fabric/test_infra/routing_test_common.hpp
+++ b/tests/tt_metal/tt_fabric/test_infra/routing_test_common.hpp
@@ -9,6 +9,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include "llrt.hpp"
+#include "impl/device/device_impl.hpp"
 
 static inline std::string to_string(pkt_dest_size_choices_t choice) {
     switch (choice) {

--- a/tests/tt_metal/tt_metal/api/buffer_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/api/buffer_test_utils.hpp
@@ -7,9 +7,9 @@
 #include <stdint.h>
 #include <vector>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/device/device_impl.hpp"
 
 namespace tt::test::buffer::detail {
 inline void writeL1Backdoor(

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -43,6 +43,7 @@
 #include "impl/program/program_impl.hpp"
 // Access to CircularBufferImpl::size(), local_buffer_indices(), etc.
 #include "impl/buffers/circular_buffer.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 using std::vector;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
@@ -26,6 +25,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tests/tt_metal/tt_metal/api/compile_program_with_kernel_path_env_var_fixture.hpp
+++ b/tests/tt_metal/tt_metal/api/compile_program_with_kernel_path_env_var_fixture.hpp
@@ -13,6 +13,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "impl/context/metal_context.hpp"
+#include "impl/device/device_impl.hpp"
 
 class CompileProgramWithKernelPathEnvVarFixture : public ::testing::Test {
 protected:

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
@@ -42,10 +42,10 @@
 #include "impl/context/metal_context.hpp"
 #include "impl/dataflow_buffer/dataflow_buffer.hpp"
 #include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 #include "tt_metal/impl/host_api/temp_quasar_api.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -18,7 +18,6 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -32,7 +31,6 @@
 #include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 #include "impl/dataflow_buffer/dataflow_buffer.hpp"
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel.hpp"
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt-metalium/experimental/distributed_tensor/topology/tensor_topology.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
@@ -48,6 +46,8 @@
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "impl/context/metal_context.hpp"
 #include <llrt/tt_cluster.hpp>
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -19,7 +19,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
@@ -34,6 +33,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "impl/program/program_impl.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 namespace {
@@ -446,7 +446,7 @@ TEST_F(MeshDeviceFixture, AliasDFBAddressEquality1Sx1S) {
     Program program = MakeProgramFromSpec(*devices_.at(0), spec);
 
     IDevice* device = devices_.at(0)->get_devices()[0];
-    detail::CompileProgram(device, program);
+    program.impl().compile(device);
     program.impl().finalize_dataflow_buffer_configs();
     program.impl().allocate_dataflow_buffers(device);
 
@@ -775,7 +775,7 @@ TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryAddressEquality) {
     Program program = MakeProgramFromSpec(*devices_.at(0), spec);
 
     IDevice* device = devices_.at(0)->get_devices()[0];
-    detail::CompileProgram(device, program);
+    program.impl().compile(device);
     program.impl().finalize_dataflow_buffer_configs();
     program.impl().allocate_dataflow_buffers(device);
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -14,8 +14,6 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
@@ -30,6 +28,7 @@
 #include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "impl/program/program_impl.hpp"
 #include "metal2_host_api/test_helpers.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 namespace {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
@@ -18,7 +18,6 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -35,6 +34,8 @@
 #include "llrt/rtoptions.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "umd/device/driver_atomics.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -20,7 +20,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
@@ -29,13 +28,13 @@
 #include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel.hpp"
 #include <gmock/gmock.h>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "../metal2_host_api/test_helpers.hpp"
 #include "dfb_test_common.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
@@ -13,7 +13,6 @@
 #include <gtest/gtest.h>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
@@ -26,6 +25,7 @@
 #include "impl/program/program_impl.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "../metal2_host_api/test_helpers.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 namespace {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
@@ -5,6 +5,8 @@
 // Edge-case coverage: counter-wrap, ring-pressure, decoy, long-run (Metal 2.0).
 
 #include "dfb_test_common.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
@@ -9,6 +9,8 @@
 #include <array>
 #include <map>
 #include <string_view>
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
@@ -5,6 +5,8 @@
 // Multi-core and multi-DFB (concurrent/sequential) tests (Metal 2.0).
 
 #include "dfb_test_common.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -546,7 +548,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
     // Pre-fill each DFB's L1 ring directly via uniform_alloc_addr after manual
     // finalize+allocate. No borrowed_from / ring tensor needed; the compute
     // kernel is TRISC-only and can't carry tensor bindings.
-    detail::CompileProgram(device, program);
+    program.impl().compile(device);
     program.impl().finalize_dataflow_buffer_configs();
     program.impl().allocate_dataflow_buffers(device);
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
@@ -5,6 +5,8 @@
 // DFB re-entry / entry-size / num-entries override runtime tests (legacy-only).
 
 #include "dfb_test_common.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace distribution_spec_tests {
 using tt::tt_metal::BufferDistributionSpec;  // NOLINT(misc-unused-using-decls)

--- a/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
@@ -21,12 +21,13 @@
 #include <cstdint>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include "device_fixture.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/emule/test_cb_leak.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_cb_leak.cpp
@@ -10,9 +10,10 @@
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/emule/test_cb_pages.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_cb_pages.cpp
@@ -10,9 +10,10 @@
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/emule/test_host_alignment.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_host_alignment.cpp
@@ -25,10 +25,10 @@
 #include <cstdint>
 #include <vector>
 
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "impl/device/device_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/emule/test_metadata_size.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_metadata_size.cpp
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
@@ -20,6 +19,8 @@
 #include <tt-metalium/allocator.hpp>
 #include "impl/context/metal_context.hpp"
 #include "device_fixture.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
@@ -8,12 +8,13 @@
 #include <gtest/gtest.h>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "device_fixture.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
@@ -10,10 +10,11 @@
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
 #include "impl/emulation/host_sanitizers.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/emule/test_pointer_size.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_pointer_size.cpp
@@ -10,9 +10,10 @@
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
@@ -8,9 +8,10 @@
 #include <gtest/gtest.h>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
@@ -9,11 +9,11 @@
 #include <cstdint>
 #include <vector>
 
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/experimental/core_subset_write/buffer_write.hpp>
 #include "device_fixture.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -33,7 +33,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SanityCheck) {
     auto* device = this->devices_.at(0)->get_devices()[0];
 
     auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
-    DeallocateBuffer(*buffer);
+    buffer->deallocate();
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     EXPECT_DEATH(detail::WriteToBuffer(*buffer, data), ".*Use-After-Free.*WriteToBuffer.*");
@@ -45,7 +45,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
     auto* device = this->devices_.at(0)->get_devices()[0];
 
     auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
-    DeallocateBuffer(*buffer);
+    buffer->deallocate();
 
     std::vector<uint32_t> out;
     EXPECT_DEATH(detail::ReadFromBuffer(*buffer, out), ".*Use-After-Free.*ReadFromBuffer.*");
@@ -57,7 +57,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_ReadShard_SanityCheck) {
     // ReadShard's sanitizer check runs before its is_sharded() assertion, so a
     // plain interleaved buffer still drives the UAF path under test here.
     auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
-    DeallocateBuffer(*buffer);
+    buffer->deallocate();
 
     std::vector<uint8_t> out(1024);
     EXPECT_DEATH(detail::ReadShard(*buffer, out.data(), /*core_id=*/0), ".*Use-After-Free.*ReadShard.*");
@@ -69,7 +69,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_CoreSubsetWriteToBuffer_SanityCheck) {
     auto* device = this->devices_.at(0)->get_devices()[0];
 
     auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
-    DeallocateBuffer(*buffer);
+    buffer->deallocate();
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     CoreRangeSet logical_core_filter{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}};
@@ -91,7 +91,7 @@ TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) 
     auto* device = this->devices_.at(0)->get_devices()[0];
 
     auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
-    DeallocateBuffer(*buffer);
+    buffer->deallocate();
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     EXPECT_DEATH(detail::WriteToBuffer(buffer, data), ".*Use-After-Free.*WriteToBuffer.*");

--- a/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
@@ -10,9 +10,10 @@
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
@@ -11,9 +11,10 @@
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
@@ -13,6 +13,8 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
@@ -26,6 +26,7 @@
 #include "device_fixture.hpp"
 #include "multi_device_fixture.hpp"
 #include "test_helpers.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal::experimental {
 namespace {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -40,9 +40,9 @@
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
 
-#include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include "test_helpers.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal::experimental {
 namespace {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -43,9 +43,7 @@
 #include "impl/host_api/temp_quasar_api.hpp"  // for QuasarComputeConfig
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/tt_metal.hpp>  // for CompileProgram (JIT trigger)
 #include <hostdevcommon/tensor_accessor/arg_config.hpp>  // tensor_accessor::ArgsConfig / ArgConfig::RuntimePageSize
-#include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/context/metal_env.hpp>
@@ -53,6 +51,7 @@
 #include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 
 #include "test_helpers.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal::experimental {
 namespace {
@@ -3974,7 +3973,7 @@ void kernel_main() {
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
     IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(device));
 }
 
 // ----------------------------------------------------------------------------
@@ -4011,7 +4010,7 @@ void kernel_main() {
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
     IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(device));
 }
 
 // Compute-kernel counterpart. A scratchpad binding works on a compute kernel: scratchpad.h only
@@ -4039,7 +4038,7 @@ void kernel_main() {
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
     IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(device));
 }
 
 // Compile-only: a range-based for loop over a Scratchpad must compile. Exercises begin()/end() and the
@@ -4073,7 +4072,7 @@ void kernel_main() {
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
     IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(device));
 }
 
 // ============================================================================
@@ -4134,7 +4133,7 @@ TEST_F(ProgramSpecTestGen1, TtKernelComputeShimCompiles) {
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
     IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(device));
 }
 
 // ============================================================================

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -30,6 +30,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "test_helpers.hpp"
 #include "impl/program/program_impl.hpp"  // ScratchpadBaseReDeliveredAfterDfbResize: DFB allocated-address query
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal::experimental {
 namespace {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_scratchpad_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_scratchpad_hw.cpp
@@ -26,7 +26,6 @@
 
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>

--- a/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
+++ b/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
@@ -17,13 +17,12 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
-#include <tt-metalium/tt_metal.hpp>
 
-#include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include "jit_build/build.hpp"
 #include "jit_build/build_env_manager.hpp"
 #include "multi_device_fixture.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 
@@ -71,7 +70,7 @@ void kernel_main() {
 
     EXPECT_NO_THROW({
         CreateKernelFromString(program, kernel_src, CoreCoord{0, 0}, config);
-        detail::CompileProgram(device, program);
+        program.impl().compile(device);
     });
 
     fs::remove_all(include_dir);
@@ -120,7 +119,7 @@ void kernel_main() {
 
     EXPECT_NO_THROW({
         CreateKernelFromString(program, kernel_src, CoreCoord{0, 0}, config);
-        detail::CompileProgram(device, program);
+        program.impl().compile(device);
     });
 
     fs::remove_all(absolute_include_dir);
@@ -203,7 +202,6 @@ TEST_F(CompilerIncludePathsTest, TensixHeaderEditTriggersRebuild) {
     const std::string kernel_src = R"(
 #include "api/dataflow/dataflow_api.h"
 #include "user_header.h"
-
 void kernel_main() {
     volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)0x100000;
     *l1_ptr = USER_HEADER_SENTINEL;
@@ -221,7 +219,7 @@ void kernel_main() {
             .compiler_include_paths = {include_dir},
         };
         auto kernel_handle = CreateKernelFromString(program, kernel_src, CoreCoord{0, 0}, config);
-        detail::CompileProgram(device, program);
+        program.impl().compile(device);
 
         const uint32_t tensix_core_type =
             MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -35,6 +35,8 @@
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -25,7 +25,6 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/device.hpp>
 #include "context/metal_context.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "mesh_dispatch_fixture.hpp"
 #include "gtest/gtest.h"
 #include <tt-metalium/hal.hpp>
@@ -35,6 +34,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include "impl/kernels/kernel.hpp"
 
 using namespace tt;
 

--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -16,9 +16,10 @@
 
 #include "device_fixture.hpp"
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "llrt/hal.hpp"
 #include "llrt/tt_cluster.hpp"
+#include "impl/device/device_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
@@ -7,7 +7,6 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/global_circular_buffer.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <exception>
 #include <map>
 #include <utility>
@@ -100,7 +99,7 @@ TEST_F(MeshDispatchFixture, TensixProgramGlobalCircularBuffersAPI) {
             std::exception);
         auto remote_cb =
             tt::tt_metal::experimental::CreateCircularBuffer(program, receiver_cores, global_cb_config, global_cb);
-        tt::tt_metal::detail::CompileProgram(mesh_device.get(), program);
+        program.impl().compile(mesh_device.get());
         program.impl().finalize_offsets(mesh_device.get());
         tt::tt_metal::experimental::UpdateDynamicCircularBufferAddress(program, remote_cb, global_cb);
         EXPECT_THROW(UpdateDynamicCircularBufferAddress(program, remote_cb, dummy_global_cb), std::exception);

--- a/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
@@ -21,7 +21,6 @@
 #include "jit_build/build.hpp"
 #include "jit_build/build_env_manager.hpp"
 #include <tt-metalium/program.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include "impl/kernels/kernel.hpp"
 // Access to internal API: ProgramImpl::get_kernels
 #include "impl/program/program_impl.hpp"
@@ -41,7 +40,7 @@ TEST_F(MeshDeviceFixture, TensixTestEquivalentDataMovementKernelsWithDifferentPr
         Program program = CreateProgram();
         KernelHandle kernel_handle_riscv_0 = CreateKernel(program, kernel_file, CoreCoord(0, 0), config_riscv_0);
         KernelHandle kernel_handle_riscv_1 = CreateKernel(program, kernel_file, CoreCoord(0, 0), config_riscv_1);
-        detail::CompileProgram(device, program);
+        program.impl().compile(device);
 
         const uint32_t tensix_core_type =
             MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -7,7 +7,6 @@
 #include "distributed/mesh_device_impl.hpp"
 #include "llrt/core_descriptor.hpp"
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <exception>
 #include <set>
 #include <string>
@@ -24,8 +23,8 @@
 #include "gtest/gtest.h"
 #include <tt-metalium/program.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 
@@ -98,7 +97,7 @@ TEST_F(MeshDispatchFixture, DISABLED_TensixIdleEthCreateKernelsOnDispatchCores) 
 TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderMetalRootDir) {
     const std::string& kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_4.cpp";
     create_kernel(kernel_file);
-    detail::CompileProgram(this->device_, this->program_);
+    this->program_.impl().compile(this->device_);
 }
 
 TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderKernelRootDir) {
@@ -106,7 +105,7 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderKernelRootDir
     const std::string& new_kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/new_kernel.cpp";
     this->setup_kernel_dir(orig_kernel_file, new_kernel_file);
     this->create_kernel(new_kernel_file);
-    detail::CompileProgram(this->device_, this->program_);
+    this->program_.impl().compile(this->device_);
     this->cleanup_kernel_dir();
 }
 
@@ -114,7 +113,7 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderMetalRootDirA
     const std::string& kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_4.cpp";
     this->setup_kernel_dir(kernel_file, kernel_file);
     this->create_kernel(kernel_file);
-    detail::CompileProgram(this->device_, this->program_);
+    this->program_.impl().compile(this->device_);
     this->cleanup_kernel_dir();
 }
 

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -11,7 +11,6 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/hal_types.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
@@ -20,6 +19,7 @@
 #include "impl/context/metal_context.hpp"
 #include "device_fixture.hpp"
 #include "metal2_host_api/test_helpers.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal::experimental {
 namespace {

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -32,8 +32,9 @@
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "llrt/hal.hpp"
+#include "impl/device/device_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 using namespace tt;
 using namespace tt::test_utils;

--- a/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
+++ b/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
@@ -20,11 +20,11 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tile.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include "device_fixture.hpp"
 #include "jit_build/build.hpp"
 #include "llrt/rtoptions.hpp"
 #include "tt_metal/jit_build/build_cache_telemetry.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -255,7 +255,7 @@ TEST_F(MeshDeviceFixture, RuntimePrecompiledHitLoadsWithoutJit) {
 
     jit_build_cache_clear();
     JitSrcsBaseline jit_srcs;
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(device));
     EXPECT_EQ(jit_srcs.delta(), 0u);
 }
 
@@ -303,7 +303,7 @@ TEST_F(MeshDeviceFixture, RuntimePrecompiledHitWithCbMetadataLoadsWithoutJit) {
 
     jit_build_cache_clear();
     JitSrcsBaseline jit_srcs;
-    EXPECT_NO_THROW(detail::CompileProgram(device, runtime_program));
+    EXPECT_NO_THROW(runtime_program.impl().compile(device));
     EXPECT_EQ(jit_srcs.delta(), 0u);
 }
 
@@ -314,7 +314,7 @@ TEST_F(MeshDeviceFixture, RuntimeMissingPrecompiledFallsBackToJit) {
 
     jit_build_cache_clear();
     JitSrcsBaseline jit_srcs;
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(device));
     EXPECT_GT(jit_srcs.delta(), 0u);
 }
 
@@ -326,7 +326,7 @@ TEST_F(MeshDeviceFixture, RuntimeMissingPrecompiledErrorsOnPolicyError) {
     jit_build_cache_clear();
     JitSrcsBaseline jit_srcs;
     try {
-        detail::CompileProgram(device, program);
+        program.impl().compile(device);
         FAIL() << "Expected PrecompiledKernelNotFoundError";
     } catch (const experimental::PrecompiledKernelNotFoundError& ex) {
         EXPECT_EQ(ex.kernel_name(), kReaderKernelName);

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -32,11 +32,11 @@
 
 #include "device_fixture.hpp"
 #include <umd/device/types/xy_pair.hpp>
+#include "impl/kernels/kernel.hpp"
 
 // Access to internal API: ProgramImpl::num_kernel, get_kernel
 #include "impl/program/program_impl.hpp"
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <iostream>
 #include <memory>
@@ -26,6 +25,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/xy_pair.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
+++ b/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
@@ -16,12 +16,12 @@
 #include "llrt/metal_soc_descriptor.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/context/metal_context.hpp"
-#include "tt_metal.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <umd/device/coordinates/coordinate_manager.hpp>
 #include <umd/device/types/arch.hpp>
 #include "common/tt_backend_api_types.hpp"
 #include <llrt/tt_cluster.hpp>
+#include "impl/device/device_impl.hpp"
 
 using namespace tt;
 using namespace tt::test_utils;

--- a/tests/tt_metal/tt_metal/api/test_tensor_accessor_default_page_size.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tensor_accessor_default_page_size.cpp
@@ -29,9 +29,9 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <hostdevcommon/tensor_accessor/arg_config.hpp>  // tensor_accessor::ArgConfig (RuntimePageSize / IsDram)
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include <tt-metalium/tt_metal.hpp>
 
 #include "device_fixture.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
@@ -34,7 +34,6 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
@@ -46,6 +45,7 @@
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 
 #include "gtest/gtest.h"
+#include "impl/buffers/buffer_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -16,11 +16,11 @@
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/context/metal_context.hpp"
 #include "llrt.hpp"
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 // #22835: These Fixtures will be removed once tests are fully migrated, and replaced by UnitMeshCQFixtures

--- a/tests/tt_metal/tt_metal/common/matmul_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/common/matmul_test_utils.hpp
@@ -6,13 +6,12 @@
 
 #include <string>
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "hostdevcommon/common_values.hpp"
 #include "llrt.hpp"
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -11,7 +11,6 @@
 
 // Prefer to use API rather than internals in this
 // test as we are testing end to end functionality
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
@@ -48,6 +47,8 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include "impl/kernels/kernel.hpp"
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -17,6 +17,7 @@
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
 #include <distributed/mesh_device_impl.hpp>
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <distributed/mesh_device_impl.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d.cpp
@@ -14,6 +14,7 @@
 #include <distributed/mesh_device_impl.hpp>
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d_v2.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d_v2.cpp
@@ -14,6 +14,7 @@
 #include <distributed/mesh_device_impl.hpp>
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <distributed/mesh_device_impl.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <distributed/mesh_device_impl.hpp>
 #include <algorithm>
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -17,11 +17,11 @@
 #include <cerrno>
 #include "tt_stl/assert.hpp"
 #include "fmt/format.h"
+#include "impl/kernels/kernel.hpp"
 
-// Access to internal API: BuildEnvManager, CompileProgram, get_kernel
+// Access to internal API: BuildEnvManager, ProgramImpl::compile, get_kernel
 #include "jit_build/build_env_manager.hpp"
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 
@@ -340,7 +340,7 @@ public:
 
         SetRuntimeArgs(program_, kernel_handle, core, runtime_args);
         auto* device = mesh_device->get_devices()[0];
-        detail::CompileProgram(device, program_);
+        program_.impl().compile(device);
 
         // Find compiled kernel and extract format string from it to compare with expected_format_message
         const auto& hal = tt::tt_metal::MetalContext::instance().hal();

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -25,13 +25,13 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
-#include "impl/kernels/kernel.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "internal/tt-2xx/quasar/error_handling.h"
 #include "impl/debug/debug_helpers.hpp"
 #include "impl/dispatch/dispatch_engine_cores.hpp"
 #include "host_api/temp_quasar_api.hpp"
 #include <umd/device/types/core_coordinates.hpp>
+#include "impl/kernels/kernel.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher asserts.

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -23,9 +23,9 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include "impl/kernels/kernel.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher pause feature.

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -21,8 +21,8 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel.hpp"
 #include <umd/device/types/core_coordinates.hpp>
+#include "impl/kernels/kernel.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking debug ring buffer feature.

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -24,8 +24,8 @@
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/arch.hpp>
-#include "impl/kernels/kernel.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include "impl/kernels/kernel.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher waypoints.

--- a/tests/tt_metal/tt_metal/deployment/deployment_common.hpp
+++ b/tests/tt_metal/tt_metal/deployment/deployment_common.hpp
@@ -8,6 +8,7 @@
 #include "tt_metal/api/tt-metalium/hal.hpp"
 #include "command_queue_fixture.hpp"
 #include "tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp"
+#include "impl/device/device_impl.hpp"
 
 #define TEST_PARAM(type, var, initial, envvar) \
     type var = (initial);                      \

--- a/tests/tt_metal/tt_metal/deployment/eth/common.hpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/common.hpp
@@ -13,6 +13,8 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "command_queue_fixture.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include "impl/device/device_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 /* Performance debug helpers */
 #define NOW() std::chrono::high_resolution_clock::now()
@@ -286,7 +288,7 @@ static void wait_to_finish_eth_timeout_cores(
     }
 
     for (const auto& [dev, workload] : devices) {
-        detail::CompileProgram(dev->get_devices()[0], *programs[dev]);
+        programs[dev]->impl().compile(dev->get_devices()[0]);
         devices[dev]->add_program(device_range, std::move(*programs[dev]));
     }
 

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -41,6 +41,7 @@
 #include "math.hpp"
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include <distributed/mesh_device_impl.hpp>
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/device/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_pool.cpp
@@ -13,8 +13,8 @@
 #include "hostdevcommon/common_values.hpp"
 #include "context/metal_context.hpp"
 #include "impl/allocator/allocator.hpp"
-#include "tt_metal.hpp"
 #include <llrt/tt_cluster.hpp>
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <umd/device/types/arch.hpp>
 
 #include <cstdlib>
@@ -17,6 +16,7 @@
 #include "impl/profiler/profiler_state_manager.hpp"
 #include "llrt/get_platform_architecture.hpp"
 #include "llrt/tt_cluster.hpp"
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/device/test_release_ownership.cpp
+++ b/tests/tt_metal/tt_metal/device/test_release_ownership.cpp
@@ -12,11 +12,11 @@
 #include "gtest/gtest.h"
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "impl/context/metal_context.hpp"
 #include "llrt/tt_cluster.hpp"
+#include "impl/device/device_impl.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -9,7 +9,6 @@
 #include <sys/types.h>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/host_api.hpp>
 #include "allocator/allocator.hpp"
 #include "dispatch/system_memory_manager.hpp"
 #include <tt-metalium/tt_metal.hpp>
@@ -50,6 +49,7 @@
 
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -53,10 +53,10 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include "impl/kernels/kernel.hpp"
 
 // Access to internal API: ProgramImpl::get_cb_base_addr, get_kernel
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
@@ -10,10 +10,10 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "impl/dataflow_buffer/dataflow_buffer.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -36,11 +36,11 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include "impl/kernels/kernel.hpp"
 
 // Access to internal API: ProgramImpl::get_cb_base_addr, ProgramImpl::get_cb_size, Eth, EthernetConfig,
 // CreateSemaphore with CoreType
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "impl/buffers/semaphore.hpp"
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_program_with_kernel_created_from_string.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_program_with_kernel_created_from_string.cpp
@@ -5,13 +5,13 @@
 #include <gtest/gtest.h>
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "program_with_kernel_created_from_string_fixture.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 
@@ -85,7 +85,6 @@ TEST_F(ProgramWithKernelCreatedFromStringFixture, ActiveEthEthernetKernel) {
     const std::string& kernel_src_code = R"(
     #include "api/debug/dprint.h"
     #include "api/dataflow/dataflow_api.h"
-
     void kernel_main() {
 
         DPRINT("Hello, I am running a void ethernet kernel.\n");

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
@@ -41,6 +41,7 @@
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/experimental/realtime_profiler.hpp>
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 namespace {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -41,6 +41,8 @@
 
 // Access to internal API: ProgramImpl::get_id
 #include "impl/program/program_impl.hpp"
+#include "impl/device/device_impl.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -12,10 +12,11 @@
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/context/metal_context.hpp"
+#include "impl/host_api/device_queries.hpp"
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
@@ -14,9 +14,9 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/buffers/semaphore.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "dispatch_test_utils.hpp"
 #include "tt_metal/tt_metal/eth/eth_test_common.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp
@@ -7,8 +7,8 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/global_semaphore.hpp>
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "sub_device.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
@@ -31,6 +31,7 @@
 #include "llrt/llrt.hpp"
 #include "llrt/tt_cluster.hpp"
 #include "mesh_dispatch_fixture.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal::distributed::test {
 
@@ -234,7 +235,7 @@ TEST_F(ServiceCoreSdFixture, PersistentServiceMultiCycle) {
         SetRuntimeArgs(
             prog, kernel, svc_core, {(uint32_t)stop_addr, (uint32_t)counter_addr, (uint32_t)service_done_addr});
 
-        tt::tt_metal::detail::CompileProgram(device, prog, /*force_slow_dispatch=*/true);
+        prog.impl().compile(device, /*force_slow_dispatch=*/true);
         tt::tt_metal::detail::WriteRuntimeArgsToDevice(device, prog, /*force_slow_dispatch=*/true);
         tt::tt_metal::detail::LaunchProgram(
             device, prog, /*wait_until_cores_done=*/false, /*force_slow_dispatch=*/true);

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -6,7 +6,6 @@
 #include <gtest/gtest.h>
 #include <cstddef>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <cstdint>
 #include <map>
@@ -38,6 +37,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include "eth_test_common.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <array>
 #include <cstdint>
@@ -45,6 +44,7 @@
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <umd/device/types/arch.hpp>
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
@@ -41,6 +40,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
@@ -41,6 +40,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/integration/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_flatten.cpp
@@ -30,6 +30,9 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
+#include "impl/context/metal_context.hpp"
+#include "impl/device/device_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -287,8 +290,8 @@ bool flatten_stress(
         // Async write input
         distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, *src_vec, false);
         // Share ownership of buffer with program
-        AssignGlobalBufferToProgram(
-            std::shared_ptr<Buffer>(src_dram_buffer->get_backing_buffer()), program_on_workload);
+        detail::DispatchStateCheck(MetalContext::instance().rtoptions().get_fast_dispatch());
+        program_on_workload.impl().add_buffer(std::shared_ptr<Buffer>(src_dram_buffer->get_backing_buffer()));
         // Main thread gives up ownership of buffer and src data (this is what python does)
         src_dram_buffer.reset();
         src_vec.reset();

--- a/tests/tt_metal/tt_metal/jit_build/test_compile_stress.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_compile_stress.cpp
@@ -63,10 +63,10 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include "common/env_lib.hpp"
 #include "common/tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -306,7 +306,7 @@ TEST_F(CompileStressFixture, DISABLED_TensixCompileStress) {
                 .set_page_size(tt::CBIndex::c_16, single_tile_size);
         CreateCircularBuffer(warmup, CoreCoord(0, 0), cb16);
         CreateKernel(warmup, kernel_path, CoreCoord(0, 0), ComputeConfig{.compile_args = {UINT32_MAX, private_seed}});
-        detail::CompileProgram(dev, warmup);
+        warmup.impl().compile(dev);
     }
     log_info(LogTest, "Warmup compile done");
 
@@ -341,7 +341,7 @@ TEST_F(CompileStressFixture, DISABLED_TensixCompileStress) {
     std::vector<std::future<void>> futures;
     futures.reserve(num_programs);
     for (auto& program : programs) {
-        futures.push_back(std::async(std::launch::async, [dev, &program] { detail::CompileProgram(dev, program); }));
+        futures.push_back(std::async(std::launch::async, [dev, &program] { program.impl().compile(dev); }));
     }
     for (auto& f : futures) {
         f.get();

--- a/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
@@ -117,7 +117,7 @@
 //     if (buffers_vec.size() > 0) {
 //         log_info(tt::LogTest, "Explicitly deallocating {} buffers now.", buffers_vec.size());
 //         for (auto& buffer : buffers_vec) {
-//             DeallocateBuffer(*buffer);
+//             buffer->deallocate();
 //         }
 //     }
 
@@ -292,7 +292,7 @@
 //     const uint32_t num_buffers = 5;
 //     for (uint32_t i = 0; i < num_buffers; i++) {
 //         auto buf = Buffer::create(device_, 64, 64, BufferType::DRAM);
-//         DeallocateBuffer(*buf);
+//         buf->deallocate();
 //     }
 // }
 
@@ -372,7 +372,7 @@
 //     if (dynamic_cb) {
 //         cb_in_buf = CreateBuffer(InterleavedBufferConfig{device, cb_size_bytes, cb_size_bytes, BufferType::L1});
 //         if (dealloc_cb_buf_early) {
-//             DeallocateBuffer(*cb_in_buf);
+//             cb_in_buf->deallocate();
 //         }
 //         program = create_simple_unary_program(*input, *output, cb_in_buf.get());
 //     } else {

--- a/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
@@ -27,12 +27,12 @@
 #include <tt_stl/span.hpp>
 #include "test_golden_impls.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 class IDevice;

--- a/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
@@ -32,7 +32,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include <tt-metalium/tt_metal.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 class IDevice;

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -14,13 +14,13 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "llk_device_fixture.hpp"
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/float8_utils.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
@@ -22,7 +22,6 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/arch.hpp>
@@ -33,6 +32,7 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -17,7 +17,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mxfp4.hpp>
 #include <tt-metalium/tile.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
@@ -27,6 +26,8 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/float8_utils.hpp"
 #include "tt_metal/test_utils/mx_utils.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
@@ -17,7 +17,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mxfp6.hpp>
 #include <tt-metalium/tile.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
@@ -27,6 +26,8 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/float8_utils.hpp"
 #include "tt_metal/test_utils/mx_utils.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
@@ -17,7 +17,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mxfp8.hpp>
 #include <tt-metalium/tile.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
@@ -27,6 +26,8 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/float8_utils.hpp"
 #include "tt_metal/test_utils/mx_utils.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
@@ -17,7 +17,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mxint.hpp>
 #include <tt-metalium/tile.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
@@ -27,6 +26,8 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/float8_utils.hpp"
 #include "tt_metal/test_utils/mx_utils.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
@@ -6,7 +6,6 @@
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <functional>
 #include <memory>
@@ -27,6 +26,7 @@
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include <umd/device/types/arch.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 class IDevice;

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -39,6 +39,8 @@
 #include <umd/device/types/arch.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 class IDevice;

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -8,9 +8,7 @@
 #include <gtest/gtest.h>
 #include <sys/types.h>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <cmath>
 #include <cstdint>
 #include <functional>
@@ -45,6 +43,7 @@
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt-metalium/mxfp4.hpp>
 #include <tt-metalium/tile.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 class IDevice;

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -10,7 +10,6 @@
 #include <cstdint>
 #include <random>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <cmath>
 #include <functional>
@@ -46,6 +45,8 @@
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/int8.hpp>
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -7,7 +7,6 @@
 #include <gtest/gtest.h>
 #include <cstddef>
 #include <cstdint>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <bit>
@@ -38,6 +37,7 @@
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/distributed.hpp>
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 class IDevice;

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -9,7 +9,6 @@
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <unistd.h>
 #include <array>
 #include <map>
@@ -44,6 +43,7 @@
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 class IDevice;

--- a/tests/tt_metal/tt_metal/llk/test_top32_rm_dev.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_top32_rm_dev.cpp
@@ -20,7 +20,6 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/arch.hpp>
 
@@ -28,6 +27,7 @@
 #include <tt-metalium/distributed.hpp>
 
 #include "tt_metal/test_utils/packing.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -11,9 +11,7 @@
 #include <iterator>
 #include <random>
 #include <sys/types.h>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <map>
 #include <memory>
 #include <string>
@@ -40,6 +38,7 @@
 #include "impl/data_format/bfloat16_utils.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 class IDevice;

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -48,6 +48,8 @@
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/buffer.hpp>
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 class IDevice;

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <sys/types.h>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <bit>
 #include <cctype>
@@ -47,6 +46,7 @@
 #include "impl/data_format/bfloat16_utils.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 class IDevice;

--- a/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
+++ b/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
@@ -26,8 +26,8 @@
 #include <tt-metalium/distributed.hpp>
 #include "mesh_dispatch_fixture.hpp"
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "impl/buffers/semaphore.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -14,7 +14,6 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/allocator.hpp>
 
-#include "tt_metal.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/command_queue_common.hpp"
 
@@ -37,6 +36,7 @@
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "impl/dispatch/dispatch_engine_cores.hpp"
 #include "host_api/temp_quasar_api.hpp"
+#include "device/device_impl.hpp"
 
 namespace tt::tt_metal::tt_dispatch_tests::Common {
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -19,6 +19,8 @@
 #include "tt_metal/impl/host_api/temp_quasar_api.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h"
+#include "impl/device/device_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 /*
  * DISPATCHER MICROBENCHMARK SUITE (Fast Dispatch + Slow Dispatch)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -34,7 +34,6 @@
 #include <tt-metalium/program.hpp>
 #include "impl/context/metal_context.hpp"
 #include "impl/buffers/semaphore.hpp"
-#include "impl/kernels/kernel.hpp"
 #include <tt_stl/span.hpp>
 #include "test_common.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
@@ -45,6 +44,7 @@
 #include <tt-metalium/sub_device.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include <distributed/mesh_device_impl.hpp>
+#include "impl/kernels/kernel.hpp"
 
 constexpr uint32_t DEFAULT_ITERATIONS = 10000;
 constexpr uint32_t DEFAULT_WARMUP_ITERATIONS = 100;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -30,6 +30,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <vector>
+#include "impl/device/device_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 /*
  * DISPATCHER MICROBENCHMARK SUITE (Fast Dispatch + Slow Dispatch)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -28,7 +28,6 @@
 #include "tt_metal/test_utils/df/df.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/impl/profiler/profiler_paths.hpp"
-#include "tt_metal/impl/kernels/kernel.hpp"
 
 #include <thread>
 #include "impl/context/metal_context.hpp"
@@ -38,6 +37,8 @@
 
 #include <enchantum/enchantum.hpp>
 #include <llrt/tt_cluster.hpp>
+#include "impl/program/program_impl.hpp"
+#include "tt_metal/impl/kernels/kernel.hpp"
 
 using namespace tt;
 using namespace tt::test_utils;
@@ -412,7 +413,7 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
     for (size_t i = 0; i < device_helper.devices.size(); i++) {
         const auto& device = device_helper.devices[i];
         try {
-            tt_metal::detail::CompileProgram(device.get(), programs[i]);
+            programs[i].impl().compile(device.get());
         } catch (std::exception& e) {
             log_error(tt::LogTest, "Failed to compile program on device {}: {}", i, e.what());
             throw e;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -7,7 +7,6 @@
 #include <cstdlib>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <map>
 #include <string>
 #include <variant>
@@ -20,6 +19,8 @@
 #include "impl/context/metal_context.hpp"
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include <llrt/tt_cluster.hpp>
+#include "impl/device/device_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 
@@ -58,7 +59,7 @@ void measure_latency(const std::string& kernel_name) {
 
     tt::tt_metal::detail::SetDeviceProfilerDir(kernel_name + "_microbenchmark");
     tt::tt_metal::detail::FreshProfilerDeviceLog();
-    tt::tt_metal::detail::CompileProgram(device, program);
+    program.impl().compile(device);
     tt_metal::detail::LaunchProgram(device, program);
     tt_metal::CloseDevice(device);
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
@@ -23,6 +23,7 @@
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "test_common.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
@@ -9,7 +9,6 @@
 #include <cstdlib>
 #include <ctime>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include "impl/context/metal_context.hpp"
@@ -25,6 +24,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "test_common.hpp"
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 class IDevice;

--- a/tests/tt_metal/tt_metal/test_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_add_two_ints.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -14,7 +14,6 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/constants.hpp>
@@ -22,6 +21,8 @@
 #include <tt-logger/tt-logger.hpp>
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -10,8 +10,6 @@
 #include <vector>
 
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tilize_utils.hpp>
@@ -20,6 +18,8 @@
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/test_compile_args.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_args.cpp
@@ -10,8 +10,9 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/jit_build/build_env_manager.hpp"
+#include "impl/device/device_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does
@@ -56,7 +57,7 @@ bool test_compile_args(std::vector<uint32_t> compile_args_vec, tt_metal::IDevice
     ////////////////////////////////////////////////////////////////////////////
     //                      Compile Application
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::detail::CompileProgram(device, program);
+    program.impl().compile(device);
 
     return true;
 }

--- a/tests/tt_metal/tt_metal/test_compile_failure_drain.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_failure_drain.cpp
@@ -41,10 +41,11 @@
 
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 
 #include "jit_build/build.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
+#include "impl/device/device_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 namespace {
@@ -121,7 +122,7 @@ TEST(CompileFailureDrainTest, CompileProgramWithFailingKernelThrowsCleanly) {
         Program good = CreateProgram();
         add_tile_cbs(good, CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
         CreateKernel(good, kGoodComputeKernel, CoreCoord(0, 0), ComputeConfig{.compile_args = {1u, 0u}});
-        EXPECT_NO_THROW(detail::CompileProgram(dev, good));
+        EXPECT_NO_THROW(good.impl().compile(dev));
     }
 
     // Force every repro kernel to compile from scratch (see clear_kernel_cache) so the valid
@@ -160,7 +161,7 @@ TEST(CompileFailureDrainTest, CompileProgramWithFailingKernelThrowsCleanly) {
 
     // sync_build_steps drains all in-flight steps, then rethrows the compile failure
     // -> a clean exception. Without the drain: abandons in-flight steps -> UAF -> SIGSEGV.
-    EXPECT_THROW(detail::CompileProgram(dev, program), std::exception);
+    EXPECT_THROW(program.impl().compile(dev), std::exception);
 
     std::error_code ec;
     std::filesystem::remove_all(regression_tmp_dir(), ec);

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -12,16 +12,15 @@
 
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 
 #include "hal_types.hpp"
 #include "jit_build/build.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include <umd/device/types/arch.hpp>
+#include "impl/kernels/kernel.hpp"
 
 // Access to internal API: ProgramImpl::num_kernel, get_kernel
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel.hpp"
 
 using std::vector;
 using namespace tt;
@@ -72,7 +71,7 @@ KernelCacheStatus CompileProgramTestWrapper(IDevice* device, Program& program, b
             .get_device_build_env(device->build_id())
             .build_env.get_out_kernel_root_path());
 
-    detail::CompileProgram(device, program);
+    program.impl().compile(device);
 
     std::unordered_map<std::string, std::string> post_compile_kernel_to_hash_str = get_last_program_binary_path(
         program,

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -13,7 +13,6 @@
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/hal_types.hpp>
@@ -21,10 +20,11 @@
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "tt_memory.h"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include <umd/device/types/arch.hpp>
+#include "impl/device/device_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 using std::vector;
 using namespace tt;
@@ -162,7 +162,7 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
         auto mask = BuildEnvManager::get_instance(extract_context_id(device))
                         .get_device_build_env(device->build_id())
                         .build_key();
-        detail::CompileProgram(device, program);
+        program.impl().compile(device);
         compute_binaries.insert({mask, compute_kernel->binaries(mask)});
         TT_FATAL(compute_binaries.at(mask).size() == 3, "Expected 3 Compute binaries!");
         brisc_binaries.insert({mask, riscv0_kernel->binaries(mask)});
@@ -204,7 +204,7 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
                     auto mask = BuildEnvManager::get_instance(extract_context_id(device))
                                     .get_device_build_env(device->build_id())
                                     .build_key();
-                    detail::CompileProgram(device, program);
+                    program.impl().compile(device);
                     uint32_t programmable_core_index = MetalContext::instance().hal().get_programmable_core_type_index(
                         HalProgrammableCoreType::TENSIX);
                     const KernelGroup* kernel_group = program.impl().kernels_on_core(core, programmable_core_index);

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -21,11 +21,12 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include "impl/kernels/kernel.hpp"
 
 // Access to internal API: ProgramImpl::get_sem_base_addr, get_sem_size, num_kernels, get_kernel
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "impl/context/metal_context.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 using std::vector;
 using namespace tt;
@@ -165,7 +166,7 @@ TEST_F(MeshDeviceSingleCardFixture, CoreRangeSet) {
 
     check_program_is_mapped_to_correct_cores(program, core_ranges, compute_kernel_args);
 
-    detail::CompileProgram(dev, program);
+    program.impl().compile(dev);
 
     std::vector<uint32_t> src_vec =
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -10,9 +10,10 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -10,10 +10,11 @@
 
 #include <tt-metalium/bfloat8.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
@@ -7,10 +7,11 @@
 #include <random>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <tt-metalium/tilize_utils.hpp>
+#include "impl/device/device_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -11,10 +11,11 @@
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -6,11 +6,10 @@
 
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include "impl/context/metal_context.hpp"
 #include "llrt/tt_cluster.hpp"
+#include "impl/device/device_impl.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -10,7 +10,6 @@
 #include <cstdlib>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <cstdint>
 #include <cstring>
 #include <exception>
@@ -29,6 +28,8 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does

--- a/tests/tt_metal/tt_metal/test_dram_loopback_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_multi_core.cpp
@@ -9,8 +9,10 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
+#include "impl/device/device_impl.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////
 // 1. Host writes data to buffer in DRAM

--- a/tests/tt_metal/tt_metal/test_dram_loopback_multi_core_db.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_multi_core_db.cpp
@@ -9,8 +9,10 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
+#include "impl/device/device_impl.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////
 // All buffers are double buffered

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -10,8 +10,9 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 using namespace tt;
 using namespace tt::tt_metal;
 

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -41,6 +41,8 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // This test is similar to test_matmul_large_block.

--- a/tests/tt_metal/tt_metal/test_globals_tls.cpp
+++ b/tests/tt_metal/tt_metal/test_globals_tls.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/device/device_impl.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""

--- a/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
@@ -10,8 +10,8 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 using namespace tt;
 using namespace tt::tt_metal;
 

--- a/tests/tt_metal/tt_metal/test_l1_to_l1_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_l1_to_l1_multi_core.cpp
@@ -9,6 +9,9 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include "impl/device/device_impl.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -10,10 +10,11 @@
 
 #include <tt-metalium/bfloat8.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -13,9 +13,10 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -14,10 +14,11 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -11,11 +11,12 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -6,11 +6,11 @@
 
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "hal.hpp"
 #include "llrt/rtoptions.hpp"
+#include "impl/device/device_impl.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -9,12 +9,12 @@
 #include <random>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <tt-metalium/tilize_utils.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
@@ -14,7 +14,6 @@
 #include <cstdlib>
 #include <tt-metalium/host_api.hpp>
 #include "llrt/metal_soc_descriptor.hpp"
-#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <cstdint>
 #include <map>
@@ -36,6 +35,7 @@
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <llrt/tt_cluster.hpp>
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -13,13 +13,14 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
@@ -11,7 +11,6 @@
 #include <sys/types.h>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
@@ -31,6 +30,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/span.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // This test verifies that the slow dispatch path can perform device reads and writes when the page size is not a

--- a/tests/ttnn/tracy/cpp/test_get_programs_perf_data.cpp
+++ b/tests/ttnn/tracy/cpp/test_get_programs_perf_data.cpp
@@ -10,10 +10,10 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/profiler.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include "impl/context/metal_context.hpp"
 #include "impl/profiler/profiler_paths.hpp"
 #include <umd/device/types/cluster_descriptor_types.hpp>
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal::experimental {
 void to_json(nlohmann::json& j, const ProgramExecutionUID& program_execution_uid) {

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -16,8 +16,6 @@
 #include <string>
 #include <vector>
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/distributed.hpp>
@@ -32,6 +30,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/api/ttnn/distributed/api.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace {
 

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -283,6 +283,9 @@ public:
     // Mark the buffer as deallocated, without releasing underlying device memory
     void mark_as_deallocated();
 
+    // Deallocate is allowed to be called multiple times on the same buffer
+    void deallocate();
+
     Buffer(
         IDevice* device,
         DeviceAddr size,
@@ -303,11 +306,8 @@ private:
 
     void allocate_impl();
 
-    // Deallocate is allowed to be called multiple times on the same buffer
-    void deallocate();
     void deallocate_impl();
     friend class AllocatorImpl;
-    friend void DeallocateBuffer(Buffer& buffer);
     friend bool experimental::per_core_allocation::is_per_core_allocation(const Buffer&);
     friend DeviceAddr experimental::per_core_allocation::get_per_core_address(const Buffer&, CoreCoord);
     friend const std::unordered_map<CoreCoord, DeviceAddr>& experimental::per_core_allocation::get_per_core_addresses(

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -72,13 +72,6 @@ void SetRootDir(const std::string& root_dir);
 size_t GetNumAvailableDevices();
 
 /**
- * Returns whether Tenstorrent devices are in a Galaxy cluster
- *
- * Return value: bool
- */
-bool IsGalaxyCluster();
-
-/**
  * Returns number of Tenstorrent devices that are connected to host via PCIe and can be targeted
  *
  * Return value: size_t
@@ -86,53 +79,6 @@ bool IsGalaxyCluster();
 size_t GetNumPCIeDevices();
 
 ChipId GetPCIeDeviceID(ChipId device_id);
-
-// clang-format off
-/**
- * Instantiates a device object.
- *
- * Return value: IDevice*
- *
- * | Argument   | Description                | Type            | Valid Range                       | Required |
- * |------------|----------------------------|-----------------|-----------------------------------|----------|
- * | device_id  | ID of the device to target| ChipId (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
- * */
-// clang-format on
-IDevice* CreateDevice(
-    ChipId device_id,
-    uint8_t num_hw_cqs = 1,
-    size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
-    size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
-    const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
-    const std::vector<uint32_t>& l1_bank_remap = {},
-    size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
-
-// clang-format off
-/**
- * Instantiates a device with minimal setup, used to attach to a device in a bad state.
- *
- * Return value: IDevice*
- *
- * | Argument   | Description                | Type            | Valid Range                       | Required |
- * |------------|----------------------------|-----------------|-----------------------------------|----------|
- * | device_id  | ID of the device to target| ChipId (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
- * */
-// clang-format on
-IDevice* CreateDeviceMinimal(
-    ChipId device_id, uint8_t num_hw_cqs = 1, const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{});
-
-// clang-format off
-/**
- * Resets device and closes device
- *
- * Return value: bool
- *
- * | Argument | Description                | Type     | Valid Range | Required |
- * |----------|----------------------------|----------|-------------|----------|
- * | device   | Pointer to a device object | IDevice* |             | True     |
- */
-// clang-format on
-bool CloseDevice(IDevice* device);
 
 // ==================================================
 //                  HOST API: program & kernels
@@ -164,26 +110,6 @@ Program CreateProgram();
 KernelHandle CreateKernel(
     Program& program,
     const std::string& file_name,
-    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-    const std::variant<DataMovementConfig, ComputeConfig>& config);
-
-// clang-format off
-/**
- * Creates a data movement or compute kernel from source code with the given config and adds it to the program.
- *
- * Return value: Kernel ID (uintptr_t)
- *
- * | Argument           | Description                                                                                                                          | Type                                                                    | Valid Range | Required |
- * |--------------------|--------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|-------------|----------|
- * | program            | The program to which this kernel will be added to                                                                                    | Program &                                                               |             | Yes      |
- * | kernel_src_code    | Source code for kernel                                                                                                               | const std::string &                                                     |             | Yes      |
- * | core_spec          | Either a single logical core, a range of logical cores or a set of logical core ranges that indicate which cores kernel is placed on | const std::variant<CoreCoord, CoreRange, CoreRangeSet> &                |             | Yes      |
- * | config             | Config for data movement or compute kernel                                                                                           | const std::variant<DataMovementConfig, ComputeConfig> &                 |             | Yes      |
- */
-// clang-format on
-KernelHandle CreateKernelFromString(
-    Program& program,
-    const std::string& kernel_src_code,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
     const std::variant<DataMovementConfig, ComputeConfig>& config);
 
@@ -230,7 +156,6 @@ const CircularBufferConfig& GetCircularBufferConfig(Program& program, CBHandle c
 // clang-format off
 /**
  * Update the total size of the circular buffer at the given circular buffer handle. Updating a program-local circular buffer requires all circular buffers in the program to be reallocated.
- * If it is required to update the address and total size of a dynamic circular buffer, use `UpdateDynamicCircularBufferAddressAndTotalSize`.
  *
  * Return value: void
  *
@@ -262,7 +187,6 @@ void UpdateCircularBufferPageSize(Program& program, CBHandle cb_handle, uint8_t 
 // clang-format off
 /**
  * Update the address of a dynamic circular buffer. Dynamic circular buffers share the same address space as L1 buffers.
- * If it is required to update the address and total size of a dynamic circular buffer, use `UpdateDynamicCircularBufferAddressAndTotalSize`.
  *
  * Return value: void
  *
@@ -277,26 +201,6 @@ void UpdateDynamicCircularBufferAddress(Program& program, CBHandle cb_handle, co
 void UpdateDynamicCircularBufferAddress(
     Program& program, CBHandle cb_handle, const Buffer& buffer, uint32_t address_offset);
 void UpdateDynamicCircularBufferAddress(Program& program, CBHandle cb_handle, const MeshTensor& tensor);
-
-// clang-format off
-/**
- * Update the address and total size of a dynamic circular buffer. Dynamic circular buffers share the same address space as L1 buffers.
- *
- * Return value: void
- *
- * | Argument   | Description                                                                              | Type                         | Valid Range | Required |
- * |------------|------------------------------------------------------------------------------------------|------------------------------|-------------|----------|
- * | program    | The program containing the circular buffer                                               | Program &                    |             | Yes      |
- * | cb_handle  | ID of the circular buffer, returned by `CreateCircularBuffers`                           | CBHandle (uintptr_t) |       | Yes         |          |
- * | buffer     | Dynamically allocated L1 buffer that shares address space of circular buffer `cb_handle` | const Buffer &               | L1 buffer   | Yes      |
- * | total_size | New size of the circular buffer in bytes                                                 | uint32_t                     |             | Yes      |
- */
-// clang-format on
-void UpdateDynamicCircularBufferAddressAndTotalSize(
-    Program& program, CBHandle cb_handle, const Buffer& buffer, uint32_t total_size);
-
-void UpdateDynamicCircularBufferAddressAndTotalSize(
-    Program& program, CBHandle cb_handle, const MeshTensor& tensor, uint32_t total_size);
 
 // clang-format off
 /**
@@ -431,33 +335,6 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, DeviceAd
 */
 // clang-format on
 std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, SubDeviceId sub_device_id);
-
-// clang-format off
-/**
-*  Deallocates buffer from device by marking its memory as free.
-*
-*  Return value: void
-*
-*  | Argument | Description                          | Type     | Valid Range | Required |
-*  |----------|--------------------------------------|----------|-------------|----------|
-*  | buffer   | The buffer to deallocate from device | Buffer & |             | Yes      |
-*/
-// clang-format on
-void DeallocateBuffer(Buffer& buffer);
-
-// clang-format off
-/**
-*  Gives the specified program ownership of the buffer: the buffer will remain on device at least until the program is enqueued. This is required for asynchronous Command Queues.
-*
-*  Return value: void
-*
-*  | Argument | Description                                  | Type                           | Valid Range | Required |
-*  |----------|----------------------------------------------|--------------------------------|-------------|----------|
-*  | buffer   | The buffer that will be owned by the program | std::shared_ptr<Buffer> buffer |             | Yes      |
-*  | program  | The program getting ownership of the buffer  | Program &                      |             | Yes      |
-*/
-// clang-format on
-void AssignGlobalBufferToProgram(const std::shared_ptr<Buffer>& buffer, Program& program);
 
 // clang-format off
 // ==================================================

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -5,23 +5,15 @@
 #pragma once
 #include <stdint.h>
 #include <cstddef>
-#include <map>
 #include <memory>
 #include <optional>
 #include <string>
 #include <span>
 #include <vector>
 
-#include <hostdevcommon/common_values.hpp>
 #include <tt_stl/span.hpp>
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/buffer.hpp>
-#include <tt-metalium/cluster.hpp>
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/dispatch_core_common.hpp>
-#include <tt-metalium/mesh_device.hpp>
-#include <tt-metalium/profiler_optional_metadata.hpp>
-#include <tt-metalium/profiler_types.hpp>
 #include <tt-metalium/device_types.hpp>
 // UMD: re-exports CoreType (used in SetRuntimeArgs/GetRuntimeArgs default parameter).
 #include <umd/device/types/core_coordinates.hpp>
@@ -32,45 +24,6 @@ class IDevice;
 class Program;
 
 namespace detail {
-
-bool DispatchStateCheck(bool isFastDispatch);
-
-std::map<ChipId, IDevice*> CreateDevices(
-    // TODO: delete this in favour of DeviceManager
-    const std::vector<ChipId>& device_ids,
-    uint8_t num_hw_cqs = 1,
-    size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
-    size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
-    const tt_metal::DispatchCoreConfig& dispatch_core_config = tt_metal::DispatchCoreConfig{},
-    const std::vector<uint32_t>& l1_bank_remap = {},
-    size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE,
-    bool init_profiler = true,
-    [[deprecated]] bool ignored = false,  // This argument was not used
-    bool initialize_fabric_and_dispatch_fw = true);
-
-/**
- * Close all devices in the given map.
- *
- * This function closes all devices in the given map, releasing many associated resources. After this call, this process
- * still controls all devices. Call ReleaseOwnership() to fully release ownership.
- *
- * Return value: void
- */
-void CloseDevices(const std::map<ChipId, IDevice*>& devices);
-
-/**
- * Release ownership of the MetalContext singleton instance.
- *
- * The MetalContext is created when a hal function is called or a MeshDevice or IDevice are created. Only one process
- * can have a MetalContext at any one time. This function destroys the MetalContext instance, releasing all associated
- * resources and allowing another process to create a new MetalContext.
- * All devices must be closed before calling this function.
- *
- * After calling this function, the MetalContext will be re-created on the next access.
- *
- * Return value: void
- */
-void ReleaseOwnership();
 
 /**
  * Returns a pointer to an active device with the given ID, NULL otherwise
@@ -83,64 +36,6 @@ void ReleaseOwnership();
  * | device_id   | ID of the device to look for                    | ChipId                  | Valid device IDs | Yes |
  */
 IDevice* GetActiveDevice(ChipId device_id);
-
-/**
- * Copies data from a host buffer into the specified buffer
- *
- * Return value: void
- *
- * | Argument    | Description                                     | Data type               | Valid range | Required |
- * |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
- * | buffer      | Buffer to send data to                          | Buffer &                | | Yes      | |
- * host_buffer | Buffer on host to copy data from                | Span<const uint8_t> &   | Host buffer size must match
- * buffer               | Yes      |
- */
-void WriteToBuffer(Buffer& buffer, ttsl::Span<const uint8_t> host_buffer);
-/**
- * Copies data from a host buffer into the specified buffer
- *
- * Return value: void
- *
- * | Argument    | Description                                     | Data type               | Valid range | Required |
- * |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
- * | buffer      | Buffer to send data to                          | Buffer &                | | Yes      | |
- * host_buffer | Buffer on host to copy data from                | std::vector<DType> &    | Host buffer size must match
- * buffer               | Yes      |
- */
-template <typename DType>
-void WriteToBuffer(Buffer& buffer, const std::vector<DType>& host_buffer) {
-    WriteToBuffer(
-        buffer,
-        ttsl::Span<const uint8_t>(
-            reinterpret_cast<const uint8_t*>(host_buffer.data()), host_buffer.size() * sizeof(DType)));
-}
-template <typename DType>
-void WriteToBuffer(const std::shared_ptr<Buffer>& buffer, const std::vector<DType>& host_buffer) {
-    WriteToBuffer(*buffer, host_buffer);
-}
-
-void ReadFromBuffer(Buffer& buffer, uint8_t* host_buffer);
-/**
- * Copies data from a buffer into a host buffer
- *
- * Return value: void
- *
- * | Argument    | Description                                     | Data type               | Valid range | Required |
- * |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
- * | buffer      | Buffer to read data from                        | Buffer &                | | Yes      | |
- * host_buffer | Buffer on host to copy data into                | std::vector<DType> &    | | Yes      | |
- */
-template <typename DType>
-void ReadFromBuffer(Buffer& buffer, std::vector<DType>& host_buffer) {
-    auto buffer_size = buffer.size();
-    TT_FATAL(buffer_size % sizeof(DType) == 0, "Buffer size is not divisible by dtype size");
-    host_buffer.resize(buffer.size() / sizeof(DType));
-    ReadFromBuffer(buffer, reinterpret_cast<uint8_t*>(host_buffer.data()));
-}
-template <typename DType>
-void ReadFromBuffer(const std::shared_ptr<Buffer>& buffer, std::vector<DType>& host_buffer) {
-    ReadFromBuffer(*buffer, host_buffer);
-}
 
 void ReadShard(Buffer& buffer, uint8_t* host_buffer, const uint32_t& core_id);
 /**
@@ -160,63 +55,6 @@ void ReadShard(Buffer& buffer, std::vector<DType>& host_buffer, const uint32_t& 
     ReadShard(buffer, reinterpret_cast<uint8_t*>(host_buffer.data()), core_id);
 }
 
-// Launches all kernels on cores specified with kernels in the program.
-// All kernels on a given Tensix core must be launched.
-void LaunchProgram(
-    IDevice* device, Program& program, bool wait_until_cores_done = true, bool force_slow_dispatch = false);
-void LaunchProgram(
-    IDevice* device,
-    const std::shared_ptr<Program>& program,
-    bool wait_until_cores_done = true,
-    bool force_slow_dispatch = false);
-void WaitProgramDone(IDevice* device, Program& program, bool read_device_profiler_results = true);
-
-/**
- *  Compiles all kernels within the program, and generates binaries that are written to
- * `<tt-metal-cache directory>/<build_key>/kernels/<kernel name>/<kernel hash>`
- *
- *  The build key component accounts for device architecture as binaries are not compatible across architectures.
- *  To speed up compilation there is a kernel compilation cache that skips over generating binaries for the previously
- * compiled kernels. Kernel uniqueness is determined by the kernel hash which is computed based on compile time args,
- * defines, and kernel type specific attributes such as NOC for data movement kernels and math fidelity for compute
- * kernels.
- *  On cache hits the kernel is not recompiled if the output binary directory exists, otherwise the kernel is compiled.
- *  This cache is static and is enabled for the duration of the running process.
- *  Across runs, previously compiled kernels are recompiled if the source code or dependencies have changed.
- *
- *  Return value: void
- *
- * | Argument                  | Description                                                      | Type      | Valid
- * Range                                        | Required |
- * |---------------------------|------------------------------------------------------------------|-----------|----------------------------------------------------|----------|
- * | device                    | Which device the program is compiled for                         | IDevice*  | Must be
- * initialized via tt_metal::InitializeDevice | Yes      | | program                   | The program to compile |
- * Program & |                                                    | Yes      | | force_slow_dispatch        | Set when
- * a user wants to compile a program with Slow Dispatch Force Enabled (advanced feature, currently used internally to
- * launch Fast Dispatch Firmware and in the Device Performance Profiler)           | bool      | | No |
- */
-void CompileProgram(IDevice* device, Program& program, bool force_slow_dispatch = false);
-
-/**
- * Writes runtime args that are saved in the program to device
- *
- * Return value: void
- *
- * | Argument            | Description                                                            | Type | Valid Range
- * | Required |
- * |---------------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
- * | device              | The device to which runtime args will be written                       | IDevice* | | Yes |
- * | program             | The program holding the runtime args                                   | const Program & | |
- * Yes      |
- */
-void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool force_slow_dispatch = false);
-
-// Configures a given device with a given program.
-// - Loads all kernel binaries into L1s of assigned Tensix cores
-// - Configures circular buffers (inits regs with buffer data)
-// - Takes the device out of reset
-bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_slow_dispatch = false);
-
 /**
  * Generate a (unique) per device ID for a program (potentially) running across multiple devices. The generated ID is
  * used by the performance profiler.
@@ -233,86 +71,6 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
  * |                          | no       |
  */
 uint32_t EncodePerDeviceProgramID(uint32_t base_program_id, uint32_t device_id, bool is_host_fallback_op = false);
-
-/**
- * Decode per device program ID to get encoded values (base program id, device id, and a flag indicating whether
- * it's an op run entirely on host).
- *
- * Return value: tuple<uint32_t, uint32_t, bool>
- *
- * | Argument             | Description                                                                         |  Data
- * type            | Valid range              | required |
- * |----------------------|-------------------------------------------------------------------------------------|-----------------------|--------------------------|----------|
- * | device_program_id    | Encoded device specific id used by the performance profiler  |
- * uint32_t        | 0 - 2^32 - 1             | yes      |
- */
-DeviceProgramId DecodePerDeviceProgramID(uint32_t device_program_id);
-
-// clang-format off
-/**
- * Copies data from a host buffer into a buffer within the device DRAM channel
- *
- * Return value: bool
- *
- * | Argument     | Description                                            | Data type                | Valid range                               | required |
- * |--------------|--------------------------------------------------------|--------------------------|-------------------------------------------|----------|
- * | device       | The device whose DRAM to write data into               | IDevice*                 |                                           | Yes      |
- * | dram_channel | Channel index of DRAM to write into                    | int                      | On Grayskull, [0, 7] inclusive            | Yes      |
- * | address      | Starting address on DRAM channel to begin writing data | uint32_t                 | [DRAM_UNRESERVED_BASE, dram_size)         | Yes      |
- * | host_buffer  | Buffer on host to copy data from                       | std::span<const uint8_t> | Host buffer must be fully fit DRAM buffer | Yes      |
- */
-// clang-format on
-bool WriteToDeviceDRAMChannel(
-    IDevice* device, int dram_channel, uint32_t address, std::span<const uint8_t> host_buffer);
-/**
- * Copies data from a host buffer into a buffer within the device DRAM channel
- *
- * Return value: bool
- *
- * | Argument     | Description                                            | Data type             | Valid range |
- * required |
- * |--------------|--------------------------------------------------------|-----------------------|-------------------------------------------|----------|
- * | device       | The device whose DRAM to write data into               | IDevice*              | | Yes      | |
- * dram_channel | Channel index of DRAM to write into                    | int                   | On Grayskull, [0, 7]
- * inclusive            | Yes      | | address      | Starting address on DRAM channel to begin writing data | uint32_t
- * | [DRAM_UNRESERVED_BASE, dram_size)         | Yes      | | host_buffer  | Buffer on host to copy data from |
- * std::vector<uint32_t> | Host buffer must be fully fit DRAM buffer | Yes      |
- */
-bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t address, std::vector<uint32_t>& host_buffer);
-
-// clang-format off
-/**
- * Copy data from a device DRAM channel to a host buffer
- *
- * Return value: bool
- *
- * | Argument     | Description                                                  | Data type             | Valid range                    | required |
- * |--------------|--------------------------------------------------------------|-----------------------|--------------------------------|----------|
- * | device       | The device whose DRAM to read data from                      | IDevice*              |                                | Yes      |
- * | dram_channel | Channel index of DRAM to read from                           | int                   | On Grayskull, [0, 7] inclusive | Yes      |
- * | address      | Starting address on DRAM channel from which to begin reading | uint32_t              |                                | Yes      |
- * | host_buffer  | Buffer on host to copy data into                             | std::span<uint8_t>    |                                | Yes      |
- */
-// clang-format on
-bool ReadFromDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t address, std::span<uint8_t> host_buffer);
-
-/**
- * Copy data from a device DRAM channel to a host buffer
- *
- * Return value: bool
- *
- * | Argument     | Description                                                  | Data type             | Valid range
- * | required |
- * |--------------|--------------------------------------------------------------|-----------------------|--------------------------------|----------|
- * | device       | The device whose DRAM to read data from                      | IDevice*              | | Yes      |
- * | dram_channel | Channel index of DRAM to read from                           | int                   | On Grayskull,
- * [0, 7] inclusive | Yes      | | address      | Starting address on DRAM channel from which to begin reading |
- * uint32_t              |                                | Yes      | | size         | Size of buffer to read from
- * device in bytes                  | uint32_t              |                                | Yes      | | host_buffer
- * | Buffer on host to copy data into                             | std::vector<uint32_t> | | Yes      |
- */
-bool ReadFromDeviceDRAMChannel(
-    IDevice* device, int dram_channel, uint32_t address, uint32_t size, std::vector<uint32_t>& host_buffer);
 
 // clang-format off
 /**
@@ -353,8 +111,6 @@ bool WriteToDeviceL1(
     uint32_t address,
     std::vector<uint32_t>& host_buffer,
     CoreType core_type = CoreType::WORKER);
-
-bool WriteRegToDevice(IDevice* device, const CoreCoord& logical_core, uint32_t address, const uint32_t& regval);
 
 // clang-format off
 /**
@@ -400,8 +156,6 @@ bool ReadFromDeviceL1(
     uint32_t size,
     std::vector<uint32_t>& host_buffer,
     CoreType core_type = CoreType::WORKER);
-
-bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t address, uint32_t& regval);
 
 /**
  * Return the name of the architecture present.

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -17,8 +17,8 @@
 #include <internal/service/service_core_manager.hpp>
 #include "impl/internal/service/service_core_manager_impl.hpp"
 #include "impl/context/metal_context.hpp"
-#include <tt-metalium/tt_metal.hpp>
 #include "llrt/tt_cluster.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -15,7 +15,6 @@
 #include "impl/sub_device/sub_device_impl.hpp"
 #include <system_mesh.hpp>
 #include <maybe_remote.hpp>
-#include <tt_metal.hpp>
 #include <tt-metalium/experimental/inspector.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <algorithm>

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -20,6 +20,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include "impl/program/program_impl.hpp"
 
 #if defined(__linux__)
 #include <sys/prctl.h>
@@ -739,7 +740,7 @@ void RealtimeProfilerManager::initialize_devices(const std::shared_ptr<MeshDevic
             CreateKernel(
                 realtime_profiler_program, realtime_profiler_push_kernel_path, realtime_profiler_core, ncrisc_config);
 
-            tt::tt_metal::detail::CompileProgram(device, realtime_profiler_program, /*force_slow_dispatch=*/true);
+            realtime_profiler_program.impl().compile(device, /*force_slow_dispatch=*/true);
             ::tt::tt_metal::detail::WriteRuntimeArgsToDevice(
                 device, realtime_profiler_program, /*force_slow_dispatch=*/true);
             ::tt::tt_metal::detail::LaunchProgram(

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -12,8 +12,8 @@
 #include <tt-metalium/experimental/core_subset_write/buffer_write.hpp>
 #include <tt-metalium/experimental/dispatch_context.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/graph_tracking.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 #ifdef TT_METAL_USE_EMULE
 #include "tt_metal/impl/emulation/emulated_program_runner.hpp"  // emule mesh register/run split
 #endif

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -12,7 +12,6 @@
 #include "tt_metal/fabric/builder/fabric_builder_helpers.hpp"
 #include "tt_metal/fabric/builder/fabric_core_placement.hpp"
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "tt_metal/third_party/umd/device/api/umd/device/types/core_coordinates.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
@@ -20,6 +19,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/fmt.hpp>
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -23,13 +23,13 @@
 
 #include "impl/context/metal_context.hpp"
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include "distributed/mesh_device_impl.hpp"
 
 #include "fabric_host_utils.hpp"
 #include "fabric_context.hpp"
 #include "fabric_builder_context.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 class Program;

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "impl/context/metal_context.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
+#include "impl/program/program_impl.hpp"
 
 // hack for test_basic_fabric_apis.cpp
 // https://github.com/tenstorrent/tt-metal/issues/20000
@@ -41,8 +42,7 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
     builder.create_kernels();
 
     // Compile the program
-    tt::tt_metal::detail::CompileProgram(
-        device, *fabric_program_ptr, tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
+    fabric_program_ptr->impl().compile(device, tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
 
     return fabric_program_ptr;
 }

--- a/tt_metal/fabric/fabric_switch_manager.cpp
+++ b/tt_metal/fabric/fabric_switch_manager.cpp
@@ -5,13 +5,13 @@
 #include <tt-metalium/experimental/fabric/fabric_switch_manager.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
-#include <tt-metalium/tt_metal.hpp>
 
 #include <map>
 #include <vector>
 
 #include "impl/context/metal_context.hpp"
 #include "hostdevcommon/common_values.hpp"
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/impl/buffers/buffer_impl.hpp
+++ b/tt_metal/impl/buffers/buffer_impl.hpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <tt_stl/assert.hpp>
+#include <tt_stl/span.hpp>
+#include <tt-metalium/buffer.hpp>
+
+namespace tt::tt_metal {
+
+namespace detail {
+
+void WriteToBuffer(Buffer& buffer, ttsl::Span<const uint8_t> host_buffer);
+
+template <typename DType>
+void WriteToBuffer(Buffer& buffer, const std::vector<DType>& host_buffer) {
+    WriteToBuffer(
+        buffer,
+        ttsl::Span<const uint8_t>(
+            reinterpret_cast<const uint8_t*>(host_buffer.data()), host_buffer.size() * sizeof(DType)));
+}
+template <typename DType>
+void WriteToBuffer(const std::shared_ptr<Buffer>& buffer, const std::vector<DType>& host_buffer) {
+    WriteToBuffer(*buffer, host_buffer);
+}
+
+void ReadFromBuffer(Buffer& buffer, uint8_t* host_buffer);
+
+template <typename DType>
+void ReadFromBuffer(Buffer& buffer, std::vector<DType>& host_buffer) {
+    auto buffer_size = buffer.size();
+    TT_FATAL(buffer_size % sizeof(DType) == 0, "Buffer size is not divisible by dtype size");
+    host_buffer.resize(buffer.size() / sizeof(DType));
+    ReadFromBuffer(buffer, reinterpret_cast<uint8_t*>(host_buffer.data()));
+}
+template <typename DType>
+void ReadFromBuffer(const std::shared_ptr<Buffer>& buffer, std::vector<DType>& host_buffer) {
+    ReadFromBuffer(*buffer, host_buffer);
+}
+
+}  // namespace detail
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -10,7 +10,6 @@
 #include <global_semaphore.hpp>
 #include <host_api.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt_metal.hpp>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -21,6 +20,7 @@
 #include "mesh_device.hpp"
 #include <tt_stl/reflection.hpp>
 #include "impl/context/metal_context.hpp"
+#include "buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/buffers/simulator_direct_write.cpp
+++ b/tt_metal/impl/buffers/simulator_direct_write.cpp
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "buffers/simulator_direct_write.hpp"
+#include "buffers/buffer_impl.hpp"
 
 #if defined(TT_UMD_BUILD_SIMULATION)
 
 #include "llrt/rtoptions.hpp"
 #include <tt-metalium/experimental/core_subset_write/buffer_write.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt_stl/span.hpp>
 
 namespace tt::tt_metal::tt_sim {

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -27,7 +27,6 @@
 #include <tt-metalium/mesh_command_queue.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/program.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/experimental/global_circular_buffer.hpp>
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
@@ -37,6 +36,7 @@
 #include "impl/kernels/kernel.hpp"  // DramConfig + CreateKernel(DramConfig)
 #include "llrt/metal_soc_descriptor.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"  // receiver_socket_md (for L1 layout sizing)
+#include "program/program_impl.hpp"
 
 namespace tt::tt_metal::distributed {
 
@@ -593,7 +593,7 @@ void TensorPrefetcherManager::start() {
 
     // Launch programs (non-blocking — kernels park on the socket immediately).
     for (uint32_t d = 0; d < devices_.size(); ++d) {
-        ::tt::tt_metal::detail::CompileProgram(devices_[d], *programs_[d], /*force_slow_dispatch=*/true);
+        programs_[d]->impl().compile(devices_[d], /*force_slow_dispatch=*/true);
         ::tt::tt_metal::detail::WriteRuntimeArgsToDevice(devices_[d], *programs_[d], /*force_slow_dispatch=*/true);
         ::tt::tt_metal::detail::LaunchProgram(
             devices_[d], *programs_[d], /*wait_until_cores_done=*/false, /*force_slow_dispatch=*/true);

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -18,8 +18,8 @@
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "tt_metal/impl/program/program_impl.hpp"
-#include "tt_metal/impl/kernels/kernel.hpp"
 #include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
+#include "tt_metal/impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal::experimental::dfb::detail {
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -19,7 +19,6 @@
 #include <tt-metalium/program_cache.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt_align.hpp>
-#include <tt_metal.hpp>
 #include <tt_stl/span.hpp>
 #include <algorithm>
 #include <cstdint>

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -4,15 +4,21 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <span>
 #include <unordered_set>
+#include <vector>
 
 #include <tt-metalium/device.hpp>
 #include <hostdevcommon/common_values.hpp>
 #include <hostdevcommon/dispatch_telemetry_types.hpp>
 #include <hostdevcommon/kernel_structs.h>  // Leaked up to ttnn level from here
+#include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include "context/metal_context.hpp"
 #include "impl/context/context_types.hpp"
@@ -288,5 +294,52 @@ private:
 
     friend class experimental::DispatchContext;
 };
+
+IDevice* CreateDevice(
+    ChipId device_id,
+    uint8_t num_hw_cqs = 1,
+    size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
+    size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
+    const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
+    const std::vector<uint32_t>& l1_bank_remap = {},
+    size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
+
+IDevice* CreateDeviceMinimal(
+    ChipId device_id, uint8_t num_hw_cqs = 1, const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{});
+
+bool CloseDevice(IDevice* device);
+
+namespace detail {
+
+bool DispatchStateCheck(bool isFastDispatch);
+
+std::map<ChipId, IDevice*> CreateDevices(
+    // TODO: delete this in favour of DeviceManager
+    const std::vector<ChipId>& device_ids,
+    uint8_t num_hw_cqs = 1,
+    size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
+    size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
+    const tt_metal::DispatchCoreConfig& dispatch_core_config = tt_metal::DispatchCoreConfig{},
+    const std::vector<uint32_t>& l1_bank_remap = {},
+    size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE,
+    bool init_profiler = true,
+    [[deprecated]] bool ignored = false,  // This argument was not used
+    bool initialize_fabric_and_dispatch_fw = true);
+
+void CloseDevices(const std::map<ChipId, IDevice*>& devices);
+
+void ReleaseOwnership();
+
+bool WriteToDeviceDRAMChannel(
+    IDevice* device, int dram_channel, uint32_t address, std::span<const uint8_t> host_buffer);
+bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t address, std::vector<uint32_t>& host_buffer);
+
+bool ReadFromDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t address, std::span<uint8_t> host_buffer);
+bool ReadFromDeviceDRAMChannel(
+    IDevice* device, int dram_channel, uint32_t address, uint32_t size, std::vector<uint32_t>& host_buffer);
+
+bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t address, uint32_t& regval);
+
+}  // namespace detail
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -11,7 +11,6 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
-#include <tt_metal.hpp>
 #include "context/metal_env_accessor.hpp"
 #include "dispatch/dispatch_query_manager.hpp"
 #include "dprint_server.hpp"

--- a/tt_metal/impl/device/mock_device.cpp
+++ b/tt_metal/impl/device/mock_device.cpp
@@ -10,8 +10,8 @@
 #include "llrt/get_platform_architecture.hpp"
 #include "llrt/tt_cluster.hpp"
 #include "impl/context/metal_context.hpp"
-#include <tt-metalium/tt_metal.hpp>
 #include "impl/device/mock_device_util.hpp"
+#include "device/device_impl.hpp"
 
 namespace tt::tt_metal::experimental {
 

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -7,9 +7,9 @@
 
 #include <cstdint>
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "tt-metalium/program.hpp"
 #include "data_collector.hpp"
+#include "impl/kernels/kernel.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/impl/dispatch/data_collector.cpp
+++ b/tt_metal/impl/dispatch/data_collector.cpp
@@ -11,8 +11,8 @@
 #include <filesystem>
 #include <tt-logger/tt-logger.hpp>
 #include "impl/context/metal_env_impl.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "tt-metalium/program.hpp"
+#include "impl/kernels/kernel.hpp"
 
 using tt::tt_metal::detail::ProgramImpl;
 namespace tt::tt_metal {

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -21,13 +21,13 @@
 #include "device/device_manager.hpp"
 #include "dispatch_settings.hpp"
 #include "hal_types.hpp"
-#include "host_api.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "system_memory_cq_interface.hpp"
 #include "system_memory_manager.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include <llrt/tt_cluster.hpp>
+#include "device/device_impl.hpp"
 
 namespace tt::tt_metal {
 class IDevice;

--- a/tt_metal/impl/dispatch/dispatch_engine_kernel.cpp
+++ b/tt_metal/impl/dispatch/dispatch_engine_kernel.cpp
@@ -13,9 +13,9 @@
 #include <tt_stl/assert.hpp>
 
 #include "host_api/temp_quasar_api.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "impl/kernels/kernel_source.hpp"
 #include "impl/program/program_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal::detail {
 

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -5,9 +5,7 @@
 #include <tt_stl/fmt.hpp>
 #include <tt_stl/assert.hpp>
 #include <buffer.hpp>
-#include <host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
-#include <tt_metal.hpp>
 #include <functional>
 #include <memory>
 
@@ -26,6 +24,7 @@
 #include <impl/dispatch/dispatch_query_manager.hpp>
 #include <impl/debug/dprint_server.hpp>
 #include <impl/debug/watcher_server.hpp>
+#include "device/device_impl.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -21,9 +21,9 @@
 #include "impl/context/context_descriptor.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/dispatch/dispatch_engine_cores.hpp"
-#include "kernels/kernel.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/debug/dprint_server.hpp>
+#include "kernels/kernel.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include <sys/resource.h>  // getrlimit(RLIMIT_NOFILE) — bound JIT compile fan-out under the fd limit
 #include <csignal>
+#include "impl/kernels/kernel.hpp"
 #if defined(__x86_64__) && defined(__linux__)
 #include <ucontext.h>
 #include <sys/ucontext.h>
@@ -53,7 +54,6 @@
 #error "TT_EMULE_CXX_STANDARD must be defined by CMake"
 #endif
 
-#include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include "impl/buffers/circular_buffer.hpp"
 #include "impl/buffers/semaphore.hpp"

--- a/tt_metal/impl/emulation/host_sanitizers.cpp
+++ b/tt_metal/impl/emulation/host_sanitizers.cpp
@@ -17,7 +17,6 @@
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/program.hpp>
 #include "impl/context/metal_context.hpp"
-#include "impl/program/program_impl.hpp"
 #include "llrt/tt_cluster.hpp"
 #include "emule_live_ranges.hpp"
 

--- a/tt_metal/impl/experimental/blaze/named_kernel_args.cpp
+++ b/tt_metal/impl/experimental/blaze/named_kernel_args.cpp
@@ -23,9 +23,9 @@
 #include <tt_stl/assert.hpp>
 #include <tt_stl/reflection.hpp>  // ttsl::hash for hash_named_args_schema
 
-#include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include "jit_build/jit_build_settings.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal::experimental::blaze {
 

--- a/tt_metal/impl/experimental/offline_compile/offline_kernel_compile.cpp
+++ b/tt_metal/impl/experimental/offline_compile/offline_kernel_compile.cpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/program.hpp>
 
 #include "impl/buffers/circular_buffer.hpp"
-#include "impl/kernels/kernel.hpp"
 #include "impl/program/kernel_compile_utils.hpp"
 #include "impl/program/program_impl.hpp"
 #include "jit_build/build.hpp"
@@ -31,6 +30,7 @@
 #include <type_traits>
 #include <unordered_set>
 #include <variant>
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal::experimental {
 

--- a/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.hpp
+++ b/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.hpp
@@ -6,11 +6,11 @@
 
 #include "program_types_generated.h"
 #include <variant>
-#include "kernels/kernel.hpp"
 #include <core_coord.hpp>
 #include <kernel_types.hpp>
 #include <sub_device_types.hpp>
 #include <tt_stl/assert.hpp>
+#include "kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/host_api/device_queries.hpp
+++ b/tt_metal/impl/host_api/device_queries.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace tt::tt_metal {
+
+/**
+ * Returns whether Tenstorrent devices are in a Galaxy cluster.
+ *
+ * Return value: bool
+ */
+bool IsGalaxyCluster();
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/host_api/helpers.hpp
+++ b/tt_metal/impl/host_api/helpers.hpp
@@ -11,7 +11,9 @@
 
 #include <tt-metalium/core_coord.hpp>
 
-namespace tt::tt_metal::detail {
+namespace tt::tt_metal {
+
+namespace detail {
 
 inline CoreRangeSet GetCoreRangeSet(const std::variant<CoreCoord, CoreRange, CoreRangeSet>& specified_core_spec) {
     ZoneScoped;
@@ -24,4 +26,6 @@ inline CoreRangeSet GetCoreRangeSet(const std::variant<CoreCoord, CoreRange, Cor
         specified_core_spec);
 }
 
-}  // namespace tt::tt_metal::detail
+}  // namespace detail
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/host_api/temp_quasar_api.cpp
+++ b/tt_metal/impl/host_api/temp_quasar_api.cpp
@@ -18,9 +18,9 @@
 #include <tt-metalium/kernel_types.hpp>
 
 #include "impl/context/metal_context.hpp"
+#include "impl/program/program_impl.hpp"
 #include "host_api/helpers.hpp"
 #include "impl/kernels/kernel.hpp"
-#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal::experimental::quasar {
 

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -11,7 +11,6 @@
 #include "context/context_types.hpp"
 #include "context/metal_env_accessor.hpp"
 #include "device/device_manager.hpp"
-#include "host_api/helpers.hpp"
 #include <global_circular_buffer.hpp>
 #include <global_semaphore.hpp>
 #include <host_api.hpp>
@@ -40,7 +39,6 @@
 #include <filesystem>
 #include "device.hpp"
 #include "context/metal_context.hpp"
-#include "kernels/kernel.hpp"
 #include "dispatch/dispatch_settings.hpp"
 #include "device/device_impl.hpp"
 #include "hal_types.hpp"
@@ -69,6 +67,10 @@
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include <internal/service/service_core_manager.hpp>
+#include "kernels/kernel.hpp"
+#include "host_api/device_queries.hpp"
+#include "host_api/helpers.hpp"
+#include "buffers/buffer_impl.hpp"
 
 #ifdef TT_METAL_USE_EMULE
 #include "impl/emulation/emulated_program_runner.hpp"
@@ -301,12 +303,6 @@ bool WriteToDeviceL1(
         address,
         std::span(reinterpret_cast<const std::uint8_t*>(host_buffer.data()), host_buffer.size() * sizeof(uint32_t)),
         core_type);
-}
-
-bool WriteRegToDevice(IDevice* device, const CoreCoord& logical_core, uint32_t address, const uint32_t& regval) {
-    auto worker_core = device->worker_core_from_logical_core(logical_core);
-    MetalContext::instance().get_cluster().write_reg(&regval, tt_cxy_pair(device->id(), worker_core), address);
-    return true;
 }
 
 bool ReadFromDeviceL1(
@@ -949,7 +945,7 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         if (MetalContext::instance().get_cluster().get_target_device_type() != tt::TargetDevice::Emule)
 #endif
         {
-            detail::CompileProgram(device, program);
+            program.impl().compile(device);
         }
         program.impl().finalize_dataflow_buffer_configs();
         if (!program.impl().is_finalized()) {
@@ -1245,11 +1241,6 @@ void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool force_slow
             }
         }
     }
-}
-
-void CompileProgram(IDevice* device, Program& program, bool force_slow_dispatch) {
-    ZoneScoped;
-    program.impl().compile(device, force_slow_dispatch);
 }
 
 }  // namespace detail
@@ -1697,20 +1688,6 @@ void UpdateDynamicCircularBufferAddress(Program& program, CBHandle cb_handle, co
     circular_buffer->assign_global_address();
 }
 
-void UpdateDynamicCircularBufferAddressAndTotalSize(
-    Program& program, CBHandle cb_handle, const Buffer& buffer, uint32_t total_size) {
-    auto circular_buffer = program.impl().get_circular_buffer(cb_handle);
-    circular_buffer->config().set_globally_allocated_address_and_total_size(buffer, total_size);
-    circular_buffer->assign_global_address();
-}
-
-void UpdateDynamicCircularBufferAddressAndTotalSize(
-    Program& program, CBHandle cb_handle, const MeshTensor& tensor, uint32_t total_size) {
-    auto circular_buffer = program.impl().get_circular_buffer(cb_handle);
-    circular_buffer->config().set_globally_allocated_address_and_total_size(tensor, total_size);
-    circular_buffer->assign_global_address();
-}
-
 uint32_t CreateSemaphore(
     Program& program, const std::variant<CoreRange, CoreRangeSet>& core_spec, uint32_t initial_value) {
     return CreateSemaphore(program, core_spec, initial_value, CoreType::WORKER);
@@ -1779,13 +1756,6 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, SubDevic
         BufferShardingArgs(config.shard_parameters, config.buffer_layout),
         std::nullopt,
         sub_device_id);
-}
-
-void DeallocateBuffer(Buffer& buffer) { buffer.deallocate(); }
-
-void AssignGlobalBufferToProgram(const std::shared_ptr<Buffer>& buffer, Program& program) {
-    detail::DispatchStateCheck(MetalContext::instance().rtoptions().get_fast_dispatch());
-    program.impl().add_buffer(buffer);
 }
 
 void SetRuntimeArgs(

--- a/tt_metal/impl/internal/disaggregation/kv_chunk_address_table.cpp
+++ b/tt_metal/impl/internal/disaggregation/kv_chunk_address_table.cpp
@@ -13,6 +13,7 @@
 
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/internal/disaggregation/noc_addr.hpp"
+#include "device/device_impl.hpp"
 
 namespace tt::tt_metal::internal::disaggregation {
 

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -21,10 +21,10 @@
 #include "core_coord.hpp"
 #include "hal_types.hpp"
 #include "jit_build/jit_build_settings.hpp"
-#include "impl/program/program_impl.hpp"
 #include "impl/kernels/kernel_source.hpp"
 #include <enchantum/enchantum.hpp>
 #include "tt_cluster.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 
@@ -63,6 +63,12 @@ KernelHandle CreateKernel(
     const std::string& file_name,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
     const EthernetConfig& config);
+
+KernelHandle CreateKernelFromString(
+    Program& program,
+    const std::string& kernel_src_code,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const std::variant<DataMovementConfig, ComputeConfig>& config);
 
 KernelHandle CreateKernelFromString(
     Program& program,

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -15,8 +15,7 @@
 #include "lightmetal/lightmetal_capture.hpp"
 #include "flatbuffer/program_types_to_flatbuffer.hpp"
 #include "flatbuffer/buffer_types_to_flatbuffer.hpp"
-
-#include "impl/program/program_impl.hpp"
+#include "program/program_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -13,13 +13,13 @@
 
 #include <host_api.hpp>
 #include "env_lib.hpp"
-#include <tt-metalium/tt_metal.hpp>
 #include "trace/trace_buffer.hpp"
 #include <tt-metalium/device.hpp>
 #include "flatbuffer/program_types_from_flatbuffer.hpp"
 #include "flatbuffer/buffer_types_from_flatbuffer.hpp"
 
-#include "impl/program/program_impl.hpp"
+#include "program/program_impl.hpp"
+#include "device/device_impl.hpp"
 
 namespace tt::tt_metal::experimental::lightmetal {
 
@@ -455,7 +455,7 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::BufferDealloc
         cmd->global_id());
 
     log_debug(tt::LogMetalTrace, "LightMetalReplay(BufferDeallocate) global_id: {}", cmd->global_id());
-    DeallocateBuffer(*buffer);  // Buffer& expected.
+    buffer->deallocate();
 }
 
 void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::BufferDeleteCommand* cmd) {

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -13,7 +13,6 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/circular_buffer.hpp>
-
 #include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -14,8 +14,8 @@
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/metal2_host_api/tensor_spec_relaxations.hpp>
-#include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal::experimental {
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -25,7 +25,6 @@
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <hostdevcommon/tensor_accessor/arg_config.hpp>
-#include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/context/metal_env_accessor.hpp"
@@ -35,6 +34,7 @@
 #include <core_descriptor.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <variant>
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal::experimental {
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -14,7 +14,6 @@
 #include "impl/threading/thread_pool.hpp"
 #include "tools/profiler/event_metadata.hpp"
 #include "distributed/fd_mesh_command_queue.hpp"
-#include <host_api.hpp>
 #include <enchantum/enchantum.hpp>
 #include <nlohmann/json.hpp>
 #include <stack>
@@ -59,6 +58,7 @@
 #include "tools/profiler/perf_counters.hpp"
 #include "debug/noc_debugging.hpp"
 #include "tools/profiler/noc_debugging_metadata.hpp"
+#include "program/program_impl.hpp"
 
 #if !defined(TRACY_ENABLE) && defined(__clang__)
 #pragma clang diagnostic push

--- a/tt_metal/impl/profiler/profiler_analysis.cpp
+++ b/tt_metal/impl/profiler/profiler_analysis.cpp
@@ -12,7 +12,6 @@
 #include <nlohmann/json.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/profiler.hpp>
-#include <tt_metal.hpp>
 #include <fstream>
 
 #include "context/metal_env_accessor.hpp"
@@ -25,6 +24,7 @@
 #include <impl/dispatch/data_collection.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include <llrt/tt_cluster.hpp>
+#include "program/program_impl.hpp"
 
 namespace std {
 std::size_t hash<tt::tt_metal::experimental::ProgramExecutionUID>::operator()(

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -53,7 +53,6 @@
 #include "profiler_types.hpp"
 #include "profiler_state_manager.hpp"
 #include "program.hpp"
-#include "kernels/kernel.hpp"
 #include "device/device_manager.hpp"
 #include "rtoptions.hpp"
 #include "tracy/Tracy.hpp"
@@ -63,6 +62,8 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <impl/debug/noc_debugging.hpp>
+#include "program/program_impl.hpp"
+#include "kernels/kernel.hpp"
 
 #if !defined(TRACY_ENABLE) && defined(__clang__)
 #pragma clang diagnostic push
@@ -426,8 +427,8 @@ void syncDeviceDevice(ChipId device_id_sender, ChipId device_id_receiver) {
             tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = ct_args});
 
         try {
-            detail::CompileProgram(device_sender, program_sender);
-            detail::CompileProgram(device_receiver, program_receiver);
+            program_sender.impl().compile(device_sender);
+            program_receiver.impl().compile(device_receiver);
         } catch (std::exception& e) {
             log_error(tt::LogMetal, "Failed compile: {}", e.what());
             throw e;

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -69,11 +69,11 @@
 #include "vector_aligned.hpp"
 #include "dispatch/worker_config_buffer.hpp"
 #include "tt_metal/distributed/mesh_workload_impl.hpp"
-#include "kernels/kernel.hpp"
 #include <impl/dispatch/dispatch_query_manager.hpp>
 
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include "hostdev/rta_constants.h"
+#include "kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 enum NOC : uint8_t;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -81,8 +81,6 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "host_api.hpp"
-#include "tt_metal.hpp"  // WriteRuntimeArgsToDevice
-#include "kernels/kernel.hpp"
 #include <tt-metalium/experimental/blaze/named_kernel_args.hpp>
 #include <tt_stl/reflection.hpp>
 #include <impl/dispatch/dispatch_query_manager.hpp>
@@ -91,6 +89,8 @@
 #include <internal/service/service_core_manager.hpp>
 #include "impl/internal/service/service_core_manager_impl.hpp"
 #include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
+#include "kernels/kernel.hpp"
+#include "program/program_impl.hpp"
 
 namespace tt {
 enum CBIndex : std::uint8_t;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -14,6 +14,7 @@
 #include "tt-metalium/hal_types.hpp"     // HalProgrammableCoreType
 #include "tt-metalium/kernel_types.hpp"  // KernelHandle
 #include "tt-metalium/program.hpp"       // KernelGroup
+#include "tt-metalium/profiler_types.hpp"
 #include "program_device_map.hpp"        // ProgramTransferInfo
 #include "impl/buffers/semaphore.hpp"
 #include "tt-metalium/sub_device_types.hpp"
@@ -593,6 +594,21 @@ private:
     friend distributed::MeshWorkload;
     friend distributed::MeshWorkloadImpl;
 };
+
+void LaunchProgram(
+    IDevice* device, Program& program, bool wait_until_cores_done = true, bool force_slow_dispatch = false);
+void LaunchProgram(
+    IDevice* device,
+    const std::shared_ptr<Program>& program,
+    bool wait_until_cores_done = true,
+    bool force_slow_dispatch = false);
+void WaitProgramDone(IDevice* device, Program& program, bool read_device_profiler_results = true);
+
+void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool force_slow_dispatch = false);
+
+bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_slow_dispatch = false);
+
+DeviceProgramId DecodePerDeviceProgramID(uint32_t device_program_id);
 
 }  // namespace detail
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/trace/trace_buffer.cpp
+++ b/tt_metal/impl/trace/trace_buffer.cpp
@@ -6,12 +6,12 @@
 
 #include <device.hpp>
 #include <fmt/ranges.h>
-#include <tt_metal.hpp>
 #include <utility>
 
 #include "buffer.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <fmt/core.h>
+#include "buffers/buffer_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/tools/mem_bench/CMakeLists.txt
+++ b/tt_metal/tools/mem_bench/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(
     PRIVATE
         ${PROJECT_SOURCE_DIR}
         ${PROJECT_SOURCE_DIR}/tt_metal
+        ${PROJECT_SOURCE_DIR}/tt_metal/impl
         ${PROJECT_SOURCE_DIR}/tt_metal/common
         ${PROJECT_SOURCE_DIR}/tests
         .

--- a/tt_metal/tools/mem_bench/mem_bench.cpp
+++ b/tt_metal/tools/mem_bench/mem_bench.cpp
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include "impl/context/metal_context.hpp"
 #include <iostream>
 #include <map>
@@ -26,6 +25,8 @@
 #include "vector_aligned.hpp"
 #include "work_thread.hpp"
 #include <llrt/tt_cluster.hpp>
+#include "impl/device/device_impl.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/tools/watcher_dump/CMakeLists.txt
+++ b/tt_metal/tools/watcher_dump/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(
     PRIVATE
         ${PROJECT_SOURCE_DIR}
         ${PROJECT_SOURCE_DIR}/tt_metal
+        ${PROJECT_SOURCE_DIR}/tt_metal/impl
         ${PROJECT_SOURCE_DIR}/tt_metal/common
         ${PROJECT_SOURCE_DIR}/tests
         .

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -18,6 +18,7 @@
 #include "impl/dispatch/debug_tools.hpp"
 #include "impl/dispatch/system_memory_manager.hpp"
 #include <impl/debug/watcher_server.hpp>
+#include "impl/device/device_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/ttnn/core/cluster.cpp
+++ b/ttnn/core/cluster.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/cluster.hpp"
-#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/cluster.hpp>
 #include <tt-metalium/internal/cluster.hpp>
 
 namespace ttnn {

--- a/ttnn/cpp/ttnn-nanobind/cluster.cpp
+++ b/ttnn/cpp/ttnn-nanobind/cluster.cpp
@@ -6,7 +6,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
-#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/cluster.hpp>
 
 #include "ttnn/cluster.hpp"
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Runtime team is performing surface area reduction.

This PR cleans up the unused surface area for `tt_metal.hpp` & `host_api.hpp`.

Closes #33845 , Closes #34527 .

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

#### Moved functions

The litmus test we use to determine if a function is an internal function is:

A function is internal if and only if:
- There are no usage of this function within tenstorrent repos outside of the tt_metal folder and the tests folder.
- The function is not a known externally used function

| Function | Destination |
|---|---|
| `IsGalaxyCluster` | `tt_metal/impl/host_api/device_queries.hpp` |
| `CreateDevice` | `tt_metal/impl/device/device_impl.hpp` |
| `CreateDeviceMinimal` | `tt_metal/impl/device/device_impl.hpp` |
| `CloseDevice` | `tt_metal/impl/device/device_impl.hpp` |
| `detail::CreateDevices` | `tt_metal/impl/device/device_impl.hpp` |
| `detail::CloseDevices` | `tt_metal/impl/device/device_impl.hpp` |
| `detail::ReleaseOwnership` | `tt_metal/impl/device/device_impl.hpp` |
| `detail::DispatchStateCheck` | `tt_metal/impl/device/device_impl.hpp` |
| `detail::WriteToDeviceDRAMChannel` | `tt_metal/impl/device/device_impl.hpp` |
| `detail::ReadFromDeviceDRAMChannel` | `tt_metal/impl/device/device_impl.hpp` |
| `detail::ReadRegFromDevice` | `tt_metal/impl/device/device_impl.hpp` |
| `CreateKernelFromString` | `tt_metal/impl/kernels/kernel.hpp` |
| `detail::WriteToBuffer` | `tt_metal/impl/buffers/buffer_impl.hpp` |
| `detail::ReadFromBuffer` | `tt_metal/impl/buffers/buffer_impl.hpp` |
| `detail::LaunchProgram` | `tt_metal/impl/program/program_impl.hpp` |
| `detail::WaitProgramDone` | `tt_metal/impl/program/program_impl.hpp` |
| `detail::WriteRuntimeArgsToDevice` | `tt_metal/impl/program/program_impl.hpp` |
| `detail::ConfigureDeviceWithProgram` | `tt_metal/impl/program/program_impl.hpp` |
| `detail::DecodePerDeviceProgramID` | `tt_metal/impl/program/program_impl.hpp` |

#### Removed / inlined

| Function | What happened |
|---|---|
| `DeallocateBuffer` | inlined → `Buffer::deallocate()` |
| `AssignGlobalBufferToProgram` | inlined → `program.impl().add_buffer()` |
| `detail::CompileProgram` | inlined → `program.impl().compile()` |
| `UpdateDynamicCircularBufferAddressAndTotalSize` | deleted (unused) |
| `detail::WriteRegToDevice` | deleted (unused) |

#### Still used in production (kept public; example outside `tt_metal/` / tests)

All free functions remaining in `host_api.hpp` / `tt_metal.hpp`:

| Function | Header | Usages[^usages] | Example use site |
|---|---|---:|---|
| `SetRootDir` | `host_api.hpp` | 1 | `ttnn/cpp/ttnn-nanobind/device.cpp:356` |
| `GetNumAvailableDevices` | `host_api.hpp` | 4 | `tt-train/sources/examples/sample_app/main.cpp:53` |
| `GetNumPCIeDevices` | `host_api.hpp` | 1 | `ttnn/cpp/ttnn-nanobind/device.cpp:348` |
| `GetPCIeDeviceID` | `host_api.hpp` | 1 | `ttnn/cpp/ttnn-nanobind/device.cpp:352` |
| `CreateProgram` | `host_api.hpp` | 43 | `ttnn/core/services/h2d_socket_service.cpp:345` |
| `CreateKernel` | `host_api.hpp` | 102 | `ttnn/core/services/h2d_socket_service.cpp:372` |
| `CreateCircularBuffer` | `host_api.hpp` | 85 | `ttnn/core/services/h2d_socket_service.cpp:354` |
| `GetCircularBufferConfig` | `host_api.hpp` | 2 | `ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_program_factory.cpp:61` |
| `UpdateCircularBufferTotalSize` | `host_api.hpp` | 2 | `ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_program_factory.cpp:64` |
| `UpdateCircularBufferPageSize` | `host_api.hpp` | 2 | `ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_program_factory.cpp:70` |
| `UpdateDynamicCircularBufferAddress` | `host_api.hpp` | 38 | `ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp:2928` |
| `CreateSemaphore` | `host_api.hpp` | 43 | `ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp:1965` |
| `CreateGlobalSemaphore` | `host_api.hpp` | 2 | `ttnn/core/global_semaphore.cpp:94` |
| `CreateBuffer` | `host_api.hpp` | 1 | `tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp:356` |
| `SetRuntimeArgs` | `host_api.hpp` | 120 | `ttnn/core/services/h2d_socket_service.cpp:381` |
| `SetCommonRuntimeArgs` | `host_api.hpp` | 3 | `ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp:1152` |
| `GetRuntimeArgs` | `host_api.hpp` | 119 | `tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_program_factory.cpp:414` |
| `GetCommonRuntimeArgs` | `host_api.hpp` | 10 | `ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/moe_padding_config_device_operation.cpp:234` |
| `ReadMeshDeviceProfilerResults` | `host_api.hpp` | 2 | `tt-train/sources/ttml/core/tt_profiler.cpp:45` |
| `PushCurrentCommandQueueIdForThread` | `host_api.hpp` | 1 | `ttnn/core/core.cpp:44` |
| `PopCurrentCommandQueueIdForThread` | `host_api.hpp` | 1 | `ttnn/core/core.cpp:46` |
| `GetCurrentCommandQueueIdForThread` | `host_api.hpp` | 1 | `ttnn/core/core.cpp:42` |
| `detail::GetActiveDevice` | `tt_metal.hpp` | 1 | `ttnn/cpp/tools/profiler/op_profiler_json.cpp:52` |
| `detail::ReadShard` | `tt_metal.hpp` | 1 | `ttnn/core/tensor/tensor_impl.cpp:455` |
| `detail::EncodePerDeviceProgramID` | `tt_metal.hpp` | 2 | `ttnn/api/tools/profiler/op_profiler.hpp:184` |
| `detail::WriteToDeviceL1` | `tt_metal.hpp` | 3 | `ttnn/core/services/h2d_socket_service.cpp:576` |
| `detail::ReadFromDeviceL1` | `tt_metal.hpp` | 1 | `ttnn/core/services/d2h_socket_service.cpp:859` |
| `detail::get_platform_architecture_name` | `tt_metal.hpp` | 1 | `ttnn/cpp/ttnn-nanobind/device.cpp:637` |

[^usages]: Number of unique files referencing this symbol outside of `tt_metal`/ `tests`.
