### PR TITLE
[LLK][test] generalized_moe_gate: drop GATE from the bit-exact ND suite

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -1719,11 +1719,15 @@ class TestConfig:
             # expected to differ and comparing them would be meaningless.
             return "L1 accumulation makes every run add onto the previous result"
         if self.expected_nondeterministic:
-            # Negative controls that deliberately run with a corrupt HW config
-            # (e.g. a zeroed addrmod) leave DEST addressing undefined, so the
-            # result is not bit-reproducible by contract. The functional check
-            # (expect_mismatch) still validates the single run; only the
-            # bit-exact re-run comparison is meaningless here.
+            # Set for two kinds of variant whose packed buffer is not bit-reproducible
+            # by contract, though the single run the functional check validates is fine:
+            #   1. Negative controls that deliberately run with a corrupt HW config
+            #      (e.g. a zeroed addrmod), leaving DEST addressing undefined.
+            #   2. Ops that define only part of the packed tile and leave scratch in the
+            #      rest (e.g. generalized_moe_gate writes row 0 and leaves the bitonic
+            #      sort's leftovers in rows 1-15). That scratch tracks the DEST residue
+            #      the op starts from, so run 0 (cold) differs from the re-run fixed point
+            #      -- a defined-output vs packed-extent mismatch, not flaky hardware.
             return "variant intentionally exercises undefined hardware state"
         return None
 

--- a/tt_metal/tt-llk/tests/python_tests/test_generalized_moe_gate.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_generalized_moe_gate.py
@@ -240,6 +240,13 @@ def _config(
             num_faces=num_faces,
         ),
         dest_acc=DestAccumulation.No,
+        # GATE defines only row 0 of the SCORES/IDS tiles (the top-k the asserts read); the bitonic
+        # sort leaves its scratch in rows 1-15, which the packer ships but nothing validates. Those
+        # lanes are a deterministic function of the DEST residue the op starts from, so run 0 (cold,
+        # inheriting the previous test's residue) differs from every re-run (which sit at the gate's
+        # own fixed point) -- NOT hardware non-determinism, so opt the gate out of the bit-exact check.
+        # MOVE/RUN/BINARY build and check a full DEST image and stay in the suite.
+        expected_nondeterministic=(gmg.mode == MODE_GATE),
     )
 
 


### PR DESCRIPTION
## Problem
The scheduled **LLK bit-exact** job flags `test_generalized_moe_gate` GATE variants (`ties`, `sigmoid`, `grouped`, base) as non-deterministic — e.g. run [31292693999](https://github.com/tenstorrent/tt-metal/actions/runs/31292693999), `499/499 re-runs differed from run 0`, 6–142 of 8192 bytes.

## Root cause (not HW non-determinism)
Every re-run is byte-identical to every other; only run 0 differs, by the *same* stable bytes each time. All diverging bytes are in the **SCORES tile, face 0, rows ≥ 1** — never row 0, which is the op's real output (the top-k the asserts read, which is bit-stable → the functional asserts pass).

GATE defines only row 0; the bitonic sort + `finalize_ungrouped` leave scratch (incl. the op's own documented "junk" non-rank lanes) in rows 1–15. The packer ships the whole tile, so that scratch is compared. Its value is a deterministic function of the DEST residue the op starts from: run 0 inherits the previous test's residue, runs 1+ sit at the gate's own fixed point. A defined-output vs packed-extent mismatch, not flaky silicon.

## Change
Mark GATE configs `expected_nondeterministic` (the harness's existing opt-out). They stay **functional** tests; only the bit-exact re-run comparison is skipped. `MOVE/RUN/BINARY` build and check a full DEST image and stay in the ND suite. Also widened the `expected_nondeterministic` docstring to cover this second legitimate case.

Draft: opened to trigger the bit-exact workflow and confirm the GATE variants are now skipped.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/gmg-drop-from-nd-suite)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/gmg-drop-from-nd-suite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/gmg-drop-from-nd-suite)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/gmg-drop-from-nd-suite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/gmg-drop-from-nd-suite)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/gmg-drop-from-nd-suite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/gmg-drop-from-nd-suite)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/gmg-drop-from-nd-suite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/gmg-drop-from-nd-suite)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/gmg-drop-from-nd-suite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/gmg-drop-from-nd-suite)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/gmg-drop-from-nd-suite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/gmg-drop-from-nd-suite)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/gmg-drop-from-nd-suite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/gmg-drop-from-nd-suite)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/gmg-drop-from-nd-suite)