### PR TITLE
#9147: Add optional output tensor support for ttnn::repeat

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
@@ -1053,7 +1053,7 @@ def test_repeat_composite_edge_cases(shape, repeat_shape, in_mc_fn, out_mc_fn, p
     )
 
 
-# Optional output tensor — preallocated buffer reuse.
+# Optional output tensor — one case per distinct prealloc path (no shape matrix).
 @pytest.mark.parametrize(
     "layout",
     [
@@ -1061,25 +1061,17 @@ def test_repeat_composite_edge_cases(shape, repeat_shape, in_mc_fn, out_mc_fn, p
         pytest.param(ttnn.TILE_LAYOUT, id="TILE"),
     ],
 )
-@pytest.mark.parametrize(
-    "shape, repeat_shape",
-    [
-        pytest.param((1, 2, 32, 32), (1, 2, 1, 1), id="rep_n"),
-        pytest.param((2, 3, 32, 64), (1, 1, 1, 2), id="rep_w"),
-        pytest.param((1, 1, 32, 32), (2, 3, 1, 1), id="rep_multi"),
-    ],
-)
-def test_repeat_optional_output_tensor(device, layout, shape, repeat_shape):
-    n = 1
-    for s in shape:
-        n *= s
-    torch_input = torch.arange(0, n, dtype=torch.bfloat16).reshape(shape)
+def test_repeat_optional_output_tensor(device, layout):
+    """L1-interleaved direct-land happy path (one RM + one TILE)."""
+    shape = (1, 2, 32, 32)
+    repeat_shape = (1, 2, 1, 1)
+    out_shape = (1, 4, 32, 32)
+    torch_input = torch.arange(0, 1 * 2 * 32 * 32, dtype=torch.bfloat16).reshape(shape)
     torch_result = torch_input.repeat(repeat_shape)
 
     input_tensor = ttnn.from_torch(
         torch_input, layout=layout, device=device, dtype=ttnn.bfloat16, memory_config=L1_INTERLEAVED
     )
-    out_shape = tuple(s * r for s, r in zip(shape, repeat_shape))
     optional_output = ttnn.empty(out_shape, ttnn.bfloat16, layout, device, L1_INTERLEAVED)
 
     output = ttnn.repeat(input_tensor, list(repeat_shape), optional_output_tensor=optional_output)

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
@@ -1087,3 +1087,14 @@ def test_repeat_optional_output_tensor(device, layout, shape, repeat_shape):
 
     assert_equal(torch_result, ttnn.to_torch(output))
     assert_equal(torch_result, ttnn.to_torch(optional_output))
+
+
+def test_repeat_optional_output_aliases_input_raises(device, expect_error):
+    """Prealloc must be a distinct buffer; shared storage would corrupt on direct-write paths."""
+    shape = (1, 2, 32, 32)
+    torch_input = torch.arange(0, 1 * 2 * 32 * 32, dtype=torch.bfloat16).reshape(shape)
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=L1_INTERLEAVED
+    )
+    with expect_error(RuntimeError, "must not alias the input buffer"):
+        ttnn.repeat(input_tensor, [1, 1, 1, 1], optional_output_tensor=input_tensor)

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
@@ -1051,3 +1051,39 @@ def test_repeat_composite_edge_cases(shape, repeat_shape, in_mc_fn, out_mc_fn, p
         input_mem_config=in_mc_fn(device),
         output_mem_config=out_mc_fn(device),
     )
+
+
+# Optional output tensor — preallocated buffer reuse.
+@pytest.mark.parametrize(
+    "layout",
+    [
+        pytest.param(ttnn.ROW_MAJOR_LAYOUT, id="RM"),
+        pytest.param(ttnn.TILE_LAYOUT, id="TILE"),
+    ],
+)
+@pytest.mark.parametrize(
+    "shape, repeat_shape",
+    [
+        pytest.param((1, 2, 32, 32), (1, 2, 1, 1), id="rep_n"),
+        pytest.param((2, 3, 32, 64), (1, 1, 1, 2), id="rep_w"),
+        pytest.param((1, 1, 32, 32), (2, 3, 1, 1), id="rep_multi"),
+    ],
+)
+def test_repeat_optional_output_tensor(device, layout, shape, repeat_shape):
+    n = 1
+    for s in shape:
+        n *= s
+    torch_input = torch.arange(0, n, dtype=torch.bfloat16).reshape(shape)
+    torch_result = torch_input.repeat(repeat_shape)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=layout, device=device, dtype=ttnn.bfloat16, memory_config=L1_INTERLEAVED
+    )
+    out_shape = tuple(s * r for s, r in zip(shape, repeat_shape))
+    optional_output = ttnn.empty(out_shape, ttnn.bfloat16, layout, device, L1_INTERLEAVED)
+
+    output = ttnn.repeat(input_tensor, list(repeat_shape), optional_output_tensor=optional_output)
+    assert output.buffer_address() == optional_output.buffer_address()
+
+    assert_equal(torch_result, ttnn.to_torch(output))
+    assert_equal(torch_result, ttnn.to_torch(optional_output))

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
@@ -1098,3 +1098,96 @@ def test_repeat_optional_output_aliases_input_raises(device, expect_error):
     )
     with expect_error(RuntimeError, "must not alias the input buffer"):
         ttnn.repeat(input_tensor, [1, 1, 1, 1], optional_output_tensor=input_tensor)
+
+
+def test_repeat_optional_output_sharded_i2s(device):
+    """Sharded prealloc lands via interleaved_to_sharded(..., i2s_out)."""
+    shape = (1, 1, 64, 64)
+    repeat_shape = (1, 1, 1, 2)
+    out_shape = (1, 1, 64, 128)
+    torch_input = torch.arange(0, 1 * 1 * 64 * 64, dtype=torch.bfloat16).reshape(shape)
+    torch_result = torch_input.repeat(repeat_shape)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=L1_INTERLEAVED
+    )
+    out_mc = _height_shard_config(out_shape, device, num_cores=2, layout=ttnn.TILE_LAYOUT)
+    optional_output = ttnn.empty(out_shape, ttnn.bfloat16, ttnn.TILE_LAYOUT, device, out_mc)
+
+    output = ttnn.repeat(input_tensor, list(repeat_shape), memory_config=out_mc, optional_output_tensor=optional_output)
+    assert output.buffer_address() == optional_output.buffer_address()
+    assert output.is_sharded()
+    assert output.memory_config().memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    assert_equal(torch_result, ttnn.to_torch(output))
+
+
+def test_repeat_optional_output_tile_rm_roundtrip_copy(device):
+    """TILE not tile-repeat-eligible → RM roundtrip then finalize_into_preallocated copy."""
+    # H=16 is not a multiple of TILE_HEIGHT, so is_tile_repeat_eligible is false.
+    shape = (1, 2, 16, 32)
+    repeat_shape = (1, 2, 1, 1)
+    out_shape = (1, 4, 16, 32)
+    torch_input = torch.arange(0, 1 * 2 * 16 * 32, dtype=torch.bfloat16).reshape(shape)
+    torch_result = torch_input.repeat(repeat_shape)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=L1_INTERLEAVED
+    )
+    optional_output = ttnn.empty(out_shape, ttnn.bfloat16, ttnn.TILE_LAYOUT, device, L1_INTERLEAVED)
+
+    output = ttnn.repeat(input_tensor, list(repeat_shape), optional_output_tensor=optional_output)
+    assert output.buffer_address() == optional_output.buffer_address()
+    assert_equal(torch_result, ttnn.to_torch(output))
+    assert_equal(torch_result, ttnn.to_torch(optional_output))
+
+
+def test_repeat_optional_output_identity(device):
+    """All-ones repeat copies into the prealloc (no longer a bare return of input)."""
+    shape = (1, 2, 32, 32)
+    torch_input = torch.arange(0, 1 * 2 * 32 * 32, dtype=torch.bfloat16).reshape(shape)
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=L1_INTERLEAVED
+    )
+    optional_output = ttnn.empty(shape, ttnn.bfloat16, ttnn.TILE_LAYOUT, device, L1_INTERLEAVED)
+
+    output = ttnn.repeat(input_tensor, [1, 1, 1, 1], optional_output_tensor=optional_output)
+    assert output.buffer_address() == optional_output.buffer_address()
+    assert output.buffer_address() != input_tensor.buffer_address()
+    assert_equal(torch_input, ttnn.to_torch(output))
+    assert_equal(torch_input, ttnn.to_torch(optional_output))
+
+
+def test_repeat_optional_output_zero_reps(device):
+    """Zero-repetition + prealloc: zeros then finalize copy into the zero-volume dst."""
+    shape = (1, 1, 32, 32)
+    repeat_shape = (1, 0, 1, 1)
+    out_shape = (1, 0, 32, 32)
+    torch_input = torch.arange(0, 1 * 1 * 32 * 32, dtype=torch.bfloat16).reshape(shape)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=L1_INTERLEAVED
+    )
+    optional_output = ttnn.empty(out_shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, device, L1_INTERLEAVED)
+
+    output = ttnn.repeat(input_tensor, list(repeat_shape), optional_output_tensor=optional_output)
+    assert output.buffer_address() == optional_output.buffer_address()
+    got = ttnn.to_torch(output)
+    assert got.numel() == 0
+    assert tuple(got.shape) == out_shape
+
+
+def test_repeat_optional_output_mismatched_shard_spec_raises(device, expect_error):
+    """Explicit memory_config shard_spec must equal the prealloc's."""
+    shape = (1, 1, 64, 64)
+    repeat_shape = (1, 1, 1, 2)
+    out_shape = (1, 1, 64, 128)
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=L1_INTERLEAVED
+    )
+    prealloc_mc = _height_shard_config(out_shape, device, num_cores=2, layout=ttnn.TILE_LAYOUT)
+    other_mc = _height_shard_config(out_shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT)
+    optional_output = ttnn.empty(out_shape, ttnn.bfloat16, ttnn.TILE_LAYOUT, device, prealloc_mc)
+
+    with expect_error(RuntimeError, "shard_spec must match"):
+        ttnn.repeat(input_tensor, list(repeat_shape), memory_config=other_mc, optional_output_tensor=optional_output)

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/codegen/repeat_codegen_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/codegen/repeat_codegen_device_operation.cpp
@@ -27,10 +27,23 @@ void RepeatCodegenDeviceOperation::validate_on_program_cache_miss(
         ttnn::operations::data_movement::repeat_codegen::supported_by_codegen(
             input, operation_attributes.rep_dim, operation_attributes.num_repeats),
         "Input is not supported by RepeatCodegen");
+
+    if (tensor_args.optional_output_tensor.has_value()) {
+        const auto& out = tensor_args.optional_output_tensor.value();
+        auto expected_shape = input.logical_shape();
+        expected_shape[operation_attributes.rep_dim] *= operation_attributes.num_repeats;
+        TT_FATAL(out.logical_shape() == expected_shape, "Repeat codegen optional output shape mismatch");
+        TT_FATAL(out.dtype() == input.dtype(), "Repeat codegen optional output dtype mismatch");
+        TT_FATAL(out.layout() == input.layout(), "Repeat codegen optional output layout mismatch");
+        TT_FATAL(out.device() == input.device(), "Repeat codegen optional output must be on the same device");
+    }
 }
 
 RepeatCodegenDeviceOperation::spec_return_value_t RepeatCodegenDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.optional_output_tensor.has_value()) {
+        return tensor_args.optional_output_tensor->tensor_spec();
+    }
     const auto& input = tensor_args.input;
     auto output_shape = input.logical_shape();
     output_shape[operation_attributes.rep_dim] *= operation_attributes.num_repeats;
@@ -42,6 +55,9 @@ RepeatCodegenDeviceOperation::spec_return_value_t RepeatCodegenDeviceOperation::
 
 RepeatCodegenDeviceOperation::tensor_return_value_t RepeatCodegenDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.optional_output_tensor.has_value()) {
+        return tensor_args.optional_output_tensor.value();
+    }
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
@@ -55,9 +71,11 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> RepeatCodegenDeviceOp
 }
 
 RepeatCodegenDeviceOperation::tensor_return_value_t repeat_codegen(
-    const Tensor& input, const RepeatCodegenParams& params) {
+    const Tensor& input, const RepeatCodegenParams& params, std::optional<Tensor> optional_output_tensor) {
     using OperationType = RepeatCodegenDeviceOperation;
-    return ttnn::device_operation::launch<OperationType>(params, OperationType::tensor_args_t{.input = input});
+    return ttnn::device_operation::launch<OperationType>(
+        params,
+        OperationType::tensor_args_t{.input = input, .optional_output_tensor = std::move(optional_output_tensor)});
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/codegen/repeat_codegen_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/codegen/repeat_codegen_device_operation.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/data_movement/repeat/codegen/repeat_codegen_program_factory.hpp"
 #include "ttnn/types.hpp"
@@ -35,6 +37,8 @@ struct RepeatCodegenDeviceOperation {
 };
 
 RepeatCodegenDeviceOperation::tensor_return_value_t repeat_codegen(
-    const Tensor& input, const RepeatCodegenParams& params);
+    const Tensor& input,
+    const RepeatCodegenParams& params,
+    std::optional<Tensor> optional_output_tensor = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/codegen/repeat_codegen_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/codegen/repeat_codegen_program_factory.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
@@ -11,10 +13,7 @@
 
 namespace ttnn::prim {
 
-// CB depth shared by all three program-factory branches (TILE-interleaved, RM
-// last-dim, RM higher-dim). Matches ops/repeat/spec.py's _CB_DEPTH. Also
-// consulted by repeat_codegen_supported.cpp's L1-capacity gate, so this is the
-// single source of truth rather than a value duplicated across files.
+// Shared CB depth for codegen factories and L1-capacity gate (ops/repeat/spec.py `_CB_DEPTH`).
 inline constexpr uint32_t kRepeatCbDepth = 8;
 
 struct RepeatCodegenParams {
@@ -30,6 +29,7 @@ struct RepeatCodegenParams {
 
 struct RepeatCodegenInputs {
     Tensor input;
+    std::optional<Tensor> optional_output_tensor;
 };
 
 struct RepeatCodegenProgramFactory {

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/codegen/repeat_codegen_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/codegen/repeat_codegen_program_factory.hpp
@@ -13,7 +13,10 @@
 
 namespace ttnn::prim {
 
-// Shared CB depth for codegen factories and L1-capacity gate (ops/repeat/spec.py `_CB_DEPTH`).
+// CB depth shared by all three program-factory branches (TILE-interleaved, RM
+// last-dim, RM higher-dim). Matches ops/repeat/spec.py's _CB_DEPTH. Also
+// consulted by repeat_codegen_supported.cpp's L1-capacity gate, so this is the
+// single source of truth rather than a value duplicated across files.
 inline constexpr uint32_t kRepeatCbDepth = 8;
 
 struct RepeatCodegenParams {

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -46,11 +46,28 @@ void RepeatDeviceOperation::validate_on_program_cache_miss(
             "Can only work with UINT16, BFLOAT16, UINT32, INT32, FLOAT32 data types");
     }
 
-    // Dropped memory_layout equality check; predicate + compute_output_specs handle sharded I/O.
+    if (tensor_args.optional_output_tensor.has_value()) {
+        const auto& out = tensor_args.optional_output_tensor.value();
+        const auto& input_shape = input_tensor_a.logical_shape();
+        auto expected_shape = input_shape;
+        const int32_t effective_repeat_dim =
+            operation_attributes.m_repeat_dim >= 0
+                ? operation_attributes.m_repeat_dim
+                : (operation_attributes.m_is_last_dim ? static_cast<int32_t>(input_shape.rank()) - 1 : 1);
+        expected_shape[effective_repeat_dim] *= operation_attributes.m_num_repeats;
+        TT_FATAL(out.logical_shape() == expected_shape, "Repeat optional output shape mismatch");
+        TT_FATAL(out.dtype() == input_tensor_a.dtype(), "Repeat optional output dtype mismatch");
+        TT_FATAL(out.layout() == input_tensor_a.layout(), "Repeat optional output layout mismatch");
+        TT_FATAL(out.device() == input_tensor_a.device(), "Repeat optional output must be on the same device");
+    }
 }
 
 RepeatDeviceOperation::spec_return_value_t RepeatDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& input_tensors) {
+    if (input_tensors.optional_output_tensor.has_value()) {
+        return input_tensors.optional_output_tensor->tensor_spec();
+    }
+
     const auto& input_tensor_a = input_tensors.input;
     const auto& input_shape = input_tensor_a.logical_shape();
     auto output_shape = input_shape;
@@ -91,6 +108,9 @@ RepeatDeviceOperation::spec_return_value_t RepeatDeviceOperation::compute_output
 
 RepeatDeviceOperation::tensor_return_value_t RepeatDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& input_tensors) {
+    if (input_tensors.optional_output_tensor.has_value()) {
+        return input_tensors.optional_output_tensor.value();
+    }
     return create_device_tensor(
         compute_output_specs(operation_attributes, input_tensors), input_tensors.input.device());
 }
@@ -110,12 +130,13 @@ RepeatDeviceOperation::tensor_return_value_t repeat(
     const Tensor& input,
     uint32_t m_num_repeats,
     bool m_is_last_dim,
-    const tt::tt_metal::MemoryConfig& output_mem_config) {
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    std::optional<Tensor> optional_output_tensor) {
     using OperationType = RepeatDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .m_num_repeats = m_num_repeats, .m_is_last_dim = m_is_last_dim, .m_output_mem_config = output_mem_config},
-        OperationType::tensor_args_t{.input = input});
+        OperationType::tensor_args_t{.input = input, .optional_output_tensor = std::move(optional_output_tensor)});
 }
 
 RepeatDeviceOperation::tensor_return_value_t repeat_tile(
@@ -126,7 +147,8 @@ RepeatDeviceOperation::tensor_return_value_t repeat_tile(
     uint32_t tile_higher_pages,
     uint32_t tile_rep_dim_pages,
     uint32_t tile_lower_pages,
-    uint32_t tile_page_size_bytes) {
+    uint32_t tile_page_size_bytes,
+    std::optional<Tensor> optional_output_tensor) {
     using OperationType = RepeatDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
@@ -138,6 +160,6 @@ RepeatDeviceOperation::tensor_return_value_t repeat_tile(
             .m_tile_lower_pages = tile_lower_pages,
             .m_tile_page_size_bytes = tile_page_size_bytes,
             .m_repeat_dim = repeat_dim},
-        OperationType::tensor_args_t{.input = input});
+        OperationType::tensor_args_t{.input = input, .optional_output_tensor = std::move(optional_output_tensor)});
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/data_movement/repeat/device/repeat_device_operation_types.hpp"
 #include "ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.hpp"
@@ -40,7 +42,8 @@ RepeatDeviceOperation::tensor_return_value_t repeat(
     const Tensor& input,
     uint32_t m_num_repeats,
     bool m_is_last_dim,
-    const tt::tt_metal::MemoryConfig& output_mem_config);
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    std::optional<Tensor> optional_output_tensor = std::nullopt);
 
 RepeatDeviceOperation::tensor_return_value_t repeat_tile(
     const Tensor& input,
@@ -50,5 +53,6 @@ RepeatDeviceOperation::tensor_return_value_t repeat_tile(
     uint32_t tile_higher_pages,
     uint32_t tile_rep_dim_pages,
     uint32_t tile_lower_pages,
-    uint32_t tile_page_size_bytes);
+    uint32_t tile_page_size_bytes,
+    std::optional<Tensor> optional_output_tensor = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
@@ -23,6 +25,7 @@ struct RepeatParams {
 
 struct RepeatInputs {
     Tensor input;
+    std::optional<Tensor> optional_output_tensor;
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -195,7 +195,10 @@ ttnn::Tensor repeat_dim_tile(
         std::move(optional_output_tensor));
 }
 
-// Pad/view to 4D for codegen kernels, then view output back to the logical shape.
+// Single-dim codegen repeat step. repeat_codegen's kernels assume a 4D input
+// (ops/repeat/spec.py's _page_map / build_repeat_rm_factory), so `tensor` is
+// padded up to 4D here (prepending 1s) regardless of its original rank; the
+// output is viewed back down to the true logical shape before returning.
 ttnn::Tensor repeat_dim_codegen(
     const ttnn::Tensor& tensor,
     const uint32_t dim,
@@ -273,7 +276,11 @@ ttnn::Tensor repeat_dim_codegen(
     return ttnn::view(out, ttnn::Shape(expected_shape));
 }
 
-// Multi-dim repeat as reverse-order single-dim codegen steps (axes are independent).
+// Decomposes a (possibly multi-dim) repeat into a sequence of single-dim
+// prim::repeat_codegen calls, mirroring the reverse-order per-dim loops
+// above (native TILE/RM) and ops/repeat/repeat.py's RepeatCodegen.repeat --
+// each single-dim step is independent (orthogonal axes), so iteration order
+// doesn't affect correctness.
 ttnn::Tensor repeat_via_codegen(
     const ttnn::Tensor& tensor,
     const ttsl::SmallVector<uint32_t>& repetition_vector,
@@ -321,6 +328,12 @@ ttnn::Tensor repeat(
             memory_config->buffer_type() == optional_output_tensor->memory_config().buffer_type() &&
                 memory_config->memory_layout() == optional_output_tensor->memory_config().memory_layout(),
             "repeat: memory_config must match optional_output_tensor memory config");
+        // Explicit shard_spec must match prealloc; omit shard_spec to derive-from-prealloc.
+        if (memory_config->shard_spec().has_value()) {
+            TT_FATAL(
+                memory_config->shard_spec() == optional_output_tensor->memory_config().shard_spec(),
+                "repeat: memory_config shard_spec must match optional_output_tensor");
+        }
     }
     auto working_output_mem_config = output_mem_config;
 
@@ -399,7 +412,13 @@ ttnn::Tensor repeat(
     };
 
     {
-        // Codegen needs interleaved same-placement output; sharded/cross-placement use native.
+        // Sharded *output* has no resharding path in this port (codegen only ever produces an
+        // interleaved output tensor); gate it here rather than in supported_by_codegen(), which
+        // is about the input side per the manifest's hand-authored sharded case.
+        // Placement must match too: the RM factories derive CB slot sizes and per-page
+        // transfer sizes from one side's aligned page size, and DRAM/L1 page alignments
+        // differ, so a cross-placement call can overrun destination pages or CB slots.
+        // Native derives both sides' pitches independently and handles the conversion.
         const bool placement_matches = output_mem_config.buffer_type() == working_tensor.memory_config().buffer_type();
         const bool codegen_output_ok = !output_mem_config.is_sharded() && placement_matches;
         if (sel != repeat_codegen::ImplementationSelector::Native) {
@@ -453,7 +472,8 @@ ttnn::Tensor repeat(
             input_orientation_hint = input_tensor.shard_spec()->orientation;
         }
         if (working_tensor.memory_config().is_sharded()) {
-            // DRAM-sharded → L1 interleaved staging (keeps match_input_rank padding).
+            // DRAM-sharded fallback via to_memory_config (sharded_to_interleaved is L1-only);
+            // use working_tensor to keep rank padding from match_input_rank.
             const MemoryConfig l1_interleaved{TensorMemoryLayout::INTERLEAVED, BufferType::L1};
             working_tensor = ttnn::to_memory_config(working_tensor, l1_interleaved, std::nullopt);
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -334,6 +334,9 @@ ttnn::Tensor repeat(
         TT_FATAL(out.dtype() == input_tensor.dtype(), "repeat optional output dtype mismatch");
         TT_FATAL(out.layout() == input_tensor.layout(), "repeat optional output layout mismatch");
         TT_FATAL(out.logical_shape() == expected_logical_shape, "repeat optional output shape mismatch");
+        // Direct-write kernels read input while writing output; shared storage corrupts (slice forbids this).
+        TT_FATAL(
+            out.buffer() != input_tensor.buffer(), "repeat: optional_output_tensor must not alias the input buffer");
     }
 
     // Copy into preallocated when the composite path could not write it directly.
@@ -386,7 +389,13 @@ ttnn::Tensor repeat(
     const bool needs_final_i2s = output_mem_config.is_sharded();  // refined after native_sharded below
     // Tentative: codegen/tile paths can take optional; RM+TILE roundtrip cannot.
     auto maybe_direct_out = [&](bool allow) -> std::optional<Tensor> {
-        return (allow && optional_output_tensor.has_value()) ? optional_output_tensor : std::nullopt;
+        if (!allow || !optional_output_tensor.has_value()) {
+            return std::nullopt;
+        }
+        if (working_tensor.buffer() == optional_output_tensor->buffer()) {
+            return std::nullopt;
+        }
+        return optional_output_tensor;
     };
 
     {
@@ -434,7 +443,8 @@ ttnn::Tensor repeat(
 
     const bool will_i2s = !native_sharded && needs_final_i2s;
     // Prim can own the prealloc when no subsequent to_layout/i2s reallocates.
-    const bool prim_can_land = optional_output_tensor.has_value() && !needs_rm_tilize_roundtrip && !will_i2s;
+    const bool prim_can_land = optional_output_tensor.has_value() && !needs_rm_tilize_roundtrip && !will_i2s &&
+                               working_tensor.buffer() != optional_output_tensor->buffer();
 
     // Snapshot orientation before the L1-interleaved staging hop strips it.
     std::optional<ShardOrientation> input_orientation_hint;

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -285,7 +285,7 @@ ttnn::Tensor repeat_via_codegen(
     const ttnn::Tensor& tensor,
     const ttsl::SmallVector<uint32_t>& repetition_vector,
     const MemoryConfig& output_mem_config,
-    std::optional<Tensor> optional_output_tensor = std::nullopt) {
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt) {
     ttnn::Tensor working_tensor = tensor;
     for (auto it = repetition_vector.crbegin(); it != repetition_vector.crend(); ++it) {
         if (*it == 1) {
@@ -539,7 +539,7 @@ ttnn::Tensor repeat(
         }
         auto i2s_out = optional_output_tensor.has_value() ? optional_output_tensor : std::nullopt;
         working_tensor = ttnn::interleaved_to_sharded(
-            working_tensor, final_mc, /*data_type=*/std::nullopt, /*keep_l1_aligned=*/std::nullopt, i2s_out);
+            working_tensor, final_mc, /*data_type_arg=*/std::nullopt, /*keep_l1_aligned=*/std::nullopt, i2s_out);
     }
 
     return finalize_into_preallocated(working_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -5,12 +5,14 @@
 #include <algorithm>
 #include <array>
 #include <functional>
+#include <optional>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/creation/creation.hpp"
+#include "ttnn/operations/data_movement/copy/copy.hpp"
 #include "ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.hpp"
 #include "ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.hpp"
 #include "ttnn/operations/data_movement/view/view.hpp"
@@ -34,7 +36,11 @@ struct UpperRepeatDims {
 };
 
 ttnn::Tensor repeat_upper_dims_rm(
-    const ttnn::Tensor& tensor, const uint32_t dim, const uint32_t repetitions, const MemoryConfig& output_mem_config) {
+    const ttnn::Tensor& tensor,
+    const uint32_t dim,
+    const uint32_t repetitions,
+    const MemoryConfig& output_mem_config,
+    std::optional<Tensor> optional_output_tensor = std::nullopt) {
     const auto& input_shape = tensor.logical_shape();
     ttsl::SmallVector<uint32_t> collapsed_shape_vector(4);
 
@@ -47,8 +53,16 @@ ttnn::Tensor repeat_upper_dims_rm(
 
     auto input_tensor = ttnn::view(tensor, ttnn::Shape(collapsed_shape_vector));
 
+    std::optional<Tensor> prim_output = std::nullopt;
+    if (optional_output_tensor.has_value()) {
+        auto collapsed_out = collapsed_shape_vector;
+        collapsed_out[UpperRepeatDims::repeat] *= repetitions;
+        prim_output = ttnn::view(optional_output_tensor.value(), ttnn::Shape(collapsed_out));
+    }
+
     constexpr bool is_final_dim = false;
-    auto out_tensor = ttnn::prim::repeat(input_tensor, repetitions, is_final_dim, output_mem_config);
+    auto out_tensor =
+        ttnn::prim::repeat(input_tensor, repetitions, is_final_dim, output_mem_config, std::move(prim_output));
     auto expected_shape = input_shape;
     expected_shape[dim] *= repetitions;
 
@@ -56,7 +70,10 @@ ttnn::Tensor repeat_upper_dims_rm(
 }
 
 ttnn::Tensor repeat_last_dim_rm(
-    const ttnn::Tensor& tensor, const uint32_t repetitions, const MemoryConfig& output_mem_config) {
+    const ttnn::Tensor& tensor,
+    const uint32_t repetitions,
+    const MemoryConfig& output_mem_config,
+    std::optional<Tensor> optional_output_tensor = std::nullopt) {
     const auto& input_shape = tensor.logical_shape();
     ttsl::SmallVector<uint32_t> collapsed_shape_vector(2);
 
@@ -66,8 +83,16 @@ ttnn::Tensor repeat_last_dim_rm(
 
     auto input_tensor = ttnn::view(tensor, ttnn::Shape(collapsed_shape_vector));
 
+    std::optional<Tensor> prim_output = std::nullopt;
+    if (optional_output_tensor.has_value()) {
+        auto collapsed_out = collapsed_shape_vector;
+        collapsed_out[1] *= repetitions;
+        prim_output = ttnn::view(optional_output_tensor.value(), ttnn::Shape(collapsed_out));
+    }
+
     constexpr bool is_final_dim = true;
-    auto out_tensor = ttnn::prim::repeat(input_tensor, repetitions, is_final_dim, output_mem_config);
+    auto out_tensor =
+        ttnn::prim::repeat(input_tensor, repetitions, is_final_dim, output_mem_config, std::move(prim_output));
 
     auto expected_shape = input_shape;
     expected_shape[-1] *= repetitions;
@@ -123,7 +148,11 @@ bool is_tile_repeat_eligible(const ttnn::Tensor& tensor) {
 }
 
 ttnn::Tensor repeat_dim_tile(
-    const ttnn::Tensor& tensor, const uint32_t dim, const uint32_t repetitions, const MemoryConfig& output_mem_config) {
+    const ttnn::Tensor& tensor,
+    const uint32_t dim,
+    const uint32_t repetitions,
+    const MemoryConfig& output_mem_config,
+    std::optional<Tensor> optional_output_tensor = std::nullopt) {
     const auto& shape = tensor.logical_shape();
     const auto rank = shape.rank();
 
@@ -155,15 +184,24 @@ ttnn::Tensor repeat_dim_tile(
     }
 
     return ttnn::prim::repeat_tile(
-        tensor, repetitions, dim, output_mem_config, higher, rep_dim_pages, lower, tile_page_size);
+        tensor,
+        repetitions,
+        dim,
+        output_mem_config,
+        higher,
+        rep_dim_pages,
+        lower,
+        tile_page_size,
+        std::move(optional_output_tensor));
 }
 
-// Single-dim codegen repeat step. repeat_codegen's kernels assume a 4D input
-// (ops/repeat/spec.py's _page_map / build_repeat_rm_factory), so `tensor` is
-// padded up to 4D here (prepending 1s) regardless of its original rank; the
-// output is viewed back down to the true logical shape before returning.
+// Pad/view to 4D for codegen kernels, then view output back to the logical shape.
 ttnn::Tensor repeat_dim_codegen(
-    const ttnn::Tensor& tensor, const uint32_t dim, const uint32_t repetitions, const MemoryConfig& output_mem_config) {
+    const ttnn::Tensor& tensor,
+    const uint32_t dim,
+    const uint32_t repetitions,
+    const MemoryConfig& output_mem_config,
+    std::optional<Tensor> optional_output_tensor = std::nullopt) {
     const auto& shape = tensor.logical_shape();
     const uint32_t ndim = shape.rank();
     TT_FATAL(ndim <= 4, "RepeatCodegen supports rank <= 4, got {}", ndim);
@@ -221,29 +259,36 @@ ttnn::Tensor repeat_dim_codegen(
         .output_mem_config = output_mem_config,
     };
 
-    auto out = ttnn::prim::repeat_codegen(working, params);
+    std::optional<Tensor> prim_output = std::nullopt;
+    if (optional_output_tensor.has_value()) {
+        auto expected4d = shape4d;
+        expected4d[rep_dim_4d] *= repetitions;
+        prim_output = ttnn::view(optional_output_tensor.value(), ttnn::Shape(expected4d));
+    }
+
+    auto out = ttnn::prim::repeat_codegen(working, params, std::move(prim_output));
 
     auto expected_shape = shape;
     expected_shape[dim] *= repetitions;
     return ttnn::view(out, ttnn::Shape(expected_shape));
 }
 
-// Decomposes a (possibly multi-dim) repeat into a sequence of single-dim
-// prim::repeat_codegen calls, mirroring the reverse-order per-dim loops
-// above (native TILE/RM) and ops/repeat/repeat.py's RepeatCodegen.repeat --
-// each single-dim step is independent (orthogonal axes), so iteration order
-// doesn't affect correctness.
+// Multi-dim repeat as reverse-order single-dim codegen steps (axes are independent).
 ttnn::Tensor repeat_via_codegen(
     const ttnn::Tensor& tensor,
     const ttsl::SmallVector<uint32_t>& repetition_vector,
-    const MemoryConfig& output_mem_config) {
+    const MemoryConfig& output_mem_config,
+    std::optional<Tensor> optional_output_tensor = std::nullopt) {
     ttnn::Tensor working_tensor = tensor;
     for (auto it = repetition_vector.crbegin(); it != repetition_vector.crend(); ++it) {
         if (*it == 1) {
             continue;
         }
         const auto dim = repetition_vector.crend() - it - 1;
-        working_tensor = repeat_dim_codegen(working_tensor, dim, *it, output_mem_config);
+        // Only the final non-1 dim can land in the preallocated buffer.
+        const bool is_last = std::none_of(std::next(it), repetition_vector.crend(), [](uint32_t r) { return r != 1; });
+        auto step_out = is_last ? optional_output_tensor : std::nullopt;
+        working_tensor = repeat_dim_codegen(working_tensor, dim, *it, output_mem_config, std::move(step_out));
     }
     return working_tensor;
 }
@@ -256,18 +301,52 @@ ttnn::Tensor repeat(
     const ttnn::Tensor& input_tensor,
     const ttsl::SmallVector<uint32_t>& repetition_vector,
     const std::optional<MemoryConfig>& memory_config,
-    const std::string& implementation) {
+    const std::string& implementation,
+    const std::optional<Tensor>& optional_output_tensor) {
     namespace repeat_codegen = operations::data_movement::repeat_codegen;
     // Validate before any early return so invalid values fail consistently.
     const auto sel = repeat_codegen::parse_implementation(implementation);
 
     auto [working_tensor, working_repetition_vector] =
         operations::data_movement::detail::match_input_rank(input_tensor, repetition_vector);
-    // Strip shard_spec from sharded input; device op re-derives for new output shape.
+    // Prefer preallocated output's memory config when provided.
     const auto& input_mc = input_tensor.memory_config();
-    MemoryConfig output_mem_config = memory_config.value_or(
-        input_mc.is_sharded() ? MemoryConfig(input_mc.memory_layout(), input_mc.buffer_type()) : input_mc);
+    MemoryConfig output_mem_config =
+        optional_output_tensor.has_value()
+            ? optional_output_tensor->memory_config()
+            : memory_config.value_or(
+                  input_mc.is_sharded() ? MemoryConfig(input_mc.memory_layout(), input_mc.buffer_type()) : input_mc);
+    if (optional_output_tensor.has_value() && memory_config.has_value()) {
+        TT_FATAL(
+            memory_config->buffer_type() == optional_output_tensor->memory_config().buffer_type() &&
+                memory_config->memory_layout() == optional_output_tensor->memory_config().memory_layout(),
+            "repeat: memory_config must match optional_output_tensor memory config");
+    }
     auto working_output_mem_config = output_mem_config;
+
+    auto expected_logical_shape = working_tensor.logical_shape();
+    for (size_t i = 0; i < working_repetition_vector.size(); ++i) {
+        expected_logical_shape[i] *= working_repetition_vector[i];
+    }
+    if (optional_output_tensor.has_value()) {
+        const auto& out = optional_output_tensor.value();
+        TT_FATAL(out.device() == input_tensor.device(), "repeat optional output must be on the same device");
+        TT_FATAL(out.dtype() == input_tensor.dtype(), "repeat optional output dtype mismatch");
+        TT_FATAL(out.layout() == input_tensor.layout(), "repeat optional output layout mismatch");
+        TT_FATAL(out.logical_shape() == expected_logical_shape, "repeat optional output shape mismatch");
+    }
+
+    // Copy into preallocated when the composite path could not write it directly.
+    auto finalize_into_preallocated = [&](const ttnn::Tensor& result) -> ttnn::Tensor {
+        if (!optional_output_tensor.has_value() || result.storage_type() != StorageType::DEVICE) {
+            return result;
+        }
+        const auto& dst = optional_output_tensor.value();
+        if (result.buffer() == dst.buffer()) {
+            return result;
+        }
+        return ttnn::copy(result, dst);
+    };
 
     if (std::any_of(
             working_repetition_vector.cbegin(), working_repetition_vector.cend(), [](auto x) { return x == 0; })) {
@@ -279,14 +358,18 @@ ttnn::Tensor repeat(
             working_repetition_vector.cbegin(),
             working_repetition_vector.begin(),
             std::multiplies<uint32_t>());
-        const MemoryConfig zero_mc = memory_config.value_or(
-            MemoryConfig{TensorMemoryLayout::INTERLEAVED, input_tensor.memory_config().buffer_type()});
-        return ttnn::zeros(
+        const MemoryConfig zero_mc =
+            optional_output_tensor.has_value()
+                ? optional_output_tensor->memory_config()
+                : memory_config.value_or(
+                      MemoryConfig{TensorMemoryLayout::INTERLEAVED, input_tensor.memory_config().buffer_type()});
+        auto zeros_out = ttnn::zeros(
             ttnn::Shape(working_repetition_vector),
             input_tensor.dtype(),
             input_tensor.layout(),
             *input_tensor.device(),
             zero_mc);
+        return finalize_into_preallocated(zeros_out);
     }
 
     TT_FATAL(working_tensor.logical_shape().rank() > 0, "repeat does not support rank 0 tensors");
@@ -294,17 +377,20 @@ ttnn::Tensor repeat(
     // nothing to do!
     if (std::all_of(
             working_repetition_vector.cbegin(), working_repetition_vector.cend(), [](auto x) { return x == 1; })) {
-        return input_tensor;
+        return finalize_into_preallocated(input_tensor);
     }
 
+    // Direct prim write only when no later layout/reshard hop will reallocate.
+    const bool needs_rm_tilize_roundtrip = input_tensor.layout() == ttnn::TILE_LAYOUT &&
+                                           !operations::data_movement::detail::is_tile_repeat_eligible(working_tensor);
+    const bool needs_final_i2s = output_mem_config.is_sharded();  // refined after native_sharded below
+    // Tentative: codegen/tile paths can take optional; RM+TILE roundtrip cannot.
+    auto maybe_direct_out = [&](bool allow) -> std::optional<Tensor> {
+        return (allow && optional_output_tensor.has_value()) ? optional_output_tensor : std::nullopt;
+    };
+
     {
-        // Sharded *output* has no resharding path in this port (codegen only ever produces an
-        // interleaved output tensor); gate it here rather than in supported_by_codegen(), which
-        // is about the input side per the manifest's hand-authored sharded case.
-        // Placement must match too: the RM factories derive CB slot sizes and per-page
-        // transfer sizes from one side's aligned page size, and DRAM/L1 page alignments
-        // differ, so a cross-placement call can overrun destination pages or CB slots.
-        // Native derives both sides' pitches independently and handles the conversion.
+        // Codegen needs interleaved same-placement output; sharded/cross-placement use native.
         const bool placement_matches = output_mem_config.buffer_type() == working_tensor.memory_config().buffer_type();
         const bool codegen_output_ok = !output_mem_config.is_sharded() && placement_matches;
         if (sel != repeat_codegen::ImplementationSelector::Native) {
@@ -315,13 +401,13 @@ ttnn::Tensor repeat(
                     supported,
                     "repeat: implementation=\"codegen\" requires a supported input and an interleaved output "
                     "memory configuration in the same buffer type as the input");
-                return operations::data_movement::detail::repeat_via_codegen(
-                    working_tensor, working_repetition_vector, output_mem_config);
+                return finalize_into_preallocated(operations::data_movement::detail::repeat_via_codegen(
+                    working_tensor, working_repetition_vector, output_mem_config, maybe_direct_out(true)));
             }
             // Auto: codegen iff supported and not perf-demoted; else fall through to native below.
             if (supported && !repeat_codegen::is_demoted(working_tensor, working_repetition_vector)) {
-                return operations::data_movement::detail::repeat_via_codegen(
-                    working_tensor, working_repetition_vector, output_mem_config);
+                return finalize_into_preallocated(operations::data_movement::detail::repeat_via_codegen(
+                    working_tensor, working_repetition_vector, output_mem_config, maybe_direct_out(true)));
             }
         }
     }
@@ -346,6 +432,10 @@ ttnn::Tensor repeat(
         }
     }
 
+    const bool will_i2s = !native_sharded && needs_final_i2s;
+    // Prim can own the prealloc when no subsequent to_layout/i2s reallocates.
+    const bool prim_can_land = optional_output_tensor.has_value() && !needs_rm_tilize_roundtrip && !will_i2s;
+
     // Snapshot orientation before the L1-interleaved staging hop strips it.
     std::optional<ShardOrientation> input_orientation_hint;
     if (!native_sharded) {
@@ -353,8 +443,7 @@ ttnn::Tensor repeat(
             input_orientation_hint = input_tensor.shard_spec()->orientation;
         }
         if (working_tensor.memory_config().is_sharded()) {
-            // DRAM-sharded fallback via to_memory_config (sharded_to_interleaved is L1-only);
-            // use working_tensor to keep rank padding from match_input_rank.
+            // DRAM-sharded → L1 interleaved staging (keeps match_input_rank padding).
             const MemoryConfig l1_interleaved{TensorMemoryLayout::INTERLEAVED, BufferType::L1};
             working_tensor = ttnn::to_memory_config(working_tensor, l1_interleaved, std::nullopt);
         }
@@ -371,8 +460,11 @@ ttnn::Tensor repeat(
                 continue;
             }
             auto dim = working_repetition_vector.crend() - it - 1;
-            working_tensor =
-                operations::data_movement::detail::repeat_dim_tile(working_tensor, dim, *it, working_output_mem_config);
+            const bool is_last =
+                std::none_of(std::next(it), working_repetition_vector.crend(), [](uint32_t r) { return r != 1; });
+            auto step_out = (prim_can_land && is_last) ? optional_output_tensor : std::nullopt;
+            working_tensor = operations::data_movement::detail::repeat_dim_tile(
+                working_tensor, dim, *it, working_output_mem_config, std::move(step_out));
         }
     } else {
         // RM path: TILE->RM, repeat, RM->TILE.
@@ -384,13 +476,17 @@ ttnn::Tensor repeat(
             if (*it == 1) {
                 continue;
             }
+            const bool is_last =
+                std::none_of(std::next(it), working_repetition_vector.crend(), [](uint32_t r) { return r != 1; });
+            // RM prim lands only when final layout already matches (no later tilize).
+            auto step_out = (prim_can_land && is_last) ? optional_output_tensor : std::nullopt;
             if (it == working_repetition_vector.crbegin()) {
                 working_tensor = operations::data_movement::detail::repeat_last_dim_rm(
-                    working_tensor, *it, working_output_mem_config);
+                    working_tensor, *it, working_output_mem_config, std::move(step_out));
             } else {
                 auto i = working_repetition_vector.crend() - it - 1;
                 working_tensor = operations::data_movement::detail::repeat_upper_dims_rm(
-                    working_tensor, i, *it, working_output_mem_config);
+                    working_tensor, i, *it, working_output_mem_config, std::move(step_out));
             }
         }
 
@@ -408,22 +504,28 @@ ttnn::Tensor repeat(
             if (synth.has_value()) {
                 final_mc = MemoryConfig(final_mc.memory_layout(), final_mc.buffer_type(), synth);
             } else {
-                return working_tensor;  // No valid spec; keep interleaved.
+                return finalize_into_preallocated(working_tensor);  // No valid spec; keep interleaved.
             }
         }
-        working_tensor = ttnn::interleaved_to_sharded(working_tensor, final_mc, std::nullopt);
+        auto i2s_out = optional_output_tensor.has_value() ? optional_output_tensor : std::nullopt;
+        working_tensor = ttnn::interleaved_to_sharded(
+            working_tensor, final_mc, /*data_type=*/std::nullopt, /*keep_l1_aligned=*/std::nullopt, i2s_out);
     }
 
-    return working_tensor;
+    return finalize_into_preallocated(working_tensor);
 }
 
 ttnn::Tensor repeat(
-    const ttnn::Tensor& input_tensor, const ttnn::Shape& repeat_dims, const std::string& implementation) {
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Shape& repeat_dims,
+    const std::string& implementation,
+    const std::optional<Tensor>& optional_output_tensor) {
     return ttnn::repeat(
         input_tensor,
         ttsl::SmallVector<uint32_t>(repeat_dims.cbegin(), repeat_dims.cend()),
         std::nullopt,
-        implementation);
+        implementation,
+        optional_output_tensor);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.hpp
@@ -10,7 +10,9 @@
 
 namespace ttnn {
 
-// `implementation`: "auto"/"native"/"codegen"; auto picks codegen when supported and not demoted.
+// `implementation`: "auto" (default) picks codegen when the codegen prim
+// supports the call and it isn't perf-demoted, else native; "native" and
+// "codegen" force the respective prim ("codegen" TT_FATALs if unsupported).
 ttnn::Tensor repeat(
     const ttnn::Tensor& input_tensor,
     const ttsl::SmallVector<uint32_t>& repetition_vector,

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.hpp
@@ -3,22 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <optional>
 #include <string>
 
 #include "ttnn/types.hpp"
 
 namespace ttnn {
 
-// `implementation`: "auto" (default) picks codegen when the codegen prim
-// supports the call and it isn't perf-demoted, else native; "native" and
-// "codegen" force the respective prim ("codegen" TT_FATALs if unsupported).
+// `implementation`: "auto"/"native"/"codegen"; auto picks codegen when supported and not demoted.
 ttnn::Tensor repeat(
     const ttnn::Tensor& input_tensor,
     const ttsl::SmallVector<uint32_t>& repetition_vector,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
-    const std::string& implementation = "auto");
+    const std::string& implementation = "auto",
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
 ttnn::Tensor repeat(
-    const ttnn::Tensor& input_tensor, const ttnn::Shape& repeat_dims, const std::string& implementation = "auto");
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Shape& repeat_dims,
+    const std::string& implementation = "auto",
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat_nanobind.cpp
@@ -29,6 +29,7 @@ void bind_repeat(nb::module_& mod) {
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             implementation (str, optional): "auto" (default), "native", or "codegen".
+            optional_output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -41,12 +42,14 @@ void bind_repeat(nb::module_& mod) {
             const ttnn::Tensor&,
             const ttsl::SmallVector<uint32_t>&,
             const std::optional<MemoryConfig>&,
-            const std::string&>(&ttnn::repeat),
+            const std::string&,
+            const std::optional<Tensor>&>(&ttnn::repeat),
         nb::arg("input_tensor"),
         nb::arg("repeat_dims"),
         nb::kw_only(),
         nb::arg("memory_config") = nb::none(),
-        nb::arg("implementation") = "auto");
+        nb::arg("implementation") = "auto",
+        nb::arg("optional_output_tensor") = nb::none());
 }
 
 }  // namespace ttnn::operations::data_movement


### PR DESCRIPTION
### Ticket
Link to Github Issue #9147

### Problem
`ttnn::repeat` did not accept a preallocated optional output tensor. Callers that want to reuse a buffer (trace capture, multi-iteration loops, memory-constrained pipelines) had to allocate on every call. Peer TM ops (`slice`, `permute`) and unary already expose this; `repeat` was missing it. Queue ID support from the same issue is intentionally deferred.

### What this PR does
- **Public API + nanobind** — add `optional_output_tensor` kwarg to `ttnn.repeat` (defaults to `None`).
- **Native device prim** — thread optional output through `RepeatInputs` / `prim::repeat` / `prim::repeat_tile` with validate + reuse-or-allocate (`create_output_tensors`), matching unary/TM convention.
- **Codegen device prim** — same optional-output plumbing on `RepeatCodegenInputs` / `prim::repeat_codegen` so `implementation="auto"` / `"codegen"` paths honor prealloc too.
- **Composite host path** — prefer prealloc memory config; validate final shape/dtype/layout/device up front; land in the prealloc on the last prim write when safe (with view for collapsed/4D intermediates); `interleaved_to_sharded` prealloc when that is the final hop; `finalize_into_preallocated` via `ttnn::copy` otherwise (same pattern as `slice`).
- **Unit tests** — 8 optional-output path/guard cases (direct-land, i2s, finalize-copy, identity, zero-reps, alias/shard_spec fatals).

### Tests
All on Wormhole B0 (`-k optional_output` → **8/8 PASSED**):
- Direct-land L1 interleaved — `test_repeat_optional_output_tensor` (RM + TILE).
- Sharded prealloc / i2s hop — `test_repeat_optional_output_sharded_i2s`.
- TILE RM-roundtrip + `ttnn::copy` finalize — `test_repeat_optional_output_tile_rm_roundtrip_copy`.
- All-ones into prealloc — `test_repeat_optional_output_identity`.
- Zero-repetition + prealloc — `test_repeat_optional_output_zero_reps`.
- Alias / mismatched shard_spec rejected — `*_aliases_input_raises`, `*_mismatched_shard_spec_raises`.
- Baseline smoke (`test_repeat` / `test_repeat_codegen` TILE bf16 subset) — 9/9 PASSED.
### Notes for Reviewers
- Queue ID from #9147 is **not** in this PR (left out of scope by design).
- Codegen files are intentionally touched: default `auto` often routes to codegen, so optional output must work on both backends.
- Rejects `optional_output_tensor` that aliases the input buffer (`TT_FATAL`), matching `slice`; direct-write paths also skip landing when `working_tensor` shares storage.
- When both `memory_config` and prealloc are given and `memory_config.shard_spec` is set, require shard-spec equality (derive-it-for-me still allowed when unset).
- Restored pre-existing rationale comments that were over-trimmed in the optional-output diff.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/repeat-optional-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/repeat-optional-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/repeat-optional-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/repeat-optional-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/repeat-optional-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/repeat-optional-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/repeat-optional-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/repeat-optional-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/repeat-optional-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/repeat-optional-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/repeat-optional-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/repeat-optional-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/repeat-optional-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/repeat-optional-output)




