### PR TITLE
fix(eltwise): step one ULP toward the target in nextafter, not a fixed epsilon away from it

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -48,8 +48,9 @@ def test_binary_nextafter_ttnn(input_shapes, device):
     golden_function = ttnn.get_golden_function(ttnn.nextafter)
     golden_tensor = golden_function(in_data1, in_data2)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    # nextafter moves its input by one ULP, so a PCC check cannot referee it: it cannot
+    # separate a+1ulp from a-1ulp, nor either of them from a left alone.
+    assert_with_ulp(golden_tensor, output_tensor, 0)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_nextafter.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_nextafter.py
@@ -8,20 +8,66 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+
+# nextafter moves its input by exactly one ULP, so a correlation check cannot referee it: a PCC
+# threshold cannot separate `a + 1ulp` from `a - 1ulp`, nor either of them from `a` left alone.
+# These assert equality against torch.nextafter instead.
 
 
-@pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
-def test_nextafter(device, shape):
-    torch.manual_seed(0)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize(
+    "a_value, b_value",
+    [
+        (1.0, 2.0),  # step up from the bottom of a binade
+        (1.0, 0.0),  # step down across a binade boundary
+        (2.0, 1.0),
+        (100.0, 200.0),  # a magnitude where a fixed FLT_EPSILON rounds away entirely
+        (1.0e10, 2.0e10),
+        (1.0e-5, 1.0),
+        (-1.0, 0.0),  # negative operands: the step must shrink the magnitude
+        (-1.0, -2.0),  # and here it must grow it
+        (0.0, 1.0),  # zero has no magnitude bits: the neighbour is the smallest subnormal
+        (0.0, -1.0),
+        (7.5, 7.5),  # nextafter(x, x) is x
+    ],
+)
+def test_nextafter_is_exact(device, dtype, a_value, b_value):
+    shape = (1, 1, 32, 32)
+    torch_a = torch.full(shape, a_value, dtype=dtype)
+    torch_b = torch.full(shape, b_value, dtype=dtype)
+    expected = torch.nextafter(torch_a, torch_b)
 
-    torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
-    torch_input_tensor_b = torch.rand(shape, dtype=torch.bfloat16)
+    a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device)
+    actual = ttnn.to_torch(ttnn.nextafter(a, b))
 
-    torch_output_tensor = torch.nextafter(torch_input_tensor_a, torch_input_tensor_b)
+    assert torch.equal(actual, expected), (
+        f"nextafter({a_value}, {b_value}) in {dtype}: got {actual[0, 0, 0, 0].item()!r}, "
+        f"expected {expected[0, 0, 0, 0].item()!r}"
+    )
 
-    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
-    output_tensor = ttnn.nextafter(input_tensor_a, input_tensor_b)
-    output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_nextafter_moves_toward_the_target(device, dtype):
+    # The direction is the property a PCC assertion is blindest to, so it gets its own check
+    # across twelve decades in both directions.
+    exponents = torch.arange(-6, 7, dtype=torch.float32)
+    magnitudes = torch.cat([torch.pow(10.0, exponents), -torch.pow(10.0, exponents)])
+
+    for magnitude in magnitudes.tolist():
+        for target in (magnitude * 2.0, magnitude * 0.5):
+            shape = (1, 1, 32, 32)
+            torch_a = torch.full(shape, magnitude, dtype=dtype)
+            torch_b = torch.full(shape, target, dtype=dtype)
+            if torch.equal(torch_a, torch_b):
+                continue
+
+            a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device)
+            b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device)
+            actual = ttnn.to_torch(ttnn.nextafter(a, b))
+
+            assert torch.equal(actual, torch.nextafter(torch_a, torch_b)), (
+                f"nextafter({magnitude}, {target}) in {dtype}: got "
+                f"{actual[0, 0, 0, 0].item()!r}, expected "
+                f"{torch.nextafter(torch_a, torch_b)[0, 0, 0, 0].item()!r}"
+            )

--- a/tests/ttnn/unit_tests/operations/eltwise/test_nextafter.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_nextafter.py
@@ -8,6 +8,8 @@ import torch
 
 import ttnn
 
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
 
 # nextafter moves its input by exactly one ULP, so a correlation check cannot referee it: a PCC
 # threshold cannot separate `a + 1ulp` from `a - 1ulp`, nor either of them from `a` left alone.
@@ -41,10 +43,8 @@ def test_nextafter_is_exact(device, dtype, a_value, b_value):
     b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device)
     actual = ttnn.to_torch(ttnn.nextafter(a, b))
 
-    assert torch.equal(actual, expected), (
-        f"nextafter({a_value}, {b_value}) in {dtype}: got {actual[0, 0, 0, 0].item()!r}, "
-        f"expected {expected[0, 0, 0, 0].item()!r}"
-    )
+    # ulp_threshold=0 is exactness in the units this op is defined in.
+    assert_with_ulp(expected, actual, 0)
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
@@ -66,8 +66,4 @@ def test_nextafter_moves_toward_the_target(device, dtype):
             b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device)
             actual = ttnn.to_torch(ttnn.nextafter(a, b))
 
-            assert torch.equal(actual, torch.nextafter(torch_a, torch_b)), (
-                f"nextafter({magnitude}, {target}) in {dtype}: got "
-                f"{actual[0, 0, 0, 0].item()!r}, expected "
-                f"{torch.nextafter(torch_a, torch_b)[0, 0, 0, 0].item()!r}"
-            )
+            assert_with_ulp(torch.nextafter(torch_a, torch_b), actual, 0)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -31,23 +31,51 @@ namespace ttnn {
 using namespace operations;
 
 // nextafter
+//
+// Returns the value adjacent to input_a in the direction of input_b.
+//
+// The previous implementation had two independent defects. It stepped in the wrong direction --
+// it added eps where input_a > input_b and subtracted it where input_a < input_b, that is, away
+// from input_b rather than toward it -- and it stepped by hal::get_eps(), which is FLT_EPSILON
+// and so is one ULP only inside [1, 2): above that band the addition rounds straight back to
+// input_a, below it the step overshoots. Over 120 (magnitude, direction) pairs spanning 1e-6 to
+// 1e6 the old composite returned the correct neighbour 0 times, in float32 and bfloat16 alike.
+//
+// Stepping the magnitude's bit pattern by one is exactly one ULP at every magnitude, subnormals
+// included, which is how nextafter is defined. Working on the magnitude and restoring the sign
+// afterwards keeps the sign handling in one place; input_a == 0 is then the only special case,
+// because zero has no magnitude bits to walk down and its neighbour in either direction is the
+// smallest subnormal.
 Tensor nextafter(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    const float eps = tt::tt_metal::hal::get_eps();
-    Tensor result(input_a);
-    {
-        Tensor eps_gt(input_a);
-        {
-            eps_gt = ttnn::where(
-                ttnn::gt(input_a, input_b, std::nullopt, output_mem_config),
-                ttnn::add(input_a, eps, std::nullopt, output_mem_config),
-                input_a);
-        }
-        result = ttnn::where(
-            ttnn::lt(input_a, input_b, std::nullopt, output_mem_config),
-            ttnn::subtract(input_a, eps, std::nullopt, output_mem_config),
-            eps_gt);
-    }
-    return result;
+    const DataType dtype = input_a.dtype();
+    const DataType bits_dtype = (dtype == DataType::FLOAT32) ? DataType::UINT32 : DataType::UINT16;
+
+    // The magnitude grows when the direction of travel agrees with the sign of input_a.
+    Tensor grows = ttnn::eq(
+        ttnn::gt(input_b, input_a, std::nullopt, output_mem_config),
+        ttnn::gtz(input_a, output_mem_config),
+        std::nullopt,
+        output_mem_config);
+
+    Tensor magnitude_bits = ttnn::bitcast(ttnn::abs(input_a, output_mem_config), bits_dtype, output_mem_config);
+    Tensor stepped = ttnn::where(
+        grows,
+        ttnn::add(magnitude_bits, 1, std::nullopt, output_mem_config),
+        ttnn::subtract(magnitude_bits, 1, std::nullopt, output_mem_config),
+        output_mem_config);
+    Tensor magnitude = ttnn::bitcast(stepped, dtype, output_mem_config);
+    Tensor result = ttnn::where(
+        ttnn::ltz(input_a, output_mem_config), ttnn::neg(magnitude, output_mem_config), magnitude, output_mem_config);
+
+    // input_a == 0: the neighbour is the smallest subnormal, carrying the sign of input_b.
+    Tensor smallest = ttnn::bitcast(ttnn::full_like(magnitude_bits, 1), dtype, output_mem_config);
+    Tensor smallest_signed = ttnn::where(
+        ttnn::ltz(input_b, output_mem_config), ttnn::neg(smallest, output_mem_config), smallest, output_mem_config);
+    result = ttnn::where(ttnn::eqz(input_a, output_mem_config), smallest_signed, result, output_mem_config);
+
+    // IEEE-754: nextafter(x, x) is x, for every x.
+    return ttnn::where(
+        ttnn::eq(input_a, input_b, std::nullopt, output_mem_config), input_b, result, output_mem_config);
 }
 
 Tensor minimum(


### PR DESCRIPTION
### Ticket

Addresses item 1 of #51218 (`ttnn::nextafter` moves away from `input_b`). Deliberately not using a closing keyword — that issue tracks six defects and this PR only covers the first.

### What's wrong

#51218 has the diagnosis right: both arms of the `where` chain are swapped, so the op steps away from `input_b` instead of toward it. The suggested fix there is to swap the two value arms back.

I would have sent exactly that patch, so I measured it first, and it does not fix the op. There is a second, independent defect in the same function: **`eps` is not a ULP.** It is `hal::get_eps()`, which the source documents as `FLT_EPSILON`:

```c
// tt_metal/hw/ckernels/{blackhole,wormhole_b0}/metal/llk_api/llk_math_common_api.h:17
#define EPS 1.19209e-07  // std::numeric_limits::epsilon() for FP32
```

That is the ULP at `1.0`, used as an absolute increment at every magnitude. It is one ULP only inside `[1, 2)`. Above that band `a + eps` rounds straight back to `a`; below it the step overshoots by several ULPs.

Reimplementing the composite as written — same branches, same constant — in float32 and bfloat16 with round-to-nearest-even, over 120 (magnitude, direction) pairs from `1e-6` to `1e6` in both directions:

| | float32 | bfloat16 |
|---|---|---|
| today | **0 / 120 correct** | **0 / 120 correct** |
| swapping the two arms, as #51218 suggests | **3 / 120** | **6 / 120** |
| this PR | **120 / 120** | **120 / 120** |

The middle row is the reason this is not a two-line change. With the step size left alone, the direction fix leaves the op wrong in 117 of 120 cases; in bfloat16 the composite is the *identity* in 102 of the 120, a bfloat16 ULP at 1.0 being `2^-8` against the `2^-23` being added.

### What changed

The magnitude's bit pattern is stepped by one, which is exactly one ULP at every magnitude, subnormals included. Working on the magnitude and restoring the sign afterwards keeps the sign handling in one place and leaves `input_a == 0` as the only special case: zero has no magnitude bits to walk down, and its neighbour in either direction is the smallest subnormal, carrying the sign of `input_b`.

`ttnn::bitcast` already supports the two pairs this needs — `UINT32 <-> FLOAT32` and `UINT16 <-> BFLOAT16` — and `where` and the integer `add`/`subtract` paths already accept `UINT32`/`UINT16`, so no new device support is involved.

### Measured

The composite as written in this PR, emulated in float32 and bfloat16 against `torch.nextafter`: **245 of 245 exact**, across twelve decades in both directions and both signs, plus `input_a == 0` in both directions and `input_a == input_b`.

### Test

#51218 also notes that the existing test cannot catch this, and that is worth acting on rather than just recording. The test was not using the wrong golden — `torch.nextafter` is correct and already attached — it was asserting with `assert_with_pcc`. Since `nextafter` differs from its input by one ULP, a PCC threshold cannot separate `a + 1ulp` from `a - 1ulp`, nor either from `a` left alone. The test passes today against an implementation that is wrong in every case.

It now asserts equality against `torch.nextafter`: across binade boundaries, at magnitudes where a fixed epsilon vanishes entirely, with negative operands in both directions, with `input_a == 0` in both directions, and with `input_a == input_b`.

### What I could not check

**This has not been compiled or run on a device.** I have no Tenstorrent hardware; every number above comes from reimplementing the arithmetic on x86 and comparing against `torch`. The first thing I would look at on real silicon is the `input_a == 0` path, which produces the smallest subnormal — if the device flushes it, that case needs handling closer to `nan_to_num` than a plain bitcast. I would rather say so than have a reviewer find it.

If someone already has a fix in flight for this item, say so and I will close this.