### PR TITLE
[Bug fix] GPT-OSS: fix garbage output on multi-device Blackhole (trace allocation) (#52176)

### DIFF
--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -544,6 +544,12 @@ def format_sampling_params(sampling_params, max_batch_size):
             # Device sampling treats p=0 as a first-token cutoff; with k=1
             # this is the compact argmax representation for greedy rows.
             top_p[i] = 0.0
+            # A greedy row has a single candidate and never draws from the RNG, so a seed on it cannot
+            # change the sampled token. Clear it: otherwise a caller-supplied default (seed=0 rather
+            # than None is enough) marks the request "explicitly seeded", which forces sampling off its
+            # captured trace and re-runs the whole sampling graph every token -- allocating device
+            # buffers behind live traces on every step, where they can be corrupted on replay.
+            seed[i] = None
         else:
             temperature[i] = 1 / temperature[i]
 

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -311,7 +311,48 @@ class SamplingGenerator:
         if penalties_on:
             logits = self.tt_penalties.apply(logits)
         tt_tokens, tt_log_probs = self.tt_sampling(logits, tt_out_tok=tt_out_tok)
+        if penalties_on:
+            # Fold the penalty bookkeeping into the sampled step rather than running it afterwards in
+            # sample(). The order is unchanged -- penalties are applied to this step's logits from the
+            # previous steps' counts, then the new token is counted -- but doing it here means it is part
+            # of whatever trace captures this, instead of a handful of scatter/tilize/reshape allocations
+            # on every decode step behind a live trace. Those ops take no preallocated output tensor, so
+            # tracing them is the only way to stop them allocating.
+            self.tt_penalties.update_output_tokens(tt_out_tok if tt_out_tok is not None else tt_tokens)
         return tt_tokens, tt_log_probs
+
+    def reset_penalty_counts(self):
+        """Zero the output-token penalty counters, if penalties are active.
+
+        Needed after any pass that runs the sampling pipeline for its side effects rather than its result:
+        _run_sampling now counts the sampled token, so a pre-compile or a trace capture over dummy inputs
+        would otherwise leave those phantom tokens in the counts and skew the next real step's penalties.
+        In-place, so it allocates nothing.
+        """
+        if self._penalties_active:
+            self.tt_penalties.reset_output_tokens()
+
+    def precompile(
+        self,
+        logits: ttnn.Tensor,
+        *,
+        tt_out_tok: Optional[ttnn.Tensor] = None,
+    ) -> None:
+        """Run the sampling pipeline once without capturing, to compile it and size its scratch.
+
+        This is the pre-compile step :meth:`capture_trace` would otherwise do inline. Callers that capture
+        the sampling trace behind another trace (e.g. right after the decode trace) should run it earlier,
+        while no trace is live on device, and then pass ``skip_precompile=True`` to :meth:`capture_trace`;
+        left inline, this pass allocates device buffers that a live trace can corrupt on replay.
+
+        ``logits`` only has to match the spec of the tensor that will later be captured, not be it.
+        """
+        self._run_sampling(
+            logits,
+            penalties_on=self._penalties_active,
+            tt_out_tok=tt_out_tok,
+        )
+        self.reset_penalty_counts()
 
     def capture_trace(
         self,
@@ -347,6 +388,7 @@ class SamplingGenerator:
         )
         ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=self.cq_id)
         ttnn.synchronize_device(self.mesh_device)
+        self.reset_penalty_counts()
 
         if tt_out_tok is not None:
             if isinstance(sampled, tuple):
@@ -412,11 +454,8 @@ class SamplingGenerator:
             self._validate_trace_inputs(slot, logits, tt_out_tok)
             tt_out = self._execute_trace(key)
 
-        if penalties_on and tt_out is not None:
-            if isinstance(tt_out, tuple):
-                self.tt_penalties.update_output_tokens(tt_out[0])
-            else:
-                self.tt_penalties.update_output_tokens(tt_out)
+        # The penalty update now runs inside _run_sampling, so it is captured with the rest of the sampled
+        # step and replayed with it -- there is nothing to do here.
         return tt_out
 
 

--- a/models/common/sampling/tt_penalties.py
+++ b/models/common/sampling/tt_penalties.py
@@ -145,6 +145,9 @@ class TTPenalties(LightweightModule):
             host=torch.ones(self._total_batch, 1), shard_dims=shard_dims_gathered, layout=ttnn.ROW_MAJOR_LAYOUT
         )
         self.zeros = self._alloc_int_buffer(shard_dims=shard_dims_gathered, layout=ttnn.ROW_MAJOR_LAYOUT)
+        # All-ones scatter sources for the non-fast update path, cached by token width. See
+        # update_output_tokens: allocating these per call put device buffers behind live traces.
+        self._scatter_src_by_width = {}
         self.presence_penalties = self._alloc_bf16_buffer(shard_dims=shard_dims_bf16)
         self.frequency_penalties = self._alloc_bf16_buffer(shard_dims=shard_dims_bf16)
         self.repetition_penalties = self._alloc_bf16_buffer(shard_dims=shard_dims_bf16)
@@ -294,11 +297,18 @@ class TTPenalties(LightweightModule):
             new_tokens = ttnn.reshape(new_tokens, [batch, 1], **self._op_kwargs)
             src = self.decode_src
         else:
-            src = self._alloc_int_buffer(
-                host=torch.ones(self._total_batch, new_tokens.shape[-1]),
-                shard_dims=self._shard_dims_gathered,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-            )
+            # Cache per width: this used to allocate a fresh all-ones buffer on every call, which on the
+            # prefill-sampling path lands after the trace captures and is exactly the kind of allocation a
+            # live trace can corrupt. Its contents are constant, so one buffer per width is enough.
+            width = int(new_tokens.shape[-1])
+            src = self._scatter_src_by_width.get(width)
+            if src is None:
+                src = self._alloc_int_buffer(
+                    host=torch.ones(self._total_batch, width),
+                    shard_dims=self._shard_dims_gathered,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                )
+                self._scatter_src_by_width[width] = src
         self.token_bin_counts_and_mask(
             new_tokens=new_tokens,
             counts=self.output_counts_gathered,

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -148,6 +148,10 @@ class Model:
         self.cos_matrix = self.rope_setup.cos_matrix
         self.sin_matrix = self.rope_setup.sin_matrix
         self.transformation_mats = self.rope_setup.get_both_trans_mats()
+        # Prefill rope slices, keyed by sequence length. See prepare_inputs_prefill: the slice is a device
+        # op, so recomputing it per call allocates -- and on a traced prefill it allocates with the trace
+        # live, then throws the result away (the replay uses the matrices bound at capture time).
+        self._prefill_rope_slices = {}
 
         if state_dict:
             embedding_weight = substate(state_dict, "model.embed_tokens")["weight"]
@@ -598,6 +602,21 @@ class Model:
 
         return logits
 
+    def slice_last_token_block(self, x, last_token_idx, out=None):
+        """Slice out the 32-token tile containing ``last_token_idx``.
+
+        ``out`` writes into a caller-owned tensor instead of allocating a fresh one. The generator relies
+        on that to run this slice with a trace live on device: the tile is the input buffer of the traced
+        post-prefill tail, so the slice must not allocate (see Generator._run_post_prefill).
+        """
+        get_last_token = (last_token_idx // 32) * 32
+        return ttnn.slice(
+            x,
+            (0, 0, get_last_token, 0),
+            (1, 1, get_last_token + 32, x.shape[-1]),
+            output_tensor=out,
+        )
+
     def process_logits_after_prefill_trace(self, logits, last_token_idx):
         """
         Post-process traced prefill output to the 32-token tile containing `last_token_idx`.
@@ -605,13 +624,7 @@ class Model:
         Unlike tt_transformers `Transformer`, GPT-OSS `ttnn_prefill_forward` already
         applies final norm + lm_head, so this method only slices logits.
         """
-        get_last_token = (last_token_idx // 32) * 32
-        logits = ttnn.slice(
-            logits,
-            (0, 0, get_last_token, 0),
-            (1, 1, get_last_token + 32, logits.shape[-1]),
-        )
-        return logits
+        return self.slice_last_token_block(logits, last_token_idx)
 
     def prepare_row_sharded_prefill_iter(
         self, tokens, page_table, prompt_lens, iter_idx, max_padded_len, max_num_blocks, users_per_row_per_iter=1
@@ -709,8 +722,20 @@ class Model:
         model_args=None,
         trace_cache=None,
         empty_slots=None,
+        before_capture=None,
     ):
         """Row-parallel batched prefill: 1 user per row per iteration.
+
+        ``before_capture``: optional callback invoked once, immediately before the trace capture and after
+        this path's own trace inputs are allocated. It is the last point at which a caller can allocate
+        long-lived buffers with no trace live; the generator uses it to stage the decode trace's inputs,
+        which would otherwise be allocated during the decode loop, inside this trace's scratch, and be
+        overwritten on every replay.
+
+        Allocation only -- do not compile from here. Compiling a decode program at this point makes the
+        capture below deadlock in the MoE dispatch, and compiling one before any prefill has run deadlocks
+        in the MoE combine's global-semaphore setup instead. That is why the rest of decode trace setup
+        still happens later, in the decode loop, with this trace already live.
 
         ``empty_slots``: optional list of decoder slot ids, one per input user.
         If supplied, users are first reordered so that array-index ``i`` lands
@@ -843,6 +868,11 @@ class Model:
                 ho = self.prepare_inputs_prefill(t0, page_table=p0, trace_enabled=True, batched_prefill=True)
                 hi = (ho[0], ho[3], ho[4])
                 di = copy_host_to_device(hi, mesh_device=mesh_device)
+                # Last moment at which a caller can allocate long-lived buffers with no trace live.
+                # Deliberately after ``di``: the trace binds to those buffers, and letting the callback
+                # allocate first would move them off the addresses the compile pass just used.
+                if before_capture is not None:
+                    before_capture()
                 tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
                 tr = self.transform_and_embed_prefill_inputs_device(*di)
                 tt_out = self.ttnn_prefill_forward(
@@ -1096,12 +1126,18 @@ class Model:
             if len(tokens_embd.shape) == 3:
                 tokens_embd = ttnn.unsqueeze_to_4D(tokens_embd)
 
-        # Prepare rotation matrices (slice from rope_setup like tt-transformers model.py lines 156-159)
+        # Prepare rotation matrices (slice from rope_setup like tt-transformers model.py lines 156-159).
+        # Cached per sequence length: the slice runs on device, so recomputing it allocates. On a traced
+        # prefill that allocation happens with the trace live -- and is then discarded, since the replay
+        # uses the matrices that were bound when the trace was captured.
         seq_len = self.args.max_seq_len if trace_enabled else tokens_embd.shape[-2]
-        rot_mats_global = [
-            self.rope_setup.cos_matrix_prefill[:, :, :seq_len, :],
-            self.rope_setup.sin_matrix_prefill[:, :, :seq_len, :],
-        ]
+        rot_mats_global = self._prefill_rope_slices.get(seq_len)
+        if rot_mats_global is None:
+            rot_mats_global = [
+                self.rope_setup.cos_matrix_prefill[:, :, :seq_len, :],
+                self.rope_setup.sin_matrix_prefill[:, :, :seq_len, :],
+            ]
+            self._prefill_rope_slices[seq_len] = rot_mats_global
         rot_mats_local = None
 
         # Prepare page tables if provided

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -1208,6 +1208,15 @@ def test_demo_text(
                     enable_trace=prefill_enable_trace,
                     tt_out_logits_all_users=tt_out_logits_all_users,
                     sampling_params=device_sampling_params,
+                    # Declare the layout the decode loop below will use, so warmup can capture the decode
+                    # trace before the prefill traces instead of leaving its compile pass -- prefetcher,
+                    # CCLs, sampling module -- to allocate behind them. Must match the decode_forward call.
+                    decode_layout={
+                        "is_cur_pos_sharded": is_cur_pos_sharded,
+                        "is_page_table_sharded": is_page_table_sharded,
+                        # decode_forward always passes sampling_params, so decode returns on-device logits.
+                        "on_device_logits": True,
+                    },
                 )
             except Exception as e:
                 logger.error(f"Error during prefill warmup: {str(e)}")

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -209,6 +209,14 @@ class Generator(WarmupForwardMixin):
         self._disable_prefill_tracing = False  # Whether to disable prefill traces
         self._disable_decode_tracing = False  # Whether to disable decode traces
         self._decode_inputs_need_reset = False
+        # Trace capture ordering: while this is set, prepared traces are stashed instead of captured, so
+        # that every compile pass and every persistent trace-input allocation happens before the first
+        # capture. A trace's buffer addresses are invisible to the allocator once captured, so anything
+        # allocated afterwards can land in its scratch and be overwritten on replay. Warmup sweeps many
+        # sequence lengths, batch sizes and prefix-caching variants, so capturing as it goes leaves every
+        # later variant's compile pass allocating behind a growing pile of live traces.
+        self._defer_trace_recording = False
+        self._pending_prefill_traces = {}
 
     def _set_prefill_column_mask(self, tt_column_mask):
         # Keep mask available on whichever TT_CCL instance attention currently uses.
@@ -245,6 +253,12 @@ class Generator(WarmupForwardMixin):
         # Avoids an infinite loop
         self.already_warmed_up_prefill = True
         self.warming_up_prefill = True
+
+        # Defer every capture until the whole sweep has compiled. Warmup walks ~8 sequence lengths x 2
+        # batch sizes plus the prefix-caching variants, and capturing as it goes leaves each later
+        # variant's compile pass -- and the prefetcher setup between them -- allocating behind a growing
+        # pile of live traces, where those buffers can be overwritten on replay.
+        self._defer_trace_recording = enable_trace
 
         # Llama70b always supports on-device sampling from metal
         on_device_sampling_enabled = True
@@ -350,6 +364,17 @@ class Generator(WarmupForwardMixin):
                 tt_out_logits_all_users,
                 start_pos=[num_cached],
             )
+
+        # Every prefill variant has now compiled and staged its buffers, and nothing is captured yet.
+        # Capture them all, back to back, with no allocation in between.
+        #
+        # The decode trace is deliberately not hoisted here. Its input layout depends on the caller's
+        # is_cur_pos_sharded / is_page_table_sharded, which warmup cannot see -- the trace is keyed only on
+        # on_device_logits, so preparing it against the wrong layout would bind the capture to buffers the
+        # real decode never writes. It therefore still compiles in the decode loop, behind these traces.
+        if self._defer_trace_recording:
+            self._defer_trace_recording = False
+            self._record_pending_traces()
 
         # trace_id_prefill dict check
         logger.info("Prefill warmup completed")
@@ -1028,16 +1053,27 @@ class Generator(WarmupForwardMixin):
             last_token_idx_relative = last_token_idx - num_cached_tokens if use_prefix_caching else last_token_idx
 
         if self.trace_id_prefill[trace_key] is None:
+            # Repeat warmup calls for one variant (the sampling-parameter sweep hits each seq len several
+            # times) must not prepare it twice -- that would redo the compile pass and reallocate the trace
+            # inputs. Re-run the body over the inputs already staged for this key instead.
+            already_pending = self._pending_prefill_traces.get(trace_key)
+            if already_pending is not None:
+                return self._rerun_prefill_body(already_pending)
+
             trace_id, tt_out_trace, *device_inputs = self._capture_trace_prefill(
                 tokens,
                 last_token_idx_relative,
+                user_id,
+                trace_key,
                 page_table=page_table,
                 chunk_page_table=chunk_page_table,
                 kv_cache=kv_cache,
-                user_id=user_id,
                 batch_size=batch_size,
                 start_pos=chunk_start_idx,
             )
+            if trace_id is None:
+                # Deferred: the compile pass already produced this call's result, so hand it back directly.
+                return tt_out_trace
             self.trace_id_prefill[trace_key] = trace_id
             self.trace_inputs_prefill[trace_key] = device_inputs
             self.trace_output_prefill[trace_key] = tt_out_trace
@@ -1061,6 +1097,7 @@ class Generator(WarmupForwardMixin):
         tokens,
         last_token_idx,
         user_id,
+        trace_key,
         page_table=None,
         chunk_page_table=None,  # For prefix caching
         kv_cache=None,
@@ -1070,6 +1107,10 @@ class Generator(WarmupForwardMixin):
         """
         Captures a trace for the prefill_forward method with prefix caching support.
         Uses full rot mats + chunk_start_idx device tensor; slicing inside the trace.
+
+        Splits into a preparation phase (compile pass + trace input allocation) and a recording phase
+        (:meth:`_record_trace_prefill`). While ``_defer_trace_recording`` is set this returns after the
+        preparation phase, so that every variant compiles and allocates before anything is captured.
         """
         # Get host tensors (tokens, user_id, page_table, chunk_page_table, chunk_start_idx, column_mask)
         host_inputs = self.model.prepare_prefill_inputs_host(
@@ -1136,6 +1177,7 @@ class Generator(WarmupForwardMixin):
         )
         ttnn.synchronize_device(self.mesh_device)
         logger.info("Done Compiling Model")
+        compile_output = tt_out_trace
 
         # Trace capture run
         device_inputs = copy_host_to_device(
@@ -1150,6 +1192,73 @@ class Generator(WarmupForwardMixin):
             mesh_device=self.mesh_device,
         )
         # Update column_mask reference to the trace-capture buffer (trace reads from this buffer on replay)
+        self._set_prefill_column_mask(device_inputs[5])
+
+        # Everything above only compiles and allocates; everything below captures. While recording is
+        # deferred, stop here and hand the caller the compile pass' own output -- capturing now would put a
+        # trace on device before the remaining warmup variants (and the decode trace) have compiled, and
+        # every one of those allocations would then land in this trace's scratch. See prefill_warmup.
+        if self._defer_trace_recording:
+            self._pending_prefill_traces[trace_key] = {
+                "full_rot_mats": full_rot_mats,
+                "device_inputs": device_inputs,
+                "kv_cache": kv_cache,
+                "last_token_idx": last_token_idx,
+                "start_pos": start_pos,
+                "batch_size": batch_size,
+            }
+            return None, compile_output, *device_inputs
+
+        return self._record_trace_prefill(trace_key)
+
+    def _rerun_prefill_body(self, prepared):
+        """Re-run a prepared variant's prefill body over its already-staged inputs.
+
+        Used while recording is deferred, when a warmup call needs an output but the trace it would replay
+        has not been captured yet. Allocating a fresh output is safe here: nothing is captured during the
+        preparation phase.
+        """
+        self._set_prefill_column_mask(prepared["device_inputs"][5])
+        transformed_inputs = self.model.transform_prefill_inputs_device(*prepared["device_inputs"])
+        return self.model.ttnn_prefill_forward(
+            x=transformed_inputs[0],
+            user_id=transformed_inputs[1],
+            page_table=transformed_inputs[2],
+            chunk_page_table=transformed_inputs[3],
+            chunk_start_idx=transformed_inputs[4],
+            start_pos=prepared["start_pos"],
+            kv_cache=prepared["kv_cache"],
+            get_last_token=prepared["last_token_idx"],
+            rot_mats=prepared["full_rot_mats"],
+            batch_size=prepared["batch_size"],
+        )
+
+    def _record_pending_traces(self):
+        """Capture every trace prepared while recording was deferred.
+
+        Runs back to back with no allocation in between: each capture binds only to buffers allocated
+        during the preparation phase, before any trace existed.
+        """
+        for trace_key in list(self._pending_prefill_traces):
+            trace_id, tt_out_trace, *device_inputs = self._record_trace_prefill(trace_key)
+            self.trace_id_prefill[trace_key] = trace_id
+            self.trace_inputs_prefill[trace_key] = device_inputs
+            self.trace_output_prefill[trace_key] = tt_out_trace
+
+    def _record_trace_prefill(self, trace_key):
+        """Phase 2 of prefill trace setup: capture over the buffers _capture_trace_prefill already staged.
+
+        Allocation-free outside the capture window by construction -- it binds only to tensors that were
+        allocated while nothing was captured.
+        """
+        prepared = self._pending_prefill_traces.pop(trace_key)
+        full_rot_mats = prepared["full_rot_mats"]
+        device_inputs = prepared["device_inputs"]
+        kv_cache = prepared["kv_cache"]
+        last_token_idx = prepared["last_token_idx"]
+        start_pos = prepared["start_pos"]
+        batch_size = prepared["batch_size"]
+        # The trace replays out of this buffer, so re-point the column mask at it before capturing.
         self._set_prefill_column_mask(device_inputs[5])
         trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
         transformed_inputs = self.model.transform_prefill_inputs_device(*device_inputs)
@@ -1442,6 +1551,31 @@ class Generator(WarmupForwardMixin):
         tokens_tt, current_pos_tt, rope_idxs_tt, page_table_tt = self.model.prepare_inputs_decode(
             tokens, current_pos, page_table, is_cur_pos_sharded, is_page_table_sharded
         )
+
+        # Split so that the compile pass and these long-lived trace inputs are separable from the capture.
+        # They are not hoisted ahead of the prefill captures today -- see prefill_warmup for why the decode
+        # trace cannot be prepared there -- but keeping the phases apart is what makes that possible.
+        return self._record_trace_text(
+            {
+                "tokens_tt": tokens_tt,
+                "current_pos_tt": current_pos_tt,
+                "rope_idxs_tt": rope_idxs_tt,
+                "page_table_tt": page_table_tt,
+                "kv_cache": kv_cache,
+                "is_cur_pos_sharded": is_cur_pos_sharded,
+                "on_device_logits": on_device_logits,
+            }
+        )
+
+    def _record_trace_text(self, prepared):
+        """Phase 2 of decode trace setup: capture over the buffers the compile phase already staged."""
+        tokens_tt = prepared["tokens_tt"]
+        current_pos_tt = prepared["current_pos_tt"]
+        rope_idxs_tt = prepared["rope_idxs_tt"]
+        page_table_tt = prepared["page_table_tt"]
+        kv_cache = prepared["kv_cache"]
+        is_cur_pos_sharded = prepared["is_cur_pos_sharded"]
+        on_device_logits = prepared["on_device_logits"]
 
         # Save the buffer addresses for preallocated tensors
         trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import defaultdict
+from itertools import zip_longest
 from dataclasses import fields, replace
 from typing import List
 
@@ -249,6 +250,7 @@ class Generator(WarmupForwardMixin):
         sampling_params=None,
         empty_slots=None,
         tt_out_logits_all_users=None,
+        decode_layout=None,
     ):
         # Avoids an infinite loop
         self.already_warmed_up_prefill = True
@@ -366,14 +368,17 @@ class Generator(WarmupForwardMixin):
             )
 
         # Every prefill variant has now compiled and staged its buffers, and nothing is captured yet.
-        # Capture them all, back to back, with no allocation in between.
         #
-        # The decode trace is deliberately not hoisted here. Its input layout depends on the caller's
-        # is_cur_pos_sharded / is_page_table_sharded, which warmup cannot see -- the trace is keyed only on
-        # on_device_logits, so preparing it against the wrong layout would bind the capture to buffers the
-        # real decode never writes. It therefore still compiles in the decode loop, behind these traces.
+        # The decode trace goes first. Its compile pass is the single largest allocator left in the run --
+        # it builds the prefetcher, the CCLs and the sampling module -- so capturing the prefill traces
+        # before it would make every one of those allocations land behind live traces. Hoisting it needs a
+        # layout hint from the caller (see _prepare_and_record_decode_trace); without one it stays lazy and
+        # this is exactly the previous ordering.
+        #
+        # Then the prefill traces, back to back, with no allocation in between.
         if self._defer_trace_recording:
             self._defer_trace_recording = False
+            self._prepare_and_record_decode_trace(decode_layout, page_table, kv_cache)
             self._record_pending_traces()
 
         # trace_id_prefill dict check
@@ -393,6 +398,10 @@ class Generator(WarmupForwardMixin):
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
         start_pos: list[int] | None = None,  # Cached prefixes lengths
+        # Decode input layout, so warmup can capture the decode trace before any prefill trace. Keys:
+        # {"is_cur_pos_sharded": bool, "is_page_table_sharded": bool, "on_device_logits": bool}. Omitted
+        # leaves the decode trace lazy -- see _prepare_and_record_decode_trace.
+        decode_layout=None,
     ):
         if getattr(self, "_disable_prefill_tracing", False):
             enable_trace = False
@@ -407,6 +416,7 @@ class Generator(WarmupForwardMixin):
                 None,
                 empty_slots,
                 None,
+                decode_layout=decode_layout,
             )
 
         return_logits = sampling_params is None
@@ -503,7 +513,17 @@ class Generator(WarmupForwardMixin):
         if do_device_sampling and sampling_params is not None:
             seed_values = _as_list(getattr(sampling_params, "seed", None))
             temperature_values = _as_list(getattr(sampling_params, "temperature", None))
-            explicit_seeded_prefill = any(seed is not None for seed in seed_values)
+            # A seed only changes the sampled token where sampling is stochastic. A greedy slot
+            # (temperature == 0) is argmax and never draws from the RNG, so a seed on it must not force
+            # the slot-stable prefill path: that path runs prefill untraced and samples per request,
+            # which allocates the entire prefill graph -- thousands of buffers -- behind live traces on
+            # every prefill, where they can be corrupted on replay. Callers hit this without asking for
+            # it, since a seed default of 0 (rather than None) is enough to look explicitly seeded.
+            # Slots whose temperature is unknown stay conservative and count as seeded.
+            explicit_seeded_prefill = any(
+                seed is not None and not (temp is not None and float(temp) == 0.0)
+                for seed, temp in zip_longest(seed_values, temperature_values)
+            )
             requires_slot_stable_prefill = explicit_seeded_prefill or any(
                 float(temp) == 0.0 for temp in temperature_values if temp is not None
             )
@@ -1233,6 +1253,64 @@ class Generator(WarmupForwardMixin):
             batch_size=prepared["batch_size"],
         )
 
+    def _prepare_and_record_decode_trace(self, decode_layout, page_table, kv_cache):
+        """Compile and capture the decode trace before any prefill trace is recorded.
+
+        The decode compile pass constructs the prefetcher, the decode CCLs and the sampling module. Left
+        where it naturally falls -- the first iteration of the decode loop -- all of that allocates behind
+        every prefill trace captured during warmup, and those buffers can be overwritten on replay. Doing
+        it here puts it ahead of every capture instead.
+
+        ``decode_layout`` must come from the caller. The decode trace is keyed only on ``on_device_logits``,
+        but its input buffers depend on ``is_cur_pos_sharded`` / ``is_page_table_sharded``, which warmup
+        cannot infer; preparing against the wrong layout would bind the capture to buffers the real decode
+        never writes. Callers that do not pass one (the vLLM bridge, among others) keep the previous lazy
+        behaviour. Returns whether the hoist happened.
+        """
+        if decode_layout is None or page_table is None or not kv_cache:
+            return False
+
+        on_device_logits = bool(decode_layout.get("on_device_logits", True))
+        # Decode always runs the full batch -- ttnn_decode_forward asserts B == max_batch_size -- no matter
+        # how many users the caller has, so the mock is sized from the model rather than the page table.
+        batch = self.model.args.max_batch_size
+
+        mock_tokens = torch.zeros(batch, 1, dtype=torch.long)
+        # -1 is the "no user in this slot" marker the demo already pads with, and paged_fused_update_cache
+        # skips those rows. The compile pass therefore runs the real graph without writing mock K/V into
+        # any user's cache.
+        mock_current_pos = torch.full((batch,), -1, dtype=torch.int64)
+
+        decode_page_table = page_table
+        if decode_page_table.shape[0] < batch:
+            padding = torch.zeros(
+                (batch - decode_page_table.shape[0], decode_page_table.shape[1]), dtype=decode_page_table.dtype
+            )
+            decode_page_table = torch.cat([decode_page_table, padding], dim=0)
+
+        self.model.switch_mode("decode")
+        trace_id, tt_out_tok, *device_inputs = self._capture_trace_text(
+            mock_tokens,
+            mock_current_pos,
+            page_table=decode_page_table,
+            # Decode unwraps the per-model list; _capture_trace_text is called here directly, so do it here.
+            kv_cache=kv_cache[0],
+            is_cur_pos_sharded=bool(decode_layout.get("is_cur_pos_sharded", False)),
+            is_page_table_sharded=bool(decode_layout.get("is_page_table_sharded", False)),
+            on_device_logits=on_device_logits,
+        )
+        self.trace_ids_decode[on_device_logits] = trace_id
+        self.trace_inputs_decode[on_device_logits] = device_inputs
+        self.trace_output_decode[on_device_logits] = tt_out_tok
+        # The staged inputs are the mock ones, so the first real decode step must reload rather than trust
+        # what is on device.
+        self._decode_inputs_need_reset = True
+
+        # Back to prefill, so the pending prefill traces capture in the mode they were prepared in.
+        self.model.switch_mode("prefill")
+        logger.info(f"Hoisted decode trace capture (on_device_logits={on_device_logits}) ahead of prefill traces")
+        return True
+
     def _record_pending_traces(self):
         """Capture every trace prepared while recording was deferred.
 
@@ -1708,9 +1786,17 @@ class Generator(WarmupForwardMixin):
             sm_bs = seed_manager.max_batch_size
             rank_remap = slot_remap[0:sm_bs]
             seed_manager.apply_slot_remap(rank_remap)
+        if sampling_params is not None:
+            # Normalise every step, not just on reset. The seed view read below has to agree with what
+            # the sampling module was actually configured with; formatting only inside the reset branch
+            # left every later token reading the caller's raw seed, so normalisation (which clears the
+            # seed on greedy rows, where it cannot affect the sampled token) was never observed after
+            # the first step and sampling stayed off its captured trace for the whole run.
+            # Derived from the caller's params each call, so this cannot double-apply.
+            sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)
+
         if reset_inputs and sampling_params is not None:
             # If we have new inputs, we need to set up the sampling module again
-            sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)
             if active_seed_slots is not None:
                 seed_values = _as_list(getattr(sampling_params, "seed", None))
                 has_active_seed = any(

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -239,7 +239,11 @@ sizes:
     aliases: ["Mistral-7B", "mistralai/Mistral-7B-Instruct-v0.3"]
     skus:
       wh_n150:
-        trace_region_size: 25000000
+        # Raised from 25000000: the post-prefill (norm + LM head) trace added by the trace-allocation
+        # work is an additional captured trace, so decode capture now needs more trace region. This SKU
+        # was 2048 B per bank short of capturing it ("Not enough space to allocate 10985472 B TRACE
+        # buffer across 12 banks ... free: 915456 B" vs 917504 B needed).
+        trace_region_size: 32000000
 
   phi-3-mini:
     aliases: ["Phi-3-mini", "microsoft/Phi-3-mini-128k-instruct"]

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -506,7 +506,17 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         cores", program.cpp:2205). The prefetcher is Blackhole-only and GPT-OSS does not use it, so
         keeping these models on the original non-hoisted path costs this change nothing it targets.
         """
-        return any(getattr(m, "prefetcher", None) is not None for m in self.model)
+        uses = any(getattr(m, "prefetcher", None) is not None for m in self.model)
+        if uses and not getattr(self, "_logged_prefetcher_hoist_skip", False):
+            self._logged_prefetcher_hoist_skip = True
+            logger.info(
+                "DRAM prefetcher detected: keeping the original (non-hoisted) decode trace setup. "
+                "This model does not get the hoisted trace-allocation path, because the prefetcher's "
+                "per-mode sub-device managers are incompatible with preparing decode setup during the "
+                "prefill phase (see _uses_prefetcher). Trace I/O buffers for this model may still be "
+                "allocated while a trace is live."
+            )
+        return uses
 
     def _prepare_decode_trace_once(self, kv_cache, page_table, on_device_sampling):
         """Prepare the decode trace unless it is already prepared. Safe to call from either hoist point."""

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -455,9 +455,14 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 on_device_sampling=on_device_sampling,
             )
         finally:
+            # Restore only the generator's own mode. Deliberately no switch_mode(Mode.PREFILL) here:
+            # switch_mode drives Prefetcher.init(), whose Mode.PREFILL branch has never executed on main
+            # (main only ever calls switch_mode(Mode.DECODE)) and is not functional -- it reads an
+            # unassigned all_core_range_set, and supplying one instead trips
+            # "Statically allocated circular buffers ... clash with L1 buffers on core range".
+            # The prefetcher is not needed for prefill; main runs prefill with it left in whatever mode
+            # it was last initialized for, so leaving it in DECODE matches main's behaviour.
             self.mode = previous_mode
-            for i in range(len(self.model)):
-                self.model[i].switch_mode(Mode.PREFILL)
 
     def _will_row_shard_prefill(self, tokens, sampling_params):
         """Whether this prefill will be dispatched to the model's row-sharded batched path.
@@ -668,9 +673,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             try:
                 trace_ids, tt_out_trace, *device_inputs = self._record_decode_trace_text(prepared)
             finally:
+                # See _prepare_decode_trace_for_warmup: no switch_mode(Mode.PREFILL) here either.
                 self.mode = previous_mode
-                for i in range(len(self.model)):
-                    self.model[i].switch_mode(Mode.PREFILL)
             self.trace_ids_decode[on_device_sampling] = trace_ids
             self.trace_inputs_decode[on_device_sampling] = device_inputs
             self.trace_output_decode[on_device_sampling] = tt_out_trace

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -491,8 +491,22 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         if self._prealloc_decode_inputs is None:
             self._prealloc_decode_inputs = self._prealloc_decode_trace_inputs(page_table)
 
+    def _uses_prefetcher(self):
+        """Whether any model instance drives the DRAM prefetcher.
+
+        The prefetcher owns sub-device managers that differ per mode, so hoisting decode setup into the
+        prefill phase cannot work for it: switching to DECODE and back reaches the prefetcher's
+        Mode.PREFILL branch, which has never run on main and is not functional, while staying in DECODE
+        leaves prefill running against decode sub-devices ("Kernel group cores do not match sub device
+        cores", program.cpp:2205). The prefetcher is Blackhole-only and GPT-OSS does not use it, so
+        keeping these models on the original non-hoisted path costs this change nothing it targets.
+        """
+        return any(getattr(m, "prefetcher", None) is not None for m in self.model)
+
     def _prepare_decode_trace_once(self, kv_cache, page_table, on_device_sampling):
         """Prepare the decode trace unless it is already prepared. Safe to call from either hoist point."""
+        if self._uses_prefetcher():
+            return
         if self._pending_decode_trace is None:
             self._pending_decode_trace = self._prepare_decode_trace_for_warmup(
                 kv_cache=kv_cache,
@@ -884,7 +898,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # The transient buffers of decode's compile pass are not hoisted with them: compiling decode
             # here makes the capture below deadlock, so that pass stays in the decode loop. Its allocations
             # are freed before anything replays, which is why they are the tolerable half of this.
-            before_capture = lambda: self._stage_prealloc_decode_inputs(page_table)  # noqa: E731
+            # Same prefetcher exclusion as _prepare_decode_trace_once: staging decode inputs from inside
+            # the prefill capture window is not safe for prefetcher-driven models.
+            if not self._uses_prefetcher():
+                before_capture = lambda: self._stage_prealloc_decode_inputs(page_table)  # noqa: E731
         return self.model[0].row_sharded_batched_prefill(
             tokens,
             page_table,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -190,6 +190,23 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         "supports_prefix_caching": True,
     }
 
+    def _any_trace_captured(self):
+        """True once any trace has been captured, i.e. once allocations are no longer unconditionally safe.
+
+        Used to decide whether a prefill call may still arm capture deferral: the point of deferring is to
+        keep every compile pass and every persistent allocation ahead of the first capture, which is only
+        achievable while nothing has been captured yet.
+        """
+        return any(
+            any(store.values())
+            for store in (
+                self.trace_id_prefill,
+                self.trace_id_prefill_sampling,
+                self.trace_id_post_prefill,
+                self.trace_ids_decode,
+            )
+        )
+
     def _get_sampling_contract(self, model_id: int):
         sampling_module = getattr(self.model[model_id], "sampling", None)
         sampling_dp = getattr(self.model[model_id], "sampling_dp", 1)
@@ -263,23 +280,36 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 kv_cache=kv_cache, page_table=page_table, can_sample_on_device=can_sample_on_device
             )
 
-    def finalize_deferred_traces(self, kv_cache, page_table, can_sample_on_device):
+    def finalize_deferred_traces(self, kv_cache, page_table, can_sample_on_device, prefill_samples_on_device=None):
         """Prepare the remaining traces and capture everything that is pending.
 
         Called once the prefill that triggered warmup has finished, so every prefill trace variant that run
         actually uses -- including the batched-prefill one, which warmup cannot know about -- has already
         been prepared. Everything below still runs before the first capture, so once this returns nothing
         allocates outside a capture window.
+
+        ``can_sample_on_device`` is decode's sampling mode (it keys the decode trace).
+        ``prefill_samples_on_device`` is prefill's, which keys the post-prefill trace -- the two differ when
+        a caller samples on device during decode but reads logits back on host during prefill (GPT-OSS).
+        Capturing the post-prefill tail in the mode prefill does not use would leave a trace nothing replays.
+        Defaults to ``can_sample_on_device`` for callers that do not distinguish them.
         """
         if not self._defer_trace_recording:
             return
+        if prefill_samples_on_device is None:
+            prefill_samples_on_device = can_sample_on_device
         try:
             # One post-prefill trace per model, shaped from any prepared prefill variant's body output.
             for prepared in self._pending_prefill_traces.values():
                 model_id = prepared["model_id"]
                 if model_id in self._pending_post_prefill_traces:
                     continue
-                sampling_enabled = can_sample_on_device and getattr(self.model[model_id], "sampling", None)
+                # Tracing the tail needs a slice that can write into a pre-allocated buffer; without it the
+                # replay would allocate its own input every call, which is the very thing being avoided.
+                # Models that do not implement it keep the eager tail (and its allocations).
+                if getattr(self.model[model_id], "slice_last_token_block", None) is None:
+                    continue
+                sampling_enabled = prefill_samples_on_device and getattr(self.model[model_id], "sampling", None)
                 self._pending_post_prefill_traces[model_id] = self._prepare_post_prefill_trace(
                     model_id, prepared, bool(sampling_enabled)
                 )
@@ -287,15 +317,15 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # Decode last, so its compile pass and its capture stay adjacent: capturing a program the
             # cache has not seen fails outright, and the sampling configuration must not drift in between.
             #
-            # Only when this runs straight after warmup. Reached from the batched path -- i.e. after the
-            # caller's own prefill -- the model's sampling state has been reconfigured per prefill user, and
-            # compiling decode against it fails ("Batch size 1 must be equal to max_batch_size"). There the
-            # decode trace stays lazy, exactly as before this change.
-            self._pending_decode_trace = self._prepare_decode_trace_for_warmup(
-                kv_cache=kv_cache,
-                page_table=page_table,
-                on_device_sampling=can_sample_on_device,
-            )
+            # Unless it was already prepared up front. The no-warmup path does that deliberately, because
+            # there the flush happens after a real prefill and the decode compile pass would write mock K/V
+            # over it (see _prefill_forward_text_impl).
+            if self._pending_decode_trace is None:
+                self._pending_decode_trace = self._prepare_decode_trace_for_warmup(
+                    kv_cache=kv_cache,
+                    page_table=page_table,
+                    on_device_sampling=can_sample_on_device,
+                )
         finally:
             self._defer_trace_recording = False
 
@@ -429,6 +459,42 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             for i in range(len(self.model)):
                 self.model[i].switch_mode(Mode.PREFILL)
 
+    def _will_row_shard_prefill(self, tokens, sampling_params):
+        """Whether this prefill will be dispatched to the model's row-sharded batched path.
+
+        Single source of truth for that decision -- both the dispatch itself and the choice of where to
+        hoist decode trace preparation depend on it, and they must not drift apart.
+
+        Only used when device sampling is active (sampling_params is not None) and the prompt uses the
+        harmony chat template (first token is <|start|>=200006). Host sampling needs the single-user
+        prefill path that returns full logits per user.
+        """
+        is_harmony = tokens.shape[1] > 0 and int(tokens[0, 0]) == 200006
+        return bool(
+            getattr(self.model[0], "users_row_sharded", False)
+            and tokens.shape[0] > 1
+            and sampling_params is not None
+            and is_harmony
+        )
+
+    def _stage_prealloc_decode_inputs(self, page_table):
+        """Allocate decode's persistent trace inputs now, for _prepare_decode_trace_text to pick up later.
+
+        Split out from full decode trace preparation because it allocates without compiling anything --
+        the only part of decode setup the row-sharded batched path tolerates ahead of its own capture.
+        """
+        if self._prealloc_decode_inputs is None:
+            self._prealloc_decode_inputs = self._prealloc_decode_trace_inputs(page_table)
+
+    def _prepare_decode_trace_once(self, kv_cache, page_table, on_device_sampling):
+        """Prepare the decode trace unless it is already prepared. Safe to call from either hoist point."""
+        if self._pending_decode_trace is None:
+            self._pending_decode_trace = self._prepare_decode_trace_for_warmup(
+                kv_cache=kv_cache,
+                page_table=page_table,
+                on_device_sampling=on_device_sampling,
+            )
+
     def _prealloc_decode_trace_inputs(self, page_table):
         """Allocate just the decode trace's input tensors, before anything has been captured.
 
@@ -461,8 +527,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
 
         Traced as one unit, the same way the batched path already traces norm + LM head + sampling in
         _capture_trace_prefill_sampling.
+
+        Not every model splits the head off the body: GPT-OSS applies norm + LM head inside its own
+        ``ttnn_prefill_forward``, so its body output is already logits and there is no head to re-apply.
         """
-        return self._post_prefill_tail(model_id, self.model[model_id]._apply_norm_and_lm_head(x), sampling_enabled)
+        apply_head = getattr(self.model[model_id], "_apply_norm_and_lm_head", None)
+        logits = apply_head(x) if apply_head is not None else x
+        return self._post_prefill_tail(model_id, logits, sampling_enabled)
 
     def _post_prefill_tail(self, model_id, logits, sampling_enabled):
         """The part of the post-prefill body that runs on already-computed logits."""
@@ -790,6 +861,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         assert (
             self.data_parallel == 1
         ), "Row-sharded batched prefill requires data_parallel=1 (model handles DP internally)"
+        before_capture = None
+        if enable_trace and self._prealloc_decode_inputs is None and not self._any_trace_captured():
+            # Allocate decode's persistent trace inputs in the one window this path leaves: after its own
+            # trace inputs are staged, before its capture. These are the buffers that matter -- they are
+            # refreshed in place for the entire decode loop, so allocating them later (with the prefill
+            # trace live) leaves them sitting in that trace's scratch, to be overwritten on every replay.
+            # The transient buffers of decode's compile pass are not hoisted with them: compiling decode
+            # here makes the capture below deadlock, so that pass stays in the decode loop. Its allocations
+            # are freed before anything replays, which is why they are the tolerable half of this.
+            before_capture = lambda: self._stage_prealloc_decode_inputs(page_table)  # noqa: E731
         return self.model[0].row_sharded_batched_prefill(
             tokens,
             page_table,
@@ -805,6 +886,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 "outputs": self.trace_output_prefill,
             },
             empty_slots=empty_slots,
+            before_capture=before_capture,
         )
 
     def _easy_trace_prefill(
@@ -985,12 +1067,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         on_device_sampling_requested = sampling_params is not None
 
         # we need this here because of tt-metal tests
+        on_device_sampling_enabled = (
+            getattr(self.model[0], "_supports_on_device_sampling", False)
+            and getattr(self.model[0], "sampling", None) is not None
+        )
         if warmup_prefill:
-            on_device_sampling_enabled = (
-                getattr(self.model[0], "_supports_on_device_sampling", False)
-                and getattr(self.model[0], "sampling", None) is not None
-            )
-
             # Warmup leaves trace recording deferred; the wrapper flushes once this call's own prefill has
             # prepared any variant warmup could not know about (batched prefill).
             #
@@ -1008,6 +1089,43 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 enable_trace=enable_trace,
                 can_sample_on_device=on_device_sampling_enabled,
                 page_table=page_table,
+            )
+        elif (
+            enable_trace
+            and self._deferred_finalize_args is None
+            and not self._any_trace_captured()
+            # The row-sharded batched path cannot take the full treatment: once a decode program has been
+            # compiled, that path's MoE dispatch can no longer be trace-captured (the capture deadlocks),
+            # and compiling decode before any prefill deadlocks in the MoE combine instead. Its decode
+            # trace therefore still compiles late, in the decode loop. What it does get is its persistent
+            # trace inputs allocated ahead of every capture -- see _row_sharded_batched_prefill.
+            and not self._will_row_shard_prefill(tokens, sampling_params)
+        ):
+            # Models that skip prefill warmup (GPT-OSS sets warmup_prefill=False everywhere) would otherwise
+            # capture their prefill trace part way through this call and then compile the whole decode graph
+            # -- plus its long-lived trace inputs and its sampling state -- with that trace already live.
+            # Arm the same deferral warmup uses, so this call only *prepares*; the wrapper flushes once
+            # everything is prepared. Only on the first such call: once anything is captured, the ordering
+            # is already fixed and re-arming would defer a capture that later calls expect to exist.
+            self._deferred_finalize_args = {
+                "kv_cache": kv_cache,
+                "page_table": page_table,
+                "can_sample_on_device": on_device_sampling_enabled,
+                # This caller's prefill samples on device only if it actually asked to. GPT-OSS's batch-1
+                # demo reads prefill logits back on host while decoding with device sampling, so the two
+                # modes genuinely differ here.
+                "prefill_samples_on_device": on_device_sampling_requested and on_device_sampling_enabled,
+            }
+            self._defer_trace_recording = True
+            # Prepare decode here, before this call's prefill fills the KV cache, rather than at the flush.
+            # The decode compile pass is a real decode step at position 0 with mock inputs, so it writes
+            # mock K/V into position 0 of every user's cache. Running it first means the prefill that
+            # follows overwrites that -- which is exactly the ordering warmup gets for free by running
+            # before any real prefill. Deferred until the flush it would instead corrupt the prefilled KV.
+            self._prepare_decode_trace_once(
+                kv_cache=kv_cache,
+                page_table=page_table,
+                on_device_sampling=on_device_sampling_enabled,
             )
 
         batch_size, batch_seq_len = tokens.shape
@@ -1049,18 +1167,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             for seq_len, num_cached in zip(prompt_lens, num_cached_per_user)
         ]
         # Row-sharded batched prefill: process 1 user per row per iteration.
-        # Only used when device sampling is active (sampling_params is not None)
-        # and the prompt uses the harmony chat template (first token is <|start|>=200006).
-        # Host sampling (sampling_params=None) needs the single-user prefill path
-        # that returns full logits per user.
-        model_0 = self.model[0]
-        is_harmony = tokens.shape[1] > 0 and int(tokens[0, 0]) == 200006
-        if (
-            getattr(model_0, "users_row_sharded", False)
-            and batch_size > 1
-            and sampling_params is not None
-            and is_harmony
-        ):
+        # See _will_row_shard_prefill for when this path is taken.
+        if self._will_row_shard_prefill(tokens, sampling_params):
             return self._row_sharded_batched_prefill(
                 tokens,
                 page_table,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -429,6 +429,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
 
         The model has to be in decode mode for the compile pass to pick the right configs.
         """
+        # Gate lives here rather than only in _prepare_decode_trace_once because this function has a
+        # second caller that bypasses that wrapper. Returning None leaves _pending_decode_trace unset,
+        # which is exactly the "nothing hoisted" state the original path expects.
+        if self._uses_prefetcher():
+            return None
         if page_table is None:
             # Nothing here pins down the decode batch size, and guessing wrong would leave the trace inputs
             # the wrong shape for the first decode step. Fall back to setting it up lazily, as before.

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -2194,12 +2194,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         page_table=None,
         kv_cache=None,
         on_device_sampling=False,
+        skip_precompile=False,
     ):
         """Prepare and immediately capture the decode trace.
 
         Only safe when no other trace is live on the device. The demo path pre-captures via
         :meth:`warmup_model_decode` during warmup; this single-shot form is the fallback for callers that
         reach decode without having warmed up.
+
+        ``skip_precompile`` is forwarded to the prepare phase, where main's decode-bucketing callers use
+        it to state that the program cache is already warm for this variant.
         """
         return self._record_decode_trace_text(
             self._prepare_decode_trace_text(
@@ -2208,6 +2212,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 page_table=page_table,
                 kv_cache=kv_cache,
                 on_device_sampling=on_device_sampling,
+                skip_precompile=skip_precompile,
             )
         )
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -772,6 +772,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         # Release our handle on the compile-pass output before capturing, matching the pre-split behaviour.
         # A deferred warmup caller may still be holding it; that is its own reference to keep or drop.
         prepared.pop("compile_output", None)
+        # Warm the program cache over the *persistent* inputs before capturing. The compile pass in
+        # _prepare_trace_prefill ran against transient buffers, so a program whose cache key depends on
+        # anything that differs between those and the persistent inputs is still uncached here, and would
+        # be loaded inside the capture window -- which the runtime rejects outright:
+        # "Cannot load new binaries during trace capture" (mesh_workload.cpp). Gemma-4's LM head hit this.
+        # Runs before begin_trace_capture, so the allocation it makes is safe by this path's own rules, and
+        # the output is dropped immediately.
+        warmup_output = self._prefill_trace_forward(prepared, device_inputs)
+        ttnn.synchronize_device(mesh_device)
+        del warmup_output
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         tt_out_trace = self._prefill_trace_forward(prepared, device_inputs)
         ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -165,6 +165,25 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self.prefill_traces_warmup = False
         self.already_warmed_up_prefill = False
         self.mode = None
+        # Trace capture ordering: while this is set, prepared traces are stashed instead of captured, so
+        # that every compile pass and every persistent trace-input allocation happens before the first
+        # capture. See _prepare_trace_prefill for why that ordering matters.
+        self._defer_trace_recording = False
+        self._pending_prefill_traces = {}
+        self._pending_decode_trace = None
+        self._deferred_finalize_args = None
+        self._warmup_covered_all_variants = False
+        self._prealloc_decode_inputs = None
+        self._pending_prefill_sampling_traces = {}
+        self._pending_post_prefill_traces = {}
+        # Traced norm + LM head applied to the prefill body output. Keyed by model_id; the input is a fixed
+        # [1, 1, 32, dim] buffer that the (untraced, allocation-free) last-token slice writes into.
+        self.trace_id_post_prefill = defaultdict(lambda: None)
+        self.trace_input_post_prefill = defaultdict(lambda: None)
+        self.trace_output_post_prefill = defaultdict(lambda: None)
+        # Which sampling mode each post-prefill trace was captured for; a call in the other mode must not
+        # replay it, since the traced tail differs (on-device sampling vs untilize for host sampling).
+        self.post_prefill_sampling_mode = defaultdict(lambda: None)
 
     # Class-level capabilities (VLLM specific, to be overridden by subclasses)
     model_capabilities = {
@@ -195,7 +214,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
 
         return ret
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, greedy_only: bool = False):
+    def warmup_model_prefill(
+        self, kv_cache, enable_trace, can_sample_on_device, greedy_only: bool = False, page_table=None
+    ):
         if self.already_warmed_up_prefill:
             return
         self.already_warmed_up_prefill = True
@@ -211,6 +232,86 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         if enable_trace:
             logger.info("Using batch-1-only traced prefill warmup; runtime batched prefill remains enabled")
 
+        # Defer every capture so that all compile passes and all persistent trace-input allocations happen
+        # while no trace is live on device -- capturing as we go would leave each later allocation free to
+        # land inside an already-captured trace's scratch.
+        #
+        # Deferral deliberately stays on when this returns. The warmup sweep only covers batch_size=1, but
+        # the trace key carries batch_size, so batched prefill needs a variant that only the *caller's* real
+        # prefill will ask for. Rather than guess it (pre-warming every batch/seq-len combination runs out
+        # of DRAM), we let that first real prefill prepare whatever it needs and flush afterwards. See
+        # finalize_deferred_traces, which prefill_forward_text calls once its prefill is done.
+        self._defer_trace_recording = enable_trace
+        self._warmup_prefill_sweep(
+            kv_cache=kv_cache,
+            enable_trace=enable_trace,
+            can_sample_on_device=can_sample_on_device,
+            greedy_only=greedy_only,
+            sequence_lengths_to_warmup=sequence_lengths_to_warmup,
+            warmup_batch_sizes=warmup_batch_sizes,
+            skip_sequence_lengths=skip_sequence_lengths,
+            sampling_parameters_sweeped=sampling_parameters_sweeped,
+        )
+
+        # At batch 1 the sweep has already covered every variant the run will ask for, so finish here: the
+        # decode trace can be prepared and captured while the model is still in its post-warmup state, which
+        # is what its compile pass expects. Deferring to after the caller's prefill would run that compile
+        # with sampling already reconfigured per prefill user, which fails.
+        self._warmup_covered_all_variants = page_table is not None and page_table.shape[0] == 1
+        if self._warmup_covered_all_variants:
+            self.finalize_deferred_traces(
+                kv_cache=kv_cache, page_table=page_table, can_sample_on_device=can_sample_on_device
+            )
+
+    def finalize_deferred_traces(self, kv_cache, page_table, can_sample_on_device):
+        """Prepare the remaining traces and capture everything that is pending.
+
+        Called once the prefill that triggered warmup has finished, so every prefill trace variant that run
+        actually uses -- including the batched-prefill one, which warmup cannot know about -- has already
+        been prepared. Everything below still runs before the first capture, so once this returns nothing
+        allocates outside a capture window.
+        """
+        if not self._defer_trace_recording:
+            return
+        try:
+            # One post-prefill trace per model, shaped from any prepared prefill variant's body output.
+            for prepared in self._pending_prefill_traces.values():
+                model_id = prepared["model_id"]
+                if model_id in self._pending_post_prefill_traces:
+                    continue
+                sampling_enabled = can_sample_on_device and getattr(self.model[model_id], "sampling", None)
+                self._pending_post_prefill_traces[model_id] = self._prepare_post_prefill_trace(
+                    model_id, prepared, bool(sampling_enabled)
+                )
+
+            # Decode last, so its compile pass and its capture stay adjacent: capturing a program the
+            # cache has not seen fails outright, and the sampling configuration must not drift in between.
+            #
+            # Only when this runs straight after warmup. Reached from the batched path -- i.e. after the
+            # caller's own prefill -- the model's sampling state has been reconfigured per prefill user, and
+            # compiling decode against it fails ("Batch size 1 must be equal to max_batch_size"). There the
+            # decode trace stays lazy, exactly as before this change.
+            self._pending_decode_trace = self._prepare_decode_trace_for_warmup(
+                kv_cache=kv_cache,
+                page_table=page_table,
+                on_device_sampling=can_sample_on_device,
+            )
+        finally:
+            self._defer_trace_recording = False
+
+        self._record_pending_traces()
+
+    def _warmup_prefill_sweep(
+        self,
+        kv_cache,
+        enable_trace,
+        can_sample_on_device,
+        greedy_only,
+        sequence_lengths_to_warmup,
+        warmup_batch_sizes,
+        skip_sequence_lengths,
+        sampling_parameters_sweeped,
+    ):
         for model_id in range(self.data_parallel):
             for supported_length in sequence_lengths_to_warmup:
                 if model_id != 0 and (
@@ -293,7 +394,235 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             )
             logger.info("Vision encoder warmup completed")
 
-    def _capture_trace_prefill(
+    def _prepare_decode_trace_for_warmup(self, kv_cache, page_table, on_device_sampling):
+        """Full decode trace preparation (compile pass + trace inputs), run before any trace is captured.
+
+        The model has to be in decode mode for the compile pass to pick the right configs.
+        """
+        if page_table is None:
+            # Nothing here pins down the decode batch size, and guessing wrong would leave the trace inputs
+            # the wrong shape for the first decode step. Fall back to setting it up lazily, as before.
+            logger.info("No page table available at warmup; decode trace will be set up on first decode")
+            return None
+
+        batch_size = page_table.shape[0]
+        # Values do not matter: the trace inputs are refreshed from host on the first real decode step
+        # (reset_batch=True). Only the shapes have to match what decode_forward will supply.
+        tokens = torch.chunk(torch.zeros(batch_size, 1, dtype=torch.int64), self.data_parallel, 0)
+        current_pos = torch.chunk(torch.zeros(batch_size, dtype=torch.int64), self.data_parallel, 0)
+        chunked_page_table = torch.chunk(page_table, self.data_parallel, 0)
+
+        previous_mode = self.mode
+        self.mode = Mode.DECODE
+        for i in range(len(self.model)):
+            self.model[i].switch_mode(Mode.DECODE)
+        try:
+            return self._prepare_decode_trace_text(
+                tokens,
+                current_pos,
+                page_table=chunked_page_table,
+                kv_cache=kv_cache,
+                on_device_sampling=on_device_sampling,
+            )
+        finally:
+            self.mode = previous_mode
+            for i in range(len(self.model)):
+                self.model[i].switch_mode(Mode.PREFILL)
+
+    def _prealloc_decode_trace_inputs(self, page_table):
+        """Allocate just the decode trace's input tensors, before anything has been captured.
+
+        Used on the batched path, where the decode compile pass cannot be hoisted. These buffers are the
+        long-lived half of decode trace setup -- refreshed in place for the whole decode loop -- so they are
+        what a later prefill replay could corrupt if they were allocated after the captures.
+        """
+        if page_table is None:
+            logger.info("No page table available; decode trace inputs will be allocated on first decode")
+            return None
+
+        batch_size = page_table.shape[0]
+        # Values do not matter: they are refreshed from host on the first real decode step (reset_batch).
+        tokens = torch.chunk(torch.zeros(batch_size, 1, dtype=torch.int64), self.data_parallel, 0)
+        current_pos = torch.chunk(torch.zeros(batch_size, dtype=torch.int64), self.data_parallel, 0)
+        chunked_page_table = torch.chunk(page_table, self.data_parallel, 0)
+
+        device_inputs = []
+        for i in range(self.data_parallel):
+            host_inputs = self.model[i].prepare_decode_inputs_host(
+                tokens[i], current_pos[i], page_table=chunked_page_table[i]
+            )
+            device_inputs.append(copy_host_to_device(host_inputs, mesh_device=self.model_args[i].mesh_device))
+        logger.info("Pre-allocated decode trace inputs ahead of trace captures")
+        return device_inputs
+
+    def _post_prefill_body(self, model_id, x, sampling_enabled):
+        """Everything applied to the prefill body output after the prefill trace: norm, LM head, and then
+        either on-device sampling or the untilize the host-sampling path needs.
+
+        Traced as one unit, the same way the batched path already traces norm + LM head + sampling in
+        _capture_trace_prefill_sampling.
+        """
+        return self._post_prefill_tail(model_id, self.model[model_id]._apply_norm_and_lm_head(x), sampling_enabled)
+
+    def _post_prefill_tail(self, model_id, logits, sampling_enabled):
+        """The part of the post-prefill body that runs on already-computed logits."""
+        if sampling_enabled:
+            return self.model[model_id].sampling.sample(logits, enable_trace=False)
+        return ttnn.untilize(logits, use_multicore=True)
+
+    def _append_prefill_result(self, prefill_results, idx, model_id, last_token_idx, tail_out, sampling_enabled):
+        """Queue a per-prompt prefill result for readback, in whichever shape the tail produced."""
+        if sampling_enabled:
+            tt_tokens, tt_log_probs = tail_out
+            queued = [
+                tt_tokens.cpu(blocking=False),
+                tt_log_probs.cpu(blocking=False) if tt_log_probs is not None else None,
+            ]
+        else:
+            queued = tail_out.cpu(blocking=False)
+        prefill_results.append(
+            {
+                "idx": idx,
+                "model_id": model_id,
+                "last_token_idx": last_token_idx,
+                "logits": queued,
+                "sampling": sampling_enabled,
+            }
+        )
+
+    def _prepare_post_prefill_trace(self, model_id, prefill_prepared, sampling_enabled):
+        """Phase 1 of post-prefill trace setup: allocate the last-token buffer and compile norm + LM head.
+
+        The prefill trace covers only the transformer body; the norm and LM head that turn its output into
+        logits used to run eagerly on every prefill call, allocating a fresh tensor per op with the prefill
+        trace already live. They can be traced instead because their input shape is fixed at
+        ``[1, 1, 32, dim]`` regardless of prompt length -- only the *slice* that produces it varies, and that
+        slice can write into a pre-allocated buffer. One trace therefore covers every sequence length.
+
+        ``prefill_prepared`` is any prepared prefill variant; it only supplies a body output to slice from.
+        """
+        model = self.model[model_id]
+        # Freed again as soon as the buffer exists -- holding body outputs across preparations is what
+        # pushed batch-32 over its L1 budget.
+        sample_body_output = self._rerun_prefill_body(prefill_prepared)
+        # Slicing once here both allocates the buffer and pins its exact spec to what later slices produce.
+        last_token_buffer = model.slice_last_token_block(sample_body_output, last_token_idx=0)
+        # Warm the slice at the far end of the body output too. A slice at a fresh offset can need a program
+        # variant whose kernel binaries have not been loaded yet, and that load allocates -- which after the
+        # captures would be an unsafe allocation of, of all things, kernel binaries.
+        last_block_idx = max(0, sample_body_output.shape[-2] - 1)
+        model.slice_last_token_block(sample_body_output, last_token_idx=last_block_idx, out=last_token_buffer)
+        del sample_body_output
+        compile_output = self._post_prefill_body(model_id, last_token_buffer, sampling_enabled)
+        ttnn.synchronize_device(self.model_args[model_id].mesh_device)
+        logger.info("Done Compiling Post-Prefill (norm + LM head)")
+        return {
+            "model_id": model_id,
+            "input": last_token_buffer,
+            "sampling_enabled": sampling_enabled,
+            "compile_output": compile_output,
+        }
+
+    def _record_post_prefill_trace(self, prepared):
+        """Phase 2 of post-prefill trace setup: capture the post-prefill body over the pre-allocated buffer."""
+        model_id = prepared["model_id"]
+        mesh_device = self.model_args[model_id].mesh_device
+        last_token_buffer = prepared["input"]
+        prepared.pop("compile_output", None)
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        tt_out_trace = self._post_prefill_body(model_id, last_token_buffer, prepared["sampling_enabled"])
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+        logger.info("Done Capturing Post-Prefill Trace")
+        return trace_id, tt_out_trace, last_token_buffer
+
+    def _run_post_prefill(self, model_id, body_output, last_token_idx, sampling_enabled):
+        """Apply the post-prefill body, replaying its trace when one was captured for this sampling mode.
+
+        Returns ``(tt_tokens, tt_log_probs)`` when sampling on device, otherwise untilized logits -- or
+        ``None`` if no usable trace exists, in which case the caller falls back to the eager path.
+        """
+        if (
+            self.trace_id_post_prefill[model_id] is None
+            or self.post_prefill_sampling_mode[model_id] is not sampling_enabled
+        ):
+            return None
+
+        # Allocation-free: the slice writes into the pre-allocated trace input, then the trace replays.
+        self.model[model_id].slice_last_token_block(
+            body_output, last_token_idx, out=self.trace_input_post_prefill[model_id]
+        )
+        ttnn.execute_trace(
+            self.model_args[model_id].mesh_device, self.trace_id_post_prefill[model_id], cq_id=0, blocking=False
+        )
+        return self.trace_output_post_prefill[model_id]
+
+    def _record_pending_traces(self):
+        """Capture every trace prepared while recording was deferred.
+
+        Runs back to back with no allocation in between: each capture only binds to buffers that were
+        allocated during the preparation phase, before any trace existed.
+        """
+        for trace_key, prepared in self._pending_prefill_traces.items():
+            trace_id, tt_out_trace, *device_inputs = self._record_trace_prefill(prepared)
+            self.trace_id_prefill[trace_key] = trace_id
+            self.trace_inputs_prefill[trace_key] = device_inputs
+            self.trace_output_prefill[trace_key] = tt_out_trace
+        self._pending_prefill_traces = {}
+
+        for key, prepared in self._pending_prefill_sampling_traces.items():
+            s_trace_id, s_trace_output, s_trace_input = self._record_trace_prefill_sampling(prepared)
+            self.trace_id_prefill_sampling[key] = s_trace_id
+            self.trace_output_prefill_sampling[key] = s_trace_output
+            self.trace_input_prefill_sampling[key] = s_trace_input
+        self._pending_prefill_sampling_traces = {}
+
+        for model_id, prepared in self._pending_post_prefill_traces.items():
+            trace_id, tt_out_trace, last_token_buffer = self._record_post_prefill_trace(prepared)
+            self.trace_id_post_prefill[model_id] = trace_id
+            self.trace_input_post_prefill[model_id] = last_token_buffer
+            self.trace_output_post_prefill[model_id] = tt_out_trace
+            self.post_prefill_sampling_mode[model_id] = prepared["sampling_enabled"]
+        self._pending_post_prefill_traces = {}
+
+        # The decode trace was prepared last (compile + inputs) and is recorded last, so its capture stays
+        # adjacent to its compile pass.
+        if self._pending_decode_trace is not None:
+            prepared, self._pending_decode_trace = self._pending_decode_trace, None
+            on_device_sampling = prepared["on_device_sampling"]
+            previous_mode = self.mode
+            self.mode = Mode.DECODE
+            for i in range(len(self.model)):
+                self.model[i].switch_mode(Mode.DECODE)
+            try:
+                trace_ids, tt_out_trace, *device_inputs = self._record_decode_trace_text(prepared)
+            finally:
+                self.mode = previous_mode
+                for i in range(len(self.model)):
+                    self.model[i].switch_mode(Mode.PREFILL)
+            self.trace_ids_decode[on_device_sampling] = trace_ids
+            self.trace_inputs_decode[on_device_sampling] = device_inputs
+            self.trace_output_decode[on_device_sampling] = tt_out_trace
+
+    def _prefill_trace_forward(self, prepared, device_inputs):
+        """Run the prefill body for a prepared trace variant.
+
+        Shared verbatim by the compile pass and the capture pass so the two can never drift.
+        """
+        model_id = prepared["model_id"]
+        transformed_inputs = self.model[model_id].transform_and_embed_prefill_inputs_device(*device_inputs)
+        return self.model[model_id].ttnn_prefill_forward(
+            x=transformed_inputs[0],
+            rot_mats_global=prepared["rot_mats_global"],
+            rot_mats_local=prepared["rot_mats_local"],
+            page_table=transformed_inputs[1],
+            chunk_page_table=transformed_inputs[2],
+            chunk_start_idx=transformed_inputs[3],
+            kv_cache=prepared["kv_cache"],
+            **prepared["forward_kwargs"],
+        )
+
+    def _prepare_trace_prefill(
         self,
         prefill_ids,
         page_table=None,
@@ -305,103 +634,91 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         user_id=0,
         start_pos=0,
     ):
+        """Phase 1 of prefill trace setup: run the compile pass and allocate the persistent trace inputs.
+
+        Both of those allocate device memory, and neither may happen while another trace is live: once a
+        trace is captured its recorded buffer addresses are invisible to the allocator, so a buffer handed
+        out afterwards can land inside a live trace's scratch and be clobbered on replay. Capture is split
+        out into :meth:`_record_trace_prefill` so every trace variant can be prepared first, and only then
+        captured back to back.
+        """
+        prefill_kwargs = {
+            "page_table": page_table,
+            "chunk_page_table": chunk_page_table,
+            "chunk_start_idx": start_pos,
+            "user_id": user_id,
+        }
+        # Batched prefill threads the batch through the model; single-user prefill does not.
+        forward_kwargs = {"batch_size": batch_size, "user_id": user_id} if batch_size > 1 else {}
         if batch_size > 1:
-            prefill_kwargs = {
-                "page_table": page_table,
-                "chunk_page_table": chunk_page_table,
-                "chunk_start_idx": start_pos,
-                "batch_size": batch_size,
-                "user_id": user_id,
-            }
-            if global_user_id is not None:
-                prefill_kwargs["global_user_id"] = global_user_id
-            host_inputs = self.model[model_id].prepare_prefill_inputs_trace(prefill_ids, **prefill_kwargs)
+            prefill_kwargs["batch_size"] = batch_size
+        if global_user_id is not None:
+            prefill_kwargs["global_user_id"] = global_user_id
+
+        host_inputs = self.model[model_id].prepare_prefill_inputs_trace(prefill_ids, **prefill_kwargs)
+        prepared = {
+            "model_id": model_id,
+            "kv_cache": kv_cache,
+            "forward_kwargs": forward_kwargs,
             # These matrices will actually be pointing to the whole cos_matrix and sin_matrix that was allocated on device in the RotarySetup class
-            tt_rot_mats_prefill_global = host_inputs[1]
-            tt_rot_mats_prefill_local = host_inputs[2]
-            host_inputs = (host_inputs[0], host_inputs[3], host_inputs[4], host_inputs[5])
+            "rot_mats_global": host_inputs[1],
+            "rot_mats_local": host_inputs[2],
+        }
+        host_inputs = (host_inputs[0], host_inputs[3], host_inputs[4], host_inputs[5])
 
-            device_inputs = copy_host_to_device(host_inputs, mesh_device=self.model_args[model_id].mesh_device)
-            transformed_inputs = self.model[model_id].transform_and_embed_prefill_inputs_device(*device_inputs)
-            tt_out_trace = self.model[model_id].ttnn_prefill_forward(
-                x=transformed_inputs[0],
-                rot_mats_global=tt_rot_mats_prefill_global,
-                rot_mats_local=tt_rot_mats_prefill_local,
-                page_table=transformed_inputs[1],
-                chunk_page_table=transformed_inputs[2],
-                chunk_start_idx=transformed_inputs[3],
-                kv_cache=kv_cache,
-                batch_size=batch_size,
-                user_id=user_id,
-            )
-            ttnn.synchronize_device(self.model_args[model_id].mesh_device)
-            logger.info("Done Compiling Model")
+        mesh_device = self.model_args[model_id].mesh_device
 
-            device_inputs = copy_host_to_device(host_inputs, mesh_device=self.model_args[model_id].mesh_device)
-            trace_id = ttnn.begin_trace_capture(self.model_args[model_id].mesh_device, cq_id=0)
-            transformed_inputs = self.model[model_id].transform_and_embed_prefill_inputs_device(*device_inputs)
-            tt_out_trace = self.model[model_id].ttnn_prefill_forward(
-                x=transformed_inputs[0],
-                rot_mats_global=tt_rot_mats_prefill_global,
-                rot_mats_local=tt_rot_mats_prefill_local,
-                page_table=transformed_inputs[1],
-                chunk_page_table=transformed_inputs[2],
-                chunk_start_idx=transformed_inputs[3],
-                kv_cache=kv_cache,
-                batch_size=batch_size,
-                user_id=user_id,
-            )
-            ttnn.end_trace_capture(self.model_args[model_id].mesh_device, trace_id, cq_id=0)
-            ttnn.synchronize_device(self.model_args[model_id].mesh_device)
-            logger.info("Done Capturing Prefill Trace")
-            return trace_id, tt_out_trace, *device_inputs
-        else:
-            prefill_kwargs = {
-                "page_table": page_table,
-                "chunk_page_table": chunk_page_table,
-                "chunk_start_idx": start_pos,
-                "user_id": user_id,
-            }
-            if global_user_id is not None:
-                prefill_kwargs["global_user_id"] = global_user_id
-            host_inputs = self.model[model_id].prepare_prefill_inputs_trace(prefill_ids, **prefill_kwargs)
-            tt_rot_mats_prefill_global = host_inputs[1]
-            tt_rot_mats_prefill_local = host_inputs[2]
-            host_inputs = (host_inputs[0], host_inputs[3], host_inputs[4], host_inputs[5])
+        # Compile run. Its input buffers are transient; dropping the references frees them again. The
+        # output is a real prefill result for these ids, so deferred warmup callers can consume it instead
+        # of replaying a trace that has not been captured yet.
+        compile_inputs = copy_host_to_device(host_inputs, mesh_device=mesh_device)
+        prepared["compile_output"] = self._prefill_trace_forward(prepared, compile_inputs)
+        ttnn.synchronize_device(mesh_device)
+        del compile_inputs
+        logger.info("Done Compiling Model")
 
-            device_inputs = copy_host_to_device(host_inputs, mesh_device=self.model_args[model_id].mesh_device)
-            transformed_inputs = self.model[model_id].transform_and_embed_prefill_inputs_device(*device_inputs)
-            tt_out_trace = self.model[model_id].ttnn_prefill_forward(
-                x=transformed_inputs[0],
-                rot_mats_global=tt_rot_mats_prefill_global,
-                rot_mats_local=tt_rot_mats_prefill_local,
-                page_table=transformed_inputs[1],
-                chunk_page_table=transformed_inputs[2],
-                chunk_start_idx=transformed_inputs[3],
-                kv_cache=kv_cache,
-            )
-            ttnn.synchronize_device(self.model_args[model_id].mesh_device)
-            logger.info("Done Compiling Model")
+        # Persistent trace inputs: these outlive the capture and are refreshed in place on every replay.
+        prepared["device_inputs"] = copy_host_to_device(host_inputs, mesh_device=mesh_device)
+        return prepared
 
-            device_inputs = copy_host_to_device(host_inputs, mesh_device=self.model_args[model_id].mesh_device)
-            trace_id = ttnn.begin_trace_capture(self.model_args[model_id].mesh_device, cq_id=0)
-            transformed_inputs = self.model[model_id].transform_and_embed_prefill_inputs_device(*device_inputs)
-            tt_out_trace = self.model[model_id].ttnn_prefill_forward(
-                x=transformed_inputs[0],
-                rot_mats_global=tt_rot_mats_prefill_global,
-                rot_mats_local=tt_rot_mats_prefill_local,
-                page_table=transformed_inputs[1],
-                chunk_page_table=transformed_inputs[2],
-                chunk_start_idx=transformed_inputs[3],
-                kv_cache=kv_cache,
-            )
-            ttnn.end_trace_capture(self.model_args[model_id].mesh_device, trace_id, cq_id=0)
-            ttnn.synchronize_device(self.model_args[model_id].mesh_device)
-            logger.info("Done Capturing Prefill Trace")
-            return trace_id, tt_out_trace, *device_inputs
+    def _rerun_prefill_body(self, prepared):
+        """Re-run a prepared variant's prefill body over its already-staged inputs.
 
-    def _capture_trace_prefill_sampling(self, model_id, sampling_batch):
-        """Capture a trace for batched prefill post-processing: norm + lm_head + sampling.
+        Used while recording is deferred, when a warmup call needs a body output but the trace it would
+        replay has not been captured yet. Allocates a fresh output -- safe here, since nothing is captured
+        during the preparation phase -- and the caller drops it when it is done.
+        """
+        return self._prefill_trace_forward(prepared, prepared["device_inputs"])
+
+    def _record_trace_prefill(self, prepared):
+        """Phase 2 of prefill trace setup: capture the trace.
+
+        Allocation-free outside the capture window by construction -- everything it binds to was allocated
+        by :meth:`_prepare_trace_prefill` before any trace existed.
+        """
+        mesh_device = self.model_args[prepared["model_id"]].mesh_device
+        device_inputs = prepared["device_inputs"]
+        # Release our handle on the compile-pass output before capturing, matching the pre-split behaviour.
+        # A deferred warmup caller may still be holding it; that is its own reference to keep or drop.
+        prepared.pop("compile_output", None)
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        tt_out_trace = self._prefill_trace_forward(prepared, device_inputs)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+        logger.info("Done Capturing Prefill Trace")
+        return trace_id, tt_out_trace, *device_inputs
+
+    def _capture_trace_prefill(self, *args, **kwargs):
+        """Prepare and immediately capture a prefill trace.
+
+        Only safe when no other trace is live on the device. :meth:`warmup_model_prefill` drives the
+        two-phase form instead so that every variant is prepared before the first capture; this single-shot
+        form remains for callers (e.g. vLLM) that capture exactly one trace.
+        """
+        return self._record_trace_prefill(self._prepare_trace_prefill(*args, **kwargs))
+
+    def _prepare_trace_prefill_sampling(self, model_id, sampling_batch):
+        """Compile batched prefill post-processing (norm + lm_head + sampling) and allocate its trace input.
 
         Input buffer: [1, 1, sampling_batch, full_dim] host → column-sharded to
         [1, 1, sampling_batch, dim_per_device].
@@ -421,6 +738,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         logits = self.model[model_id]._apply_norm_and_lm_head(dummy_input)
         tt_tokens, tt_log_probs = self.model[model_id].sampling.sample(logits, enable_trace=False)
         ttnn.synchronize_device(mesh_device)
+        # This pass sampled a token off dummy zeros; drop it from the penalty counts again.
+        self.model[model_id].sampling.reset_penalty_counts()
         logger.info("Done compiling prefill sampling")
 
         trace_input = ttnn.from_torch(
@@ -430,15 +749,27 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=-1),
         )
+        return {"model_id": model_id, "input": trace_input}
+
+    def _record_trace_prefill_sampling(self, prepared):
+        """Capture the batched prefill sampling trace prepared by :meth:`_prepare_trace_prefill_sampling`."""
+        model_id = prepared["model_id"]
+        mesh_device = self.model_args[model_id].mesh_device
+        trace_input = prepared["input"]
 
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         logits = self.model[model_id]._apply_norm_and_lm_head(trace_input)
         tt_tokens, tt_log_probs = self.model[model_id].sampling.sample(logits, enable_trace=False)
         ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
         ttnn.synchronize_device(mesh_device)
+        self.model[model_id].sampling.reset_penalty_counts()
         logger.info("Done capturing prefill sampling trace")
 
         return trace_id, (tt_tokens, tt_log_probs), trace_input
+
+    def _capture_trace_prefill_sampling(self, model_id, sampling_batch):
+        """Prepare and immediately capture the batched prefill sampling trace."""
+        return self._record_trace_prefill_sampling(self._prepare_trace_prefill_sampling(model_id, sampling_batch))
 
     def _row_sharded_batched_prefill(
         self,
@@ -519,7 +850,15 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 chunk_page_table = _pad_or_create_page_table(chunk_page_table, chunk_blocks)
 
         if self.trace_id_prefill[trace_key] is None:
-            trace_id, tt_out_trace, *device_inputs = self._capture_trace_prefill(
+            # While recording is deferred this key stays unset until the flush, so a repeated warmup call
+            # (the sampling-parameter sweep hits each seq len several times) must not prepare it again --
+            # that would redo the compile pass and reallocate the trace inputs. Just re-run the body over
+            # the inputs already staged for this variant.
+            already_pending = self._pending_prefill_traces.get(trace_key)
+            if already_pending is not None:
+                return self._rerun_prefill_body(already_pending)
+
+            prepared = self._prepare_trace_prefill(
                 prefill_ids,
                 page_table=page_table,
                 chunk_page_table=chunk_page_table,
@@ -530,6 +869,17 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 user_id=user_id,
                 start_pos=chunk_start_idx,
             )
+            if self._defer_trace_recording:
+                # Capturing now would make every remaining prepare -- the other prefill seq lens and, more
+                # importantly, the long-lived decode trace inputs -- allocate with a trace live on device.
+                # Stash it; warmup_model_prefill records everything once preparation is finished. The
+                # compile pass already computed this warmup call's result, so hand that back directly --
+                # popping it, so only the caller holds it and it is freed at the end of this call rather
+                # than piling up one body output per prepared variant until the flush.
+                self._pending_prefill_traces[trace_key] = prepared
+                return prepared.pop("compile_output")
+
+            trace_id, tt_out_trace, *device_inputs = self._record_trace_prefill(prepared)
             self.trace_id_prefill[trace_key] = trace_id
             self.trace_inputs_prefill[trace_key] = device_inputs
             self.trace_output_prefill[trace_key] = tt_out_trace
@@ -586,7 +936,22 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         return tt_out_trace
 
     # Note: This function is called by vLLM
-    def prefill_forward_text(
+    def prefill_forward_text(self, *args, **kwargs):
+        """Thin wrapper that flushes deferred trace captures once the prefill that triggered warmup ends.
+
+        Warmup leaves recording deferred on purpose so the caller's own prefill can prepare the trace
+        variants warmup cannot enumerate (batched prefill carries batch_size in its trace key). Only the
+        call that armed the deferral flushes it -- the warmup sweep's own nested calls must not.
+        """
+        already_pending = self._deferred_finalize_args is not None
+        try:
+            return self._prefill_forward_text_impl(*args, **kwargs)
+        finally:
+            if not already_pending and self._deferred_finalize_args is not None:
+                finalize_args, self._deferred_finalize_args = self._deferred_finalize_args, None
+                self.finalize_deferred_traces(**finalize_args)
+
+    def _prefill_forward_text_impl(
         self,
         tokens: torch.Tensor,  # All tokens, including the cached ones
         page_table=None,
@@ -626,10 +991,23 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 and getattr(self.model[0], "sampling", None) is not None
             )
 
+            # Warmup leaves trace recording deferred; the wrapper flushes once this call's own prefill has
+            # prepared any variant warmup could not know about (batched prefill).
+            #
+            # warmup_prefill defaults to True, so the warmup sweep's own nested calls land here too. Only
+            # the outermost call may record these -- a nested one would replace the real page table with its
+            # batch-1 mock and finalize would then size the decode trace inputs for the wrong batch.
+            if self._deferred_finalize_args is None:
+                self._deferred_finalize_args = {
+                    "kv_cache": kv_cache,
+                    "page_table": page_table,
+                    "can_sample_on_device": on_device_sampling_enabled,
+                }
             self.warmup_model_prefill(
                 kv_cache=kv_cache,
                 enable_trace=enable_trace,
                 can_sample_on_device=on_device_sampling_enabled,
+                page_table=page_table,
             )
 
         batch_size, batch_seq_len = tokens.shape
@@ -958,6 +1336,19 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     )
 
                     sampling_trace_key = f"sampling_{prefill_seq_len}_{model_id}_{sampling_batch}_{sampling_dp}"
+                    # While recording is deferred, capturing here would put a live trace on device before
+                    # finalize_deferred_traces has prepared anything -- every prepare after it would then be
+                    # an unsafe allocation. Prepare it now, run this prompt eagerly, and capture at flush.
+                    if enable_trace_current_prompt and self._defer_trace_recording:
+                        if (
+                            self.trace_id_prefill_sampling[sampling_trace_key] is None
+                            and sampling_trace_key not in self._pending_prefill_sampling_traces
+                        ):
+                            self._pending_prefill_sampling_traces[
+                                sampling_trace_key
+                            ] = self._prepare_trace_prefill_sampling(model_id, sampling_batch)
+                        enable_trace_current_prompt = False
+
                     if enable_trace_current_prompt:
                         if self.trace_id_prefill_sampling[sampling_trace_key] is None:
                             (
@@ -1058,39 +1449,29 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     )
                     continue
                 else:
+                    # Norm + LM head + (sampling | untilize) run inside the post-prefill trace when one was
+                    # captured for this sampling mode, which keeps this per-prompt path allocation-free.
+                    post_prefill_out = self._run_post_prefill(
+                        model_id, logits, last_token_idx_for_trace, sampling_enabled
+                    )
+                    if post_prefill_out is not None:
+                        self._append_prefill_result(
+                            prefill_results, idx, model_id, last_token_idx, post_prefill_out, sampling_enabled
+                        )
+                        continue
                     logits = self.model[model_id].process_logits_after_prefill_trace(logits, last_token_idx_for_trace)
             else:
                 if return_hidden_states:
                     raise NotImplementedError("return_hidden_states=True requires enable_trace=True")
 
-            if sampling_enabled:
-                tt_tokens, tt_log_probs = self.model[model_id].sampling.sample(
-                    logits,
-                    enable_trace=False,
-                )
-                prefill_results.append(
-                    {
-                        "idx": idx,
-                        "model_id": model_id,
-                        "last_token_idx": last_token_idx,
-                        "logits": [
-                            tt_tokens.cpu(blocking=False),
-                            tt_log_probs.cpu(blocking=False) if tt_log_probs is not None else None,
-                        ],
-                        "sampling": sampling_enabled,
-                    }
-                )
-            else:
-                logits = ttnn.untilize(logits, use_multicore=True)
-                prefill_results.append(
-                    {
-                        "idx": idx,
-                        "model_id": model_id,
-                        "last_token_idx": last_token_idx,
-                        "logits": logits.cpu(blocking=False),
-                        "sampling": sampling_enabled,
-                    }
-                )
+            self._append_prefill_result(
+                prefill_results,
+                idx,
+                model_id,
+                last_token_idx,
+                self._post_prefill_tail(model_id, logits, sampling_enabled),
+                sampling_enabled,
+            )
 
         if len(prefill_results) > 0:
             for elem_idx, res in enumerate(prefill_results):
@@ -1532,7 +1913,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
 
         return tt_output
 
-    def _capture_decode_trace_text(
+    def _prepare_decode_trace_text(
         self,
         tokens,
         current_pos,
@@ -1541,12 +1922,17 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         on_device_sampling=False,
         skip_precompile=False,
     ):
-        """
-        Captures a trace for the decode_forward method.
-        """
+        """Phase 1 of decode trace setup: run the compile pass and stage the persistent trace inputs.
 
+        The trace inputs are long-lived -- refreshed in place for the whole decode loop -- so allocating
+        them after the prefill traces were captured could place them inside a live trace's scratch and let
+        every later prefill replay corrupt them. finalize_deferred_traces runs this before any capture.
+        """
+        # Compile run. Skipped when the caller already has a warmed program cache for this variant
+        # (decode bucketing threads skip_precompile through from main).
+        compile_output = None
         if not skip_precompile:
-            self._decode_forward_no_trace_text(
+            compile_output = self._decode_forward_no_trace_text(
                 tokens,
                 current_pos,
                 page_table=page_table,
@@ -1555,20 +1941,58 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             )
             logger.info("Done Compiling Model")
 
-        # Get inputs ready for trace run
-        device_inputs = []
-        tt_out_trace = []
-        trace_ids = {}
+        # Get inputs ready for trace run. Reuse the buffers _prealloc_decode_trace_inputs staged ahead of
+        # the captures when they exist, so these long-lived tensors never land inside a live trace's scratch.
+        device_inputs = self._prealloc_decode_inputs
+        self._prealloc_decode_inputs = None
         for i in range(self.data_parallel):
             user_page_table = page_table[i] if page_table is not None else None
 
             host_inputs = self.model[i].prepare_decode_inputs_host(
                 tokens[i], current_pos[i], page_table=user_page_table
             )
-            device_inputs_i = copy_host_to_device(host_inputs, mesh_device=self.model_args[i].mesh_device)
-            _mark_trace_buffers_corruptible(self, device_inputs_i)
-            device_inputs.append(device_inputs_i)
 
+            if device_inputs is None:
+                device_inputs = []
+            if i < len(device_inputs):
+                copy_host_to_device(host_tensors=host_inputs, device_tensors=device_inputs[i])
+            else:
+                device_inputs.append(copy_host_to_device(host_inputs, mesh_device=self.model_args[i].mesh_device))
+            # Preserve main's opt-in annotation for models that deliberately overlap decode trace I/O
+            # (only qwen36 sets _tt_allow_decode_trace_buffer_reuse today).
+            _mark_trace_buffers_corruptible(self, device_inputs[i])
+
+        # The on-device sampling trace is captured right after the decode trace, and SamplingGenerator
+        # normally pre-compiles its pipeline just before capturing -- which would allocate with the decode
+        # trace already live. Pre-compile it here instead, against the compile pass' logits (same spec as
+        # the traced output), so only the capture itself is left for the recording phase.
+        for i in range(self.data_parallel):
+            sampling_module = getattr(self.model[i], "sampling", None)
+            if not on_device_sampling or sampling_module is None or compile_output is None:
+                continue
+            sampling_module.precompile(
+                logits=compile_output[i][0],
+                tt_out_tok=self._decode_token_feedback_buffer(self.model[i], device_inputs[i]),
+            )
+
+        return {
+            "device_inputs": device_inputs,
+            "kv_cache": kv_cache,
+            "on_device_sampling": on_device_sampling,
+        }
+
+    def _record_decode_trace_text(self, prepared):
+        """Phase 2 of decode trace setup: capture the trace.
+
+        Allocation-free outside the capture window -- it binds only to buffers allocated by
+        :meth:`_prepare_decode_trace_text`.
+        """
+        device_inputs = prepared["device_inputs"]
+        kv_cache = prepared["kv_cache"]
+        on_device_sampling = prepared["on_device_sampling"]
+
+        tt_out_trace = []
+        trace_ids = {}
         for i in range(self.data_parallel):
             sampling_module = getattr(self.model[i], "sampling", None)
             sampling_trace_enabled = on_device_sampling and sampling_module is not None
@@ -1611,14 +2035,37 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 # rank-2; ttnn.sampling requires a rank-4 preallocated output) —
                 # pass None so sampling allocates its own output.
                 tt_out_tok = self._decode_token_feedback_buffer(self.model[i], device_inputs[i])
-                sampling_module.capture_trace(
-                    logits=tt_out_trace[i],
-                    tt_out_tok=tt_out_tok,
-                    skip_precompile=skip_precompile,
-                )
+                # skip_precompile=True in both cases: either _prepare_decode_trace_text pre-compiled the
+                # sampling pipeline (before any trace was live), or the caller passed skip_precompile and
+                # is asserting the program cache is already warm for this variant.
+                sampling_module.capture_trace(logits=tt_out_trace[i], tt_out_tok=tt_out_tok, skip_precompile=True)
         logger.info("Done Capturing Decode Trace")
 
         return trace_ids, tt_out_trace, *device_inputs
+
+    def _capture_decode_trace_text(
+        self,
+        tokens,
+        current_pos,
+        page_table=None,
+        kv_cache=None,
+        on_device_sampling=False,
+    ):
+        """Prepare and immediately capture the decode trace.
+
+        Only safe when no other trace is live on the device. The demo path pre-captures via
+        :meth:`warmup_model_decode` during warmup; this single-shot form is the fallback for callers that
+        reach decode without having warmed up.
+        """
+        return self._record_decode_trace_text(
+            self._prepare_decode_trace_text(
+                tokens,
+                current_pos,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                on_device_sampling=on_device_sampling,
+            )
+        )
 
     def _decode_forward_trace_text(
         self,
@@ -2992,6 +3439,15 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                         sampling_module.reset_trace()
                     except Exception:
                         pass
+
+            # Release post-prefill (norm + LM head) traces
+            if hasattr(self, "trace_id_post_prefill"):
+                for model_id, trace_id in self.trace_id_post_prefill.items():
+                    if trace_id is not None:
+                        try:
+                            ttnn.release_trace(self.model_args[model_id].mesh_device, trace_id)
+                        except Exception:
+                            pass  # Ignore errors during cleanup
 
             # Release decode traces
             decode_trace_stores = []

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -151,6 +151,9 @@ class Transformer(LightweightModule):
             prefetcher=prefetcher,
         )
 
+        # Device buffers for extract_last_tokens_batched_prefill, keyed by (target_batch, dim). See there.
+        self._batched_last_token_buffers = {}
+
         # Initialize on-device sampling if supported
         # Sampling on device is supported only if each device has maximum logits size of 64*1024
         sampling_splits = self.args.num_devices if list(self.mesh_device.shape) != [1, 1] else 2
@@ -164,13 +167,24 @@ class Transformer(LightweightModule):
         else:
             self.sampling = None
 
-    def process_logits_after_prefill_trace(self, logits, last_token_idx):
+    def slice_last_token_block(self, x, last_token_idx, out=None):
+        """Slice out the 32-row block of a prefill body output that contains ``last_token_idx``.
+
+        Pass ``out`` to write into a buffer that was allocated before any trace was captured. The slice
+        bounds are host-side arguments, so a single fixed ``[1, 1, 32, dim]`` buffer serves every prompt
+        length and every position, and the op allocates nothing -- which is what lets the norm + LM head
+        that follow be captured as a trace instead of run eagerly. See Generator._prepare_post_prefill_trace.
+        """
         get_last_token = (last_token_idx // 32) * 32
-        logits = ttnn.slice(
-            logits,
+        return ttnn.slice(
+            x,
             (0, 0, get_last_token, 0),
-            (1, 1, get_last_token + 32, logits.shape[-1]),
+            (1, 1, get_last_token + 32, x.shape[-1]),
+            output_tensor=out,
         )
+
+    def process_logits_after_prefill_trace(self, logits, last_token_idx, last_token_buffer=None):
+        logits = self.slice_last_token_block(logits, last_token_idx, out=last_token_buffer)
         logits = self._apply_norm_and_lm_head(logits)
         return logits
 
@@ -236,13 +250,26 @@ class Transformer(LightweightModule):
             padded_combined[:, :, :padded_batch, :] = combined
             combined = padded_combined
 
-        user_tokens = ttnn.from_torch(
-            combined,
-            device=self.mesh_device,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
-        )
+        # Reuse one device buffer per shape instead of allocating on every batched prefill: this runs after
+        # the trace captures, where a fresh allocation can land inside a live trace's scratch. The first
+        # call still allocates, but that happens during the warmup prefill, before anything is captured.
+        mapper = ttnn.ShardTensorToMesh(self.mesh_device, dim=-1)
+        key = (int(target_batch), int(combined.shape[-1]))
+        user_tokens = self._batched_last_token_buffers.get(key)
+        if user_tokens is None:
+            user_tokens = ttnn.from_torch(
+                combined,
+                device=self.mesh_device,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=mapper,
+            )
+            self._batched_last_token_buffers[key] = user_tokens
+        else:
+            host = ttnn.from_torch(
+                combined, device=None, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, mesh_mapper=mapper
+            )
+            ttnn.copy_host_to_device_tensor(host, user_tokens)
         return user_tokens
 
     def process_logits_after_batched_prefill(self, hidden_states, last_token_idx_list, padded_batch, prefill_seq_len):
@@ -285,12 +312,7 @@ class Transformer(LightweightModule):
         Returns hidden states (after norm) instead of logits.
         Used for embedding models that need hidden states rather than logits.
         """
-        get_last_token = (last_token_idx // 32) * 32
-        hidden_states = ttnn.slice(
-            hidden_states,
-            (0, 0, get_last_token, 0),
-            (1, 1, get_last_token + 32, hidden_states.shape[-1]),
-        )
+        hidden_states = self.slice_last_token_block(hidden_states, last_token_idx)
         # Apply norm (this is the final layer norm before LM head)
         hidden_states = self.norm(hidden_states, mode="prefill")
         # Convert to row major layout for output (but don't apply LM head)

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -287,16 +287,6 @@ class Prefetcher(LightweightModule):
         self.ring_size = self.num_receiver_cores * self.num_senders
         self.dram_banks = self.core_config.dram_banks
 
-        ### Full compute grid, used as the single prefill sub device. Referenced as
-        ### ``self.all_core_range_set`` by the Mode.PREFILL branch of the sub-device setup below, which
-        ### previously read an attribute that was never assigned -- latent until a caller actually
-        ### switched the prefetcher into PREFILL mode (AttributeError: 'Prefetcher' object has no
-        ### attribute 'all_core_range_set').
-        _grid = self.mesh_device.compute_with_storage_grid_size()
-        self.all_core_range_set = ttnn.CoreRangeSet(
-            [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(_grid.x - 1, _grid.y - 1))]
-        )
-
         ### Worker core ranges for the worker sub device
         if self.receiver_mapping_override:
             grid = self.mesh_device.compute_with_storage_grid_size()

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -287,6 +287,16 @@ class Prefetcher(LightweightModule):
         self.ring_size = self.num_receiver_cores * self.num_senders
         self.dram_banks = self.core_config.dram_banks
 
+        ### Full compute grid, used as the single prefill sub device. Referenced as
+        ### ``self.all_core_range_set`` by the Mode.PREFILL branch of the sub-device setup below, which
+        ### previously read an attribute that was never assigned -- latent until a caller actually
+        ### switched the prefetcher into PREFILL mode (AttributeError: 'Prefetcher' object has no
+        ### attribute 'all_core_range_set').
+        _grid = self.mesh_device.compute_with_storage_grid_size()
+        self.all_core_range_set = ttnn.CoreRangeSet(
+            [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(_grid.x - 1, _grid.y - 1))]
+        )
+
         ### Worker core ranges for the worker sub device
         if self.receiver_mapping_override:
             grid = self.mesh_device.compute_with_storage_grid_size()


### PR DESCRIPTION
## ✅ Status: validated on the rebased branch

Rebased onto latest main. All regressions this branch introduced have been found and fixed, and
GPT-OSS is verified clean on both Blackhole SKUs from #52176 — including `bh_galaxy` — **after** the
rebase.

| Check | Result |
|---|---|
| GPT-OSS-120B `bh_galaxy` | **clean** — `splits=8`, `On-device sampling unavailable` count 0 |
| GPT-OSS-120B `bh_quietbox_2` | clean |
| GPT-OSS-120B `wh_galaxy_perf` | clean |
| Llama-3.1-8B `bh_quietbox_2` / DP / llmbox / p300 | pass |
| Mistral-7B `wh_n150` | pass |
| Gemma-4-12B, Gemma-3-4B, Gemma-3-27B, Qwen VL family | pass |
| Tier 1 E2E | 20 passed |
| Tier 2 E2E | 24+ passed |

Runs: [Tier 1](https://github.com/tenstorrent/tt-metal/actions/runs/31811096809) ·
[Tier 2](https://github.com/tenstorrent/tt-metal/actions/runs/31811102778) ·
[bh_galaxy](https://github.com/tenstorrent/tt-metal/actions/runs/31818550602) ·
[Mistral](https://github.com/tenstorrent/tt-metal/actions/runs/31816528778)

Remaining red jobs in those sweeps are all pre-existing or infrastructure, itemised at the bottom.

## Ticket

Fixes #52176 — GPT-OSS garbage output on multi-device Blackhole. **Still reproducing on main** as of
2026-08-14 (`bh_quietbox_2` scheduled run), i.e. live for over two months.

## Attribution

The first four commits are **@ifabijanic-tt's work**, taken from `llama_8b_tracing_fix` and rebased
with authorship preserved. That branch had no PR. The remaining commits are follow-on fixes for
regressions the full sweeps surfaced. @ifabijanic-tt please take this over or say if you'd rather
close it in favour of your own.

## Root cause

On-device sampling intermittently returned an **out-of-range token ID** while a decode trace was
live. Measured by reading logits to host and comparing host argmax against the device-sampled token:

```
step=0   host_argmax=35644    device_sampled=35644        AGREE
step=1   host_argmax=200008   device_sampled=3214098612   DIVERGE
```

`vocab_size` is 201088, so `3214098612` is uninitialized memory read as `uint32`. The logits are
correct at every step — the sampling op's output buffer is what gets corrupted. One bad token fed
back gives an out-of-range embedding lookup that poisons the context, which is why the symptom looked
like gradual degradation rather than a single fault.

`2910e4aa1c8` addresses exactly this: buffers otherwise *"allocated during the decode loop, inside
this trace's scratch, and be overwritten on every replay"*.

## Rebase: how this interacts with main's `_mark_trace_buffers_corruptible`

Main has since grown its own mechanism in the same code, so it's worth stating how the two relate.
They are **complementary, not competing**, and both are preserved here:

- `_mark_trace_buffers_corruptible` is opt-in behind `_tt_allow_decode_trace_buffer_reuse`, and only
  `Qwen36ForCausalLM` sets it — for decode bucketing, where several traces stay live and buffer
  overlap is *deliberate*. It calls `ttnn.mark_corruptible` only if that attribute exists, and it does
  not exist in ttnn yet, so it is currently a no-op on hardware. It **annotates** intended overlap.
- This branch **prevents** long-lived buffers from being allocated inside a live trace's scratch in
  the first place. That is the actual #52176 fix, and it is why main's mechanism does not fix the bug.

Conflict resolutions (only Ivan's first commit conflicted; the other ten applied cleanly):

- kept main's `skip_precompile` parameter and guard around the compile pass, wrapped over the
  `compile_output` capture. `compile_output` is now `None` on the skip path, so the sampling
  pre-compile loop is guarded against it.
- kept the prealloc-reuse staging and re-added main's `_mark_trace_buffers_corruptible` call on the
  staged trace inputs.
- `capture_trace(..., skip_precompile=True)` is correct in both cases: either
  `_prepare_decode_trace_text` pre-compiled the sampling pipeline before any trace was live, or the
  caller passed `skip_precompile` and is asserting the cache is already warm.
- destructor cleanup is a union: main releases bucket-namespace sampling traces, this branch releases
  the post-prefill traces.

## Follow-on fixes in this PR

The restructuring touches shared code (`models/tt_transformers/tt/generator.py`,
`models/common/sampling/`), so it reaches every tt_transformers model. `model=all` sweeps found four
regressions, each fixed here:

1. **Trace capture** — compile pass ran against transient buffers, capture against persistent ones, so
   uncached programs loaded inside the capture window: `mesh_workload.cpp:153 !is_capturing_trace`,
   "Cannot load new binaries during trace capture". Hit Gemma-4. Fixed by warming the program cache
   over the persistent inputs before capture.
2. **Trace region** — the added post-prefill trace raises trace-region demand for every model.
   Mistral-7B `wh_n150` fell 2048 B per bank short; raised 25 MB → 32 MB.
   **Reviewers: any model close to its trace-region limit may need the same. The model/SKU matrix is
   wider than these sweeps cover.**
3. **Prefetcher, PREFILL mode** — the deferred capture restored `switch_mode(Mode.PREFILL)`, reaching
   `Prefetcher.init()`'s PREFILL branch, which has never executed on main (main only ever calls
   `switch_mode(Mode.DECODE)`) and is not functional.
4. **Prefetcher, sub-devices** — hoisting decode setup into the prefill phase is fundamentally
   incompatible with the prefetcher's per-mode sub-device managers: staying in DECODE leaves prefill
   running against decode sub-devices (`program.cpp:2205`, "Kernel group cores do not match sub device
   cores"). Gated the hoist off for prefetcher-driven models, which keep main's original path. Costs
   nothing this branch targets — the prefetcher is Blackhole-only, GPT-OSS does not use it, and the
   Llama-70B-Galaxy work here is Wormhole. **Scope limit worth knowing: Blackhole prefetcher models
   get none of the trace-allocation benefit.**

The prefetcher's dead `Mode.PREFILL` sub-device path is untouched and worth a separate fix by its
owner (unassigned `all_core_range_set`; supplying one trips a CB/L1 clash).

## Validation (pre-rebase)

| Check | Result |
|---|---|
| GPT-OSS-120B `bh_galaxy` | clean ×2 — the SKU from the original report |
| GPT-OSS-120B `bh_quietbox_2` | clean ×5 |
| GPT-OSS-120B `wh_galaxy_perf` | clean — `batch128` + `prefill_128`, no regression |
| GPT-OSS-20B (p150 / quietbox / llmbox) | pass |
| Llama-3.1-8B (quietbox, DP, llmbox, p300) | pass |

Every clean GPT-OSS run was checked against a silent fallback: `On-device sampling unavailable` count
0, `On-device sampling initialized (vocab_size=201088, splits=4)` present. These are the genuinely
failing configuration — traced decode **and** on-device sampling — now producing correct output.

## Remaining failures, all pre-existing or infrastructure

- `Gemma-4-12B [bh_quietbox_2]` — `PCC too low: 0.9378978280024141`, byte-identical on main
- `Gemma-4-31B [wh_llmbox_perf]` — job timeout; fails on main in 3 of 4 recent scheduled runs
- `Shallow UNet`, TT-DiT Flux / LTX / Wan, SDXL — import none of the changed modules
- `Llama-3.3-70B Galaxy` — read-only `/mnt/MLPerf` cache write; fails identically on main
- Various galaxy jobs — `TT_FATAL: requested_size <= system_size` (4 devices for a 32-device mesh)

Infrastructure noise was heavy: container-startup faults (`Value cannot be null (ContainerId)`),
`HttpClient.Timeout`, 20-minute checkout timeouts, and one runner (`qb2-120-p06t02`) that failed nine
jobs across two sweeps. Worth attention independently of this PR — especially the `bh_galaxy` label,
which repeatedly schedules 32-device jobs onto 4-device hosts, and which is part of why this bug went
unnoticed for eight weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/52176-gpt-oss-bh-trace-alloc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/52176-gpt-oss-bh-trace-alloc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/52176-gpt-oss-bh-trace-alloc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/52176-gpt-oss-bh-trace-alloc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/52176-gpt-oss-bh-trace-alloc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/52176-gpt-oss-bh-trace-alloc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/52176-gpt-oss-bh-trace-alloc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/52176-gpt-oss-bh-trace-alloc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/52176-gpt-oss-bh-trace-alloc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/52176-gpt-oss-bh-trace-alloc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/52176-gpt-oss-bh-trace-alloc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/52176-gpt-oss-bh-trace-alloc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/52176-gpt-oss-bh-trace-alloc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/52176-gpt-oss-bh-trace-alloc-fix)