### PR TITLE
fix(sfpu): saturate pow 21f overflow to +inf instead of NaN (bf16 dest path)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -113,6 +113,14 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
 
     sfpi::vFloat y = sfpi::as<sfpi::vFloat>(zii);
 
+    // High-side guard, mirroring the fp32 path: z >= 128 means the result's biased
+    // exponent overflows 8 bits, so the exponent-field reconstruction above wraps
+    // instead of saturating and returns NaN for large finite results
+    // (e.g. pow(2.0f, 128.0f), pow(1000.0f, 15.0f)). z_f32 still holds z * 2**23
+    // (addexp above), so the threshold is 128 * 2**23 = 2**30.
+    v_if(z_f32 >= 0x1p30f) { y = std::numeric_limits<float>::infinity(); }
+    v_endif;
+
     // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
     // Check valid base range
     auto pow_int = sfpi::convert<sfpi::vSMag16>(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -112,6 +112,14 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
 
     sfpi::vFloat y = sfpi::as<sfpi::vFloat>(zii);
 
+    // High-side guard, mirroring the fp32 path: z >= 128 means the result's biased
+    // exponent overflows 8 bits, so the exponent-field reconstruction above wraps
+    // instead of saturating and returns NaN for large finite results
+    // (e.g. pow(2.0f, 128.0f), pow(1000.0f, 15.0f)). z_f32 still holds z * 2**23
+    // (addexp above), so the threshold is 128 * 2**23 = 2**30.
+    v_if(z_f32 >= 0x1p30f) { y = std::numeric_limits<float>::infinity(); }
+    v_endif;
+
     // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
     if constexpr (!IS_POSITIVE_EXPONENT) {
         v_if(abs_base == 0.f) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -113,6 +113,14 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
 
     sfpi::vFloat y = sfpi::as<sfpi::vFloat>(zii);
 
+    // High-side guard, mirroring the fp32 path: z >= 128 means the result's biased
+    // exponent overflows 8 bits, so the exponent-field reconstruction above wraps
+    // instead of saturating and returns NaN for large finite results
+    // (e.g. pow(2.0f, 128.0f), pow(1000.0f, 15.0f)). z_f32 still holds z * 2**23
+    // (addexp above), so the threshold is 128 * 2**23 = 2**30.
+    v_if(z_f32 >= 0x1p30f) { y = std::numeric_limits<float>::infinity(); }
+    v_endif;
+
     // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
     // Check valid base range
     auto pow_int = sfpi::convert<sfpi::vSMag16>(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -114,6 +114,14 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
 
     sfpi::vFloat y = sfpi::as<sfpi::vFloat>(zii);
 
+    // High-side guard, mirroring the fp32 path: z >= 128 means the result's biased
+    // exponent overflows 8 bits, so the exponent-field reconstruction above wraps
+    // instead of saturating and returns NaN for large finite results
+    // (e.g. pow(2.0f, 128.0f), pow(1000.0f, 15.0f)). z_f32 still holds z * 2**23
+    // (addexp above), so the threshold is 128 * 2**23 = 2**30.
+    v_if(z_f32 >= 0x1p30f) { y = std::numeric_limits<float>::infinity(); }
+    v_endif;
+
     // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
     if constexpr (!IS_POSITIVE_EXPONENT) {
         v_if(abs_base == 0.f) {


### PR DESCRIPTION
### Problem

The bf16/non-fp32-dest pow path (`_sfpu_unary_power_21f_` / `_sfpu_binary_power_21f_`) clamps `z = y*log2(x)` only on the low side (`z < -127`). For `z >= 128` the biased-exponent reconstruction wraps instead of saturating, so large **finite** results come back as **NaN**:

```
ttnn.pow(x, 128.0)  with x=2.0     -> NaN   (want +inf)
10.0 ** 39.0                        -> NaN   (want +inf)
1000.0 ** 15.0                      -> NaN   (want +inf)
```

This is part 1 of #52675, per the suggested two-PR split there (the accuracy fix for the same path is the follow-up).

### Fix

Add the high-side guard the fp32 path already has (`v_if(out_exp >= 255) { y = infinity; }` in `_sfpu_pow2_f32_accurate_hilo_`), adapted to the 21f path:

- Predicated on the **live `z_f32` register**, which at that point holds `z * 2**23` (after the `addexp(z_f32, 23)` rescale) — hence the `2**30` threshold. No extra LReg is consumed, no new `v_if` cascade beyond the single guard.
- Placed **before** the zero-base NaN override and the negative-base handling, so `pow(0, -p) -> NaN` still wins and the sign for negative bases with odd integer exponents is still applied via `setsgn2` (`(-2)**129` -> `-inf`).

Applied to the Wormhole and Blackhole copies of both the unary and binary kernels (the four files share the algorithm).

### Testing

- Float32-faithful simulation of the kernel algorithm (same model that reproduces the error tables in #52675 exactly): all 1263 overflow cases in a sweep over bf16-exact bases in [0.001, 1000] × y in [-1000, 1000] now return correctly-signed inf; non-overflow results are bit-identical to the current kernel.
- I don't have silicon; happy to run ttsim per `tt_metal/tt-llk/tests/TTSIM.md` if maintainers want device confirmation, and the guard mirrors an existing in-repo pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
