### PR TITLE
Fix Galaxy layouts for large-vocabulary Qwen models

### DIFF
--- a/models/tt_transformers/tests/test_distributed_norm_utils.py
+++ b/models/tt_transformers/tests/test_distributed_norm_utils.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from models.tt_transformers.tt.distributed_norm import galaxy_distributed_norm_core_grid
+
+
+@pytest.mark.parametrize(
+    ("dim", "expected"),
+    [
+        (3072, (3, 8)),
+        (4096, (4, 8)),
+        (5120, (5, 2)),
+        (8192, (4, 8)),
+    ],
+)
+def test_galaxy_distributed_norm_core_grid(dim, expected):
+    core_grid = galaxy_distributed_norm_core_grid(dim)
+    num_cores = core_grid[0] * core_grid[1]
+
+    assert core_grid == expected
+    assert (dim // 4) % (num_cores * 32) == 0
+
+
+def test_galaxy_distributed_norm_core_grid_rejects_unaligned_width(expect_error):
+    with expect_error(ValueError, "is not tile-shardable"):
+        galaxy_distributed_norm_core_grid(4608)

--- a/models/tt_transformers/tests/test_model_config_utils.py
+++ b/models/tt_transformers/tests/test_model_config_utils.py
@@ -4,7 +4,11 @@
 
 import pytest
 
-from models.tt_transformers.tt.model_config import compute_padded_vocab_size, should_pad_sampling_logits_to_power_of_2
+from models.tt_transformers.tt.model_config import (
+    compute_galaxy_padded_vocab_size,
+    compute_padded_vocab_size,
+    should_pad_sampling_logits_to_power_of_2,
+)
 
 
 @pytest.mark.parametrize(
@@ -26,9 +30,25 @@ def test_compute_padded_vocab_size(vocab_size, num_devices, expected):
     assert (padded_vocab_size // num_devices) % 32 == 0
 
 
-def test_compute_padded_vocab_size_rejects_invalid_num_devices():
-    with pytest.raises(ValueError, match="num_devices must be >= 1"):
+def test_compute_padded_vocab_size_rejects_invalid_num_devices(expect_error):
+    with expect_error(ValueError, "num_devices must be >= 1"):
         compute_padded_vocab_size(32000, 0)
+
+
+@pytest.mark.parametrize(
+    ("vocab_size", "num_devices", "expected"),
+    [
+        (128256, 32, 128 * 1024),
+        (151936, 32, 152576),
+        (152064, 32, 152576),
+    ],
+)
+def test_compute_galaxy_padded_vocab_size(vocab_size, num_devices, expected):
+    padded_vocab_size = compute_galaxy_padded_vocab_size(vocab_size, num_devices)
+
+    assert padded_vocab_size == expected
+    assert padded_vocab_size >= vocab_size
+    assert padded_vocab_size % (32 * num_devices) == 0
 
 
 @pytest.mark.parametrize(
@@ -43,6 +63,6 @@ def test_should_pad_sampling_logits_to_power_of_2(base_model_name, padded_vocab_
     assert should_pad_sampling_logits_to_power_of_2(base_model_name, padded_vocab_size, sampling_splits) is expected
 
 
-def test_should_pad_sampling_logits_to_power_of_2_rejects_invalid_sampling_splits():
-    with pytest.raises(ValueError, match="sampling_splits must be >= 1"):
+def test_should_pad_sampling_logits_to_power_of_2_rejects_invalid_sampling_splits(expect_error):
+    with expect_error(ValueError, "sampling_splits must be >= 1"):
         should_pad_sampling_logits_to_power_of_2("Llama-3.1-70B", 128256, 0)

--- a/models/tt_transformers/tests/test_model_config_utils.py
+++ b/models/tt_transformers/tests/test_model_config_utils.py
@@ -73,7 +73,7 @@ def test_compute_galaxy_width_shard_cores(width, expected):
     [
         ("Llama-3.1-70B", 128256, 4, True),
         ("Llama-3.1-70B", 131072, 4, False),
-        ("Llama-3.1-8B", 128256, 4, False),
+        ("Llama-3.1-8B", 128256, 4, True),
     ],
 )
 def test_should_pad_sampling_logits_to_power_of_2(base_model_name, padded_vocab_size, sampling_splits, expected):

--- a/models/tt_transformers/tests/test_model_config_utils.py
+++ b/models/tt_transformers/tests/test_model_config_utils.py
@@ -59,6 +59,8 @@ def test_compute_galaxy_padded_vocab_size(vocab_size, num_devices, expected):
         (1024, 32),
         (1280, 20),
         (2048, 32),
+        (3584, 28),
+        (4096, 32),
     ],
 )
 def test_compute_galaxy_width_shard_cores(width, expected):

--- a/models/tt_transformers/tests/test_model_config_utils.py
+++ b/models/tt_transformers/tests/test_model_config_utils.py
@@ -6,6 +6,7 @@ import pytest
 
 from models.tt_transformers.tt.model_config import (
     compute_galaxy_padded_vocab_size,
+    compute_galaxy_width_shard_cores,
     compute_padded_vocab_size,
     should_pad_sampling_logits_to_power_of_2,
 )
@@ -49,6 +50,22 @@ def test_compute_galaxy_padded_vocab_size(vocab_size, num_devices, expected):
     assert padded_vocab_size == expected
     assert padded_vocab_size >= vocab_size
     assert padded_vocab_size % (32 * num_devices) == 0
+
+
+@pytest.mark.parametrize(
+    ("width", "expected"),
+    [
+        (768, 24),
+        (1024, 32),
+        (1280, 20),
+        (2048, 32),
+    ],
+)
+def test_compute_galaxy_width_shard_cores(width, expected):
+    num_cores = compute_galaxy_width_shard_cores(width)
+
+    assert num_cores == expected
+    assert (width // num_cores) % 32 == 0
 
 
 @pytest.mark.parametrize(

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -185,29 +185,40 @@ class Attention(LightweightModule):
 
         # Create combined QKV bias if present in state dict
         if f"{wq_str}.bias" in state_dict:
+            bias_num_devices = self.num_devices_per_group if self.TG else configuration.num_devices
             qkv_bias = torch.concat(
                 [
                     torch.concat(
                         [
-                            torch.chunk(state_dict[f"{wq_str}.bias"], configuration.num_devices)[i],
-                            torch.chunk(state_dict[f"{wk_str}.bias"], configuration.num_devices)[i],
-                            torch.chunk(state_dict[f"{wv_str}.bias"], configuration.num_devices)[i],
+                            torch.chunk(state_dict[f"{wq_str}.bias"], bias_num_devices)[i],
+                            torch.chunk(state_dict[f"{wk_str}.bias"], bias_num_devices)[i],
+                            torch.chunk(state_dict[f"{wv_str}.bias"], bias_num_devices)[i],
                         ],
                         dim=-1,
                     )
-                    for i in range(configuration.num_devices)
+                    for i in range(bias_num_devices)
                 ],
                 dim=-1,
             )
+            bias_mesh_mapper = (
+                ttnn.ShardTensor2dMesh(
+                    self.mesh_device,
+                    dims=(-1, None),
+                    mesh_shape=configuration.cluster_shape,
+                )
+                if self.TG
+                else ttnn.ShardTensorToMesh(self.mesh_device, dim=-1)
+            )
+            bias_cache_suffix = "sharded_2d" if self.TG else "sharded"
             # Prefill can use broadcasting on the bias add so wants a 1d tensor
             self.wqkv_bias_prefill = ttnn.as_tensor(
                 qkv_bias,
                 device=self.mesh_device,
-                mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+                mesh_mapper=bias_mesh_mapper,
                 dtype=ttnn.bfloat16,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 layout=ttnn.TILE_LAYOUT,
-                cache_file_name=cache_name("wqkv_bias_prefill_sharded"),
+                cache_file_name=cache_name(f"wqkv_bias_prefill_{bias_cache_suffix}"),
             )
             # as_tensor returns (32, dim) which is incorrect, this reshape updates the padded size to the correct size
             self.wqkv_bias_prefill = ttnn.reshape(
@@ -228,11 +239,11 @@ class Attention(LightweightModule):
                 bias_tensor = ttnn.as_tensor(
                     qkv_bias_decode,
                     device=self.mesh_device,
-                    mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+                    mesh_mapper=bias_mesh_mapper,
                     dtype=ttnn.bfloat16,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                     layout=ttnn.TILE_LAYOUT,
-                    cache_file_name=cache_name(f"wqkv_bias_decode_sharded_{batch_size}"),
+                    cache_file_name=cache_name(f"wqkv_bias_decode_{bias_cache_suffix}_{batch_size}"),
                 )
                 self.wqkv_bias_decode.append(bias_tensor)
 
@@ -623,17 +634,7 @@ class Attention(LightweightModule):
             # select the bias tensor based on the number of tiles in the rows
             # WARNING: must not change the batch size between compiling and executing a trace
             num_tiles = int(math.ceil(xqkv_fused_sharded.shape[-2] / self.tile_size))
-            wqkv_bias = self.wqkv_bias_decode[num_tiles - 1]
-            if wqkv_bias.shape[-2] != xqkv_fused_sharded.shape[-2]:
-                # Keep the tile-padded storage while matching the linear output's logical batch height.
-                # The TG interleaved linear preserves sub-tile decode batch sizes, whereas the cached
-                # bias is expanded to a whole tile for trace execution.
-                wqkv_bias = ttnn.reshape(
-                    wqkv_bias,
-                    (xqkv_fused_sharded.shape[-2], wqkv_bias.shape[-1]),
-                    wqkv_bias.padded_shape,
-                )
-            xqkv_fused_sharded = xqkv_fused_sharded + wqkv_bias
+            xqkv_fused_sharded = xqkv_fused_sharded + self.wqkv_bias_decode[num_tiles - 1]
 
         ttnn.deallocate(x)
         qkv_all_reduce_mem_cfg = self.args.get_attn_qkv_all_reduce_output_mem_config(

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -623,7 +623,17 @@ class Attention(LightweightModule):
             # select the bias tensor based on the number of tiles in the rows
             # WARNING: must not change the batch size between compiling and executing a trace
             num_tiles = int(math.ceil(xqkv_fused_sharded.shape[-2] / self.tile_size))
-            xqkv_fused_sharded = xqkv_fused_sharded + self.wqkv_bias_decode[num_tiles - 1]
+            wqkv_bias = self.wqkv_bias_decode[num_tiles - 1]
+            if wqkv_bias.shape[-2] != xqkv_fused_sharded.shape[-2]:
+                # Keep the tile-padded storage while matching the linear output's logical batch height.
+                # The TG interleaved linear preserves sub-tile decode batch sizes, whereas the cached
+                # bias is expanded to a whole tile for trace execution.
+                wqkv_bias = ttnn.reshape(
+                    wqkv_bias,
+                    (xqkv_fused_sharded.shape[-2], wqkv_bias.shape[-1]),
+                    wqkv_bias.padded_shape,
+                )
+            xqkv_fused_sharded = xqkv_fused_sharded + wqkv_bias
 
         ttnn.deallocate(x)
         qkv_all_reduce_mem_cfg = self.args.get_attn_qkv_all_reduce_output_mem_config(

--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -8,6 +8,24 @@ from models.tt_transformers.tt.ccl import tt_distributed_rmsnorm, tt_sharded_dis
 from models.tt_transformers.tt.common import Mode
 
 
+def galaxy_distributed_norm_core_grid(dim: int) -> tuple[int, int]:
+    """Choose a tile-aligned Galaxy decode RMSNorm grid as (y, x)."""
+    hidden_size_per_device = dim // 4
+    if hidden_size_per_device == 1280:
+        # Qwen's silicon-validated Galaxy layout: 10 cores with four tiles per shard.
+        core_grid = (5, 2)
+    else:
+        core_grid = (min(4, hidden_size_per_device // 32 // 8), 8)
+
+    num_cores = core_grid[0] * core_grid[1]
+    if num_cores == 0 or hidden_size_per_device % (num_cores * 32) != 0:
+        raise ValueError(
+            f"Galaxy distributed norm hidden size {hidden_size_per_device} is not tile-shardable "
+            f"across grid {core_grid}"
+        )
+    return core_grid
+
+
 class DistributedNorm(LightweightModule):
     def __init__(self, norm, args, tt_ccl, prefetcher=None, TG=False, ag_config_key=None, enable_all_gather=True):
         self.norm = norm
@@ -20,10 +38,7 @@ class DistributedNorm(LightweightModule):
         self.enable_all_gather = enable_all_gather
 
         if TG:
-            core_grid_ln = (
-                min(4, args.dim // 4 // 32 // 8),
-                8,
-            )  # dividing by 4 and 8 for num_cols and num_rows of mesh, and 32 for tile size
+            core_grid_ln = galaxy_distributed_norm_core_grid(args.dim)
             num_cores_ln = core_grid_ln[0] * core_grid_ln[1]
             hidden_size_per_device_distributed_ln = args.dim // 4
             self.gather_in_mem_cfg = ttnn.create_sharded_memory_config(

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -108,6 +108,17 @@ def compute_galaxy_padded_vocab_size(vocab_size: int, num_devices: int) -> int:
     return compute_padded_vocab_size(max(vocab_size, 128 * 1024), num_devices)
 
 
+def compute_galaxy_width_shard_cores(width: int, max_cores: int = 32) -> int:
+    """Use the largest core count that leaves a tile-aligned width shard."""
+    if width % ttnn.TILE_SIZE != 0:
+        raise ValueError(f"width must be tile-aligned, got {width}")
+    width_tiles = width // ttnn.TILE_SIZE
+    num_cores = min(max_cores, width_tiles)
+    while width_tiles % num_cores != 0:
+        num_cores -= 1
+    return num_cores
+
+
 def should_pad_sampling_logits_to_power_of_2(
     base_model_name: str, padded_vocab_size: int, sampling_splits: int
 ) -> bool:
@@ -4147,8 +4158,8 @@ class ModelArgs:
             )
 
             self.model_config["SELF_OUT_GATHERED_MEMCFG"] = lambda mesh_rows: ttnn.create_sharded_memory_config(
-                shape=(32 * mesh_rows, self.dim // 4 // min(32, self.dim // 4 // 32)),
-                core_grid=num_to_coregrid(min(32, self.dim // 4 // 32)),
+                shape=(32 * mesh_rows, self.dim // 4 // compute_galaxy_width_shard_cores(self.dim // 4)),
+                core_grid=num_to_coregrid(compute_galaxy_width_shard_cores(self.dim // 4)),
                 strategy=ttnn.ShardStrategy.WIDTH,
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,
                 use_height_and_width_as_shard_shape=True,

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -103,6 +103,11 @@ def compute_padded_vocab_size(vocab_size: int, num_devices: int) -> int:
     return nearest_multiple(vocab_size, ttnn.TILE_SIZE * num_devices)
 
 
+def compute_galaxy_padded_vocab_size(vocab_size: int, num_devices: int) -> int:
+    """Preserve Galaxy's 128K layout while accommodating larger vocabularies."""
+    return compute_padded_vocab_size(max(vocab_size, 128 * 1024), num_devices)
+
+
 def should_pad_sampling_logits_to_power_of_2(
     base_model_name: str, padded_vocab_size: int, sampling_splits: int
 ) -> bool:
@@ -2732,7 +2737,7 @@ class ModelArgs:
         # Pad vocab_size to be divisible by (32 * num_devices) for proper shard alignment
         tile_size = 32
         if self.is_galaxy:
-            self.padded_vocab_size = 128 * 1024
+            self.padded_vocab_size = compute_galaxy_padded_vocab_size(self.vocab_size, self.num_devices)
         elif self.num_devices == 0:
             # No mesh (e.g. reference-output generation): pad to tile_size only
             self.padded_vocab_size = math.ceil(self.vocab_size / tile_size) * tile_size

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -4154,11 +4154,12 @@ class ModelArgs:
                 use_height_and_width_as_shard_shape=True,
             )
             if self.dim == 5120:
-                # Preserve Qwen's silicon-validated Galaxy user-gather layout.
+                # Qwen's unified attention output is [32, 1024] after the user
+                # gather, requiring one 32-wide shard on each of 32 cores.
                 self.model_config["GATHER_USERS_MEMCFG"] = lambda mesh_cols: ttnn.create_sharded_memory_config(
-                    shape=(32, 128),
+                    shape=(32 * mesh_cols, 32),
                     core_grid=num_to_coregrid(32),
-                    strategy=ttnn.ShardStrategy.HEIGHT,
+                    strategy=ttnn.ShardStrategy.WIDTH,
                     orientation=ttnn.ShardOrientation.ROW_MAJOR,
                     use_height_and_width_as_shard_shape=True,
                 )

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -4153,13 +4153,23 @@ class ModelArgs:
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,
                 use_height_and_width_as_shard_shape=True,
             )
-            self.model_config["GATHER_USERS_MEMCFG"] = lambda mesh_cols: ttnn.create_sharded_memory_config(
-                shape=(32 * mesh_cols, 32),  # mesh_cols = 4
-                core_grid=num_to_coregrid(min(32, self.dim // 8 // 32)),
-                strategy=ttnn.ShardStrategy.WIDTH,
-                orientation=ttnn.ShardOrientation.ROW_MAJOR,
-                use_height_and_width_as_shard_shape=True,
-            )
+            if self.dim == 5120:
+                # Preserve Qwen's silicon-validated Galaxy user-gather layout.
+                self.model_config["GATHER_USERS_MEMCFG"] = lambda mesh_cols: ttnn.create_sharded_memory_config(
+                    shape=(32, 128),
+                    core_grid=num_to_coregrid(32),
+                    strategy=ttnn.ShardStrategy.HEIGHT,
+                    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                    use_height_and_width_as_shard_shape=True,
+                )
+            else:
+                self.model_config["GATHER_USERS_MEMCFG"] = lambda mesh_cols: ttnn.create_sharded_memory_config(
+                    shape=(32 * mesh_cols, 32),  # mesh_cols = 4
+                    core_grid=num_to_coregrid(min(32, self.dim // 8 // 32)),
+                    strategy=ttnn.ShardStrategy.WIDTH,
+                    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                    use_height_and_width_as_shard_shape=True,
+                )
         else:
             qkv_core_grid = self.dram_shard_core_grid_for_k(self.dim)
             self.model_config["QKV_OUT_GATHERED_MEMCFG"] = lambda mesh_rows: ttnn.create_sharded_memory_config(

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -930,11 +930,19 @@ class ModelArgs:
             # TODO: Migrate these to use getter methods after TTTv2 migration
             # These configs are used by mlp.py for TG (Galaxy) multi-device setups
             # ============================================================================
+            if self.hidden_dim == 32768:
+                ff1_reduce_scatter_cores = 32
+                ff1_reduce_scatter_grid = ttnn.CoreGrid(x=8, y=4)
+            else:
+                # Preserve the silicon-validated Llama-70B 7x4 layout.
+                ff1_reduce_scatter_cores = 28
+                ff1_reduce_scatter_grid = ttnn.CoreRangeSet(
+                    {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 3))}
+                )
             ff1_reduce_scatter_width = self.hidden_dim // self.cluster_shape[1]
-            ff1_reduce_scatter_cores = compute_galaxy_width_shard_cores(ff1_reduce_scatter_width)
             self.model_config["FF1_OUT_REDUCE_SCATTER_MEMCFG"] = ttnn.create_sharded_memory_config(
                 shape=(32, ff1_reduce_scatter_width // ff1_reduce_scatter_cores),
-                core_grid=num_to_coregrid(ff1_reduce_scatter_cores),
+                core_grid=ff1_reduce_scatter_grid,
                 strategy=ttnn.ShardStrategy.WIDTH,
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,
                 use_height_and_width_as_shard_shape=True,

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -930,9 +930,11 @@ class ModelArgs:
             # TODO: Migrate these to use getter methods after TTTv2 migration
             # These configs are used by mlp.py for TG (Galaxy) multi-device setups
             # ============================================================================
+            ff1_reduce_scatter_width = self.hidden_dim // self.cluster_shape[1]
+            ff1_reduce_scatter_cores = compute_galaxy_width_shard_cores(ff1_reduce_scatter_width)
             self.model_config["FF1_OUT_REDUCE_SCATTER_MEMCFG"] = ttnn.create_sharded_memory_config(
-                shape=(32, self.hidden_dim // 28 // 8),  # shard_grid_cores = 28, num_devices=8
-                core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 3))}),
+                shape=(32, ff1_reduce_scatter_width // ff1_reduce_scatter_cores),
+                core_grid=num_to_coregrid(ff1_reduce_scatter_cores),
                 strategy=ttnn.ShardStrategy.WIDTH,
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,
                 use_height_and_width_as_shard_shape=True,


### PR DESCRIPTION
## Summary

- pad Galaxy vocabularies above the existing 128K baseline with per-device tile alignment
- match Galaxy QKV bias placement to the 2D-sharded QKV weights
- use tile-aligned distributed RMSNorm, gather, attention-reduction, and MLP reduce-scatter layouts for Qwen
- preserve the silicon-validated Llama-70B 7x4 MLP reduce-scatter grid
- add regression coverage for Galaxy vocab padding, shard-core selection, and norm grids

## Validation

- model-config and distributed-norm tests: 24 passed
- pre-commit hooks pass on all changed files
- Qwen3-32B BH Galaxy simulator: 6 decode steps, min PCC 0.92842987096, GSIM_EXIT=0
- Qwen2.5-32B BH Galaxy simulator: 6 decode steps, min PCC 0.948060356356, GSIM_EXIT=0
- Qwen2.5-72B BH Galaxy simulator: 6 decode steps, min PCC 0.96459581931, GSIM_EXIT=0
- broad WH PR smoke failures are unrelated target-branch runtime/UMD failures: trivial SDK add, SFPU, and matmul examples abort with exit 134 on separate runners; this diff changes only tt_transformers Python and tests