### PR TITLE
#52630: Don't dequantize a checkpoint that is already dequantized

### DIFF
--- a/models/demos/deepseek_v3/tests/test_hf_model_utils.py
+++ b/models/demos/deepseek_v3/tests/test_hf_model_utils.py
@@ -15,6 +15,7 @@ import torch
 
 from models.demos.deepseek_v3.utils.hf_model_utils import (
     _default_quad_ring_shard_maps,
+    convert_state_dict,
     default_quad_ring_model_path,
     default_stacked_dequantized_model_path,
     index_model_weights,
@@ -412,7 +413,7 @@ def test_save_dequantized_hf_checkpoint_rewrites_dequantized_shards_when_stackin
     )
 
 
-def test_save_dequantized_hf_checkpoint_rejects_incomplete_stacked_expert_groups(tmp_path: Path):
+def test_save_dequantized_hf_checkpoint_rejects_incomplete_stacked_expert_groups(tmp_path: Path, expect_error):
     source_dir = tmp_path / "deepseek-source"
     output_dir = default_stacked_dequantized_model_path(source_dir)
     source_dir.mkdir(parents=True, exist_ok=True)
@@ -427,11 +428,11 @@ def test_save_dequantized_hf_checkpoint_rejects_incomplete_stacked_expert_groups
     safetensors.torch.save_file(expert_tensors, str(shard))
     _write_index(source_dir, {key: shard.name for key in expert_tensors})
 
-    with pytest.raises(ValueError, match="do not match n_routed_experts=2"):
+    with expect_error(ValueError, "do not match n_routed_experts=2"):
         save_dequantized_hf_checkpoint(source_dir, output_model_path=output_dir, stack_experts=True)
 
 
-def test_save_dequantized_hf_checkpoint_rejects_missing_required_moe_projection_groups(tmp_path: Path):
+def test_save_dequantized_hf_checkpoint_rejects_missing_required_moe_projection_groups(tmp_path: Path, expect_error):
     source_dir = tmp_path / "deepseek-source"
     output_dir = default_stacked_dequantized_model_path(source_dir)
     source_dir.mkdir(parents=True, exist_ok=True)
@@ -460,7 +461,7 @@ def test_save_dequantized_hf_checkpoint_rejects_missing_required_moe_projection_
     safetensors.torch.save_file(expert_tensors, str(shard))
     _write_index(source_dir, {key: shard.name for key in expert_tensors})
 
-    with pytest.raises(ValueError, match="missing required expert projections"):
+    with expect_error(ValueError, "missing required expert projections"):
         save_dequantized_hf_checkpoint(source_dir, output_model_path=output_dir, stack_experts=True)
 
 
@@ -521,6 +522,75 @@ def test_dequantize_state_dict_compat_shim_handles_quantized_inputs():
     assert torch.equal(dequantized["plain.weight"], plain_weight.to(torch.bfloat16))
 
 
+def test_convert_state_dict_passes_through_dequantized_checkpoint():
+    # A dequantized checkpoint's config.json carries no `quantization_config`, so nothing may reach the
+    # dequantizer -- it would raise on the missing `weight_block_size` (the Kimi prefill-block failure).
+    hf_config = SimpleNamespace()
+    weight = torch.tensor([[1.25, -0.75]], dtype=torch.float32)
+    token_ids = torch.tensor([3, 7], dtype=torch.int64)
+
+    def _must_not_run(*args, **kwargs):
+        raise AssertionError("dequantizer must not be called for an unquantized checkpoint")
+
+    converted = convert_state_dict(
+        {"layer.weight": weight, "embed.ids": token_ids},
+        hf_config,
+        dequantizer=_must_not_run,
+    )
+
+    assert set(converted) == {"layer.weight", "embed.ids"}
+    assert converted["layer.weight"].dtype == torch.bfloat16
+    assert torch.equal(converted["layer.weight"], weight.to(torch.bfloat16))
+    assert converted["embed.ids"].dtype == torch.int64
+    assert torch.equal(converted["embed.ids"], token_ids)
+
+
+def test_convert_state_dict_dequantizes_quantized_checkpoint():
+    quantized_weight = torch.tensor([[1.0, -2.0], [3.0, -4.0]], dtype=torch.float32).to(torch.float8_e4m3fn)
+    inverse_scale = torch.tensor([[0.5]], dtype=torch.float32)
+    hf_config = SimpleNamespace(quantization_config={"weight_block_size": [2, 2]})
+
+    converted = convert_state_dict(
+        {"layer.weight": quantized_weight, "layer.weight_scale_inv": inverse_scale},
+        hf_config,
+    )
+
+    assert set(converted) == {"layer.weight"}
+    assert torch.equal(
+        converted["layer.weight"],
+        _dequantize_reference_tensor(quantized_weight, inverse_scale, (2, 2)).to(torch.bfloat16),
+    )
+
+
+def test_convert_state_dict_reads_quantization_config_nested_under_text_config():
+    # Kimi's multimodal checkpoint nests the LM config; missing it would pass fp8 weights through raw.
+    quantized_weight = torch.tensor([[1.0, -2.0], [3.0, -4.0]], dtype=torch.float32).to(torch.float8_e4m3fn)
+    inverse_scale = torch.tensor([[0.5]], dtype=torch.float32)
+    hf_config = SimpleNamespace(text_config=SimpleNamespace(quantization_config={"weight_block_size": [2, 2]}))
+
+    seen = {}
+
+    def _record(state_dict, config, dtype):
+        seen["called"] = True
+        return {"layer.weight": torch.zeros(1)}
+
+    convert_state_dict(
+        {"layer.weight": quantized_weight, "layer.weight_scale_inv": inverse_scale},
+        hf_config,
+        dequantizer=_record,
+    )
+
+    assert seen.get("called") is True
+
+
+def test_convert_state_dict_rejects_float8_without_quantization_config(expect_error):
+    hf_config = SimpleNamespace()
+    quantized_weight = torch.tensor([[1.0, -2.0]], dtype=torch.float32).to(torch.float8_e4m3fn)
+
+    with expect_error(ValueError, "no `quantization_config`"):
+        convert_state_dict({"layer.weight": quantized_weight}, hf_config)
+
+
 def test_prepare_model_state_dict_returns_lazy_state_dict_for_hf_weights(tmp_path: Path):
     model_dir = tmp_path / "deepseek-dequantized"
     model_dir.mkdir(parents=True, exist_ok=True)
@@ -551,7 +621,7 @@ def test_prepare_model_state_dict_returns_lazy_state_dict_for_hf_weights(tmp_pat
     assert torch.equal(state_dict["lm_head.weight"], lm_head)
 
 
-def test_prepare_model_state_dict_rejects_quantized_hf_weights(tmp_path: Path):
+def test_prepare_model_state_dict_rejects_quantized_hf_weights(tmp_path: Path, expect_error):
     model_dir = tmp_path / "deepseek-quantized"
     model_dir.mkdir(parents=True, exist_ok=True)
 
@@ -573,7 +643,7 @@ def test_prepare_model_state_dict_rejects_quantized_hf_weights(tmp_path: Path):
         },
     )
 
-    with pytest.raises(RuntimeError, match="Detected quantized HF tensors"):
+    with expect_error(RuntimeError, "Detected quantized HF tensors"):
         prepare_model_state_dict(SimpleNamespace(), random_weights=False, model_path=str(model_dir))
 
 
@@ -667,7 +737,7 @@ def test_materialized_stacked_checkpoint_load_hooks_resolve_expert_aliases(tmp_p
     assert target_tensor.numel() == 0
 
 
-def test_load_weight_from_weights_dict_rejects_mixed_expert_checkpoint():
+def test_load_weight_from_weights_dict_rejects_mixed_expert_checkpoint(expect_error):
     expert_key = "model.layers.3.mlp.experts.1.gate_proj.weight"
     stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
     weights_dict = {
@@ -678,7 +748,7 @@ def test_load_weight_from_weights_dict_rejects_mixed_expert_checkpoint():
     load_weight = load_weight_from_weights_dict(weights_dict)
     unload_weight = unload_weight_from_weights_dict(weights_dict)
 
-    with pytest.raises(RuntimeError, match="mixes legacy expert tensor"):
+    with expect_error(RuntimeError, "mixes legacy expert tensor"):
         load_weight(expert_key, torch.empty((2, 4), dtype=torch.bfloat16))
-    with pytest.raises(RuntimeError, match="mixes legacy expert tensor"):
+    with expect_error(RuntimeError, "mixes legacy expert tensor"):
         unload_weight(expert_key, torch.empty((2, 4), dtype=torch.bfloat16))

--- a/models/demos/deepseek_v3/utils/hf_model_utils.py
+++ b/models/demos/deepseek_v3/utils/hf_model_utils.py
@@ -174,8 +174,22 @@ def _get_weight_block_shape_from_quant_config(quantization_config: Any) -> tuple
     return tuple(int(dim) for dim in block_shape)
 
 
+def get_quantization_config(hf_config: Any) -> Any | None:
+    """Return the checkpoint's `quantization_config`, or `None` when the checkpoint is already dequantized.
+
+    Multimodal checkpoints (Kimi) nest the language-model config under `text_config`, so look there too --
+    otherwise a quantized checkpoint reads as dequantized and its weights are passed through raw.
+    """
+    quantization_config = getattr(hf_config, "quantization_config", None)
+    if quantization_config is None:
+        text_config = getattr(hf_config, "text_config", None)
+        if text_config is not None:
+            quantization_config = getattr(text_config, "quantization_config", None)
+    return quantization_config
+
+
 def get_weight_block_shape(hf_config: PretrainedConfig) -> tuple[int, ...]:
-    return _get_weight_block_shape_from_quant_config(getattr(hf_config, "quantization_config", None))
+    return _get_weight_block_shape_from_quant_config(get_quantization_config(hf_config))
 
 
 def get_weight_block_shape_from_model_path(model_path: str | Path) -> tuple[int, ...]:
@@ -241,6 +255,42 @@ def dequantize_weight_tensor(
     return out[original_slices].to(dtype).contiguous()
 
 
+def _cast_unquantized_tensor(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    """Materialize an already-dequantized tensor: floats are cast to `dtype`, everything else is copied."""
+    return tensor.to(dtype).contiguous() if tensor.is_floating_point() else tensor.clone()
+
+
+def _iter_weight_names(state_dict: Mapping[str, torch.Tensor]) -> list[str]:
+    """Weight keys of a (sub-)state_dict in a stable order, excluding the `_scale_inv` companions."""
+    return sorted(key for key in state_dict.keys() if not key.endswith("_scale_inv"))
+
+
+def passthrough_state_dict(
+    state_dict: Mapping[str, torch.Tensor],
+    dtype: torch.dtype = torch.bfloat16,
+) -> dict[str, torch.Tensor]:
+    """Convert an already-dequantized (sub-)state_dict without touching quantization metadata.
+
+    This is the no-scale half of `dequantize_state_dict`, split out so a checkpoint that ships without a
+    `quantization_config` never enters the dequantization path -- that path needs
+    `quantization_config.weight_block_size` and raises when the config does not carry it.
+    """
+    converted_state_dict: dict[str, torch.Tensor] = {}
+
+    for name in _iter_weight_names(state_dict):
+        tensor = state_dict[name]
+        if tensor is None:
+            raise ValueError(f"Expected tensor {name} to exist in state_dict but it was None")
+        if tensor.dtype == torch.float8_e4m3fn:
+            raise ValueError(
+                f"Found float8 tensor '{name}' in a checkpoint whose config has no `quantization_config`. "
+                "The weights are quantized but the dequantization metadata is missing from config.json."
+            )
+        converted_state_dict[name] = _cast_unquantized_tensor(tensor, dtype)
+
+    return converted_state_dict
+
+
 def dequantize_state_dict(
     state_dict: Mapping[str, torch.Tensor],
     hf_config: PretrainedConfig,
@@ -249,7 +299,7 @@ def dequantize_state_dict(
     dequantized_state_dict: dict[str, torch.Tensor] = {}
     block_shape = get_weight_block_shape(hf_config)
 
-    for name in sorted(key for key in state_dict.keys() if not key.endswith("_scale_inv")):
+    for name in _iter_weight_names(state_dict):
         tensor = state_dict[name]
         if tensor is None:
             raise ValueError(f"Expected tensor {name} to exist in state_dict but it was None")
@@ -263,9 +313,56 @@ def dequantize_state_dict(
 
         if tensor.dtype == torch.float8_e4m3fn:
             raise ValueError(f"Found float8 tensor '{name}' without matching inverse scale '{scale_name}'.")
-        dequantized_state_dict[name] = tensor.to(dtype).contiguous() if tensor.is_floating_point() else tensor.clone()
+        dequantized_state_dict[name] = _cast_unquantized_tensor(tensor, dtype)
 
     return dequantized_state_dict
+
+
+_LOGGED_CONVERSION_MODES: set[str] = set()
+
+
+def _log_conversion_mode(message: str) -> None:
+    """Log the quantized/dequantized conclusion once per process; repeats drop to debug.
+
+    `convert_state_dict` runs per module and per layer (60+ times for a full checkpoint), so logging at
+    info every time would bury the rest of the weight-load output.
+    """
+    if message in _LOGGED_CONVERSION_MODES:
+        logger.debug(message)
+        return
+    _LOGGED_CONVERSION_MODES.add(message)
+    logger.info(message)
+
+
+def convert_state_dict(
+    state_dict: Mapping[str, torch.Tensor],
+    hf_config: PretrainedConfig,
+    dtype: torch.dtype = torch.bfloat16,
+    dequantizer: Callable[..., dict[str, torch.Tensor]] | None = None,
+) -> dict[str, torch.Tensor]:
+    """Bring a (sub-)state_dict into `dtype`, dequantizing only when the checkpoint is actually quantized.
+
+    Every model ships in a quantized and a dequantized variant behind the same loading path, and only the
+    checkpoint's config tells them apart: a `quantization_config` means quantized weights, so we hand off
+    to `dequantizer` (default `dequantize_state_dict`); its absence means the checkpoint is already
+    dequantized, so the weights are passed through untouched. Callers with their own dequantizer -- e.g.
+    the d_p pipeline, which owns Kimi's INT4 pack-quant path -- inject it through `dequantizer`.
+    """
+    quantization_config = get_quantization_config(hf_config)
+
+    if quantization_config is None:
+        _log_conversion_mode(
+            "No `quantization_config` found in hf_config -> checkpoint is already dequantized; "
+            "passing weights through without dequantization."
+        )
+        return passthrough_state_dict(state_dict, dtype)
+
+    quant_method = quantization_config.get("quant_method") if isinstance(quantization_config, dict) else None
+    _log_conversion_mode(
+        f"Found `quantization_config` in hf_config (quant_method={quant_method!r}) -> checkpoint is "
+        "quantized; dequantizing weights."
+    )
+    return (dequantizer or dequantize_state_dict)(state_dict, hf_config, dtype)
 
 
 def _load_model_weight_map(model_path: Path) -> tuple[dict[str, str], dict[str, Any]]:

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -40,7 +40,7 @@ from models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_2 import GLM52Adapte
 
 TEST_VARIANTS["glm_5_2"] = GLM52Adapter()
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
-from models.demos.deepseek_v3_d_p.utils.test_utils import dequantize_state_dict, detect_language_model_prefix
+from models.demos.deepseek_v3_d_p.utils.test_utils import convert_state_dict, detect_language_model_prefix
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import download_infinitebench_subset
 
 # Shared FABRIC_2D parametrize entries for the prefill block + transformer tests.
@@ -863,7 +863,7 @@ def pretrained_transformer_weights(variant, model_path, hf_config, state_dict, r
     Dequantized pretrained weights for N-layer transformer in TT state_dict format.
 
     Extracts embed, norm, and per-layer weights (attention, FFN/MoE) using
-    sub_state_dict() + dequantize_state_dict(), matching the format produced
+    sub_state_dict() + convert_state_dict(), matching the format produced
     by extract_tt_state_dict() in transformer_helpers.py.
 
     Parametrize with num_layers (default 6) via indirect fixture or marker:
@@ -894,14 +894,14 @@ def pretrained_transformer_weights(variant, model_path, hf_config, state_dict, r
 
     # Embed tokens
     embed_sd = sub_state_dict(state_dict, f"{prefix}model.embed_tokens.")
-    embed_dequant = dequantize_state_dict(embed_sd, hf_config)
+    embed_dequant = convert_state_dict(embed_sd, hf_config)
     result = {
         "embed_weight": embed_dequant["weight"].float(),
     }
 
     # Final norm
     norm_sd = sub_state_dict(state_dict, f"{prefix}model.norm.")
-    norm_dequant = dequantize_state_dict(norm_sd, hf_config)
+    norm_dequant = convert_state_dict(norm_sd, hf_config)
     result["norm_weight"] = norm_dequant["weight"]
 
     # Per-layer weights
@@ -909,7 +909,7 @@ def pretrained_transformer_weights(variant, model_path, hf_config, state_dict, r
     for i in range(num_layers):
         logger.info(f"Loading layer {i} weights...")
         layer_sd = sub_state_dict(state_dict, f"{prefix}model.layers.{i}.")
-        layer_dequant = dequantize_state_dict(layer_sd, hf_config)
+        layer_dequant = convert_state_dict(layer_sd, hf_config)
 
         layer_dict = {
             "attn_norm_weight": layer_dequant["input_layernorm.weight"],

--- a/models/demos/deepseek_v3_d_p/utils/test_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/test_utils.py
@@ -12,6 +12,7 @@ from loguru import logger
 from safetensors import safe_open
 
 import ttnn
+from models.demos.deepseek_v3.utils.hf_model_utils import convert_state_dict as _convert_state_dict
 from models.demos.deepseek_v3.utils.hf_model_utils import dequantize_state_dict as _fp8_dequantize_state_dict
 
 # Wormhole B0 worker-L1 override for ring MLA tests. On Blackhole we use the platform default.
@@ -360,3 +361,18 @@ def dequantize_state_dict(
     if is_pack_quantized_int4(quant_cfg):
         return _dequantize_pack_quantized_state_dict(state_dict, quant_cfg, dtype=dtype)
     return _fp8_dequantize_state_dict(state_dict, hf_config, dtype)
+
+
+def convert_state_dict(
+    state_dict: Mapping[str, torch.Tensor],
+    hf_config: Any,
+    dtype: torch.dtype = torch.bfloat16,
+) -> dict[str, torch.Tensor]:
+    """Convert an HF (sub-)state_dict for the d_p pipeline, dequantizing only if the checkpoint needs it.
+
+    Each model ships as both a quantized and a dequantized checkpoint, and the loader cannot tell them
+    apart from the path alone -- `hf_config.quantization_config` decides. When it is present the state
+    dict goes through this module's `dequantize_state_dict`, keeping Kimi's INT4 pack-quant path intact;
+    when it is absent the weights are already dequantized and are passed straight through.
+    """
+    return _convert_state_dict(state_dict, hf_config, dtype, dequantizer=dequantize_state_dict)

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -480,7 +480,7 @@ def load_and_compute_layer_by_layer(
     from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
     from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
     from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TtPrefillBlock
-    from models.demos.deepseek_v3_d_p.utils.test_utils import dequantize_state_dict, detect_language_model_prefix
+    from models.demos.deepseek_v3_d_p.utils.test_utils import convert_state_dict, detect_language_model_prefix
 
     if gate_fallback_mode is None:
         gate_fallback_mode = GateComputeMode.HOST_ALL
@@ -531,7 +531,7 @@ def load_and_compute_layer_by_layer(
     # --- Process Embeddings ---
     logger.info("Processing embeddings...")
     embed_sd = sub_state_dict(lazy_sd, f"{prefix}model.embed_tokens.")
-    embed_dequant = dequantize_state_dict(embed_sd, config)
+    embed_dequant = convert_state_dict(embed_sd, config)
 
     if compute_reference:
         embed_with_prefix = {f"embed_tokens.{k}": v for k, v in embed_dequant.items()}
@@ -572,7 +572,7 @@ def load_and_compute_layer_by_layer(
         logger.info(f"Processing layer {i}/{num_layers}...")
 
         layer_sd = sub_state_dict(lazy_sd, f"{prefix}model.layers.{i}.")
-        layer_dequant = dequantize_state_dict(layer_sd, config)
+        layer_dequant = convert_state_dict(layer_sd, config)
 
         if compute_reference:
             layer_with_prefix = {f"layers.{i}.{k}": v for k, v in layer_dequant.items()}
@@ -691,7 +691,7 @@ def load_and_compute_layer_by_layer(
     # --- Process Norm ---
     logger.info("Processing norm...")
     norm_sd = sub_state_dict(lazy_sd, f"{prefix}model.norm.")
-    norm_dequant = dequantize_state_dict(norm_sd, config)
+    norm_dequant = convert_state_dict(norm_sd, config)
 
     if compute_reference:
         norm_with_prefix = {f"norm.{k}": v for k, v in norm_dequant.items()}
@@ -720,7 +720,7 @@ def load_and_compute_layer_by_layer(
     # --- Process LM Head ---
     logger.info("Processing lm_head...")
     lm_head_sd = sub_state_dict(lazy_sd, f"{prefix}lm_head.")
-    lm_head_dequant = dequantize_state_dict(lm_head_sd, config)
+    lm_head_dequant = convert_state_dict(lm_head_sd, config)
 
     if compute_reference:
         # Apply lm_head projection: logits = h_ref @ lm_head_weight.T


### PR DESCRIPTION
### Ticket

Closes #52630

### Problem description

The `Blaze - Kimi Prefill Block` job ([failing run](https://github.com/tenstorrent/tt-metal/actions/runs/31241236255/job/93073764769)) fails during weight loading with:

```
ValueError: Missing DeepSeek quantization_config.weight_block_size.
The source checkpoint config must retain the original quantization metadata.
```

The job points `KIMI_K2_6_HF_MODEL` at `/mnt/models/Kimi-K2_6-dequantized`, whose `config.json` has no `quantization_config` at all — the weights are already bf16. But `load_and_compute_layer_by_layer` called `dequantize_state_dict` unconditionally, and that function reads `quantization_config.weight_block_size` up front, before it ever looks at whether a tensor actually has a `_scale_inv` companion. So a checkpoint that needs no dequantization can't get through the dequantizer.

Every model in this family ships as both a quantized and a dequantized checkpoint, and nothing in the path tells them apart — only the checkpoint's own config does.

### What's changed

Split the two halves of `dequantize_state_dict` apart and pick between them from the config:

- **`passthrough_state_dict`** (`deepseek_v3/utils/hf_model_utils.py`) — the no-scale half of `dequantize_state_dict`, extracted verbatim: cast floats to `dtype`, copy everything else. It raises if it meets a float8 tensor, since that means the weights are quantized but the config lost its metadata.
- **`convert_state_dict`** (same file) — dequantizes when `quantization_config` is present, passes through when it isn't, and logs which conclusion it reached. An optional `dequantizer` hook lets a caller supply its own dequantizer.
- **`get_quantization_config`** (same file) — also looks under `text_config`. Kimi's multimodal checkpoint nests the LM config there; without this a quantized Kimi would read as dequantized and its fp8 weights would be passed through raw.
- **`deepseek_v3_d_p/utils/test_utils.py`** — a `convert_state_dict` wrapper that injects the d_p dequantizer, so Kimi's INT4 pack-quant path stays intact.
- **`transformer_helpers.py`** and **`deepseek_v3_d_p/tests/conftest.py`** — call sites swapped to `convert_state_dict`. The conftest fixture (`pretrained_transformer_weights`, used by `test_mla` and `test_kv_cache_table`) had the identical bug against the same checkpoint.

The quantized path is unchanged: with a `quantization_config` present, `convert_state_dict` forwards to exactly the dequantizer that ran before.

The pre-existing `pytest.raises` calls in `test_hf_model_utils.py` are converted to the `expect_error` fixture, since the `prefer-expect-error` pre-commit hook blocks any commit touching that file otherwise.

### Checklist

Verified on a Blackhole Galaxy (8x4), running the CI job's own commands against the CI model path:

| Test | main | this branch |
| --- | --- | --- |
| `test_kimi_prefill_block` · `pcc-prompt_5k` (dense + moe_gate_device) | 2 failed — `ValueError: Missing DeepSeek quantization_config.weight_block_size` | **2 passed** (294s) |
| `test_kimi_prefill_block` · `pcc-prompt_25k` (dense + moe_gate_device) | 2 failed — same | **2 passed** (517s) |
| `test_ds_prefill_block` · DeepSeek fp8, quantized path (regression) | 6 passed | **6 passed** (327s) |
| `models/demos/deepseek_v3/tests/test_hf_model_utils.py` | 20 passed | **24 passed** (4 new) |

PCC on the Kimi 5k run: 0.99977 / 0.99993 / 0.99995 (dense), 0.99947 / 0.99991 / 0.99985 (moe) — all above threshold.

Both branches confirmed from the logs:

```
Kimi dequantized:  No `quantization_config` found in hf_config -> checkpoint is already
                   dequantized; passing weights through without dequantization.
DeepSeek fp8:      Found `quantization_config` in hf_config (quant_method='fp8') ->
                   checkpoint is quantized; dequantizing weights.
```

- [Blaze Models Prefill tests — `kimi_prefill_block` on this branch](https://github.com/tenstorrent/tt-metal/actions/runs/31388020651)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/52630)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/52630)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/52630)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/52630)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kgrujcic/52630)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kgrujcic/52630)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/52630)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/52630)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/52630)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/52630)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/52630)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/52630)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/52630)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/52630)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/52630)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/52630)