### PR TITLE
[Test Only] Skip Blackhole ring-joint SDPA matrix in CI

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_attention.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_attention.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import ttnn
 from loguru import logger
 import pytest
@@ -26,6 +28,7 @@ def skip_on_large_clusters():
         )
 
 
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Heavyweight ring-joint SDPA matrix is not run in CI")
 @bh_qb_ge_unit_test_params
 @pytest.mark.parametrize(
     "device_params, all_gather_topology",


### PR DESCRIPTION
### PR Category

Test Only

### Summary

The Blackhole QB/GE ring-joint SDPA matrix is a heavyweight nightly and development test. Its model-scale cases and host correctness references are not suitable for the routine CI job budget.

Mark the entire parameterized `test_ring_joint_sdpa_dit_bh_qb_ge` test skipped when `CI=true`. Non-CI runs continue to execute all five shapes with `skip_check=False`, preserving their existing PCC and MSE validation.

### Notes for reviewers

The skip applies only to this test function. Other tests in `test_ring_joint_attention.py` are unaffected.

This intentionally makes the CI exclusion explicit instead of silently downgrading the WAN 720p case to execution-only coverage.

Validation:

- Full changed-file pre-commit suite passed.
- [Blackhole QB2 SDPA nightly](https://github.com/tenstorrent/tt-metal/actions/runs/31312472419/job/93243228852) passed on commit `161c54f38fc`: 121 passed, 92 skipped. The log reports all five target parameters skipped by this marker.

### CI impact

Compared with four recent successful pre-change QB2 SDPA jobs, this removes approximately six minutes from each run:

| Measurement | Before skip | After skip | Savings |
|---|---:|---:|---:|
| Pytest median | 16m 38s | 10m 32s | **6m 05s (36.6%)** |
| Full job median | 19m 23s | 13m 10s | **6m 13s (32.1%)** |

Observed pytest savings across the baseline samples ranged from 4m 16s to 6m 55s. The post-change result is [job 93243228852](https://github.com/tenstorrent/tt-metal/actions/runs/31312472419/job/93243228852); the successful pre-change baselines are [93231908752](https://github.com/tenstorrent/tt-metal/actions/runs/31307862341/job/93231908752), [93234221260](https://github.com/tenstorrent/tt-metal/actions/runs/31308824899/job/93234221260), [93234984061](https://github.com/tenstorrent/tt-metal/actions/runs/31308826454/job/93234984061), and [93236516126](https://github.com/tenstorrent/tt-metal/actions/runs/31309749500/job/93236516126).

These figures cover the QB2 SDPA job and pytest phases; shared build and runner queue time are unchanged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/sdpa-720p-skip-check-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/sdpa-720p-skip-check-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/sdpa-720p-skip-check-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/sdpa-720p-skip-check-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/sdpa-720p-skip-check-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/sdpa-720p-skip-check-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sdpa-720p-skip-check-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/sdpa-720p-skip-check-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/sdpa-720p-skip-check-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/sdpa-720p-skip-check-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/sdpa-720p-skip-check-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/sdpa-720p-skip-check-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/sdpa-720p-skip-check-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/sdpa-720p-skip-check-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/sdpa-720p-skip-check-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/sdpa-720p-skip-check-ci)