### PR TITLE
[Performance] Optimize generic all-to-all packet scheduling

### DIFF
--- a/tests/nightly/t3000/ccl/test_all_to_all_async_generic.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all_async_generic.py
@@ -10,6 +10,12 @@ from loguru import logger
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
 
 
+def create_fabric_router_config(max_payload_size):
+    config = ttnn.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = max_payload_size
+    return config
+
+
 def run_with_trace(
     mesh_device,
     topology,
@@ -82,12 +88,13 @@ def run_all_to_all_impl(
     do_check=True,
     reuse_inputs=False,
     cluster_axis=None,
+    worker_core_range=None,
 ):
     if num_iters < 1:
         pytest.fail("num_iters must be >= 1")
 
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
-    ccl_sub_device_crs = ttnn.CoreRangeSet(
+    ccl_sub_device_crs = worker_core_range or ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
     )
     worker_sub_device = ttnn.SubDevice(
@@ -300,7 +307,12 @@ def run_all_to_all_impl(
             ),
         ),  # test 3-2
     ],
-    ids=["test1-2:mesh1x8:dram", "test2-1:mesh2x4:1:block", "test2-3:mesh2x4:1:l1_h", "test3-2:mesh2x4:0:l1_w"],
+    ids=[
+        "test1-2:mesh1x8:dram",
+        "test2-1:mesh2x4:1:block",
+        "test2-3:mesh2x4:1:l1_h",
+        "test3-2:mesh2x4:0:l1_w",
+    ],
     indirect=["mesh_device"],
 )
 @pytest.mark.parametrize(
@@ -354,6 +366,76 @@ def test_all_to_all_fabric_1d_ring(mesh_device):
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         topology=ttnn.Topology.Ring,
+        num_iters=2,
+        input_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        do_check=True,
+        trace_mode=False,
+        reuse_inputs=False,
+        cluster_axis=1,
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "trace_region_size": 100000,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+            "fabric_router_config": create_fabric_router_config(14336),
+        }
+    ],
+    indirect=True,
+)
+def test_all_to_all_fabric_1d_ring_bank_owned_mux(mesh_device):
+    run_all_to_all_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        [1, 128, 128, 512],
+        in_dim=1,
+        out_dim=2,
+        num_links=1,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        topology=ttnn.Topology.Ring,
+        num_iters=2,
+        input_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        cluster_axis=1,
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "trace_region_size": 100000,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_router_config": create_fabric_router_config(14336),
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "logical_shape",
+    [
+        pytest.param([1, 128, 128, 512], id="muxed-large-message"),
+        pytest.param([1, 16, 128, 512], id="legacy-small-message"),
+    ],
+)
+def test_all_to_all_fabric_1d_linear_bank_owned(mesh_device, logical_shape):
+    run_all_to_all_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        logical_shape,
+        in_dim=1,
+        out_dim=2,
+        num_links=1,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        topology=ttnn.Topology.Linear,
         num_iters=2,
         input_mem_config=ttnn.DRAM_MEMORY_CONFIG,
         output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -457,6 +539,58 @@ def test_all_to_all_fabric_1d_ring(mesh_device):
             False,
             id="axis0-link2-ring-3to2-dram",
         ),
+        pytest.param(
+            1,
+            2,
+            [1, 128, 128, 512],
+            1,
+            2,
+            ttnn.Topology.Linear,
+            ttnn.DRAM_MEMORY_CONFIG,
+            ttnn.DRAM_MEMORY_CONFIG,
+            False,
+            False,
+            id="axis1-link2-linear-1to2-dram-reader-half-tile",
+        ),
+        pytest.param(
+            1,
+            2,
+            [1, 128, 128, 512],
+            2,
+            1,
+            ttnn.Topology.Linear,
+            ttnn.DRAM_MEMORY_CONFIG,
+            ttnn.DRAM_MEMORY_CONFIG,
+            False,
+            False,
+            id="axis1-link2-linear-2to1-dram-writer-half-tile",
+        ),
+        pytest.param(
+            1,
+            2,
+            [1, 128, 128, 512],
+            1,
+            2,
+            ttnn.Topology.Linear,
+            ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+            ttnn.DRAM_MEMORY_CONFIG,
+            False,
+            False,
+            id="axis1-link2-linear-1to2-l1-interleaved-to-dram",
+        ),
+        pytest.param(
+            1,
+            2,
+            [1, 4, 128, 32],
+            1,
+            2,
+            ttnn.Topology.Linear,
+            ttnn.DRAM_MEMORY_CONFIG,
+            ttnn.DRAM_MEMORY_CONFIG,
+            False,
+            False,
+            id="axis1-link2-linear-1to2-dram-fewer-blocks-than-links",
+        ),
     ],
 )
 def test_all_to_all_fabric_2d(
@@ -489,4 +623,101 @@ def test_all_to_all_fabric_2d(
         trace_mode=trace_mode,
         reuse_inputs=reuse_inputs,
         cluster_axis=cluster_axis,
+    )
+
+
+@pytest.mark.parametrize(
+    "mesh_device,device_params,cluster_axis",
+    [
+        pytest.param(
+            (2, 4),
+            {"trace_region_size": 100000, "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X},
+            0,
+            id="torus-x-ring-on-non-wrapping-axis-y",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_all_to_all_ring_falls_back_on_partial_torus_non_wrapping_axis(mesh_device, cluster_axis):
+    """A logical ring on the open partial-torus axis must not create a physical wrap connection."""
+    run_all_to_all_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        logical_shape=[1, 128, 128, 512],
+        in_dim=1,
+        out_dim=2,
+        num_links=2,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        topology=ttnn.Topology.Ring,
+        num_iters=2,
+        input_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        do_check=True,
+        trace_mode=False,
+        reuse_inputs=False,
+        cluster_axis=cluster_axis,
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"trace_region_size": 100000, "fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "worker_grid_end",
+    [
+        pytest.param((1, 6), id="two-mux-workers-per-direction"),  # 14 cores: 7 per link
+        pytest.param((0, 5), id="one-direct-worker-per-direction"),  # 6 cores: 3 per link
+    ],
+)
+def test_all_to_all_adapts_direction_workers_to_subdevice(mesh_device, worker_grid_end):
+    run_all_to_all_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        logical_shape=[1, 128, 128, 512],
+        in_dim=1,
+        out_dim=2,
+        num_links=2,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        topology=ttnn.Topology.Linear,
+        num_iters=2,
+        input_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        cluster_axis=1,
+        worker_core_range=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(*worker_grid_end))}),
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "trace_region_size": 100000,
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "fabric_router_config": create_fabric_router_config(14336),
+        }
+    ],
+    indirect=True,
+)
+def test_all_to_all_bank_owned_falls_back_on_restricted_subdevice(mesh_device):
+    run_all_to_all_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        logical_shape=[1, 128, 128, 512],
+        in_dim=1,
+        out_dim=2,
+        num_links=2,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        topology=ttnn.Topology.Linear,
+        num_iters=2,
+        input_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        cluster_axis=1,
+        worker_core_range=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 5))}),
     )

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.cpp
@@ -19,17 +19,33 @@ void AllToAllAsyncGenericDeviceOperation::validate_on_program_cache_miss(
     }
 
     const auto& input_tensor = tensor_args.input_tensor;
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_to_all_async must be on device");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to all_to_all_async must be allocated in buffers on device");
+
     const auto& page_size = input_tensor.buffer()->page_size();
     const auto& input_shape = input_tensor.logical_shape();
     auto rank = input_shape.rank();
+    auto* mesh_device = input_tensor.device();
+    const auto subdevice_id = operation_attributes.sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
+    const auto available_worker_cores =
+        mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id).num_cores();
+    const auto max_payload_size = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
 
     TT_FATAL(operation_attributes.in_dim >= 0 && operation_attributes.in_dim < rank, "in_dim out of range");
     TT_FATAL(operation_attributes.out_dim >= 0 && operation_attributes.out_dim < rank, "out_dim out of range");
 
     TT_FATAL(page_size % input_tensor.buffer()->alignment() == 0, "AllToAllAsync currently requires aligned pages");
 
-    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_to_all_async must be on device");
-    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to all_to_all_async must be allocated in buffers on device");
+    TT_FATAL(
+        available_worker_cores >= operation_attributes.num_links,
+        "All-to-all requires at least one worker per link: requested {} links, but subdevice has {} workers",
+        operation_attributes.num_links,
+        available_worker_cores);
+    TT_FATAL(
+        max_payload_size >= page_size,
+        "Fabric maximum payload {} must fit at least one tensor page of size {}",
+        max_payload_size,
+        page_size);
 
     TT_FATAL(
         input_shape[operation_attributes.out_dim] % operation_attributes.num_devices == 0,
@@ -141,6 +157,12 @@ ttsl::hash::hash_t AllToAllAsyncGenericDeviceOperation::compute_program_hash(
     auto* mesh_device = tensor_args.input_tensor.device();
     auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
     auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
+    const auto fabric_config = tt::tt_fabric::GetFabricConfig();
+    const auto axis_topology = ttnn::ccl::get_axis_topology(
+        tensor_args.input_tensor, fabric_config, operation_attributes.cluster_axis.value_or(0));
+    const auto max_payload_size = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
+    // The cached program contains the fabric mux kernel and client ABI. Bump this whenever either changes.
+    constexpr uint32_t fabric_mux_implementation_version = 2;
     return tt::tt_metal::operation::hash_operation<AllToAllAsyncGenericDeviceOperation>(
         operation_attributes.in_dim,
         operation_attributes.out_dim,
@@ -150,6 +172,10 @@ ttsl::hash::hash_t AllToAllAsyncGenericDeviceOperation::compute_program_hash(
         operation_attributes.topology,
         operation_attributes.cluster_axis,
         subdevice_core_range_set,
+        fabric_config,
+        axis_topology,
+        max_payload_size,
+        fabric_mux_implementation_version,
         tensor_args);
 }
 
@@ -165,6 +191,7 @@ Tensor all_to_all_async_generic(
     std::optional<uint32_t> cluster_axis) {
     using OperationType = AllToAllAsyncGenericDeviceOperation;
     uint32_t num_devices = ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
+    TT_FATAL(num_links > 0, "all_to_all_async requires at least one fabric link");
     TT_FATAL(
         num_devices > 1,
         "all_to_all_async is a collective operation and requires more than 1 device, but has {}",

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
@@ -11,7 +11,10 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <algorithm>
+#include <set>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace ttnn::experimental::prim {
 
@@ -34,6 +37,23 @@ ttnn::Shape get_tiled_shape(const ttnn::Tensor& input_tensor) {
     }
     return ttnn::Shape(tiled_shape);
 }
+
+constexpr uint32_t banks_owned_by_link(uint32_t num_dram_banks, uint32_t num_links, uint32_t link) {
+    if (link >= num_dram_banks) {
+        return 0;
+    }
+    return 1 + (num_dram_banks - 1 - link) / num_links;
+}
+
+static_assert(
+    banks_owned_by_link(8, 3, 0) == 3 && banks_owned_by_link(8, 3, 1) == 3 && banks_owned_by_link(8, 3, 2) == 2,
+    "Uneven 8-bank/3-link ownership must distribute as 3, 3, 2");
+
+constexpr uint32_t direction_schedule_cores_per_link(uint32_t workers_per_direction) {
+    const uint32_t mux_cores = workers_per_direction > 1 ? 2 : 0;
+    return 2 * workers_per_direction + mux_cores + 1;  // two directions, optional muxes, and local copy
+}
+
 }  // namespace
 
 AllToAllAsyncGenericProgram::cached_mesh_workload_t AllToAllAsyncGenericProgram::create_mesh_workload(
@@ -84,20 +104,29 @@ AllToAllAsyncGenericProgram::create_at(
     const uint32_t cluster_axis = operation_attributes.cluster_axis.value_or(0);
     const auto sender_device_fabric_node_id = tensor_args.input_tensor.device()->get_fabric_node_id(mesh_coordinate);
 
+    const auto fabric_config = tt::tt_fabric::GetFabricConfig();
+    const bool is_fabric_2d = tt::tt_fabric::is_2d_fabric_config(fabric_config);
+    // FABRIC_2D_TORUS_X/Y wraps only one mesh axis even though get_fabric_topology() reports Torus for both.
+    // Resolve wrapping for the collective's axis so a Ring on the other axis cannot open a nonexistent hop.
+    const auto axis_fabric_topology =
+        ttnn::ccl::get_axis_topology(tensor_args.input_tensor, fabric_config, cluster_axis);
+    const bool fabric_has_wrap_links = axis_fabric_topology == tt::tt_fabric::Topology::Ring;
+    const bool operation_uses_wrap_links =
+        operation_attributes.topology == ttnn::ccl::Topology::Ring && fabric_has_wrap_links;
+    const auto effective_topology =
+        operation_attributes.topology == ttnn::ccl::Topology::Ring && !operation_uses_wrap_links
+            ? ttnn::ccl::Topology::Linear
+            : operation_attributes.topology;
+    const auto connection_topology =
+        operation_uses_wrap_links ? tt::tt_fabric::Topology::Ring : tt::tt_fabric::Topology::Linear;
     const std::optional<MeshCoordinate> forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        tensor_args.input_tensor, mesh_coordinate, 1, operation_attributes.topology, operation_attributes.cluster_axis);
+        tensor_args.input_tensor, mesh_coordinate, 1, effective_topology, operation_attributes.cluster_axis);
     const std::optional<MeshCoordinate> backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-        tensor_args.input_tensor,
-        mesh_coordinate,
-        -1,
-        operation_attributes.topology,
-        operation_attributes.cluster_axis);
-
-    const bool is_fabric_2d = tt::tt_fabric::is_2d_fabric_config(tt::tt_fabric::GetFabricConfig());
+        tensor_args.input_tensor, mesh_coordinate, -1, effective_topology, operation_attributes.cluster_axis);
     const auto [fabric_neighbors, fabric_directions] = ttnn::operations::ccl::common::get_neighbors(
         tensor_args.input_tensor.device()->get_view(),
         mesh_coordinate,
-        tt::tt_fabric::Topology::Linear,
+        connection_topology,
         operation_attributes.cluster_axis);
 
     TT_FATAL(device_index < operation_attributes.num_devices, "DEBUG: device_index: {}", device_index);
@@ -107,19 +136,162 @@ AllToAllAsyncGenericProgram::create_at(
 
     std::vector<Tensor> input_tensors = {tensor_args.input_tensor};
     std::vector<Tensor> output_tensors = {tensor_return_value};
-    const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, operation_attributes.topology);
+    const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, effective_topology);
 
-    const bool is_ring = operation_attributes.topology == ttnn::ccl::Topology::Ring;
-    const size_t num_senders_per_link = 1;
-    const auto [sender_worker_core_range, sender_worker_cores] = ttnn::ccl::choose_worker_cores(
-        operation_attributes.num_links, num_senders_per_link, device, operation_attributes.sub_device_id);
+    const auto input_shape = get_tiled_shape(tensor_args.input_tensor);
+    uint32_t src_in_dims = 1;
+    for (uint32_t i = operation_attributes.out_dim + 1; i < input_shape.size(); ++i) {
+        src_in_dims *= input_shape[i];
+    }
+    const auto output_shape = get_tiled_shape(tensor_return_value);
+    uint32_t dst_out_dims = 1;
+    uint32_t dst_in_dims = 1;
+    for (uint32_t i = 0; i < operation_attributes.in_dim; ++i) {
+        dst_out_dims *= output_shape[i];
+    }
+    const uint32_t reader_has_extra_half_tile =
+        operation_attributes.out_dim == input_shape.size() - 2 &&
+        tensor_return_value.logical_shape()[operation_attributes.out_dim] % 32 == 16;
+    const uint32_t writer_has_extra_half_tile =
+        operation_attributes.in_dim == input_shape.size() - 2 &&
+        tensor_args.input_tensor.logical_shape()[operation_attributes.in_dim] % 32 == 16;
+    for (uint32_t i = operation_attributes.in_dim + 1; i < output_shape.size(); ++i) {
+        dst_in_dims *= output_shape[i];
+    }
+    const uint32_t concat_num_half_tiles =
+        output_shape[operation_attributes.in_dim] * 2 / operation_attributes.num_devices;
+    const uint32_t concat_num_tiles = (concat_num_half_tiles + 1) / 2;
+    const uint32_t num_blocks = dst_out_dims * dst_in_dims * concat_num_tiles;
+
+    const bool is_ring = effective_topology == ttnn::ccl::Topology::Ring;
+    const auto sub_device_id = operation_attributes.sub_device_id.value_or(device->get_sub_device_ids().at(0));
+    const auto available_worker_cores =
+        device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id).num_cores();
+    const uint32_t page_size = op_config.get_page_size();
+    const uint32_t max_payload_size = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
+    const uint32_t payload_capacity_pages = max_payload_size / page_size;
+    const uint32_t num_dram_banks = device->allocator()->get_num_banks(tt::tt_metal::BufferType::DRAM);
+    // With more than four pages, assign each stream whole destination DRAM banks. Output pages separated by the
+    // bank count are physically contiguous within a bank, so the receiver can coalesce a full fabric payload even
+    // though a scatter header can encode only four independent destination runs. Source pages are individually
+    // address-generated, so this schedule is equally valid for DRAM and L1 inputs; that also lets the L1-input
+    // perf proxy isolate reader DRAM work without silently switching to a different worker/fabric program. Keep
+    // the generic scatter schedule for small payloads and non-DRAM outputs. Link l owns banks
+    // l, l + num_links, ...; this remains valid when bank count is not divisible by link count.
+    const bool use_bank_owned_schedule =
+        payload_capacity_pages > 4 && tensor_return_value.buffer()->buffer_type() == BufferType::DRAM &&
+        tensor_return_value.buffer()->buffer_layout() == TensorMemoryLayout::INTERLEAVED && num_dram_banks > 0 &&
+        num_blocks >= num_dram_banks;
+    const uint32_t number_pages_per_packet =
+        use_bank_owned_schedule ? payload_capacity_pages : std::min<uint32_t>(4, payload_capacity_pages);
+    const uint32_t block_stride = use_bank_owned_schedule ? num_dram_banks : 1;
+
+    // Direction ownership, worker parallelism, and bank ownership are independent choices. Large messages use up to
+    // three workers per physical direction; two or one are selected when a restricted subdevice cannot fit the
+    // preferred schedule. Multiple workers share one fabric connection through a mux, while a one-worker direction
+    // connects directly. Logical Ring over a non-wrapping mesh retains the legacy schedule because the sign of its
+    // logical shortest path does not identify the first physical hop.
+    constexpr uint32_t preferred_workers_per_direction = 3;
+    constexpr uint32_t mux_num_directions = 2;
+    const bool direction_routing_is_physical = !is_ring || fabric_has_wrap_links;
+    const uint32_t max_useful_workers_per_direction =
+        is_ring ? preferred_workers_per_direction
+                : std::min(preferred_workers_per_direction, operation_attributes.num_devices - 1);
+    TT_FATAL(max_useful_workers_per_direction > 0, "Direction-owned all-to-all requires at least two devices");
+    // Normalize the message into full-payload packet equivalents per direction-worker lane. A lane is the pair of
+    // same-index positive/negative workers: destination placement decides which member receives the work, while the
+    // total message determines whether adding that lane can amortize its worker and mux startup. Five-run size sweeps
+    // put the Linear crossover at 16 packet equivalents per lane. Ring needs only four because the legacy schedule
+    // serializes both physical directions through one remote stream. Unlike a byte cutoff, this scales with fabric
+    // payload capacity, tensor page size, link count, and the number of useful worker lanes.
+    constexpr uint32_t linear_min_packets_per_lane = 16;
+    constexpr uint32_t ring_min_packets_per_lane = 4;
+    const uint32_t min_packets_per_lane = is_ring ? ring_min_packets_per_lane : linear_min_packets_per_lane;
+    const uint64_t packets_per_lane =
+        tensor_return_value.buffer()->num_pages() / (static_cast<uint64_t>(operation_attributes.num_links) *
+                                                     max_useful_workers_per_direction * number_pages_per_packet);
+    const bool parallel_workers_are_worthwhile = packets_per_lane >= min_packets_per_lane;
+    uint32_t workers_per_direction = 0;
+    if (direction_routing_is_physical && parallel_workers_are_worthwhile) {
+        // Deliberately qualify the preferred three-worker schedule before adapting to core capacity. Two workers are
+        // a restricted-subdevice fallback for large messages, not a lower size tier; sweeps on full-core systems did
+        // not find a message-size region where choosing two workers was better than both legacy and three workers.
+        for (uint32_t candidate = max_useful_workers_per_direction; candidate > 0; --candidate) {
+            if (direction_schedule_cores_per_link(candidate) * operation_attributes.num_links <=
+                available_worker_cores) {
+                workers_per_direction = candidate;
+                break;
+            }
+        }
+    }
+    // A single direct worker per direction is safe for the generic scatter order on a line. Bank-owned batches can
+    // cyclically block independent direct directions. On a 2D Ring/Torus, routing can choose either equal-cost path
+    // for an antipodal destination, while a direct direction-owned worker opens only one of them. Retain the proven
+    // legacy remote/local schedule for either case when a restricted subdevice cannot fit a mux tier. A muxed stream
+    // is safe on a 2D Ring/Torus because it injects through a concrete physical neighbor; that first hop breaks an
+    // antipodal tie, after which routing from the neighbor continues along the selected arc.
+    if (workers_per_direction == 1 && (use_bank_owned_schedule || (is_fabric_2d && fabric_has_wrap_links))) {
+        workers_per_direction = 0;
+    }
+    const bool use_direction_owned_schedule = workers_per_direction > 0;
+    const bool use_worker_mux = workers_per_direction > 1;
+    const uint32_t mux_cores_per_direction = workers_per_direction + 1;
+    const uint32_t direction_senders_per_link = mux_num_directions * workers_per_direction + 1;
+    const uint32_t direction_total_cores_per_link = direction_schedule_cores_per_link(workers_per_direction);
+    const size_t num_senders_per_link = use_direction_owned_schedule
+                                            ? direction_senders_per_link
+                                            : (available_worker_cores >= 2 * operation_attributes.num_links ? 2 : 1);
+    const uint32_t total_cores_per_link =
+        use_direction_owned_schedule ? direction_total_cores_per_link : num_senders_per_link;
+    const auto [all_worker_core_range, all_worker_cores] = ttnn::ccl::choose_worker_cores(
+        operation_attributes.num_links, total_cores_per_link, device, operation_attributes.sub_device_id);
+    (void)all_worker_core_range;
+    TT_FATAL(
+        all_worker_cores.size() == static_cast<size_t>(operation_attributes.num_links) * total_cores_per_link,
+        "All-to-all needs {} worker cores ({} links x {} cores/link), but only {} were selected",
+        operation_attributes.num_links * total_cores_per_link,
+        operation_attributes.num_links,
+        total_cores_per_link,
+        all_worker_cores.size());
+
+    std::vector<CoreCoord> sender_worker_cores;
+    sender_worker_cores.reserve(operation_attributes.num_links * num_senders_per_link);
+    std::vector<std::array<CoreCoord, mux_num_directions>> mux_cores(
+        use_worker_mux ? operation_attributes.num_links : 0);
+    std::set<CoreRange> sender_worker_core_set;
+    for (uint32_t link = 0; link < operation_attributes.num_links; ++link) {
+        const uint32_t link_base = link * total_cores_per_link;
+        if (use_worker_mux) {
+            mux_cores[link][0] = all_worker_cores[link_base];
+            mux_cores[link][1] = all_worker_cores[link_base + mux_cores_per_direction];
+            for (uint32_t worker = 0; worker < workers_per_direction; ++worker) {
+                sender_worker_cores.push_back(all_worker_cores[link_base + 1 + worker]);
+            }
+            for (uint32_t worker = 0; worker < workers_per_direction; ++worker) {
+                sender_worker_cores.push_back(all_worker_cores[link_base + mux_cores_per_direction + 1 + worker]);
+            }
+            sender_worker_cores.push_back(all_worker_cores[link_base + direction_total_cores_per_link - 1]);
+        } else if (use_direction_owned_schedule) {
+            for (uint32_t worker = 0; worker < mux_num_directions * workers_per_direction; ++worker) {
+                sender_worker_cores.push_back(all_worker_cores[link_base + worker]);
+            }
+            sender_worker_cores.push_back(all_worker_cores[link_base + direction_total_cores_per_link - 1]);
+        } else {
+            for (uint32_t stream = 0; stream < num_senders_per_link; ++stream) {
+                sender_worker_cores.push_back(all_worker_cores[link_base + stream]);
+            }
+        }
+        for (uint32_t stream = 0; stream < num_senders_per_link; ++stream) {
+            sender_worker_core_set.emplace(sender_worker_cores[link * num_senders_per_link + stream]);
+        }
+    }
+    const CoreRangeSet sender_worker_core_range(sender_worker_core_set);
 
     // Create CB
-    const uint32_t page_size = op_config.get_page_size();
-    const uint32_t packet_size = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
-
-    const uint32_t number_pages_per_packet = 2;
-    const uint32_t cb_size = (packet_size / page_size) * page_size * number_pages_per_packet;  // round_down
+    // Three packet slots provide reader/writer overlap without coupling pipeline depth to payload/page geometry.
+    // In particular, a one-page payload still needs multiple slots to avoid fully serializing both kernels.
+    constexpr uint32_t cb_depth = 3;
+    const uint32_t cb_size = cb_depth * number_pages_per_packet * page_size;
     const tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_tensor.dtype());
 
     auto cb_src0_config = tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CB::c_in0, data_format}})
@@ -138,35 +310,6 @@ AllToAllAsyncGenericProgram::create_at(
             .set_page_size(reserved_packet_header_CB_index, packet_header_size_bytes);
     CreateCircularBuffer(program, sender_worker_core_range, cb_reserved_packet_header_config);
 
-    const auto input_shape = get_tiled_shape(tensor_args.input_tensor);
-    uint32_t src_in_dims = 1;
-
-    for (uint32_t i = operation_attributes.out_dim + 1; i < input_shape.size(); ++i) {
-        src_in_dims *= input_shape[i];
-    }
-    const auto output_shape = get_tiled_shape(tensor_return_value);
-    uint32_t dst_out_dims = 1;
-    uint32_t dst_in_dims = 1;
-    for (uint32_t i = 0; i < operation_attributes.in_dim; ++i) {
-        dst_out_dims *= output_shape[i];
-    }
-
-    const uint32_t reader_has_extra_half_tile =
-        operation_attributes.out_dim == input_shape.size() - 2 &&
-        tensor_return_value.logical_shape()[operation_attributes.out_dim] % 32 == 16;
-    const uint32_t writer_has_extra_half_tile =
-        operation_attributes.in_dim == input_shape.size() - 2 &&
-        tensor_args.input_tensor.logical_shape()[operation_attributes.in_dim] % 32 == 16;
-    for (uint32_t i = operation_attributes.in_dim + 1; i < output_shape.size(); ++i) {
-        dst_in_dims *= output_shape[i];
-    }
-
-    const uint32_t concat_num_half_tiles =
-        output_shape[operation_attributes.in_dim] * 2 / operation_attributes.num_devices;
-    const uint32_t concat_num_tiles = (concat_num_half_tiles + 1) / 2;
-    const uint32_t num_blocks = dst_out_dims * dst_in_dims * concat_num_tiles;
-
-    const uint32_t num_blocks_devices = num_senders_per_link;
     const uint32_t num_cores_per_blocks = operation_attributes.num_links;
     const uint32_t blocks_per_core = num_blocks / num_cores_per_blocks;
 
@@ -182,7 +325,8 @@ AllToAllAsyncGenericProgram::create_at(
         reader_has_extra_half_tile,                 // has_reader_tail
         writer_has_extra_half_tile,                 // has_writer_tail
         concat_num_tiles,                           // concat_num_tiles
-        dst_in_dims                                 // dst_inner_dims_size
+        dst_in_dims,                                // dst_inner_dims_size
+        number_pages_per_packet                     // max_pages_per_packet
     };
 
     tt::tt_metal::TensorAccessorArgs(tensor_args.input_tensor.buffer())
@@ -195,15 +339,35 @@ AllToAllAsyncGenericProgram::create_at(
         sender_worker_core_range,
         sender_reader_kernel_config);
 
-    std::vector<int32_t> device_offsets[2];
-    std::vector<std::vector<int32_t>> block_starts[2], block_ends[2];
-    for (int i = 0; i < 2; ++i) {
+    std::vector<std::vector<int32_t>> device_offsets(num_senders_per_link);
+    std::vector<std::vector<uint32_t>> destination_groups(num_senders_per_link);
+    std::vector<int32_t> ring_ordered_offsets;
+    std::vector<std::vector<std::vector<uint32_t>>> block_starts(num_senders_per_link),
+        block_ends(num_senders_per_link), block_strides(num_senders_per_link), completion_flags(num_senders_per_link);
+    for (size_t i = 0; i < num_senders_per_link; ++i) {
         block_starts[i].resize(operation_attributes.num_links);
         block_ends[i].resize(operation_attributes.num_links);
+        block_strides[i].resize(operation_attributes.num_links);
+        completion_flags[i].resize(operation_attributes.num_links);
     }
+    const size_t local_sender_stream = num_senders_per_link - 1;
+    uint32_t positive_target_index = 0;
+    uint32_t negative_target_index = 0;
+    auto sender_stream_for_offset = [&](int32_t device_offset) {
+        if (device_offset == 0 && num_senders_per_link > 1) {
+            return local_sender_stream;
+        }
+        if (use_direction_owned_schedule) {
+            if (device_offset < 0) {
+                return size_t{workers_per_direction + (negative_target_index++ % workers_per_direction)};
+            }
+            return size_t{positive_target_index++ % workers_per_direction};
+        }
+        return size_t{0};
+    };
     if (is_ring) {
         // Visit global destinations in the same order on every source to avoid a cyclic fabric schedule.
-        // Use the shortest signed Ring offset; choose the positive arc for an even-size antipode.
+        // Use the shortest signed Ring offset; preserve the raw sign for an even-size antipode.
         for (uint32_t target_device = 0; target_device < operation_attributes.num_devices; ++target_device) {
             int32_t device_offset = static_cast<int32_t>(target_device) - static_cast<int32_t>(device_index);
             const int32_t half_ring = static_cast<int32_t>(operation_attributes.num_devices / 2);
@@ -212,61 +376,254 @@ AllToAllAsyncGenericProgram::create_at(
             } else if (device_offset > half_ring) {
                 device_offset -= operation_attributes.num_devices;
             }
-            device_offsets[0].push_back(device_offset);
+            if (use_direction_owned_schedule && use_bank_owned_schedule) {
+                ring_ordered_offsets.push_back(device_offset);
+            } else {
+                const size_t sender_stream = sender_stream_for_offset(device_offset);
+                device_offsets[sender_stream].push_back(device_offset);
+                destination_groups[sender_stream].push_back(target_device);
+            }
         }
     } else {
-        // Linear topology
-        for (uint32_t i = 0; i < operation_attributes.num_devices; ++i) {
-            device_offsets[0].push_back(i - device_index);
+        // Keep a common global order on every source, but alternate destinations from opposite ends of the line.
+        // This gives the independent positive/negative fabric connections a chance to drain concurrently instead
+        // of issuing every destination on one side before turning to the other side.
+        for (uint32_t step = 0; step < operation_attributes.num_devices; ++step) {
+            const uint32_t target_device = step % 2 == 0 ? step / 2 : operation_attributes.num_devices - 1 - step / 2;
+            const int32_t device_offset = static_cast<int32_t>(target_device) - static_cast<int32_t>(device_index);
+            const size_t sender_stream = sender_stream_for_offset(device_offset);
+            device_offsets[sender_stream].push_back(device_offset);
+            destination_groups[sender_stream].push_back(step / 2);
         }
     }
-    uint32_t semaphore_sent = 0;
-    for (int l = 0; l < operation_attributes.num_links; ++l) {
-        uint32_t current_start_block = l * blocks_per_core;
-        uint32_t current_end_block = (l + 1) * blocks_per_core;
-        if (l == operation_attributes.num_links - 1) {
-            current_end_block = num_blocks;
-        }
-        for (int c = 0; c < num_senders_per_link; ++c) {
-            for (int d = 0; d < device_offsets[c].size(); ++d) {
-                semaphore_sent++;
-                block_starts[c][l].push_back(current_start_block);
-                block_ends[c][l].push_back(current_end_block);
+    std::vector<std::vector<uint32_t>> bank_indices(num_senders_per_link);
+    if (use_bank_owned_schedule) {
+        const uint32_t max_banks_per_link = banks_owned_by_link(num_dram_banks, operation_attributes.num_links, 0);
+        if (is_ring && use_direction_owned_schedule) {
+            // A TP4 Ring has only one or two remote destinations per direction. Assigning a whole destination to one
+            // worker would leave most mux clients idle, so stripe each destination's DRAM banks across all workers in
+            // that direction. Each bank still owns a full contiguous packet stream; opposite directions retain
+            // opposite bank order to reduce receiver-side bank contention.
+            for (uint32_t target_index = 0; target_index < ring_ordered_offsets.size(); ++target_index) {
+                const int32_t device_offset = ring_ordered_offsets[target_index];
+                const bool local = device_offset == 0;
+                const bool antipodal = !local && std::abs(device_offset) * 2 == operation_attributes.num_devices;
+                const int32_t half_ring = static_cast<int32_t>(operation_attributes.num_devices / 2);
+                for (uint32_t bank_phase = 0; bank_phase < max_banks_per_link; ++bank_phase) {
+                    // Split an even Ring's antipodal destination evenly across both arcs. Source parity swaps which
+                    // arc owns bank 0 so adjacent sources do not start on the same direction. Other negative routes
+                    // retain reverse bank order to avoid matching the positive direction's receiver-bank phase.
+                    const int32_t routed_offset =
+                        antipodal ? (((bank_phase + device_index) % 2 == 0) ? half_ring : -half_ring) : device_offset;
+                    const uint32_t direction_base = routed_offset < 0 ? workers_per_direction : 0;
+                    const uint32_t bank_in_link =
+                        !antipodal && routed_offset < 0 ? max_banks_per_link - 1 - bank_phase : bank_phase;
+                    const size_t sender_stream =
+                        local ? local_sender_stream
+                              : direction_base + ((bank_phase + target_index) % workers_per_direction);
+                    device_offsets[sender_stream].push_back(routed_offset);
+                    bank_indices[sender_stream].push_back(bank_in_link);
+                }
+            }
+        } else {
+            for (uint32_t stream = 0; stream < num_senders_per_link; ++stream) {
+                auto& stream_offsets = device_offsets[stream];
+                const auto ordered_targets = stream_offsets;
+                const auto ordered_groups = destination_groups[stream];
+                stream_offsets.clear();
+                stream_offsets.reserve(ordered_targets.size() * max_banks_per_link);
+                bank_indices[stream].reserve(ordered_targets.size() * max_banks_per_link);
+                // Alternate the two globally paired destinations after each bank slice. This preserves the common
+                // destination order while reducing the interval during which only one fabric direction is issued.
+                const uint32_t num_destination_groups =
+                    is_ring ? operation_attributes.num_devices : (operation_attributes.num_devices + 1) / 2;
+                for (uint32_t group = 0; group < num_destination_groups; ++group) {
+                    for (uint32_t bank_phase = 0; bank_phase < max_banks_per_link; ++bank_phase) {
+                        const bool negative_direction_stream = use_direction_owned_schedule &&
+                                                               stream >= workers_per_direction &&
+                                                               stream < mux_num_directions * workers_per_direction;
+                        // Walk opposite directions in opposite bank orders. This preserves each same-bank contiguous
+                        // packet and avoids making both directions contend for the same bank at the same time.
+                        const uint32_t bank_in_link =
+                            negative_direction_stream ? max_banks_per_link - 1 - bank_phase : bank_phase;
+                        for (uint32_t target_index = 0; target_index < ordered_targets.size(); ++target_index) {
+                            if (ordered_groups[target_index] == group) {
+                                stream_offsets.push_back(ordered_targets[target_index]);
+                                bank_indices[stream].push_back(bank_in_link);
+                            }
+                        }
+                    }
+                }
+                destination_groups[stream].clear();
             }
         }
     }
 
-    const uint32_t fabric_direction_mask = ttnn::operations::ccl::common::fabric_directions_to_mask(fabric_directions);
+    for (uint32_t link = 0; link < operation_attributes.num_links; ++link) {
+        uint32_t current_start_block = link * blocks_per_core;
+        uint32_t current_end_block = (link + 1) * blocks_per_core;
+        if (link == operation_attributes.num_links - 1) {
+            current_end_block = num_blocks;
+        }
+        for (size_t stream = 0; stream < num_senders_per_link; ++stream) {
+            for (size_t schedule_index = 0; schedule_index < device_offsets[stream].size(); ++schedule_index) {
+                if (use_bank_owned_schedule) {
+                    const uint32_t bank_in_link = bank_indices[stream][schedule_index];
+                    const uint32_t bank_start = bank_in_link * operation_attributes.num_links + link;
+                    // The final bank phase can be absent on some links when bank count is not divisible by link
+                    // count. Keep the common stream schedule and represent that link's missing bank as empty work.
+                    const bool link_owns_bank =
+                        bank_in_link < banks_owned_by_link(num_dram_banks, operation_attributes.num_links, link);
+                    block_starts[stream][link].push_back(link_owns_bank ? bank_start : num_blocks);
+                    block_ends[stream][link].push_back(num_blocks);
+                } else {
+                    block_starts[stream][link].push_back(current_start_block);
+                    block_ends[stream][link].push_back(current_end_block);
+                }
+                completion_flags[stream][link].push_back(false);
+                block_strides[stream][link].push_back(block_stride);
+            }
+        }
+    }
 
-    auto sender_writer_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
-    sender_writer_kernel_config.compile_args = {
-        tt::CB::c_in0,                                         // cb0_id
-        device_index,                                          // device_index
-        operation_attributes.num_devices,                      // num_devices
-        output_shape[operation_attributes.in_dim],             // concat_dim_size
-        dst_in_dims,                                           // inner_dims_size
-        writer_has_extra_half_tile,                            // has_writer_tail
-        page_size,                                             // intermediate_page_size
-        reserved_packet_header_CB_index,                       // reserved_packet_header_cb_id
-        semaphore_sent,                                        // semaphore_expected_value
-        concat_num_tiles,                                      // concat_num_tiles
-        (concat_num_half_tiles * device_index) / 2,            // full_block_offset
-        static_cast<uint32_t>(operation_attributes.topology),  // topology
-        cluster_axis,                                          // replicate_axis
-        sender_device_fabric_node_id.chip_id,                  // source_chip_id
-        *sender_device_fabric_node_id.mesh_id,                 // source_mesh_id
-        is_fabric_2d,                                          // is_fabric_2d
-        fabric_direction_mask                                  // fabric_direction_mask
-    };
+    // Direction-owned schedules signal at the end of each contiguous non-empty destination run. The legacy
+    // bank-owned schedule can alternate two destinations within a bank phase, so retain its original one signal
+    // per destination and link. Both rules skip absent bank phases and generic empty work ranges.
+    // Each device must send the same number of completion signals that its transpose peer schedule sends back;
+    // the final barrier relies on this symmetric per-pair completion-count invariant.
+    uint32_t semaphore_sent = 0;
+    for (size_t stream = 0; stream < num_senders_per_link; ++stream) {
+        for (uint32_t link = 0; link < operation_attributes.num_links; ++link) {
+            std::unordered_set<int32_t> completed_offsets;
+            bool has_next_nonempty_offset = false;
+            int32_t next_nonempty_offset = 0;
+            for (size_t schedule_index = device_offsets[stream].size(); schedule_index-- > 0;) {
+                if (block_starts[stream][link][schedule_index] >= block_ends[stream][link][schedule_index]) {
+                    continue;
+                }
+                const int32_t device_offset = device_offsets[stream][schedule_index];
+                const bool target_complete = use_bank_owned_schedule && !use_direction_owned_schedule
+                                                 ? completed_offsets.insert(device_offset).second
+                                                 : (!has_next_nonempty_offset || device_offset != next_nonempty_offset);
+                if (target_complete) {
+                    completion_flags[stream][link][schedule_index] = true;
+                    ++semaphore_sent;
+                }
+                has_next_nonempty_offset = true;
+                next_nonempty_offset = device_offset;
+            }
+        }
+    }
 
-    tt::tt_metal::TensorAccessorArgs(tensor_return_value.buffer()).append_to(sender_writer_kernel_config.compile_args);
+    std::vector<CoreRangeSet> sender_stream_core_ranges(num_senders_per_link);
+    for (uint32_t core_id = 0; core_id < sender_worker_cores.size(); ++core_id) {
+        const auto& core = sender_worker_cores[core_id];
+        const size_t stream = core_id % num_senders_per_link;
+        sender_stream_core_ranges[stream] =
+            sender_stream_core_ranges[stream].merge(CoreRangeSet(CoreRange(core, core)));
+    }
 
-    auto sender_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/"
-        "all_to_all_sender_writer.cpp",
-        sender_worker_core_range,
-        sender_writer_kernel_config);
+    const uint32_t all_fabric_direction_mask =
+        ttnn::operations::ccl::common::fabric_directions_to_mask(fabric_directions);
+    std::vector<uint32_t> sender_stream_direction_masks(num_senders_per_link, 0);
+    if (use_direction_owned_schedule) {
+        // Direction indices follow {East, West, North, South}. Axis 1 is horizontal and axis 0 is vertical.
+        // A 1D connection only needs distinct non-zero masks; its low-latency header routes by signed hop count.
+        const uint32_t positive_direction = !is_fabric_2d || cluster_axis == 1 ? 0 : 3;
+        const uint32_t negative_direction = !is_fabric_2d || cluster_axis == 1 ? 1 : 2;
+        const bool has_positive_connection =
+            is_fabric_2d ? fabric_directions[positive_direction] : forward_coord.has_value();
+        const bool has_negative_connection =
+            is_fabric_2d ? fabric_directions[negative_direction] : backward_coord.has_value();
+        if (has_positive_connection) {
+            for (uint32_t worker = 0; worker < workers_per_direction; ++worker) {
+                sender_stream_direction_masks[worker] = 1U << positive_direction;
+            }
+        }
+        if (has_negative_connection) {
+            for (uint32_t worker = 0; worker < workers_per_direction; ++worker) {
+                sender_stream_direction_masks[workers_per_direction + worker] = 1U << negative_direction;
+            }
+        }
+    } else {
+        sender_stream_direction_masks[0] = all_fabric_direction_mask;
+    }
+
+    constexpr uint8_t num_mux_buffers_per_channel = 2;
+    const uint32_t mux_config_clients = std::max(1u, workers_per_direction);
+    tt::tt_fabric::FabricMuxV2Config mux_config(
+        /*num_channels=*/static_cast<uint8_t>(mux_config_clients),
+        /*num_buffers_per_channel=*/num_mux_buffers_per_channel,
+        /*channel_buffer_size_bytes=*/tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes(),
+        /*base_l1_address=*/device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1));
+    if (use_worker_mux) {
+        TT_FATAL(
+            mux_config.get_memory_map_end_address() <= device->l1_size_per_core(),
+            "All-to-all fabric mux requires L1 through address {:#x}, but each Tensix core has only {:#x} bytes",
+            mux_config.get_memory_map_end_address(),
+            device->l1_size_per_core());
+    }
+
+    if (use_worker_mux) {
+        for (uint32_t link = 0; link < operation_attributes.num_links; ++link) {
+            const std::array<std::optional<MeshCoordinate>, mux_num_directions> direction_neighbors = {
+                forward_coord, backward_coord};
+            for (uint32_t direction = 0; direction < mux_num_directions; ++direction) {
+                const uint32_t representative_stream = direction * workers_per_direction;
+                if (sender_stream_direction_masks[representative_stream] == 0) {
+                    continue;
+                }
+                TT_FATAL(direction_neighbors[direction].has_value(), "Active all-to-all mux direction has no neighbor");
+                tt::tt_fabric::add_fabric_mux_v2_to_program(
+                    program,
+                    mux_config,
+                    mux_cores[link][direction],
+                    sender_device_fabric_node_id,
+                    device->get_fabric_node_id(*direction_neighbors[direction]),
+                    link);
+            }
+        }
+    }
+
+    std::vector<tt::tt_metal::KernelHandle> sender_writer_kernel_ids;
+    sender_writer_kernel_ids.reserve(num_senders_per_link);
+    for (size_t stream = 0; stream < num_senders_per_link; ++stream) {
+        auto sender_writer_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
+        sender_writer_kernel_config.compile_args = {
+            tt::CB::c_in0,                               // cb0_id
+            device_index,                                // device_index
+            operation_attributes.num_devices,            // num_devices
+            output_shape[operation_attributes.in_dim],   // concat_dim_size
+            dst_in_dims,                                 // inner_dims_size
+            writer_has_extra_half_tile,                  // has_writer_tail
+            page_size,                                   // intermediate_page_size
+            reserved_packet_header_CB_index,             // reserved_packet_header_cb_id
+            semaphore_sent,                              // semaphore_expected_value
+            concat_num_tiles,                            // concat_num_tiles
+            (concat_num_half_tiles * device_index) / 2,  // full_block_offset
+            static_cast<uint32_t>(effective_topology),   // topology
+            cluster_axis,                                // replicate_axis
+            sender_device_fabric_node_id.chip_id,        // source_chip_id
+            *sender_device_fabric_node_id.mesh_id,       // source_mesh_id
+            is_fabric_2d,                                // is_fabric_2d
+            sender_stream_direction_masks[stream],       // fabric_direction_mask
+            number_pages_per_packet                      // max_pages_per_packet
+        };
+
+        tt::tt_metal::TensorAccessorArgs(tensor_return_value.buffer())
+            .append_to(sender_writer_kernel_config.compile_args);
+        const bool stream_uses_mux = use_worker_mux && stream < mux_num_directions * workers_per_direction &&
+                                     sender_stream_direction_masks[stream] != 0;
+        sender_writer_kernel_config.compile_args.push_back(stream_uses_mux);
+        sender_writer_kernel_config.compile_args.push_back(workers_per_direction);
+
+        sender_writer_kernel_ids.push_back(tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/"
+            "all_to_all_sender_writer.cpp",
+            sender_stream_core_ranges[stream],
+            sender_writer_kernel_config));
+    }
 
     CoreRange sender_box = sender_worker_core_range.bounding_box();
     // Swap start and end coord
@@ -282,13 +639,16 @@ AllToAllAsyncGenericProgram::create_at(
         const auto& core = sender_worker_cores[core_id];
         std::vector<uint32_t> sender_reader_rt_args = {
             tensor_args.input_tensor.buffer()->address(),
-            device_offsets[core_id % num_blocks_devices].size(),
+            device_offsets[core_id % num_senders_per_link].size(),
         };
-        for (uint32_t i = 0; i < device_offsets[core_id % num_blocks_devices].size(); ++i) {
-            sender_reader_rt_args.push_back(device_offsets[core_id % num_blocks_devices][i]);
+        for (uint32_t i = 0; i < device_offsets[core_id % num_senders_per_link].size(); ++i) {
+            sender_reader_rt_args.push_back(device_offsets[core_id % num_senders_per_link][i]);
             sender_reader_rt_args.push_back(
-                block_starts[core_id % num_blocks_devices][core_id / num_blocks_devices][i]);
-            sender_reader_rt_args.push_back(block_ends[core_id % num_blocks_devices][core_id / num_blocks_devices][i]);
+                block_starts[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
+            sender_reader_rt_args.push_back(
+                block_ends[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
+            sender_reader_rt_args.push_back(
+                block_strides[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
         }
         tt::tt_metal::SetRuntimeArgs(program, sender_reader_kernel_id, {core}, sender_reader_rt_args);
 
@@ -296,8 +656,8 @@ AllToAllAsyncGenericProgram::create_at(
             tensor_return_value.buffer()->address(),
             init_barrier_semaphore.address(),
             final_barrier_semaphore.address(),
-            core_id % num_blocks_devices,
-            core_id / num_blocks_devices,
+            core_id % num_senders_per_link,
+            core_id / num_senders_per_link,
             mcast_dest_noc_start_x,
             mcast_dest_noc_start_y,
             mcast_dest_noc_end_x,
@@ -305,21 +665,26 @@ AllToAllAsyncGenericProgram::create_at(
             mcast_size,
             drain_sync_core.x,
             drain_sync_core.y,
-            device_offsets[core_id % num_blocks_devices].size(),
+            device_offsets[core_id % num_senders_per_link].size(),
         };
 
-        for (uint32_t i = 0; i < device_offsets[core_id % num_blocks_devices].size(); ++i) {
-            sender_writer_rt_args.push_back(device_offsets[core_id % num_blocks_devices][i]);
+        for (uint32_t i = 0; i < device_offsets[core_id % num_senders_per_link].size(); ++i) {
+            sender_writer_rt_args.push_back(device_offsets[core_id % num_senders_per_link][i]);
             sender_writer_rt_args.push_back(
-                block_starts[core_id % num_blocks_devices][core_id / num_blocks_devices][i]);
-            sender_writer_rt_args.push_back(block_ends[core_id % num_blocks_devices][core_id / num_blocks_devices][i]);
+                block_starts[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
+            sender_writer_rt_args.push_back(
+                block_ends[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
+            sender_writer_rt_args.push_back(
+                block_strides[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
+            sender_writer_rt_args.push_back(
+                completion_flags[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
 
-            const int32_t device_offset = device_offsets[core_id % num_blocks_devices][i];
+            const int32_t device_offset = device_offsets[core_id % num_senders_per_link][i];
             const auto target_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
                 tensor_args.input_tensor,
                 mesh_coordinate,
                 device_offset,
-                operation_attributes.topology,
+                effective_topology,
                 operation_attributes.cluster_axis);
             TT_FATAL(target_coord.has_value(), "No all-to-all target at device offset {}", device_offset);
 
@@ -333,22 +698,50 @@ AllToAllAsyncGenericProgram::create_at(
                 sender_writer_rt_args.push_back(std::abs(device_offset));
             }
         }
-        if (is_fabric_2d) {
-            // Append connections in the same {E, W, N, S} order as the compile-time direction mask.
-            for (const auto& neighbor_coord : fabric_neighbors) {
-                tt::tt_fabric::append_fabric_connection_rt_args(
-                    sender_device_fabric_node_id,
-                    device->get_fabric_node_id(neighbor_coord),
-                    core_id / num_senders_per_link,
-                    program,
-                    {core},
-                    sender_writer_rt_args);
+        const size_t sender_stream = core_id % num_senders_per_link;
+        const bool is_remote_sender = sender_stream != local_sender_stream || num_senders_per_link == 1;
+        const bool stream_uses_mux = use_worker_mux && sender_stream < mux_num_directions * workers_per_direction &&
+                                     sender_stream_direction_masks[sender_stream] != 0;
+        if (stream_uses_mux) {
+            const uint32_t link = core_id / num_senders_per_link;
+            const uint32_t direction = sender_stream / workers_per_direction;
+            const uint32_t worker = sender_stream % workers_per_direction;
+            const auto mux_virtual_core = device->worker_core_from_logical_core(mux_cores[link][direction]);
+            const auto flow_control_sem_id = tt::tt_metal::CreateSemaphore(program, core, 0);
+            const auto teardown_sem_id = tt::tt_metal::CreateSemaphore(program, core, 0);
+            mux_config.append_client_connection_rt_args(
+                mux_virtual_core,
+                static_cast<uint8_t>(worker),
+                {.flow_control_sem_id = flow_control_sem_id, .teardown_sem_id = teardown_sem_id},
+                sender_writer_rt_args);
+        } else if (is_fabric_2d) {
+            if (is_remote_sender) {
+                // Append connections in the same {E, W, N, S} order as the compile-time direction mask.
+                size_t neighbor_index = 0;
+                for (uint32_t direction = 0; direction < fabric_directions.size(); ++direction) {
+                    if (!fabric_directions[direction]) {
+                        continue;
+                    }
+                    const auto& neighbor_coord = fabric_neighbors[neighbor_index++];
+                    if ((sender_stream_direction_masks[sender_stream] & (1U << direction)) == 0) {
+                        continue;
+                    }
+                    tt::tt_fabric::append_fabric_connection_rt_args(
+                        sender_device_fabric_node_id,
+                        device->get_fabric_node_id(neighbor_coord),
+                        core_id / num_senders_per_link,
+                        program,
+                        {core},
+                        sender_writer_rt_args);
+                }
             }
         } else {
-            bool with_forward =
-                (num_senders_per_link == 1 || (core_id % num_blocks_devices == 0)) && forward_coord.has_value();
-            bool with_backward =
-                (num_senders_per_link == 1 || (core_id % num_blocks_devices == 1)) && backward_coord.has_value();
+            const bool owns_positive_direction = !use_direction_owned_schedule || sender_stream < workers_per_direction;
+            const bool owns_negative_direction =
+                !use_direction_owned_schedule ||
+                (sender_stream >= workers_per_direction && sender_stream < mux_num_directions * workers_per_direction);
+            const bool with_forward = is_remote_sender && owns_positive_direction && forward_coord.has_value();
+            const bool with_backward = is_remote_sender && owns_negative_direction && backward_coord.has_value();
             sender_writer_rt_args.push_back(with_forward);
 
             if (with_forward) {
@@ -372,14 +765,15 @@ AllToAllAsyncGenericProgram::create_at(
                     sender_writer_rt_args);
             }
         }
-        tt::tt_metal::SetRuntimeArgs(program, sender_writer_kernel_id, {core}, sender_writer_rt_args);
+        tt::tt_metal::SetRuntimeArgs(program, sender_writer_kernel_ids[sender_stream], {core}, sender_writer_rt_args);
     }
 
     return {
         std::move(program),
         {.sender_reader_kernel_id = sender_reader_kernel_id,
-         .sender_writer_kernel_id = sender_writer_kernel_id,
+         .sender_writer_kernel_ids = std::move(sender_writer_kernel_ids),
          .sender_worker_cores = sender_worker_cores,
+         .num_senders_per_link = num_senders_per_link,
          .init_barrier_semaphore = init_barrier_semaphore,
          .final_barrier_semaphore = final_barrier_semaphore}};
 }
@@ -399,8 +793,11 @@ void AllToAllAsyncGenericProgram::override_runtime_arguments(
         auto& shared_variables = cached_workload.shared_variables.at(coordinate_range);
 
         auto& sender_reader_runtime_args = GetRuntimeArgs(program, shared_variables.sender_reader_kernel_id);
-        auto& sender_writer_runtime_args = GetRuntimeArgs(program, shared_variables.sender_writer_kernel_id);
-        for (const auto& core : shared_variables.sender_worker_cores) {
+        for (size_t core_id = 0; core_id < shared_variables.sender_worker_cores.size(); ++core_id) {
+            const auto& core = shared_variables.sender_worker_cores[core_id];
+            const auto writer_kernel_id =
+                shared_variables.sender_writer_kernel_ids[core_id % shared_variables.num_senders_per_link];
+            auto& sender_writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id);
             auto& worker_sender_reader_runtime_args = sender_reader_runtime_args[core.x][core.y];
             auto& worker_sender_writer_runtime_args = sender_writer_runtime_args[core.x][core.y];
             worker_sender_reader_runtime_args[0] = tensor_args.input_tensor.buffer()->address();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.hpp
@@ -9,6 +9,7 @@
 #include "ttnn/distributed/types.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/global_semaphore.hpp>
+#include <cstddef>
 #include <vector>
 
 namespace ttnn::experimental::prim {
@@ -16,8 +17,9 @@ namespace ttnn::experimental::prim {
 struct AllToAllAsyncGenericProgram {
     struct shared_variables_t {
         tt::tt_metal::KernelHandle sender_reader_kernel_id;
-        tt::tt_metal::KernelHandle sender_writer_kernel_id;
+        std::vector<tt::tt_metal::KernelHandle> sender_writer_kernel_ids;
         std::vector<CoreCoord> sender_worker_cores;
+        std::size_t num_senders_per_link;
         tt::tt_metal::GlobalSemaphore init_barrier_semaphore;
         tt::tt_metal::GlobalSemaphore final_barrier_semaphore;
     };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
@@ -26,6 +26,7 @@ constexpr uint32_t has_reader_tail = get_compile_time_arg_val(7);
 constexpr uint32_t has_writer_tail = get_compile_time_arg_val(8);
 constexpr uint32_t concat_num_tiles = get_compile_time_arg_val(9);
 constexpr uint32_t dst_inner_dims_size = get_compile_time_arg_val(10);
+constexpr uint32_t max_pages_per_packet = get_compile_time_arg_val(11);
 
 template <typename AddrGenType>
 void read_data(
@@ -97,7 +98,7 @@ void kernel_main() {
     size_t arg_idx = 0;
     address_t input_address = get_arg_val<address_t>(arg_idx++);
     uint32_t local_num_devices = get_arg_val<uint32_t>(arg_idx++);
-    constexpr auto input_tensor_args = TensorAccessorArgs<11>();
+    constexpr auto input_tensor_args = TensorAccessorArgs<12>();
     auto input_addrgen = TensorAccessor(input_tensor_args, input_address);
     constexpr uint32_t split_num_half_tiles = split_dim_size * 2 / num_devices;
     constexpr uint32_t split_num_tiles = (split_num_half_tiles + 1) / 2;
@@ -108,11 +109,9 @@ void kernel_main() {
     CircularBuffer cb0(cb0_id);
 
     for (uint32_t did = 0; did < local_num_devices; ++did) {
-        int32_t device_offset = get_arg_val<int32_t>(arg_idx++);
-        uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
-
+        const int32_t device_offset = get_arg_val<int32_t>(arg_idx++);
+        const uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
         const uint32_t device_read_offset = (split_num_half_tiles * device_id) / 2;
-
         auto calculate_tile = [&](int b) {
             const uint32_t o = b / (split_num_tiles * inner_dims_size);
             const uint32_t s = (b / inner_dims_size) % split_num_tiles;
@@ -127,44 +126,37 @@ void kernel_main() {
         };
 
         uint32_t block_idx = get_arg_val<uint32_t>(arg_idx++);
-        uint32_t block_end_id = get_arg_val<uint32_t>(arg_idx++);
-        cb0.reserve_back(1);
-        address_t l1_write_addr = cb0.get_write_ptr();
-        uint32_t current_package_payload = 0;
-        uint32_t current_tile = 0;
-
+        const uint32_t block_end_id = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t block_stride = get_arg_val<uint32_t>(arg_idx++);
         while (block_idx < block_end_id) {
-            auto [split_idx, inner_idx, concat_idx, tile_id, payload_size] = calculate_tile(block_idx);
+            cb0.reserve_back(1);
+            address_t l1_write_addr = cb0.get_write_ptr();
+            uint32_t current_package_payload = 0;
+            uint32_t current_tile = 0;
+            while (current_tile < max_pages_per_packet) {
+                if (block_idx >= block_end_id) {
+                    break;
+                }
 
-            // If package is full, flush and start new package
-            if (current_tile == 4 || current_package_payload + payload_size > 2 * input_page_size) {
-                noc_obj.async_read_barrier();
-                cb0.push_back(1);
-                cb0.reserve_back(1);
-                l1_write_addr = cb0.get_write_ptr();
-                current_package_payload = 0;
-                current_tile = 0;
+                auto [split_idx, inner_idx, concat_idx, tile_id, payload_size] = calculate_tile(block_idx);
+                if (current_package_payload + payload_size > max_pages_per_packet * input_page_size) {
+                    break;
+                }
+                read_data(
+                    noc_obj,
+                    device_id,
+                    tile_id,
+                    l1_write_addr,
+                    input_addrgen,
+                    concat_idx,
+                    split_idx == split_num_tiles - 1,
+                    payload_size);
+                current_package_payload += payload_size;
+                current_tile++;
+                block_idx += block_stride;
             }
-
-            read_data(
-                noc_obj,
-                device_id,
-                tile_id,
-                l1_write_addr,
-                input_addrgen,
-                concat_idx,
-                split_idx == split_num_tiles - 1,
-                payload_size);
-
-            current_package_payload += payload_size;
-            current_tile++;
-            block_idx++;
-        }
-
-        // Flush remaining tiles in the last package
-        if (current_tile > 0) {
             noc_obj.async_read_barrier();
+            cb0.push_back(1);
         }
-        cb0.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -4,12 +4,14 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/circular_buffer.h"
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
 #include "cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 #include "cpp/ttnn/operations/ccl/common/types/fabric_directions.hpp"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_mux_v2_sender.hpp"
 #include "ckernel.h"
 #include <cstdint>
 
@@ -36,11 +38,31 @@ constexpr uint16_t source_chip_id = get_compile_time_arg_val(13);
 constexpr uint16_t source_mesh_id = get_compile_time_arg_val(14);
 constexpr bool is_fabric_2d = get_compile_time_arg_val(15);
 constexpr uint32_t fabric_direction_mask = get_compile_time_arg_val(16);
+constexpr uint32_t max_pages_per_packet = get_compile_time_arg_val(17);
+constexpr auto output_tensor_args = TensorAccessorArgs<18>();
+constexpr uint32_t mux_ct_base = output_tensor_args.next_compile_time_args_offset();
+constexpr bool use_worker_mux = get_compile_time_arg_val(mux_ct_base) != 0;
+constexpr uint32_t mux_num_clients = get_compile_time_arg_val(mux_ct_base + 1);
+constexpr uint32_t compile_safe_mux_num_clients = mux_num_clients == 0 ? 1 : mux_num_clients;
+constexpr bool has_fabric_connections = fabric_direction_mask != 0;
 constexpr auto fabric_directions =
     ttnn::operations::ccl::common::fabric_direction_mask_to_directions(fabric_direction_mask);
 constexpr auto num_fabric_directions = ttnn::operations::ccl::common::num_fabric_directions;
 using Fabric2DConnections = std::array<tt::tt_fabric::WorkerToFabricEdmSender, num_fabric_directions>;
-using FabricConnections = std::conditional_t<is_fabric_2d, Fabric2DConnections, FabricConnectionManager>;
+using FabricMuxSender = tt::tt_fabric::FabricMuxV2Sender<>;
+struct FabricMuxConnection {
+    FabricMuxSender sender;
+};
+using DirectFabricConnections = std::conditional_t<is_fabric_2d, Fabric2DConnections, FabricConnectionManager>;
+using FabricConnections = std::conditional_t<use_worker_mux, FabricMuxConnection, DirectFabricConnections>;
+
+inline FabricMuxSender& select_connection(
+    FabricMuxConnection& fabric_connection,
+    [[maybe_unused]] int device_offset,
+    [[maybe_unused]] uint16_t dest_mesh_id,
+    [[maybe_unused]] uint16_t dest_chip_id) {
+    return fabric_connection.sender;
+}
 
 inline tt::tt_fabric::WorkerToFabricEdmSender& select_connection(
     Fabric2DConnections& fabric_connections,
@@ -65,43 +87,134 @@ inline void finish_open_connections(Fabric2DConnections& fabric_connections) {
 
 inline void finish_open_connections(FabricConnectionManager& fabric_connections) { fabric_connections.open_finish(); }
 
+inline void finish_open_connections(FabricMuxConnection& fabric_connection) { fabric_connection.sender.open(); }
+
 inline void close_connections(Fabric2DConnections& fabric_connections) {
     ttnn::operations::ccl::common::close_direction_connections(fabric_directions, fabric_connections);
 }
 
 inline void close_connections(FabricConnectionManager& fabric_connections) { fabric_connections.close(); }
 
-template <typename PacketHeader>
-inline void set_route(
-    volatile PacketHeader* packet_header,
-    const ccl_routing_utils::line_unicast_route_info_t& route_info,
-    [[maybe_unused]] int32_t distance,
-    Fabric2DConnections&) {
-    ccl_routing_utils::fabric_set_line_unicast_route(packet_header, route_info);
+inline void close_connections(FabricMuxConnection& fabric_connection) { fabric_connection.sender.close(); }
+
+inline void send_mux_packet_blocking(
+    FabricMuxConnection& fabric_connection, uint32_t packet_header_address, size_t packet_header_size) {
+    fabric_connection.sender.wait_for_empty_write_slot();
+    fabric_connection.sender.send_payload_flush_non_blocking_from_address(packet_header_address, packet_header_size);
+    noc_async_writes_flushed();
 }
 
-template <typename PacketHeader>
-inline void set_route(
-    volatile PacketHeader* packet_header,
-    [[maybe_unused]] const ccl_routing_utils::line_unicast_route_info_t& route_info,
-    int32_t distance,
-    FabricConnectionManager&) {
-    packet_header->to_chip_unicast(distance);
+template <tt::tt_fabric::Topology Topology, typename PacketHeader>
+void send_initialization(
+    FabricMuxConnection& fabric_connection,
+    uint32_t core_id,
+    uint32_t link_id,
+    uint32_t local_num_devices,
+    size_t device_offsets_idx,
+    uint64_t init_semaphore_noc_addr_in_pkt,
+    volatile PacketHeader* pkt_hdr_sema_forward,
+    volatile PacketHeader* pkt_hdr_sema_backward,
+    uint32_t packet_header_buffer_addr_sema_forward,
+    uint32_t packet_header_buffer_addr_sema_backward) {
+    using ttnn::operations::ccl::common::ReplicateGroup;
+    static_assert(
+        Topology == tt::tt_fabric::Topology::Linear || Topology == tt::tt_fabric::Topology::Ring,
+        "Muxed all-to-all supports only Linear or Ring topology");
+    static_assert(
+        !is_fabric_2d || replicate_axis == ReplicateGroup::COLS || replicate_axis == ReplicateGroup::ROWS,
+        "Fabric2D muxed all-to-all requires a concrete cluster axis");
+
+    if (link_id != 0) {
+        return;
+    }
+    if constexpr (Topology == tt::tt_fabric::Topology::Ring) {
+        // Ring destinations are split across direction-specific mux workers. Have link 0 send one unicast
+        // initialization increment for each unique destination owned by this worker. Ring bank schedules are striped
+        // across mux clients; the client owning destination bank 0 is the single initialization owner. This is
+        // independent of 1D hop-count versus Fabric2D mesh/chip routing and guarantees exactly one increment per
+        // source at every remote destination.
+        for (uint32_t did = 0; did < local_num_devices; ++did) {
+            const size_t target_arg_idx = device_offsets_idx + did * 7;
+            const int32_t device_offset = get_arg_val<int32_t>(target_arg_idx);
+            const uint32_t block_start = get_arg_val<uint32_t>(target_arg_idx + 1);
+            if (device_offset == 0 || block_start != 0) {
+                continue;
+            }
+
+            const ccl_routing_utils::line_unicast_route_info_t route_info = {
+                .dst_mesh_id = static_cast<uint16_t>(get_arg_val<uint32_t>(target_arg_idx + 5)),
+                .dst_chip_id = static_cast<uint16_t>(get_arg_val<uint32_t>(target_arg_idx + 6))};
+            auto* packet_header = device_offset > 0 ? pkt_hdr_sema_forward : pkt_hdr_sema_backward;
+            const uint32_t packet_header_address =
+                device_offset > 0 ? packet_header_buffer_addr_sema_forward : packet_header_buffer_addr_sema_backward;
+            ccl_routing_utils::fabric_set_line_unicast_route(packet_header, route_info);
+            packet_header->to_noc_unicast_atomic_inc(
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_semaphore_noc_addr_in_pkt, 1});
+            send_mux_packet_blocking(fabric_connection, packet_header_address, sizeof(PacketHeader));
+        }
+    } else {
+        // Linear uses one multicast per direction, so only one Mux V2 client owns initialization.
+        if (core_id % compile_safe_mux_num_clients != 0) {
+            return;
+        }
+        constexpr uint32_t positive_range = num_devices - current_device_id - 1;
+        constexpr uint32_t negative_range = current_device_id;
+        constexpr uint32_t positive_direction = !is_fabric_2d || replicate_axis == ReplicateGroup::ROWS
+                                                    ? eth_chan_directions::EAST
+                                                    : eth_chan_directions::SOUTH;
+        constexpr uint32_t negative_direction = !is_fabric_2d || replicate_axis == ReplicateGroup::ROWS
+                                                    ? eth_chan_directions::WEST
+                                                    : eth_chan_directions::NORTH;
+        constexpr bool owns_positive_targets = fabric_directions[positive_direction];
+        constexpr bool owns_negative_targets = fabric_directions[negative_direction];
+
+        if constexpr (positive_range > 0) {
+            if (owns_positive_targets) {
+                if constexpr (is_fabric_2d) {
+                    constexpr uint16_t east_range = replicate_axis == ReplicateGroup::ROWS ? positive_range : 0;
+                    constexpr uint16_t south_range = replicate_axis == ReplicateGroup::COLS ? positive_range : 0;
+                    tt::tt_fabric::fabric_set_mcast_route(
+                        pkt_hdr_sema_forward, source_chip_id, source_mesh_id, east_range, 0, 0, south_range);
+                } else {
+                    pkt_hdr_sema_forward->to_chip_multicast(
+                        tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(positive_range)});
+                }
+                pkt_hdr_sema_forward->to_noc_unicast_atomic_inc(
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_semaphore_noc_addr_in_pkt, 1});
+                send_mux_packet_blocking(
+                    fabric_connection, packet_header_buffer_addr_sema_forward, sizeof(PacketHeader));
+            }
+        }
+        if constexpr (negative_range > 0) {
+            if (owns_negative_targets) {
+                if constexpr (is_fabric_2d) {
+                    constexpr uint16_t west_range = replicate_axis == ReplicateGroup::ROWS ? negative_range : 0;
+                    constexpr uint16_t north_range = replicate_axis == ReplicateGroup::COLS ? negative_range : 0;
+                    tt::tt_fabric::fabric_set_mcast_route(
+                        pkt_hdr_sema_backward, source_chip_id, source_mesh_id, 0, west_range, north_range, 0);
+                } else {
+                    pkt_hdr_sema_backward->to_chip_multicast(
+                        tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(negative_range)});
+                }
+                pkt_hdr_sema_backward->to_noc_unicast_atomic_inc(
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_semaphore_noc_addr_in_pkt, 1});
+                send_mux_packet_blocking(
+                    fabric_connection, packet_header_buffer_addr_sema_backward, sizeof(PacketHeader));
+            }
+        }
+    }
 }
+
 template <tt::tt_fabric::Topology Topology, typename PacketHeader>
 void send_initialization(
     Fabric2DConnections& fabric_connections,
-    uint32_t core_id,
+    [[maybe_unused]] uint32_t core_id,
     uint32_t link_id,
     [[maybe_unused]] uint32_t local_num_devices,
     [[maybe_unused]] size_t device_offsets_idx,
     uint64_t init_semaphore_noc_addr_in_pkt,
-    [[maybe_unused]] volatile PacketHeader* pkt_hdr_forward,
-    [[maybe_unused]] volatile PacketHeader* pkt_hdr_backward,
     volatile PacketHeader* pkt_hdr_sema_forward,
     volatile PacketHeader* pkt_hdr_sema_backward,
-    [[maybe_unused]] uint32_t packet_header_buffer_addr_forward,
-    [[maybe_unused]] uint32_t packet_header_buffer_addr_backward,
     uint32_t packet_header_buffer_addr_sema_forward,
     uint32_t packet_header_buffer_addr_sema_backward) {
     using ttnn::operations::ccl::common::ReplicateGroup;
@@ -112,7 +225,7 @@ void send_initialization(
         replicate_axis == ReplicateGroup::COLS || replicate_axis == ReplicateGroup::ROWS,
         "FABRIC_2D all-to-all requires a concrete cluster axis");
 
-    if (core_id != 0 || link_id != 0) {
+    if (link_id != 0) {
         return;
     }
     constexpr uint32_t positive_range = num_devices - current_device_id - 1;
@@ -122,7 +235,7 @@ void send_initialization(
     constexpr uint32_t negative_direction =
         replicate_axis == ReplicateGroup::COLS ? eth_chan_directions::NORTH : eth_chan_directions::WEST;
 
-    if constexpr (positive_range > 0) {
+    if constexpr (positive_range > 0 && fabric_directions[positive_direction]) {
         constexpr uint16_t east_range = replicate_axis == ReplicateGroup::ROWS ? positive_range : 0;
         constexpr uint16_t south_range = replicate_axis == ReplicateGroup::COLS ? positive_range : 0;
         tt::tt_fabric::fabric_set_mcast_route(
@@ -134,7 +247,7 @@ void send_initialization(
         connection.send_payload_flush_blocking_from_address(
             packet_header_buffer_addr_sema_forward, sizeof(PacketHeader));
     }
-    if constexpr (negative_range > 0) {
+    if constexpr (negative_range > 0 && fabric_directions[negative_direction]) {
         constexpr uint16_t west_range = replicate_axis == ReplicateGroup::ROWS ? negative_range : 0;
         constexpr uint16_t north_range = replicate_axis == ReplicateGroup::COLS ? negative_range : 0;
         tt::tt_fabric::fabric_set_mcast_route(
@@ -156,12 +269,8 @@ void send_initialization(
     [[maybe_unused]] uint32_t local_num_devices,
     [[maybe_unused]] size_t device_offsets_idx,
     uint64_t init_semaphore_noc_addr_in_pkt,
-    volatile PacketHeader* pkt_hdr_forward,
-    volatile PacketHeader* pkt_hdr_backward,
     volatile PacketHeader* pkt_hdr_sema_forward,
     volatile PacketHeader* pkt_hdr_sema_backward,
-    uint32_t packet_header_buffer_addr_forward,
-    uint32_t packet_header_buffer_addr_backward,
     uint32_t packet_header_buffer_addr_sema_forward,
     uint32_t packet_header_buffer_addr_sema_backward) {
     static_assert(
@@ -187,27 +296,27 @@ void send_initialization(
             pkt_hdr_sema_backward->to_chip_multicast(
                 tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(current_device_id)});
             fabric_connections.get_backward_connection().wait_for_empty_write_slot();
-            fabric_connections.get_backward_connection().send_payload_non_blocking_from_address(
+            fabric_connections.get_backward_connection().send_payload_flush_blocking_from_address(
                 packet_header_buffer_addr_sema_backward, sizeof(PacketHeader));
         }
     } else {
         if (fabric_connections.has_forward_connection()) {
-            pkt_hdr_forward->to_noc_unicast_atomic_inc(
+            pkt_hdr_sema_forward->to_noc_unicast_atomic_inc(
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_semaphore_noc_addr_in_pkt, 1});
             fabric_connections.get_forward_connection().wait_for_empty_write_slot();
-            pkt_hdr_forward->to_chip_multicast(
+            pkt_hdr_sema_forward->to_chip_multicast(
                 tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_devices / 2)});
             fabric_connections.get_forward_connection().send_payload_flush_blocking_from_address(
-                packet_header_buffer_addr_forward, sizeof(PacketHeader));
+                packet_header_buffer_addr_sema_forward, sizeof(PacketHeader));
         }
         if (fabric_connections.has_backward_connection()) {
-            pkt_hdr_backward->to_noc_unicast_atomic_inc(
+            pkt_hdr_sema_backward->to_noc_unicast_atomic_inc(
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_semaphore_noc_addr_in_pkt, 1});
             fabric_connections.get_backward_connection().wait_for_empty_write_slot();
-            pkt_hdr_backward->to_chip_multicast(tt::tt_fabric::MulticastRoutingCommandHeader{
+            pkt_hdr_sema_backward->to_chip_multicast(tt::tt_fabric::MulticastRoutingCommandHeader{
                 1, static_cast<uint8_t>(num_devices - num_devices / 2 - 1)});
             fabric_connections.get_backward_connection().send_payload_flush_blocking_from_address(
-                packet_header_buffer_addr_backward, sizeof(PacketHeader));
+                packet_header_buffer_addr_sema_backward, sizeof(PacketHeader));
         }
     }
 }
@@ -234,7 +343,6 @@ void write_data(
             noc_async_write(l1_read_addr, dest_addrs[part], payload_sizes[part]);
             l1_read_addr += payload_sizes[part];
         }
-        noc_obj.async_write_barrier();
     } else {
         if (last) {
             // TODO: reduce number of packages when atomic fused with scatter will be introduced
@@ -278,8 +386,12 @@ void write_data(
             for (uint32_t part = 0; part < parts_count; ++part) {
                 scatter_payload += payload_sizes[part];
             }
-            pkt_hdr->to_noc_unicast_scatter_write(
-                NocUnicastScatterCommandHeader(dest_addrs, payload_sizes, parts_count), scatter_payload);
+            if (parts_count == 1) {
+                pkt_hdr->to_noc_unicast_write(NocUnicastCommandHeader({dest_addrs[0]}), payload_sizes[0]);
+            } else {
+                pkt_hdr->to_noc_unicast_scatter_write(
+                    NocUnicastScatterCommandHeader(dest_addrs, payload_sizes, parts_count), scatter_payload);
+            }
             perform_payload_send(
                 select_connection(fabric_connections, device_offset, dest_mesh_id, dest_chip_id),
                 l1_read_addr,
@@ -311,15 +423,20 @@ void kernel_main() {
     uint32_t sender_core_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t sender_core_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t local_num_devices = get_arg_val<uint32_t>(arg_idx++);
-    constexpr auto output_args = TensorAccessorArgs<17>();
-    auto output_addrgen = TensorAccessor(output_args, output_address);
+    auto output_addrgen = TensorAccessor(output_tensor_args, output_address);
     size_t device_offsets_idx = arg_idx;
-    arg_idx += local_num_devices * 5;
+    arg_idx += local_num_devices * 7;
 
     auto fabric_connections = [&]() {
-        if constexpr (is_fabric_2d) {
+        if constexpr (use_worker_mux) {
+            auto sender = FabricMuxSender::build_from_args(arg_idx);
+            return FabricMuxConnection{.sender = sender};
+        } else if constexpr (is_fabric_2d) {
             Fabric2DConnections connections;
-            ttnn::operations::ccl::common::open_direction_connections_async(fabric_directions, connections, arg_idx);
+            if constexpr (has_fabric_connections) {
+                ttnn::operations::ccl::common::open_direction_connections_async(
+                    fabric_directions, connections, arg_idx);
+            }
             return connections;
         } else {
             return FabricConnectionManager::build_from_args<
@@ -363,99 +480,108 @@ void kernel_main() {
     volatile PACKET_HEADER_TYPE* pkt_hdr_sema_backward =
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_sema_backward);
 
-    finish_open_connections(fabric_connections);
+    {
+        if constexpr (has_fabric_connections) {
+            finish_open_connections(fabric_connections);
+        }
+    }
 
     constexpr bool has_pre_half_tile = has_half_tile && current_device_id % 2 == 1;
     constexpr bool has_post_half_tile = has_half_tile && current_device_id % 2 == 0;
 
-    send_initialization<topology>(
-        fabric_connections,
-        core_id,
-        link_id,
-        local_num_devices,
-        device_offsets_idx,
-        init_semaphore_noc_addr_in_pkt,
-        pkt_hdr_forward,
-        pkt_hdr_backward,
-        pkt_hdr_sema_forward,
-        pkt_hdr_sema_backward,
-        packet_header_buffer_addr_forward,
-        packet_header_buffer_addr_backward,
-        packet_header_buffer_addr_sema_forward,
-        packet_header_buffer_addr_sema_backward);
+    {
+        send_initialization<topology>(
+            fabric_connections,
+            core_id,
+            link_id,
+            local_num_devices,
+            device_offsets_idx,
+            init_semaphore_noc_addr_in_pkt,
+            pkt_hdr_sema_forward,
+            pkt_hdr_sema_backward,
+            packet_header_buffer_addr_sema_forward,
+            packet_header_buffer_addr_sema_backward);
 
-    if (core_id == 0 && link_id == 0) {
-        const uint64_t local_set_semaphore_noc_addr = get_noc_multicast_addr(
-            mcast_dest_noc_start_x,
-            mcast_dest_noc_start_y,
-            mcast_dest_noc_end_x,
-            mcast_dest_noc_end_y,
-            global_init_semaphore_addr);
-        uint32_t local_init_semaphore_addr_ptr = reinterpret_cast<uint32_t>(global_init_semaphore_addr_ptr);
+        if (core_id == 0 && link_id == 0) {
+            const uint64_t local_set_semaphore_noc_addr = get_noc_multicast_addr(
+                mcast_dest_noc_start_x,
+                mcast_dest_noc_start_y,
+                mcast_dest_noc_end_x,
+                mcast_dest_noc_end_y,
+                global_init_semaphore_addr);
+            uint32_t local_init_semaphore_addr_ptr = reinterpret_cast<uint32_t>(global_init_semaphore_addr_ptr);
 
-        if (mcast_size > 1) {
-            noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
-            noc_semaphore_set_multicast_loopback_src(
-                local_init_semaphore_addr_ptr, local_set_semaphore_noc_addr, mcast_size, false);
-            noc_obj.async_write_barrier();
+            if (mcast_size > 1) {
+                noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
+                noc_semaphore_set_multicast_loopback_src(
+                    local_init_semaphore_addr_ptr, local_set_semaphore_noc_addr, mcast_size, false);
+                noc_obj.async_write_barrier();
+            }
         }
+
+        noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
+        noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
     }
 
-    noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
-    noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
+    {
+        for (uint32_t did = 0; did < local_num_devices; ++did) {
+            const int32_t device_offset = get_arg_val<int32_t>(device_offsets_idx++);
+            uint32_t block_idx = get_arg_val<uint32_t>(device_offsets_idx++);
+            const uint32_t block_end_id = get_arg_val<uint32_t>(device_offsets_idx++);
+            const uint32_t block_stride = get_arg_val<uint32_t>(device_offsets_idx++);
+            const bool signal_completion = get_arg_val<uint32_t>(device_offsets_idx++) != 0;
+            const ccl_routing_utils::line_unicast_route_info_t route_info = {
+                .dst_mesh_id = static_cast<uint16_t>(get_arg_val<uint32_t>(device_offsets_idx++)),
+                .dst_chip_id = static_cast<uint16_t>(get_arg_val<uint32_t>(device_offsets_idx++))};
+            const uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
 
-    for (uint32_t did = 0; did < local_num_devices; ++did) {
-        int32_t device_offset = get_arg_val<int32_t>(device_offsets_idx++);
-        [[maybe_unused]] int32_t distance = abs(device_offset);
-        uint32_t block_idx = get_arg_val<uint32_t>(device_offsets_idx++);
-        uint32_t block_end_id = get_arg_val<uint32_t>(device_offsets_idx++);
-        const ccl_routing_utils::line_unicast_route_info_t route_info = {
-            .dst_mesh_id = static_cast<uint16_t>(get_arg_val<uint32_t>(device_offsets_idx++)),
-            .dst_chip_id = static_cast<uint16_t>(get_arg_val<uint32_t>(device_offsets_idx++))};
-        uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
+            volatile PACKET_HEADER_TYPE* pkt_hdr = nullptr;
+            if (device_offset > 0) {
+                pkt_hdr = pkt_hdr_forward;
+            } else if (device_offset < 0) {
+                pkt_hdr = pkt_hdr_backward;
+            }
+            if (device_offset != 0) {
+                ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr, route_info);
+            }
 
-        volatile PACKET_HEADER_TYPE* pkt_hdr;
-        if (device_offset > 0) {
-            pkt_hdr = pkt_hdr_forward;
-        } else if (device_offset < 0) {
-            pkt_hdr = pkt_hdr_backward;
-        }
-        if (device_offset != 0) {
-            set_route(pkt_hdr, route_info, distance, fabric_connections);
-        }
+            auto calculate_params = [&](int b) {
+                const uint32_t o = b / (concat_num_tiles * inner_dims_size);
+                const uint32_t c = (b / inner_dims_size) % concat_num_tiles;
+                const uint32_t i = b % inner_dims_size;
+                const uint32_t dest_tile_id =
+                    o * inner_dims_size * concat_dim_size + (c + full_block_offset) * inner_dims_size + i;
+                uint16_t payload_size =
+                    ((has_pre_half_tile && c == 0) || (has_post_half_tile && c == concat_num_tiles - 1))
+                        ? output_page_size / 2
+                        : output_page_size;
+                uint32_t offset = (has_pre_half_tile && c == 0) ? (current_device_id % 2) * output_page_size / 2 : 0;
+                uint64_t dst_addr =
+                    (current_device_id == device_id)
+                        ? output_addrgen.get_noc_addr(dest_tile_id, offset)
+                        : tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, dest_tile_id, offset);
+                return std::tuple{dst_addr, payload_size};
+            };
 
-        auto calculate_params = [&](int b) {
-            const uint32_t o = b / (concat_num_tiles * inner_dims_size);
-            const uint32_t c = (b / inner_dims_size) % concat_num_tiles;
-            const uint32_t i = b % inner_dims_size;
-            const uint32_t dest_tile_id =
-                o * inner_dims_size * concat_dim_size + (c + full_block_offset) * inner_dims_size + i;
-            uint16_t payload_size = ((has_pre_half_tile && c == 0) || (has_post_half_tile && c == concat_num_tiles - 1))
-                                        ? output_page_size / 2
-                                        : output_page_size;
-            uint32_t offset = (has_pre_half_tile && c == 0) ? (current_device_id % 2) * output_page_size / 2 : 0;
-            uint64_t dst_addr =
-                (current_device_id == device_id)
-                    ? output_addrgen.get_noc_addr(dest_tile_id, offset)
-                    : tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, dest_tile_id, offset);
-            return std::tuple{dst_addr, payload_size};
-        };
+            // The generic work split can assign an empty range when there are fewer blocks than links. The reader
+            // publishes no CB entry for that range, and the host excludes it from the completion-semaphore count.
+            if (block_idx >= block_end_id) {
+                continue;
+            }
 
-        cb0.wait_front(1);
-        size_t l1_read_addr = cb0.get_read_ptr();
-        uint32_t current_package_payload = 0;
-        uint32_t current_tile = 0;
-        uint64_t dst_addrs[4] = {0};
-        uint16_t payload_sizes[4] = {0};
-        while (block_idx < block_end_id) {
-            auto [dst_addr, payload_size] = calculate_params(block_idx);
-            // If package is full, flush and start new package
-            if (current_tile == 4 || current_package_payload + payload_size > 2 * output_page_size) {
+            cb0.wait_front(1);
+            size_t l1_read_addr = cb0.get_read_ptr();
+            uint32_t pages_in_cb = 0;
+            uint32_t current_package_payload = 0;
+            uint32_t current_part = 0;
+            uint64_t dst_addrs[4] = {0};
+            uint16_t payload_sizes[4] = {0};
+            auto flush_packet = [&](bool last) {
                 write_data(
                     noc_obj,
                     dst_addrs,
                     payload_sizes,
-                    current_tile,
+                    current_part,
                     pkt_hdr,
                     fabric_connections,
                     l1_read_addr,
@@ -463,41 +589,52 @@ void kernel_main() {
                     device_offset,
                     route_info.dst_mesh_id,
                     route_info.dst_chip_id,
-                    false);
-                cb0.pop_front(1);
-                cb0.wait_front(1);
-                l1_read_addr = cb0.get_read_ptr();
+                    last);
+                l1_read_addr += current_package_payload;
                 current_package_payload = 0;
-                current_tile = 0;
-            }
-            current_package_payload += payload_size;
-            payload_sizes[current_tile] = payload_size;
-            dst_addrs[current_tile] = dst_addr;
-            current_tile++;
-            block_idx++;
-        }
+                current_part = 0;
+            };
 
-        // Flush remaining tiles in the last package
-        if (current_tile > 0) {
-            write_data(
-                noc_obj,
-                dst_addrs,
-                payload_sizes,
-                current_tile,
-                pkt_hdr,
-                fabric_connections,
-                l1_read_addr,
-                output_semaphore_noc_addr_in_pkt,
-                device_offset,
-                route_info.dst_mesh_id,
-                route_info.dst_chip_id,
-                true);
+            while (block_idx < block_end_id) {
+                auto [dst_addr, payload_size] = calculate_params(block_idx);
+                const bool extends_previous_run =
+                    current_part > 0 && dst_addr == dst_addrs[current_part - 1] + payload_sizes[current_part - 1];
+                if (!extends_previous_run && current_part == 4) {
+                    // Four is a scatter-header limit, not a page limit. Flush these runs and continue consuming the
+                    // same CB page; a bank-owned batch normally remains one run for all seven pages.
+                    flush_packet(false);
+                }
+                current_package_payload += payload_size;
+                if (extends_previous_run) {
+                    payload_sizes[current_part - 1] += payload_size;
+                } else {
+                    payload_sizes[current_part] = payload_size;
+                    dst_addrs[current_part] = dst_addr;
+                    current_part++;
+                }
+                pages_in_cb++;
+                block_idx += block_stride;
+
+                const bool schedule_complete = block_idx >= block_end_id;
+                if (pages_in_cb == max_pages_per_packet || schedule_complete) {
+                    flush_packet(schedule_complete && signal_completion);
+                    cb0.pop_front(1);
+                    pages_in_cb = 0;
+                    if (!schedule_complete) {
+                        cb0.wait_front(1);
+                        l1_read_addr = cb0.get_read_ptr();
+                    }
+                }
+            }
         }
-        cb0.pop_front(1);
     }
 
     noc_obj.async_write_barrier();
-    close_connections(fabric_connections);
+    {
+        if constexpr (has_fabric_connections) {
+            close_connections(fabric_connections);
+        }
+    }
     if (core_id == 0 && link_id == 0) {
         noc_semaphore_wait(global_semaphore_addr_ptr, semaphore_expected_value);
         noc_semaphore_set(global_semaphore_addr_ptr, 0);


### PR DESCRIPTION
### PR Category

Performance

### Summary

Large interleaved-DRAM generic all-to-alls were limited by small scatter packets and a serial remote sender, leaving fabric bandwidth unused.

The new schedule assigns destination DRAM banks to links, coalesces contiguous same-bank pages into full fabric payloads, isolates local copies, and distributes remote destinations across up to three workers per physical direction through fabric muxes. Ring antipodes are balanced across both arcs. Schedule selection uses topology-aware full-packet work, while small messages, unsupported layouts, non-physical logical Rings, and unsafe restricted-core cases retain the original path.

The implementation also handles uneven or empty bank ranges, half-tile tails, completion accounting, and cached-program runtime-argument patching across the additional workers. Generic tests cover 1D and 2D Linear/Ring routing, DRAM/L1 and sharded layouts, traces, constrained subdevices, bank fallback, and below-threshold messages.

### Performance impact

Common setup: 8-chip Blackhole LoudBox, Release build, BF16 TILE tensors, interleaved DRAM input and output, two links, 14 KiB maximum fabric payload, and real-time device-profiler medians. Baseline is `origin/main` at `06994d4afda`; branch is `53db6eea4ce`. Shapes below are per chip.

| Topology / group | Reshard | Per-chip input → output | Useful remote / chip | Baseline → branch | Branch useful BW |
| --- | --- | --- | ---: | ---: | ---: |
| FABRIC_2D Linear, TP4 | head → sequence | `[1,16,640,576]` → `[1,64,160,576]` | 8.847 MB | 805.6 → 282.6 us | 31.3 GB/s |
| FABRIC_2D Linear, TP4 | sequence → head | `[1,64,160,512]` → `[1,16,640,512]` | 7.864 MB | 720.0 → 251.4 us | 31.3 GB/s |
| Native 1x8 Ring, TP8 | head → sequence | `[1,16,640,576]` → `[1,128,80,576]` | 10.322 MB | 737.8 → 324.9 us | 31.8 GB/s |
| Native 1x8 Ring, TP8 | sequence → head | `[1,128,80,512]` → `[1,16,640,512]` | 9.175 MB | 568.3 → 249.7 us | 36.7 GB/s |

The two reshards combined improve from 1.526 to 0.534 ms on Linear (-65.0%) and from 1.306 to 0.575 ms on Ring (-56.0%).

Both proxies preserve per-chip input and output element counts, but TP8 has seven remote peers and sends 87.5% of each shard remotely, versus three peers and 75% for TP4. Each result should therefore be compared with its own topology baseline; absolute Linear and Ring times are not a matched comparison.

### Notes for reviewers

This changes only the generic A2A implementation and its tests. It does not change fabric setup or topology. The main review points are the direction-worker schedule and fallback selection, Ring antipode routing, completion accounting, and cached runtime-argument patching.

### Dispatched CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/test-dispatch.yaml/badge.svg?branch=pjosipovic/all-to-all-async-packet-batching)](https://github.com/tenstorrent/tt-metal/actions/workflows/test-dispatch.yaml?query=branch:pjosipovic/all-to-all-async-packet-batching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pjosipovic/all-to-all-async-packet-batching)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pjosipovic/all-to-all-async-packet-batching)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/all-to-all-async-packet-batching)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/all-to-all-async-packet-batching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/all-to-all-async-packet-batching)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/all-to-all-async-packet-batching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/all-to-all-async-packet-batching)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/all-to-all-async-packet-batching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/all-to-all-async-packet-batching)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/all-to-all-async-packet-batching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/all-to-all-async-packet-batching)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/all-to-all-async-packet-batching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/all-to-all-async-packet-batching)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/all-to-all-async-packet-batching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/all-to-all-async-packet-batching)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/all-to-all-async-packet-batching)