### PR TITLE
[Feature] Add accurate fp32 SFPU path for ttnn.max via fast_and_approximate_mode

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_max.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_max.py
@@ -10,7 +10,7 @@ import torch
 
 import ttnn
 from models.common.utility_functions import torch_random
-from tests.ttnn.utils_for_testing import assert_equal
+from tests.ttnn.utils_for_testing import assert_allclose, assert_equal
 
 TEST_PADDING_VALUE = -42
 
@@ -142,3 +142,31 @@ def test_max_dim(device, input_shape_and_dim, keepdim):
 
     # test for equivalance
     assert_equal(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize("input_shape", [(16, 2, 32, 3), (16, 2, 32, 24), (1, 1, 64, 64)])
+@pytest.mark.parametrize("dim", [None, -1, -2])
+@pytest.mark.parametrize("fast_and_approximate_mode", [False, True], ids=["accurate", "fast"])
+def test_max_fp32_fast_and_approximate_mode(device, input_shape, dim, fast_and_approximate_mode):
+    """FLOAT32 max with both values of fast_and_approximate_mode.
+    - False (default): accurate SFPU path - result matches torch exactly.
+    - True: faster FPU/TF32 path - result is approximate.
+    """
+    torch.manual_seed(1)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    if dim is None:
+        torch_output_tensor = torch.max(torch_input_tensor)
+    else:
+        torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32)
+    input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
+
+    output_tensor = ttnn.max(input_tensor, fast_and_approximate_mode=fast_and_approximate_mode, dim=dim)
+    output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor)).reshape(torch_output_tensor.shape)
+
+    if fast_and_approximate_mode:
+        assert_allclose(torch_output_tensor, output_tensor, rtol=1e-3, atol=1e-2)
+    else:
+        assert_equal(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/reduce/test_max.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_max.py
@@ -146,8 +146,9 @@ def test_max_dim(device, input_shape_and_dim, keepdim):
 
 @pytest.mark.parametrize("input_shape", [(16, 2, 32, 3), (16, 2, 32, 24), (1, 1, 64, 64)])
 @pytest.mark.parametrize("dim", [None, -1, -2])
+@pytest.mark.parametrize("scalar", [1.0, 2.5, -2.5])
 @pytest.mark.parametrize("fast_and_approximate_mode", [False, True], ids=["accurate", "fast"])
-def test_max_fp32_fast_and_approximate_mode(device, input_shape, dim, fast_and_approximate_mode):
+def test_max_fp32_fast_and_approximate_mode(device, input_shape, dim, scalar, fast_and_approximate_mode):
     """FLOAT32 max with both values of fast_and_approximate_mode.
     - False (default): accurate SFPU path - result matches torch exactly.
     - True: faster FPU/TF32 path - result is approximate.
@@ -155,18 +156,17 @@ def test_max_fp32_fast_and_approximate_mode(device, input_shape, dim, fast_and_a
     torch.manual_seed(1)
 
     torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
-    if dim is None:
-        torch_output_tensor = torch.max(torch_input_tensor)
-    else:
-        torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim)
+    torch_output_tensor = torch.amax(scalar * torch_input_tensor, dim=dim)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32)
     input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
 
-    output_tensor = ttnn.max(input_tensor, fast_and_approximate_mode=fast_and_approximate_mode, dim=dim)
+    output_tensor = ttnn.max(input_tensor, fast_and_approximate_mode=fast_and_approximate_mode, dim=dim, scalar=scalar)
     output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor)).reshape(torch_output_tensor.shape)
 
-    if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR:
+    # A negative scalar dispatches to min, and fp32 min is not routed to the SFPU yet,
+    # so it stays on the FPU path.
+    if fast_and_approximate_mode or scalar < 0 or device.arch() == ttnn.device.Arch.QUASAR:
         assert_allclose(torch_output_tensor, output_tensor, rtol=1e-3, atol=1e-2)
     else:
         assert_equal(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/reduce/test_max.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_max.py
@@ -166,7 +166,7 @@ def test_max_fp32_fast_and_approximate_mode(device, input_shape, dim, fast_and_a
     output_tensor = ttnn.max(input_tensor, fast_and_approximate_mode=fast_and_approximate_mode, dim=dim)
     output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor)).reshape(torch_output_tensor.shape)
 
-    if fast_and_approximate_mode:
+    if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR:
         assert_allclose(torch_output_tensor, output_tensor, rtol=1e-3, atol=1e-2)
     else:
         assert_equal(torch_output_tensor, output_tensor)

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
@@ -12,8 +12,8 @@
  * @brief Float32 reduce precision mode.
  *
  * Fast keeps fp32 on the FPU/GMPOOL path (inputs truncated to tf32 — faster, lossy); Accurate
- * routes fp32 SUM through the SFPU for full-fp32 accumulation (accurate ttnn.mean). Only affects
- * Float32 SUM; Int32 always uses the SFPU regardless of this mode.
+ * routes fp32 through the SFPU at full fp32 (accurate ttnn.mean / ttnn.max). Only affects
+ * Float32 SUM and MAX; Int32 always uses the SFPU regardless of this mode.
  */
 enum class ReduceFp32Mode : uint8_t { Fast, Accurate };
 
@@ -25,8 +25,8 @@ enum class ReduceFp32Mode : uint8_t { Fast, Accurate };
  * Int32 HW reduce into a W-then-H two-step (see reduce_op.cpp use_two_step_hw_sfpu_reduce).
  * Int32 MIN drives the LLK MIN reduce directly, instead of the -MAX(-x) reduce_{h,w}_neg path that FPU MIN uses.
  *
- * Float32 SUM additionally opts into the SFPU path when the caller passes ReduceFp32Mode::Accurate
- * (accurate ttnn.mean); the host threads that mode in from the kernel's compile-time args.
+ * Float32 SUM and MAX additionally opt into the SFPU path when the caller passes
+ * ReduceFp32Mode::Accurate; the host threads that mode in from the kernel's compile-time args.
  */
 template <
     ckernel::PoolType pool_type,
@@ -41,10 +41,11 @@ constexpr bool is_sfpu_reduce_path() {
     }
     if constexpr (data_format != DataFormat::Int32) {
         // Float32 opts into the SFPU path only in Accurate mode, and only for SUM (accurate ttnn.mean,
-        // which the host lowers to SUM + a 1/N post-mul). Everything else non-Int32 stays on the FPU.
+        // which the host lowers to SUM + a 1/N post-mul) or MAX (accurate ttnn.max). Everything else
+        // non-Int32 stays on the FPU.
         if constexpr (
             fp32_mode != ReduceFp32Mode::Accurate || data_format != DataFormat::Float32 ||
-            pool_type != ckernel::PoolType::SUM) {
+            (pool_type != ckernel::PoolType::SUM && pool_type != ckernel::PoolType::MAX)) {
             return false;
         }
     }

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
@@ -299,8 +299,8 @@ struct NoOp {
  *                       SFPU; MIN dispatched via reduce_{h,w}_neg.cpp (SFPU vs FPU branch).
  * @tparam input_policy Input handling policy (default: WaitAndPopPerTile - streaming mode)
  * @tparam reconfig_mode Data format reconfiguration mode (default: INPUT_AND_OUTPUT)
- * @tparam fp32_mode Float32 precision mode (default: Fast). Accurate routes Float32 SUM through
- *                   the SFPU for full-fp32 accumulation; see ReduceFp32Mode.
+ * @tparam fp32_mode Float32 precision mode (default: Fast). Accurate routes Float32 SUM and MAX
+ *                   through the SFPU at full fp32; see ReduceFp32Mode.
  *
  * @param input_block_shape Tile grid dimensions (rows x cols x batches)
  *              Use ReduceInputBlockShape::of(r, c, b), ::row(c), ::col(r), or ::single()

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -28,14 +28,20 @@ namespace detail {
 // SFPU MAX fold
 template <DataFormat format>
 ALWI void sfpu_reduce_max_fold_init() {
-    static_assert(format == DataFormat::Int32, "SFPU reduce MAX fold: Int32 only");
-    binary_max_int32_tile_init();
+    if constexpr (format == DataFormat::Int32) {
+        binary_max_int32_tile_init();
+    } else {
+        binary_max_tile_init();
+    }
 }
 
 template <DataFormat format>
 ALWI void sfpu_reduce_max_fold_tile(uint32_t a, uint32_t b, uint32_t out) {
-    static_assert(format == DataFormat::Int32, "SFPU reduce MAX fold: Int32 only");
-    binary_max_int32_tile(a, b, out);
+    if constexpr (format == DataFormat::Int32) {
+        binary_max_int32_tile(a, b, out);
+    } else {
+        binary_max_tile(a, b, out);
+    }
 }
 
 // SFPU MIN fold
@@ -80,8 +86,8 @@ ALWI void sfpu_reduce_sum_fold_tile(uint32_t a, uint32_t b, uint32_t out) {
     }
 }
 
-// Pool-type dispatched cross-tile fold init (MAX -> binary_max, MIN -> binary_min, SUM -> add_int).
-// Used by compute_kernel_lib::reduce() for the Int32 SFPU path.
+// Pool-type dispatched cross-tile fold init (MAX -> binary_max, MIN -> binary_min, SUM -> add).
+// Used by compute_kernel_lib::reduce() for the Int32 SFPU path and for accurate fp32 SUM/MAX.
 template <PoolType pool_type, DataFormat format>
 ALWI void sfpu_reduce_fold_init() {
     if constexpr (pool_type == PoolType::SUM) {
@@ -216,9 +222,10 @@ ALWI void reload_accumulator_if_needed(
             // A vanilla copy_tile reload would leave the running max at col 0, but the
             // next GMPOOL iteration only reads row 0 — so it would be silently dropped.
             // Within-face-16x16-transpose on reload puts col 0 of each face back at row 0
-            // of that face, restoring the exact layout GMPOOL expects.
+            // of that face, restoring the exact layout GMPOOL expects. The SFPU path never runs
+            // GMPOOL — its running max is a plain full-tile value — so it must not transpose.
             constexpr bool reload_within_face_transpose =
-                (reduce_type == PoolType::MAX && reduce_dim == ReduceDim::REDUCE_ROW);
+                (reduce_type == PoolType::MAX && reduce_dim == ReduceDim::REDUCE_ROW && !is_sfpu);
 
             reconfig_data_format_srca(prev_srca_cb, accumulate.config.cb_accumulator);
             copy_tile_to_dst_init_short(
@@ -286,7 +293,7 @@ ALWI void reduce(
     ReduceInputMemoryLayout input_memory_layout,
     AccumulateT accumulate,
     PostReduceOp post_reduce_op) {
-    // Int32 MAX is routed to the SFPU path via is_sfpu_reduce_path<>(); all other formats use FPU/GMPOOL.
+    // Int32 MAX and Accurate fp32 SUM/MAX route to the SFPU via is_sfpu_reduce_path<>(); others use FPU/GMPOOL.
     constexpr DataFormat reduce_format = static_cast<DataFormat>(unpack_src_format[input_dfb_id]);
     // =============================================================================
     // Static Assertions (compile-time validation)

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -53,17 +53,18 @@ inline uint32_t dense_rm_padding_identity_bits(tt::DataFormat df, tt::tt_metal::
 
 // True when the reduce uses the SFPU path instead of the FPU GMPOOL/matmul path.
 // Int32 MAX, MIN and SUM always use SFPU (FPU has no Int32 support); Int32 MIN drives the LLK MIN
-// directly, while float/bf16 MIN lowers to -MAX(-x). Float32 SUM opts into SFPU only when the host
-// requests the accurate ttnn.mean path (`use_sfpu_reduce`): the FPU path truncates fp32 to tf32,
-// so accumulating register-to-register in the SFPU preserves full fp32. mean is lowered to SUM +
-// a 1/N post-mul before this is consulted, so only SUM (never AVG) is checked for fp32.
+// directly, while float/bf16 MIN lowers to -MAX(-x). Float32 SUM and MAX opt into SFPU only when the
+// host requests the accurate path (`use_sfpu_reduce`): the FPU path truncates fp32 to tf32,
+// so the SFPU preserves full fp32. mean is lowered to SUM + a 1/N post-mul before this is consulted,
+// so only SUM (never AVG) is checked for fp32.
 inline bool use_sfpu_reduce_path(
     tt::tt_metal::DataType dtype, tt::tt_metal::ReduceOpMath math_op, bool use_sfpu_reduce = false) {
     using tt::tt_metal::ReduceOpMath;
     if (dtype == tt::tt_metal::DataType::INT32) {
         return math_op == ReduceOpMath::MAX || math_op == ReduceOpMath::SUM || math_op == ReduceOpMath::MIN;
     }
-    return use_sfpu_reduce && dtype == tt::tt_metal::DataType::FLOAT32 && math_op == ReduceOpMath::SUM;
+    return use_sfpu_reduce && dtype == tt::tt_metal::DataType::FLOAT32 &&
+           (math_op == ReduceOpMath::SUM || math_op == ReduceOpMath::MAX);
 }
 
 // True when a non-unity scalar must be a post-reduce multiply instead of via the scaler CB: MAX/MIN,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -132,10 +132,15 @@ Tensor reduce(
         /*default_fp32_acc=*/true));
     ttnn::verify_numerical_configuration(arch, compute_kernel_config);
 
-    // Accurate fp32 mean: SFPU AVG (lowered to SUM + 1/N below); FPU fallback without fp32_dest_acc_en or on Quasar.
-    const bool use_sfpu_fp32_mean =
-        !fast_and_approximate_mode && input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 &&
-        reduce_math == tt::tt_metal::ReduceOpMath::AVG && arch != tt::ARCH::QUASAR && config.fp32_dest_acc_en;
+    // Accurate fp32 SFPU path (FPU truncates to TF32). Falls back to FPU without fp32_dest_acc_en or on Quasar.
+    const bool fp32_sfpu_eligible = !fast_and_approximate_mode &&
+                                    input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 &&
+                                    arch != tt::ARCH::QUASAR && config.fp32_dest_acc_en;
+
+    const bool use_sfpu_fp32_mean = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::AVG;
+    const bool use_sfpu_fp32_max = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::MAX && !negate;
+
+    const bool use_sfpu_fp32_reduce = use_sfpu_fp32_mean || use_sfpu_fp32_max;
 
     // Dense row-major reduce: a fast path that consumes ROW_MAJOR input directly (no host tilize)
     // and is currently restricted to mean (AVG) / sum (SUM) on 4D BF16/FLOAT32 tensors with
@@ -189,9 +194,9 @@ Tensor reduce(
     // A non-unity scalar is applied after the reduction (see requires_post_mul() in common.hpp):
     // GMPOOL keeps only the scaler's exponent for MAX/MIN, and the Int32 SFPU path ignores the
     // scaler CB. Int32 post-mul rounds through fp32, so it is lossy for |result| > 2^24.
-    // The accurate fp32 SFPU mean also post-muls (SFPU ignores the scaler CB), applying the 1/N here.
+    // The accurate fp32 SFPU reduces also post-mul: mean applies its 1/N here, max its user scalar.
     const bool use_post_mul =
-        ttnn::prim::requires_post_mul(reduce_math, prepared_input.dtype(), scaler, use_sfpu_fp32_mean);
+        ttnn::prim::requires_post_mul(reduce_math, prepared_input.dtype(), scaler, use_sfpu_fp32_reduce);
     const float reduce_scaler = use_post_mul ? 1.0f : scaler;
     const float post_mul = use_post_mul ? scaler : 1.0f;
 
@@ -227,16 +232,16 @@ Tensor reduce(
     // must take the two-step W-then-H path where the scaler is applied once.
     //
     // INT32 SFPU reduce has no REDUCE_SCALAR primitive (ROW/COL only), so Int32 HW always uses
-    // W-then-H. Float32 max HW can use single-core REDUCE_SCALAR (FPU) when num_tiles == 1;
+    // W-then-H. Fast-mode Float32 max HW can use single-core REDUCE_SCALAR (FPU) when num_tiles == 1;
     // multi-tile HW still uses W-then-H via is_multicore_hw. Applies to Int32 MAX/SUM/MIN.
-    // The accurate fp32 SFPU mean (AVG) likewise has no SFPU REDUCE_SCALAR, so it must decompose HW
-    // into W-then-H regardless of tile count; forcing the two-step keeps it off the single-core path.
+    // The accurate fp32 SFPU reduces likewise have no SFPU REDUCE_SCALAR, so they must decompose HW
+    // into W-then-H regardless of tile count; both do so exactly (sum of sums, max of maxes).
     const bool use_two_step_hw_sfpu_reduce =
         (reduce_dim == tt::tt_metal::ReduceOpDim::HW) &&
         ((prepared_input.dtype() == tt::tt_metal::DataType::INT32 &&
           (reduce_math == tt::tt_metal::ReduceOpMath::MAX || reduce_math == tt::tt_metal::ReduceOpMath::SUM ||
            reduce_math == tt::tt_metal::ReduceOpMath::MIN)) ||
-         use_sfpu_fp32_mean);
+         use_sfpu_fp32_reduce);
 
     if (is_multicore_hw || use_two_step_hw_sfpu_reduce ||
         (reduce_dim == tt::tt_metal::ReduceOpDim::HW && reduce_scaler < 0)) {
@@ -269,7 +274,7 @@ Tensor reduce(
             /*post_mul_scaler=*/1.0f,
             /*row_major_w_dense_path=*/false,
             /*row_major_h_dense_path=*/false,
-            /*use_sfpu_reduce=*/use_sfpu_fp32_mean);
+            /*use_sfpu_reduce=*/use_sfpu_fp32_reduce);
 
         if (negate && !ttnn::prim::h_reduce_negate_fits_in_l1(output_tensor, sub_core_grids)) {
             return h_reduce_with_external_negate(output_tensor, reduce_scaler, post_mul, out_final_dtype);
@@ -288,7 +293,7 @@ Tensor reduce(
             /*post_mul_scaler=*/post_mul,
             /*row_major_w_dense_path=*/false,
             /*row_major_h_dense_path=*/false,
-            /*use_sfpu_reduce=*/use_sfpu_fp32_mean);
+            /*use_sfpu_reduce=*/use_sfpu_fp32_reduce);
     }
 
     if (negate && reduce_dim == tt::tt_metal::ReduceOpDim::H &&
@@ -374,7 +379,7 @@ Tensor reduce(
         /*post_mul_scaler=*/post_mul,
         /*row_major_w_dense_path=*/use_rm_dense_w,
         /*row_major_h_dense_path=*/use_rm_dense_h,
-        /*use_sfpu_reduce=*/use_sfpu_fp32_mean,
+        /*use_sfpu_reduce=*/use_sfpu_fp32_reduce,
         /*num_h_slices=*/1,
         /*output_layout=*/use_rm_dense ? rm_dense_out_layout : tt::tt_metal::Layout::TILE);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.hpp
@@ -24,8 +24,8 @@ Tensor reduce(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
     bool negate = false,
-    // When false (default), fp32 mean runs on the accurate SFPU path (full fp32); true selects the FPU. Ignored for
-    // non-fp32/non-AVG.
+    // When false (default), fp32 mean and max run on the accurate SFPU path (full fp32); true selects the FPU.
+    // Ignored for non-fp32 and for math ops other than AVG/MAX.
     bool fast_and_approximate_mode = false,
     // Requested layout of the result; std::nullopt means "whatever the selected path emits":
     // ROW_MAJOR on the dense RM paths, TILE on the tilized ones.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -181,6 +181,10 @@ static Tensor reduce_impl(
     bool single_reduce_op = (dim.empty()) || (dim.size() == 1 && (dim[0] == rank - 1 || dim[0] == rank - 2)) ||
                             (dim.size() == 2 && dim[1] == rank - 1 && dim[0] == rank - 2);
     if (!single_reduce_op) {
+        // Multi-axis reduces run one axis at a time. Max of maxes is exact, so Max keeps the
+        // caller's fast_and_approximate_mode; Mean scales each axis by 1/N, so it stays on FPU.
+        const bool sub_step_fast_mode =
+            reduce_type == reduction_common::ReduceType::Max ? fast_and_approximate_mode : true;
         auto reduce_nd_loop = [&](const bool use_reduce_type, float scalar) -> Tensor {
             Tensor output_tensor = input_tensor_arg;
             bool first = true;
@@ -209,9 +213,6 @@ static Tensor reduce_impl(
                     // Only the smallest-axis sub-step ends the chain; earlier sub-steps stay in fp32.
                     const bool sub_is_last = chain_active && is_last_in_chain && (i_dim == min_reduce_axis);
                     if (use_reduce_type) {
-                        // Multi-axis / non-H·W single-axis means reduce via transpose-to-H here; the accurate
-                        // SFPU mean is scoped to natural W/H/HW, so keep these sub-steps on the FPU (fast/
-                        // approximate) path to preserve behavior.
                         output_tensor = reduce_impl<reduce_type>(
                             output_tensor,
                             {reduce_dim},
@@ -223,7 +224,7 @@ static Tensor reduce_impl(
                             sub_core_grids,
                             chain_active,
                             sub_is_last,
-                            /*fast_and_approximate_mode=*/true);
+                            /*fast_and_approximate_mode=*/sub_step_fast_mode);
                     } else {
                         output_tensor = reduce_impl<reduction_common::ReduceType::Sum>(
                             output_tensor,
@@ -321,7 +322,9 @@ static Tensor reduce_impl(
                 memory_config,
                 std::nullopt,
                 compute_kernel_config,
-                sub_core_grids);
+                sub_core_grids,
+                /*negate=*/false,
+                /*fast_and_approximate_mode=*/fast_and_approximate_mode);
         } else if constexpr (reduce_type == reduction_common::ReduceType::Min) {
             output_tensor = ttnn::operations::reduction::generic::detail::reduce(
                 input_tensor,
@@ -725,7 +728,8 @@ Tensor max(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
     bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    bool fast_and_approximate_mode) {
     /* Scaling is applied after reduction, so flip the op for negative scalars:
      * max(s * x) = s * min(x) when s < 0.*/
     if (scalar < 0.0f) {
@@ -747,7 +751,8 @@ Tensor max(
         compute_kernel_config,
         scalar,
         correction,
-        sub_core_grids);
+        sub_core_grids,
+        fast_and_approximate_mode);
 }
 
 Tensor min(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -65,7 +65,9 @@ Tensor max(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     float scalar = 1.0f,
     bool correction = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    // When false (default), fp32 max selects the accurate SFPU path; true selects the faster FPU path.
+    bool fast_and_approximate_mode = false);
 
 Tensor min(
     const Tensor& input_tensor_arg,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
@@ -31,7 +31,7 @@ inline std::string get_generic_reduction_doc(
                 * - INT32
                   - TILE)doc"
                                             : "";
-    // Only ttnn.mean exposes fast_and_approximate_mode.
+    // ttnn.mean and ttnn.max expose fast_and_approximate_mode.
     // ttnn.sum and ttnn.mean both expose output_layout.
     const char* output_layout_kwarg = has_output_layout ? R"doc(
             output_layout (ttnn.Layout, optional): layout of the output tensor. Defaults to `None`, which keeps the layout the chosen path produces naturally (see the Note below). `ttnn.TILE_LAYOUT` or `ttnn.ROW_MAJOR_LAYOUT` is always honored: it is produced directly by the kernel for a -2 reduce of a ROW_MAJOR input, and converted after reducing otherwise. `ttnn.ROW_MAJOR_LAYOUT` is rejected for block-float results (BFLOAT8_B, BFLOAT4_B), which only exist in TILE layout; typecast explicitly if a row-major result is needed.)doc"
@@ -158,9 +158,9 @@ inline Tensor sum_with_deprecated_correction(
         output_layout);
 }
 
-// mean exposes an extra 'fast_and_approximate_mode' opt-in that sum/min/max do not, so it needs its
-// own wrapper instead of the shared generic_reduction_with_deprecated_correction<>. Same deprecated-
-// correction handling, plus the trailing accurate flag and output_layout forwarded to ttnn::mean.
+// mean exposes both 'fast_and_approximate_mode' and 'output_layout', so it needs its own wrapper
+// instead of the shared generic_reduction_with_deprecated_correction<>. Same deprecated-correction
+// handling, plus the trailing accurate flag and output_layout forwarded to ttnn::mean.
 inline Tensor mean_with_deprecated_correction(
     const Tensor& input_tensor,
     const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim,
@@ -190,6 +190,36 @@ inline Tensor mean_with_deprecated_correction(
         sub_core_grids,
         fast_and_approximate_mode,
         output_layout);
+}
+
+// max exposes 'fast_and_approximate_mode' but not 'output_layout', so it cannot share mean's wrapper.
+inline Tensor max_with_deprecated_correction(
+    const Tensor& input_tensor,
+    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim,
+    bool keepdim,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+    float scalar,
+    std::optional<bool> correction,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    bool fast_and_approximate_mode) {
+    if (correction.has_value()) {
+        nb::gil_scoped_acquire acquire;
+        PyErr_WarnEx(
+            PyExc_DeprecationWarning,
+            "The 'correction' parameter is deprecated and will be removed in a future release.",
+            1);
+    }
+    return ttnn::max(
+        input_tensor,
+        dim,
+        keepdim,
+        memory_config,
+        compute_kernel_config,
+        scalar,
+        correction.value_or(true),
+        sub_core_grids,
+        fast_and_approximate_mode);
 }
 
 inline void bind_generic_reductions(nb::module_& mod) {
@@ -234,11 +264,12 @@ inline void bind_generic_reductions(nb::module_& mod) {
         nb::arg("fast_and_approximate_mode") = false,
         nb::arg("output_layout") = nb::none());
 
-    const auto max_doc = get_generic_reduction_doc("max", "ttnn.max", /*int32_supported=*/true);
+    const auto max_doc =
+        get_generic_reduction_doc("max", "ttnn.max", /*int32_supported=*/true, /*has_fast_approximate_mode=*/true);
     ttnn::bind_function<"max">(
         mod,
         max_doc.c_str(),
-        &generic_reduction_with_deprecated_correction<&ttnn::max>,
+        &max_with_deprecated_correction,
         nb::arg("input_tensor"),
         nb::arg("dim") = nb::none(),
         nb::arg("keepdim") = false,
@@ -247,7 +278,8 @@ inline void bind_generic_reductions(nb::module_& mod) {
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("scalar") = 1.0f,
         nb::arg("correction") = nb::none(),
-        nb::arg("sub_core_grids") = nb::none());
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("fast_and_approximate_mode") = false);
 
     const auto min_doc = get_generic_reduction_doc("min", "ttnn.min", /*int32_supported=*/true);
     ttnn::bind_function<"min">(


### PR DESCRIPTION
### PR Category
- Feature

### Summary
Fixes #51889.

FLOAT32 `ttnn.max` could return a value that was not present in the input. The FPU/GMPOOL path truncates operands to TF32 before comparing, so the packed result can be a rounded value rather than an actual input element.

This mirrors #48896, `ttnn.mean`: add `fast_and_approximate_mode` to `ttnn.max`.
- `False` (default): accurate SFPU path at full float32 (selection must match the input element exactly).
- `True`: existing faster FPU/TF32 path (approximate).

Falls back to FPU when `fp32_dest_acc_en=False` or on Quasar. No effect for non-FLOAT32.

### Notes for reviewers

**Kernel** (`reduce_helpers_common.hpp`, `reduce_helpers_compute.inl`)
- FLOAT32 MAX is eligible for the accurate SFPU path.
- Cross-tile fold uses `binary_max_tile` (same pattern as FLOAT32 SUM / Int32 MAX).
- Within-face reload transpose stays FPU-only (`!is_sfpu`); SFPU does not use GMPOOL's face layout.

**Host** (`reduce_op.cpp`, `common.hpp`)
- Accurate path: FLOAT32 + `fast_and_approximate_mode=False` + `fp32_dest_acc_en` + non-Quasar.
- AVG and MAX share that eligibility; MAX also requires `!negate` (float MIN is still `-max(-x)` on fused-negate kernels with no SFPU path).

**Multi-axis / no-dim** (`generic_reductions.cpp`)
- No-dim and other multi-axis reduces go through `reduce_nd_loop`.
- `Max` forwards the caller's `fast_and_approximate_mode` (max-of-maxes is exact).
- `Mean` keeps FPU for those sub-steps (each axis applies its own `1/N`).

**API**
- `ttnn.max(..., fast_and_approximate_mode=False)` by default.
- Mean and max share `generic_reduction_with_fast_mode` in nanobind.

**Not in this PR**
- FLOAT32 `min` stays on FPU.
- Accurate path is slower; use `fast_and_approximate_mode=True` to opt out.

**Tests**
- `test_max.py`: FLOAT32 coverage on the three #51889 shapes, both mode values (`assert_equal` for accurate, `assert_allclose` for fast).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-max-fp32-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-max-fp32-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-max-fp32-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-max-fp32-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-max-fp32-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-max-fp32-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-max-fp32-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-max-fp32-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-max-fp32-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-max-fp32-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-max-fp32-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-max-fp32-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-max-fp32-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-max-fp32-sfpu)