### PR TITLE
#52660: create prototype copy of llama quasar ops tests

### DIFF
--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/README.md
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/README.md
@@ -1,0 +1,51 @@
+# Per-op tests (`tests/prototype_ops/`)
+
+Isolated tests for **every individual ttnn op** the model executes on the
+token-accuracy path
+(`tests/demos/llama32_1b/demo.py -k "token-accuracy"`).
+
+Based on `tests/ops/` for the purpose of testing out using experimental quasar ops
+before regular ops are fully ported.
+
+## Why
+
+The end-to-end demo is extremely slow on the Quasar emulator. These tests let you
+exercise a single op — with the exact shapes / dtypes / memory configs the model
+uses — in isolation, e.g.:
+
+```bash
+MESH_DEVICE=N150 pytest models/experimental/llama32_1b_quasar/tests/prototype_ops/test_linear.py -v
+```
+
+One file per op. Each file's docstring cites the model call site(s) (`file:line`)
+that the parametrizations are derived from.
+
+## Conventions
+
+- Shared dims/helpers live in `op_utils.py` (imported as `U`). Do not re-hardcode
+  Llama-3.2-1B dims — use `U.DIM`, `U.N_HEADS`, `U.HEAD_DIM`, etc.
+- `test_rms_norm.py` is the **canonical template**; new op files mirror it.
+- Tests use the `ttnn_mesh_device` fixture (from `tests/conftest.py`), parametrized
+  `indirect`; default `[(1, 1)]` for the emulator. Multi-device ops (all_gather,
+  reduce_scatter, …) parametrize `[(1, 2)]` and skip on a single device.
+- Correctness: `U.assert_pcc(torch_ref, tt_out)` where a torch reference exists;
+  otherwise `U.assert_shape_dtype(tt_out, shape=…, dtype=…)` (shape/dtype/finite).
+
+## Running on the 2-node emulator
+
+The emulator only fits small / batch-1 shapes. Select the emulator-appropriate
+subset with the `emulator` marker:
+
+```bash
+pytest models/experimental/llama32_1b_quasar/tests/prototype_ops/ -m emulator
+```
+
+Larger cases (batch-32, long prefill) and multi-device CCL / sampling ops are
+skipped there automatically (via the `emulator` marker, per-op skips, and the
+core-count gate in `op_utils.height_sharded_batch_memcfg`), so they run on N150 /
+multi-device but stay out of the emulator run.
+
+## Status
+
+Authored from static analysis of the model source; op signatures and sharded
+configs may need refinement on a first confirming run on hardware or the emulator.

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/conftest.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/conftest.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Local conftest for the per-op suite: tags emulator-appropriate cases.
+
+The 2-node Quasar emulator can only run small / batch-1, single-device shapes.
+This hook marks every op-test *case* that fits the emulator with the ``emulator``
+marker, so you can select the whole emulator subset with:
+
+    pytest models/experimental/llama32_1b_quasar/tests/ops/ -m emulator
+
+A case is classified from its **actual parametrized values** (not display-name
+substrings), so oversized cases without a size token in their id — e.g.
+``test_reshape[mlp_prefill_fold]`` (1024 rows) or ``test_minimal_matmul[512]`` —
+are correctly excluded. A case is NOT emulator-appropriate when any of:
+  * it targets a non-(1,1) mesh (multi-device CCL cases),
+  * a batch/user param > 1,
+  * a sequence/row param (seq, seq_len, m) > 128,
+  * a shape param whose leading (row) dims multiply to > 128.
+A leading-token denylist is also honored as a backstop.
+"""
+
+# Backstop id substrings that always mean "too large for the emulator".
+_LARGE_ID_TOKENS = ("batch32", "b32", "seq512", "seq1024", "seq500")
+# Parameter names whose scalar value is a row/sequence count.
+_ROW_PARAMS = ("seq", "seq_len", "m")
+# Parameter names holding a full tensor shape tuple.
+_SHAPE_PARAMS = ("shape", "in_shape", "out_shape")
+_EMU_MAX_ROWS = 128
+
+
+def _rows_of(shape) -> int:
+    """Product of all but the last (hidden) dim — the tile-row count that drives cores/L1."""
+    dims = [d for d in shape if isinstance(d, int)]
+    rows = 1
+    for d in dims[:-1]:
+        rows *= d
+    return rows
+
+
+def _fits_emulator(item) -> bool:
+    nid = item.nodeid.lower()
+    if any(tok in nid for tok in _LARGE_ID_TOKENS):
+        return False
+    callspec = getattr(item, "callspec", None)
+    if callspec is None:
+        return True
+    params = callspec.params
+    mesh = params.get("ttnn_mesh_device")
+    if mesh is not None and tuple(mesh) != (1, 1):
+        return False
+    for name, val in params.items():
+        if name == "batch" and isinstance(val, int) and val > 1:
+            return False
+        if name in _ROW_PARAMS and isinstance(val, int) and val > _EMU_MAX_ROWS:
+            return False
+        if name in _SHAPE_PARAMS and isinstance(val, (tuple, list)) and _rows_of(val) > _EMU_MAX_ROWS:
+            return False
+    return True
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "emulator: op-test case that fits the 2-node Quasar emulator (batch-1 / small / single-device)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    import pytest
+
+    for item in items:
+        if _fits_emulator(item):
+            item.add_marker(pytest.mark.emulator)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/op_utils.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/op_utils.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared helpers for the per-op test suite (``tests/ops/``).
+
+Goal
+----
+The end-to-end token-accuracy demo
+(``tests/demos/llama32_1b/demo.py -k token-accuracy``) is extremely slow on the
+Quasar emulator. These op-level tests isolate *each individual ttnn op* that the
+model executes, with the *exact shapes / dtypes / memory configs* the model uses,
+so a single op can be exercised on the emulator in isolation.
+
+Every op file should:
+  * import dims/helpers from here (do not re-hardcode Llama-3.2-1B dims),
+  * ground each parametrization in a real call site in the model source
+    (cite ``file:line`` in a comment),
+  * use the ``ttnn_mesh_device`` fixture (provided by ``tests/conftest.py``),
+    parametrized ``indirect`` — default ``[(1, 1)]`` for the emulator,
+  * compare against a torch reference with ``assert_pcc`` where a clear reference
+    exists; otherwise assert output shape / dtype / layout and finiteness with
+    ``assert_shape_dtype``.
+
+These tests deliberately keep no dependency on the full model build — they
+allocate fresh random tensors so each op runs in <1s of device time.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.auto_compose import to_torch_auto_compose
+from models.experimental.llama32_1b_quasar.utility_functions import comp_allclose, comp_pcc
+
+# =============================================================================
+# Llama-3.2-1B-Instruct architecture constants
+# (config.json: hidden 2048, 16 layers, 32 heads / 8 kv heads, head_dim 64,
+#  intermediate 8192, vocab 128256, rms_norm_eps 1e-5, rope_theta 5e5)
+# =============================================================================
+
+DIM = 2048  # hidden_size
+N_LAYERS = 16
+N_HEADS = 32
+N_KV_HEADS = 8
+HEAD_DIM = 64
+Q_DIM = N_HEADS * HEAD_DIM  # 2048
+KV_DIM = N_KV_HEADS * HEAD_DIM  # 512
+QKV_DIM = Q_DIM + 2 * KV_DIM  # 3072 (fused qkv projection width)
+INTERMEDIATE = 8192  # MLP hidden
+VOCAB = 128256
+NORM_EPS = 1e-5
+ROPE_THETA = 500000.0
+MAX_BATCH = 32  # decode users
+TILE = 32
+
+# Representative sequence lengths / batches the demo drives through the model.
+# Prefill chunks are tile-aligned; decode runs 1 token for `batch` users.
+PREFILL_SEQ_LENS = [128, 512, 1024]
+DECODE_BATCHES = [1, 32]
+
+# Default mesh for the emulator (single logical device). Multi-device shapes are
+# added per-op only where the model actually shards across devices.
+DEFAULT_MESH = (1, 1)
+
+
+def with_default_mesh(*shapes):
+    """Parametrize the ``ttnn_mesh_device`` fixture (indirect). Default: [(1, 1)]."""
+    return pytest.mark.parametrize("ttnn_mesh_device", list(shapes) or [DEFAULT_MESH], indirect=True)
+
+
+# =============================================================================
+# Tensor helpers
+# =============================================================================
+
+
+def torch_rand(shape, dtype=torch.bfloat16, mean=0.0, std=1.0):
+    """Reproducible random torch tensor. Seed is set per-test via reset_seeds."""
+    return (torch.randn(*shape) * std + mean).to(dtype)
+
+
+def to_tt(
+    torch_tensor: torch.Tensor,
+    mesh_device,
+    *,
+    dtype=ttnn.bfloat16,
+    layout=ttnn.TILE_LAYOUT,
+    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    mesh_mapper="replicate",
+    shard_dim=None,
+) -> ttnn.Tensor:
+    """torch -> ttnn on ``mesh_device`` with the given layout / memory config.
+
+    ``mesh_mapper``: ``"replicate"`` (default) replicates across the mesh;
+    an int shards along that torch dim; ``None`` uses no mapper (single device).
+    """
+    if mesh_mapper == "replicate":
+        mapper = ttnn.replicate_tensor_to_mesh_mapper(mesh_device)
+    elif isinstance(mesh_mapper, int):
+        mapper = ttnn.shard_tensor_to_mesh_mapper(mesh_device, dim=mesh_mapper)
+    elif shard_dim is not None:
+        mapper = ttnn.shard_tensor_to_mesh_mapper(mesh_device, dim=shard_dim)
+    else:
+        mapper = None
+    return ttnn.from_torch(
+        torch_tensor,
+        dtype=dtype,
+        layout=layout,
+        device=mesh_device,
+        memory_config=memory_config,
+        mesh_mapper=mapper,
+    )
+
+
+def from_tt(tt_tensor: ttnn.Tensor, mesh_device=None) -> torch.Tensor:
+    """ttnn -> torch (host), composing across the mesh. Returns float32."""
+    return to_torch_auto_compose(tt_tensor, mesh_device).float()
+
+
+# =============================================================================
+# Sharded memory-config helpers (decode batch-core grids)
+# =============================================================================
+
+
+def height_sharded_batch_memcfg(mesh_device, num_cores, shard_shape, *, start_core=None):
+    """HEIGHT_SHARDED L1 memory config over ``num_cores`` cores (one shard/core, row-major).
+
+    The decode attention ops (nlp_concat_heads_decode, paged_update_cache,
+    rotary_embedding_llama_fused_qk) require HEIGHT_SHARDED inputs laid out one
+    *user* per core over a batch-core grid. This mirrors the model's config
+    resolver — e.g. ``decode_scores_memcfg``
+    (modules/attention/attention_1d.py:1727-1734) — and the canonical op
+    reference tests/ttnn/nightly/.../test_rotary_embedding_llama.py:233-243.
+
+    Args:
+        num_cores: number of cores == number of users/batch (one shard per core).
+        shard_shape: ``(shard_height, shard_width)`` per-core shard.
+        start_core: optional ``ttnn.CoreCoord`` origin so a second tensor can be
+            placed on a NON-OVERLAPPING grid (fused-QK Q/K requirement). Cores are
+            laid out in rows of 8 (matches attention_1d.py:_num_to_corerange).
+
+    Emulator gating: one shard is placed per core, so a decode config with
+    ``batch`` users needs ``batch`` cores (fused Q/K needs ``2*batch``). If that
+    exceeds the device's compute grid — as ``batch=32`` does on the 2-node Quasar
+    emulator — the test is SKIPPED (not failed), so the batch=1 case still passes.
+    Larger devices (e.g. N150's 8x8 grid) run every batch.
+    """
+    core_grid = mesh_device.compute_with_storage_grid_size()
+    available = core_grid.x * core_grid.y
+    # rows of 8 mirror _num_to_corerange; start offset consumes leading cores.
+    start_idx = 0 if start_core is None else (start_core.y * 8 + start_core.x)
+    needed = start_idx + num_cores
+    if needed > available:
+        pytest.skip(
+            f"height-sharded op needs {needed} cores "
+            f"({num_cores} shards" + (f" at offset {start_idx}" if start_core else "") + f"); "
+            f"device has {available} — batch too large for this device (fits batch=1)"
+        )
+    if start_core is None:
+        grid = ttnn.num_cores_to_corerangeset(num_cores, core_grid, row_wise=True)
+    else:
+        grid = ttnn.CoreRangeSet({_num_to_corerange(num_cores, start_core)})
+    return ttnn.create_sharded_memory_config(
+        shape=tuple(shard_shape),
+        core_grid=grid,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+def _num_to_corerange(num_cores: int, start_core: "ttnn.CoreCoord | None" = None) -> "ttnn.CoreRange":
+    """Contiguous CoreRange of ``num_cores`` cores in rows of 8 from ``start_core``.
+
+    Copied from modules/attention/attention_1d.py:2234 (_num_to_corerange) so the
+    fused-QK test can place Q and K on adjacent non-overlapping grids exactly as
+    _reshard_k_for_fused does (attention_1d.py:1242-1243)."""
+    if start_core is None:
+        start_core = ttnn.CoreCoord(0, 0)
+    if num_cores == 1:
+        return ttnn.CoreRange(start_core, start_core)
+    row_size = 8
+    start_x, start_y = start_core.x, start_core.y
+    total = start_x + num_cores
+    end_y = start_y + (total - 1) // row_size
+    end_x = (total - 1) % row_size
+    return ttnn.CoreRange(start_core, ttnn.CoreCoord(end_x, end_y))
+
+
+# =============================================================================
+# Assertions
+# =============================================================================
+
+
+def assert_pcc(torch_ref: torch.Tensor, tt_out: ttnn.Tensor, *, pcc=0.99, mesh_device=None):
+    """Compare a ttnn output against a torch reference by PCC."""
+    got = from_tt(tt_out, mesh_device)
+    ref = torch_ref.float()
+    # Align on the reference's element count when the op pads to tiles.
+    if got.shape != ref.shape and got.numel() >= ref.numel():
+        got = got.reshape(-1)[: ref.numel()].reshape(ref.shape)
+    passing, msg = comp_pcc(ref, got, pcc)
+    _, all_msg = comp_allclose(ref, got)
+    assert passing, f"PCC below {pcc}: {msg} | {all_msg}"
+
+
+def assert_shape_dtype(tt_out: ttnn.Tensor, *, shape=None, dtype=None, finite=True, mesh_device=None):
+    """For ops without a simple torch reference: check shape/dtype and finiteness."""
+    if shape is not None:
+        assert tuple(tt_out.shape) == tuple(shape), f"expected shape {tuple(shape)}, got {tuple(tt_out.shape)}"
+    if dtype is not None:
+        assert tt_out.dtype == dtype, f"expected dtype {dtype}, got {tt_out.dtype}"
+    if finite:
+        host = from_tt(tt_out, mesh_device)
+        assert torch.isfinite(host).all(), "output contains non-finite values"

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_add.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_add.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.add``.
+
+Model call sites (models/llama32_1b/model.py):
+  * L130  decode_forward  — residual + attn_out, [1, 1, batch, DIM]
+  * L140  decode_forward  — residual + mlp_out,  [1, 1, batch, DIM]
+  * L169  prefill_forward — residual + attn_out, [1, 1, seq, DIM]
+  * L178  prefill_forward — residual + mlp_out,  [1, 1, seq, DIM]
+
+These are the elementwise residual adds. The model passes ``memory_config`` (and
+sometimes ``dtype``); the emulator-friendly interleaved-DRAM path is exercised
+here. Reference is torch ``a + b``.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "shape",
+    [pytest.param((1, 1, seq, U.DIM), id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS]
+    + [pytest.param((1, 1, batch, U.DIM), id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES],
+)
+def test_add(ttnn_mesh_device, reset_seeds, shape):
+    mesh = ttnn_mesh_device
+
+    a_torch = U.torch_rand(shape)
+    b_torch = U.torch_rand(shape)
+
+    a = U.to_tt(a_torch, mesh)
+    b = U.to_tt(b_torch, mesh)
+
+    out = ttnn.add(a, b)
+
+    ref = a_torch.float() + b_torch.float()
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_add.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_add.py
@@ -36,7 +36,7 @@ def test_add(ttnn_mesh_device, reset_seeds, shape):
     a = U.to_tt(a_torch, mesh)
     b = U.to_tt(b_torch, mesh)
 
-    out = ttnn.add(a, b)
+    out = ttnn.experimental.quasar.add(a, b)
 
     ref = a_torch.float() + b_torch.float()
     U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_add.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_add.py
@@ -18,7 +18,7 @@ here. Reference is torch ``a + b``.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 @U.with_default_mesh()

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_all_gather.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_all_gather.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.all_gather``  (MULTI-DEVICE).
+
+Model call site (modules/sampling/sampling_1d.py):
+  * L624  _perform_all_gather — ttnn.all_gather(tensor, dim=dim, num_links=num_links,
+              memory_config=..., cluster_axis=cluster_axis, topology=ttnn.Topology.Linear)
+
+This is the non-async all-gather used to reconstruct the full vocab from
+per-device top-k shards. The isolation reproducer
+(tests/modules/sampling/test_sampling_1d.py:test_topk_allgather_isolation, L1029)
+uses dim=3 and cluster_axis = None if 1 in cluster_shape else 0.
+
+Here we shard a tensor along the last dim across the mesh and all-gather it back;
+the gathered tensor should span the full (num_devices * shard) width. We assert
+shape/dtype (the emulator default mesh (1,1) is skipped — this op only runs
+multi-device).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# CCL collective — needs a multi-device mesh. The (1, 2) parametrization below is
+# skipped automatically by the ttnn_mesh_device fixture on single-device systems
+# (N150 / 2-node emulator present as one device), so it stays out of the emulator run
+# while still exercising the op on real multi-device systems (N300 / T3K).
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 2)], indirect=True)
+def test_all_gather(ttnn_mesh_device, reset_seeds):
+    mesh = ttnn_mesh_device
+    if tuple(mesh.shape) == (1, 1):
+        pytest.skip("multi-device op")
+
+    cluster_shape = tuple(mesh.shape)
+    num_devices = max(cluster_shape)
+    cluster_axis = None if 1 in cluster_shape else 0
+
+    # Full tensor sharded along the last dim across devices (each device holds DIM/num_devices).
+    shape = (1, 1, U.MAX_BATCH, U.DIM)
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh, mesh_mapper=3)  # shard along torch dim 3
+
+    gathered = ttnn.all_gather(
+        x,
+        dim=3,
+        num_links=1,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        cluster_axis=cluster_axis,
+        topology=ttnn.Topology.Linear,
+    )
+
+    # After gather each device holds the full width again.
+    assert (
+        gathered.shape[-1] == (U.DIM // num_devices) * num_devices
+    ), f"gathered width {gathered.shape[-1]} != full {U.DIM}"
+    U.assert_shape_dtype(gathered, dtype=ttnn.bfloat16, finite=False)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_all_gather.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_all_gather.py
@@ -22,7 +22,7 @@ multi-device).
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # CCL collective — needs a multi-device mesh. The (1, 2) parametrization below is
 # skipped automatically by the ttnn_mesh_device fixture on single-device systems
@@ -37,7 +37,6 @@ def test_all_gather(ttnn_mesh_device, reset_seeds):
         pytest.skip("multi-device op")
 
     cluster_shape = tuple(mesh.shape)
-    num_devices = max(cluster_shape)
     cluster_axis = None if 1 in cluster_shape else 0
 
     # Full tensor sharded along the last dim across devices (each device holds DIM/num_devices).
@@ -54,8 +53,7 @@ def test_all_gather(ttnn_mesh_device, reset_seeds):
         topology=ttnn.Topology.Linear,
     )
 
-    # After gather each device holds the full width again.
-    assert (
-        gathered.shape[-1] == (U.DIM // num_devices) * num_devices
-    ), f"gathered width {gathered.shape[-1]} != full {U.DIM}"
-    U.assert_shape_dtype(gathered, dtype=ttnn.bfloat16, finite=False)
+    # After gather each device holds the full width again -> the gathered result is the original
+    # (pre-shard) tensor (auto_compose returns a single replica), so x_torch is the direct reference.
+    assert gathered.shape[-1] == U.DIM, f"gathered width {gathered.shape[-1]} != full {U.DIM}"
+    U.assert_pcc(x_torch, gathered, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_all_gather_async.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_all_gather_async.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.all_gather_async``  (MULTI-DEVICE).
+
+Model call sites:
+  * models/llama32_1b/model.py:227  _all_gather_rmsnorm_tensor
+  * models/llama32_1b/model.py:975  gather_and_untilize_logits
+  * modules/attention/attention_1d.py:925  _all_gather_before_wo_prefill_fused
+  * modules/sampling/sampling_1d.py:319/333  _argmax_all_gather
+
+Kwarg structure copied from _all_gather_rmsnorm_tensor (model.py:227):
+    persistent_output_buffer=None, dim=3, multi_device_global_semaphore=<handle>,
+    num_links=1, topology=..., memory_config=..., barrier_semaphore=<handle>,
+    chunks_per_sync=24, num_workers_per_link=4, num_buffers_per_channel=2.
+
+In the model the semaphore handles come from a TT-CCL manager
+(tt_ccl.get_and_cycle_ag_semaphore_handles / _barrier_semaphore_handle). Here we
+create them directly via ttnn.create_global_semaphore over the worker sub-device,
+mirroring the CCL unit tests. We assert shape/dtype of the gathered output.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# CCL collective — needs a multi-device mesh. The (1, 2) parametrization below is
+# skipped automatically by the ttnn_mesh_device fixture on single-device systems
+# (N150 / 2-node emulator present as one device), so it stays out of the emulator run
+# while still exercising the op on real multi-device systems (N300 / T3K).
+
+
+def _worker_crs(mesh):
+    grid = mesh.compute_with_storage_grid_size()
+    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 2)], indirect=True)
+def test_all_gather_async(ttnn_mesh_device, reset_seeds):
+    mesh = ttnn_mesh_device
+    if tuple(mesh.shape) == (1, 1):
+        pytest.skip("multi-device op")
+
+    num_devices = max(tuple(mesh.shape))
+
+    shape = (1, 1, U.MAX_BATCH, U.DIM)
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh, mesh_mapper=3)  # shard last dim across devices
+
+    crs = _worker_crs(mesh)
+    ag_semaphore = ttnn.create_global_semaphore(mesh, crs, 0)
+    barrier_semaphore = ttnn.create_global_semaphore(mesh, crs, 0)
+
+    gathered = ttnn.experimental.all_gather_async(
+        x,
+        persistent_output_buffer=None,
+        dim=3,
+        multi_device_global_semaphore=ag_semaphore,
+        num_links=1,
+        topology=ttnn.Topology.Linear,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        barrier_semaphore=barrier_semaphore,
+        chunks_per_sync=24,
+        num_workers_per_link=4,
+        num_buffers_per_channel=2,
+    )
+
+    assert gathered.shape[-1] == (U.DIM // num_devices) * num_devices
+    U.assert_shape_dtype(gathered, dtype=ttnn.bfloat16, finite=False)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_all_gather_async.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_all_gather_async.py
@@ -24,7 +24,7 @@ mirroring the CCL unit tests. We assert shape/dtype of the gathered output.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # CCL collective — needs a multi-device mesh. The (1, 2) parametrization below is
 # skipped automatically by the ttnn_mesh_device fixture on single-device systems
@@ -42,8 +42,6 @@ def test_all_gather_async(ttnn_mesh_device, reset_seeds):
     mesh = ttnn_mesh_device
     if tuple(mesh.shape) == (1, 1):
         pytest.skip("multi-device op")
-
-    num_devices = max(tuple(mesh.shape))
 
     shape = (1, 1, U.MAX_BATCH, U.DIM)
     x_torch = U.torch_rand(shape)
@@ -67,5 +65,6 @@ def test_all_gather_async(ttnn_mesh_device, reset_seeds):
         num_buffers_per_channel=2,
     )
 
-    assert gathered.shape[-1] == (U.DIM // num_devices) * num_devices
-    U.assert_shape_dtype(gathered, dtype=ttnn.bfloat16, finite=False)
+    # Gathered result is the original (pre-shard) tensor; auto_compose returns one replica.
+    assert gathered.shape[-1] == U.DIM, f"gathered width {gathered.shape[-1]} != full {U.DIM}"
+    U.assert_pcc(x_torch, gathered, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_all_gather_matmul_async.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_all_gather_matmul_async.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.all_gather_matmul_async``  (MULTI-DEVICE).
+
+Model call site (modules/attention/attention_1d.py):
+  * L1188  _fused_all_gather_wo_decode — Ring-topology fused all-gather + WO matmul in
+           the decode path. All-gathers the concatenated attention heads along dim=3,
+           then matmuls with the WO weight [Q_DIM, DIM].
+
+This op only makes sense on a multi-device mesh (it gathers a width-sharded tensor
+across devices before the matmul), so it is parametrized on a (1, 2) mesh and skips
+on the single-device emulator. Semaphores/kwargs are taken from the call site via the
+shared TT_CCL helper. A full torch reference is impractical (CCL + sharded matmul), so
+we assert output shape / dtype only.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.modules.tt_ccl import (
+    CCL_CHUNKS_PER_SYNC,
+    CCL_NUM_BUFFERS_PER_CHANNEL,
+    CCL_NUM_WORKERS_PER_LINK,
+    get_tt_ccl,
+)
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# CCL + matmul fused op — needs a multi-device mesh. The (1, 2) parametrization below
+# is skipped automatically by the ttnn_mesh_device fixture on single-device systems
+# (N150 / 2-node emulator present as one device), so it stays out of the emulator run
+# while still exercising the op on real multi-device systems (N300 / T3K).
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 2)], indirect=True)
+@pytest.mark.parametrize("batch", U.DECODE_BATCHES)
+def test_all_gather_matmul_async(ttnn_mesh_device, reset_seeds, batch):
+    mesh = ttnn_mesh_device
+    if tuple(mesh.shape) == (1, 1):
+        pytest.skip("multi-device op")
+
+    num_devices = mesh.get_num_devices()
+
+    # attn_output_cat: concatenated heads, width-sharded across devices on the last dim.
+    m = U.TILE * ((batch + U.TILE - 1) // U.TILE)  # tile-padded decode rows
+    x_torch = U.torch_rand((1, 1, m, U.Q_DIM))
+    # WO weight [Q_DIM, DIM], column-sharded across the mesh (dim=-1), matching the model.
+    w_torch = U.torch_rand((U.Q_DIM, U.DIM))
+
+    # Input is sharded on the gather dim (last), weight sharded on its output dim.
+    x = U.to_tt(x_torch, mesh, mesh_mapper=3)
+    w = U.to_tt(w_torch, mesh, mesh_mapper=-1)
+
+    tt_ccl = get_tt_ccl(mesh)
+
+    # Kwarg structure copied from attention_1d.py:1188.
+    _, dense_out = ttnn.experimental.all_gather_matmul_async(
+        x,
+        w,
+        persistent_output_buffer=None,
+        dim=3,
+        multi_device_global_semaphore=tt_ccl.get_and_cycle_ag_semaphore_handles(),
+        all_gather_core_grid_offset=(0, 4),
+        barrier_semaphore=tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+        num_links=1,
+        memory_config_ag=ttnn.DRAM_MEMORY_CONFIG,
+        memory_config_mm=ttnn.DRAM_MEMORY_CONFIG,
+        chunks_per_sync=CCL_CHUNKS_PER_SYNC,
+        num_workers_per_link=CCL_NUM_WORKERS_PER_LINK,
+        num_buffers_per_channel=CCL_NUM_BUFFERS_PER_CHANNEL,
+    )
+
+    # After all-gather over dim=3 (K = Q_DIM full) and matmul with WO, output width = DIM.
+    U.assert_shape_dtype(dense_out, shape=(1, 1, m, U.DIM), mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_all_gather_matmul_async.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_all_gather_matmul_async.py
@@ -25,7 +25,7 @@ from models.experimental.llama32_1b_quasar.modules.tt_ccl import (
     CCL_NUM_WORKERS_PER_LINK,
     get_tt_ccl,
 )
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # CCL + matmul fused op — needs a multi-device mesh. The (1, 2) parametrization below
 # is skipped automatically by the ttnn_mesh_device fixture on single-device systems
@@ -71,5 +71,8 @@ def test_all_gather_matmul_async(ttnn_mesh_device, reset_seeds, batch):
         num_buffers_per_channel=CCL_NUM_BUFFERS_PER_CHANNEL,
     )
 
-    # After all-gather over dim=3 (K = Q_DIM full) and matmul with WO, output width = DIM.
+    # After all-gather over dim=3 (K = Q_DIM full) and matmul with the column-sharded WO, each device
+    # produces its output-column slice; auto_compose concatenates them back to full [1,1,m,DIM] = x @ WO.
+    ref = x_torch.float() @ w_torch.float()
     U.assert_shape_dtype(dense_out, shape=(1, 1, m, U.DIM), mesh_device=mesh)
+    U.assert_pcc(ref, dense_out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_argmax.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_argmax.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.argmax``.
+
+Model call site (modules/sampling/sampling_1d.py):
+  * L284  _sample_argmax — ttnn.argmax(x_untilized, dim=-1, output_tensor=..., keepdim=False)
+          where ``x_untilized = ttnn.untilize(logits, use_multicore=True)`` (L283).
+
+The force-argmax decode path picks the max-logit token id per row. Input is the
+untilized (ROW_MAJOR) logits tensor [1, 1, batch, VOCAB]. Reference is
+torch.argmax(dim=-1); we assert an exact integer index match (mirrors the
+known-good module test test_sampling_1d.py:test_force_argmax).
+
+Note on width: exact argmax over the full VOCAB (128256) in bfloat16 is
+tie-dominated, so this op-level test uses a moderate width for a deterministic
+reference (the sampler module test uses vocab_size=1024 for the same reason).
+The full-VOCAB argmax path is exercised end-to-end in the sampling module tests.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("width", [pytest.param(w, id=f"w{w}") for w in (1024, 2048)])
+@pytest.mark.parametrize("batch", [pytest.param(b, id=f"b{b}") for b in U.DECODE_BATCHES])
+def test_argmax(ttnn_mesh_device, reset_seeds, batch, width):
+    mesh = ttnn_mesh_device
+    shape = (1, 1, batch, width)
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)
+
+    # Mirror the model: untilize before argmax (sampling_1d.py:283-289).
+    x_untilized = ttnn.untilize(x, use_multicore=True)
+    out = ttnn.argmax(x_untilized, dim=-1, keepdim=False)
+
+    # ttnn.argmax -> uint32, torch.argmax -> int64; normalize before compare.
+    got = U.from_tt(out, mesh).flatten()[:batch].long()
+    ref = x_torch.float().argmax(dim=-1).flatten()[:batch].long()
+
+    assert torch.equal(got, ref), f"argmax mismatch:\n  got: {got[:8]}\n  ref: {ref[:8]}"

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_argmax.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_argmax.py
@@ -37,7 +37,7 @@ def test_argmax(ttnn_mesh_device, reset_seeds, batch, width):
     x = U.to_tt(x_torch, mesh)
 
     # Mirror the model: untilize before argmax (sampling_1d.py:283-289).
-    x_untilized = ttnn.untilize(x, use_multicore=True)
+    x_untilized = ttnn.experimental.quasar.untilize(x, use_multicore=True)
     out = ttnn.argmax(x_untilized, dim=-1, keepdim=False)
 
     # ttnn.argmax -> uint32, torch.argmax -> int64; normalize before compare.

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_argmax.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_argmax.py
@@ -23,7 +23,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 @U.with_default_mesh()

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_chunked_scaled_dot_product_attention.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_chunked_scaled_dot_product_attention.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.transformer.chunked_scaled_dot_product_attention``  (chunked/paged prefill SDPA).
+
+Model call site (modules/attention/attention_1d.py:553-561, prefill_forward, chunked path):
+    attn_output = ttnn.transformer.chunked_scaled_dot_product_attention(
+        input_tensor_q=q_heads_sdpa,      # [B, n_heads, chunk_len, head_dim]
+        input_tensor_k=keys,              # paged cache [num_blocks, n_kv_heads, block, head_dim]
+        input_tensor_v=values,            # paged cache [num_blocks, n_kv_heads, block, head_dim]
+        page_table_tensor=page_table,     # int32 [B, blocks_per_seq]
+        chunk_start_idx=chunk_start_idx,  # int: absolute offset of this Q chunk
+        compute_kernel_config=cfg.sdpa_prefill_compute_kernel_cfg,
+        program_config=cfg.prefill_sdpa_prg_config(seq_len, chunk_start_idx),
+    )
+
+This test runs a single chunk covering the whole sequence (chunk_start_idx=0), so
+the result equals a plain causal prefill SDPA over the (unshuffled) KV cache.
+GQA: 32 query heads, 8 kv heads (head_dim 64).
+Known-good paging + direct-call pattern mirrored from
+tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_chunked.py:28-236.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+BATCH = 1  # chunked prefill is single-user (batched prefill uses the non-chunked path)
+PAGE_BLOCK_SIZE = 128
+
+
+def _page_cache(cache, b, nkv, blocks_per_seq, block_size, d, permutation):
+    paged = (
+        cache.reshape(b, nkv, blocks_per_seq, block_size, d)
+        .transpose(1, 2)
+        .reshape(b * blocks_per_seq, nkv, block_size, d)
+    )
+    return paged[permutation]
+
+
+def _torch_sdpa_causal(q, k, v, scale):
+    n_rep = q.shape[1] // k.shape[1]
+    k_rep = k.repeat_interleave(n_rep, dim=1).float()
+    v_rep = v.repeat_interleave(n_rep, dim=1).float()
+    return torch.nn.functional.scaled_dot_product_attention(q.float(), k_rep, v_rep, is_causal=True, scale=scale)
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("seq", U.PREFILL_SEQ_LENS, ids=[f"seq{s}" for s in U.PREFILL_SEQ_LENS])
+def test_chunked_scaled_dot_product_attention(ttnn_mesh_device, reset_seeds, seq):
+    mesh = ttnn_mesh_device
+    scale = U.HEAD_DIM**-0.5
+
+    blocks_per_seq = seq // PAGE_BLOCK_SIZE
+    num_blocks = BATCH * blocks_per_seq
+
+    q_torch = U.torch_rand((BATCH, U.N_HEADS, seq, U.HEAD_DIM))
+    k_torch = U.torch_rand((BATCH, U.N_KV_HEADS, seq, U.HEAD_DIM))
+    v_torch = U.torch_rand((BATCH, U.N_KV_HEADS, seq, U.HEAD_DIM))
+
+    permutation = torch.randperm(num_blocks)
+    reverse_permutation = torch.argsort(permutation)
+    page_table = reverse_permutation.reshape(BATCH, blocks_per_seq)
+    paged_k = _page_cache(k_torch, BATCH, U.N_KV_HEADS, blocks_per_seq, PAGE_BLOCK_SIZE, U.HEAD_DIM, permutation)
+    paged_v = _page_cache(v_torch, BATCH, U.N_KV_HEADS, blocks_per_seq, PAGE_BLOCK_SIZE, U.HEAD_DIM, permutation)
+
+    q = U.to_tt(q_torch, mesh)
+    k = U.to_tt(paged_k, mesh)
+    v = U.to_tt(paged_v, mesh)
+    page_table_tt = U.to_tt(page_table.to(torch.int32), mesh, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=mesh.compute_with_storage_grid_size(),
+        q_chunk_size=128,
+        k_chunk_size=128,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+
+    # One chunk covering the whole sequence: chunk_start_idx=0.
+    out = ttnn.transformer.chunked_scaled_dot_product_attention(
+        input_tensor_q=q,
+        input_tensor_k=k,
+        input_tensor_v=v,
+        page_table_tensor=page_table_tt,
+        chunk_start_idx=0,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+    )
+
+    ref = _torch_sdpa_causal(q_torch, k_torch, v_torch, scale)  # [B, n_heads, seq, head_dim]
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_chunked_scaled_dot_product_attention.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_chunked_scaled_dot_product_attention.py
@@ -26,7 +26,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 BATCH = 1  # chunked prefill is single-user (batched prefill uses the non-chunked path)
 PAGE_BLOCK_SIZE = 128

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_concat.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_concat.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.concat``.
+
+Model call site (modules/lm_head/lm_head_1d.py):
+  * L154  output = ttnn.concat(outputs, dim=-1, memory_config=cfg.output_memcfg)
+
+The LM head splits the vocab projection into several column chunks, runs a matmul
+per chunk, then concatenates the chunk outputs back along the last dim to form the
+full logits [1, 1, batch, VOCAB]. Value-preserving -> torch reference is
+``torch.cat(dim=-1)``; PCC 0.999.
+
+Chunk sizes here mirror the lm_head split structure (a few unequal tail chunks
+along dim -1); the real VOCAB (128256) is split into ~num-device-sized columns.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# (id, batch, chunk_widths) — concat is along dim=-1.
+_CONCAT_SITES = [
+    ("two_equal", 32, (1024, 1024)),
+    ("four_chunks", 32, (512, 512, 512, 512)),
+    ("uneven_tail", 32, (1024, 1024, 512)),  # last chunk smaller, as in split_sizes tail
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, batch, chunk_widths",
+    [pytest.param(*s, id=s[0]) for s in _CONCAT_SITES],
+)
+def test_concat(ttnn_mesh_device, reset_seeds, name, batch, chunk_widths):
+    mesh = ttnn_mesh_device
+
+    parts_torch = [U.torch_rand((1, 1, batch, w)) for w in chunk_widths]
+    parts_tt = [U.to_tt(p, mesh) for p in parts_torch]
+
+    out = ttnn.concat(parts_tt, dim=-1)
+
+    ref = torch.cat([p.float() for p in parts_torch], dim=-1)
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_concat.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_concat.py
@@ -20,7 +20,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # (id, batch, chunk_widths) — concat is along dim=-1.
 _CONCAT_SITES = [

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_create_sharded_memory_config.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_create_sharded_memory_config.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.create_sharded_memory_config`` (host-side config builder).
+
+Model call sites (all build the sharded MemoryConfigs the model runs with):
+  * modules/rmsnorm/rmsnorm_1d.py:502   decode_memory_config   — WIDTH shard (tile_padded_batch_rows, dim//num_cores)
+  * modules/attention/attention_1d.py:1704  decode_residual_memcfg — WIDTH shard (tile_padded_batch_rows, dim//num_cores)
+  * modules/mlp/mlp_1d.py:880 / :917    decode_input_memcfg / decode_residual_memcfg — WIDTH shard
+  * models/llama32_1b/model.py:589      lm_input_memcfg        — WIDTH shard
+  * modules/lm_head/lm_head_1d.py:263   input_memcfg           — WIDTH shard
+  * modules/rope/rope_1d.py:387         cos_sin_shard_mem_config — HEIGHT shard (TILE, head_dim)
+  * modules/rope/rope_1d.py:378         decode_trans_mat_mem_config — HEIGHT shard (TILE, TILE)
+
+``create_sharded_memory_config`` runs entirely on host (no device compute); it
+returns a ``MemoryConfig``. This test asserts the returned config is sharded with
+the expected layout, then round-trips a tensor into it via ``to_memory_config``
+(interleaved DRAM -> this sharded config -> host) and checks the values survive.
+
+NOTE: the model derives the core grid from ``dim`` at runtime (``_dram_shard_core_grid``,
+``_compute_norm_core_grid``). To keep these emulator tests self-contained they use a
+single-core grid, which makes the passed shape the exact per-core shard shape.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# Single-core grid: with use_height_and_width_as_shard_shape=True the passed
+# shape IS the per-core shard shape, so a (1,1,H,W) tensor maps exactly.
+_GRID = ttnn.CoreGrid(y=1, x=1)
+
+# (id, shape, strategy, expected_layout)
+_CONFIGS = [
+    # WIDTH-sharded residual / rmsnorm / mlp / lm_head activations: (32, dim)
+    pytest.param(
+        (U.TILE, U.DIM),
+        ttnn.ShardStrategy.WIDTH,
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        id="width-residual-32x2048",  # rmsnorm_1d.py:502, attention_1d.py:1704, mlp_1d.py:917, model.py:589
+    ),
+    # WIDTH-sharded MLP2 input: (32, intermediate-ish); use DIM-family width here.
+    pytest.param(
+        (U.TILE, U.KV_DIM),
+        ttnn.ShardStrategy.WIDTH,
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        id="width-512",  # mlp_1d.py:907 style width shard
+    ),
+    # HEIGHT-sharded rope cos/sin: (TILE, head_dim)
+    pytest.param(
+        (U.TILE, U.HEAD_DIM),
+        ttnn.ShardStrategy.HEIGHT,
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        id="height-cos-sin-32x64",  # rope_1d.py:387
+    ),
+    # HEIGHT-sharded rope transform matrix: (TILE, TILE)
+    pytest.param(
+        (U.TILE, U.TILE),
+        ttnn.ShardStrategy.HEIGHT,
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        id="height-trans-mat-32x32",  # rope_1d.py:378
+    ),
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape, strategy, expected_layout", _CONFIGS)
+def test_create_sharded_memory_config(ttnn_mesh_device, reset_seeds, shape, strategy, expected_layout):
+    mesh = ttnn_mesh_device
+
+    memcfg = ttnn.create_sharded_memory_config(
+        shape,
+        _GRID,
+        strategy,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    # Host assertions: it built a valid *sharded* config with the expected layout.
+    assert memcfg.is_sharded(), f"expected a sharded MemoryConfig, got {memcfg}"
+    assert memcfg.memory_layout == expected_layout, f"expected {expected_layout}, got {memcfg.memory_layout}"
+
+    # Round-trip: a tensor can be moved into this config and read back unchanged.
+    h, w = shape
+    x_torch = U.torch_rand((1, 1, h, w))
+    x = U.to_tt(x_torch, mesh)  # interleaved DRAM
+    x_sharded = ttnn.to_memory_config(x, memcfg)
+    U.assert_pcc(x_torch, x_sharded, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_create_sharded_memory_config.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_create_sharded_memory_config.py
@@ -86,5 +86,5 @@ def test_create_sharded_memory_config(ttnn_mesh_device, reset_seeds, shape, stra
     h, w = shape
     x_torch = U.torch_rand((1, 1, h, w))
     x = U.to_tt(x_torch, mesh)  # interleaved DRAM
-    x_sharded = ttnn.to_memory_config(x, memcfg)
+    x_sharded = ttnn.experimental.quasar.to_memory_config(x, memcfg)
     U.assert_pcc(x_torch, x_sharded, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_create_sharded_memory_config.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_create_sharded_memory_config.py
@@ -26,7 +26,7 @@ single-core grid, which makes the passed shape the exact per-core shard shape.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # Single-core grid: with use_height_and_width_as_shard_shape=True the passed
 # shape IS the per-core shard shape, so a (1,1,H,W) tensor maps exactly.

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_embedding.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_embedding.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.embedding`` — two distinct call families the model drives.
+
+Call site 1 — token embedding lookup:
+  modules/embedding/embedding_1d.py:139-144  (Embedding1D.forward)
+    out = ttnn.embedding(x, self.weights, layout=ttnn.TILE_LAYOUT,
+                         memory_config=self.config.output_memcfg)
+  * input ids: uint32, ROW_MAJOR, shape [1, 1, 1, seq] (model) — here [1, seq]
+  * weight:    bf16, ROW_MAJOR, table [VOCAB, DIM] (model stores [1, 1, VOCAB, DIM])
+  * output:    [1, seq, DIM] in TILE_LAYOUT
+  Reference: torch weight[ids].
+
+Call site 2 — RoPE cos/sin table lookup (decode):
+  modules/rope/rope_1d.py:172-173  (RotarySetup1D.decode_forward)
+    cos = ttnn.embedding(rot_idxs, self.cos_matrix, layout=ttnn.TILE_LAYOUT)
+    sin = ttnn.embedding(rot_idxs, self.sin_matrix, layout=ttnn.TILE_LAYOUT)
+  * rot_idxs:   uint32, ROW_MAJOR, shape [1, batch] (padded to nearest 32,
+                see rope_1d.py:489-490 prepare_rot_idxs)
+  * cos_matrix: bf16, TILE_LAYOUT, table [1, 1, max_seq_len, head_dim]
+  * output:     [1, batch, head_dim]
+  Reference: torch table[rot_idxs].
+
+Both compare to a torch gather reference via PCC.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+# =============================================================================
+# Call family 1: token embedding
+# =============================================================================
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("seq", U.PREFILL_SEQ_LENS, ids=lambda s: f"seq{s}")
+def test_embedding_token(ttnn_mesh_device, reset_seeds, seq):
+    mesh = ttnn_mesh_device
+    vocab, dim = U.VOCAB, U.DIM
+
+    weight_torch = U.torch_rand((vocab, dim))
+    ids_torch = torch.randint(0, vocab, (1, seq), dtype=torch.int32)
+
+    # weight: [1, 1, VOCAB, DIM] ROW_MAJOR bf16 (embedding_1d.py resolves ROW_MAJOR).
+    w = U.to_tt(weight_torch.reshape(1, 1, vocab, dim), mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+    # ids: [1, 1, 1, seq] uint32 ROW_MAJOR (embedding_1d.py forward docstring).
+    ids = U.to_tt(ids_torch.reshape(1, 1, 1, seq), mesh, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    out = ttnn.embedding(ids, w, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    ref = weight_torch[ids_torch[0].long()]  # [seq, DIM]
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)
+
+
+# =============================================================================
+# Call family 2: RoPE cos/sin table lookup
+# =============================================================================
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("batch", U.DECODE_BATCHES, ids=lambda b: f"batch{b}")
+def test_embedding_rope_lookup(ttnn_mesh_device, reset_seeds, batch):
+    mesh = ttnn_mesh_device
+    head_dim = U.HEAD_DIM
+    max_seq_len = 128  # small tile-aligned RoPE table for the emulator
+
+    table_torch = U.torch_rand((max_seq_len, head_dim))  # cos/sin table [max_seq, head_dim]
+
+    # rot_idxs are padded to the nearest tile boundary (rope_1d.py:489-490).
+    pad = (-batch) % U.TILE
+    ids_torch = torch.randint(0, max_seq_len, (1, batch), dtype=torch.int32)
+    ids_torch = torch.nn.functional.pad(ids_torch, (0, pad), "constant", 0)  # [1, nearest_32(batch)]
+
+    # cos_matrix: [1, 1, max_seq_len, head_dim] TILE_LAYOUT bf16 (rope_1d.py:397-404).
+    cos = U.to_tt(table_torch.reshape(1, 1, max_seq_len, head_dim), mesh, layout=ttnn.TILE_LAYOUT)
+    # rot_idxs: [1, nearest_32(batch)] uint32 ROW_MAJOR (prepare_rot_idxs).
+    ids = U.to_tt(ids_torch, mesh, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    out = ttnn.embedding(ids, cos, layout=ttnn.TILE_LAYOUT)
+
+    ref = table_torch[ids_torch[0].long()]  # [nearest_32(batch), head_dim]
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_embedding.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_embedding.py
@@ -30,7 +30,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 # =============================================================================

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_fill_cache.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_fill_cache.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.fill_cache``.
+
+Model call site (modules/attention/attention_1d.py):
+  * L883/884  _kv_fill_prefill_non_paged  — ttnn.fill_cache(keys, k_fill, user_id % max_batch)
+  * L915/916  _kv_fill_prefill_batched    — ttnn.fill_cache(keys, k_fill[slot:slot+1], slot % max_batch)
+
+``fill_cache(cache, input, batch_idx)`` writes ``input`` into row ``batch_idx``
+of the KV cache. Signature/shapes mirror the tt_eager unit test
+(tests/tt_eager/.../test_update_cache.py:test_fill_cache):
+    cache:  [max_batch, n_kv_heads, max_seq, head_dim]
+    input:  [1,         n_kv_heads, seq,     head_dim]
+For Llama-3.2-1B: n_kv_heads=8 (KV_DIM/HEAD_DIM), head_dim=64, max_batch=32.
+
+We fill one user slot and assert the written region of the cache equals the
+input (PCC 0.999 on the slice).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("seq", [pytest.param(s, id=f"seq{s}") for s in (128, 512)])
+@pytest.mark.parametrize("batch_idx", [pytest.param(i, id=f"user{i}") for i in (0, 5)])
+def test_fill_cache(ttnn_mesh_device, reset_seeds, seq, batch_idx):
+    mesh = ttnn_mesh_device
+    max_seq = 1024
+
+    cache_shape = (U.MAX_BATCH, U.N_KV_HEADS, max_seq, U.HEAD_DIM)
+    fill_shape = (1, U.N_KV_HEADS, seq, U.HEAD_DIM)
+
+    cache_torch = U.torch_rand(cache_shape)
+    fill_torch = U.torch_rand(fill_shape)
+
+    cache = U.to_tt(cache_torch, mesh)
+    fill = U.to_tt(fill_torch, mesh)
+
+    ttnn.fill_cache(cache, fill, batch_idx)
+
+    # Reference: the cache with row batch_idx's first `seq` positions overwritten by fill.
+    # PCC over the whole cache checks both the written region and the untouched rows.
+    ref_cache = cache_torch.float().clone()
+    ref_cache[batch_idx : batch_idx + 1, :, :seq, :] = fill_torch.float()
+    U.assert_pcc(ref_cache, cache, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_fill_cache.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_fill_cache.py
@@ -22,7 +22,7 @@ input (PCC 0.999 on the slice).
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 @U.with_default_mesh()

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_interleaved_to_sharded.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_interleaved_to_sharded.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.interleaved_to_sharded``.
+
+Model call sites:
+  * modules/rope/rope_1d.py:189,190  cos/sin -> cfg.cos_sin_shard_mem_config  (HEIGHT shard (TILE, head_dim), rope_1d.py:387)
+  * modules/attention/attention_1d.py:518,519  k_fill/v_fill -> cfg.prefill_kv_memcfg(seq_len)
+  * models/llama32_1b/model.py:913,928  x -> lm_head_memcfg  (WIDTH shard (tile_padded_batch_rows, dim//num_cores), lm_head_1d.py:263)
+
+``interleaved_to_sharded`` only re-lays-out data, so moving an interleaved tensor
+into a sharded config and reading it back must preserve values. The sharded
+configs are (re)built with ``create_sharded_memory_config`` from the real shard
+shapes / strategies used at the call sites.
+
+NOTE: single-core grid so the passed shape is the exact per-core shard shape.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+_GRID = ttnn.CoreGrid(y=1, x=1)
+
+
+def _sharded_cfg(h, w, strategy):
+    return ttnn.create_sharded_memory_config(
+        (h, w),
+        _GRID,
+        strategy,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+# (id, shape, shard_h, shard_w, strategy)
+_CASES = [
+    # rope cos/sin: HEIGHT-sharded (TILE, head_dim). rope_1d.py:189-190, cfg at :387
+    pytest.param((1, 1, U.TILE, U.HEAD_DIM), U.TILE, U.HEAD_DIM, ttnn.ShardStrategy.HEIGHT, id="rope-cos-sin-32x64"),
+    # lm_head / residual activations: WIDTH-sharded (tile_padded_batch_rows, dim). model.py:913,928
+    pytest.param((1, 1, U.TILE, U.DIM), U.TILE, U.DIM, ttnn.ShardStrategy.WIDTH, id="lm-head-input-32x2048"),
+    # attention kv-fill family width (kv_dim). attention_1d.py:518-519
+    pytest.param((1, 1, U.TILE, U.KV_DIM), U.TILE, U.KV_DIM, ttnn.ShardStrategy.WIDTH, id="kv-width-32x512"),
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape, shard_h, shard_w, strategy", _CASES)
+def test_interleaved_to_sharded(ttnn_mesh_device, reset_seeds, shape, shard_h, shard_w, strategy):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)  # interleaved DRAM
+
+    memcfg = _sharded_cfg(shard_h, shard_w, strategy)
+    out = ttnn.interleaved_to_sharded(x, memcfg)
+
+    assert out.is_sharded(), "expected a sharded output"
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_interleaved_to_sharded.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_interleaved_to_sharded.py
@@ -55,7 +55,7 @@ def test_interleaved_to_sharded(ttnn_mesh_device, reset_seeds, shape, shard_h, s
     x = U.to_tt(x_torch, mesh)  # interleaved DRAM
 
     memcfg = _sharded_cfg(shard_h, shard_w, strategy)
-    out = ttnn.interleaved_to_sharded(x, memcfg)
+    out = ttnn.experimental.quasar.interleaved_to_sharded(x, memcfg)
 
     assert out.is_sharded(), "expected a sharded output"
     U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_interleaved_to_sharded.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_interleaved_to_sharded.py
@@ -20,7 +20,7 @@ NOTE: single-core grid so the passed shape is the exact per-core shard shape.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 _GRID = ttnn.CoreGrid(y=1, x=1)
 

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_linear.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_linear.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.linear``.
+
+Covers every distinct ``ttnn.linear`` call site in the model, each with its real
+matmul dims (K = in_dim, N = out_dim). One parametrization per weight matrix:
+
+  * MLP W1 gate:   [*, DIM]          x [DIM, INTERMEDIATE]  (mlp_1d.py:227 decode / :321 prefill)
+  * MLP W3 up:     [*, DIM]          x [DIM, INTERMEDIATE]  (mlp_1d.py:241 / :330)
+  * MLP W2 down:   [*, INTERMEDIATE] x [INTERMEDIATE, DIM]  (mlp_1d.py:273 / :371)
+  * Attention QKV: [*, DIM]          x [DIM, QKV_DIM]       (attention_1d.py:439 / :660)
+  * Attention WO:  [*, Q_DIM]        x [Q_DIM, DIM]         (attention_1d.py:606 / :1222)
+  * LM head:       [*, DIM]          x [DIM, VOCAB]         (lm_head_1d.py:133 / :144)
+
+The model drives these matmuls with DRAM-sharded / width-sharded program configs;
+here we exercise the *plain* interleaved bf16 ``ttnn.linear`` (no program_config) so
+each op runs standalone on the emulator. Reference is ``x @ w``.
+
+Rows M come from the prefill sequence lengths (U.PREFILL_SEQ_LENS) and the decode
+batch sizes (U.DECODE_BATCHES) the demo drives through the model.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# (name, in_dim/K, out_dim/N, pcc). Large-K matmuls (W2 down, K=8192) accumulate more
+# bf16 rounding error over the reduction, so allow a slightly looser 0.98.
+_LINEAR_SITES = [
+    ("mlp_w1_gate", U.DIM, U.INTERMEDIATE, 0.99),
+    ("mlp_w3_up", U.DIM, U.INTERMEDIATE, 0.99),
+    ("mlp_w2_down", U.INTERMEDIATE, U.DIM, 0.98),  # K=8192 → looser pcc
+    ("attn_qkv", U.DIM, U.QKV_DIM, 0.99),
+    ("attn_wo", U.Q_DIM, U.DIM, 0.99),
+    ("lm_head", U.DIM, U.VOCAB, 0.99),
+]
+
+_M_SIZES = [pytest.param(seq, id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS] + [
+    pytest.param(batch, id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("m", _M_SIZES)
+@pytest.mark.parametrize(
+    "name, in_dim, out_dim, pcc",
+    [pytest.param(*s, id=s[0]) for s in _LINEAR_SITES],
+)
+def test_linear(ttnn_mesh_device, reset_seeds, name, in_dim, out_dim, pcc, m):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand((1, 1, m, in_dim))
+    w_torch = U.torch_rand((in_dim, out_dim))
+
+    x = U.to_tt(x_torch, mesh)
+    w = U.to_tt(w_torch, mesh)
+
+    out = ttnn.linear(x, w, dtype=ttnn.bfloat16)
+
+    ref = x_torch.float() @ w_torch.float()
+    U.assert_pcc(ref, out, pcc=pcc, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_linear.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_linear.py
@@ -58,7 +58,7 @@ def test_linear(ttnn_mesh_device, reset_seeds, name, in_dim, out_dim, pcc, m):
     x = U.to_tt(x_torch, mesh)
     w = U.to_tt(w_torch, mesh)
 
-    out = ttnn.linear(x, w, dtype=ttnn.bfloat16)
+    out = ttnn.experimental.quasar.linear(x, w, dtype=ttnn.bfloat16)
 
     ref = x_torch.float() @ w_torch.float()
     U.assert_pcc(ref, out, pcc=pcc, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_linear.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_linear.py
@@ -25,7 +25,7 @@ batch sizes (U.DECODE_BATCHES) the demo drives through the model.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # (name, in_dim/K, out_dim/N, pcc). Large-K matmuls (W2 down, K=8192) accumulate more
 # bf16 rounding error over the reduction, so allow a slightly looser 0.98.

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_minimal_matmul.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_minimal_matmul.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.minimal_matmul``.
+
+The model opts into minimal_matmul (instead of ttnn.linear) for two large prefill
+matmuls when the folded seq_len > 128 (TTTv1 parity):
+
+  * MLP W2 down:   [*, INTERMEDIATE] x [INTERMEDIATE, DIM]   (mlp_1d.py:364)
+  * Attention QKV: [*, DIM]          x [DIM, QKV_DIM]        (attention_1d.py:432)
+
+Kwarg structure copied from the call sites: positional (x, weight), plus
+``compute_kernel_config`` and a ``ttnn.MinimalMatmulConfig`` (8/8/8 blocks over the
+compute grid — mlp_1d.py:977 / attention_1d.py:1769). The block sizes mirror the
+model; the compute grid is taken from the device rather than hardcoding 8x8 so the
+op fits the emulator.
+
+Reference is ``x @ w``; large-K (INTERMEDIATE=8192) uses a looser pcc.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# Only the prefill lengths above the minimal_matmul threshold (seq_len > 128).
+_MM_SEQ_LENS = [s for s in U.PREFILL_SEQ_LENS if s > 128]
+
+# (name, in_dim/K, out_dim/N, pcc)
+_MM_SITES = [
+    ("mlp_w2_down", U.INTERMEDIATE, U.DIM, 0.98),  # K=8192 → looser pcc
+    ("attn_qkv", U.DIM, U.QKV_DIM, 0.99),
+]
+
+
+def _compute_kernel_config() -> ttnn.WormholeComputeKernelConfig:
+    # HiFi2 / fp16 acc — matches the mlp/attention prefill kernel configs.
+    return ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("seq", _MM_SEQ_LENS)
+@pytest.mark.parametrize(
+    "name, in_dim, out_dim, pcc",
+    [pytest.param(*s, id=s[0]) for s in _MM_SITES],
+)
+def test_minimal_matmul(ttnn_mesh_device, reset_seeds, name, in_dim, out_dim, pcc, seq):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand((1, 1, seq, in_dim))
+    w_torch = U.torch_rand((in_dim, out_dim))
+
+    x = U.to_tt(x_torch, mesh)
+    w = U.to_tt(w_torch, mesh)
+
+    grid = mesh.compute_with_storage_grid_size()  # emulator-sized (source uses 8x8)
+    config = ttnn.MinimalMatmulConfig(
+        M_block_size=8,
+        K_block_size=8,
+        N_block_size=8,
+        compute_with_storage_grid_size=grid,
+    )
+
+    out = ttnn.experimental.minimal_matmul(
+        x,
+        w,
+        compute_kernel_config=_compute_kernel_config(),
+        config=config,
+    )
+
+    ref = x_torch.float() @ w_torch.float()
+    U.assert_pcc(ref, out, pcc=pcc, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_minimal_matmul.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_minimal_matmul.py
@@ -22,7 +22,7 @@ Reference is ``x @ w``; large-K (INTERMEDIATE=8192) uses a looser pcc.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # Only the prefill lengths above the minimal_matmul threshold (seq_len > 128).
 _MM_SEQ_LENS = [s for s in U.PREFILL_SEQ_LENS if s > 128]

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_mul.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_mul.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.mul``.
+
+Model call sites (modules/mlp/mlp_1d.py):
+  * L256  decode_forward  — SwiGLU gate: mul(w1_out, w3_out, input_tensor_a_activations=[SILU])
+  * L344  prefill_forward — same, prefill path
+
+Both fuse the SiLU activation on ``input_tensor_a`` (the gate projection) and then
+multiply by the up projection (w3), i.e. ``silu(w1_out) * w3_out``. The operands are
+[1, 1, M, INTERMEDIATE] (the MLP hidden width). Reference is the same in torch.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+_M_SIZES = [pytest.param((1, 1, seq, U.INTERMEDIATE), id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS] + [
+    pytest.param((1, 1, batch, U.INTERMEDIATE), id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _M_SIZES)
+def test_mul_silu_gate(ttnn_mesh_device, reset_seeds, shape):
+    """SwiGLU gate: silu(w1_out) * w3_out (mlp_1d.py:256 / :344)."""
+    mesh = ttnn_mesh_device
+
+    a_torch = U.torch_rand(shape)  # w1_out (gate)
+    b_torch = U.torch_rand(shape)  # w3_out (up)
+
+    a = U.to_tt(a_torch, mesh)
+    b = U.to_tt(b_torch, mesh)
+
+    out = ttnn.mul(
+        a,
+        b,
+        input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
+        dtype=ttnn.bfloat16,
+    )
+
+    ref = torch.nn.functional.silu(a_torch.float()) * b_torch.float()
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_mul.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_mul.py
@@ -36,7 +36,7 @@ def test_mul_silu_gate(ttnn_mesh_device, reset_seeds, shape):
     a = U.to_tt(a_torch, mesh)
     b = U.to_tt(b_torch, mesh)
 
-    out = ttnn.mul(
+    out = ttnn.experimental.quasar.multiply(
         a,
         b,
         input_tensor_a_activations=[ttnn.UnaryOpType.SILU],

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_mul.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_mul.py
@@ -17,7 +17,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 _M_SIZES = [pytest.param((1, 1, seq, U.INTERMEDIATE), id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS] + [
     pytest.param((1, 1, batch, U.INTERMEDIATE), id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_multiply.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_multiply.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.multiply``.
+
+Model call site (modules/embedding/embedding_1d.py):
+  * L147  forward — embedding output scaling: multiply(out, embed_scale, memory_config=...)
+           (a tensor * python-scalar multiply, run only when embed_scale != 1.0)
+
+The embedding output is [1, 1, seq/batch, DIM]; ``embed_scale`` is a float. We also
+cover the tensor * tensor form of the same op for completeness. Reference is the
+elementwise product in torch.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+_SHAPES = [pytest.param((1, 1, seq, U.DIM), id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS] + [
+    pytest.param((1, 1, batch, U.DIM), id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES
+]
+
+# Representative embedding scale (Llama does not scale by default, so exercise a
+# non-unit factor to make the op meaningful).
+_EMBED_SCALE = 2.0
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _SHAPES)
+def test_multiply_scalar(ttnn_mesh_device, reset_seeds, shape):
+    """Embedding output scaling: multiply(out, embed_scale) (embedding_1d.py:147)."""
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)
+
+    out = ttnn.multiply(x, _EMBED_SCALE)
+
+    ref = x_torch.float() * _EMBED_SCALE
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _SHAPES)
+def test_multiply_tensor(ttnn_mesh_device, reset_seeds, shape):
+    """Elementwise tensor * tensor form of ttnn.multiply."""
+    mesh = ttnn_mesh_device
+
+    a_torch = U.torch_rand(shape)
+    b_torch = U.torch_rand(shape)
+    a = U.to_tt(a_torch, mesh)
+    b = U.to_tt(b_torch, mesh)
+
+    out = ttnn.multiply(a, b)
+
+    ref = a_torch.float() * b_torch.float()
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_multiply.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_multiply.py
@@ -36,7 +36,7 @@ def test_multiply_scalar(ttnn_mesh_device, reset_seeds, shape):
     x_torch = U.torch_rand(shape)
     x = U.to_tt(x_torch, mesh)
 
-    out = ttnn.multiply(x, _EMBED_SCALE)
+    out = ttnn.experimental.quasar.multiply(x, _EMBED_SCALE)
 
     ref = x_torch.float() * _EMBED_SCALE
     U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)
@@ -53,7 +53,7 @@ def test_multiply_tensor(ttnn_mesh_device, reset_seeds, shape):
     a = U.to_tt(a_torch, mesh)
     b = U.to_tt(b_torch, mesh)
 
-    out = ttnn.multiply(a, b)
+    out = ttnn.experimental.quasar.multiply(a, b)
 
     ref = a_torch.float() * b_torch.float()
     U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_multiply.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_multiply.py
@@ -16,7 +16,7 @@ elementwise product in torch.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 _SHAPES = [pytest.param((1, 1, seq, U.DIM), id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS] + [
     pytest.param((1, 1, batch, U.DIM), id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_concat_heads.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_concat_heads.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.nlp_concat_heads`` (prefill head concat).
+
+Model call site (modules/attention/attention_1d.py):
+  * L588  prefill_forward STAGE 11 — concatenates the per-head SDPA output back
+          into a single hidden dimension before the WO matmul:
+
+            attn_output_concat = ttnn.experimental.nlp_concat_heads(
+                attn_output, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            )
+
+Input is the per-head attention output ``[1, n_heads, seq, head_dim]`` (the
+single-user reshape at attention_1d.py:586). On a single (1,1) device
+n_heads = 32, head_dim = 64, so the concatenated output is
+``[1, 1, seq, n_heads*head_dim]`` = ``[1, 1, seq, Q_DIM]`` (Q_DIM = 2048).
+No simple torch reference — assert output shape / dtype / finiteness.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "seq",
+    [pytest.param(seq, id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS],
+)
+def test_nlp_concat_heads(ttnn_mesh_device, reset_seeds, seq):
+    mesh = ttnn_mesh_device
+
+    # Per-head attention output: [1, n_heads, seq, head_dim].
+    attn_torch = U.torch_rand((1, U.N_HEADS, seq, U.HEAD_DIM))
+    attn_output = U.to_tt(attn_torch, mesh, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    attn_output_concat = ttnn.experimental.nlp_concat_heads(attn_output, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    # Concatenated hidden dim: [1, 1, seq, n_heads*head_dim] == [1, 1, seq, Q_DIM].
+    U.assert_shape_dtype(
+        attn_output_concat,
+        shape=(1, 1, seq, U.N_HEADS * U.HEAD_DIM),
+        dtype=ttnn.bfloat16,
+        mesh_device=mesh,
+    )
+    # Values: heads concatenated along the last dim -> [1, 1, seq, n_heads*head_dim].
+    ref = attn_torch.permute(0, 2, 1, 3).reshape(1, 1, seq, U.N_HEADS * U.HEAD_DIM)
+    U.assert_pcc(ref, attn_output_concat, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_concat_heads.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_concat_heads.py
@@ -22,7 +22,7 @@ No simple torch reference — assert output shape / dtype / finiteness.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 @U.with_default_mesh()

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_concat_heads_decode.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_concat_heads_decode.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.nlp_concat_heads_decode`` (decode head concat).
+
+Model call site (modules/attention/attention_1d.py):
+  * L732  decode_forward STAGE 9 — concatenates the per-head decode SDPA output
+          into a single hidden dimension before the WO matmul:
+
+            attn_output_cat = ttnn.experimental.nlp_concat_heads_decode(
+                attn_output_sharded, num_heads=n_local_heads
+            )
+
+Input is the decode SDPA output ``[1, batch, n_heads, head_dim]`` moved to the
+scores memcfg at attention_1d.py:727-729 (``decode_scores_memcfg(batch)``). That
+memcfg is HEIGHT_SHARDED, shard ``(ceil(n_local_heads/32)*32, head_dim)`` = (32, 64),
+one shard per user over ``batch`` cores (attention_1d.py:1727-1734). The op's device
+validate requires exactly this (nlp_concat_heads_decode_device_operation.cpp:23-47:
+HEIGHT_SHARDED, shard[0]==padded_heads, shard[1]==head_dim, num_cores==num_users).
+On a single (1,1) device n_heads = 32, head_dim = 64. Output is
+``[1, 1, batch, n_heads*head_dim]`` (= Q_DIM 2048). No simple torch reference —
+assert output shape / dtype / finiteness.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "batch",
+    [pytest.param(batch, id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES],
+)
+def test_nlp_concat_heads_decode(ttnn_mesh_device, reset_seeds, batch):
+    mesh = ttnn_mesh_device
+
+    # Per-head decode attention output: [1, batch, n_heads(=32, tile-padded), head_dim].
+    attn_torch = U.torch_rand((1, batch, U.N_HEADS, U.HEAD_DIM))
+    # HEIGHT_SHARDED over `batch` cores, shard (padded_heads=32, head_dim=64) —
+    # matches decode_scores_memcfg (attention_1d.py:1727-1734).
+    scores_memcfg = U.height_sharded_batch_memcfg(mesh, batch, (U.N_HEADS, U.HEAD_DIM))
+    attn_output_sharded = U.to_tt(attn_torch, mesh, memory_config=scores_memcfg)
+
+    attn_output_cat = ttnn.experimental.nlp_concat_heads_decode(attn_output_sharded, num_heads=U.N_HEADS)
+
+    # Concatenated hidden dim: [1, 1, padded_batch, n_heads*head_dim] == [1, 1, padded_batch, Q_DIM].
+    # The op tile-pads the user/batch dim to a full tile (nearest_32(batch)): batch=1 -> 32, 32 -> 32.
+    padded_batch = ((batch + U.TILE - 1) // U.TILE) * U.TILE
+    U.assert_shape_dtype(
+        attn_output_cat,
+        shape=(1, 1, padded_batch, U.N_HEADS * U.HEAD_DIM),
+        dtype=ttnn.bfloat16,
+        mesh_device=mesh,
+    )

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_concat_heads_decode.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_concat_heads_decode.py
@@ -26,7 +26,7 @@ assert output shape / dtype / finiteness.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 @U.with_default_mesh()
@@ -55,3 +55,7 @@ def test_nlp_concat_heads_decode(ttnn_mesh_device, reset_seeds, batch):
         dtype=ttnn.bfloat16,
         mesh_device=mesh,
     )
+    # Concat is a pure reshape [1, batch, heads, head_dim] -> [1, 1, batch, heads*head_dim]; check the real
+    # (unpadded) batch rows -- assert_pcc trims got to the reference's element count (drops the tile-pad tail).
+    ref = attn_torch.reshape(1, 1, batch, U.N_HEADS * U.HEAD_DIM)
+    U.assert_pcc(ref, attn_output_cat, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_concat_heads_decode.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_concat_heads_decode.py
@@ -48,11 +48,14 @@ def test_nlp_concat_heads_decode(ttnn_mesh_device, reset_seeds, batch):
 
     # Concatenated hidden dim: [1, 1, padded_batch, n_heads*head_dim] == [1, 1, padded_batch, Q_DIM].
     # The op tile-pads the user/batch dim to a full tile (nearest_32(batch)): batch=1 -> 32, 32 -> 32.
+    # Those pad rows (users that don't exist, e.g. rows 1..31 when batch=1) are uninitialized and thus
+    # legitimately non-finite, so check shape/dtype only (finite=False) and validate the REAL rows via PCC.
     padded_batch = ((batch + U.TILE - 1) // U.TILE) * U.TILE
     U.assert_shape_dtype(
         attn_output_cat,
         shape=(1, 1, padded_batch, U.N_HEADS * U.HEAD_DIM),
         dtype=ttnn.bfloat16,
+        finite=False,
         mesh_device=mesh,
     )
     # Concat is a pure reshape [1, batch, heads, head_dim] -> [1, 1, batch, heads*head_dim]; check the real

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_create_qkv_heads.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_create_qkv_heads.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.nlp_create_qkv_heads`` (prefill head split).
+
+Model call site (modules/attention/attention_1d.py):
+  * L470  prefill_forward STAGE 4 — splits the fused QKV projection output into
+          separate Q / K / V head tensors:
+
+            q_heads, k_heads, v_heads = ttnn.experimental.nlp_create_qkv_heads(
+                xqkv_fused,
+                num_heads=n_local_heads,
+                num_kv_heads=n_local_kv_heads,
+                transpose_k_heads=False,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+Input is the fused QKV projection ``[1, 1, seq, QKV_DIM]`` (QKV_DIM = 3072 =
+Q_DIM 2048 + 2*KV_DIM 512). On a single (1,1) device n_local_heads = 32 and
+n_local_kv_heads = 8. The op has no simple torch reference, so we assert the
+three output tensors have the expected head shapes / dtype and are finite.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "seq",
+    [pytest.param(seq, id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS],
+)
+def test_nlp_create_qkv_heads(ttnn_mesh_device, reset_seeds, seq):
+    mesh = ttnn_mesh_device
+
+    # Fused QKV projection output: [1, 1, seq, QKV_DIM] (Q|K|V concatenated on -1).
+    xqkv_torch = U.torch_rand((1, 1, seq, U.QKV_DIM))
+    xqkv_fused = U.to_tt(xqkv_torch, mesh, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    q_heads, k_heads, v_heads = ttnn.experimental.nlp_create_qkv_heads(
+        xqkv_fused,
+        num_heads=U.N_HEADS,
+        num_kv_heads=U.N_KV_HEADS,
+        transpose_k_heads=False,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # Q: [1, n_heads, seq, head_dim]; K/V: [1, n_kv_heads, seq, head_dim].
+    U.assert_shape_dtype(q_heads, shape=(1, U.N_HEADS, seq, U.HEAD_DIM), dtype=ttnn.bfloat16, mesh_device=mesh)
+    U.assert_shape_dtype(k_heads, shape=(1, U.N_KV_HEADS, seq, U.HEAD_DIM), dtype=ttnn.bfloat16, mesh_device=mesh)
+    U.assert_shape_dtype(v_heads, shape=(1, U.N_KV_HEADS, seq, U.HEAD_DIM), dtype=ttnn.bfloat16, mesh_device=mesh)
+
+    # Values: split the fused QKV on -1 and reshape each into [1, heads, seq, head_dim]
+    # (transpose_k_heads=False, so K keeps the same [1, n_kv, seq, hd] layout as Q/V).
+    q_ref = xqkv_torch[..., : U.Q_DIM].reshape(1, seq, U.N_HEADS, U.HEAD_DIM).permute(0, 2, 1, 3)
+    k_ref = xqkv_torch[..., U.Q_DIM : U.Q_DIM + U.KV_DIM].reshape(1, seq, U.N_KV_HEADS, U.HEAD_DIM).permute(0, 2, 1, 3)
+    v_ref = xqkv_torch[..., U.Q_DIM + U.KV_DIM :].reshape(1, seq, U.N_KV_HEADS, U.HEAD_DIM).permute(0, 2, 1, 3)
+    U.assert_pcc(q_ref, q_heads, pcc=0.999, mesh_device=mesh)
+    U.assert_pcc(k_ref, k_heads, pcc=0.999, mesh_device=mesh)
+    U.assert_pcc(v_ref, v_heads, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_create_qkv_heads.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_create_qkv_heads.py
@@ -25,7 +25,7 @@ three output tensors have the expected head shapes / dtype and are finite.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 @U.with_default_mesh()

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_create_qkv_heads_decode.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_create_qkv_heads_decode.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.nlp_create_qkv_heads_decode`` (decode head split).
+
+Model call site (modules/attention/attention_1d.py):
+  * L685  decode_forward STAGE 3 — splits the fused QKV projection into Q/K/V
+          heads for the single-token-per-user decode path:
+
+            q_heads, k_heads, v_heads = ttnn.experimental.nlp_create_qkv_heads_decode(
+                xqkv_fused,
+                num_heads=n_local_heads,
+                num_kv_heads=n_local_kv_heads,
+                overlap_qk_coregrid=self._decode_overlap_qk_coregrid,
+                memory_config=cfg.decode_create_qkv_head_memcfg,
+            )
+
+Just before the call the model reshapes the fused QKV to
+``(1, 1, max_batch_size, QKV_DIM)`` (attention_1d.py:682). On a single (1,1)
+device n_local_heads = 32 and n_local_kv_heads = 8. Output heads are
+``[1, batch, n_heads, head_dim]`` (Q) and ``[1, batch, n_kv_heads, head_dim]``
+(K/V).
+
+Two tests:
+  * ``test_nlp_create_qkv_heads_decode`` — interleaved input. Routes to the
+    ``InterleavedProgramFactory`` (reader_interleaved_* kernel). The model never
+    feeds interleaved input, but keeping this exercises that program factory.
+  * ``test_nlp_create_qkv_heads_decode_sharded`` — WIDTH_SHARDED input, the path
+    the model actually uses. select_program_factory() branches on
+    input.is_sharded() to a *different* program factory + reader kernel
+    (nlp_create_qkv_heads_decode_device_operation.cpp:12-24), so this is the real
+    coverage. Verified with a torch reference (the split has a closed form).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "batch",
+    [pytest.param(batch, id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES],
+)
+def test_nlp_create_qkv_heads_decode(ttnn_mesh_device, reset_seeds, batch):
+    mesh = ttnn_mesh_device
+
+    # Fused QKV projection reshaped for decode: [1, 1, batch, QKV_DIM].
+    xqkv_torch = U.torch_rand((1, 1, batch, U.QKV_DIM))
+    xqkv_fused = U.to_tt(xqkv_torch, mesh, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    q_heads, k_heads, v_heads = ttnn.experimental.nlp_create_qkv_heads_decode(
+        xqkv_fused,
+        num_heads=U.N_HEADS,
+        num_kv_heads=U.N_KV_HEADS,
+        overlap_qk_coregrid=True,  # matches _decode_overlap_qk_coregrid when use_qk_fused=False
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # Decode layout: [1, batch, n_heads, head_dim] for Q; n_kv_heads for K/V.
+    U.assert_shape_dtype(q_heads, shape=(1, batch, U.N_HEADS, U.HEAD_DIM), dtype=ttnn.bfloat16, mesh_device=mesh)
+    U.assert_shape_dtype(k_heads, shape=(1, batch, U.N_KV_HEADS, U.HEAD_DIM), dtype=ttnn.bfloat16, mesh_device=mesh)
+    U.assert_shape_dtype(v_heads, shape=(1, batch, U.N_KV_HEADS, U.HEAD_DIM), dtype=ttnn.bfloat16, mesh_device=mesh)
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "batch",
+    [pytest.param(batch, id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES],
+)
+def test_nlp_create_qkv_heads_decode_sharded(ttnn_mesh_device, reset_seeds, batch):
+    """WIDTH_SHARDED input — the program-factory / reader kernel the model actually uses.
+
+    Input contract (device_operation.cpp:55-66): WIDTH_SHARDED, ROW_MAJOR, shard[0] ==
+    padded_batch. We place the full QKV width on a single core (canonical
+    max-width-shard, test_nlp_create_qkv_heads_decode.py:106-137) so batch=1 fits the
+    emulator; the model's default output config is L1_HEIGHT_SHARDED (attention_1d.py:1723).
+    """
+    mesh = ttnn_mesh_device
+    total_heads = U.N_HEADS + 2 * U.N_KV_HEADS  # 48; head_dim * total_heads == QKV_DIM
+
+    xqkv_torch = U.torch_rand((1, 1, batch, U.QKV_DIM))
+    # Host tile tensor first so we can read the tile-padded batch (canonical pattern).
+    xqkv_host = ttnn.from_torch(
+        xqkv_torch,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(mesh),
+    )
+    padded_batch = xqkv_host.padded_shape[2]
+
+    one_core = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
+    in_memcfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(one_core, [padded_batch, total_heads * U.HEAD_DIM], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    xqkv_fused = ttnn.to_device(xqkv_host, mesh, memory_config=in_memcfg)
+
+    q_heads, k_heads, v_heads = ttnn.experimental.nlp_create_qkv_heads_decode(
+        xqkv_fused,
+        num_heads=U.N_HEADS,
+        num_kv_heads=U.N_KV_HEADS,
+        overlap_qk_coregrid=True,
+        memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,  # model default (attention_1d.py:1723)
+    )
+
+    # Value check: split the fused QKV on -1 into [1, batch, heads, head_dim].
+    q_ref = xqkv_torch[:, :, :batch, : U.Q_DIM].reshape(1, batch, U.N_HEADS, U.HEAD_DIM)
+    k_ref = xqkv_torch[:, :, :batch, U.Q_DIM : U.Q_DIM + U.KV_DIM].reshape(1, batch, U.N_KV_HEADS, U.HEAD_DIM)
+    v_ref = xqkv_torch[:, :, :batch, U.Q_DIM + U.KV_DIM :].reshape(1, batch, U.N_KV_HEADS, U.HEAD_DIM)
+    U.assert_pcc(q_ref, q_heads, pcc=0.999, mesh_device=mesh)
+    U.assert_pcc(k_ref, k_heads, pcc=0.999, mesh_device=mesh)
+    U.assert_pcc(v_ref, v_heads, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_create_qkv_heads_decode.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_create_qkv_heads_decode.py
@@ -97,7 +97,7 @@ def test_nlp_create_qkv_heads_decode_sharded(ttnn_mesh_device, reset_seeds, batc
         ttnn.BufferType.L1,
         ttnn.ShardSpec(one_core, [padded_batch, total_heads * U.HEAD_DIM], ttnn.ShardOrientation.ROW_MAJOR),
     )
-    xqkv_fused = ttnn.to_device(xqkv_host, mesh, memory_config=in_memcfg)
+    xqkv_fused = ttnn.experimental.quasar.to_device(xqkv_host, mesh, memory_config=in_memcfg)
 
     q_heads, k_heads, v_heads = ttnn.experimental.nlp_create_qkv_heads_decode(
         xqkv_fused,

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_create_qkv_heads_decode.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_nlp_create_qkv_heads_decode.py
@@ -36,7 +36,7 @@ Two tests:
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 @U.with_default_mesh()

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_pad.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_pad.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.pad``.
+
+Model call site (modules/rope/rope_1d.py):
+  * L224  cos_slice = ttnn.pad(cos_slice, padding=padding, value=0.0)
+  * L225  sin_slice = ttnn.pad(sin_slice, padding=padding, value=0.0)
+
+The rope table slice [1, 1, seq_len, head_dim] is zero-padded along the sequence
+dim (dim 2) up to ``pad_to`` for SDPA alignment (rope_1d.py:218-225):
+
+    padding = [(0, 0)] * 4
+    padding[2] = (0, pad_len)        # pad_len = pad_to - seq_len
+
+Value-preserving (pad value 0.0) -> torch reference is ``F.pad`` on dim 2; PCC 0.999.
+
+NOTE: the task also mentions vocab / tile padding, but no other ``ttnn.pad`` call
+site exists in the model source (vocab width is padded at weight-prep time, not via
+ttnn.pad). Only the rope pad pattern is covered here.
+"""
+
+import pytest
+import torch.nn.functional as F
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# (id, seq_len, pad_to) — seq_len values are tile-sub-multiples padded up to a tile-aligned length.
+_PAD_SITES = [
+    ("seq96_to128", 96, 128),
+    ("seq128_to256", 128, 256),
+    ("seq500_to512", 500, 512),
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, seq_len, pad_to",
+    [pytest.param(*s, id=s[0]) for s in _PAD_SITES],
+)
+def test_pad(ttnn_mesh_device, reset_seeds, name, seq_len, pad_to):
+    mesh = ttnn_mesh_device
+    pad_len = pad_to - seq_len
+
+    x_torch = U.torch_rand((1, 1, seq_len, U.HEAD_DIM))
+    x = U.to_tt(x_torch, mesh)
+
+    padding = [(0, 0)] * 4
+    padding[2] = (0, pad_len)
+    out = ttnn.pad(x, padding=padding, value=0.0)
+
+    # F.pad pads from the last dim outward: (last_l, last_r, dim2_l, dim2_r).
+    ref = F.pad(x_torch.float(), (0, 0, 0, pad_len), value=0.0)
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_pad.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_pad.py
@@ -49,7 +49,7 @@ def test_pad(ttnn_mesh_device, reset_seeds, name, seq_len, pad_to):
 
     padding = [(0, 0)] * 4
     padding[2] = (0, pad_len)
-    out = ttnn.pad(x, padding=padding, value=0.0)
+    out = ttnn.experimental.quasar.pad(x, padding=padding, value=0.0)
 
     # F.pad pads from the last dim outward: (last_l, last_r, dim2_l, dim2_r).
     ref = F.pad(x_torch.float(), (0, 0, 0, pad_len), value=0.0)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_pad.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_pad.py
@@ -25,7 +25,7 @@ import pytest
 import torch.nn.functional as F
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # (id, seq_len, pad_to) — seq_len values are tile-sub-multiples padded up to a tile-aligned length.
 _PAD_SITES = [

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_fill_cache.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_fill_cache.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.paged_fill_cache`` (prefill KV cache fill).
+
+Model call site (modules/attention/attention_1d.py):
+  * L877-878  _kv_fill_prefill_paged — fills the paged K and V caches for one
+              user from the prefill head tensors:
+
+            ttnn.experimental.paged_fill_cache(keys, k_fill_sliced, fill_page_table, batch_idx=user_id)
+            ttnn.experimental.paged_fill_cache(values, v_fill_sliced, fill_page_table, batch_idx=user_id)
+
+  * L911-912  _kv_fill_prefill_batched — same op, one call per user in a loop.
+
+Cache layout is paged: ``[num_blocks, n_kv_heads, block_size, head_dim]``. The
+fill input is a per-user head tensor ``[1, n_kv_heads, seq, head_dim]`` and the
+page table maps the user's logical blocks to physical blocks. This test fills a
+zero cache for a single user, reads it back, and verifies the written blocks
+match the input (via PCC over the whole cache — unwritten blocks stay zero in
+both reference and result).
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+BLOCK_SIZE = 64  # paged KV block size (tile-aligned)
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "seq",
+    [pytest.param(seq, id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS],
+)
+def test_paged_fill_cache(ttnn_mesh_device, reset_seeds, seq):
+    mesh = ttnn_mesh_device
+    num_users = 1
+    batch_idx = 0
+    num_blocks_per_seq = seq // BLOCK_SIZE
+    num_blocks = num_users * num_blocks_per_seq
+
+    # Zero paged cache: [num_blocks, n_kv_heads, block_size, head_dim].
+    cache_torch = torch.zeros((num_blocks, U.N_KV_HEADS, BLOCK_SIZE, U.HEAD_DIM))
+    cache_tt = U.to_tt(cache_torch, mesh)
+
+    # Per-user fill input: [1, n_kv_heads, seq, head_dim].
+    fill_torch = U.torch_rand((1, U.N_KV_HEADS, seq, U.HEAD_DIM))
+    fill_tt = U.to_tt(fill_torch, mesh)
+
+    # Page table [num_users, num_blocks_per_seq]; arange -> logical block i == physical block i.
+    page_table_torch = torch.arange(num_blocks, dtype=torch.int32).reshape(num_users, num_blocks_per_seq)
+    page_table_tt = ttnn.from_torch(
+        page_table_torch,
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh,
+        mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(mesh),
+    )
+
+    ttnn.experimental.paged_fill_cache(cache_tt, fill_tt, page_table_tt, batch_idx=batch_idx)
+
+    # Expected cache: reshape the seq axis into (num_blocks, block_size) and move blocks to axis 0.
+    expected = fill_torch[0].reshape(U.N_KV_HEADS, num_blocks, BLOCK_SIZE, U.HEAD_DIM).permute(1, 0, 2, 3).contiguous()
+
+    U.assert_pcc(expected, cache_tt, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_fill_cache.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_fill_cache.py
@@ -25,7 +25,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 BLOCK_SIZE = 64  # paged KV block size (tile-aligned)
 

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_fused_update_cache.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_fused_update_cache.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.paged_fused_update_cache`` (fused decode KV update).
+
+Model call site (modules/attention/attention_1d.py):
+  * L1019-1021  _kv_update_decode_fused — writes the current decode step's K and V
+                heads into their caches in a single fused kernel (use_qk_fused=True):
+
+            ttnn.experimental.paged_fused_update_cache(
+                keys, k_heads, values, v_heads, update_idxs_tensor=current_pos, page_table=page_table
+            )
+
+Argument order is (keys_cache, k_heads, values_cache, v_heads). Decode inputs are
+``[1, batch, n_kv_heads, head_dim]`` (head axis padded to 32) and ``current_pos``
+is a per-user position tensor. Both new-KV inputs must be HEIGHT_SHARDED one user per
+core (shard width == head_dim, num_cores == num_users, K and V grids same core count;
+paged_fused_update_cache_device_operation.cpp:145-195) — the fused sibling of
+paged_update_cache. This test uses contiguous (non-paged, page_table=None) K and V
+caches ``[batch, n_kv_heads, max_seq_len, head_dim]``, updates one token per user,
+reads both caches back and verifies each user's written K and V slice matches the input.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+MAX_SEQ_LEN = 128  # cache depth for the contiguous decode cache
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "batch",
+    [pytest.param(batch, id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES],
+)
+def test_paged_fused_update_cache(ttnn_mesh_device, reset_seeds, batch):
+    mesh = ttnn_mesh_device
+    n_kv = U.N_KV_HEADS
+
+    # Contiguous decode caches for K and V: [batch, n_kv_heads, max_seq_len, head_dim].
+    keys_torch = torch.zeros((batch, n_kv, MAX_SEQ_LEN, U.HEAD_DIM))
+    values_torch = torch.zeros((batch, n_kv, MAX_SEQ_LEN, U.HEAD_DIM))
+    keys_tt = U.to_tt(keys_torch, mesh)
+    values_tt = U.to_tt(values_torch, mesh)
+
+    # Decode K/V heads: [1, batch, n_kv_heads, head_dim], head axis padded to 32.
+    k_torch = U.torch_rand((1, batch, n_kv, U.HEAD_DIM))
+    v_torch = U.torch_rand((1, batch, n_kv, U.HEAD_DIM))
+    # HEIGHT_SHARDED one user per core: shard (32, head_dim) over `batch` cores.
+    # The fused op requires K and V on NON-OVERLAPPING grids
+    # (paged_fused_update_cache_device_operation.cpp:227 "!is_overlap"), so V is placed on the
+    # cores after K — same non-overlap pattern as the fused-QK Q/K split.
+    k_memcfg = U.height_sharded_batch_memcfg(mesh, batch, (U.TILE, U.HEAD_DIM))
+    v_start = ttnn.CoreCoord(batch % 8, batch // 8)
+    v_memcfg = U.height_sharded_batch_memcfg(mesh, batch, (U.TILE, U.HEAD_DIM), start_core=v_start)
+    k_heads = U.to_tt(
+        torch.nn.functional.pad(k_torch, (0, 0, 0, U.TILE - n_kv), "constant", 0.0), mesh, memory_config=k_memcfg
+    )
+    v_heads = U.to_tt(
+        torch.nn.functional.pad(v_torch, (0, 0, 0, U.TILE - n_kv), "constant", 0.0), mesh, memory_config=v_memcfg
+    )
+
+    positions = [3 + i for i in range(batch)]
+    current_pos = ttnn.from_torch(
+        torch.tensor(positions, dtype=torch.int32),
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh,
+        mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(mesh),
+    )
+
+    result = ttnn.experimental.paged_fused_update_cache(
+        keys_tt, k_heads, values_tt, v_heads, update_idxs_tensor=current_pos, page_table=None
+    )
+    if result is not None:
+        keys_out, values_out = result
+    else:
+        keys_out, values_out = keys_tt, values_tt
+
+    # Reference: write each user's K/V head vector at its position.
+    keys_expected = keys_torch.clone()
+    values_expected = values_torch.clone()
+    for i in range(batch):
+        pos = positions[i]
+        keys_expected[i, 0:n_kv, pos : pos + 1, :] = k_torch.permute(1, 2, 0, 3)[i]
+        values_expected[i, 0:n_kv, pos : pos + 1, :] = v_torch.permute(1, 2, 0, 3)[i]
+
+    U.assert_pcc(keys_expected, keys_out, pcc=0.99, mesh_device=mesh)
+    U.assert_pcc(values_expected, values_out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_fused_update_cache.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_fused_update_cache.py
@@ -26,7 +26,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 MAX_SEQ_LEN = 128  # cache depth for the contiguous decode cache
 

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_scaled_dot_product_attention_decode.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_scaled_dot_product_attention_decode.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.transformer.paged_scaled_dot_product_attention_decode``  (paged decode SDPA).
+
+Model call site (modules/attention/attention_1d.py:836-847, _sdpa_decode_paged):
+    return ttnn.transformer.paged_scaled_dot_product_attention_decode(
+        q_heads,               # [1, batch, n_heads, head_dim]
+        keys,                  # paged KV cache [num_blocks, n_kv_heads, block_size, head_dim]
+        values,                # paged KV cache [num_blocks, n_kv_heads, block_size, head_dim]
+        page_table_tensor=page_table,   # int32 [batch, blocks_per_seq]
+        cur_pos_tensor=current_pos,     # int32 [batch] positions
+        scale=cfg.scale,                # head_dim ** -0.5
+        sliding_window_size=cfg.sliding_window,   # None for Llama-3.2-1B
+        program_config=cfg.decode_sdpa_prg_config,
+        compute_kernel_config=cfg.sdpa_decode_compute_kernel_cfg,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+Same math as non-paged decode, but the KV cache is stored in shuffled physical
+blocks and a page_table maps each user's virtual blocks to physical ones.
+GQA: 32 query heads, 8 kv heads (head_dim 64).
+Known-good paging + direct-call pattern mirrored from
+tests/ttnn/unit_tests/operations/sdpa/sdpa_test_utils.py:774-995.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+CACHE_SEQ = 256
+CUR_POS = 128
+BLOCK_SIZE = 64
+K_CHUNK = 128
+
+
+def _to_paged(cache, b, nkv, blocks_per_seq, block_size, d):
+    return (
+        cache.reshape(b, nkv, blocks_per_seq, block_size, d)
+        .transpose(1, 2)
+        .reshape(b * blocks_per_seq, nkv, block_size, d)
+    )
+
+
+def _torch_decode_ref(q, k, v, cur_pos, scale, padded_layer_len):
+    b, nh = q.shape[1], q.shape[2]
+    nkv = k.shape[1]
+    q_slice = q.permute(1, 2, 0, 3).float()  # [b, nh, 1, d]
+    k_slice = k[:, :, :padded_layer_len, :].repeat_interleave(nh // nkv, dim=1).float()
+    v_slice = v[:, :, :padded_layer_len, :].repeat_interleave(nh // nkv, dim=1).float()
+    mask = torch.zeros((b, nh, 1, padded_layer_len))
+    for i in range(b):
+        mask[i, :, :, cur_pos[i] + 1 :] = torch.finfo(torch.float32).min
+    expect = torch.nn.functional.scaled_dot_product_attention(
+        q_slice, k_slice, v_slice, mask, scale=scale, is_causal=False
+    )
+    return expect.squeeze(2).unsqueeze(0)  # [1, b, nh, d]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("batch", U.DECODE_BATCHES, ids=[f"batch{b}" for b in U.DECODE_BATCHES])
+def test_paged_scaled_dot_product_attention_decode(ttnn_mesh_device, reset_seeds, batch):
+    mesh = ttnn_mesh_device
+    scale = U.HEAD_DIM**-0.5
+
+    blocks_per_seq = CACHE_SEQ // BLOCK_SIZE
+    num_blocks = batch * blocks_per_seq
+
+    q_torch = U.torch_rand((1, batch, U.N_HEADS, U.HEAD_DIM))
+    k_torch = U.torch_rand((batch, U.N_KV_HEADS, CACHE_SEQ, U.HEAD_DIM))
+    v_torch = U.torch_rand((batch, U.N_KV_HEADS, CACHE_SEQ, U.HEAD_DIM))
+    cur_pos = [CUR_POS] * batch
+
+    # Page + shuffle the contiguous caches; page_table maps virtual -> physical block.
+    paged_k = _to_paged(k_torch, batch, U.N_KV_HEADS, blocks_per_seq, BLOCK_SIZE, U.HEAD_DIM)
+    paged_v = _to_paged(v_torch, batch, U.N_KV_HEADS, blocks_per_seq, BLOCK_SIZE, U.HEAD_DIM)
+    permutation = torch.randperm(num_blocks)
+    reverse_permutation = torch.argsort(permutation)
+    page_table = reverse_permutation.reshape(batch, blocks_per_seq)
+    paged_k_shuffled = paged_k[permutation]
+    paged_v_shuffled = paged_v[permutation]
+
+    q = U.to_tt(q_torch, mesh)
+    k = U.to_tt(paged_k_shuffled, mesh)
+    v = U.to_tt(paged_v_shuffled, mesh)
+    page_table_tt = U.to_tt(page_table.to(torch.int32), mesh, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)
+    cur_pos_tt = U.to_tt(torch.tensor(cur_pos, dtype=torch.int32), mesh, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=mesh.compute_with_storage_grid_size(),
+        q_chunk_size=32,  # padded_num_heads for n_heads=32
+        k_chunk_size=K_CHUNK,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+
+    out = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+        q,
+        k,
+        v,
+        page_table_tt,
+        cur_pos_tensor=cur_pos_tt,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    padded_layer_len = ((CUR_POS + 1 + K_CHUNK - 1) // K_CHUNK) * K_CHUNK
+    ref = _torch_decode_ref(q_torch, k_torch, v_torch, cur_pos, scale, padded_layer_len)  # [1, b, nh, d]
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_scaled_dot_product_attention_decode.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_scaled_dot_product_attention_decode.py
@@ -29,7 +29,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 CACHE_SEQ = 256
 CUR_POS = 128

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_update_cache.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_update_cache.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.paged_update_cache`` (decode KV cache update).
+
+Model call site (modules/attention/attention_1d.py):
+  * L1033-1034  _kv_update_decode_nonfused — writes the current decode step's K and
+                V head tensors into the KV cache at each user's current position:
+
+            ttnn.experimental.paged_update_cache(keys, k_heads, update_idxs_tensor=current_pos, page_table=page_table)
+            ttnn.experimental.paged_update_cache(values, v_heads, update_idxs_tensor=current_pos, page_table=page_table)
+
+Decode inputs are ``[1, batch, n_kv_heads, head_dim]`` (head axis padded to 32,
+matching tests/ttnn/.../test_paged_update_cache.py) and ``current_pos`` is a
+per-user position tensor. The op's device validate requires the new-KV input to be
+HEIGHT_SHARDED, one user per core: shard width == head_dim, shard grid num_cores ==
+num_users, ROW_MAJOR (paged_update_cache_device_operation.cpp:231-266). This matches
+the model, where k_heads/v_heads come out of nlp_create_qkv_heads_decode already
+sharded (decode_create_qkv_head_memcfg, attention_1d.py:685-691). This test uses the
+contiguous (non-paged, page_table=None) cache ``[batch, n_kv_heads, max_seq_len,
+head_dim]``, updates one token per user, reads back and verifies each user's written
+slice matches the input.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+MAX_SEQ_LEN = 128  # cache depth for the contiguous decode cache
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "batch",
+    [pytest.param(batch, id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES],
+)
+def test_paged_update_cache(ttnn_mesh_device, reset_seeds, batch):
+    mesh = ttnn_mesh_device
+    n_kv = U.N_KV_HEADS
+
+    # Contiguous decode cache: [batch, n_kv_heads, max_seq_len, head_dim].
+    cache_torch = torch.zeros((batch, n_kv, MAX_SEQ_LEN, U.HEAD_DIM))
+    cache_tt = U.to_tt(cache_torch, mesh)
+
+    # Decode K heads: [1, batch, n_kv_heads, head_dim], head axis padded to 32.
+    k_torch = U.torch_rand((1, batch, n_kv, U.HEAD_DIM))
+    k_pad = torch.nn.functional.pad(k_torch, (0, 0, 0, U.TILE - n_kv), "constant", 0.0)
+    # HEIGHT_SHARDED one user per core: shard (padded_heads=32, head_dim=64) over
+    # `batch` cores (num_cores==num_users) — the op's canonical decode layout
+    # (paged_update_cache_device_operation.cpp:258-266).
+    k_memcfg = U.height_sharded_batch_memcfg(mesh, batch, (U.TILE, U.HEAD_DIM))
+    k_heads = U.to_tt(k_pad, mesh, memory_config=k_memcfg)
+
+    # One update position per user (all within MAX_SEQ_LEN).
+    positions = [3 + i for i in range(batch)]
+    current_pos = ttnn.from_torch(
+        torch.tensor(positions, dtype=torch.int32),
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh,
+        mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(mesh),
+    )
+
+    result = ttnn.experimental.paged_update_cache(cache_tt, k_heads, update_idxs_tensor=current_pos, page_table=None)
+    cache_out = result if result is not None else cache_tt
+
+    # Reference: write each user's head vector at its position.
+    expected = cache_torch.clone()
+    for i in range(batch):
+        # x_view: [n_kv_heads, 1, head_dim] (permute(1,2,0,3) then index user i on the unpadded input).
+        x_view = k_torch.permute(1, 2, 0, 3)[i]  # [n_kv, 1, head_dim]
+        pos = positions[i]
+        expected[i, 0:n_kv, pos : pos + 1, :] = x_view
+
+    U.assert_pcc(expected, cache_out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_update_cache.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_paged_update_cache.py
@@ -27,7 +27,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 MAX_SEQ_LEN = 128  # cache depth for the contiguous decode cache
 

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_plus_one.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_plus_one.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.plus_one``.
+
+Model call site (models/llama32_1b/model.py):
+  * L991  increment_positions — ttnn.plus_one(current_pos, skip_negative_entries=True)
+  * L992  increment_positions — ttnn.plus_one(rot_mat_idxs)
+
+``plus_one`` increments an int position tensor in place (no return value). It is
+used to advance ``current_pos`` / ``rot_mat_idxs`` by one decode step. With
+``skip_negative_entries=True`` padded/negative slots are left untouched (padding
+slots in a batched decode carry -1). Positions are one int per decode user, so
+the tensor is [batch] (ROW_MAJOR, int32). Reference is ``x + 1`` (with negatives
+preserved when skip_negative_entries is set).
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("batch", [pytest.param(b, id=f"b{b}") for b in U.DECODE_BATCHES])
+def test_plus_one(ttnn_mesh_device, reset_seeds, batch):
+    mesh = ttnn_mesh_device
+
+    pos_torch = torch.arange(batch, dtype=torch.int32)
+    pos = U.to_tt(pos_torch, mesh, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    # In-place increment (model.py:992, rot_mat_idxs path — no skip).
+    ttnn.plus_one(pos)
+
+    got = U.from_tt(pos, mesh).flatten()[:batch].long()
+    ref = (pos_torch + 1).long()
+    assert torch.equal(got, ref), f"plus_one mismatch:\n  got: {got[:8]}\n  ref: {ref[:8]}"
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("batch", [pytest.param(b, id=f"b{b}") for b in U.DECODE_BATCHES])
+def test_plus_one_skip_negative(ttnn_mesh_device, reset_seeds, batch):
+    """skip_negative_entries=True: negative (padding) slots must stay unchanged (model.py:991)."""
+    mesh = ttnn_mesh_device
+
+    pos_torch = torch.arange(batch, dtype=torch.int32)
+    if batch > 1:
+        pos_torch[-1] = -1  # simulate a padded decode slot
+    pos = U.to_tt(pos_torch, mesh, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    ttnn.plus_one(pos, skip_negative_entries=True)
+
+    got = U.from_tt(pos, mesh).flatten()[:batch].long()
+    ref = pos_torch.clone().long()
+    ref[ref >= 0] += 1  # non-negative entries incremented, negatives untouched
+    assert torch.equal(got, ref), f"plus_one(skip_negative) mismatch:\n  got: {got[:8]}\n  ref: {ref[:8]}"

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_plus_one.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_plus_one.py
@@ -20,7 +20,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 @U.with_default_mesh()

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_reduce_scatter_minimal_async.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_reduce_scatter_minimal_async.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.reduce_scatter_minimal_async``  (MULTI-DEVICE).
+
+Model call sites (modules/attention/attention_1d.py):
+  * L1121  _all_reduce_output_decode  — reduce-scatter of the WO output (decode)
+  * L1164  _all_reduce_output_prefill — reduce-scatter of the WO output (prefill)
+
+Kwarg structure copied from _all_reduce_output_decode (attention_1d.py:1121):
+    persistent_output_buffers=None, dim=3, multi_device_global_semaphore=<handle>,
+    barrier_semaphore=<handle>, num_links=..., memory_config=...,
+    intermediate_memory_config=ttnn.DRAM_MEMORY_CONFIG, topology=...,
+    chunks_per_sync=..., num_workers_per_link=..., num_buffers_per_channel=...
+
+Semaphore handles come from a TT-CCL manager in the model
+(tt_ccl.get_and_cycle_rs_semaphore_handles / _barrier_semaphore_handle). Here we
+create them directly via ttnn.create_global_semaphore over the worker sub-device.
+reduce_scatter sums the replicated input across devices and scatters the result
+along dim 3, so the per-device output width is input_width / num_devices. We
+assert shape/dtype.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# CCL collective — needs a multi-device mesh. The (1, 2) parametrization below is
+# skipped automatically by the ttnn_mesh_device fixture on single-device systems
+# (N150 / 2-node emulator present as one device), so it stays out of the emulator run
+# while still exercising the op on real multi-device systems (N300 / T3K).
+
+
+def _worker_crs(mesh):
+    grid = mesh.compute_with_storage_grid_size()
+    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 2)], indirect=True)
+def test_reduce_scatter_minimal_async(ttnn_mesh_device, reset_seeds):
+    mesh = ttnn_mesh_device
+    if tuple(mesh.shape) == (1, 1):
+        pytest.skip("multi-device op")
+
+    num_devices = max(tuple(mesh.shape))
+
+    # WO output replicated across devices (each device contributes a full-width partial).
+    shape = (1, 1, U.MAX_BATCH, U.DIM)
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)  # replicated
+
+    crs = _worker_crs(mesh)
+    rs_semaphore = ttnn.create_global_semaphore(mesh, crs, 0)
+    barrier_semaphore = ttnn.create_global_semaphore(mesh, crs, 0)
+
+    reduced = ttnn.experimental.reduce_scatter_minimal_async(
+        x,
+        persistent_output_buffers=None,
+        dim=3,
+        multi_device_global_semaphore=rs_semaphore,
+        barrier_semaphore=barrier_semaphore,
+        num_links=1,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        intermediate_memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        topology=ttnn.Topology.Linear,
+        chunks_per_sync=10,
+        num_workers_per_link=2,
+        num_buffers_per_channel=2,
+    )
+
+    # reduce-scatter scatters the reduced result along dim 3 -> width / num_devices per device.
+    assert reduced.shape[-1] == U.DIM // num_devices, f"scattered width {reduced.shape[-1]} != {U.DIM // num_devices}"
+    U.assert_shape_dtype(reduced, dtype=ttnn.bfloat16, finite=False)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_reduce_scatter_minimal_async.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_reduce_scatter_minimal_async.py
@@ -25,7 +25,7 @@ assert shape/dtype.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # CCL collective — needs a multi-device mesh. The (1, 2) parametrization below is
 # skipped automatically by the ttnn_mesh_device fixture on single-device systems
@@ -70,6 +70,7 @@ def test_reduce_scatter_minimal_async(ttnn_mesh_device, reset_seeds):
         num_buffers_per_channel=2,
     )
 
-    # reduce-scatter scatters the reduced result along dim 3 -> width / num_devices per device.
+    # reduce-scatter sums the replicated input across devices then scatters along dim 3 -> width/num_devices
+    # per device. Every device was fed the same x, so the composed (concatenated) result is num_devices * x.
     assert reduced.shape[-1] == U.DIM // num_devices, f"scattered width {reduced.shape[-1]} != {U.DIM // num_devices}"
-    U.assert_shape_dtype(reduced, dtype=ttnn.bfloat16, finite=False)
+    U.assert_pcc(x_torch.float() * num_devices, reduced, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_reshape.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_reshape.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.reshape``.
+
+``ttnn.reshape`` is used purely to fold / unfold the batch and sequence axes so
+long-sequence matmuls fit on device; it is value-preserving (row-major), so the
+reference is ``torch.reshape``.
+
+Model call sites (distinct patterns covered here):
+  * mlp_1d.py:314        fold long prefill seq -> [1, seq//cutoff, cutoff, -1]
+                         (prefill_len_cutoff = 512 on BH / 1024 otherwise; mlp_1d.py:858)
+  * attention_1d.py:425  fold qkv seq        -> [1, seq//MAX_QKV_MM_SEQ_LEN, 2048, -1]
+  * attention_1d.py:459  unfold qkv back      -> [1, 1, seq, -1]
+  * attention_1d.py:599  fold for WO matmul   -> [1, seq//MAX_MM_SEQ_LEN, 1024, -1]
+  * mlp_1d.py:289        collapse leading dims -> [1, 1, a*b*c, N]
+
+MAX_QKV_MM_SEQ_LEN = 2048, MAX_MM_SEQ_LEN = 1024 (attention_1d.py:66,72).
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# (id, in_shape, out_shape). -1 is resolved by both torch.reshape and ttnn.reshape.
+_RESHAPE_SITES = [
+    # mlp_1d.py:314 — fold long prefill seq (cutoff = 512)
+    ("mlp_prefill_fold", (1, 1, 1024, U.DIM), (1, 1024 // 512, 512, -1)),
+    # attention_1d.py:459 — unfold folded qkv back to a single long sequence
+    ("attn_qkv_unfold", (1, 2, 512, U.DIM), (1, 1, 1024, -1)),
+    # mlp_1d.py:289 — collapse leading dims to [1, 1, M, N]
+    ("mlp_collapse", (1, 4, 256, U.DIM), (1, 1, 4 * 256, U.DIM)),
+    # attention_1d.py:599 — fold for WO matmul (MAX_MM_SEQ_LEN = 1024)
+    ("attn_wo_fold", (1, 1, 2048, U.DIM), (1, 2048 // 1024, 1024, -1)),
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, in_shape, out_shape",
+    [pytest.param(*s, id=s[0]) for s in _RESHAPE_SITES],
+)
+def test_reshape(ttnn_mesh_device, reset_seeds, name, in_shape, out_shape):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(in_shape)
+    x = U.to_tt(x_torch, mesh)
+
+    out = ttnn.reshape(x, list(out_shape))
+
+    ref = torch.reshape(x_torch.float(), out_shape)
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_reshape.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_reshape.py
@@ -49,7 +49,7 @@ def test_reshape(ttnn_mesh_device, reset_seeds, name, in_shape, out_shape):
     x_torch = U.torch_rand(in_shape)
     x = U.to_tt(x_torch, mesh)
 
-    out = ttnn.reshape(x, list(out_shape))
+    out = ttnn.experimental.quasar.reshape(x, list(out_shape))
 
     ref = torch.reshape(x_torch.float(), out_shape)
     U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_reshape.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_reshape.py
@@ -23,7 +23,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # (id, in_shape, out_shape). -1 is resolved by both torch.reshape and ttnn.reshape.
 _RESHAPE_SITES = [

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rms_norm.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rms_norm.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.rms_norm``  (CANONICAL EXEMPLAR for tests/ops/).
+
+Model call sites (modules/rmsnorm/rmsnorm_1d.py):
+  * L206  _decode_local_sharded   — sharded, with program_config/memory_config
+  * L238  _decode_local_interleaved — interleaved, program_config=None
+  * L261  _prefill_local          — interleaved, program_config=None
+
+This file covers the interleaved path (the emulator-friendly one) for the two
+tensor rank/shape families the model drives through RMSNorm: prefill
+[1, 1, seq, DIM] and decode [1, 1, batch, DIM]. The reference is torch.nn.RMSNorm.
+
+Weight layout matches the module (rmsnorm_1d.py:369-370):
+    (dim,) -> (1, 1, dim // 32, 32)
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+def _torch_rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    ref = torch.nn.RMSNorm(x.shape[-1], eps=eps, dtype=torch.float32)
+    ref.weight.data.copy_(weight.float())
+    return ref(x.float())
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "shape",
+    [pytest.param((1, 1, seq, U.DIM), id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS]
+    + [pytest.param((1, 1, batch, U.DIM), id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES],
+)
+def test_rms_norm(ttnn_mesh_device, reset_seeds, shape):
+    mesh = ttnn_mesh_device
+    dim = shape[-1]
+
+    x_torch = U.torch_rand(shape)
+    w_torch = U.torch_rand((dim,))
+
+    x = U.to_tt(x_torch, mesh)
+    # weight: (dim,) -> (1, 1, dim // TILE, TILE) in ROW_MAJOR, matching the module's
+    # norm-weight LazyWeight (rmsnorm_1d.py:369-383, layout=ROW_MAJOR_LAYOUT). ttnn.rms_norm
+    # flattens the ROW_MAJOR gamma to width `dim`; a TILE-layout gamma is read as width 32
+    # and trips "gamma logical width >= input logical width".
+    w = U.to_tt(w_torch.reshape(1, 1, dim // U.TILE, U.TILE), mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    out = ttnn.rms_norm(x, epsilon=U.NORM_EPS, weight=w)
+
+    ref = _torch_rms_norm(x_torch, w_torch, U.NORM_EPS)
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rms_norm.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rms_norm.py
@@ -21,7 +21,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 def _torch_rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rms_norm_post_all_gather.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rms_norm_post_all_gather.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.rms_norm_post_all_gather`` (distributed RMSNorm, part 2).
+
+Model call site:
+  modules/rmsnorm/rmsnorm_1d.py:306  (_prefill_1d_distributed)
+    tt_out = ttnn.rms_norm_post_all_gather(
+        x, tt_stats, epsilon=cfg.eps, weight=self.weight_distributed,
+        compute_kernel_config=cfg.compute_kernel_config)
+
+This op combines the (gathered) partial statistics from
+``ttnn.rms_norm_pre_all_gather`` with the input and the weight to produce the
+final RMSNorm output. On the single (1, 1) emulator mesh the all-gather is a
+no-op (one shard already holds the full hidden dim), so chaining
+``pre_all_gather -> post_all_gather`` reproduces a full RMSNorm and we can
+compare against torch.nn.RMSNorm via PCC.
+
+Weight layout matches the module (rmsnorm_1d.py weights are ROW_MAJOR,
+shape (1, 1, dim // 32, 32)); the post op requires the stats' first three padded
+dims to match the input and its last padded dim to be a TILE multiple.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+def _compute_kernel_config():
+    # Mirrors _resolve_1d_config (rmsnorm_1d.py:482-487).
+    return ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+
+def _torch_rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    ref = torch.nn.RMSNorm(x.shape[-1], eps=eps, dtype=torch.float32)
+    ref.weight.data.copy_(weight.float())
+    return ref(x.float())
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "shape",
+    [pytest.param((1, 1, seq, U.DIM), id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS],
+)
+def test_rms_norm_post_all_gather(ttnn_mesh_device, reset_seeds, shape):
+    mesh = ttnn_mesh_device
+    dim = shape[-1]
+    ckc = _compute_kernel_config()
+
+    x_torch = U.torch_rand(shape)
+    w_torch = U.torch_rand((dim,))
+
+    x = U.to_tt(x_torch, mesh)
+    # weight: (dim,) -> (1, 1, dim // TILE, TILE), ROW_MAJOR (rmsnorm_1d.py:531 / 546-551).
+    w = U.to_tt(w_torch.reshape(1, 1, dim // U.TILE, U.TILE), mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    # Part 1: partial stats (single device -> full stats, gather is a no-op).
+    stats = ttnn.rms_norm_pre_all_gather(x, compute_kernel_config=ckc, dtype=ttnn.bfloat16)
+
+    # Part 2: final normalized output.
+    out = ttnn.rms_norm_post_all_gather(
+        x,
+        stats,
+        epsilon=U.NORM_EPS,
+        weight=w,
+        compute_kernel_config=ckc,
+    )
+
+    ref = _torch_rms_norm(x_torch, w_torch, U.NORM_EPS)
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rms_norm_post_all_gather.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rms_norm_post_all_gather.py
@@ -26,7 +26,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 def _compute_kernel_config():

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rms_norm_pre_all_gather.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rms_norm_pre_all_gather.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.rms_norm_pre_all_gather`` (distributed RMSNorm, part 1).
+
+Model call site:
+  modules/rmsnorm/rmsnorm_1d.py:288  (_prefill_1d_distributed)
+    tt_stats = ttnn.rms_norm_pre_all_gather(
+        x, compute_kernel_config=cfg.compute_kernel_config, dtype=ttnn.bfloat16)
+
+What it computes
+----------------
+This op produces the *partial* per-shard statistics for distributed RMSNorm
+(the local sum-of-squares E[x^2], packed into a TILE-wide stats tensor of dtype
+BFLOAT16). Those stats are then all-gathered across devices and consumed by
+``ttnn.rms_norm_post_all_gather``. On the single (1, 1) emulator mesh there is no
+gather, so the stats already cover the full hidden dim.
+
+Because the stats tensor is an internal partial-reduction (not a full RMSNorm
+output), building a clean torch reference is awkward — we assert the output
+shape family / dtype / finiteness instead (per op_utils guidance). The full
+end-to-end RMSNorm result is validated in test_rms_norm_post_all_gather.py, which
+chains pre -> post.
+
+Model input shapes: prefill activations [1, 1, seq, DIM]. Weight is applied only
+in the post stage, so no weight is passed here.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+def _compute_kernel_config():
+    # Mirrors _resolve_1d_config (rmsnorm_1d.py:482-487).
+    return ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "shape",
+    [pytest.param((1, 1, seq, U.DIM), id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS],
+)
+def test_rms_norm_pre_all_gather(ttnn_mesh_device, reset_seeds, shape):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)
+
+    stats = ttnn.rms_norm_pre_all_gather(
+        x,
+        compute_kernel_config=_compute_kernel_config(),
+        dtype=ttnn.bfloat16,
+    )
+
+    # Stats: TILE layout, BFLOAT16, leading dims match input, last dim tile-multiple.
+    assert tuple(stats.shape)[:3] == tuple(shape)[:3], f"leading dims mismatch: {tuple(stats.shape)} vs {shape}"
+    assert stats.shape[-1] % U.TILE == 0, f"stats last dim {stats.shape[-1]} not a multiple of TILE"
+    U.assert_shape_dtype(stats, dtype=ttnn.bfloat16, finite=True, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rms_norm_pre_all_gather.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rms_norm_pre_all_gather.py
@@ -30,7 +30,7 @@ in the post stage, so no weight is passed here.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 def _compute_kernel_config():

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rotary_embedding_llama.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rotary_embedding_llama.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.rotary_embedding_llama`` (separate Q/K RoPE).
+
+Model call sites (modules/attention/attention_1d.py):
+  * L491  prefill_forward STAGE 6 — Q rotary (is_decode_mode=False)
+  * L499  prefill_forward STAGE 6 — K rotary (is_decode_mode=False)
+  * L997  _rotary_embed_decode_nonfused — Q rotary (is_decode_mode=True)
+  * L1000 _rotary_embed_decode_nonfused — K rotary (is_decode_mode=True)
+
+        q_heads = ttnn.experimental.rotary_embedding_llama(
+            q_heads_pre_rot, rot_mats[0], rot_mats[1],
+            cfg.transformation_mat_prefill, is_decode_mode=False,
+        )
+
+This file covers the PREFILL (interleaved, emulator-friendly) path for both the
+Q head-count (n_heads = 32) and the K head-count (n_kv_heads = 8). Inputs:
+  * heads:    [1, n(_kv)_heads, seq, head_dim]
+  * cos/sin:  [1, 1, seq, head_dim]
+  * trans_mat:[1, 1, TILE, TILE] (the base 32x32 rotation matrix)
+
+Transformation-matrix note: the rotary op applies the 32x32 rotation tile-wise, so
+the trans-mat is always [1,1,32,32] regardless of head_dim — this is what the model's
+own config resolver builds for prefill (get_rot_transformation_mat(),
+attention_1d.py:2064-2075) and what the canonical op test uses even for head_dim=64
+(tests/ttnn/nightly/.../test_rotary_embedding_llama.py:41-42,
+get_rot_transformation_mat(dhead=ttnn.TILE_SIZE)). The earlier [1,1,64,64] trans-mat
+(from the RotarySetupHelper in test_attention_1d.py:214-218) is what the op rejects
+("Transformation matrix must have 4th dim equal to TILE_WIDTH (32)").
+
+RoPE has a torch reference but it is fiddly (Meta-format cos/sin); shape / dtype /
+finiteness is an accepted assertion for this op per the suite guidance.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tensor_utils import get_rot_transformation_mat
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "n_heads",
+    [pytest.param(U.N_HEADS, id="q-heads"), pytest.param(U.N_KV_HEADS, id="k-heads")],
+)
+@pytest.mark.parametrize(
+    "seq",
+    [pytest.param(seq, id=f"prefill-seq{seq}") for seq in U.PREFILL_SEQ_LENS],
+)
+def test_rotary_embedding_llama(ttnn_mesh_device, reset_seeds, seq, n_heads):
+    mesh = ttnn_mesh_device
+    hd = U.HEAD_DIM
+
+    heads_torch = U.torch_rand((1, n_heads, seq, hd))
+    cos_torch = U.torch_rand((1, 1, seq, hd))
+    sin_torch = U.torch_rand((1, 1, seq, hd))
+
+    heads = U.to_tt(heads_torch, mesh)
+    cos = U.to_tt(cos_torch, mesh)
+    sin = U.to_tt(sin_torch, mesh)
+    # Prefill trans-mat is the base 32x32 rotation ([1,1,32,32]) — applied tile-wise
+    # for head_dim=64. Matches attention_1d.py:2066 and the canonical op test.
+    trans_mat = U.to_tt(get_rot_transformation_mat(), mesh)
+
+    out = ttnn.experimental.rotary_embedding_llama(heads, cos, sin, trans_mat, is_decode_mode=False)
+
+    U.assert_shape_dtype(out, shape=(1, n_heads, seq, hd), dtype=ttnn.bfloat16, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rotary_embedding_llama.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rotary_embedding_llama.py
@@ -38,7 +38,7 @@ import pytest
 
 import ttnn
 from models.experimental.llama32_1b_quasar.tensor_utils import get_rot_transformation_mat
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 @U.with_default_mesh()

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rotary_embedding_llama_fused_qk.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rotary_embedding_llama_fused_qk.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.experimental.rotary_embedding_llama_fused_qk`` (decode fused QK RoPE).
+
+Model call site (modules/attention/attention_1d.py):
+  * L988  _rotary_embed_decode_fused — applies RoPE to Q and K in a single kernel
+          during the decode path (use_qk_fused=True):
+
+            return ttnn.experimental.rotary_embedding_llama_fused_qk(
+                q_heads_pre_rot, k_heads_pre_rot,
+                rot_mats[0], rot_mats[1], cfg.transformation_mat_decode,
+            )
+
+On a single (1,1) device n_heads = 32, n_kv_heads = 8, head_dim = 64. Inputs
+(decode layout):
+  * q:        [1, batch, n_heads, head_dim]
+  * k:        [1, batch, n_kv_heads, head_dim]
+  * cos/sin:  [1, batch, TILE, head_dim]
+  * trans_mat:[1, 1, TILE, TILE]
+
+The fused op returns the rotated (q, k) pair. No simple torch reference — assert
+each output's shape / dtype / finiteness.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tensor_utils import get_rot_transformation_mat
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "batch",
+    [pytest.param(batch, id=f"decode-batch{batch}") for batch in U.DECODE_BATCHES],
+)
+def test_rotary_embedding_llama_fused_qk(ttnn_mesh_device, reset_seeds, batch):
+    mesh = ttnn_mesh_device
+    hd = U.HEAD_DIM
+
+    # Q/K decode heads: [1, batch, n(_kv)_heads, head_dim]. Head axis is tile-padded
+    # to 32 in the shard (nearest_32(32)=nearest_32(8)=32), matching the model's
+    # decode_create_qkv_head_memcfg output.
+    q_torch = U.torch_rand((1, batch, U.N_HEADS, hd))
+    k_torch = U.torch_rand((1, batch, U.N_KV_HEADS, hd))
+    # cos/sin are repeated across Q AND K, so cos_sin batch == 2*batch (device
+    # validate: cos_sin_batch_size == q_batch + k_batch; _fused_qk_device_op.cpp:85-90).
+    cos_torch = U.torch_rand((1, 2 * batch, U.TILE, hd))
+    sin_torch = U.torch_rand((1, 2 * batch, U.TILE, hd))
+
+    # The fused kernel requires Q and K on NON-OVERLAPPING HEIGHT_SHARDED grids, and
+    # cos/sin/trans_mat sharded over the union (2*batch cores). Grids mirror
+    # RotarySetup / _reshard_k_for_fused (attention_1d.py:1242-1250): Q on the first
+    # `batch` cores, K on the next `batch` cores (rows of 8).
+    q_memcfg = U.height_sharded_batch_memcfg(mesh, batch, (U.TILE, hd))
+    k_start = ttnn.CoreCoord(batch % 8, batch // 8)
+    k_memcfg = U.height_sharded_batch_memcfg(mesh, batch, (U.TILE, hd), start_core=k_start)
+    cos_sin_memcfg = U.height_sharded_batch_memcfg(mesh, 2 * batch, (U.TILE, hd))
+
+    q = U.to_tt(q_torch, mesh, memory_config=q_memcfg)
+    k = U.to_tt(k_torch, mesh, memory_config=k_memcfg)
+    cos = U.to_tt(cos_torch, mesh, memory_config=cos_sin_memcfg)
+    sin = U.to_tt(sin_torch, mesh, memory_config=cos_sin_memcfg)
+
+    # Decode trans-mat: the base 32x32 rotation repeated over the 2*batch Q+K cores,
+    # sharded to a single (32,32) tile per core (attention_1d.py:2046-2062).
+    trans_mat_torch = get_rot_transformation_mat().repeat(1, 1, 2 * batch, 1)  # [1,1,2*batch*32,32]
+    trans_mat_memcfg = U.height_sharded_batch_memcfg(mesh, 2 * batch, (U.TILE, U.TILE))
+    trans_mat = U.to_tt(trans_mat_torch, mesh, memory_config=trans_mat_memcfg)
+
+    q_out, k_out = ttnn.experimental.rotary_embedding_llama_fused_qk(q, k, cos, sin, trans_mat)
+
+    U.assert_shape_dtype(q_out, shape=(1, batch, U.N_HEADS, hd), dtype=ttnn.bfloat16, mesh_device=mesh)
+    # k_out head axis is tile-padded to 32 (nearest_32(n_kv_heads=8)=32), matching the sharded layout.
+    U.assert_shape_dtype(k_out, shape=(1, batch, U.TILE, hd), dtype=ttnn.bfloat16, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rotary_embedding_llama_fused_qk.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_rotary_embedding_llama_fused_qk.py
@@ -28,7 +28,7 @@ import pytest
 
 import ttnn
 from models.experimental.llama32_1b_quasar.tensor_utils import get_rot_transformation_mat
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 
 @U.with_default_mesh()

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_sampling.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_sampling.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.sampling``.
+
+Model call site (modules/sampling/sampling_1d.py):
+  * L413  _sample_topk — ttnn.sampling(topk_values, topk_global_indices,
+              k=k, p=p, temp=temp, sub_core_grids=..., output_tensor=tt_out_tok)
+    preceded by ttnn.manual_seed(seeds=..., user_ids=..., sub_core_grids=...) (L406).
+
+``ttnn.sampling`` takes the per-user top-k values and their (global) vocab
+indices, plus per-user k / p / temperature tensors, and returns one sampled
+token id per user. It is stochastic, so there is no closed-form torch reference.
+We therefore:
+  * assert the output shape/dtype (token ids) via U.assert_shape_dtype, and
+  * check determinism: the same seed must produce the same tokens.
+
+SCOPE — only the config the model actually uses:
+  The default token-accuracy run uses SAMPLING_MODE=host (host argmax) and does
+  NOT call ttnn.sampling at all. ttnn.sampling is invoked only in on_device_topk
+  mode, and the model's single on-device config is
+      SamplingParams(top_k=32, top_p=0.08, temperature=0.0)   (demo.py:599)
+  so this test uses exactly (k=32, p=0.08, temp=0.0). We deliberately do NOT test
+  other k/p/temp values (e.g. k=1) — the model never uses them, and k=1 hangs the
+  sampling kernel on the emulator (worker core stuck at NOC barrier waypoints).
+  On a single device cfg.sub_core_grids is None, so the model calls ttnn.sampling
+  with sub_core_grids=None — matching this test.
+
+k/p/temp tensor construction mirrors test_sampling_1d.py:_make_sampling_params
+(k: uint32 ROW_MAJOR, p/temp: bfloat16 ROW_MAJOR). topk_values are tiled bf16 and
+topk_global_indices are untilized int32, matching _sample_topk (L399-401, 413).
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# ttnn.sampling deadlocks inside its device kernels on the Quasar emulator: the
+# sampling core (worker 0,0) stalls with BRISC at CWFW (cb_wait_front, waiting for
+# output) and TRISC1 at MWDD (math wait DEST) — the compute kernel sampling.cpp never
+# produces a result. This happens for BOTH k=1 and k=32 (the model's on_device_topk
+# config), so it is an op/kernel-level issue, not a config we can fix from the test.
+# The default token-accuracy path uses SAMPLING_MODE=host (host argmax) and never calls
+# ttnn.sampling, so this does not affect the emulator token-accuracy run. Skipped until
+# the sampling kernel deadlock is investigated on device/LLK.
+pytestmark = pytest.mark.skip(
+    reason="ttnn.sampling device kernels deadlock on Quasar emulator (CWFW/MWDD); host argmax used on token-accuracy path"
+)
+
+_MAX_TOP_K = 32  # cfg.max_top_k default
+
+
+def _params(mesh, batch, *, k_val, p_val, temp_val):
+    """Per-user k/p/temp device tensors (mirrors _make_sampling_params)."""
+    k = ttnn.from_torch(
+        torch.full((batch,), k_val, dtype=torch.int32),
+        device=mesh,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+    p = ttnn.from_torch(torch.full((batch,), p_val), device=mesh, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+    temp = ttnn.from_torch(
+        torch.full((batch,), temp_val), device=mesh, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT
+    )
+    return k, p, temp
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "k_val,p_val,temp_val",
+    # The ONLY on-device sampling config the model uses (demo.py:599 on_device_topk).
+    [pytest.param(32, 0.08, 0.0, id="k32-p0.08-t0.0")],
+)
+@pytest.mark.parametrize("batch", [pytest.param(b, id=f"b{b}") for b in U.DECODE_BATCHES])
+def test_sampling(ttnn_mesh_device, reset_seeds, batch, k_val, p_val, temp_val):
+    mesh = ttnn_mesh_device
+    K = _MAX_TOP_K
+
+    # top-k values (descending) + their global vocab indices, as produced upstream.
+    vals_torch = torch.sort(U.torch_rand((1, 1, batch, K)).float(), dim=-1, descending=True).values
+    idxs_torch = torch.randint(0, U.VOCAB, (1, 1, batch, K), dtype=torch.int32)
+
+    topk_values = U.to_tt(vals_torch.to(torch.bfloat16), mesh)  # tiled bf16 (sampling_1d.py:413)
+    topk_global_indices = U.to_tt(idxs_torch, mesh, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)  # untilized
+
+    k, p, temp = _params(mesh, batch, k_val=k_val, p_val=p_val, temp_val=temp_val)
+
+    seeds = ttnn.from_torch(
+        torch.arange(batch, dtype=torch.int32), device=mesh, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT
+    )
+    user_ids = ttnn.from_torch(
+        torch.arange(batch, dtype=torch.int32), device=mesh, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT
+    )
+
+    def _sample():
+        ttnn.manual_seed(seeds=seeds, user_ids=user_ids)
+        return ttnn.sampling(topk_values, topk_global_indices, k=k, p=p, temp=temp)
+
+    out1 = _sample()
+    # No closed-form reference for a stochastic op: verify one token id per user is produced.
+    U.assert_shape_dtype(out1, shape=(1, 1, 1, batch), finite=True, mesh_device=mesh)
+
+    # Determinism: same seed -> same tokens.
+    out2 = _sample()
+    t1 = U.from_tt(out1, mesh).flatten()[:batch].long()
+    t2 = U.from_tt(out2, mesh).flatten()[:batch].long()
+    assert torch.equal(t1, t2), f"same seed produced different tokens:\n  {t1[:8]}\n  {t2[:8]}"

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_sampling.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_sampling.py
@@ -36,7 +36,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # ttnn.sampling deadlocks inside its device kernels on the Quasar emulator: the
 # sampling core (worker 0,0) stalls with BRISC at CWFW (cb_wait_front, waiting for
@@ -46,6 +46,7 @@ from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
 # The default token-accuracy path uses SAMPLING_MODE=host (host argmax) and never calls
 # ttnn.sampling, so this does not affect the emulator token-accuracy run. Skipped until
 # the sampling kernel deadlock is investigated on device/LLK.
+# See: https://github.com/tenstorrent/tt-llk/issues/1352
 pytestmark = pytest.mark.skip(
     reason="ttnn.sampling device kernels deadlock on Quasar emulator (CWFW/MWDD); host argmax used on token-accuracy path"
 )

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_scaled_dot_product_attention.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_scaled_dot_product_attention.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.transformer.scaled_dot_product_attention``  (prefill SDPA).
+
+Model call site (modules/attention/attention_1d.py:566-575, prefill_forward):
+    attn_output = ttnn.transformer.scaled_dot_product_attention(
+        q_heads_sdpa,          # [B, n_heads,    per_user_seq_len, head_dim]
+        k_heads_cache_dtype,   # [B, n_kv_heads, per_user_seq_len, head_dim]
+        v_heads_cache_dtype,   # [B, n_kv_heads, per_user_seq_len, head_dim]
+        is_causal=True,
+        sliding_window_size=cfg.sliding_window,   # None for Llama-3.2-1B
+        scale=cfg.scale,                          # head_dim ** -0.5
+        compute_kernel_config=cfg.sdpa_prefill_compute_kernel_cfg,
+        program_config=cfg.prefill_sdpa_prg_config(per_user_seq_len, None),
+    )
+
+GQA: 32 query heads, 8 kv heads (head_dim 64). Reference is torch SDPA with the
+kv heads expanded to 32 via repeat_interleave(n_heads // n_kv_heads).
+Known-good direct-call pattern mirrored from
+tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py:248-318.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# Single-user prefill (batch_size == 1 folds users into the sequence axis upstream).
+BATCH = 1
+
+
+def _torch_sdpa_causal(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, scale: float) -> torch.Tensor:
+    # Expand GQA kv heads to match the query head count.
+    n_rep = q.shape[1] // k.shape[1]
+    k_rep = k.repeat_interleave(n_rep, dim=1)
+    v_rep = v.repeat_interleave(n_rep, dim=1)
+    return torch.nn.functional.scaled_dot_product_attention(
+        q.float(), k_rep.float(), v_rep.float(), is_causal=True, scale=scale
+    )
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("seq", U.PREFILL_SEQ_LENS, ids=[f"seq{s}" for s in U.PREFILL_SEQ_LENS])
+def test_scaled_dot_product_attention(ttnn_mesh_device, reset_seeds, seq):
+    mesh = ttnn_mesh_device
+    scale = U.HEAD_DIM**-0.5
+
+    q_torch = U.torch_rand((BATCH, U.N_HEADS, seq, U.HEAD_DIM))
+    k_torch = U.torch_rand((BATCH, U.N_KV_HEADS, seq, U.HEAD_DIM))
+    v_torch = U.torch_rand((BATCH, U.N_KV_HEADS, seq, U.HEAD_DIM))
+
+    q = U.to_tt(q_torch, mesh)
+    k = U.to_tt(k_torch, mesh)
+    v = U.to_tt(v_torch, mesh)
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=mesh.compute_with_storage_grid_size(),
+        q_chunk_size=128,
+        k_chunk_size=128,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+
+    out = ttnn.transformer.scaled_dot_product_attention(
+        q,
+        k,
+        v,
+        is_causal=True,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+    )
+
+    ref = _torch_sdpa_causal(q_torch, k_torch, v_torch, scale)  # [B, n_heads, seq, head_dim]
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_scaled_dot_product_attention.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_scaled_dot_product_attention.py
@@ -26,7 +26,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # Single-user prefill (batch_size == 1 folds users into the sequence axis upstream).
 BATCH = 1

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_scaled_dot_product_attention_decode.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_scaled_dot_product_attention_decode.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.transformer.scaled_dot_product_attention_decode``  (non-paged decode SDPA).
+
+Model call site (modules/attention/attention_1d.py:852-862, _sdpa_decode_non_paged):
+    return ttnn.transformer.scaled_dot_product_attention_decode(
+        q_heads,               # [1, batch, n_heads, head_dim]
+        keys,                  # KV cache [batch, n_kv_heads, max_seq, head_dim]
+        values,                # KV cache [batch, n_kv_heads, max_seq, head_dim]
+        cur_pos_tensor=current_pos,     # int32 [batch] positions
+        scale=cfg.scale,                # head_dim ** -0.5
+        sliding_window_size=cfg.sliding_window,   # None for Llama-3.2-1B
+        program_config=cfg.decode_sdpa_prg_config,
+        compute_kernel_config=cfg.sdpa_decode_compute_kernel_cfg,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+Decode does one token per user: Q is [1, batch, n_heads, head_dim], the KV cache
+holds all past tokens, and cur_pos selects each user's current write index.
+GQA: 32 query heads, 8 kv heads (head_dim 64).
+Known-good direct-call pattern mirrored from
+tests/ttnn/unit_tests/operations/sdpa/sdpa_test_utils.py:342-541.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# KV-cache sequence capacity and the current decode position (same for all users).
+CACHE_SEQ = 256
+CUR_POS = 128
+K_CHUNK = 128  # divides the padded layer length (nearest_n(CUR_POS + 1, K_CHUNK) == 256 <= CACHE_SEQ)
+
+
+def _torch_decode_ref(q, k, v, cur_pos, scale, padded_layer_len):
+    # q: [1, b, nh, d]; k/v: [b, nkv, s, d]
+    b, nh = q.shape[1], q.shape[2]
+    nkv = k.shape[1]
+    q_slice = q[:, :, :, :].permute(1, 2, 0, 3).float()  # [b, nh, 1, d]
+    k_slice = k[:, :, :padded_layer_len, :].repeat_interleave(nh // nkv, dim=1).float()  # [b, nh, S, d]
+    v_slice = v[:, :, :padded_layer_len, :].repeat_interleave(nh // nkv, dim=1).float()
+    mask = torch.zeros((b, nh, 1, padded_layer_len))
+    for i in range(b):
+        mask[i, :, :, cur_pos[i] + 1 :] = torch.finfo(torch.float32).min
+    expect = torch.nn.functional.scaled_dot_product_attention(
+        q_slice, k_slice, v_slice, mask, scale=scale, is_causal=False
+    )
+    return expect.squeeze(2).unsqueeze(0)  # [1, b, nh, d]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("batch", U.DECODE_BATCHES, ids=[f"batch{b}" for b in U.DECODE_BATCHES])
+def test_scaled_dot_product_attention_decode(ttnn_mesh_device, reset_seeds, batch):
+    mesh = ttnn_mesh_device
+    scale = U.HEAD_DIM**-0.5
+
+    q_torch = U.torch_rand((1, batch, U.N_HEADS, U.HEAD_DIM))
+    k_torch = U.torch_rand((batch, U.N_KV_HEADS, CACHE_SEQ, U.HEAD_DIM))
+    v_torch = U.torch_rand((batch, U.N_KV_HEADS, CACHE_SEQ, U.HEAD_DIM))
+    cur_pos = [CUR_POS] * batch
+
+    q = U.to_tt(q_torch, mesh)
+    k = U.to_tt(k_torch, mesh)
+    v = U.to_tt(v_torch, mesh)
+    # cur_pos: int32 positions, one per user, ROW_MAJOR on device.
+    cur_pos_tt = U.to_tt(torch.tensor(cur_pos, dtype=torch.int32), mesh, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=mesh.compute_with_storage_grid_size(),
+        q_chunk_size=32,  # padded_num_heads for n_heads=32
+        k_chunk_size=K_CHUNK,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+
+    out = ttnn.transformer.scaled_dot_product_attention_decode(
+        q,
+        k,
+        v,
+        cur_pos_tensor=cur_pos_tt,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    padded_layer_len = ((CUR_POS + 1 + K_CHUNK - 1) // K_CHUNK) * K_CHUNK  # nearest_n(cur_pos+1, k_chunk)
+    ref = _torch_decode_ref(q_torch, k_torch, v_torch, cur_pos, scale, padded_layer_len)  # [1, b, nh, d]
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_scaled_dot_product_attention_decode.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_scaled_dot_product_attention_decode.py
@@ -28,7 +28,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # KV-cache sequence capacity and the current decode position (same for all users).
 CACHE_SEQ = 256

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_sharded_to_interleaved.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_sharded_to_interleaved.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.sharded_to_interleaved``.
+
+Model call sites:
+  * modules/rmsnorm/rmsnorm_1d.py:216   x = ttnn.sharded_to_interleaved(x)
+  * modules/mlp/mlp_1d.py:445           w2_out -> ttnn.L1_MEMORY_CONFIG
+  * modules/attention/attention_1d.py:1099,1116  xqkv/output -> ttnn.L1_MEMORY_CONFIG
+  * modules/lm_head/lm_head_1d.py:141   output -> cfg.output_memcfg
+  * utility_functions.py:203            tt_tensors_device -> interleaved
+
+``sharded_to_interleaved`` is the inverse of ``interleaved_to_sharded``. This test
+does the full round-trip: interleaved -> shard -> unshard, and asserts the result
+equals the original (values are preserved by pure layout conversions).
+
+NOTE: single-core grid so the passed shape is the exact per-core shard shape.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+_GRID = ttnn.CoreGrid(y=1, x=1)
+
+
+def _sharded_cfg(h, w, strategy):
+    return ttnn.create_sharded_memory_config(
+        (h, w),
+        _GRID,
+        strategy,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+# (id, shape, strategy) — shard shape is (shape[-2], shape[-1]).
+_CASES = [
+    # rmsnorm decode output: WIDTH-sharded (tile_padded_batch_rows, dim). rmsnorm_1d.py:216, cfg at :502
+    pytest.param((1, 1, U.TILE, U.DIM), ttnn.ShardStrategy.WIDTH, id="rmsnorm-decode-32x2048"),
+    # attention xqkv / dense output width family. attention_1d.py:1099,1116
+    pytest.param((1, 1, U.TILE, U.KV_DIM), ttnn.ShardStrategy.WIDTH, id="attn-width-32x512"),
+    # HEIGHT-sharded round trip (mirrors rope-style height shards). rope_1d.py:387
+    pytest.param((1, 1, U.TILE, U.HEAD_DIM), ttnn.ShardStrategy.HEIGHT, id="height-32x64"),
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape, strategy", _CASES)
+def test_sharded_to_interleaved(ttnn_mesh_device, reset_seeds, shape, strategy):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)  # interleaved DRAM
+
+    memcfg = _sharded_cfg(shape[-2], shape[-1], strategy)
+    x_sharded = ttnn.interleaved_to_sharded(x, memcfg)
+    out = ttnn.sharded_to_interleaved(x_sharded, ttnn.L1_MEMORY_CONFIG)  # mlp_1d.py:445, attention_1d.py:1099
+
+    assert not out.is_sharded(), "expected an interleaved output"
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_sharded_to_interleaved.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_sharded_to_interleaved.py
@@ -56,8 +56,10 @@ def test_sharded_to_interleaved(ttnn_mesh_device, reset_seeds, shape, strategy):
     x = U.to_tt(x_torch, mesh)  # interleaved DRAM
 
     memcfg = _sharded_cfg(shape[-2], shape[-1], strategy)
-    x_sharded = ttnn.interleaved_to_sharded(x, memcfg)
-    out = ttnn.sharded_to_interleaved(x_sharded, ttnn.L1_MEMORY_CONFIG)  # mlp_1d.py:445, attention_1d.py:1099
+    x_sharded = ttnn.experimental.quasar.interleaved_to_sharded(x, memcfg)
+    out = ttnn.experimental.quasar.sharded_to_interleaved(
+        x_sharded, ttnn.L1_MEMORY_CONFIG
+    )  # mlp_1d.py:445, attention_1d.py:1099
 
     assert not out.is_sharded(), "expected an interleaved output"
     U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_sharded_to_interleaved.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_sharded_to_interleaved.py
@@ -21,7 +21,7 @@ NOTE: single-core grid so the passed shape is the exact per-core shard shape.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 _GRID = ttnn.CoreGrid(y=1, x=1)
 

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_slice.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_slice.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.slice``.
+
+Model call sites (models/llama32_1b/model.py):
+  * L906  forward           — last-token slice before the LM head
+  * L919  post_process_prefill_output — same pattern
+
+Both trim a prefill hidden-state tensor [1, 1, seq, DIM] to the single
+tile-row window that contains the last token:
+
+    get_last_token_floor = (get_last_token // 32) * 32
+    x = ttnn.slice(x, (0, 0, floor, 0), (1, 1, floor + 32, x.shape[-1]))
+
+``ttnn.slice`` end coords are exclusive, so this yields a [1, 1, 32, DIM] window.
+Value-preserving -> torch reference is a plain narrow; PCC 0.999.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# (id, seq_len, last_token) grounded in real prefill sequence lengths (U.PREFILL_SEQ_LENS).
+_SLICE_SITES = [
+    ("seq128_last127", 128, 127),
+    ("seq512_last200", 512, 200),
+    ("seq1024_last1023", 1024, 1023),
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, seq_len, last_token",
+    [pytest.param(*s, id=s[0]) for s in _SLICE_SITES],
+)
+def test_slice(ttnn_mesh_device, reset_seeds, name, seq_len, last_token):
+    mesh = ttnn_mesh_device
+    floor = (last_token // 32) * 32
+
+    x_torch = U.torch_rand((1, 1, seq_len, U.DIM))
+    x = U.to_tt(x_torch, mesh)
+
+    out = ttnn.slice(x, (0, 0, floor, 0), (1, 1, floor + 32, x.shape[-1]))
+
+    ref = x_torch.float()[0:1, 0:1, floor : floor + 32, : U.DIM]
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_slice.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_slice.py
@@ -43,7 +43,7 @@ def test_slice(ttnn_mesh_device, reset_seeds, name, seq_len, last_token):
     x_torch = U.torch_rand((1, 1, seq_len, U.DIM))
     x = U.to_tt(x_torch, mesh)
 
-    out = ttnn.slice(x, (0, 0, floor, 0), (1, 1, floor + 32, x.shape[-1]))
+    out = ttnn.experimental.quasar.slice(x, (0, 0, floor, 0), (1, 1, floor + 32, x.shape[-1]))
 
     ref = x_torch.float()[0:1, 0:1, floor : floor + 32, : U.DIM]
     U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_slice.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_slice.py
@@ -21,7 +21,7 @@ Value-preserving -> torch reference is a plain narrow; PCC 0.999.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # (id, seq_len, last_token) grounded in real prefill sequence lengths (U.PREFILL_SEQ_LENS).
 _SLICE_SITES = [

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_split.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_split.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.split``.
+
+Model call site (modules/sampling/sampling_1d.py):
+  * L524  x_list       = ttnn.split(x_bf16, x_bf16.shape[-1] // 2, dim=3)
+  * L525  indices_list = ttnn.split(self._local_indices, ... // 2, dim=3)
+
+The single-device top-k strategy splits the vocab in half along the last dim
+(dim=3) to run two independent top-k passes. Value-preserving -> torch reference
+is ``torch.split`` along dim 3; each half compared with PCC 0.999.
+
+NOTE: the QKV projection is *not* split with ttnn.split — it uses
+``ttnn.experimental.nlp_create_qkv_heads`` (attention_1d.py:470). The only
+real ttnn.split call site is this vocab-halving one, which is what is covered.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# (id, batch, width) — width split in half along dim=3.
+_SPLIT_SITES = [
+    ("dim2048_half", 32, U.DIM),  # 2048 -> 2 x 1024
+    ("dim4096_half", 32, 4096),  # larger vocab-chunk -> 2 x 2048
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, batch, width",
+    [pytest.param(*s, id=s[0]) for s in _SPLIT_SITES],
+)
+def test_split(ttnn_mesh_device, reset_seeds, name, batch, width):
+    mesh = ttnn_mesh_device
+    half = width // 2
+
+    x_torch = U.torch_rand((1, 1, batch, width))
+    x = U.to_tt(x_torch, mesh)
+
+    parts = ttnn.split(x, half, dim=3)
+    assert len(parts) == 2, f"expected 2 splits, got {len(parts)}"
+
+    refs = torch.split(x_torch.float(), half, dim=3)
+    for i, (ref, part) in enumerate(zip(refs, parts)):
+        U.assert_pcc(ref, part, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_split.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_split.py
@@ -21,7 +21,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # (id, batch, width) — width split in half along dim=3.
 _SPLIT_SITES = [

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_to_device.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_to_device.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.to_device``.
+
+Model call site (modules/rope/rope_1d.py:169):
+    rot_idxs = ttnn.to_device(rot_idxs, cfg.device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+The model uses this to move a host-resident rotation-index tensor onto the mesh
+device (DRAM) before the cos/sin embedding lookup. This is a value-preserving
+placement op, so the reference is the original tensor read back.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "shape",
+    [pytest.param((1, U.TILE * b), id=f"rot_idxs-batch{b}") for b in U.DECODE_BATCHES]
+    + [pytest.param((1, 1, seq, U.DIM), id=f"activation-seq{seq}") for seq in U.PREFILL_SEQ_LENS],
+)
+@pytest.mark.parametrize("uint", [True, False], ids=["uint32", "bf16"])
+def test_to_device(ttnn_mesh_device, reset_seeds, shape, uint):
+    mesh = ttnn_mesh_device
+
+    if uint:
+        torch_in = torch.randint(0, 1000, shape, dtype=torch.int32)
+        dtype = ttnn.uint32
+        layout = ttnn.ROW_MAJOR_LAYOUT
+    else:
+        torch_in = U.torch_rand(shape)
+        dtype = ttnn.bfloat16
+        layout = ttnn.TILE_LAYOUT
+
+    # Build a HOST tensor (no device=), mirroring prepare_rot_idxs(on_host=True).
+    host_t = ttnn.from_torch(
+        torch_in,
+        dtype=dtype,
+        layout=layout,
+        mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(mesh),
+    )
+
+    dev_t = ttnn.to_device(host_t, mesh, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    U.assert_pcc(torch_in, dev_t, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_to_device.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_to_device.py
@@ -46,6 +46,6 @@ def test_to_device(ttnn_mesh_device, reset_seeds, shape, uint):
         mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(mesh),
     )
 
-    dev_t = ttnn.to_device(host_t, mesh, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    dev_t = ttnn.experimental.quasar.to_device(host_t, mesh, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
     U.assert_pcc(torch_in, dev_t, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_to_device.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_to_device.py
@@ -16,13 +16,15 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
+from models.experimental.llama32_1b_quasar.utility_functions import nearest_32
 
 
 @U.with_default_mesh()
 @pytest.mark.parametrize(
     "shape",
-    [pytest.param((1, U.TILE * b), id=f"rot_idxs-batch{b}") for b in U.DECODE_BATCHES]
+    # rot_idxs: prepare_rot_idxs pads [batch] -> [1, nearest_32(batch)] (rope_1d.py), i.e. 32 for both decode batches.
+    [pytest.param((1, nearest_32(b)), id=f"rot_idxs-batch{b}") for b in U.DECODE_BATCHES]
     + [pytest.param((1, 1, seq, U.DIM), id=f"activation-seq{seq}") for seq in U.PREFILL_SEQ_LENS],
 )
 @pytest.mark.parametrize("uint", [True, False], ids=["uint32", "bf16"])

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_to_memory_config.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_to_memory_config.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.to_memory_config`` (value-preserving layout/placement move).
+
+Model call sites (representative):
+  * DRAM <-> L1 interleaved:
+      - modules/attention/attention_1d.py:698,703  q/k_heads_pre_rot -> L1
+      - modules/attention/attention_1d.py:1153      output -> DRAM
+      - modules/mlp/mlp_1d.py:237                    w1_out -> DRAM
+      - models/llama32_1b/model.py:915,930           x -> DRAM
+  * interleaved -> WIDTH-sharded (residual / mlp / rmsnorm activations):
+      - models/llama32_1b/model.py:128,870,967       attn_out/x -> decode_residual_memcfg
+      - modules/rmsnorm/rmsnorm_1d.py:204            x -> decode_memory_config
+      - modules/mlp/mlp_1d.py:265,292                w2_in / w2_out_reduced -> sharded
+      - modules/attention/attention_1d.py:970,1206   dense_out -> decode_residual_memcfg
+
+``to_memory_config`` only relocates data, so a round-trip (DRAM interleaved ->
+target config -> host) must preserve values. Both the placement moves (DRAM/L1)
+and the interleaved->sharded moves are covered.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# Single-core width-shard grid; passed shape is the exact per-core shard shape.
+_GRID = ttnn.CoreGrid(y=1, x=1)
+
+
+def _width_sharded(h, w):
+    return ttnn.create_sharded_memory_config(
+        (h, w),
+        _GRID,
+        ttnn.ShardStrategy.WIDTH,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+# Placement moves: DRAM <-> L1 interleaved. Shapes from residual/activation stream.
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "target_memcfg",
+    [
+        pytest.param(ttnn.L1_MEMORY_CONFIG, id="dram-to-l1"),  # attention_1d.py:698, model.py:915
+        pytest.param(ttnn.DRAM_MEMORY_CONFIG, id="dram-to-dram"),  # attention_1d.py:1153, model.py:930
+    ],
+)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        pytest.param((1, 1, U.TILE, U.DIM), id="decode-32x2048"),
+        pytest.param((1, 1, U.PREFILL_SEQ_LENS[0], U.DIM), id=f"prefill-seq{U.PREFILL_SEQ_LENS[0]}"),
+    ],
+)
+def test_to_memory_config_placement(ttnn_mesh_device, reset_seeds, target_memcfg, shape):
+    mesh = ttnn_mesh_device
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)  # interleaved DRAM
+    out = ttnn.to_memory_config(x, target_memcfg)
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+
+
+# interleaved -> WIDTH-sharded move (the decode_residual / rmsnorm / mlp pattern).
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "width",
+    [
+        pytest.param(U.DIM, id="residual-2048"),  # model.py:128,967 ; rmsnorm_1d.py:204 (dim=2048)
+        pytest.param(U.KV_DIM, id="width-512"),  # mlp2-input-style width shard (mlp_1d.py:265)
+    ],
+)
+def test_to_memory_config_interleaved_to_sharded(ttnn_mesh_device, reset_seeds, width):
+    mesh = ttnn_mesh_device
+    shape = (1, 1, U.TILE, width)  # decode: tile_padded_batch_rows=32
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)  # interleaved DRAM
+    out = ttnn.to_memory_config(x, _width_sharded(U.TILE, width))
+    assert out.is_sharded(), "expected a sharded output"
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_to_memory_config.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_to_memory_config.py
@@ -60,7 +60,7 @@ def test_to_memory_config_placement(ttnn_mesh_device, reset_seeds, target_memcfg
     mesh = ttnn_mesh_device
     x_torch = U.torch_rand(shape)
     x = U.to_tt(x_torch, mesh)  # interleaved DRAM
-    out = ttnn.to_memory_config(x, target_memcfg)
+    out = ttnn.experimental.quasar.to_memory_config(x, target_memcfg)
     U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
 
 
@@ -78,6 +78,6 @@ def test_to_memory_config_interleaved_to_sharded(ttnn_mesh_device, reset_seeds, 
     shape = (1, 1, U.TILE, width)  # decode: tile_padded_batch_rows=32
     x_torch = U.torch_rand(shape)
     x = U.to_tt(x_torch, mesh)  # interleaved DRAM
-    out = ttnn.to_memory_config(x, _width_sharded(U.TILE, width))
+    out = ttnn.experimental.quasar.to_memory_config(x, _width_sharded(U.TILE, width))
     assert out.is_sharded(), "expected a sharded output"
     U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_to_memory_config.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_to_memory_config.py
@@ -24,7 +24,7 @@ and the interleaved->sharded moves are covered.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # Single-core width-shard grid; passed shape is the exact per-core shard shape.
 _GRID = ttnn.CoreGrid(y=1, x=1)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_topk.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_topk.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.topk``.
+
+Model call sites (modules/sampling/sampling_1d.py):
+  * L530  _topk_single_device — per half-vocab shard, k=cfg.max_top_k, dim=-1,
+          indices_tensor=<local indices>
+  * L568  _topk_multi_device  — per-device shard (padded to a power of 2),
+          k=cfg.max_top_k, dim=-1, indices_tensor=<local indices>
+
+``cfg.max_top_k`` defaults to 32 (Sampling1DConfig). The collected demo cases
+(tests/modules/sampling/test_sampling_1d.py:_list_collected_sampling_cases) use
+k ∈ {1, 10} at the sampler level; the topk op itself is always driven at
+max_top_k. We exercise k ∈ {1, 10, 32}.
+
+The single-device path splits the full vocab (VOCAB=128256) in half and runs
+topk over each ~64k shard. Full-vocab topk over bfloat16 is dominated by ties,
+so this op-level test uses tile-aligned power-of-2 widths for a stable reference
+(the padding-to-power-of-2 mirrors _topk_multi_device:559). ``indices_tensor`` is
+omitted here — the op returns fresh 0..W-1 indices, which is the reference space.
+
+Reference: ``torch.topk``. We assert the selected *values* match by PCC and that
+the selected *index sets* overlap (bfloat16 ties can reorder equal values).
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# max_top_k default (Sampling1DConfig); k=1/10 are the demo-collected sampler ks.
+_MAX_TOP_K = 32
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("width", [pytest.param(w, id=f"w{w}") for w in (1024, 2048)])
+@pytest.mark.parametrize("k", [pytest.param(k, id=f"k{k}") for k in (1, 10, _MAX_TOP_K)])
+@pytest.mark.parametrize("batch", [pytest.param(b, id=f"b{b}") for b in U.DECODE_BATCHES])
+def test_topk(ttnn_mesh_device, reset_seeds, batch, k, width):
+    mesh = ttnn_mesh_device
+    shape = (1, 1, batch, width)
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)
+
+    # Match the model's call: pass a persistent uint16 local-index tensor (TILE layout),
+    # exercising the indices_tensor overload used at sampling_1d.py:530-536 / 568-574.
+    # With arange indices the returned idxs are positional, so the torch.topk reference holds.
+    idx_torch = torch.arange(width, dtype=torch.int32).view(1, 1, 1, width).expand(1, 1, batch, width).contiguous()
+    indices_tensor = U.to_tt(idx_torch, mesh, dtype=ttnn.uint16)
+
+    values, indices = ttnn.topk(x, k=k, dim=-1, indices_tensor=indices_tensor)
+
+    # torch reference on the same bfloat16 values the device saw.
+    ref_vals, ref_idxs = torch.topk(x_torch.float(), k=k, dim=-1)  # [1,1,batch,k]
+
+    # Read back and slice per-row to the requested k (device output may be tile-padded).
+    dev_vals = U.from_tt(values, mesh).reshape(1, 1, batch, -1)[..., :k]
+    dev_idxs = U.from_tt(indices, mesh).reshape(1, 1, batch, -1)[..., :k].long()
+
+    for b in range(batch):
+        # Values: the k selected values (sorted desc) should match the reference per row.
+        got_v = torch.sort(dev_vals[0, 0, b].float(), descending=True).values
+        exp_v = torch.sort(ref_vals[0, 0, b].float(), descending=True).values
+        assert torch.allclose(got_v, exp_v, atol=0.05, rtol=0.05), f"batch {b}: top-{k} values {got_v} vs {exp_v}"
+
+        # Indices: set overlap per row (allow a small slack for bfloat16 tie reordering).
+        got_i = set(dev_idxs[0, 0, b].tolist())
+        exp_i = set(ref_idxs[0, 0, b].tolist())
+        overlap = len(got_i & exp_i)
+        assert overlap >= max(1, k - 2), f"batch {b}: top-{k} index overlap {overlap} (got {got_i} vs {exp_i})"

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_topk.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_topk.py
@@ -29,7 +29,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # max_top_k default (Sampling1DConfig); k=1/10 are the demo-collected sampler ks.
 _MAX_TOP_K = 32

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_transpose.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_transpose.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.transpose``.
+
+Model call site (modules/rope/rope_1d.py):
+  * L178  cos = ttnn.transpose(cos, 1, 2)
+  * L179  sin = ttnn.transpose(sin, 1, 2)
+
+In the decode rope path the cos/sin tables are unsqueezed to 4D
+[1, 1, batch, head_dim] (rope_1d.py:176-177) then transposed on dims (1, 2) to
+[1, batch, 1, head_dim] before being trimmed to the real batch size.
+
+Value-preserving permutation -> torch reference is ``torch.transpose(x, 1, 2)``;
+PCC 0.999.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# (id, shape, dim0, dim1) — rope transposes dims (1, 2) of [1, 1, batch, head_dim].
+_TRANSPOSE_SITES = [
+    ("rope_decode_batch1", (1, 1, 1, U.HEAD_DIM), 1, 2),
+    ("rope_decode_batch32", (1, 1, U.MAX_BATCH, U.HEAD_DIM), 1, 2),
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, shape, dim0, dim1",
+    [pytest.param(*s, id=s[0]) for s in _TRANSPOSE_SITES],
+)
+def test_transpose(ttnn_mesh_device, reset_seeds, name, shape, dim0, dim1):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)
+
+    out = ttnn.transpose(x, dim0, dim1)
+
+    ref = torch.transpose(x_torch.float(), dim0, dim1)
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_transpose.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_transpose.py
@@ -40,7 +40,7 @@ def test_transpose(ttnn_mesh_device, reset_seeds, name, shape, dim0, dim1):
     x_torch = U.torch_rand(shape)
     x = U.to_tt(x_torch, mesh)
 
-    out = ttnn.transpose(x, dim0, dim1)
+    out = ttnn.experimental.quasar.transpose(x, dim0, dim1)
 
     ref = torch.transpose(x_torch.float(), dim0, dim1)
     U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_transpose.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_transpose.py
@@ -20,7 +20,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # (id, shape, dim0, dim1) — rope transposes dims (1, 2) of [1, 1, batch, head_dim].
 _TRANSPOSE_SITES = [

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_typecast.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_typecast.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.typecast``.
+
+Model call sites:
+  * model.py:897              x = ttnn.typecast(x, activation_dtype)          # activation dtype cast
+  * attention_1d.py:489/497  ttnn.typecast(..., dtype=ttnn.bfloat16)         # q/k pre-rotary -> bf16
+  * attention_1d.py:507/510  ttnn.typecast(..., dtype=keys.dtype)            # -> KV cache dtype
+  * attention_1d.py:541      ttnn.typecast(..., dtype=cfg.activation_dtype or ttnn.bfloat8_b)
+  * attention_1d.py:1160     ttnn.typecast(output, cfg.prefill_reduce_ccl_dtype)
+
+typecast is a value-preserving dtype conversion (NOT a no-op even when src==tgt,
+per the comment at attention_1d.py:486). Reference is ``x.to(dtype)``. For casts
+to a lower-precision target (bf16, bfloat8_b) PCC is 0.99; for the bf16->fp32
+widening it is 0.999.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# (id, src_dtype, tgt_dtype, pcc)
+_CAST_SITES = [
+    ("bf16_to_fp32", ttnn.bfloat16, ttnn.float32, 0.999),  # widening -> exact
+    ("fp32_to_bf16", ttnn.float32, ttnn.bfloat16, 0.99),  # attention q/k -> bf16
+    ("bf16_to_bfp8", ttnn.bfloat16, ttnn.bfloat8_b, 0.99),  # activation / cache dtype
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, src_dtype, tgt_dtype, pcc",
+    [pytest.param(*s, id=s[0]) for s in _CAST_SITES],
+)
+def test_typecast(ttnn_mesh_device, reset_seeds, name, src_dtype, tgt_dtype, pcc):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand((1, 1, U.MAX_BATCH, U.DIM), dtype=torch.float32)
+    x = U.to_tt(x_torch, mesh, dtype=src_dtype)
+
+    out = ttnn.typecast(x, dtype=tgt_dtype)
+    assert out.dtype == tgt_dtype, f"expected dtype {tgt_dtype}, got {out.dtype}"
+
+    ref = x_torch.float()
+    U.assert_pcc(ref, out, pcc=pcc, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_typecast.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_typecast.py
@@ -42,7 +42,7 @@ def test_typecast(ttnn_mesh_device, reset_seeds, name, src_dtype, tgt_dtype, pcc
     x_torch = U.torch_rand((1, 1, U.MAX_BATCH, U.DIM), dtype=torch.float32)
     x = U.to_tt(x_torch, mesh, dtype=src_dtype)
 
-    out = ttnn.typecast(x, dtype=tgt_dtype)
+    out = ttnn.experimental.quasar.typecast(x, dtype=tgt_dtype)
     assert out.dtype == tgt_dtype, f"expected dtype {tgt_dtype}, got {out.dtype}"
 
     ref = x_torch.float()

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_typecast.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_typecast.py
@@ -21,7 +21,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # (id, src_dtype, tgt_dtype, pcc)
 _CAST_SITES = [

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_unsqueeze_to_4D.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_unsqueeze_to_4D.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.unsqueeze_to_4D``.
+
+Model call sites:
+  * rope_1d.py:176   cos = ttnn.unsqueeze_to_4D(cos)   # [1, batch, head_dim] -> [1, 1, batch, head_dim]
+  * rope_1d.py:177   sin = ttnn.unsqueeze_to_4D(sin)
+  * model.py:966/971/1013  x = ttnn.unsqueeze_to_4D(x)  # promote lower-rank tensors to rank 4
+
+``unsqueeze_to_4D`` left-pads the shape with 1s until it is rank 4; it is
+value-preserving -> torch reference is a reshape prepending leading 1s; PCC 0.999.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# (id, in_shape) — inputs of rank 2 and 3 that the model promotes to rank 4.
+_UNSQUEEZE_SITES = [
+    # rope_1d.py:176 — embedding output [1, batch, head_dim]
+    ("rope_3d", (1, U.MAX_BATCH, U.HEAD_DIM)),
+    # generic rank-2 promotion (model.py:966/1013 style)
+    ("rank2", (U.MAX_BATCH, U.DIM)),
+]
+
+
+def _torch_to_4d(x: torch.Tensor) -> torch.Tensor:
+    shape = (1,) * (4 - x.dim()) + tuple(x.shape)
+    return x.reshape(shape)
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, in_shape",
+    [pytest.param(*s, id=s[0]) for s in _UNSQUEEZE_SITES],
+)
+def test_unsqueeze_to_4D(ttnn_mesh_device, reset_seeds, name, in_shape):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(in_shape)
+    x = U.to_tt(x_torch, mesh)
+
+    out = ttnn.unsqueeze_to_4D(x)
+    assert len(out.shape) == 4, f"expected rank-4 output, got shape {tuple(out.shape)}"
+
+    ref = _torch_to_4d(x_torch.float())
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_unsqueeze_to_4D.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_unsqueeze_to_4D.py
@@ -17,7 +17,7 @@ import pytest
 import torch
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # (id, in_shape) — inputs of rank 2 and 3 that the model promotes to rank 4.
 _UNSQUEEZE_SITES = [

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_untilize.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_untilize.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.untilize``.
+
+Model call site (models/llama32_1b/model.py):
+  * L988  return ttnn.untilize(logits, use_multicore=True, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+The final logits are converted from TILE_LAYOUT to ROW_MAJOR_LAYOUT before being
+returned to host. ``untilize`` is a pure layout change (value-preserving), so the
+reference is the same tensor round-tripped: build a tile-laid-out tensor, untilize
+it, and compare the result to the original torch input; PCC 0.999.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+
+# (id, shape) — logits-shaped [1, 1, batch, N]; N kept modest (full VOCAB is large).
+_UNTILIZE_SITES = [
+    ("decode_batch1", (1, 1, 32, U.DIM)),
+    ("decode_batch32", (1, 1, U.MAX_BATCH, U.DIM)),
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, shape",
+    [pytest.param(*s, id=s[0]) for s in _UNTILIZE_SITES],
+)
+def test_untilize(ttnn_mesh_device, reset_seeds, name, shape):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh, layout=ttnn.TILE_LAYOUT)
+
+    out = ttnn.untilize(x, use_multicore=True, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    assert out.layout == ttnn.ROW_MAJOR_LAYOUT, f"expected ROW_MAJOR output, got {out.layout}"
+
+    # Value-preserving layout change -> compare against the original tensor.
+    U.assert_pcc(x_torch.float(), out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_untilize.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_untilize.py
@@ -36,7 +36,7 @@ def test_untilize(ttnn_mesh_device, reset_seeds, name, shape):
     x_torch = U.torch_rand(shape)
     x = U.to_tt(x_torch, mesh, layout=ttnn.TILE_LAYOUT)
 
-    out = ttnn.untilize(x, use_multicore=True, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    out = ttnn.experimental.quasar.untilize(x, use_multicore=True, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     assert out.layout == ttnn.ROW_MAJOR_LAYOUT, f"expected ROW_MAJOR output, got {out.layout}"
 
     # Value-preserving layout change -> compare against the original tensor.

--- a/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_untilize.py
+++ b/models/experimental/llama32_1b_quasar/tests/prototype_ops/test_untilize.py
@@ -16,7 +16,7 @@ it, and compare the result to the original torch input; PCC 0.999.
 import pytest
 
 import ttnn
-from models.experimental.llama32_1b_quasar.tests.ops import op_utils as U
+from models.experimental.llama32_1b_quasar.tests.prototype_ops import op_utils as U
 
 # (id, shape) — logits-shaped [1, 1, batch, N]; N kept modest (full VOCAB is large).
 _UNTILIZE_SITES = [

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/interleaved_to_sharded_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/interleaved_to_sharded_nanobind.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "interleaved_to_sharded_nanobind.hpp"
+
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/variant.h>
+#include <nanobind/stl/array.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "interleaved_to_sharded.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+void bind_interleaved_to_sharded(nb::module_& mod) {
+    const auto* doc =
+        R"doc(
+        Converts an interleaved tensor to a sharded tensor (Quasar / Metal 2.0).
+
+        Args:
+            input_tensor (ttnn.Tensor): the interleaved input tensor.
+            sharded_memory_config (ttnn.MemoryConfig): sharded memory configuration for the output.
+
+        Keyword Args:
+            output_dtype (ttnn.DataType, optional): data type of the output tensor. Defaults to the input dtype.
+            keep_l1_aligned (bool, optional): keep the shard L1-aligned. Defaults to `False`.
+            preallocated_output (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the sharded output tensor.
+        )doc";
+
+    ttnn::bind_function<"interleaved_to_sharded", "ttnn.experimental.quasar.">(
+        mod,
+        doc,
+        // Overload 1: explicit grid / shard_shape / scheme / orientation.
+        ttnn::overload_t(
+            nb::overload_cast<
+                const ttnn::Tensor&,
+                const std::variant<CoreCoord, CoreRangeSet>&,
+                std::array<uint32_t, 2>,
+                TensorMemoryLayout,
+                tt::tt_metal::ShardOrientation,
+                const std::optional<DataType>&,
+                const std::optional<bool>&>(&ttnn::operations::experimental::quasar::interleaved_to_sharded),
+            nb::arg("input_tensor").noconvert(),
+            nb::arg("grid"),
+            nb::arg("shard_shape"),
+            nb::arg("shard_scheme"),
+            nb::arg("shard_orientation"),
+            nb::arg("output_dtype") = nb::none(),
+            nb::kw_only(),
+            nb::arg("keep_l1_aligned") = false),
+        // Overload 2: sharded MemoryConfig -- mirrors ttnn.interleaved_to_sharded(x, sharded_memory_config).
+        ttnn::overload_t(
+            nb::overload_cast<
+                const ttnn::Tensor&,
+                const MemoryConfig&,
+                const std::optional<DataType>&,
+                const std::optional<bool>&,
+                const std::optional<ttnn::Tensor>&>(&ttnn::operations::experimental::quasar::interleaved_to_sharded),
+            nb::arg("input_tensor").noconvert(),
+            nb::arg("sharded_memory_config"),
+            nb::arg("output_dtype") = nb::none(),
+            nb::kw_only(),
+            nb::arg("keep_l1_aligned") = false,
+            nb::arg("preallocated_output") = nb::none()));
+}
+
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/interleaved_to_sharded_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/interleaved_to_sharded_nanobind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+namespace nb = nanobind;
+void bind_interleaved_to_sharded(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/quasar_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/quasar_nanobind.cpp
@@ -27,6 +27,9 @@
 #include "ttnn/operations/experimental/quasar/to_device/to_device_nanobind.hpp"
 #include "ttnn/operations/experimental/quasar/padded_slice/padded_slice_nanobind.hpp"
 #include "ttnn/operations/experimental/quasar/slice_write/slice_write_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/typecast/typecast_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/sharded_to_interleaved/sharded_to_interleaved_nanobind.hpp"
+#include "ttnn/operations/experimental/quasar/interleaved_to_sharded/interleaved_to_sharded_nanobind.hpp"
 
 namespace ttnn::operations::experimental::quasar {
 
@@ -85,7 +88,15 @@ void bind_quasar(nb::module_& mod) {
     detail::bind_padded_slice(m_quasar);
     detail::bind_slice_write(m_quasar);
 
-    // NOTE: halo and binary_ng have no python binding (internal device backends).
+    // typecast (dtype conversion).
+    detail::bind_typecast(m_quasar);
+
+    // sharded_to_interleaved / interleaved_to_sharded (standalone; to_memory_config also dispatches to these).
+    detail::bind_sharded_to_interleaved(m_quasar);
+    detail::bind_interleaved_to_sharded(m_quasar);
+
+    // NOTE: halo has no python binding (internal device backend). The binary_ng device op is exposed through the
+    // binary front-end (binary::py_module -> add/subtract/multiply/...), not a direct binary_ng binding.
 }
 
 }  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/sharded_to_interleaved_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/sharded_to_interleaved_nanobind.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sharded_to_interleaved_nanobind.hpp"
+
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "sharded_to_interleaved.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+void bind_sharded_to_interleaved(nb::module_& mod) {
+    const auto* doc =
+        R"doc(
+        Converts a sharded tensor to an interleaved tensor (Quasar / Metal 2.0).
+
+        Args:
+            input_tensor (ttnn.Tensor): the sharded input tensor.
+            memory_config (ttnn.MemoryConfig): interleaved memory configuration for the output.
+
+        Keyword Args:
+            output_dtype (ttnn.DataType, optional): data type of the output tensor. Defaults to the input dtype.
+
+        Returns:
+            ttnn.Tensor: the interleaved output tensor.
+        )doc";
+
+    ttnn::bind_function<"sharded_to_interleaved", "ttnn.experimental.quasar.">(
+        mod,
+        doc,
+        &ttnn::operations::experimental::quasar::sharded_to_interleaved,
+        nb::arg("input_tensor").noconvert(),
+        nb::arg("memory_config"),
+        nb::arg("output_dtype") = nb::none());
+}
+
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/sharded_to_interleaved_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/sharded_to_interleaved_nanobind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+namespace nb = nanobind;
+void bind_sharded_to_interleaved(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/sources.cmake
@@ -245,4 +245,7 @@ set(TTNN_OP_EXPERIMENTAL_QUASAR_NANOBIND_SRCS
     to_layout/to_layout_nanobind.cpp
     reallocate/reallocate_nanobind.cpp
     to_device/to_device_nanobind.cpp
+    typecast/typecast_nanobind.cpp
+    sharded_to_interleaved/sharded_to_interleaved_nanobind.cpp
+    interleaved_to_sharded/interleaved_to_sharded_nanobind.cpp
 )

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/typecast/typecast_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/typecast/typecast_nanobind.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "typecast_nanobind.hpp"
+
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "typecast.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+void bind_typecast(nb::module_& mod) {
+    const auto* doc =
+        R"doc(
+        Changes the data type of the input tensor (Quasar / Metal 2.0).
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+            dtype (ttnn.DataType): the target (output) data type.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+            optional_output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            sub_core_grids (ttnn.CoreRangeSet, optional): restrict execution to a subset of cores. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            A second overload accepts an explicit ``(input_dtype, output_dtype)`` pair to reinterpret the input's
+            declared dtype before casting.
+        )doc";
+
+    ttnn::bind_function<"typecast", "ttnn.experimental.quasar.">(
+        mod,
+        doc,
+        // Overload 1: single (output) dtype -- mirrors ttnn.typecast(x, dtype).
+        ttnn::overload_t(
+            nb::overload_cast<
+                const Tensor&,
+                const DataType&,
+                const std::optional<MemoryConfig>&,
+                const std::optional<Tensor>&,
+                const std::optional<CoreRangeSet>&>(&ttnn::operations::experimental::quasar::typecast),
+            nb::arg("input_tensor").noconvert(),
+            nb::arg("dtype").noconvert(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("optional_output_tensor") = nb::none(),
+            nb::arg("sub_core_grids") = nb::none()),
+        // Overload 2: explicit (input_dtype, output_dtype).
+        ttnn::overload_t(
+            nb::overload_cast<
+                const Tensor&,
+                const DataType&,
+                const DataType&,
+                const std::optional<MemoryConfig>&,
+                const std::optional<Tensor>&,
+                const std::optional<CoreRangeSet>&>(&ttnn::operations::experimental::quasar::typecast),
+            nb::arg("input_tensor").noconvert(),
+            nb::arg("input_dtype").noconvert(),
+            nb::arg("output_dtype").noconvert(),
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("optional_output_tensor") = nb::none(),
+            nb::arg("sub_core_grids") = nb::none()));
+}
+
+}  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/typecast/typecast_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/typecast/typecast_nanobind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::quasar::detail {
+
+namespace nb = nanobind;
+void bind_typecast(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::quasar::detail


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #52660 

- Copied over models/experimental/llama32_1b_quasar/tests/ops/ to models/experimental/llama32_1b_quasar/tests/prototype_ops/ to allow testing out using experimental/quasar ops.
- Exposes more experimental/quasar ops via nanobind
- Converts those tests that can use experimental/quasar ops to use them

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Local testing:
Tested locally that all added tests after applying proposed fix in https://github.com/tenstorrent/tt-metal/issues/53338 are skipped or pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-52660_qsr_llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-52660_qsr_llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-52660_qsr_llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-52660_qsr_llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-52660_qsr_llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-52660_qsr_llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-52660_qsr_llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-52660_qsr_llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-52660_qsr_llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-52660_qsr_llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-52660_qsr_llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-52660_qsr_llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-52660_qsr_llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-52660_qsr_llama)