### PR TITLE
Qwen3-32B Blackhole Galaxy decode: prefetcher bring-up + fused CCL ports (44.8 -> 56.9 tok/s/user)

### DIFF
--- a/BH_FUSED_RS_MATMUL_WIP.md
+++ b/BH_FUSED_RS_MATMUL_WIP.md
@@ -3,7 +3,7 @@
 Status doc for resuming later. Branch: `mgiermakowski/bh-fused-test`
 (branched from `mgiermakowski/bh-qwen-prefetcher`, which is the working prefetcher-only baseline).
 
-Last updated: 2026-08-05.
+Last updated: 2026-08-07 (deadlock FIXED — see "FIXED" section; e2e demo validation in progress).
 
 ---
 
@@ -20,12 +20,12 @@ fused matmul + reduce-scatter op for the MLP FF1/FF3, for maximum decode perf.
 ## TL;DR of current state
 
 - The fused op is integrated (MLP FF1/FF3), compiles, and is **numerically correct**:
-  decode PCC **0.9978 / 0.9979** for tokens 0 and 1, matching the unfused baseline (~0.9975).
-- It **deadlocks on the 3rd decode token (token index 2)**, every run, deterministically.
-- The deadlock is **not** in the fused op's own kernels — it is in a *downstream* op (a
-  `ttnn.slice` reader, or a standard `all_gather`) running on cores the fused ring matmul used.
-  The fused op leaves persistent L1 / circular-buffer / semaphore state that corrupts a later op,
-  and it accumulates until it deadlocks on iteration 3.
+  decode PCC **~0.9977** per token, matching the unfused baseline (~0.9975).
+- The former token-2 deadlock is **FIXED** (2026-08-07): it was NOT the fused op — `ttnn.pad`'s
+  row-major sharded program factories placed CBs on the full device grid, and dispatch multicast
+  the CB config onto the prefetcher sender column, corrupting the cached DramPrefetcher kernel
+  text. See the "FIXED" section near the bottom for the full story.
+- `test_qwen_decoder.py` passes all 10 decode iterations with prefetcher + fused op enabled.
 
 ## How to reproduce
 
@@ -191,7 +191,143 @@ tokens 0/1: the counter was still consistent at those wait points.
 Probe script: `/home/mgiermak/probe_dispatch_wait.py` (run under the broker while hung).
 Artifacts: `/home/mgiermak/triage_fused_hang.txt` (4 MB), `/home/mgiermak/qwen_fused_hang3.log`.
 
-## Suggested next steps
+## BREAKTHROUGH 2 (2026-08-07): the dispatch deficit is a SYMPTOM — token-1's DramPrefetcher never exits
+
+Fresh repro + three new frozen-mesh probes (`probe_worker_mailboxes.py`, `probe_gcb_credits.py`,
+fixed `probe_dispatch_wait.py`) overturned the "one worker program loses its 100 done-signals"
+reading:
+
+1. **Worker launch-mailbox dump (all 130 tensix cores, device 0)**: every one of the 100 worker
+   sub-device cores is `DONE` at `launch_msg_rd_ptr=2`, uniformly. `host_assigned_id` in the launch
+   ring == the ttnn op id (`fetch_and_increment_device_operation_id`), which lets us map slots to
+   ops: the decoder test dispatches 53 ops/token, prefetchers are op 3 (token 0), 56 (token 1),
+   109 (token 2). Workers consumed ALL 106 worker programs of tokens 0-1 (stream 49 = 10600 = 106
+   x 100, exactly). No worker program lost any dones.
+2. **Prefetcher (col-0) mailboxes**: slot 0 (op 3, token-0 prefetcher) consumed -> token 0 drained
+   cleanly. The cores are in `GO` at rd_ptr=1 — **still running op 56, token-1's
+   DramPrefetcherOperation** — with token-2's op 109 launch message pre-written at slot 2, its GO
+   forever queued in dispatch_s behind op 56's completion (gos are fully serialized per sub-device:
+   each go's `wait_count` = expected-workers-completed *before* that program).
+3. **Global-CB credits (scanned config page @0xa9200, counters @0xa9240)**: perfectly balanced —
+   every sender (0,0)-(0,7) shows `pages_sent == pages_acked == 216832` for all 3 receivers, and
+   216832 = 2 x 108416 = exactly two tokens' worth. **The prefetcher is NOT starved by the fused op
+   under-consuming weights**: token-1's streaming completed and was fully acked.
+
+So the failure chain is: token-1 `DramPrefetcherOperation` finishes streaming but **never exits its
+kernels** (core stays GO) -> token-2's prefetcher go can't be sent (dispatch_s serialized) ->
+dispatcher's config-buffer wait for a token-2 worker program (stream 49 target 10700; some devices
+10800) never satisfies -> mesh-wide stall. The worker-side "deficit" was just the not-yet-sent go.
+
+Where can the writer/reader pair be stuck AFTER all pushes are acked? The exit path is:
+`remote_cb_sender_barrier` (polls the exact L1 words the probe read as equal -> should pass) ->
+`update_remote_cb_config_in_l1` -> `noc_async_atomic_barrier` -> writer pushes `sync_cb` ->
+reader's final `cb_wait_front(sync_cb)` (reader_dram.cpp:114) -> exit. The old triage found the
+reader parked at that final sync wait, i.e. the WRITER never delivered the exit credit — despite
+balanced remote credits. Current suspicion is therefore in the writer's post-stream sequence or
+the reader/writer local-CB handshake state across cached re-runs, possibly corrupted by something
+the fused-op program does to shared L1 state on the *receiver* columns (the prefetcher's
+`update_remote_cb_config_in_l1` persists GCB pointers for the next program; the fused matmul does
+the same from the receiver side).
+
+Why the baseline doesn't hang: identical prefetcher, identical worker consumption totals — the
+only delta is the fused matmul+RS program structure. Token 0 (program-cache miss) drains; the hang
+requires the cached-run token 1. A triage callstack of the sender cores' BRISC (writer_l1) +
+NCRISC (reader_dram) on the frozen mesh is queued (run script now includes a parallel tt-triage
+pass) to pin the exact parked line.
+
+Probe artifacts: `/home/mgiermak/mailbox_probe4.log` (+5), `/home/mgiermak/gcb_credits_probe5.log`,
+`/home/mgiermak/dispatch_probe5.log`, `/home/mgiermak/inspector_fused_hang5/`.
+
+## ROOT CAUSE FOUND (2026-08-07, evening): kernel-TEXT CORRUPTION on the prefetcher sender cores
+
+New probes (`probe_reader_pc.py`, `probe_sync_cb.py`) on the frozen mesh nailed the mechanism:
+
+1. **The writer_l1 BRISC finished cleanly** (parked in firmware `wait_ncrisc_trisc`, PC moving) and
+   **delivered the exit credit**: the reader-writer sync CB (stream 3) shows
+   `pages_received=1, pages_acked=0` on every sender core. No credit bug.
+2. **The reader_dram NCRISC is HARD-FROZEN at PC 0xbad4** (identical, non-moving, on all 8 senders
+   of every device).
+3. From the launch mailbox, op 56's kernel config base is 0xad80 with NCRISC text offset +0x940 →
+   **reader text loads at L1 [0xb6c0, 0xbb78)**. Byte-diffing L1 against the cached
+   `reader_dram/.../ncrisc.elf.xip.elf` shows **68 corrupted words at L1 [0xb9c0, 0xbad0)**
+   (ELF VMA 0x6450-0x655c) — exactly the code for the tail of the block loop, the final barrier,
+   and the `cb_wait_front/cb_pop_front(sync_cb)` exit handshake. The frozen PC (VMA 0x6564) sits
+   just past the corrupted region: the reader streamed all 3600 blocks fine (local CB counters
+   3600/3600), then walked into clobbered instructions and died before consuming the exit credit.
+4. **The corrupting payload is a kernel-config CB TABLE**, not data: 17 four-word records with
+   entries {CB0: addr 0xa0680, 8 KB, 32 pages of 256 B}, {CB1: addr 0x1b380 (= L1 unreserved base),
+   256 B, 1 page}, {CB16: addr 0xa3fc0, 8 KB, 32 pages of 256 B}, rest zero.
+5. **The same 68 words appear at the SAME address 0xb9c0 on worker core (4,0)** (a fabric-mux core
+   of the fused program), where they are LEGITIMATE program config. Ring matmul cores (1-3,0) and
+   RS writer cores (6,0)/(9,0) have different content there. So a kernel-config multicast for some
+   worker program's kernel group is ALSO being sent to logical cores (0,0)-(0,7) — the prefetcher
+   senders — where 0xb9c0 lands inside op 56's kernel text.
+6. Why only token 2: config-ring layout luck. Op 3 (token 0) text sat at [0xa8c0, 0xadd8) — the
+   0xb9c0 write missed it. Op 56 (token 1, cached re-dispatch) text at [0xb6c0, 0xbb78) — hit.
+
+Suspicious detail: (0,0)-(0,7) is EXACTLY what `choose_worker_cores(8 workers, sub-device 0)`
+returns — and sub-device 0 is the PREFETCHER sub-device. I.e. some CCL helper inside the fused op
+(or an op it pulls in) is choosing cores with a defaulted `sub_device_id` (`get_sub_device_ids().at(0)`)
+and creating CBs there. Kernels get sub-device validation; CBs do not, so this slips through and
+dispatch happily multicasts the CB config onto foreign cores.
+
+A temporary host-side debug log (`TT_DBG_COL0_CB=1`, in `ProgramImpl::add_circular_buffer_`) is in
+place to identify the exact program; map its id via inspector `kernels.yaml`.
+
+## FIXED (2026-08-07, night): the offender was `ttnn.pad` (row-major sharded factories), not the fused op
+
+The `TT_DBG_COL0_CB` hunt (with C++ backtrace) caught it immediately. Two per-token programs
+created CBs on the FULL 12x10 grid `[0-0 - 11-9]`, i.e. including prefetcher sender column 0:
+
+```
+COL0-CB: program=320 range=[0-0 - 11-9] total_size=8192 globally_allocated=true   <- input shard CB
+COL0-CB: program=320 range=[0-0 - 11-9] total_size=8192 globally_allocated=true   <- output shard CB
+COL0-CB: program=320 range=[0-0 - 11-9] total_size=256  globally_allocated=false  <- pad-value stick CB
+backtrace: ... PadDeviceOperation ... pad_impl ... invoke_rm ... ttnn::to_layout ...
+```
+
+That is EXACTLY the corrupting CB table found at 0xb9c0 (CB0 8 KB / CB1 256 B / CB16 8 KB).
+The call chain is `ttnn.to_layout` → `ttnn::pad` (row-major sharded path) in the per-token
+host input prep (rot-mat / page-table massaging), NOT the fused op. It was always there; the
+fused op only changed the config-ring layout so token-1's prefetcher reader text happened to
+land under the stray 0xb9c0 write (see "why only token 2" above).
+
+Root bug: `pad_rm_sharded_height_only_program_factory.cpp` and
+`pad_rm_sharded_width_only_program_factory.cpp` placed all three CBs on
+`CoreRange({0,0}, compute_with_storage_grid_size - 1)` (the whole device grid) while their
+kernels only run on the shard grids. Dispatch multicasts CB configs to every CB core — including
+column 0, which belongs to the *prefetcher sub-device* whose kernel-config ring uses the same
+addresses for kernel TEXT. CBs get no sub-device validation, so this silently corrupted the
+cached DramPrefetcher `reader_dram` kernel.
+
+Fix (both factories): place CBs only on `input_shard_grid.merge(output_shard_grid)`.
+
+Validation: `test_qwen_decoder.py` with `QWEN_BH_PREFETCHER=1 QWEN_BH_FUSED_ASYNC_RS_MATMUL=1`
+now passes **all 10 decode iterations**, PCC ~0.9977 each token. No more token-2 deadlock.
+The temporary `TT_DBG_COL0_CB` instrumentation has been removed.
+
+## E2E results with the fix (2026-08-07, night)
+
+Full demo (`text_qwen_demo.py -k batch-32 --max_generated_tokens 64`, prefetcher + fused):
+- **PASSED**, all 64 decode iterations, no hang.
+- **47.82 tok/s/user average** (1530 tok/s throughput, 20.91 ms/iter) vs **45.98 t/s/u** for the
+  unfused control run on the same build — **+4% decode perf** from the fused op
+  (vs the older 44.8 t/s/u baseline number: +6.7%).
+
+Accuracy (`test_qwen_accuracy.py`, 511 teacher-forced tokens):
+- fused:   Top-1 **27.2%**, Top-5 34%
+- unfused: Top-1 **27.4%**, Top-5 34% (same build, same flags minus fusion)
+- => The fused op does NOT regress accuracy — it exactly matches the unfused prefetcher path.
+
+**Open issue (pre-existing, NOT caused by the fused op):** the prefetcher decode path
+(`QWEN_BH_PREFETCHER=1 QWEN_BH_UNFUSED_CCL=1`) scores ~27% Top-1 on this accuracy test,
+uniformly from the first token window (20-43% per 100-token window; no drift over time), and demo
+text is garbled. The 96%-Top-1 runs from July were on the non-prefetcher e2e branch. Wrong tokens
+repeat a small set of junk vocab entries (脏, _CAMERA, satu, 漂) which smells like corrupted logits
+for specific vocab shards (lm_head gather / fast_reduce_nc path?). Needs its own investigation on
+the prefetcher baseline branch, independent of this fused-op work.
+
+## Suggested next steps (2026-08-06 list — items 1-2 RESOLVED by Breakthrough 2)
 
 1. Identify the missing program slot. Only ~3 worker programs run between token-1's PCC readback
    (which waited successfully) and the stuck op 57 (two Embeddings + possibly a reshard) — but if

--- a/BH_FUSED_RS_MATMUL_WIP.md
+++ b/BH_FUSED_RS_MATMUL_WIP.md
@@ -450,10 +450,48 @@ trace capture trips "static circular buffers clash with L1 buffers" (lowest buff
 To revive: shrink to a single cos/sin pair (q and k bounds are identical => 2 tensors, 16 KB) or
 carve headroom out of the ring matmul CB budget.
 
-### Remaining ideas towards ~55 t/s/u
+### Fix landed: distributed force-argmax (+2.1 t/s/u, 2026-08-08)
 
-- Distributed local argmax: per-column argmax over the 19456-wide shard + tiny cross-column
-  combine would cut sampling from ~2.5 ms to ~0.35 ms total (saves another ~1.3 ms vs the wide
-  grid's 0.85 ms argmax + full-width gather/untilize).
+`tt_sampling._distributed_force_argmax` (default on via `QWEN_BH_DIST_ARGMAX`, BH prefetcher path
+only): each column device argmaxes/maxes its local 32 x 19456 shard, only the per-column
+(value, index) candidate tiles are gathered (1-link `all_gather_async`, worker sub-device), the
+winner column comes from a small argmax over the gathered values, and the token id is
+reconstructed exactly with int32 SFPU arithmetic (hi/lo byte split for the TF32-safe one-hot
+select, then `<< 8 | lo` + column offset — see the TF32 note in the code).
+
+Demo-flow engagement gotcha: the galaxy generator passes the decode trace's frozen token-input
+buffer (RM uint32 [1,1,1,32]) as `tt_out_tok`, and the first cut of the guard bailed on any
+caller-provided buffer — so the first "with dist argmax" perf run (19.48 ms @ 51.33) actually ran
+the old path. The write-back is now a no-op `ttnn.bitwise_or(tok, 0, output_tensor=tt_out_tok,
+sub_core_grids=worker_grid)`: `ttnn.copy` can't be used because its factory grids from core
+(0,0), which under the split senders/worker sub-device manager lands the copy on the senders
+sub-device and races the worker-sub-device producers under trace replay (same failure mode as
+the unpinned all_gather). binary_ng honors `sub_core_grids` directly and supports RM uint32.
+Verified by `test_qwen_sampling_argmax.py` (now passes a demo-style `tt_out_tok`; 8 trace
+replays, 0 mismatches).
+
+Result (batch-32, 64 tokens): **18.93 ms @ 52.82 tok/s/user (1690 tok/s)** — up from
+19.73 ms @ 50.68.
+
+Also landed: rotary K-share (`compute_decode_rot_slices` reuses the Q cos/sin slices for K when
+the bounds differ only in the heads dim) — removes 2 slice + 2 to_layout ops per layer on the
+per-layer (non-hoisted) path.
+
+### Rotary hoist retry with K-share: still 19 KB short (2026-08-08)
+
+With the K-share halving the cached slices to one cos/sin pair, `QWEN_BH_HOIST_ROT_SLICES=1`
+now fails trace capture with lowest buffer 425088 < 444480 (was 365568-392320 with 4 tensors) —
+the deficit is now exactly the persistent footprint (2 x 8 KB shards + alignment). L1 buffer
+allocation is lock-step across banks, so any persistent addition lowers the global floor by its
+size regardless of allocation order or shard placement; the only remaining lever is carving
+>=19392 B out of the ring FF matmul CB budget (region ends 444480 on cols 1-6), which is
+perf-critical matmul surgery. Parked again.
+
+### Remaining ideas towards ~55 t/s/u (need ~0.75 ms)
+
 - The ~42 us stalls before reduce_scatter in ~9 layers/token; the QK-norm reshard sandwich
   (4 reshards/layer); the 2-op distributed-norm gather chains (WH uses fused RMSAllGather).
+- ~5 TypecastDeviceOperations/layer (bf16<->bfp8, DRAM interleaved 128x128) of unclear origin
+  (not in the model python; likely inside composite CCL/reshard paths) — ~1-1.5 ms/token
+  including gaps in the 2026-08-07 capture; needs a fresh profile to attribute.
+- Fresh tracy profile of the 18.93 ms build queued (qwen_trace_pf_b32_v3) to re-rank the above.

--- a/BH_FUSED_RS_MATMUL_WIP.md
+++ b/BH_FUSED_RS_MATMUL_WIP.md
@@ -487,11 +487,49 @@ size regardless of allocation order or shard placement; the only remaining lever
 >=19392 B out of the ring FF matmul CB budget (region ends 444480 on cols 1-6), which is
 perf-critical matmul surgery. Parked again.
 
-### Remaining ideas towards ~55 t/s/u (need ~0.75 ms)
+### Fresh profile of the 18.93 ms build (qwen_trace_pf_b32_v3, 2026-08-08)
 
-- The ~42 us stalls before reduce_scatter in ~9 layers/token; the QK-norm reshard sandwich
-  (4 reshards/layer); the 2-op distributed-norm gather chains (WH uses fused RMSAllGather).
-- ~5 TypecastDeviceOperations/layer (bf16<->bfp8, DRAM interleaved 128x128) of unclear origin
-  (not in the model python; likely inside composite CCL/reshard paths) — ~1-1.5 ms/token
-  including gaps in the 2026-08-07 capture; needs a fresh profile to attribute.
-- Fresh tracy profile of the 18.93 ms build queued (qwen_trace_pf_b32_v3) to re-rank the above.
+Capture: batch-32 demo, 6 tokens, QWEN_PROFILE_DRAIN=1 under tracy. Device 16, decode trace id 9
+(2404 ops/replay = one token) + sampling trace id 10 (19 ops/replay — the distributed argmax).
+Analysis from `cpp_device_perf_report.csv` only (the 44 GB `profile_log_device.csv` post-process
+step is unnecessary and was skipped; report CSV is written incrementally by the drain).
+
+Union-of-intervals busy per token = 18.87 ms == the measured wall (18.93), i.e. no dispatch
+holes are left; the time is in the serialized op chain. Critical-path attribution (increment
+each op adds to the busy frontier, one full token):
+
+| op | n/token | critical | note |
+|---|---|---|---|
+| MatmulReduceScatterAsync (fused FF pair) | 128 | 5.43 ms | FF3 kern ~62 us: gated by prefetcher DRAM stream |
+| Matmul (QKV / attn-out / FF2 / lm_head) | 193 | 2.85 ms | QKV kern 41 us, attn-out 38 us |
+| AllReduceAsync | 192 | 2.79 ms | 3/layer, 14.5 us critical each (FW window ~30-47 us incl. wait) |
+| LayerNorm | 386 | 1.83 ms | 6/layer: 2 distributed-norm pre/post pairs + 2 QK norms |
+| AllGatherAsync | 100 | 1.22 ms | |
+| Reshard | 671 | 1.02 ms | 10.5/layer, ~1.5 us each |
+| SdpaDecode | 64 | 0.68 ms | |
+| AllGather (legacy, 2-core norm-stats gather) | 74 | 0.64 ms | 8.6 us critical each — fabric-latency bound |
+| BinaryNg | 198 | 0.56 ms | kern 1.3-2.8 us; FW window up to 64 us = waiting for all 100 cores free |
+| everything else (incl. sampling ArgMax 0.20) | | ~1.9 ms | sampling total now ~0.4 ms |
+
+### Remaining ideas towards ~55 t/s/u (need ~0.75 ms), effort-ranked
+
+- Distributed-norm chain (reshard + LN-pre + 2-core legacy AllGather + LN-post + reshard, x2 per
+  layer): LN 1.83 + legacy AG 0.64 + a chunk of the reshards ~= 2.5-3 ms/token. WH fuses this
+  into RMSAllGather (`fused_rms_minimal`), whose 1D-multicast writer no-ops on the BH 2D-torus
+  fabric — porting it is the same class of kernel co-design as the fused RS matmul was, and the
+  single biggest lever left (~1.5-1.8 ms -> ~57-58 t/s/u by itself). Merely swapping the 2-core
+  legacy stats gather for all_gather_async is NOT a win: the async gathers average the same
+  ~12 us critical (fabric-latency bound at this size).
+- QK-norm reshard sandwich (4 reshards + 2 LNs per layer on 16/8-core grids).
+- Rotary hoist: blocked on 19392 B of L1 under the ring-matmul CB ceiling (see above); would
+  need CB-budget surgery on the gathered matmul.
+- FF3 kernel time (62 us vs FF1's 21 us) is prefetcher-DRAM-stream bound — check
+  enable_performance_mode / reader tuning headroom before touching anything else.
+
+### Accuracy with distributed argmax (2026-08-08)
+
+Full accuracy run (512-token teacher-forced, batch 32) with the distributed argmax engaged:
+**Top-1 93% | Top-5 99%** — up from 88-89% / 97.7% with the single-op full-vocab argmax. The
+distributed path typecasts the logits shard to bf16 before both max and argmax (so reduce and
+argmax see identical values) and reconstructs indices with exact int32 arithmetic, which appears
+to have removed a residual quantization artifact of the old path as a side effect.

--- a/BH_FUSED_RS_MATMUL_WIP.md
+++ b/BH_FUSED_RS_MATMUL_WIP.md
@@ -533,3 +533,151 @@ Full accuracy run (512-token teacher-forced, batch 32) with the distributed argm
 distributed path typecasts the logits shard to bf16 before both max and argmax (so reduce and
 argmax see identical values) and reconstructs indices with exact int32 arithmetic, which appears
 to have removed a residual quantization artifact of the old path as a side effect.
+
+## Fused distributed norm (fused_rms_minimal) PORTED to BH 2D torus (2026-08-08)
+
+The RMSAllGather writer (`rms_allgather/device/kernels/dataflow/rms_writer.cpp`) built raw 1D
+`MulticastRoutingCommandHeader`s for its stats all-gather, which no-op on the BH 2D-torus fabric
+(PACKET_HEADER_TYPE = HybridMeshPacketHeader needs dst mesh/chip ids + per-direction hop counts).
+Port = the same kernel co-design pattern as the fused RS matmul:
+
+- Host (`rms_allgather_program_factory.cpp`): compute neighbor coords
+  (`get_physical_neighbor_from_physical_coord`) and emit 6+6 multicast route CT args via
+  `get_forward_backward_line_mcast_configuration` (exactly what the BH-proven
+  all_gather_async llama-sharded writer does).
+- Kernel: `ccl_routing_utils::fabric_set_line_multicast_route(pkt_hdr_fwd/bwd, route_info)`
+  replaces the raw 1D headers. The fused write+atomic-inc packet works fine over the 2D
+  multicast route (all_reduce_async uses the same combination).
+- On 1D fabrics the route helper reproduces the old behavior bit-for-bit -> WH unaffected.
+
+Model wiring (BH prefetcher only, gated `QWEN_BH_FUSED_RMS`, default ON, requires unfused-CCL path):
+- `use_bh_fused_rms` in qwen_model_config; DistributedNorm decode routes back through
+  `tt_sharded_distributed_rmsnorm` (fused op) instead of the unfused pre/AG/post chain.
+- Fused norm runs on the LN grid at col 7 ((7,0)-(8,4)) to stay clear of the prefetcher GCB
+  receiver cols; input is resharded there first (`ln_sharded_input_memcfg`).
+- LAYERNORM persistent stats buffer moved to (7,0) (must live on the op's sender core).
+- Dedicated global-semaphore pool on the full worker grid (cols 1-10) since `sub_device_crs`
+  excludes col 7.
+
+Unit test `models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_fused_rms_allgather.py`
+(exact model geometry: 5120 hidden / 4-way row fracture / Ring / 10-core grid at (7,0), stats on
+sender core): eager + 3x trace replay all pass PCC 0.999 on all 8 mesh rows.
+
+### E2E result: 18.51 ms @ 54.03 t/s/u (from 18.93 @ 52.82)
+
+Demo (batch-32, 64 tokens): early iterations 18.44-18.51 ms, drifting to ~18.8-19.0 by iter 11+
+(same drift pattern existed before; average 18.51). Only ~0.4 ms of the predicted 1.5-1.8 ms
+materialized. Follow-ups queued: accuracy run + fresh tracy profile to see where the fused chain
+actually lands (suspects: the added reshard-in to col 7, fused-op stats-gather serialization,
+or the norm chain simply overlapping less than the old profile suggested).
+
+### Residual grid moved to LN cols 7-8: 18.4 ms @ 54.36 t/s/u (2026-08-08)
+
+Post-fused-norm tracy showed ReshardDeviceOperation at 0.836 ms critical; the biggest slice was
+the per-norm reshard of the residual (cols 1-2) onto the fused-norm LN grid (cols 7-8),
+129 instances/token. Fix: when `use_bh_fused_rms`, DECODE_RESIDUAL_MEMCFG now lives on
+(7,0)-(8,4) directly (qwen_model_config), making the norm's reshard-in a no-op — all other
+residual consumers (adds, attn/MLP output all-reduces, embedding) are grid-agnostic.
+
+One trap: `all_reduce_async` requires every *output* core to hold a shard of the persistent
+interim buffer (the buffer doubles as per-output-core reduction scratch;
+`buffer.grid.contains(output.grid)` is validated). The axis-0 CCL buffer was sharded on
+sub_core_grids (cols 1-3, 5-6) only, so the dense-out/FF2 all-reduce writing to the relocated
+residual grid failed validation. Fixed in llama_ccl.get_persistent_buffers: merge the residual
+grid into the axis-0 buffer CRS (50 -> 60 cores, ~35 KB extra L1 on each of the 10 LN cores).
+
+Accuracy with the relocated residual grid is unchanged: Top-1 93%, Top-5 100% (511 tokens).
+
+Net: 18.4 ms @ 54.36 t/s/u (was 18.51 @ 54.03) — only ~0.1 ms, so the norm-input reshard was
+NOT the dominant reshard cost; the remaining Reshard critical time is spread across norm-out
+-> ring grid and attention-side reshards. Remaining gap to 58 t/s/u is ~1.35 ms, with the top
+critical-path items being MatmulReduceScatterAsync (5.45 ms), AllReduceAsync (3.19 ms) and
+Matmul (3.11 ms).
+
+### llama_rs_matmul BH hang ROOT-CAUSED + FIXED (2026-08-09)
+
+Two independent bugs, both now fixed:
+
+1. **RS writer fabric routing (fixed earlier today)**: writer_llama_reduce_scatter used
+   hop-count-only unicast routes (fabric_set_unicast_route(num_hops)) which the BH 2D-torus
+   HybridMesh routers cannot resolve. Ported to host-computed {mesh_id, chip_id} routes via
+   ccl_routing_utils (same mechanism as the fused-RMS/all_gather_async ports). Standalone
+   test_bh_llama_reduce_scatter passes (PCC 0.9998, eager+trace).
+
+2. **Packet-worker / matmul-ring core overlap (the actual model hang)**: the fused
+   llama_rs_matmul builds ONE program with the ring matmul + RS. The matmul factory subtracts
+   the RS cores from its worker set (restricted_cores, matmul_multicore_reuse_mcast_1d
+   factory line ~1998) and silently drops any ring core inside the RS grid. On WH the ring
+   (PREFETCHER_NOC1_GRID) and PACKET_WORKER_CRS are disjoint by design (the comment in
+   qwen_model_config even documents the constraint); on BH the ring is cols 1-3 rows 0-7,
+   which fully covers the old PACKET_WORKER_CRS ((1,1)-(3,2),(1,3)-(2,3)). Result: 8 of 25
+   ring cores got no matmul kernel and the in0 ring gather deadlocked at
+   noc_semaphore_wait_min (confirmed by tt-triage on the hung unit test: only 17 ring cores
+   running, no RS kernels, readers parked in signal_sem.wait_min).
+
+   Fix: BH PACKET_WORKER_CRS moved off-ring to (5,0)-(6,2) + (5,4)-(6,4) (8 cores, avoiding
+   the RS sender row (5,3),(6,3) and hop core (3,8)). qwen_model_config.py.
+
+Unit test: models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_llama_rs_matmul.py —
+fused ring-matmul + RS + signaler geometry (single-weight rs_tensor variant; the two-weight
+variant requires the prefetcher global CB and DRAM-sharded weights, rejected standalone by
+matmul validation). PASSES: RS PCC 0.9998, matmul PCC 0.9997, eager + trace.
+
+Demo run with QWEN_BH_FUSED_RS_MATMUL=1 QWEN_BH_FUSED_ASYNC_RS_MATMUL=0 in flight.
+Result: 56.38 tok/s/u, accuracy 93% top-1 / 100% top-5.
+
+### llama_rs_create_heads BH hang ROOT-CAUSED + FIXED (2026-08-09)
+
+Despite carrying the same {mesh_id, chip_id} routing port as the (working) plain
+llama_reduce_scatter, the create-heads variant still deadlocked: tt-triage on the hung unit
+test showed all packet-worker readers parked in noc_semaphore_wait (reader line 158, waiting
+for 3 fabric increments) with every sender kernel already finished - packets entered the
+fabric and vanished, wedging eth cores (board needed glx_reset afterwards).
+
+Root cause: **fabric injection direction vs. source-computed 2D route mismatch**. On the 2D
+torus, fabric_set_unicast_route(HybridMeshPacketHeader, dst_chip, dst_mesh) encodes the FULL
+hop-by-hop route into header->route_buffer from the *sender's* routing table
+(decode_route_to_buffer), so the packet must be injected into the EDM connection matching the
+table's first hop. The create-heads writer load-balances ring 2-hop targets by chip parity
+(odd chips inject them into the BACKWARD connection) while the routing table resolves 2-hop
+ties FORWARD (the plain-RS writer always picks forward on ties, which is why it worked).
+Backward-injected packets carried a forward route program and were never delivered.
+
+Fix (kernel-only, llama_reduce_scatter_create_heads writer): on 2D fabrics choose the
+injection direction from shortest-path-forward-on-ties (matching the routing table); 1D
+fabrics keep the parity load-balancing so WH 6U is unchanged.
+
+Unit tests (all PASS): test_bh_llama_rs_create_heads (eager+trace, q/k/v PCC 0.99996),
+test_bh_all_gather_concat (eager+trace x wh_order/bh_ring_order after the factory fixes:
+dynamic concat_arg_cores, sender-worker exclusion by actual cores, runtime-arg NOC coords,
+dynamic semaphore mcast ranges/dest counts).
+
+Demo run with all three fused CCL ops (QWEN_BH_FUSED_RS_MATMUL=1 QWEN_BH_FUSED_QKV_RS=1
+QWEN_BH_FUSED_AG_CONCAT=1): 56.71 tok/s/u, accuracy 93% top-1 / 99% top-5 (accuracy test
+needed its hardcoded _IS_BLACKHOLE rot-table gates switched to tt_model.use_fused_rope,
+since the BH fused-QKV path now uses the fused-qk rope tables).
+
+### Traced-decode device profile with all fused ops (2026-08-09)
+
+Tracy capture (qwen_prof_allfused): per decode token on device 0, worker sub-device is ~94%
+busy (op sum ~16.5 ms of ~17.6 ms token). Per-layer big rocks (us/call):
+Matmul_RS 70.9 | plain Matmuls 3x ~9.2 | w3 ReduceScatterMinimalAsync 20.8 |
+RMSAllGather 2x 10.1 | AllReduceAsync 2x 9.9 | SDPA 17.8 | AllGatherConcat 16.7 |
+w2-in AllGatherAsync 12.6 | qk-norm chain (2 LayerNorm + 8 reshard + tilize/untilize) ~17.
+Sampling tail ~0.5 ms (2x ArgMax 125 us + 3x Reduce 87 us).
+
+Follow-up experiments:
+- w3 RS via the ported llama_reduce_scatter instead of reduce_scatter_minimal_async:
+  ~1 ms/token SLOWER in the full model (54.2 vs 56.7) despite the standalone op being
+  faster - it serializes against the fused Matmul_RS packet workers / interim buffers.
+  REVERTED (note left in llama_ccl.line_reduce_scatter).
+- Paged SDPA k_chunk 64 -> 128 (QWEN_BH_SDPA_K_CHUNK, default now 128): K/V CBs ~128 KB
+  still clear the resident-global-CB L1 clash, halves flash-decode K iterations.
+  56.92 tok/s/u (17.57 ms). KEPT.
+
+Remaining gap analysis (why not faster yet): Matmul_RS at 70.9 us is ~9x its pure-compute
+cost (~8 us); FF1+FF3 weights are 8.7 MB/device/layer, so the ring matmuls are paced by the
+prefetcher stream rate (~134 GB/s effective vs >500 GB/s DRAM). All ring matmuls together
+are ~6.3 ms/token of the 17.6 ms budget. The single biggest future lever is the BH
+dram_prefetcher streaming rate (readers x receivers geometry, global-CB churn, mcast
+cadence), not another CCL fusion; the CCLs are at or near their 2-link fabric floors.

--- a/BH_FUSED_RS_MATMUL_WIP.md
+++ b/BH_FUSED_RS_MATMUL_WIP.md
@@ -411,3 +411,49 @@ ttnn C++ (device kernels — JIT, no host rebuild needed):
 
 NOTE: a full `ttnn` C++ rebuild is required for the host-side changes (the `.so`). The device
 kernel `.cpp`/`.hpp` recompile automatically by hash on first run.
+
+## Decode perf: 47.6 -> 50.7 t/s/u (2026-08-08)
+
+Traced-decode profiling (qwen_trace_pf_b32_v2 capture, device 16, one replay = one token,
+~20.4 ms span):
+
+- Worker stream: 15.6 ms busy + 4.9 ms dispatch gaps across 2673 ops/token (~42 ops/layer on the
+  unfused-CCL path vs ~25 on WH's fused-CCL path — that op-count delta is the structural gap).
+- Per layer (~330 us): FF1/FF3 ring matmul pair 73 us (the second one is gated by the prefetcher's
+  DRAM stream), 2x reduce_scatter_minimal_async 45 us, 3x all_reduce 26 us, 2x distributed-norm
+  chains (reshard+LN+AllGather+LN+reshard) ~28 us, QK-norm with 4 reshards ~10 us, 4 rotary
+  cos/sin slices ~9 us.
+- Sampling trace (separate trace, serialized after decode, every token): gather 206 us +
+  untilize 201 us + **argmax 2.1 ms**. Argmax is a scalar-RISC compare loop over the full gathered
+  padded vocab (32 x 155648) and was pinned to the 40-core `sub_core_grids`.
+
+### Fix landed: wide force-argmax grid (+3 t/s/u)
+
+`qwen_model_config.py` now sets `force_argmax_sub_core_grids` = the full 100-core worker
+sub-device (cols 1-10, rows 0-9) on the BH prefetcher path; `tt_sampling.py` prefers it over
+`sub_core_grids` for the force-argmax untilize/argmax. Argmax/untilize CBs are tiny, so unlike
+top-k they coexist with the resident global CB on receiver columns 1-3.
+
+Result (batch-32, 64 tokens, prefetcher + fused async RS matmul):
+**19.73 ms @ 50.68 tok/s/user (1622 tok/s)**, steady-state iterations ~20.07 ms — up from
+20.99 ms @ 47.64 t/s/u. Accuracy re-verified after the change (see accuracy section).
+
+### Tried and parked: rotary slice hoist (QWEN_BH_HOIST_ROT_SLICES=1, default off)
+
+The 4 rotary cos/sin slices + 4 to_layouts per layer are loop-invariant (same rot_mats object,
+static head shapes) — hoisting them to once-per-token would save ~0.5 ms. Implemented as a
+tt_ccl-cached memo (llama_attention.compute_decode_rot_slices) with a model-level preamble
+preslice, but the cached tensors persist through the layer loop and the BH ring FF matmul's
+static CB region (ends 444480 on cols 1-6) leaves ~zero persistent L1 headroom on those cores:
+trace capture trips "static circular buffers clash with L1 buffers" (lowest buffer 365568-392320
+< 444480) even when the tensors allocate at the very top of the decode forward. Env-gated off.
+To revive: shrink to a single cos/sin pair (q and k bounds are identical => 2 tensors, 16 KB) or
+carve headroom out of the ring matmul CB budget.
+
+### Remaining ideas towards ~55 t/s/u
+
+- Distributed local argmax: per-column argmax over the 19456-wide shard + tiny cross-column
+  combine would cut sampling from ~2.5 ms to ~0.35 ms total (saves another ~1.3 ms vs the wide
+  grid's 0.85 ms argmax + full-width gather/untilize).
+- The ~42 us stalls before reduce_scatter in ~9 layers/token; the QK-norm reshard sandwich
+  (4 reshards/layer); the 2-op distributed-norm gather chains (WH uses fused RMSAllGather).

--- a/BH_FUSED_RS_MATMUL_WIP.md
+++ b/BH_FUSED_RS_MATMUL_WIP.md
@@ -327,6 +327,39 @@ repeat a small set of junk vocab entries (脏, _CAMERA, satu, 漂) which smells 
 for specific vocab shards (lm_head gather / fast_reduce_nc path?). Needs its own investigation on
 the prefetcher baseline branch, independent of this fused-op work.
 
+## RESOLVED (2026-08-08): prefetcher-path accuracy 27% -> 89% Top-1
+
+Two independent bugs, both now fixed:
+
+1. **lm_head DRAM-sharded weights broken on BH (27% -> ~61%).** The lm_head decode ring matmul's
+   `create_dram_sharded_mem_config_lm_head` bank/offset layout is hardcoded for WH's 12 DRAM banks;
+   on BH's 8 banks the ring cores read misaligned weight slices, producing near-random logits in
+   specific vocab shards (the junk-token clusters). Fix: on BH keep the lm_head decode weight
+   DRAM-**interleaved** (`lm_head.py`), and make `LM_HEAD_OUT_RING_MEMCFG` use the input ring
+   grid's core ordering (`qwen_model_config.py`).
+
+2. **Force-argmax sampling gather raced the untilize/argmax under trace (61% -> 89%).**
+   `tt_sampling.py`'s force-argmax `all_gather_async` did not pass `subdevice_id`, so
+   `choose_worker_cores` defaulted to `get_sub_device_ids()[0]` — which, with the prefetcher
+   decode sub-device manager loaded, is the **prefetcher/senders sub-device (col 0)**, not the
+   worker sub-device where the downstream untilize/argmax run. Dispatch (and trace replay) only
+   serializes programs *within* a sub-device stream (`simple_trace_allocator.cpp` skips nodes with
+   a different `sub_device_id`), so under trace the untilize launched concurrently with the gather
+   and read the gather's output buffer before this step's writes landed -> argmax returned the
+   *previous* step's tokens (the +3-chunk "displacement" was stale data, not a permutation).
+   Eager runs masked it because per-op host dispatch latency exceeds the gather runtime.
+   Repro: `test_qwen_sampling_argmax.py` with `QWEN_SAMPLING_TEST_TRACE=1` (fails 24-32/32 rows
+   stale-by-one-iteration before the fix, deterministic with `QWEN_SAMPLING_TEST_SYNC_BEFORE=1`).
+   Fix: pass `subdevice_id=tt_ccl.worker_sub_device_id` to the gather (`tt_sampling.py`), matching
+   every other CCL call in `llama_ccl.py`.
+
+Post-fix (`test_qwen_accuracy.py`, 511 teacher-forced tokens, prefetcher on): Top-1 **89%**,
+Top-5 **~98%** (assert threshold 98% is borderline: observed 97.7-98.1 across runs). With
+`QWEN_ACC_HOST_ARGMAX=1` the on-device sampled token matched the host argmax of the logits on
+**all 511 steps** — the sampling path is now exact. The residual ~7-point Top-1 gap vs the 96%
+non-prefetcher baseline is numerics of the prefetcher compute path (bfp8 ring matmuls / CCL
+dataformats), not corruption.
+
 ## Suggested next steps (2026-08-06 list — items 1-2 RESOLVED by Breakthrough 2)
 
 1. Identify the missing program slot. Only ~3 worker programs run between token-1's PCC readback

--- a/BH_FUSED_RS_MATMUL_WIP.md
+++ b/BH_FUSED_RS_MATMUL_WIP.md
@@ -1,0 +1,199 @@
+# WIP: BH Galaxy Qwen3-32B — Prefetcher + Fused `matmul_reduce_scatter_async`
+
+Status doc for resuming later. Branch: `mgiermakowski/bh-fused-test`
+(branched from `mgiermakowski/bh-qwen-prefetcher`, which is the working prefetcher-only baseline).
+
+Last updated: 2026-08-05.
+
+---
+
+## Goal
+
+Run Qwen3-32B decode on Blackhole (BH) Galaxy with **both** the `dram_prefetcher` **and** a
+fused matmul + reduce-scatter op for the MLP FF1/FF3, for maximum decode perf.
+
+- Prefetcher-only (no fused op) already works end-to-end: ~44.8 t/s/u decode. That is the shippable
+  baseline and lives on `mgiermakowski/bh-qwen-prefetcher`.
+- The fused op is an incremental gain layered on top. It is what this branch adds, and it is
+  **not yet working end-to-end** (see "Remaining blocker").
+
+## TL;DR of current state
+
+- The fused op is integrated (MLP FF1/FF3), compiles, and is **numerically correct**:
+  decode PCC **0.9978 / 0.9979** for tokens 0 and 1, matching the unfused baseline (~0.9975).
+- It **deadlocks on the 3rd decode token (token index 2)**, every run, deterministically.
+- The deadlock is **not** in the fused op's own kernels — it is in a *downstream* op (a
+  `ttnn.slice` reader, or a standard `all_gather`) running on cores the fused ring matmul used.
+  The fused op leaves persistent L1 / circular-buffer / semaphore state that corrupts a later op,
+  and it accumulates until it deadlocks on iteration 3.
+
+## How to reproduce
+
+From `/home/mgiermak/tt-metal`:
+
+Fused (hangs at token 2):
+```
+HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/home/mgiermak/bh_qwen_cache \
+  QWEN_BH_PREFETCHER=1 QWEN_BH_UNFUSED_CCL=1 QWEN_BH_FUSED_ASYNC_RS_MATMUL=1 \
+  ./python_env/bin/pytest -svq \
+  models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder.py
+```
+
+Baseline that passes all 10 tokens (drop the fused flag):
+```
+HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/home/mgiermak/bh_qwen_cache \
+  QWEN_BH_PREFETCHER=1 QWEN_BH_UNFUSED_CCL=1 \
+  ./python_env/bin/pytest -svq \
+  models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder.py
+```
+
+The decoder test runs `generation_length = 10` iterations and prints
+`All 10 Llama decode iterations Passed!` on success. It hangs after token 1's PCC print.
+
+Useful debug env vars:
+- `TT_METAL_WATCHER=10 TT_METAL_WATCHER_DISABLE_ETH=1` — enable the Metal watcher (10s poll).
+- `TT_METAL_WATCHER_DISABLE_ASSERT=1` — let it run past the soft assert to the real deadlock,
+  then read the last complete dump in `generated/watcher/watcher.log`.
+- `QWEN_DBG_FUSED_SYNC=1` — (added in `llama_mlp.py`) drains the worker sub-device after the two
+  fused ops. Diagnostic only; does NOT fix the hang (see below).
+
+Standalone single-shot op test (passes, PCC ~1.0 — does not exercise the decode loop):
+`models/demos/llama3_70b_galaxy/tests/unit_tests/test_matmul_reduce_scatter_async_bh.py`
+
+NOTE: the device on this host is shared and occasionally needs a `tt-smi -glx_reset` between runs
+(look for "Timed out while waiting for active ethernet core ... to become active" at
+`open_mesh_device` — that is a dirty device, not a code bug).
+
+## Design of the fused op (what was built)
+
+`matmul_reduce_scatter_async` originally supported only a 2D-multicast matmul with no global CB.
+It was generalized to fuse the BH prefetcher's **1D gathered ring matmul** (streaming global-CB
+weights) with the BH-working `reduce_scatter_minimal_async` backend, in a single program.
+
+Signaling co-design ("Option B"): the prefetcher's 1D gathered matmul natively emits the
+`LLAMA_REDUCE_SCATTER` signal, but the BH-working `reduce_scatter_minimal_async` consumes the
+`REDUCE_SCATTER` `OpSignaler` protocol. Rather than debug the BH 2D-torus fabric for the llama-RS
+writer, the 1D gathered matmul reader was taught to also emit `REDUCE_SCATTER` signals via
+`OpSignaler`, and the RS reader consumes them via `ReduceScatterOpReceiver::wait_for_matmul_batch`.
+
+Core placement (single fused program, so matmul and RS must be on disjoint cores):
+- col 0: prefetcher senders (resident global CB producers)
+- cols 1–3: ring matmul workers
+- cols 4–10: reduce-scatter workers (confined via new `reduce_scatter_sub_core_grid` param;
+  an additive `core_grid_offset` overflows off-grid, so an explicit sub-core-grid was needed)
+- col 11: tensix dispatch
+
+Model wiring: `use_bh_fused_async_rs_matmul` flag (env `QWEN_BH_FUSED_ASYNC_RS_MATMUL=1`).
+`TT_CCL.matmul_reduce_scatter_async` wrapper + double-buffered persistent buffers
+(`get_decode_fused_rs_matmul_buffers`). `llama_mlp.py` FF1/FF3 branch calls it and skips the
+post-branch `line_reduce_scatter`. Deallocation of the persistent output buffers is guarded off
+in the fused path (they are reused across layers/tokens).
+
+## Bugs FIXED along the way
+
+1. **PCC gap 0.984 -> 0.9978 (persistent buffer logical width).**
+   The fused op's `persistent_intermediate` / `persistent_output` were allocated at the *padded*
+   FF-hidden width (3840, and 960/device) instead of the *logical unpadded* width
+   (`intermediate_dim_per_tp` = 3200, and 800/device). The reduce-scatter derives its scatter
+   partition from the matmul output's logical width, so allocating at the padded width folded the
+   640 padding columns into the logical result. Fix: allocate `torch.zeros` at the logical width and
+   let the memory-config handle physical padding (`llama_ccl.py::get_decode_fused_rs_matmul_buffers`,
+   uses `self.model_args.intermediate_dim_per_tp`).
+
+2. **Persistent output buffer deallocated between layers.**
+   `llama_mlp.py` was deallocating `w1/w3_out_reduced`, which in the fused path ARE the TT_CCL
+   persistent buffers -> "Input Tensor is not allocated" on the next layer. Fix: guard the
+   deallocate off when `use_bh_fused_async_rs_matmul`.
+
+3. **Fused signal-semaphore never reset across cached dispatches (latent leak, real but not the
+   deadlock cause).** `ReduceScatterOpReceiver::wait_for_matmul_batch` uses a cumulative
+   `wait_min(batch_idx+1)` on a semaphore created once via `CreateSemaphore(..., 0)`. Under program
+   caching the L1 value persists and accumulates across decode iterations. Added
+   `ReduceScatterOpReceiver::reset()` (zeroes the semaphore) and call it after the RS batch loop in
+   both `ring_` and `line_reduce_scatter_minimal_async_reader.cpp`. Correct to keep, but it does
+   **not** resolve the token-2 hang.
+
+## Remaining blocker (token-2 deadlock) — investigation
+
+Symptom: tokens 0,1 pass with good PCC; token 2 hangs, deterministically. Baseline (no fused op)
+runs all 10 tokens.
+
+Watcher localization (`generated/watcher/watcher.log`), device 0:
+- Asserts ON: `ttnn/.../ccl/all_gather/device/kernels/multicast_reader.cpp` trips on core `(1,0)`.
+- Asserts OFF (runs to the real hang): deadlocks in
+  `ttnn/.../data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded.cpp`
+  (kernel id 1038), NCRISC stuck at waypoint `R` (NOC read wait), on cols 1,2,3,5,6.
+  Prefetcher senders (col 0) also waiting.
+
+Key deductions:
+- The stuck kernels are **downstream data-movement / all_gather ops**, NOT the fused matmul or RS
+  kernels. So the fused op itself completes and returns correct data (hence good PCC), but leaves
+  corrupt persistent state on the cores it used (cols 1–3), which a later op inherits.
+- The failure point **moves under the watcher** (token 2 without it; token 0 with it), i.e. it is
+  timing-sensitive — consistent with a producer/consumer ring pointer that drifts per iteration.
+
+Hypotheses RULED OUT:
+- Fused signal-semaphore leak — reset added, no change.
+- Async overlap / drain hazard — a full `ttnn.synchronize_device` on the worker sub-device after
+  the fused ops (`QWEN_DBG_FUSED_SYNC=1`) does NOT fix it, so the corruption is persistent L1 state,
+  not unfinished work.
+- Wrapper semaphore bookkeeping — verified identical to the proven-good standalone
+  `reduce_scatter_minimal_async` usage in `llama_ccl.py` (which loops fine in the baseline).
+- Global-CB *release* path in the matmul reader (non-streaming `ENABLE_GLOBAL_CB && !STREAMING_IN1`
+  branch) is unchanged by the edits; only the signaling branch was added.
+
+Prime remaining suspect:
+- The co-designed 1D gathered matmul reader's **remote/global circular-buffer pointer accounting**
+  (`experimental::remote_cb_pop_front` / `update_remote_cb_config_in_l1(remote_cb_id)` at the end of
+  `reader_bmm_tile_layout_in1_ring_all_gather.cpp`). A small per-iteration drift in the remote-CB
+  ring would desync after 2–3 prefetcher refills and strand a downstream op's NOC read — matches the
+  token-2, timing-sensitive signature and the fact that the prefetcher senders are also parked.
+- Secondary suspect: L1 semaphore-id / CB-config aliasing between the fused program and the
+  downstream slice/all_gather programs on the shared cores (cols 1–3).
+
+## Suggested next steps
+
+1. Add device-side `DPRINT` in `reader_bmm_tile_layout_in1_ring_all_gather.cpp` to trace the
+   remote-CB read pointer / `remote_cb_pop_front` counts per batch across iterations; run 3 tokens
+   and diff iteration 0 vs 2. (DPRINT perturbs timing, so also compare against the watcher dumps.)
+2. Narrow the repro: fuse only FF1 (leave FF3 unfused) to confirm whether a single fused call per
+   layer still deadlocks — isolates per-call vs per-layer accumulation.
+3. If it is remote-CB drift: ensure the fused reader restores the exact remote-CB config the plain
+   prefetcher matmul (`ttnn.linear` with `global_cb`) leaves, i.e. compare
+   `update_remote_cb_config_in_l1` behavior between the two on the non-streaming path.
+4. Otherwise escalate to the CCL/matmul op team with this doc + the watcher dumps; this is
+   fused-op remote-CB lifecycle co-design.
+
+## Files changed on this branch (relative to `mgiermakowski/bh-qwen-prefetcher`)
+
+Model (Python):
+- `models/demos/llama3_70b_galaxy/tt/llama_mlp.py` — FF1/FF3 fused branch; `QWEN_DBG_FUSED_SYNC`
+  diagnostic; guarded deallocate.
+- `models/demos/llama3_70b_galaxy/tt/llama_ccl.py` — `matmul_reduce_scatter_async` wrapper;
+  `get_decode_fused_rs_matmul_buffers` (logical-width fix); stores `self.model_args`.
+- `models/demos/llama3_70b_galaxy/tt/qwen_model_config.py` — `use_bh_fused_async_rs_matmul` flag.
+- `models/demos/llama3_70b_galaxy/tests/unit_tests/test_matmul_reduce_scatter_async_bh.py` — new
+  standalone op test (single-shot, passes).
+
+ttnn C++ (host): generalize `matmul_reduce_scatter_async` for global_cb + 1D gathered program
+config + `reduce_scatter_sub_core_grid`:
+- `.../experimental/ccl/matmul_reduce_scatter_async/matmul_reduce_scatter_async{.cpp,.hpp,_nanobind.cpp}`
+- `.../experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation{.cpp,.hpp}`
+- `.../experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation_types.hpp`
+- `.../experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_program_factory{.cpp,.hpp}`
+- `.../experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp`
+- `.../experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_{ring,line}_program_factory.hpp`
+- `.../ccl/reduce_scatter/device/reduce_scatter_program_factory.cpp`
+- `.../matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp`
+
+ttnn C++ (device kernels — JIT, no host rebuild needed):
+- `.../ccl/kernel_common/worker_sync_utils.hpp` — `ReduceScatterOpReceiver::reset()`.
+- `.../experimental/ccl/reduce_scatter_minimal_async/device/kernels/{ring,line}_reduce_scatter_minimal_async_reader.cpp`
+  — call `matmul_receiver.reset()` after the batch loop.
+- `.../matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp` — REDUCE_SCATTER
+  `OpSignaler` path + `cb_sync` handshake for streaming.
+- `.../matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp`
+  — `RS_STREAMING_SYNC` credit.
+
+NOTE: a full `ttnn` C++ rebuild is required for the host-side changes (the `.so`). The device
+kernel `.cpp`/`.hpp` recompile automatically by hash on first run.

--- a/BH_FUSED_RS_MATMUL_WIP.md
+++ b/BH_FUSED_RS_MATMUL_WIP.md
@@ -142,27 +142,72 @@ Hypotheses RULED OUT:
 - Global-CB *release* path in the matmul reader (non-streaming `ENABLE_GLOBAL_CB && !STREAMING_IN1`
   branch) is unchanged by the edits; only the signaling branch was added.
 
-Prime remaining suspect:
-- The co-designed 1D gathered matmul reader's **remote/global circular-buffer pointer accounting**
-  (`experimental::remote_cb_pop_front` / `update_remote_cb_config_in_l1(remote_cb_id)` at the end of
-  `reader_bmm_tile_layout_in1_ring_all_gather.cpp`). A small per-iteration drift in the remote-CB
-  ring would desync after 2–3 prefetcher refills and strand a downstream op's NOC read — matches the
-  token-2, timing-sensitive signature and the fact that the prefetcher senders are also parked.
-- Secondary suspect: L1 semaphore-id / CB-config aliasing between the fused program and the
-  downstream slice/all_gather programs on the shared cores (cols 1–3).
+Prime remaining suspect (SUPERSEDED — see BREAKTHROUGH section below):
+- ~~The co-designed 1D gathered matmul reader's remote/global circular-buffer pointer accounting~~
+- ~~L1 semaphore-id / CB-config aliasing between the fused program and downstream programs~~
+- Actual mechanism: dispatch-level worker done-signal deficit; see next section.
+
+## BREAKTHROUGH (2026-08-06): live tt-triage post-mortem — it is a DISPATCH-LEVEL go/done deficit
+
+The watcher-based localization above is superseded. The watcher itself is an artifact: the
+baseline (prefetcher, no fused op) also hangs at token 0 under `TT_METAL_WATCHER=10`, so all
+watcher-derived conclusions (slice reader / all_gather multicast_reader) were observer effects.
+
+New method that works (use this next time):
+- Reproduce WITHOUT watcher; while pytest is HUNG (do not kill it — the inspector RPC must stay
+  alive), run `python tools/tt-triage.py --llm-output --llm-output-path=...` in parallel.
+  Needs `tt-exalens==0.3.27` (upgraded in python_env). On the shared broker, emit heartbeat
+  output every ~25 s or the 300 s no-output kill fires before triage runs.
+
+Findings from the frozen mesh (all 32 devices identical):
+- Op window: token 1 completed fully (both fused ops included; PCC 0.9979). Token 2's
+  `DramPrefetcherOperation` (op id 56) is the only RUNNING op; ops 57+ (first worker op of
+  token 2, a Reshard) were **never dispatched**.
+- Prefetcher `reader_dram` NCRISC is parked in `cb_pop_front` with a clean callstack — starved,
+  not corrupted, waiting for consumers that never launch.
+- `cq_dispatch` BRISC is stuck in `process_wait` (wait_stream loop, cq_dispatch.cpp:1059).
+  Reading its locals via ttexalens (`last_wait_stream`@0xffb00d14, `last_wait_count`@0xffb00d18,
+  BRISC private mem, dispatch core logical (12,1)) and the live stream counters
+  (`0xFFB40000 + stream*0x1000 + 297*4`; stream 48 = sub-device 0/prefetcher,
+  49 = sub-device 1/worker; base 48 from `dispatch_stream_base_`):
+  **wait is on stream 49 (WORKER sub-device), target 10700, counter stuck at 10600.**
+- The worker sub-device has exactly 100 cores and every mesh program on a sub-device produces one
+  done-increment per sub-device core, so the counts are multiples of 100:
+  **exactly ONE worker program slot's entire done cycle (100 signals) is missing.**
+- `cq_dispatch_subordinate` (go-signal sender) is likewise parked in `wait_for_workers`.
+  (Its `last_wait_count` is in NCRISC private mem, unreadable on BH — "ncrisc does not have
+  debug hardware" — so whether the missing slot's GO was ever multicast is still unconfirmed.)
+- `check_binary_integrity` reported ~6k `.text` mismatches, but the same per-RISC offsets repeat
+  across unrelated kernels and the RUNNING kernels backtrace cleanly — treat as a stale-slot
+  checker artifact, not real corruption, unless later evidence says otherwise.
+
+Interpretation: everything previously suspected (OpSignaler semaphores, global-CB pointer
+accounting, L1 CB aliasing) is off the table as the primary cause. The fused program breaks the
+mesh dispatch go/done accounting such that, ~107 worker-program slots in (early token 2), one
+program's 100 done-signals never arrive and the dispatcher deadlocks waiting for them. This also
+explains why `QWEN_DBG_FUSED_SYNC=1` (worker-sub-device sync after each fused op) passed at
+tokens 0/1: the counter was still consistent at those wait points.
+
+Probe script: `/home/mgiermak/probe_dispatch_wait.py` (run under the broker while hung).
+Artifacts: `/home/mgiermak/triage_fused_hang.txt` (4 MB), `/home/mgiermak/qwen_fused_hang3.log`.
 
 ## Suggested next steps
 
-1. Add device-side `DPRINT` in `reader_bmm_tile_layout_in1_ring_all_gather.cpp` to trace the
-   remote-CB read pointer / `remote_cb_pop_front` counts per batch across iterations; run 3 tokens
-   and diff iteration 0 vs 2. (DPRINT perturbs timing, so also compare against the watcher dumps.)
-2. Narrow the repro: fuse only FF1 (leave FF3 unfused) to confirm whether a single fused call per
-   layer still deadlocks — isolates per-call vs per-layer accumulation.
-3. If it is remote-CB drift: ensure the fused reader restores the exact remote-CB config the plain
-   prefetcher matmul (`ttnn.linear` with `global_cb`) leaves, i.e. compare
-   `update_remote_cb_config_in_l1` behavior between the two on the non-streaming path.
-4. Otherwise escalate to the CCL/matmul op team with this doc + the watcher dumps; this is
-   fused-op remote-CB lifecycle co-design.
+1. Identify the missing program slot. Only ~3 worker programs run between token-1's PCC readback
+   (which waited successfully) and the stuck op 57 (two Embeddings + possibly a reshard) — but if
+   the wait targets launch-ring-slot reuse (wait for slot N-ring_size), 10700 may map to an
+   earlier slot, i.e. the fused op itself. Read a worker core's mailbox launch ring / go-message
+   state (dev_msgs.h `mailboxes_t`) on the frozen mesh to see whether the missing slot's GO was
+   delivered.
+2. Audit mesh `EnqueueProgram`/dispatch_s expected-worker accounting for the fused program: it has
+   kernel groups on disjoint, non-rectangular core sets (ring matmul cols 1–3 incl. hop cores + RS
+   sub-grid cols 4–10) inside a 100-core sub-device. Compare `num_active_cores` /
+   go-mcast rectangles vs the plain (non-fused) matmul and RS programs.
+3. Narrow the repro: fuse only FF1 (one fused call per layer) — if the hang moves to token 4-ish,
+   it is a per-fused-call accounting leak; if still token 2, it is per-program-structure.
+4. Escalate to the runtime/dispatch team with this doc: "one worker-sub-device program slot loses
+   all 100 done-signals after N dispatches of a multi-kernel-group fused program under sub-devices
+   + program cache on BH" is their domain.
 
 ## Files changed on this branch (relative to `mgiermakowski/bh-qwen-prefetcher`)
 

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
+import os
 import sys
 
 import torch
@@ -624,6 +625,27 @@ class TTSampling(LightweightModule):
                     f"Force argmax sampling all-gather: cluster_axis={cluster_axis}, "
                     f"num_links={num_links}, topology={topology}"
                 )
+                # NOTE: do NOT pass a persistent_output_buffer here. The all_gather_async factory
+                # disables its barrier semaphore when persistent buffers are used, and the barrier
+                # is what bounds cross-invocation skew: without it a fast device's next-invocation
+                # writes/increments can reach a peer before that peer's reader has reset its
+                # out_ready semaphore, leaving residual counts that make later waits pass early
+                # (argmax then reads the previous step's logits). Under trace the fresh output
+                # allocation is frozen at capture, so the address is stable anyway.
+                barrier_accessor = getattr(
+                    self.tt_ccl,
+                    "get_sampling_barrier_semaphore_handle",
+                    self.tt_ccl.get_and_cycle_barrier_semaphore_handle,
+                )
+                # Pin the gather's worker cores to the same sub-device as the downstream
+                # untilize/argmax. Without this, all_gather_async defaults to sub-device 0, which
+                # under the galaxy prefetcher decode manager is the prefetcher/senders sub-device.
+                # Dispatch only serializes programs within a sub-device, so a gather on sub-device 0
+                # runs concurrently with the untilize on the worker sub-device: under trace replay
+                # (back-to-back go signals) the untilize/argmax read the gather output buffer before
+                # this step's writes land and return the previous step's argmax (stale tokens).
+                # Eager mode masks this because per-op host dispatch latency exceeds the gather time.
+                ag_sub_device_id = getattr(self.tt_ccl, "worker_sub_device_id", None)
                 x = ttnn.experimental.all_gather_async(
                     x,
                     persistent_output_buffer=None,
@@ -633,14 +655,23 @@ class TTSampling(LightweightModule):
                     memory_config=x.memory_config(),
                     cluster_axis=cluster_axis,
                     topology=topology,
-                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+                    barrier_semaphore=barrier_accessor(cluster_axis),
                     chunks_per_sync=self.argmax_chunks_per_sync,
                     num_workers_per_link=self.argmax_num_workers_per_link,
                     num_buffers_per_channel=2,
+                    subdevice_id=ag_sub_device_id,
                 )
+                if os.environ.get("TT_SAMPLING_DEBUG_ADDR") == "1":
+                    logger.info(f"force-argmax gather out addr {x.buffer_address():#x}")
+                if os.environ.get("QWEN_SAMPLING_KEEP_GATHERED") == "1":
+                    # Keep a handle to the gathered logits so tests can read the trace-resident
+                    # buffer back after replay and diff its slots against host-composed logits.
+                    self.debug_gathered = x
             if slice_valid_vocab:
                 x = self._slice_valid_vocab_for_argmax(x)
             x_untilized = ttnn.untilize(x, use_multicore=True, sub_core_grids=self._force_argmax_sub_core_grids)
+            if os.environ.get("QWEN_SAMPLING_KEEP_GATHERED") == "1":
+                self.debug_untilized = x_untilized
             tt_out_tok = ttnn.argmax(
                 x_untilized,
                 dim=-1,

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
+import math
 import os
 import sys
 
@@ -162,6 +163,9 @@ class TTSampling(LightweightModule):
             if getattr(args, "use_unfused_ccl", False)
             else None
         )
+        # Distributed force-argmax (see _distributed_force_argmax): lazily created constants.
+        self._dist_argmax_iota = None
+        self._dist_argmax_fp32_ckc = None
 
         # sampling_dp > 1 when multiple mesh groups each sample users independently
         # (e.g. GPT-OSS on [4,8]: 4 rows × 32 users; Llama Galaxy on [8,4]: 4 cols × 8 users)
@@ -520,6 +524,277 @@ class TTSampling(LightweightModule):
 
         return max(1, num_links), topology
 
+    def _use_distributed_argmax(self, x, tt_out_tok, cluster_axis):
+        """Whether the distributed (local-argmax + tiny gather) greedy path applies.
+
+        Only used on the BH galaxy prefetcher path (where _force_argmax_sub_core_grids is set):
+        the full-logits gather + full-width argmax there costs ~1.15 ms/token, dominated by the
+        scalar-RISC argmax over the 32 x 155648 gathered tensor. The distributed variant argmaxes
+        each device's 32 x (vocab/ncols) shard locally and combines per-column (value, index)
+        candidates, ~5x cheaper. Kept off elsewhere so no other model's behaviour changes.
+        """
+        if os.environ.get("QWEN_BH_DIST_ARGMAX", "1") != "1":
+            return False
+        if self._force_argmax_sub_core_grids is None or self._sampling_dp != 1:
+            return False
+        if cluster_axis is None:
+            return False
+        # A caller-provided output buffer (the decode trace's token input in the galaxy demo flow,
+        # RM uint32 [1,1,1,B]) is written back via a worker-grid copy; only a single-page RM
+        # uint32 buffer with B in the last dim is supported.
+        if tt_out_tok is not None:
+            shp = list(tt_out_tok.shape)
+            if (
+                tt_out_tok.dtype != ttnn.uint32
+                or tt_out_tok.layout != ttnn.ROW_MAJOR_LAYOUT
+                or shp[-1] != self.max_batch_size
+                or math.prod(shp) != self.max_batch_size
+            ):
+                return False
+        w = x.shape[-1]
+        return x.shape[-2] == self.max_batch_size and self.max_batch_size == 32 and w % ttnn.TILE_SIZE == 0
+
+    def _distributed_force_argmax(self, x, cluster_axis, topology, tt_out_tok=None):
+        """Greedy sampling via per-device argmax + tiny cross-column combine.
+
+        Instead of all-gathering the full padded-vocab logits (32 x 155648) and running one huge
+        argmax, each column device computes the argmax/max over its local 32 x W shard, then only
+        the per-column candidate (max value, argmax index) pairs are gathered (one tile per
+        device). The winner column per user is picked by a small argmax over the gathered values,
+        and the final token id is reconstructed as local_idx[winner] + W * winner_col via a
+        one-hot select (byte-split fp32 select + exact int32 recombination; see the TF32 note
+        below).
+
+        Tie-break matches the single-op argmax: within a column argmax returns the first max, and
+        the cross-column argmax picks the lowest winning column, i.e. the global first occurrence.
+
+        Everything is pinned to the worker sub-core grid / sub-device (same reasons as the
+        non-distributed path: split senders/worker sub-device manager on the BH galaxy).
+        """
+        grids = self._force_argmax_sub_core_grids
+        w = x.shape[-1]
+        batch = self.max_batch_size
+        ncols = self.cluster_shape[cluster_axis]
+        if self._dist_argmax_iota is None:
+            # Row-index iota over the gathered-candidates height (ncols tiles of 32 rows): the
+            # gathered index tensor holds column c's candidates at row block 32*c, and the winner
+            # position from argmax over the gathered (tile-padded) values is exactly 32*c.
+            rows = ncols * ttnn.TILE_SIZE
+            iota = torch.arange(rows, dtype=torch.float32).reshape(1, 1, rows, 1).expand(1, 1, rows, batch)
+            self._dist_argmax_iota = ttnn.from_torch(
+                iota.contiguous(),
+                dtype=ttnn.float32,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+            # fp32 accumulation: bf16 logits and index sums up to padded_vocab must stay exact
+            # (fp16 dest would round integers > 2048 and saturate logits > 65504).
+            self._dist_argmax_fp32_ckc = ttnn.init_device_compute_kernel_config(
+                self.mesh_device.arch(),
+                math_fidelity=ttnn.MathFidelity.HiFi4,
+                fp32_dest_acc_en=True,
+            )
+
+        barrier_accessor = getattr(
+            self.tt_ccl,
+            "get_sampling_barrier_semaphore_handle",
+            self.tt_ccl.get_and_cycle_barrier_semaphore_handle,
+        )
+        ag_sub_device_id = getattr(self.tt_ccl, "worker_sub_device_id", None)
+
+        _debug_sync = os.environ.get("QWEN_DIST_ARGMAX_SYNC") == "1"
+
+        def ck(step):
+            # Debug: block after each step so a device hang is attributable to one op.
+            if _debug_sync:
+                ttnn.synchronize_device(self.mesh_device)
+                logger.info(f"dist-argmax step ok: {step}")
+
+        def argmax_grid(width):
+            # The multicore argmax factory gives every core ceil(blocks/num_cores) reduction units
+            # and only lets the LAST core be partial. If (num_cores-1)*units_per_core >= width the
+            # last core's unit count underflows (huge uint32) and trailing cores read out of bounds
+            # -> device hang. Cap the core count so every core lands inside the row. Granularity 64
+            # is a safe multiple of the factory's alignment-derived minimum (16/32/64 elements).
+            gran = 64
+            blocks = -(-width // gran)
+            max_cores = grids.num_cores()
+            units_per_core = -(-blocks // max_cores) * gran
+            n = -(-width // units_per_core)
+            if n >= max_cores:
+                return grids
+            return ttnn.num_cores_to_corerangeset_in_subcoregrids(self.start_core, n, grids, row_wise=True)
+
+        def tiny_gather(t, dim):
+            # 1 link: each device contributes a single tile page, nothing to split across links.
+            return ttnn.experimental.all_gather_async(
+                t,
+                persistent_output_buffer=None,
+                dim=dim,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis),
+                num_links=1,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                cluster_axis=cluster_axis,
+                topology=topology,
+                barrier_semaphore=barrier_accessor(cluster_axis),
+                chunks_per_sync=self.argmax_chunks_per_sync,
+                num_workers_per_link=1,
+                num_buffers_per_channel=2,
+                subdevice_id=ag_sub_device_id,
+            )
+
+        # Local shard argmax + max. Typecast to bf16 first so the reduce max value is exactly the
+        # value the argmax saw (a bfp8_b-quantized reduce output could disagree with the bf16
+        # untilize output near cross-column ties).
+        x_bf16 = ttnn.typecast(x, ttnn.bfloat16, sub_core_grids=grids) if x.dtype != ttnn.bfloat16 else x
+        ck("typecast x bf16")
+        x_unt = ttnn.untilize(x_bf16, use_multicore=True, sub_core_grids=grids)
+        ck("untilize local")
+        local_idx = ttnn.argmax(x_unt, dim=-1, keepdim=False, sub_core_grids=argmax_grid(w))  # [1,1,B] RM u32
+        ck("argmax local")
+        # Rank-4 view (same single RM page) so the pad/tilize/gather below address H and W plainly.
+        local_idx = ttnn.reshape(local_idx, [1, 1, 1, batch], sub_core_grids=grids)
+        ck("reshape local_idx")
+        x_unt.deallocate(True)
+        local_max = ttnn.max(
+            x_bf16, dim=3, keepdim=True, sub_core_grids=grids, compute_kernel_config=self._dist_argmax_fp32_ckc
+        )  # [1,1,B,1] tile bf16
+        ck("max local")
+        if x_bf16 is not x:
+            x_bf16.deallocate(True)
+
+        # Values: pad the [B,1] column to a full logical tile width with -inf so the gathered
+        # [B, 32*ncols] tensor has column c's max at width 32*c and -inf in the pad lanes (the
+        # physical tile pad lanes of the reduce output are undefined, so they must be overwritten).
+        # Sub-tile-width pad on TILE layout is unproven here, so round-trip through row-major.
+        local_max_rm = ttnn.untilize(local_max, use_multicore=True, sub_core_grids=grids)
+        ck("untilize local_max")
+        local_max.deallocate(True)
+        vals_rm = ttnn.pad(
+            local_max_rm, [(0, 0), (0, 0), (0, 0), (0, ttnn.TILE_SIZE - 1)], value=-3.38e38, sub_core_grids=grids
+        )
+        ck("pad vals")
+        local_max_rm.deallocate(True)
+        vals_p = ttnn.tilize(vals_rm, sub_core_grids=grids)  # [1,1,B,32] tile bf16
+        ck("tilize vals")
+        vals_rm.deallocate(True)
+        vals_g = tiny_gather(vals_p, dim=3)  # [1,1,B,32*ncols] tile bf16
+        ck("gather vals")
+        vals_p.deallocate(True)
+
+        # Indices: pad the [1,B] row to a full logical tile height (zeros), tilize, and typecast
+        # to int32 (exact) for the gather. Gather on dim 2 stacks column c's candidates at row
+        # block 32*c.
+        idx_p = ttnn.pad(local_idx, [(0, 0), (0, 0), (0, ttnn.TILE_SIZE - 1), (0, 0)], value=0, sub_core_grids=grids)
+        ck("pad idx")
+        local_idx.deallocate(True)
+        idx_t = ttnn.tilize(idx_p, sub_core_grids=grids)
+        ck("tilize idx")
+        idx_p.deallocate(True)
+        idx_i = ttnn.typecast(idx_t, ttnn.int32, sub_core_grids=grids)
+        ck("typecast idx i32")
+        idx_t.deallocate(True)
+        idx_g = tiny_gather(idx_i, dim=2)  # [1,1,32*ncols,B] tile int32
+        ck("gather idx")
+        idx_i.deallocate(True)
+
+        # Winner position per user: 32 * winner_col (pad lanes are -inf; ties pick lowest column).
+        vals_gu = ttnn.untilize(vals_g, use_multicore=True, sub_core_grids=grids)
+        ck("untilize vals_g")
+        vals_g.deallocate(True)
+        g_pos = ttnn.argmax(
+            vals_gu, dim=-1, keepdim=False, sub_core_grids=argmax_grid(vals_gu.shape[-1])
+        )  # [1,1,B] RM u32
+        ck("argmax g_pos")
+        vals_gu.deallocate(True)
+        g_pos = ttnn.reshape(g_pos, [1, 1, 1, batch], sub_core_grids=grids)
+        g_pos_t = ttnn.tilize_with_val_padding(
+            g_pos, [1, 1, ttnn.TILE_SIZE, batch], 0, sub_core_grids=grids
+        )  # logical [1,1,1,B] tile
+        ck("tilize g_pos")
+        g_pos.deallocate(True)
+        g_pos_f = ttnn.typecast(g_pos_t, ttnn.float32, sub_core_grids=grids)
+        ck("typecast g_pos f32")
+        g_pos_t.deallocate(True)
+
+        # One-hot select of the winning column's local index, then add the column offset:
+        # final = idx_g[32*c, u] + W * c, with W * c == (W / 32) * g_pos.
+        #
+        # TF32 hazard: the FPU eltwise mul/add unpack fp32 operands as TF32 (11-bit mantissa), so
+        # any fp32 value > 2048 that isn't on the TF32 grid gets truncated (observed: index 3031
+        # -> 3028). All values that flow through FPU mul/sum are therefore kept <= 2048: the index
+        # is split into hi/lo bytes for the one-hot select, and the recombination (<< 8 | lo, plus
+        # the column offset) is done with exact SFPU int32 shifts/adds. The colterm product
+        # (W/32) * g_pos = W * c is exactly representable in TF32 for tile-aligned W (multiple of
+        # 128 with a small mantissa), so that one multiply is safe.
+        onehot = ttnn.eq(self._dist_argmax_iota, g_pos_f, sub_core_grids=grids)  # bcast H: [rows,B] vs [1,B]
+        ck("eq onehot")
+        hi_i = ttnn.bitwise_right_shift(idx_g, 8, sub_core_grids=grids)
+        lo_i = ttnn.bitwise_and(idx_g, 255, sub_core_grids=grids)
+        ck("split idx hi/lo")
+        idx_g.deallocate(True)
+        hi_f = ttnn.typecast(hi_i, ttnn.float32, sub_core_grids=grids)
+        lo_f = ttnn.typecast(lo_i, ttnn.float32, sub_core_grids=grids)
+        hi_i.deallocate(True)
+        lo_i.deallocate(True)
+        picked_hi = ttnn.multiply(onehot, hi_f, sub_core_grids=grids)
+        picked_lo = ttnn.multiply(onehot, lo_f, sub_core_grids=grids)
+        ck("mul picked")
+        onehot.deallocate(True)
+        hi_f.deallocate(True)
+        lo_f.deallocate(True)
+        sel_hi = ttnn.sum(
+            picked_hi, dim=2, keepdim=True, compute_kernel_config=self._dist_argmax_fp32_ckc, sub_core_grids=grids
+        )  # [1,1,1,B] fp32, < 2048
+        sel_lo = ttnn.sum(
+            picked_lo, dim=2, keepdim=True, compute_kernel_config=self._dist_argmax_fp32_ckc, sub_core_grids=grids
+        )  # [1,1,1,B] fp32, < 256
+        ck("sum sel")
+        picked_hi.deallocate(True)
+        picked_lo.deallocate(True)
+        colterm = ttnn.multiply(g_pos_f, float(w // ttnn.TILE_SIZE), sub_core_grids=grids)
+        ck("mul colterm")
+        g_pos_f.deallocate(True)
+        sel_hi_i = ttnn.typecast(sel_hi, ttnn.int32, sub_core_grids=grids)
+        sel_lo_i = ttnn.typecast(sel_lo, ttnn.int32, sub_core_grids=grids)
+        col_i = ttnn.typecast(colterm, ttnn.int32, sub_core_grids=grids)
+        ck("typecast pieces i32")
+        sel_hi.deallocate(True)
+        sel_lo.deallocate(True)
+        colterm.deallocate(True)
+        hi_shifted = ttnn.bitwise_left_shift(sel_hi_i, 8, sub_core_grids=grids)
+        sel_hi_i.deallocate(True)
+        local_part = ttnn.add(hi_shifted, sel_lo_i, sub_core_grids=grids)  # int32 add: exact
+        hi_shifted.deallocate(True)
+        sel_lo_i.deallocate(True)
+        final_i = ttnn.add(local_part, col_i, sub_core_grids=grids)
+        ck("add final")
+        local_part.deallocate(True)
+        col_i.deallocate(True)
+        final_u = ttnn.typecast(final_i, ttnn.uint32, sub_core_grids=grids)
+        ck("typecast final u32")
+        final_i.deallocate(True)
+        tok = ttnn.untilize(final_u, use_multicore=True, sub_core_grids=grids)  # [1,1,1,B] RM u32
+        ck("untilize final")
+        final_u.deallocate(True)
+        if tt_out_tok is None:
+            # Match the single-op argmax output shape ([1,1,B], keepdim=False) expected downstream.
+            return ttnn.reshape(tok, [1, 1, batch], sub_core_grids=grids)
+        # Reshape to the caller buffer's logical shape (a view: same single RM page).
+        tok = ttnn.reshape(tok, list(tt_out_tok.shape), sub_core_grids=grids)
+        # Write the token into the caller's persistent buffer (the decode trace's frozen token
+        # input in the galaxy demo flow). ttnn.copy can't be used here: its factory grids from
+        # core (0,0), which under the split senders/worker sub-device manager lands the copy on
+        # the senders sub-device, where dispatch runs it concurrently with the worker-sub-device
+        # producers under trace replay (stale-token race, same failure mode as the unpinned
+        # all_gather). A no-op bitwise_or pinned to the worker grid keeps ordering correct.
+        out = ttnn.bitwise_or(tok, 0, output_tensor=tt_out_tok, sub_core_grids=grids)
+        ck("copy to tt_out_tok")
+        tok.deallocate(True)
+        return out
+
     def reset_params(
         self,
         k,
@@ -629,6 +904,10 @@ class TTSampling(LightweightModule):
             if num_devices > 1:
                 cluster_axis = self._get_sampling_cluster_axis()
                 num_links, topology = self._get_force_argmax_all_gather_config(cluster_axis)
+                if self._use_distributed_argmax(x, tt_out_tok, cluster_axis):
+                    tok = self._distributed_force_argmax(x, cluster_axis, topology, tt_out_tok=tt_out_tok)
+                    self.tt_log_probs = None
+                    return tok, self.tt_log_probs
                 logger.debug(
                     f"Force argmax sampling all-gather: cluster_axis={cluster_axis}, "
                     f"num_links={num_links}, topology={topology}"

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -146,6 +146,13 @@ class TTSampling(LightweightModule):
             if self.sub_core_grids is not None
             else None
         )
+        # Blackhole galaxy prefetcher (unfused-CCL) keeps a split senders/worker sub-device manager
+        # loaded during prefill sampling (prefill samples in decode mode). Auto-multicore ops grab the
+        # full 12-wide compute grid, which includes the dispatch column that no loaded sub-device covers
+        # ("kernel group cores do not match sub device cores"). Pin the force-argmax untilize/argmax to
+        # the worker sub-core grids so they stay inside the worker sub-device. Left None elsewhere so no
+        # other arch's behaviour changes.
+        self._force_argmax_sub_core_grids = self.sub_core_grids if getattr(args, "use_unfused_ccl", False) else None
 
         # sampling_dp > 1 when multiple mesh groups each sample users independently
         # (e.g. GPT-OSS on [4,8]: 4 rows × 32 users; Llama Galaxy on [8,4]: 4 cols × 8 users)
@@ -596,8 +603,17 @@ class TTSampling(LightweightModule):
         )
         if self._force_argmax_sampling:
             logger.info("Forcing argmax sampling")
-            slice_valid_vocab = self._can_slice_valid_vocab_for_argmax()
-            if not slice_valid_vocab:
+            # BH galaxy prefetcher (unfused-CCL) keeps a split senders/worker sub-device manager
+            # loaded during decode. The vocab-trim ttnn.slice and the tail-mask slices auto-grid a
+            # 32-core block from origin (0,0) (they don't honor sub_core_grids on the DRAM-interleaved
+            # path), which spills into the uncovered senders-column tail -> "kernel group cores do not
+            # match sub device cores" fatal. Skip the vocab trim on this path: the padded-vocab logits
+            # are exactly 0 (the lm_head weight is zero-padded), so argmax over the full padded width
+            # still selects the top valid token, and the following untilize/argmax are pinned to the
+            # worker sub-core grid via _force_argmax_sub_core_grids.
+            force_argmax_skip_vocab_trim = self._force_argmax_sub_core_grids is not None
+            slice_valid_vocab = self._can_slice_valid_vocab_for_argmax() and not force_argmax_skip_vocab_trim
+            if not slice_valid_vocab and not force_argmax_skip_vocab_trim:
                 x = self._mask_invalid_vocab_logits(x)
             # Gather the output across all devices and untilize the tensor (for argmax)
             num_devices = self.mesh_device.get_num_devices()
@@ -624,12 +640,13 @@ class TTSampling(LightweightModule):
                 )
             if slice_valid_vocab:
                 x = self._slice_valid_vocab_for_argmax(x)
-            x_untilized = ttnn.untilize(x, use_multicore=True)
+            x_untilized = ttnn.untilize(x, use_multicore=True, sub_core_grids=self._force_argmax_sub_core_grids)
             tt_out_tok = ttnn.argmax(
                 x_untilized,
                 dim=-1,
                 output_tensor=tt_out_tok,
                 keepdim=False,
+                sub_core_grids=self._force_argmax_sub_core_grids,
             )
             # Argmax path: logprobs not supported (force-argmax is disabled
             # when logprobs are enabled via format_sampling_params guard).

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -153,7 +153,15 @@ class TTSampling(LightweightModule):
         # ("kernel group cores do not match sub device cores"). Pin the force-argmax untilize/argmax to
         # the worker sub-core grids so they stay inside the worker sub-device. Left None elsewhere so no
         # other arch's behaviour changes.
-        self._force_argmax_sub_core_grids = self.sub_core_grids if getattr(args, "use_unfused_ccl", False) else None
+        # force_argmax_sub_core_grids (optional): a wider grid than sub_core_grids for the
+        # force-argmax untilize/argmax. Argmax is a scalar-RISC compare loop over the full gathered
+        # vocab, so its runtime scales ~1/num_cores; the BH galaxy passes the full 100-core worker
+        # sub-device here instead of the 40-core sub_core_grids (2.1 ms -> ~0.85 ms per token).
+        self._force_argmax_sub_core_grids = (
+            (getattr(args, "force_argmax_sub_core_grids", None) or self.sub_core_grids)
+            if getattr(args, "use_unfused_ccl", False)
+            else None
+        )
 
         # sampling_dp > 1 when multiple mesh groups each sample users independently
         # (e.g. GPT-OSS on [4,8]: 4 rows × 32 users; Llama Galaxy on [8,4]: 4 cols × 8 users)

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -27,6 +27,7 @@ from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 
 # Qwen-specific imports
 from models.demos.llama3_70b_galaxy.tt.qwen_model_config import TtQwenModelArgs
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import DECODE_FABRIC_CONFIG as _FABRIC_CONFIG
 from transformers import AutoTokenizer
 from models.demos.llama3_70b_galaxy.demo.demo_common import load_inputs_advanced
 
@@ -483,7 +484,7 @@ def create_tt_qwen_model(
             "num_command_queues": 1,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "worker_l1_size": 1345000,
-            "fabric_config": True,
+            "fabric_config": _FABRIC_CONFIG,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -937,7 +937,10 @@ def test_qwen_demo_text(
                 if apc_test and iteration == 0:
                     tt_out_logits_saved_iter_0 = tt_out_logits_saved
             except Exception as e:
+                import traceback
+
                 logger.error(f"Error during decoding: {str(e)}")
+                logger.error("QWEN_BH_DECODE_TRACEBACK:\n" + traceback.format_exc())
                 break
 
             if iteration == 0:  # First iteration will account the compile time

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -846,6 +846,11 @@ def test_qwen_demo_text(
         profiler.end(f"inference_prefill", iteration=batch_idx)
         logger.info(f"Prefill finished")
 
+        if os.environ.get("QWEN_PROFILE_DRAIN") == "1":
+            # Drain device-profiler DRAM buffers after prefill so decode trace-replay markers are not
+            # dropped ("Profiler DRAM buffers were full"): batch-32 prefill alone fills the buffers.
+            ttnn.ReadDeviceProfiler(mesh_device)
+
         if prefill_profile:  # If we are profiling prefill, we stop here
             model.tt_ccl.close()
             return True
@@ -1064,6 +1069,10 @@ def test_qwen_demo_text(
 
             current_pos += 1
             iteration += 1
+
+            if os.environ.get("QWEN_PROFILE_DRAIN") == "1":
+                # Drain profiler buffers every token so each decode trace replay's markers survive.
+                ttnn.ReadDeviceProfiler(mesh_device)
 
             # Upper limit of generated tokens for each user; if users_decoding is already False (say by hitting eos), then we don't need to check the max_generated_tokens.
             if users_decoding:

--- a/models/demos/llama3_70b_galaxy/tests/test_qwen_accuracy.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_qwen_accuracy.py
@@ -17,6 +17,10 @@ from models.demos.llama3_70b_galaxy.tt.llama_embedding import TtLlamaEmbedding
 from models.demos.llama3_70b_galaxy.tt.llama_model import TtTransformer
 from models.common.sampling.tt_sampling import TTSampling
 from models.tt_transformers.tt.model_config import ModelArgs
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
+    IS_BLACKHOLE as _IS_BLACKHOLE,
+    DECODE_FABRIC_CONFIG as _FABRIC_CONFIG,
+)
 from transformers import AutoTokenizer
 from tqdm import tqdm
 
@@ -73,7 +77,7 @@ from tqdm import tqdm
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 102000000,
-            "fabric_config": True,
+            "fabric_config": _FABRIC_CONFIG,
         }
     ],
     indirect=True,
@@ -272,8 +276,13 @@ def test_qwen_model_acc(
         ]
     )
 
-    # Get the first input tensors
-    _, rot_mat_idxs = tt_model.rope_setup.get_rm_rot_mats(current_pos, return_rot_idxs=True)
+    # Get the first input tensors. No-prefetcher (BH) decode uses the non-fused rotary op, which
+    # needs the simple get_rot_* tables (get_rm_rot_* is the fused-qk expanded layout and yields a
+    # wrong rotary at pos>0 on the non-fused op). Wormhole keeps main's fused get_rm_rot_* tables.
+    if _IS_BLACKHOLE:
+        _, rot_mat_idxs = tt_model.rope_setup.get_rot_mats(current_pos, return_rot_idxs=True)
+    else:
+        _, rot_mat_idxs = tt_model.rope_setup.get_rm_rot_mats(current_pos, return_rot_idxs=True)
 
     ref_token = input_ids[0, 0].item()  # First token
     ref_token = torch.tensor([[ref_token]], dtype=torch.int32)
@@ -285,7 +294,10 @@ def test_qwen_model_acc(
     )
 
     def run_model():
-        rot_mats = tt_model.rope_setup.get_rm_rot_mats(rot_mat_idxs)
+        if _IS_BLACKHOLE:
+            rot_mats = tt_model.rope_setup.get_rot_mats(rot_mat_idxs)
+        else:
+            rot_mats = tt_model.rope_setup.get_rm_rot_mats(rot_mat_idxs)
 
         tt_out = tt_model(
             decode_input,
@@ -342,7 +354,10 @@ def test_qwen_model_acc(
 
     # Reset the current position and output token tensors for the real decode run
     ttnn.copy_host_to_device_tensor(current_pos_reset, current_pos_tensor)
-    rot_mat_idxs_reset = tt_model.rope_setup.get_rm_rot_idxs(current_pos, on_host=True)
+    if _IS_BLACKHOLE:
+        rot_mat_idxs_reset = tt_model.rope_setup.get_rot_idxs(current_pos, on_host=True)
+    else:
+        rot_mat_idxs_reset = tt_model.rope_setup.get_rm_rot_idxs(current_pos, on_host=True)
     ttnn.copy_host_to_device_tensor(rot_mat_idxs_reset, rot_mat_idxs)
 
     ttnn.synchronize_device(mesh_device)
@@ -410,14 +425,20 @@ def test_qwen_model_acc(
                 mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(3, 1), mesh_shape=model_args.cluster_shape),
             )[0, 0, 0, : model_args.vocab_size]
 
-        tt_argmax_token = ttnn.to_torch(
-            tt_out_tok[0],
-            mesh_composer=ttnn.ConcatMesh2dToTensor(
-                mesh_device,
-                dims=(3, 1),
-                mesh_shape=model_args.cluster_shape,
-            ),
-        )[0, 0, 0, 0]
+        if _IS_BLACKHOLE:
+            # The argmax token is replicated across the mesh, so read device 0's shard and flatten.
+            # This is rank-agnostic: the regular sampling kernel returns [1,1,1,32] while the
+            # force-argmax (Blackhole) path returns [1,1,32]; reshape(-1) handles both.
+            tt_argmax_token = ttnn.to_torch(ttnn.get_device_tensors(tt_out_tok[0])[0]).reshape(-1)[0]
+        else:
+            tt_argmax_token = ttnn.to_torch(
+                tt_out_tok[0],
+                mesh_composer=ttnn.ConcatMesh2dToTensor(
+                    mesh_device,
+                    dims=(3, 1),
+                    mesh_shape=model_args.cluster_shape,
+                ),
+            )[0, 0, 0, 0]
 
         # Modify the accuracy checking section when using reference text
         if not use_reference_file:

--- a/models/demos/llama3_70b_galaxy/tests/test_qwen_accuracy.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_qwen_accuracy.py
@@ -425,7 +425,76 @@ def test_qwen_model_acc(
                 mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(3, 1), mesh_shape=model_args.cluster_shape),
             )[0, 0, 0, : model_args.vocab_size]
 
-        if _IS_BLACKHOLE:
+        if os.environ.get("QWEN_ACC_HOST_ARGMAX") == "1":
+            # Diagnostic: score from the host-composed lm_head logits instead of the on-device
+            # sampling argmax. Discriminates lm_head-output corruption from sampling-path
+            # (cross-column gather / argmax) corruption.
+            host_logits_full = ttnn.to_torch(
+                tt_out,
+                mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(3, 1), mesh_shape=model_args.cluster_shape),
+            )[0, 0, 0, :]
+            host_logits = host_logits_full[: model_args.vocab_size]
+            tt_argmax_token = host_logits.argmax()
+            if i < 8:
+                # One-time diagnostic: check whether any vocab chunk of the lm_head output is a
+                # duplicate of another (device row computing the wrong weight slice).
+                chunk_w = host_logits_full.shape[0] // 8
+                chunks = host_logits_full.view(8, chunk_w)
+                for a in range(8):
+                    for b in range(a + 1, 8):
+                        max_diff = (chunks[a] - chunks[b]).abs().max().item()
+                        if max_diff < 1e-3:
+                            logger.warning(f"step {i}: vocab chunk {a} and {b} are IDENTICAL (max diff {max_diff})")
+            # Also read the on-device sampled token and log divergences from the host argmax,
+            # including the host logit values at both positions (isolates argmax-vs-logits issues).
+            dev_token = int(ttnn.to_torch(ttnn.get_device_tensors(tt_out_tok[0])[0]).reshape(-1)[0])
+            host_token = int(tt_argmax_token)
+            if dev_token != host_token:
+                dev_logit = host_logits[dev_token].item() if dev_token < model_args.vocab_size else float("nan")
+                logger.warning(
+                    f"step {i}: device tok {dev_token} != host argmax {host_token} "
+                    f"(host logits: dev={dev_logit:.3f} host={host_logits[host_token].item():.3f}, "
+                    f"padded_region={dev_token >= model_args.vocab_size})"
+                )
+                untilized = getattr(tt_sampling, "debug_untilized", None)
+                if untilized is not None:
+                    # The gathered (tiled) logits were verified slot-perfect; now inspect the
+                    # TRACED untilize output (the argmax input) to localize the displacement:
+                    # if it is already displaced, untilize is at fault; if it is clean, argmax is.
+                    u = ttnn.to_torch(ttnn.get_device_tensors(untilized)[0]).float()[0, 0, 0, :]
+                    exp_val = host_logits_full[host_token].item()
+                    u_at_host = u[host_token].item()
+                    u_at_dev = u[dev_token].item() if dev_token < u.shape[0] else float("nan")
+                    max_diff = (u - host_logits_full).abs().max().item()
+                    logger.warning(
+                        f"step {i}: traced untilize out: u[host_tok]={u_at_host:.3f} "
+                        f"u[dev_tok]={u_at_dev:.3f} expected_max={exp_val:.3f} "
+                        f"max|untilized-host|={max_diff:.4f}"
+                    )
+                    # Map the permutation: for each 1/16th segment of the untilized row, find the
+                    # best-matching host segment (reveals which regions were written where).
+                    nseg = 16
+                    seg_w = u.shape[0] // nseg
+                    mapping = []
+                    for s in range(nseg):
+                        useg = u[s * seg_w : (s + 1) * seg_w]
+                        diffs = [
+                            (host_logits_full[c * seg_w : (c + 1) * seg_w] - useg).abs().max().item()
+                            for c in range(nseg)
+                        ]
+                        best = min(range(nseg), key=lambda c: diffs[c])
+                        mapping.append(f"{s}<-{best}({diffs[best]:.2f})")
+                    logger.warning(f"step {i}: untilize segment mapping: {' '.join(mapping)}")
+                    # Also rerun argmax eagerly on the traced untilize output.
+                    sub_grids = tt_sampling._force_argmax_sub_core_grids
+                    eager_tok = ttnn.argmax(untilized, dim=-1, keepdim=False, sub_core_grids=sub_grids)
+                    eager_token = int(ttnn.to_torch(ttnn.get_device_tensors(eager_tok)[0]).reshape(-1)[0])
+                    ttnn.deallocate(eager_tok)
+                    logger.warning(
+                        f"step {i}: eager argmax on traced untilize out -> {eager_token} "
+                        f"(host {host_token}, traced-device {dev_token})"
+                    )
+        elif _IS_BLACKHOLE:
             # The argmax token is replicated across the mesh, so read device 0's shard and flatten.
             # This is rank-agnostic: the regular sampling kernel returns [1,1,1,32] while the
             # force-argmax (Blackhole) path returns [1,1,32]; reshape(-1) handles both.

--- a/models/demos/llama3_70b_galaxy/tests/test_qwen_accuracy.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_qwen_accuracy.py
@@ -276,13 +276,14 @@ def test_qwen_model_acc(
         ]
     )
 
-    # Get the first input tensors. No-prefetcher (BH) decode uses the non-fused rotary op, which
-    # needs the simple get_rot_* tables (get_rm_rot_* is the fused-qk expanded layout and yields a
-    # wrong rotary at pos>0 on the non-fused op). Wormhole keeps main's fused get_rm_rot_* tables.
-    if _IS_BLACKHOLE:
-        _, rot_mat_idxs = tt_model.rope_setup.get_rot_mats(current_pos, return_rot_idxs=True)
-    else:
+    # Get the first input tensors. The non-fused rotary op needs the simple get_rot_* tables
+    # (get_rm_rot_* is the fused-qk expanded layout and yields a wrong rotary at pos>0 on the
+    # non-fused op); the fused-qk rotary op needs get_rm_rot_*. Follow the model's gating so the
+    # table layout always matches the rotary op it will run (BH fused-QKV uses fused rope too).
+    if tt_model.use_fused_rope:
         _, rot_mat_idxs = tt_model.rope_setup.get_rm_rot_mats(current_pos, return_rot_idxs=True)
+    else:
+        _, rot_mat_idxs = tt_model.rope_setup.get_rot_mats(current_pos, return_rot_idxs=True)
 
     ref_token = input_ids[0, 0].item()  # First token
     ref_token = torch.tensor([[ref_token]], dtype=torch.int32)
@@ -294,10 +295,10 @@ def test_qwen_model_acc(
     )
 
     def run_model():
-        if _IS_BLACKHOLE:
-            rot_mats = tt_model.rope_setup.get_rot_mats(rot_mat_idxs)
-        else:
+        if tt_model.use_fused_rope:
             rot_mats = tt_model.rope_setup.get_rm_rot_mats(rot_mat_idxs)
+        else:
+            rot_mats = tt_model.rope_setup.get_rot_mats(rot_mat_idxs)
 
         tt_out = tt_model(
             decode_input,
@@ -354,10 +355,10 @@ def test_qwen_model_acc(
 
     # Reset the current position and output token tensors for the real decode run
     ttnn.copy_host_to_device_tensor(current_pos_reset, current_pos_tensor)
-    if _IS_BLACKHOLE:
-        rot_mat_idxs_reset = tt_model.rope_setup.get_rot_idxs(current_pos, on_host=True)
-    else:
+    if tt_model.use_fused_rope:
         rot_mat_idxs_reset = tt_model.rope_setup.get_rm_rot_idxs(current_pos, on_host=True)
+    else:
+        rot_mat_idxs_reset = tt_model.rope_setup.get_rot_idxs(current_pos, on_host=True)
     ttnn.copy_host_to_device_tensor(rot_mat_idxs_reset, rot_mat_idxs)
 
     ttnn.synchronize_device(mesh_device)

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/qwen_test_utils.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/qwen_test_utils.py
@@ -2,11 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared arch-detection helpers for the Qwen3-32B galaxy unit tests.
+"""Shared arch-detection helpers for the Qwen3-32B galaxy tests.
 
-Both the attention and MLP unit tests select their execution path (Wormhole prefetcher vs
-Blackhole no-prefetcher) from the detected architecture. Keeping the detection here avoids the
-two test files drifting apart.
+The attention, MLP, decoder, prefill and e2e-accuracy tests all select their execution path
+(Wormhole prefetcher vs Blackhole no-prefetcher) and fabric config from the detected architecture.
+Keeping the detection here avoids the test files drifting apart.
 """
 
 import os
@@ -42,3 +42,6 @@ IS_BLACKHOLE = is_blackhole_galaxy()
 # requires a 2D-torus fabric (FABRIC_1D / FABRIC_1D_RING throw `IndexError: map::at` on the cross-column
 # route). Wormhole keeps main's fabric_config=True.
 DECODE_FABRIC_CONFIG = ttnn.FabricConfig.FABRIC_2D_TORUS_XY if IS_BLACKHOLE else True
+
+# Prefill collectives need the same 2D-torus fabric on Blackhole; Wormhole keeps main's FABRIC_1D_RING.
+PREFILL_FABRIC_CONFIG = ttnn.FabricConfig.FABRIC_2D_TORUS_XY if IS_BLACKHOLE else ttnn.FabricConfig.FABRIC_1D_RING

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_all_gather_concat.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_all_gather_concat.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Blackhole-galaxy port test for ttnn.experimental.all_gather_concat (fused SDPA-output
+users-gather + nlp_concat_heads_decode).
+
+The writer built raw 1D MulticastRoutingCommandHeaders, which no-op on the BH 2D-torus fabric
+(HybridMeshPacketHeader routing) - the gather never delivered and the op deadlocked, which is why
+the BH decode path fell back to the unfused all_gather_async + nlp_concat_heads_decode + reshard
+chain. The port emits host-computed route info via ccl_routing_utils (same mechanism as the
+fused-RMS / llama_reduce_scatter ports); dynamic-alternate header swapping is disabled on 2D
+fabrics because routes are direction-specific. 1D fabrics keep the original behavior.
+
+Geometry mirrors the Qwen/Llama galaxy decode: gather 8-user SDPA outputs across the 4 devices of
+each mesh row into the 32-user concat-heads layout.
+"""
+
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
+    DECODE_FABRIC_CONFIG as _FABRIC_CONFIG,
+)
+from models.perf.benchmarking_utils import BenchmarkProfiler
+from tests.ttnn.unit_tests.operations.ccl.fusion_subtests.concat_fuse_test import run_concat_fuse_impl
+
+
+_WH_ORDER_OUTPUT_GRID = ttnn.CoreRangeSet(
+    [
+        ttnn.CoreRange(ttnn.CoreCoord(6, 6), ttnn.CoreCoord(6, 6)),
+        ttnn.CoreRange(ttnn.CoreCoord(6, 7), ttnn.CoreCoord(6, 7)),
+        ttnn.CoreRange(ttnn.CoreCoord(6, 9), ttnn.CoreCoord(6, 9)),
+        ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 0)),
+        ttnn.CoreRange(ttnn.CoreCoord(6, 1), ttnn.CoreCoord(6, 1)),
+        ttnn.CoreRange(ttnn.CoreCoord(6, 2), ttnn.CoreCoord(6, 2)),
+        ttnn.CoreRange(ttnn.CoreCoord(6, 4), ttnn.CoreCoord(6, 4)),
+        ttnn.CoreRange(ttnn.CoreCoord(6, 5), ttnn.CoreCoord(6, 5)),
+        ttnn.CoreRange(ttnn.CoreCoord(5, 5), ttnn.CoreCoord(5, 5)),
+        ttnn.CoreRange(ttnn.CoreCoord(5, 6), ttnn.CoreCoord(5, 6)),
+        ttnn.CoreRange(ttnn.CoreCoord(5, 7), ttnn.CoreCoord(5, 7)),
+        ttnn.CoreRange(ttnn.CoreCoord(5, 9), ttnn.CoreCoord(5, 9)),
+        ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(5, 0)),
+        ttnn.CoreRange(ttnn.CoreCoord(5, 1), ttnn.CoreCoord(5, 1)),
+        ttnn.CoreRange(ttnn.CoreCoord(5, 2), ttnn.CoreCoord(5, 2)),
+        ttnn.CoreRange(ttnn.CoreCoord(5, 4), ttnn.CoreCoord(5, 4)),
+        ttnn.CoreRange(ttnn.CoreCoord(1, 4), ttnn.CoreCoord(1, 4)),
+        ttnn.CoreRange(ttnn.CoreCoord(1, 5), ttnn.CoreCoord(1, 5)),
+        ttnn.CoreRange(ttnn.CoreCoord(1, 9), ttnn.CoreCoord(1, 9)),
+        ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0)),
+        ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 0)),
+        ttnn.CoreRange(ttnn.CoreCoord(2, 4), ttnn.CoreCoord(2, 4)),
+        ttnn.CoreRange(ttnn.CoreCoord(2, 5), ttnn.CoreCoord(2, 5)),
+        ttnn.CoreRange(ttnn.CoreCoord(2, 9), ttnn.CoreCoord(2, 9)),
+    ]
+)
+
+# BH model geometry: SHARDED_ATTN_WO_INPUT_RING_MEMCFG puts the concat output on the matmul ring
+# cores in ring order (PREFETCHER_NOC1_GRID_BH: cols 1-3, x fast, y slow). The first 16 ring cores
+# include (1,0),(2,0),(3,0), which used to be wrongly excluded by the factory's hardcoded WH
+# worker-core check (no runtime args -> TT_FATAL in override), and the concat-ready semaphore mcast
+# targeted the WH cols-5-6 rectangles (cores without the concat kernel).
+_BH_RING_ORDER_OUTPUT_GRID = ttnn.CoreRangeSet(
+    [ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for y in range(8) for x in (1, 2, 3)]
+)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+    [
+        # Before Concat Heads (same geometry as the WH 6U test; all grids fit the BH worker area)
+        pytest.param(
+            4,
+            [1, 32, 32, 128],
+            1,
+            ttnn.ROW_MAJOR_LAYOUT,
+            (32, 128),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
+                }
+            ),
+            (32, 64),
+            _WH_ORDER_OUTPUT_GRID,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            id="wh_order",
+        ),
+        # BH model geometry: output on the matmul-ring cores in ring order (see comment above)
+        pytest.param(
+            4,
+            [1, 32, 32, 128],
+            1,
+            ttnn.ROW_MAJOR_LAYOUT,
+            (32, 128),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
+                }
+            ),
+            (32, 64),
+            _BH_RING_ORDER_OUTPUT_GRID,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            id="bh_ring_order",
+        ),
+    ],
+)
+@pytest.mark.parametrize("num_links", [2])
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("num_iters, warmup_iters", [[8, 2]])
+@pytest.mark.parametrize("trace_mode", [False, True])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "trace_region_size": 23887872,
+            "fabric_config": _FABRIC_CONFIG,
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_bh_all_gather_concat(
+    mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    num_iters,
+    warmup_iters,
+    function_level_defaults,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    tensor_mem_layout,
+    trace_mode,
+):
+    logger.info(f"BH all_gather_concat: trace={trace_mode} links={num_links} iters={num_iters}")
+    profiler = BenchmarkProfiler()
+    run_concat_fuse_impl(
+        mesh_device,
+        num_devices,
+        output_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        function_level_defaults,
+        input_shard_shape,
+        input_shard_grid,
+        all_gather_topology=ttnn.Topology.Ring,
+        warmup_iters=warmup_iters,
+        num_iters=num_iters,
+        output_shard_shape=output_shard_shape,
+        output_shard_grid=output_shard_grid,
+        tensor_mem_layout=tensor_mem_layout,
+        trace_mode=trace_mode,
+        profiler=profiler,
+    )

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_argmax_subcore.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_argmax_subcore.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Repro for the BH force-argmax index displacement.
+
+The Qwen accuracy run with the prefetcher (unfused-CCL) path shows the on-device force-argmax
+returning true_index + 3*19456 whenever the max logit lives in vocab chunk 0. This test drives the
+exact untilize + argmax (sub_core_grids-pinned) sequence tt_sampling uses, with a known max planted
+at various positions.
+"""
+
+import pytest
+import torch
+from loguru import logger
+import ttnn
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(8, 4)],
+    indirect=True,
+)
+def test_bh_argmax_subcore(mesh_device):
+    torch.manual_seed(1234)
+    width = 155648  # padded vocab as gathered in the model
+    batch = 32
+
+    sub_core_grids = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 7)),
+            ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 7)),
+        ]
+    )
+
+    # Plant the max at known positions per row; positions span multiple vocab chunks.
+    positions = [198, 257, 279, 11, 19456 + 5, 2 * 19456 + 100, 3 * 19456 + 7, 4 * 19456 + 3000]
+    x = torch.rand(1, 1, batch, width) * 10.0 - 5.0
+    expected = []
+    for r in range(batch):
+        pos = positions[r % len(positions)]
+        x[0, 0, r, :] = torch.clamp(x[0, 0, r, :], max=20.0)
+        x[0, 0, r, pos] = 50.0 + r  # unambiguous max
+        expected.append(pos)
+
+    tt_x = ttnn.from_torch(
+        x,
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    for grids, label in ((None, "default"), (sub_core_grids, "sub_core_grids")):
+        x_unt = ttnn.untilize(tt_x, use_multicore=True, sub_core_grids=grids)
+        tok = ttnn.argmax(x_unt, dim=-1, keepdim=False, sub_core_grids=grids)
+        got = ttnn.to_torch(ttnn.get_device_tensors(tok)[0]).reshape(-1).tolist()
+        errs = [(r, expected[r], got[r]) for r in range(batch) if got[r] != expected[r]]
+        logger.info(f"[{label}] mismatches: {len(errs)}")
+        for r, exp, g in errs[:10]:
+            logger.warning(f"[{label}] row {r}: expected {exp} got {g} (delta {g - exp}, chunks {(g - exp) / 19456})")
+        assert not errs, f"argmax misattributed indices with {label}: {errs[:5]}"

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_fused_rms_allgather.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_fused_rms_allgather.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Blackhole-galaxy port test for the fused RMSAllGather (ttnn.fused_rms_minimal).
+
+The fused op's writer used raw 1D MulticastRoutingCommandHeaders for its stats all-gather, which
+no-op on the BH 2D-torus fabric (HybridMeshPacketHeader routing). The port emits host-computed
+route info via ccl_routing_utils (same mechanism as the BH-proven all_gather_async writers).
+
+This test mirrors the Qwen3-32B decode norm geometry exactly:
+- 8x4 mesh, cluster_axis=1 (4 devices per row), Ring topology
+- hidden 5120 -> 1280 per device, width-sharded on the 10-core LN grid at (7,0)-(8,4)
+- stats persistent buffer (1,1,32,128) on the sender core (7,0)
+- eager + trace-replay correctness against a torch RMS reference
+"""
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
+    DECODE_FABRIC_CONFIG as _FABRIC_CONFIG,
+)
+
+HIDDEN = 5120
+RING_SIZE = 4  # devices per mesh row (cluster_axis=1)
+SHARD_H = 32
+LN_GRID_OFFSET = ttnn.CoreCoord(7, 0)
+LN_GRID_END = ttnn.CoreCoord(8, 4)  # 2 cols x 5 rows = 10 cores
+NUM_CORES_LN = 10
+PER_DEV = HIDDEN // RING_SIZE  # 1280
+SHARD_W = PER_DEV // NUM_CORES_LN  # 128
+
+
+def torch_rms(x, gamma, eps):
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps) * gamma
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": _FABRIC_CONFIG,
+            "trace_region_size": 23887872,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(8, 4)],
+    indirect=True,
+)
+def test_bh_fused_rms_allgather(mesh_device, reset_seeds):
+    torch.manual_seed(1234)
+    eps = 1e-6
+    num_iters = int(os.environ.get("FUSED_RMS_TEST_ITERS", "8"))
+    trace_mode = os.environ.get("FUSED_RMS_TEST_TRACE", "1") == "1"
+
+    ln_grid = ttnn.CoreRangeSet([ttnn.CoreRange(LN_GRID_OFFSET, LN_GRID_END)])
+    input_memcfg = ttnn.create_sharded_memory_config(
+        shape=(SHARD_H, SHARD_W),
+        core_grid=ln_grid,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    output_memcfg = input_memcfg  # skip_write_back path, same as model when out grid == in grid
+
+    prg_cfg = ttnn.LayerNormShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=(2, 5),
+        subblock_w=SHARD_W // 32,
+        block_h=SHARD_H // 32,
+        block_w=SHARD_W // 32,
+        inplace=False,
+    )
+
+    # Stats gather buffer on the sender core (first core of the LN grid), like the model's
+    # LAYERNORM persistent buffer. Width = ring_size tiles.
+    stats_memcfg = ttnn.create_sharded_memory_config(
+        shape=(32, 32 * RING_SIZE),
+        core_grid=ttnn.CoreRangeSet([ttnn.CoreRange(LN_GRID_OFFSET, LN_GRID_OFFSET)]),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    tt_stats = ttnn.from_torch(
+        torch.zeros((1, 1, 32, 32 * RING_SIZE)),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=stats_memcfg,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    # Semaphores on a grid covering the LN cores (model uses a worker-grid pool).
+    sem_crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(10, 9))])
+    semaphores = [ttnn.create_global_semaphore(mesh_device, sem_crs, 0) for _ in range(2)]
+
+    ref_in, ref_gamma, tt_in, tt_gamma = [], [], [], []
+    for i in range(num_iters):
+        x = torch.randn(1, 1, SHARD_H, HIDDEN)
+        g = torch.randn(1, 1, 1, HIDDEN) * 0.5 + 1.0
+        ref_in.append(x)
+        ref_gamma.append(g)
+        tt_in.append(
+            ttnn.from_torch(
+                x,
+                dtype=ttnn.bfloat16,
+                device=mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=input_memcfg,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 3), mesh_shape=(8, 4)),
+            )
+        )
+        tt_gamma.append(
+            ttnn.from_torch(
+                g.reshape([1, 1, HIDDEN // 32, 32]),
+                dtype=ttnn.bfloat16,
+                device=mesh_device,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 2), mesh_shape=(8, 4)),
+            )
+        )
+
+    def run_op(i):
+        return ttnn.fused_rms_minimal(
+            tt_in[i],
+            prg_cfg,
+            1,  # cluster_axis
+            mesh_device,
+            semaphores[i % 2],
+            topology=ttnn.Topology.Ring,
+            residual_input_tensor=None,
+            num_links=1,
+            epsilon=eps,
+            weight=tt_gamma[i],
+            stats=tt_stats,
+            memory_config=output_memcfg,
+            use_noc1_only=False,
+        )
+
+    def check(i, tt_out, tag):
+        out = ttnn.to_torch(
+            tt_out,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, 3), mesh_shape=(8, 4)),
+        )  # [8, 1, 32, 5120]
+        ref = torch_rms(ref_in[i], ref_gamma[i], eps)[0]  # [1, 32, 5120]
+        ok_all = True
+        for row in range(8):
+            passing, msg = comp_pcc(out[row : row + 1], ref.unsqueeze(0), 0.999)
+            if not passing:
+                logger.error(f"{tag} iter {i} mesh-row {row}: {msg}")
+                ok_all = False
+        assert ok_all, f"{tag} iter {i}: PCC failure (see log)"
+        logger.info(f"{tag} iter {i}: PCC ok")
+
+    # Eager
+    logger.info("eager run")
+    eager_outs = [run_op(i) for i in range(num_iters)]
+    ttnn.synchronize_device(mesh_device)
+    for i in range(num_iters):
+        check(i, eager_outs[i], "eager")
+        eager_outs[i].deallocate(True)
+
+    if trace_mode:
+        logger.info("capturing trace")
+        trace_outs = []
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        for i in range(num_iters):
+            trace_outs.append(run_op(i))
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        for rep in range(3):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+            for i in range(num_iters):
+                check(i, trace_outs[i], f"trace-rep{rep}")
+        ttnn.release_trace(mesh_device, trace_id)
+
+    logger.info("test_bh_fused_rms_allgather passed")

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_llama_reduce_scatter.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_llama_reduce_scatter.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Blackhole-galaxy port test for ttnn.experimental.llama_reduce_scatter.
+
+The writer set fabric routes with hop counts only (fabric_set_unicast_route<false>(num_hops)),
+which the BH 2D-torus routers cannot resolve - packets were never delivered and the op deadlocked
+(this was the long-standing QWEN_BH_FUSED_RS_MATMUL blocker). The port emits host-computed
+{mesh_id, chip_id} route info per target device via ccl_routing_utils, the same mechanism as the
+BH-proven all_gather_async / fused-RMS writers. 1D fabrics keep hop counts, so WH is unchanged.
+
+Geometry mirrors the Qwen3-32B decode FF1/FF3 reduce-scatter: 8x4 mesh, scatter over the 4 devices
+of each row (cluster_axis=1), Ring topology, 24 input cores, bfp8.
+"""
+
+import os
+
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
+    DECODE_FABRIC_CONFIG as _FABRIC_CONFIG,
+)
+from tests.ttnn.unit_tests.operations.ccl.test_llama_reduce_scatter_async_TG import run_reduce_scatter_test
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": _FABRIC_CONFIG,
+            "trace_region_size": 23887872,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+@pytest.mark.parametrize("trace_mode", [False, True])
+@pytest.mark.parametrize("num_links", [2])
+@pytest.mark.parametrize("topology", [ttnn.Topology.Ring])
+def test_bh_llama_reduce_scatter(mesh_device, trace_mode, num_links, topology):
+    num_iters = int(os.environ.get("BH_RS_TEST_ITERS", "8"))
+    warmup_iters = 2 if trace_mode else 0
+
+    logger.info(f"BH llama_reduce_scatter: trace={trace_mode} links={num_links} iters={num_iters}")
+    run_reduce_scatter_test(
+        mesh_device,
+        dim=3,
+        shard_height=32,
+        shard_width=160,
+        num_devices_scatter=4,
+        num_devices_fracture=8,
+        num_cores=24,
+        num_iters=num_iters,
+        warmup_iters=warmup_iters,
+        trace_mode=trace_mode,
+        num_links=num_links,
+        scheme="random",
+        topology=topology,
+    )

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_llama_rs_create_heads.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_llama_rs_create_heads.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Blackhole-galaxy port test for ttnn.experimental.llama_rs_create_heads (fused QKV
+reduce-scatter + nlp_create_qkv_heads_decode).
+
+The underlying llama_reduce_scatter_create_heads writer used hop-count-only unicast routes
+(fabric_set_unicast_route(num_hops)), which the BH 2D-torus routers cannot resolve - packets were
+never delivered and the op deadlocked, which is why the BH decode path fell back to the unfused
+column all-reduce + off-receiver reshard + nlp_create_qkv_heads_decode chain. The port emits
+host-computed {mesh_id, chip_id} route info per target device via ccl_routing_utils (same
+mechanism as the llama_reduce_scatter / fused-RMS ports). 1D fabrics keep hop counts, WH unchanged.
+
+Geometry mirrors the galaxy decode QKV: 8x4 mesh, reduce-scatter over the 4 devices of each row
+(cluster_axis=1), 20 input cores x 64-wide shards = 1280 = (8 q + 2*1 kv) * 128 head_dim.
+"""
+
+import os
+
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
+    DECODE_FABRIC_CONFIG as _FABRIC_CONFIG,
+)
+from tests.ttnn.unit_tests.operations.ccl.test_llama_reduce_scatter_create_heads_async_TG import (
+    run_reduce_scatter_test,
+)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": _FABRIC_CONFIG,
+            "trace_region_size": 23887872,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+@pytest.mark.parametrize("trace_mode", [False, True])
+@pytest.mark.parametrize("num_links", [2])
+@pytest.mark.parametrize("topology", [ttnn.Topology.Ring])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_bh_llama_rs_create_heads(mesh_device, trace_mode, num_links, topology, dtype):
+    num_iters = int(os.environ.get("BH_RS_TEST_ITERS", "8"))
+    warmup_iters = 2 if trace_mode else 0
+
+    logger.info(f"BH llama_rs_create_heads: trace={trace_mode} links={num_links} iters={num_iters}")
+    run_reduce_scatter_test(
+        mesh_device,
+        dim=3,
+        shard_height=32,
+        shard_width=64,
+        num_devices_scatter=4,
+        num_devices_fracture=8,
+        num_cores=20,
+        num_iters=num_iters,
+        warmup_iters=warmup_iters,
+        trace_mode=trace_mode,
+        num_links=num_links,
+        scheme="random",
+        dtype=dtype,
+        topology=topology,
+    )

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_llama_rs_matmul.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_llama_rs_matmul.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Blackhole-galaxy repro/port test for ttnn.experimental.llama_rs_matmul (fused gathered ring
+matmul + llama_reduce_scatter connected by MatmulFusedOpSignaler).
+
+This is the same fused program the model's matmul_line_reduce_scatter /
+double_matmul_line_reduce_scatter paths use for FF1/FF3 (the two-weight variant additionally
+requires the prefetcher global CB with DRAM-sharded weights, which cannot be replicated
+standalone - matmul validation rejects 3 input tensors without a global CB). The RS-side
+fabric routing was ported to 2D-torus routes (test_bh_llama_reduce_scatter passes); this test
+adds the matmul + signaler on top, which is where the model-level QWEN_BH_FUSED_RS_MATMUL hang
+lives.
+
+Geometry mirrors Qwen3-32B FF1/FF3 decode: 24-core BH ring (PREFETCHER_NOC1_GRID_BH, cols 1-3
+rows 0-7), hop core (3,8), scatter over the 4 devices of each mesh row (cluster_axis=1, Ring),
+RS input 24 cores x [32,160], RS output 30 cores x [32,32].
+"""
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from models.demos.llama3_70b_galaxy.tt.model_config import PREFETCHER_NOC1_GRID_BH, num_to_coregrid
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
+    DECODE_FABRIC_CONFIG as _FABRIC_CONFIG,
+)
+from tests.ttnn.unit_tests.operations.ccl.test_llama_reduce_scatter_async_TG import gen_tensor
+from tests.ttnn.unit_tests.operations.ccl.test_new_all_reduce import (
+    SUB_DEVICE_CRS,
+    FF1_CRS_RS_OUT,
+)
+
+M = 32
+K = 1536  # per-device K (padded), 48 tiles -> in0_block_w=2 on 24 cores
+N = 3840  # per-device N (padded), 120 tiles -> per_core_N=5 on 24 cores
+RING_SIZE = 24
+NUM_SCATTER_DEVICES = 4
+NUM_FRACTURE_DEVICES = 8
+CLUSTER_SHAPE = (8, 4)
+SHARD_HEIGHT = 32
+SHARD_WIDTH = N // RING_SIZE  # 160
+NUM_PAGES_PER_PACKET = 4
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": _FABRIC_CONFIG,
+            "trace_region_size": 23887872,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+def test_bh_llama_rs_matmul(mesh_device, reset_seeds):
+    torch.manual_seed(1234)
+    num_iters = int(os.environ.get("BH_RS_MM_TEST_ITERS", "4"))
+    trace_mode = os.environ.get("BH_RS_MM_TEST_TRACE", "1") == "1"
+    num_links = int(os.environ.get("BH_RS_MM_TEST_LINKS", "2"))
+
+    ring_crs = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for x, y in PREFETCHER_NOC1_GRID_BH]
+    )
+    hop_crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(3, 8), ttnn.CoreCoord(3, 8))])
+
+    # Matmul tensors (identical on all devices).
+    in0_memcfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(ring_crs, [M, K // RING_SIZE], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    in1_memcfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(ring_crs, [K, N // RING_SIZE], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    mm_out_memcfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(ring_crs, [M, N // RING_SIZE], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    # RS tensors: same geometry as the passing test_bh_llama_reduce_scatter harness.
+    rs_in_memcfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(ring_crs, [SHARD_HEIGHT, SHARD_WIDTH], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    # Packet-worker (interim) cores must NOT overlap the matmul ring: the matmul factory subtracts
+    # the RS cores (restricted_cores) from its worker set, so any ring core inside the RS grid gets
+    # no matmul kernel and the ring gather deadlocks (this was the BH QWEN_BH_FUSED_RS_MATMUL hang).
+    # BH ring = cols 1-3 rows 0-7 + hop (3,8); RS senders = (5,3),(6,3). Use cols 5-6 off row 3.
+    packet_worker_crs = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 2)),
+            ttnn.CoreRange(ttnn.CoreCoord(5, 4), ttnn.CoreCoord(6, 4)),
+        ]
+    )
+    interim_memcfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            packet_worker_crs,
+            [SHARD_HEIGHT, NUM_SCATTER_DEVICES * NUM_PAGES_PER_PACKET * 32],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+    rs_out_memcfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(FF1_CRS_RS_OUT, [SHARD_HEIGHT, 32], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+    grid = num_to_coregrid(RING_SIZE)
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(grid.x, grid.y),
+        in0_block_w=K // RING_SIZE // 32,
+        out_subblock_h=1,
+        out_subblock_w=5,
+        per_core_M=M // 32,
+        per_core_N=N // RING_SIZE // 32,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+        gather_in0=True,
+        hop_cores=hop_crs,
+        untilize_out=False,
+    )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        mesh_device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+        dst_full_sync_en=True,
+    )
+
+    in0 = torch.randn(1, 1, M, K)
+    w1 = torch.randn(1, 1, K, N)
+    in0_t = ttnn.from_torch(
+        in0, device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b, memory_config=in0_memcfg
+    )
+    w1_t = ttnn.from_torch(
+        w1, device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b, memory_config=in1_memcfg
+    )
+
+    rs_input = gen_tensor(
+        3, SHARD_HEIGHT, SHARD_WIDTH, NUM_SCATTER_DEVICES, NUM_FRACTURE_DEVICES, RING_SIZE, scheme="random"
+    )
+    # Golden: reduce the 4 column-device shards, then scatter chunks back across the column.
+    intermediate_outputs = torch.chunk(rs_input, chunks=NUM_SCATTER_DEVICES, dim=1)
+    reduced = torch.zeros(intermediate_outputs[0].shape)
+    for t in intermediate_outputs:
+        reduced += t
+    rs_golden = torch.cat(torch.chunk(reduced, chunks=NUM_SCATTER_DEVICES, dim=3), dim=1)
+    mm_golden = in0.float() @ w1.float()
+
+    rs_in_t = ttnn.from_torch(
+        rs_input,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        memory_config=rs_in_memcfg,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, 1), mesh_shape=list(CLUSTER_SHAPE)),
+    )
+    interim_t = ttnn.from_torch(
+        torch.zeros(
+            (
+                NUM_FRACTURE_DEVICES,
+                NUM_SCATTER_DEVICES,
+                SHARD_HEIGHT,
+                NUM_SCATTER_DEVICES * NUM_PAGES_PER_PACKET * 32 * packet_worker_crs.num_cores(),
+            )
+        ),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        memory_config=interim_memcfg,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, 1), mesh_shape=list(CLUSTER_SHAPE)),
+    )
+
+    worker_sub_device = ttnn.SubDevice([SUB_DEVICE_CRS])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+
+    semaphores = [ttnn.create_global_semaphore(mesh_device, SUB_DEVICE_CRS, 0) for _ in range(2)]
+
+    def run_once(i):
+        # Same unpacking as the model's matmul_line_reduce_scatter: (matmul_out, rs_out).
+        mm_out, rs_out = ttnn.experimental.llama_rs_matmul(
+            in0_t,
+            w1_t,
+            interim_t,
+            3,
+            semaphores[i % 2],
+            1,  # cluster_axis
+            mesh_device,
+            num_links,
+            worker_sub_device_id,
+            rs_tensor=rs_in_t,
+            memory_config_rs=rs_out_memcfg,
+            compute_kernel_config=compute_kernel_config,
+            dtype=ttnn.bfloat8_b,
+            program_config=program_config,
+            memory_config_mm=mm_out_memcfg,
+            second_weight_tensor=None,
+            topology=ttnn.Topology.Ring,
+        )
+        return mm_out, rs_out
+
+    logger.info(f"eager compile run (links={num_links})")
+    mm_out_t, rs_out_t = run_once(0)
+    ttnn.synchronize_device(mesh_device)
+    logger.info("eager run done")
+
+    # Identify outputs by shape in case the binding orders them differently.
+    if mm_out_t.shape[-1] != N:
+        mm_out_t, rs_out_t = rs_out_t, mm_out_t
+
+    def check(rs_tensor_dev, mm_tensor_dev, tag):
+        rs_torch = ttnn.to_torch(
+            rs_tensor_dev,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, 1), mesh_shape=list(CLUSTER_SHAPE)),
+        )
+        ok, pcc = comp_pcc(rs_golden, rs_torch, 0.99)
+        logger.info(f"[{tag}] rs pcc: {pcc}")
+        assert ok, f"[{tag}] rs output mismatch: {pcc}"
+        if mm_tensor_dev is not None:
+            mm_torch = ttnn.to_torch(
+                mm_tensor_dev,
+                mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, 1), mesh_shape=list(CLUSTER_SHAPE)),
+            )
+            ok, pcc = comp_pcc(mm_golden[0], mm_torch[0:1, 0], 0.99)
+            logger.info(f"[{tag}] matmul pcc: {pcc}")
+            assert ok, f"[{tag}] matmul output mismatch: {pcc}"
+
+    check(rs_out_t, mm_out_t, "eager")
+
+    if trace_mode:
+        logger.info("capturing trace")
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        for i in range(num_iters):
+            mm_o, rs_o = run_once(i)
+            if mm_o.shape[-1] != N:
+                mm_o, rs_o = rs_o, mm_o
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+        logger.info("executing trace")
+        ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.synchronize_device(mesh_device)
+        check(rs_o, mm_o, "trace")
+
+    mesh_device.reset_sub_device_stall_group()
+    logger.info("PASSED bh llama_rs_matmul")

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_untilize_argmax_trace.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_bh_untilize_argmax_trace.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Minimal repro for the BH traced untilize(sub_core_grids)+argmax corruption.
+
+In the Qwen accuracy run (prefetcher / unfused-CCL path) the traced untilize writes the
+sampling logits displaced by exactly 1824 tiles (3/8 of the row), so the on-device argmax
+returns token+58368. Eagerly rerunning the same ops on the same input is correct, and the
+gathered input is verified byte-perfect, so the corruption needs: program-cache reuse with a
+DIFFERENT input address (compile vs capture) + trace capture/replay + sub_core_grids.
+
+This test mirrors that: compile untilize+argmax on input A (eager), then capture a trace on
+input B allocated at a different address, replay with fresh data in B, and verify argmax.
+"""
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+import ttnn
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 102000000}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(8, 4)],
+    indirect=True,
+)
+def test_bh_untilize_argmax_trace(mesh_device):
+    torch.manual_seed(1234)
+    width = 155648
+    batch = 32
+    chunk = width // 8
+
+    sub_core_grids = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
+            ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 9)),
+        ]
+    )
+
+    def make_input(seed_offset):
+        torch.manual_seed(1234 + seed_offset)
+        x = torch.rand(1, 1, batch, width) * 4.0 - 2.0
+        expected = []
+        positions = [198, 257, 11, 279, chunk + 5, 2 * chunk + 100, 3 * chunk + 7, 5 * chunk + 3000]
+        for r in range(batch):
+            pos = (positions[r % len(positions)] + seed_offset * 31) % width
+            x[0, 0, r, pos] = 30.0 + r
+            expected.append(pos)
+        return x, expected
+
+    def upload(x):
+        return ttnn.from_torch(
+            x,
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            dtype=ttnn.bfloat8_b,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def run(inp):
+        x_unt = ttnn.untilize(inp, use_multicore=True, sub_core_grids=sub_core_grids)
+        tok = ttnn.argmax(x_unt, dim=-1, keepdim=False, sub_core_grids=sub_core_grids)
+        return x_unt, tok
+
+    def check(tok, expected, label):
+        got = ttnn.to_torch(ttnn.get_device_tensors(tok)[0]).reshape(-1).tolist()
+        errs = [(r, expected[r], got[r]) for r in range(batch) if got[r] != expected[r]]
+        logger.info(f"[{label}] mismatches: {len(errs)}")
+        for r, exp, g in errs[:6]:
+            logger.warning(f"[{label}] row {r}: expected {exp} got {g} (delta {g - exp} = {(g - exp) / chunk} chk)")
+        return not errs
+
+    # ---- compile run (eager) on input A ----
+    x_a, exp_a = make_input(0)
+    tt_a = upload(x_a)
+    unt_a, tok_a = run(tt_a)
+    ok = check(tok_a, exp_a, "compile-eager")
+    ttnn.deallocate(unt_a)
+    ttnn.deallocate(tok_a)
+    ttnn.deallocate(tt_a)
+    assert ok, "eager compile run wrong — different bug"
+
+    # Shift the allocator so input B lands at a different address than A.
+    pad = ttnn.from_torch(
+        torch.zeros(1, 1, 32, 4096),
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # ---- trace capture on input B (program-cache hit, new addresses) ----
+    x_b, exp_b = make_input(1)
+    tt_b = upload(x_b)
+    logger.info(f"input A vs B addresses differ; B addr {tt_b.buffer_address():#x}")
+
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    unt_b, tok_b = run(tt_b)
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    host_b = ttnn.from_torch(
+        x_b,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    n_replays = int(os.environ.get("QWEN_UNTILIZE_TEST_ITERS", "5"))
+    all_pass = True
+    for it in range(n_replays):
+        x_i, exp_i = make_input(2 + it)
+        host_i = ttnn.from_torch(
+            x_i,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            dtype=ttnn.bfloat8_b,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_i, tt_b)
+        ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=True)
+        if not check(tok_b, exp_i, f"trace-replay-{it}"):
+            all_pass = False
+            # diagnose: readback untilize output
+            u = ttnn.to_torch(ttnn.get_device_tensors(unt_b)[0]).float()[0, 0, 0, :]
+            ref = torch.from_numpy(ttnn.to_torch(ttnn.get_device_tensors(tt_b)[0]).float()[0, 0, 0, :].numpy())
+            max_diff = (u - ref).abs().max().item()
+            logger.warning(f"replay {it}: max|untilized - input| = {max_diff}")
+
+    ttnn.release_trace(mesh_device, trace_id)
+    assert all_pass, "traced untilize+argmax returned wrong indices"

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_matmul_reduce_scatter_async_bh.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_matmul_reduce_scatter_async_bh.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone Blackhole-Galaxy validation for ttnn.experimental.matmul_reduce_scatter_async.
+
+Goal: prove the *fused* matmul + reduce-scatter (built on the BH-working reduce_scatter_minimal_async
+primitive, with the matmul->RS overlap signaler) runs on the 8x4 Blackhole Galaxy 2D-torus fabric with
+a column-axis (cluster_axis=1) reduce-scatter and produces correct numerics -- WITHOUT the Wormhole
+llama_reduce_scatter path (which deadlocks on BH).
+
+This isolates the op from the model's tensor-parallel FF layout: we control every shape here. A K-parallel
+matmul is sharded on the contraction dim across the 4 column devices; each device computes a partial
+[M, N]; the fused reduce-scatter sums the partials across the 4-device column ring and scatters N.
+
+Run (on a Blackhole Galaxy):
+    pytest -svq models/demos/llama3_70b_galaxy/tests/unit_tests/test_matmul_reduce_scatter_async_bh.py
+"""
+
+import math
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import DECODE_FABRIC_CONFIG as _FABRIC_CONFIG
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": _FABRIC_CONFIG,
+            "trace_region_size": 200000,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+@pytest.mark.parametrize(
+    "M, K_full, N",
+    [
+        (256, 2048, 2048),
+    ],
+)
+@pytest.mark.parametrize("num_links", [1])
+def test_matmul_reduce_scatter_async_bh(mesh_device, M, K_full, N, num_links, reset_seeds):
+    mesh_shape = (8, 4)
+    cluster_axis = 1
+    num_col_devices = mesh_shape[1]  # cluster_axis=1 -> 4 devices in a column ring
+    assert K_full % num_col_devices == 0
+    assert N % num_col_devices == 0
+    K_per_dev = K_full // num_col_devices
+
+    # ----- sub-device (full worker grid) + semaphores -----
+    grid = mesh_device.compute_with_storage_grid_size()
+    logger.info(f"compute_with_storage_grid_size = ({grid.x}, {grid.y})")
+    ccl_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    worker_sub_device = ttnn.SubDevice([ccl_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+
+    rs_semaphores = [ttnn.create_global_semaphore(mesh_device, ccl_crs, 0) for _ in range(3)]
+    barrier_semaphore = ttnn.create_global_semaphore(mesh_device, ccl_crs, 0)
+
+    dram = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+    # ----- persistent buffers required by the fused RS -----
+    # intermediate = matmul output per device [1,1,M,N]; output = scattered [1,1,M,N/num_col_devices]
+    persistent_intermediate = ttnn.from_torch(
+        torch.zeros([1, 1, M, N]),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=dram,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+    persistent_output = ttnn.from_torch(
+        torch.zeros([1, 1, M, N // num_col_devices]),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=dram,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    # ----- weights: [1,1,K_full,N], K sharded across the 4 column devices, replicated across rows -----
+    weights_torch = torch.randn([1, 1, K_full, N]).bfloat16()
+    weight_tt = ttnn.from_torch(
+        weights_torch,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=dram,
+        mesh_mapper=ttnn.create_mesh_mapper(
+            mesh_device,
+            ttnn.MeshMapperConfig([ttnn.PlacementReplicate(), ttnn.PlacementShard(2)], ttnn.MeshShape(*mesh_shape)),
+        ),
+    )
+
+    # ----- input: [1,1,M,K_full], K sharded across the 4 column devices, replicated across rows -----
+    input_torch = torch.rand([1, 1, M, K_full]).bfloat16()
+    input_tt = ttnn.from_torch(
+        input_torch,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=dram,
+        mesh_mapper=ttnn.create_mesh_mapper(
+            mesh_device,
+            ttnn.MeshMapperConfig([ttnn.PlacementReplicate(), ttnn.PlacementShard(3)], ttnn.MeshShape(*mesh_shape)),
+        ),
+    )
+
+    # ----- 2D multicast matmul program config (fused op requires MatmulMultiCoreReuseMultiCast) -----
+    core_grid = (8, 4)
+    in0_block_w = max(1, min(4, K_per_dev // 32 // core_grid[0]))
+    per_core_M = max(1, math.ceil(M / 32 / core_grid[1]))
+    per_core_N = max(1, math.ceil(N / 32 / core_grid[0]))
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=core_grid,
+        in0_block_w=in0_block_w,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=per_core_M,
+        per_core_N=per_core_N,
+        out_block_w=max(1, per_core_N // 2),
+        transpose_mcast=False,
+        fused_activation=None,
+        fuse_batch=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    # ----- torch reference: full K-reduced matmul, then scatter N across the column ring -----
+    ref_full = torch.matmul(input_torch.float(), weights_torch.float())  # [1,1,M,N]
+    ref_scatter = torch.chunk(ref_full, num_col_devices, dim=3)  # each [1,1,M,N/4]
+
+    logger.info("Dispatching fused matmul_reduce_scatter_async (cluster_axis=1) ...")
+    mm_out, rs_out = ttnn.experimental.matmul_reduce_scatter_async(
+        input_tt,
+        weight_tt,
+        persistent_intermediate_buffer=persistent_intermediate,
+        persistent_output_buffer=persistent_output,
+        dim=3,
+        multi_device_global_semaphore=rs_semaphores,
+        reduce_scatter_core_grid_offset=(0, core_grid[1]),
+        barrier_semaphore=barrier_semaphore,
+        num_links=num_links,
+        memory_config_rs=dram,
+        memory_config_mm=dram,
+        topology=ttnn.Topology.Ring,
+        subdevice_id=worker_sub_device_id,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        cluster_axis=cluster_axis,
+    )
+    ttnn.synchronize_device(mesh_device, sub_device_ids=[worker_sub_device_id])
+    logger.info("Fused op completed (no hang).")
+
+    # ----- verify matmul partial-sum output -----
+    mm_torch = ttnn.to_torch(
+        ttnn.from_device(mm_out),
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(0, 3)),
+    )
+    # dims=(0,3): mesh rows -> tensor dim0 (8 identical copies), mesh cols -> tensor dim3 (the 4 partials).
+    # Summing the 4 column partials along dim3 reconstructs the full reduced matmul.
+    mm_row0 = mm_torch[0:1]  # one column-row copy: [1,1,M,N*? ] -> actually [1,1,M,N] with 4 partials concatenated
+    mm_reduced = torch.sum(torch.stack(torch.chunk(mm_row0, num_col_devices, dim=3)), dim=0)
+    ok_mm, pcc_mm = comp_pcc(mm_reduced, ref_full, 0.99)
+    logger.info(f"matmul PCC: {pcc_mm}")
+
+    # ----- verify reduce-scatter output -----
+    rs_torch = ttnn.to_torch(
+        ttnn.from_device(rs_out),
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(0, 3)),
+    )
+    rs_row0 = rs_torch[0:1]  # [1,1,M,N] = the 4 scattered shards concatenated
+    ref_rs_full = torch.cat(ref_scatter, dim=3)
+    ok_rs, pcc_rs = comp_pcc(rs_row0, ref_rs_full, 0.99)
+    logger.info(f"reduce-scatter PCC: {pcc_rs}")
+
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
+
+    assert ok_mm, f"matmul PCC failed: {pcc_mm}"
+    assert ok_rs, f"reduce-scatter PCC failed: {pcc_rs}"

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_attention_prefill.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_attention_prefill.py
@@ -2,6 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+# Single parametrized prefill test. Wormhole runs the original (main) prefetcher path; Blackhole
+# Galaxy runs the no-prefetcher bring-up path. The architecture is detected once at import so the
+# fabric config and in-body setup select the right path automatically.
 import torch
 import pytest
 from loguru import logger
@@ -20,6 +23,12 @@ from models.common.utility_functions import (
 )
 from models.demos.llama3_70b_galaxy.tt.prefetcher_common import TtLlamaPrefetcherSetup
 from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
+
+
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
+    IS_BLACKHOLE as _IS_BLACKHOLE,
+    PREFILL_FABRIC_CONFIG as _PREFILL_FABRIC_CONFIG,
+)
 
 
 @torch.no_grad()
@@ -56,7 +65,7 @@ from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}],
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": _PREFILL_FABRIC_CONFIG}],
     indirect=True,
 )
 def test_qwen_attention_inference_prefill(
@@ -131,9 +140,16 @@ def test_qwen_attention_inference_prefill(
             mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
 
-    prefetcher_setup = TtLlamaPrefetcherSetup(mesh_device, n_tensors=0, n_layers=1, mode="prefill")
-    mesh_device.set_sub_device_stall_group([prefetcher_setup.worker_sub_device_id])
-    tt_ccl = TT_CCL(mesh_device, model_args, prefetcher_setup.worker_sub_device_id, mode="prefill", is_qwen=True)
+    # Blackhole runs prefill on the full compute grid (no narrow prefetcher worker sub-device);
+    # Wormhole keeps main's prefill prefetcher setup so the worker sub-device matches production.
+    if _IS_BLACKHOLE:
+        prefetcher_setup = None
+        worker_sub_device_id = None
+    else:
+        prefetcher_setup = TtLlamaPrefetcherSetup(mesh_device, n_tensors=0, n_layers=1, mode="prefill")
+        mesh_device.set_sub_device_stall_group([prefetcher_setup.worker_sub_device_id])
+        worker_sub_device_id = prefetcher_setup.worker_sub_device_id
+    tt_ccl = TT_CCL(mesh_device, model_args, worker_sub_device_id, mode="prefill", is_qwen=True)
 
     tt_model = TtLlamaAttention(
         mesh_device,

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder.py
@@ -25,7 +25,6 @@ from models.common.utility_functions import (
 from models.demos.llama3_70b_galaxy.tt.prefetcher_common import TtLlamaPrefetcherSetup
 from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
 from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
-    IS_BLACKHOLE as _IS_BLACKHOLE,
     DECODE_FABRIC_CONFIG as _FABRIC_CONFIG,
 )
 
@@ -83,14 +82,13 @@ def test_llama_decoder_inference(
     dtype = ttnn.bfloat8_b
 
     model_args = TtQwenModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len, dummy_weights=False)
-    if _IS_BLACKHOLE:
-        # Blackhole bring-up runs the unit test without the runtime prefetcher.
-        model_args.use_prefetcher = False
     model_args.n_layers = 1
+    # Prefetcher is on for Wormhole and for Blackhole only when QWEN_BH_PREFETCHER=1 (bring-up).
+    use_prefetcher = model_args.use_prefetcher
 
     state_dict = model_args.load_state_dict()
 
-    if _IS_BLACKHOLE:
+    if not use_prefetcher:
         prefetcher_setup = None
         worker_sub_device_id = None
     else:
@@ -199,7 +197,7 @@ def test_llama_decoder_inference(
         ),
     )
     # Explicitly allocate global CB to avoid memory fragmentation
-    if not _IS_BLACKHOLE:
+    if use_prefetcher:
         prefetcher_setup.create_global_cb()
 
     for i in range(generation_length):
@@ -216,7 +214,7 @@ def test_llama_decoder_inference(
 
         # Get cos/sin matrices for the current position of each user
         rot_mats = rope_setup.get_rm_rot_mats(current_pos)
-        if not _IS_BLACKHOLE:
+        if use_prefetcher:
             tt_pf = prefetcher_setup.get_input_tensors()
             ttnn.dram_prefetcher(
                 tt_pf,

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder_prefill.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder_prefill.py
@@ -2,6 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+# Single parametrized prefill test. Wormhole runs the original (main) prefetcher path; Blackhole
+# Galaxy runs the no-prefetcher bring-up path. The architecture is detected once at import so the
+# fabric config and in-body setup select the right path automatically.
 import torch
 import pytest
 from loguru import logger
@@ -20,6 +23,12 @@ from models.common.utility_functions import (
 )
 from models.demos.llama3_70b_galaxy.tt.prefetcher_common import TtLlamaPrefetcherSetup
 from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
+
+
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
+    IS_BLACKHOLE as _IS_BLACKHOLE,
+    PREFILL_FABRIC_CONFIG as _PREFILL_FABRIC_CONFIG,
+)
 
 
 @torch.no_grad()
@@ -54,7 +63,7 @@ from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}],
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": _PREFILL_FABRIC_CONFIG}],
     indirect=True,
 )
 def test_qwen_decoder_inference_prefill(
@@ -131,9 +140,16 @@ def test_qwen_decoder_inference_prefill(
             mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
 
-    prefetcher_setup = TtLlamaPrefetcherSetup(mesh_device, n_tensors=0, n_layers=1, mode="prefill")
-    mesh_device.set_sub_device_stall_group([prefetcher_setup.worker_sub_device_id])
-    tt_ccl = TT_CCL(mesh_device, model_args, prefetcher_setup.worker_sub_device_id, mode="prefill", is_qwen=True)
+    # Blackhole runs prefill on the full compute grid (no narrow prefetcher worker sub-device);
+    # Wormhole keeps main's prefill prefetcher setup so the worker sub-device matches production.
+    if _IS_BLACKHOLE:
+        prefetcher_setup = None
+        worker_sub_device_id = None
+    else:
+        prefetcher_setup = TtLlamaPrefetcherSetup(mesh_device, n_tensors=0, n_layers=1, mode="prefill")
+        mesh_device.set_sub_device_stall_group([prefetcher_setup.worker_sub_device_id])
+        worker_sub_device_id = prefetcher_setup.worker_sub_device_id
+    tt_ccl = TT_CCL(mesh_device, model_args, worker_sub_device_id, mode="prefill", is_qwen=True)
 
     # Initialize TT model
     tt_model = TtTransformerBlock(

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_lm_head.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_lm_head.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Isolated accuracy test for the Qwen3 LM head on Galaxy.
+
+Runs LMHead.forward in decode mode against a torch reference. With QWEN_BH_PREFETCHER=1 this
+exercises the ring (gather_in0) lm_head matmul + BH gather-reduce path used by the full model in
+decode — the component the decoder-layer unit test never touches. Diagnostic for the ~27% top-1
+accuracy regression seen on the BH prefetcher path.
+"""
+
+import os
+
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from models.demos.llama3_70b_galaxy.tt.lm_head import LMHead
+from models.demos.llama3_70b_galaxy.tt.qwen_model_config import TtQwenModelArgs
+from models.common.utility_functions import (
+    comp_pcc,
+)
+from models.demos.llama3_70b_galaxy.tt.prefetcher_common import TtLlamaPrefetcherSetup
+from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
+    DECODE_FABRIC_CONFIG as _FABRIC_CONFIG,
+)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": _FABRIC_CONFIG,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        (8, 4),
+    ],
+    indirect=True,
+)
+def test_qwen_lm_head_inference(mesh_device, reset_seeds):
+    dtype = ttnn.bfloat8_b
+    seq_len = 32  # decode M: batch 32 fused into M
+
+    model_args = TtQwenModelArgs(mesh_device, max_batch_size=32, max_seq_len=256, dummy_weights=False)
+    model_args.n_layers = 1
+    use_prefetcher = model_args.use_prefetcher
+    logger.info(f"use_prefetcher={use_prefetcher}")
+
+    state_dict = model_args.load_state_dict()
+    state_dict_prefix = model_args.get_state_dict_prefix("", None)
+    torch_weight = state_dict[f"{state_dict_prefix}output.weight"]  # [vocab, dim]
+
+    if not use_prefetcher:
+        prefetcher_setup = None
+        worker_sub_device_id = None
+    else:
+        prefetcher_setup = TtLlamaPrefetcherSetup(
+            mesh_device,
+            n_tensors=0,
+            n_layers=model_args.n_layers,
+            is_qwen=True,
+        )
+        mesh_device.set_sub_device_stall_group(
+            [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]
+        )
+        worker_sub_device_id = prefetcher_setup.worker_sub_device_id
+
+    tt_ccl = TT_CCL(mesh_device, model_args, worker_sub_device_id, is_qwen=True)
+
+    tt_model = LMHead(
+        args=model_args,
+        mesh_device=mesh_device,
+        dtype=dtype,
+        state_dict=state_dict,
+        state_dict_prefix=state_dict_prefix,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        tt_ccl=tt_ccl,
+        prefetcher_setup=prefetcher_setup,
+    )
+
+    torch_input = torch.randn(1, 1, seq_len, model_args.dim)
+    reference_output = torch_input.float() @ torch_weight.float().t()  # [1, 1, seq, vocab]
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 3), mesh_shape=model_args.cluster_shape),
+        dtype=ttnn.bfloat8_b,
+        memory_config=model_args.model_config["SHARDED_LM_HEAD_INPUT_32_RING_MEMCFG"],
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    logger.info("Run Qwen LM Head (decode)")
+    if hasattr(tt_ccl, "tt_lm_head_buffer") and tt_ccl.tt_lm_head_buffer is not None:
+        tt_ccl.tt_lm_head_buffer_l1 = ttnn.to_memory_config(tt_ccl.tt_lm_head_buffer, tt_ccl.lm_head_buffer_mem_cfg)
+
+    # Repeat to catch sporadic corruption (the full model shows intermittent junk logits in
+    # specific ring slices, not a static offset bug).
+    n_iters = int(os.environ.get("QWEN_LM_HEAD_TEST_ITERS", "10"))
+    pcc_required = 0.99
+    worst_pcc = 1.0
+    all_pass = True
+    for it in range(n_iters):
+        tt_outputs = tt_model(tt_input, worker_sub_device_id, mode="decode")
+        tt_outputs_torch = [
+            ttnn.to_torch(
+                tt_output,
+                mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(3, 1), mesh_shape=model_args.cluster_shape),
+            )
+            for tt_output in tt_outputs
+        ]
+        for t in tt_outputs:
+            ttnn.deallocate(t)
+        tt_output_torch = torch.concat(tt_outputs_torch, dim=-1)
+        tt_output_torch = tt_output_torch[:, 0:1, :, : model_args.vocab_size]
+
+        passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+        pcc_val = float(str(pcc_message).split(",")[-1].strip().split(" ")[-1]) if passing else 0.0
+        logger.info(f"iter {it}: PCC: {pcc_message}")
+        if not passing:
+            all_pass = False
+            # Localize: per-vocab-range PCC (832 = per-ring-core slice width on one device column)
+            vocab = model_args.vocab_size
+            for c in range(0, vocab, 19456):
+                lo, hi = c, min(c + 19456, vocab)
+                ok, msg = comp_pcc(reference_output[..., lo:hi], tt_output_torch[..., lo:hi], pcc_required)
+                if not ok:
+                    logger.warning(f"iter {it} vocab[{lo}:{hi}] PCC: {msg}")
+
+    tt_ccl.close()
+
+    assert all_pass, f"Qwen LM head PCC below {pcc_required} in at least one iteration"

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp_prefill.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp_prefill.py
@@ -2,6 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+# Single parametrized prefill test. Wormhole runs the original (main) prefetcher path; Blackhole
+# Galaxy runs the no-prefetcher bring-up path. The architecture is detected once at import so the
+# fabric config and in-body setup select the right path automatically.
 import torch
 import pytest
 from loguru import logger
@@ -16,6 +19,12 @@ from models.common.utility_functions import (
 from models.demos.llama3_70b_galaxy.tt.prefetcher_common import TtLlamaPrefetcherSetup
 from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
 from models.demos.llama3_70b_galaxy.reference.qwen import FeedForward
+
+
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
+    IS_BLACKHOLE as _IS_BLACKHOLE,
+    PREFILL_FABRIC_CONFIG as _PREFILL_FABRIC_CONFIG,
+)
 
 
 @torch.no_grad()
@@ -36,7 +45,7 @@ from models.demos.llama3_70b_galaxy.reference.qwen import FeedForward
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}],
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": _PREFILL_FABRIC_CONFIG}],
     indirect=True,
 )
 def test_qwen_mlp_inference_prefill(seq_len, batch_size, mesh_device, reset_seeds, ensure_gc):
@@ -74,9 +83,16 @@ def test_qwen_mlp_inference_prefill(seq_len, batch_size, mesh_device, reset_seed
 
     logger.info(f"Qwen Model Loaded")
 
-    prefetcher_setup = TtLlamaPrefetcherSetup(mesh_device, n_tensors=0, n_layers=1, mode="prefill")
-    mesh_device.set_sub_device_stall_group([prefetcher_setup.worker_sub_device_id])
-    tt_ccl = TT_CCL(mesh_device, model_args, prefetcher_setup.worker_sub_device_id, mode="prefill", is_qwen=True)
+    # Blackhole runs prefill on the full compute grid (no narrow prefetcher worker sub-device);
+    # Wormhole keeps main's prefill prefetcher setup so the worker sub-device matches production.
+    if _IS_BLACKHOLE:
+        prefetcher_setup = None
+        worker_sub_device_id = None
+    else:
+        prefetcher_setup = TtLlamaPrefetcherSetup(mesh_device, n_tensors=0, n_layers=1, mode="prefill")
+        mesh_device.set_sub_device_stall_group([prefetcher_setup.worker_sub_device_id])
+        worker_sub_device_id = prefetcher_setup.worker_sub_device_id
+    tt_ccl = TT_CCL(mesh_device, model_args, worker_sub_device_id, mode="prefill", is_qwen=True)
 
     model_args.WEIGHTS_DTYPE = dtype
     tt_model = TtLlamaMLP(

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_sampling_argmax.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_sampling_argmax.py
@@ -84,6 +84,20 @@ def test_qwen_sampling_argmax(mesh_device, reset_seeds):
     use_trace = os.environ.get("QWEN_SAMPLING_TEST_TRACE", "0") == "1"
     all_pass = True
 
+    # Mirror the demo flow: the generator passes the decode trace's frozen token-input buffer
+    # (RM uint32 [1,1,1,B], replicated) as tt_out_tok, and sampling must write the token into it.
+    out_tok = None
+    if os.environ.get("QWEN_SAMPLING_TEST_OUT_TOK", "1") == "1":
+        out_tok = ttnn.from_torch(
+            torch.zeros(1, 1, 1, batch, dtype=torch.int32),
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        logger.info("scoring from caller-provided tt_out_tok buffer")
+
     def make_input(it):
         x = torch.rand(1, 1, batch, padded_vocab) * 4.0 - 2.0
         expected = []
@@ -120,18 +134,18 @@ def test_qwen_sampling_argmax(mesh_device, reset_seeds):
     if not use_trace:
         for it in range(n_iters):
             x, expected = make_input(it)
-            tok, _ = tt_sampling(to_dev(x))
+            tok, _ = tt_sampling(to_dev(x), tt_out_tok=out_tok)
             score(it, tok, expected)
     else:
         # Mirror the model's trace lifecycle: eager compile call on a persistent input buffer, then
         # capture sampling into a trace and replay it with fresh data copied into the same buffer.
         x0, expected0 = make_input(0)
         x_dev = to_dev(x0)
-        tok, _ = tt_sampling(x_dev)
+        tok, _ = tt_sampling(x_dev, tt_out_tok=out_tok)
         score(0, tok, expected0, tag=" [compile]")
 
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-        tok, _ = tt_sampling(x_dev)
+        tok, _ = tt_sampling(x_dev, tt_out_tok=out_tok)
         ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
 
         for it in range(1, n_iters):

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_sampling_argmax.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_sampling_argmax.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Isolated repro for the BH prefetcher-path force-argmax corruption.
+
+The full Qwen accuracy run with QWEN_BH_PREFETCHER=1 returns argmax indices displaced by exactly
++3 vocab chunks (3*19456) whenever the winning logit lives in device column 0. Host-composed
+logits are correct, and untilize/argmax are correct in isolation, so the suspect is the sampling
+path's cross-column all_gather_async. This drives TTSampling exactly as the model does, on
+synthetic column-sharded logits with known per-row maxima.
+"""
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+import ttnn
+from models.demos.llama3_70b_galaxy.tt.qwen_model_config import TtQwenModelArgs
+from models.demos.llama3_70b_galaxy.tt.prefetcher_common import TtLlamaPrefetcherSetup
+from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
+from models.common.sampling.tt_sampling import TTSampling
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
+    DECODE_FABRIC_CONFIG as _FABRIC_CONFIG,
+)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": _FABRIC_CONFIG,
+            "trace_region_size": 23887872,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(8, 4)],
+    indirect=True,
+)
+def test_qwen_sampling_argmax(mesh_device, reset_seeds):
+    model_args = TtQwenModelArgs(mesh_device, dummy_weights=True, max_batch_size=32, max_seq_len=256)
+    model_args.n_layers = 1
+    use_prefetcher = model_args.use_prefetcher
+    logger.info(f"use_prefetcher={use_prefetcher} use_unfused_ccl={getattr(model_args, 'use_unfused_ccl', None)}")
+
+    if not use_prefetcher:
+        prefetcher_setup = None
+        worker_sub_device_id = None
+    else:
+        prefetcher_setup = TtLlamaPrefetcherSetup(mesh_device, n_tensors=0, n_layers=1, is_qwen=True)
+        mesh_device.set_sub_device_stall_group(
+            [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]
+        )
+        worker_sub_device_id = prefetcher_setup.worker_sub_device_id
+
+    tt_ccl = TT_CCL(mesh_device, model_args, worker_sub_device_id, is_qwen=True)
+
+    tt_sampling = TTSampling(
+        args=model_args,
+        mesh_device=mesh_device,
+        tt_ccl=tt_ccl,
+        k=torch.ones(32),
+        p=torch.zeros(32),
+        temp=torch.ones(32),
+    )
+    logger.info(f"force_argmax={tt_sampling.force_argmax_sampling}")
+
+    batch = 32
+    padded_vocab = model_args.padded_vocab_size  # 155648
+    chunk = padded_vocab // 8  # 19456 per device column
+
+    # Known max positions covering all 8 vocab chunks, including the low-id (chunk 0) region where
+    # the model shows the +3-chunk displacement. Shift positions per iteration so a stale gather
+    # buffer (previous iteration's data) also fails the check.
+    positions = [198, 257, 11, 279, chunk + 5, 2 * chunk + 100, 3 * chunk + 7, 5 * chunk + 3000]
+
+    n_iters = int(os.environ.get("QWEN_SAMPLING_TEST_ITERS", "5"))
+    use_trace = os.environ.get("QWEN_SAMPLING_TEST_TRACE", "0") == "1"
+    all_pass = True
+
+    def make_input(it):
+        x = torch.rand(1, 1, batch, padded_vocab) * 4.0 - 2.0
+        expected = []
+        for r in range(batch):
+            pos = (positions[r % len(positions)] + it * 31) % padded_vocab
+            x[0, 0, r, pos] = 30.0 + r
+            expected.append(pos)
+        return x, expected
+
+    def to_dev(x):
+        # Mirror the model: lm_head output is column-sharded (vocab) and row-replicated (after the
+        # cross-row all-reduce), DRAM interleaved, bfloat8_b.
+        return ttnn.from_torch(
+            x,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(3, None), mesh_shape=model_args.cluster_shape),
+            dtype=ttnn.bfloat8_b,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def score(it, tok, expected, tag=""):
+        nonlocal all_pass
+        got = ttnn.to_torch(ttnn.get_device_tensors(tok)[0]).reshape(-1).tolist()
+        errs = [(r, expected[r], got[r]) for r in range(batch) if got[r] != expected[r]]
+        logger.info(f"iter {it}{tag}: mismatches {len(errs)}")
+        for r, exp, g in errs[:8]:
+            logger.warning(
+                f"iter {it}{tag} row {r}: expected {exp} got {g} (delta {g - exp} = {(g - exp) / chunk} chunks)"
+            )
+        if errs:
+            all_pass = False
+
+    if not use_trace:
+        for it in range(n_iters):
+            x, expected = make_input(it)
+            tok, _ = tt_sampling(to_dev(x))
+            score(it, tok, expected)
+    else:
+        # Mirror the model's trace lifecycle: eager compile call on a persistent input buffer, then
+        # capture sampling into a trace and replay it with fresh data copied into the same buffer.
+        x0, expected0 = make_input(0)
+        x_dev = to_dev(x0)
+        tok, _ = tt_sampling(x_dev)
+        score(0, tok, expected0, tag=" [compile]")
+
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        tok, _ = tt_sampling(x_dev)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+
+        for it in range(1, n_iters):
+            x, expected = make_input(it)
+            x_host = ttnn.from_torch(
+                x,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(3, None), mesh_shape=model_args.cluster_shape),
+                dtype=ttnn.bfloat8_b,
+                layout=ttnn.TILE_LAYOUT,
+            )
+            ttnn.copy_host_to_device_tensor(x_host, x_dev)
+            if os.environ.get("QWEN_SAMPLING_TEST_SYNC_BEFORE", "0") == "1":
+                # Drain the input copy before launching the replay (tests whether the trace's
+                # first consumer races the host->device write of its input buffer).
+                ttnn.synchronize_device(mesh_device)
+            ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+            if os.environ.get("QWEN_SAMPLING_TEST_FULL_SYNC", "0") == "1":
+                # Block until every device in the mesh finished this replay before scoring and
+                # before enqueueing the next replay (rules out cross-replay device skew).
+                ttnn.synchronize_device(mesh_device)
+            score(it, tok, expected, tag=" [replay]")
+
+        ttnn.release_trace(mesh_device, trace_id)
+
+    tt_ccl.close()
+    assert all_pass, "on-device sampling argmax returned displaced indices"

--- a/models/demos/llama3_70b_galaxy/tt/distributed_norm.py
+++ b/models/demos/llama3_70b_galaxy/tt/distributed_norm.py
@@ -2,9 +2,16 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.demos.llama3_70b_galaxy.tt.llama_ccl import tt_distributed_rmsnorm, tt_sharded_distributed_rmsnorm
+
+# Interim Blackhole-prefetcher bring-up: route the distributed-norm collective through the unfused,
+# 2D-torus-aware stable all_gather instead of the fused RMSAllGather (fused_rms_minimal), which uses a
+# 1D-multicast writer that no-ops on the BH 2D-torus fabric. Opt-in (default on) so it only affects the
+# QWEN_BH_PREFETCHER path; Wormhole and BH no-prefetcher are untouched.
+BH_UNFUSED_CCL = os.environ.get("QWEN_BH_UNFUSED_CCL", "1") == "1"
 
 
 class DistributedNorm(LightweightModule):
@@ -18,6 +25,15 @@ class DistributedNorm(LightweightModule):
             core_grid_ln, grid_offset = (5, 2), ttnn.CoreCoord(1, 0)
         else:
             core_grid_ln, grid_offset = (8, 2), ttnn.CoreCoord(2, 0)
+        # Blackhole prefetcher path: columns 1-3 are the dram_prefetcher's global-CB receiver cores
+        # and columns 5-6 hold the persistent CCL buffers (sub_core_grids). The default LN grid on
+        # columns 1-2 puts the LayerNorm static CB on top of the resident global CB, which only shows
+        # up during trace capture (all programs resident at once) as a small CB/L1 clash. Move the norm
+        # grid onto free worker columns (7+) that carry no resident prefetcher/CCL L1. Same core count
+        # and shard math, just a different origin, so gather_in_mem_cfg / ln_prg_cfg / stats configs
+        # below all follow automatically.
+        if getattr(args, "is_blackhole", False) and getattr(args, "use_prefetcher", False):
+            grid_offset = ttnn.CoreCoord(7, 0)
         core_range = ttnn.CoreRange(
             grid_offset, ttnn.CoreCoord(core_grid_ln[1] + grid_offset.x - 1, core_grid_ln[0] + grid_offset.y - 1)
         )
@@ -51,17 +67,19 @@ class DistributedNorm(LightweightModule):
             # No-prefetcher decode uses tt_distributed_rmsnorm; these are never consumed.
             self.gather_in_mem_cfg = None
             self.ln_prg_cfg = None
-        self.ln_sharded_stats_memcfg = None
-        # self.ln_sharded_stats_memcfg = ttnn.create_sharded_memory_config(
-        #     shape=[1, 1, 32, 32 * 4],
-        #     core_grid=ttnn.CoreGrid(y=1, x=1),
-        #     strategy=ttnn.ShardStrategy.WIDTH,
-        # )
-        # ttnn.create_sharded_memory_config(
-        #     shape=[1, 1, 32, 32 * 4],
-        #     core_grid=ttnn.CoreGrid(y=1, x=1),
-        #     strategy=ttnn.ShardStrategy.WIDTH,
-        # )
+        # Sharded stats config for the unfused BH-prefetcher distributed norm. rms_norm_post_all_gather
+        # with a sharded program config requires the gathered stats to be sharded too. Place the single
+        # 32x(32*4) stats shard on the first worker core of the LN grid (grid_offset, e.g. (1,0)) so it
+        # never lands on the prefetcher sender column. Only needed/consumed on the BH unfused path.
+        if self.use_sharded_decode:
+            self.ln_sharded_stats_memcfg = ttnn.create_sharded_memory_config(
+                shape=(1, 1, 32, 32 * 4),
+                core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(grid_offset, grid_offset)}),
+                strategy=ttnn.ShardStrategy.WIDTH,
+                use_height_and_width_as_shard_shape=True,
+            )
+        else:
+            self.ln_sharded_stats_memcfg = None
         self.ln_cfg = ttnn.WormholeComputeKernelConfig(
             math_fidelity=ttnn.MathFidelity.HiFi2,
             math_approx_mode=False,
@@ -76,18 +94,40 @@ class DistributedNorm(LightweightModule):
         # the residual, so force it to bf8 to keep activation/CB footprint small (avoids L1 clashes
         # at long prefill sequence lengths). Other paths keep their input-derived dtype (None).
         norm_output_dtype = ttnn.bfloat8_b if self.args.blackhole_no_prefetcher else None
+        # BH prefetcher path: use_sharded_decode is True but the fused RMSAllGather hangs on the 2D-torus
+        # fabric, so fall through to the unfused distributed rmsnorm (stable all_gather) and reshard to
+        # the sharded output the downstream matmul expects. Only triggers on BH + sharded-decode.
+        bh_unfused_norm = (
+            mode == "decode"
+            and self.use_sharded_decode
+            and getattr(self.args, "is_blackhole", False)
+            and BH_UNFUSED_CCL
+        )
         if mode == "decode":
-            if not self.use_sharded_decode:
+            if (not self.use_sharded_decode) or bh_unfused_norm:
                 # BH no-prefetch decode. The residual stream is column-fractured (dim/4 per
                 # device), so a plain local rms_norm would (incorrectly) normalize over only
                 # dim/4. Add the residual, then run the distributed RMS norm: per-device partial
                 # stats are gathered across columns and combined so the normalization is over the
                 # full hidden dim. That column-axis stats all_gather runs on device over the 2D-torus
                 # fabric (see TT_CCL.line_all_gather -> ttnn.all_gather on the no-prefetch branch).
-                x = ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
-                if res is not None:
-                    res = ttnn.to_memory_config(res, ttnn.DRAM_MEMORY_CONFIG)
-                    x = ttnn.add(x, res, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+                #
+                # On the BH prefetcher path (bh_unfused_norm) the resident dram_prefetcher owns the
+                # sender column, so the norm compute must be confined to the worker sub-device grid.
+                # Reshard the input onto gather_in_mem_cfg (cols 1-2) and hand the sharded LayerNorm
+                # program config to the pre/post ops so their compute never lands on a sender core.
+                if bh_unfused_norm:
+                    norm_input_memcfg = self.gather_in_mem_cfg
+                    norm_program_config = self.ln_prg_cfg
+                    norm_stats_memcfg = self.ln_sharded_stats_memcfg
+                else:
+                    x = ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
+                    if res is not None:
+                        res = ttnn.to_memory_config(res, ttnn.DRAM_MEMORY_CONFIG)
+                        x = ttnn.add(x, res, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+                    norm_input_memcfg = None
+                    norm_program_config = None
+                    norm_stats_memcfg = None
                 x, _ = tt_distributed_rmsnorm(
                     x,
                     epsilon=self.norm.eps,
@@ -96,6 +136,10 @@ class DistributedNorm(LightweightModule):
                     compute_kernel_config=self.ln_cfg,
                     tt_ccl=self.tt_ccl,
                     output_dtype=norm_output_dtype,
+                    force_stable_ag=bh_unfused_norm,
+                    input_memcfg=norm_input_memcfg,
+                    program_config=norm_program_config,
+                    stats_memcfg=norm_stats_memcfg,
                 )
                 if self.norm.output_mem_config is not None:
                     x = ttnn.to_memory_config(x, self.norm.output_mem_config)

--- a/models/demos/llama3_70b_galaxy/tt/distributed_norm.py
+++ b/models/demos/llama3_70b_galaxy/tt/distributed_norm.py
@@ -94,14 +94,17 @@ class DistributedNorm(LightweightModule):
         # the residual, so force it to bf8 to keep activation/CB footprint small (avoids L1 clashes
         # at long prefill sequence lengths). Other paths keep their input-derived dtype (None).
         norm_output_dtype = ttnn.bfloat8_b if self.args.blackhole_no_prefetcher else None
-        # BH prefetcher path: use_sharded_decode is True but the fused RMSAllGather hangs on the 2D-torus
-        # fabric, so fall through to the unfused distributed rmsnorm (stable all_gather) and reshard to
+        # BH prefetcher path: use_sharded_decode is True but the fused RMSAllGather originally hung on
+        # the 2D-torus fabric (1D-multicast writer). With the writer ported to fabric-topology-aware
+        # routing (use_bh_fused_rms), decode goes back through the fused tt_sharded_distributed_rmsnorm;
+        # otherwise fall through to the unfused distributed rmsnorm (stable all_gather) and reshard to
         # the sharded output the downstream matmul expects. Only triggers on BH + sharded-decode.
         bh_unfused_norm = (
             mode == "decode"
             and self.use_sharded_decode
             and getattr(self.args, "is_blackhole", False)
             and BH_UNFUSED_CCL
+            and not getattr(self.args, "use_bh_fused_rms", False)
         )
         if mode == "decode":
             if (not self.use_sharded_decode) or bh_unfused_norm:

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -898,13 +898,13 @@ class Generator(WarmupForwardMixin):
                         tt_sampled = tt_sampled[0]
 
                     sampled_tokens = ttnn.to_torch(ttnn.get_device_tensors(tt_sampled)[0]).to(torch.int32)
-                    sampled_token = sampled_tokens[0, 0, 0, 0]
+                    sampled_token = sampled_tokens.reshape(-1)[0]
                     sampled_values.append(sampled_token)
                     slot_output_tokens[slot, 0] = sampled_token
 
                     if tt_log_probs is not None:
                         log_probs_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_log_probs)[0])
-                        log_prob_values.append(log_probs_torch[0, 0, 0, 0])
+                        log_prob_values.append(log_probs_torch.reshape(-1)[0])
 
                     ttnn.deallocate(single_logits_batch)
 
@@ -947,8 +947,11 @@ class Generator(WarmupForwardMixin):
 
                 sampled_tokens = ttnn.to_torch(ttnn.get_device_tensors(tt_sampled)[0]).to(torch.int32)
 
-                # sampled_tokens has 32 entries ordered by slot.
-                sampled_tensor = sampled_tokens[0, 0, 0, :]  # Shape: [32]
+                # sampled_tokens has 32 entries ordered by slot. The leading
+                # dims are all 1 but their count varies by arch (e.g. Blackhole
+                # returns a rank-3 tensor vs rank-4 on Wormhole), so flatten
+                # rather than hard-indexing a fixed rank.
+                sampled_tensor = sampled_tokens.reshape(-1)  # Shape: [32]
                 output_toks = sampled_tensor[empty_slots]
                 _log_sampling_debug(
                     self._sampling_debug_enabled,
@@ -961,7 +964,7 @@ class Generator(WarmupForwardMixin):
                 if tt_log_probs is not None:
                     tt_lp = tt_log_probs
                     log_probs_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_lp)[0])
-                    prefill_log_probs = log_probs_torch[0, 0, 0, :][empty_slots]
+                    prefill_log_probs = log_probs_torch.reshape(-1)[empty_slots]
 
         self._decode_inputs_need_reset = True
 
@@ -1814,8 +1817,10 @@ class Generator(WarmupForwardMixin):
             ttnn.synchronize_device(self.mesh_device)
             return tt_out[0, 0, :, : self.model.vocab_size].unsqueeze(1), tt_log_probs[0, 0, :, :]
 
-        # If not sharded (it is a sampled token), convert directly from device tensor to torch tensor
-        return tt_out[0, 0, 0, :], tt_log_probs[0, 0, 0, :]
+        # If not sharded (it is a sampled token), convert directly from device tensor to torch tensor.
+        # Leading dims are all 1 but their count varies by arch (Blackhole returns
+        # rank-3 vs rank-4 on Wormhole), so flatten instead of hard-indexing a fixed rank.
+        return tt_out.reshape(-1), tt_log_probs.reshape(-1)
 
     def chat_completion(
         self,

--- a/models/demos/llama3_70b_galaxy/tt/llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_attention.py
@@ -390,6 +390,62 @@ class TtLlamaAttention(LightweightModule):
             self.prefetcher_setup.insert_tensor(self.wo)
         self.tt_ccl = tt_ccl
 
+    def compute_decode_rot_slices(self, rot_mats, q_rot_end, k_rot_end, store_cache=False):
+        """Slice/reshard the expanded decode rot_mats into the rotary op's expected layout and
+        cache the result on the shared tt_ccl, keyed by the rot_mats identity. The slices are
+        loop-invariant across layers within one decode step (same rot_mats object, static head
+        shapes), so this runs once per step: either from llama_model's decode forward preamble
+        (preferred: the persistent tensors allocate before any per-layer transients and land high
+        in L1, clear of the ring-matmul CB region) or lazily from layer 0. The cache holds a
+        reference to rot_mats so the id()-based key cannot alias a freed tensor; the next decode
+        step allocates a new rot_mats and naturally invalidates the cache."""
+        # Prefetcher resident (unfused-CCL): pin the auto-gridding slice kernels to the worker
+        # sub-core grid. Otherwise ttnn.slice packs a 32-core block column-major from origin
+        # (0,0), spilling into the uncovered senders-column tail (cores (0,8)/(0,9)) and hitting
+        # the "kernel group cores do not match sub device cores" fatal under the split
+        # senders/worker sub-device manager. None on the WH / no-prefetcher path (no split mgr).
+        rot_slice_sub_core_grids = self._worker_sub_core_grids if self.use_unfused_ccl else None
+        q_rot_cos = ttnn.slice(
+            rot_mats[0],
+            [0, 0, 0, 0],
+            q_rot_end,
+            memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
+            sub_core_grids=rot_slice_sub_core_grids,
+        )
+        q_rot_sin = ttnn.slice(
+            rot_mats[1],
+            [0, 0, 0, 0],
+            q_rot_end,
+            memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
+            sub_core_grids=rot_slice_sub_core_grids,
+        )
+        k_rot_cos = ttnn.slice(
+            rot_mats[0],
+            [0, 0, 0, 0],
+            k_rot_end,
+            memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
+            sub_core_grids=rot_slice_sub_core_grids,
+        )
+        k_rot_sin = ttnn.slice(
+            rot_mats[1],
+            [0, 0, 0, 0],
+            k_rot_end,
+            memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
+            sub_core_grids=rot_slice_sub_core_grids,
+        )
+        q_rot_cos = ttnn.to_layout(q_rot_cos, ttnn.TILE_LAYOUT)
+        q_rot_sin = ttnn.to_layout(q_rot_sin, ttnn.TILE_LAYOUT)
+        k_rot_cos = ttnn.to_layout(k_rot_cos, ttnn.TILE_LAYOUT)
+        k_rot_sin = ttnn.to_layout(k_rot_sin, ttnn.TILE_LAYOUT)
+        if store_cache:
+            self.tt_ccl._decode_rot_slice_cache = (
+                (id(rot_mats[0]), id(rot_mats[1])),
+                (tuple(q_rot_end), tuple(k_rot_end)),
+                (q_rot_cos, q_rot_sin, k_rot_cos, k_rot_sin),
+                (rot_mats[0], rot_mats[1]),
+            )
+        return q_rot_cos, q_rot_sin, k_rot_cos, k_rot_sin
+
     def _apply_decode_qk_norm(self, q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD):
         # unfused-CCL (BH prefetcher) path: the create-head output is an ND round-robin height-sharded
         # tensor (user-parallel), which neither the fused sharded reshard (expects the head-parallel
@@ -829,44 +885,32 @@ class TtLlamaAttention(LightweightModule):
                     k_heads_pre_rot_1BKD.shape[2],
                     self.head_dim,
                 ]
-                # Prefetcher resident (unfused-CCL): pin the auto-gridding slice kernels to the worker
-                # sub-core grid. Otherwise ttnn.slice packs a 32-core block column-major from origin
-                # (0,0), spilling into the uncovered senders-column tail (cores (0,8)/(0,9)) and hitting
-                # the "kernel group cores do not match sub device cores" fatal under the split
-                # senders/worker sub-device manager. None on the WH / no-prefetcher path (no split mgr).
-                rot_slice_sub_core_grids = self._worker_sub_core_grids if self.use_unfused_ccl else None
-                q_rot_cos = ttnn.slice(
-                    rot_mats[0],
-                    [0, 0, 0, 0],
-                    q_rot_end,
-                    memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
-                    sub_core_grids=rot_slice_sub_core_grids,
-                )
-                q_rot_sin = ttnn.slice(
-                    rot_mats[1],
-                    [0, 0, 0, 0],
-                    q_rot_end,
-                    memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
-                    sub_core_grids=rot_slice_sub_core_grids,
-                )
-                k_rot_cos = ttnn.slice(
-                    rot_mats[0],
-                    [0, 0, 0, 0],
-                    k_rot_end,
-                    memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
-                    sub_core_grids=rot_slice_sub_core_grids,
-                )
-                k_rot_sin = ttnn.slice(
-                    rot_mats[1],
-                    [0, 0, 0, 0],
-                    k_rot_end,
-                    memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
-                    sub_core_grids=rot_slice_sub_core_grids,
-                )
-                q_rot_cos = ttnn.to_layout(q_rot_cos, ttnn.TILE_LAYOUT)
-                q_rot_sin = ttnn.to_layout(q_rot_sin, ttnn.TILE_LAYOUT)
-                k_rot_cos = ttnn.to_layout(k_rot_cos, ttnn.TILE_LAYOUT)
-                k_rot_sin = ttnn.to_layout(k_rot_sin, ttnn.TILE_LAYOUT)
+                # EXPERIMENTAL (QWEN_BH_HOIST_ROT_SLICES=1, default off): these slices/layout-casts
+                # are loop-invariant within a decode step (same rot_mats object for all layers,
+                # static head shapes), so they can be computed once and reused via a cache on the
+                # shared tt_ccl, removing 4 slice + 4 to_layout ops from 63 of 64 layers (~0.5
+                # ms/token on BH galaxy). Disabled by default: the cached tensors persist for the
+                # whole layer loop and the BH ring FF matmul's static CB region (ends 444480 on
+                # cols 1-6) leaves no persistent L1 headroom on those cores, tripping "static
+                # circular buffers clash with L1 buffers" at trace capture even when the tensors
+                # allocate at the very top of the decode forward.
+                _rot_bounds = (tuple(q_rot_end), tuple(k_rot_end))
+                if os.environ.get("QWEN_BH_HOIST_ROT_SLICES", "0") == "1":
+                    _rot_key = (id(rot_mats[0]), id(rot_mats[1]))
+                    _rot_cache = getattr(self.tt_ccl, "_decode_rot_slice_cache", None)
+                    if _rot_cache is not None and _rot_cache[0] == _rot_key and _rot_cache[1] == _rot_bounds:
+                        q_rot_cos, q_rot_sin, k_rot_cos, k_rot_sin = _rot_cache[2]
+                    else:
+                        q_rot_cos, q_rot_sin, k_rot_cos, k_rot_sin = self.compute_decode_rot_slices(
+                            rot_mats, q_rot_end, k_rot_end, store_cache=True
+                        )
+                    # Publish the (static) bounds so llama_model can preslice at the top of
+                    # subsequent decode forwards without knowing the head shapes.
+                    self.tt_ccl._decode_rot_slice_bounds = _rot_bounds
+                else:
+                    q_rot_cos, q_rot_sin, k_rot_cos, k_rot_sin = self.compute_decode_rot_slices(
+                        rot_mats, q_rot_end, k_rot_end, store_cache=False
+                    )
             q_heads_1BQD = ttnn.experimental.rotary_embedding_llama(
                 q_heads_pre_rot_1BQD,
                 q_rot_cos,

--- a/models/demos/llama3_70b_galaxy/tt/llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_attention.py
@@ -2,8 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import torch
 import ttnn
+from loguru import logger
 from models.common.lightweightmodule import LightweightModule
 from models.common.rmsnorm import RMSNorm
 
@@ -124,6 +127,9 @@ class TtLlamaAttention(LightweightModule):
         # Also mirrored into model_config for any config-dict consumers.
         self.use_prefetcher = configuration.use_prefetcher
         self.model_config["USE_PREFETCHER"] = configuration.use_prefetcher
+        # BH-prefetcher bring-up: keep the ring matmuls (gated by use_prefetcher) but route the
+        # post-matmul collectives through the stable/no-prefetcher branches (gated by use_unfused_ccl).
+        self.use_unfused_ccl = getattr(configuration, "use_unfused_ccl", False)
         self.sdpa_decode_compute_kernel_config = self.model_config["SDPA_DECODE_COMPUTE_PROGCFG"]
         self.ccl_topology = configuration.ccl_topology()
         self.is_multichip = configuration.is_multichip
@@ -176,6 +182,9 @@ class TtLlamaAttention(LightweightModule):
         self._create_head_input_memcfg_nlp = None
         sub_core_grids = getattr(configuration, "sub_core_grids", None)
         start_core = getattr(configuration, "start_core", None)
+        # Worker sub-core grid used to pin auto-gridding tail ops (e.g. the create-head slice) so they
+        # stay inside the prefetcher worker sub-device instead of grabbing the full 12-wide compute grid.
+        self._worker_sub_core_grids = sub_core_grids
         if sub_core_grids is not None and start_core is not None and self._qkv_n_local % self.head_dim == 0:
             n_qkv_heads_local = self._qkv_n_local // self.head_dim
             self._create_head_input_memcfg_nlp = ttnn.MemoryConfig(
@@ -382,9 +391,89 @@ class TtLlamaAttention(LightweightModule):
         self.tt_ccl = tt_ccl
 
     def _apply_decode_qk_norm(self, q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD):
+        # unfused-CCL (BH prefetcher) path: the create-head output is an ND round-robin height-sharded
+        # tensor (user-parallel), which neither the fused sharded reshard (expects the head-parallel
+        # single-core layout) nor the flat path (DRAM round-trip violates single-sub-device with the
+        # resident prefetcher) can consume. Normalize in place on the worker cores instead.
+        if self.use_prefetcher and self.use_unfused_ccl:
+            return self._apply_decode_qk_norm_unfused(q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD)
         if self.use_prefetcher:
             return self._apply_decode_qk_norm_sharded(q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD)
         return self._apply_decode_qk_norm_flat(q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD)
+
+    def _apply_decode_qk_norm_unfused(self, q_heads, k_heads):
+        """Worker-confined RMSNorm over head_dim for the user-parallel create-head layout.
+
+        The create-head output is TILE + HEIGHT_SHARDED [32, head_dim] with one shard per head on worker
+        cores (round-robin ND spec). ttnn.rms_norm rejects HEIGHT_SHARDED input, and the fused sharded
+        QK-norm's reshard-to-1-core intermediate can't collapse the ND spec. Instead reshard straight to a
+        WIDTH_SHARDED worker layout (head_dim split across 4 worker cores), run the sharded rms_norm there
+        (cross-core reduction over head_dim), then reshard back to the native layout. All ops stay on
+        worker cores, so it coexists with the resident prefetcher."""
+
+        def _norm_one(heads, norm_mod, core_start):
+            rm = heads.memory_config()
+            # The create-head output physically pads each head's users to a full tile (32 rows) and puts
+            # one head per shard, so the physical height is (num_head_shards * 32), not the logical row
+            # count.
+            src_spec = heads.memory_config().shard_spec
+            phys_rows = int(src_spec.shape[0]) * src_spec.grid.num_cores()
+            num_head_shards = phys_rows // 32  # one 32-row (tile-padded) group per head
+            # Split head_dim across 2 width cores (2 tiles each). Both q_heads and k_heads carry
+            # num_head_shards == n_local_heads (8) tile-padded row groups, so each block-shard grid is
+            # ncores_w x 8. With only cols 4,7-10 free of prefetcher/CCL L1, a 4-wide split can't fit two
+            # 8-row grids side by side (8 columns needed); a 2-wide split lets Q use cols 7-8 and K cols
+            # 9-10, both within rows 0-7 of the worker grid.
+            ncores_w = 2
+            width_per_core = self.head_dim // ncores_w
+            # BLOCK-shard the [phys_rows, head_dim] norm input as num_head_shards row-groups x ncores_w
+            # width cores: each core holds exactly one head's [32, 32] tile. The sharded rms_norm reduces
+            # head_dim across the ncores_w cores in each row (row-wise mcast), each row an independent
+            # head. This keeps block_h at 1 tile instead of stacking all heads' rows onto a 4-core WIDTH
+            # shard (block_h = num_head_shards, e.g. 8 for the Q heads). That tall CB overflowed the L1
+            # left free above the full-worker-grid resident decode buffer during trace capture
+            # ("static circular buffers clash with L1 buffers ... region ends at 430656"); block_h=1 fits.
+            core_grid = ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(
+                        ttnn.CoreCoord(core_start[0], core_start[1]),
+                        ttnn.CoreCoord(core_start[0] + ncores_w - 1, core_start[1] + num_head_shards - 1),
+                    )
+                }
+            )
+            block_mc = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                ttnn.BufferType.L1,
+                ttnn.ShardSpec(core_grid, [32, width_per_core], ttnn.ShardOrientation.ROW_MAJOR),
+            )
+            prog_cfg = ttnn.LayerNormShardedMultiCoreProgramConfig(
+                compute_with_storage_grid_size=[ncores_w, num_head_shards],
+                subblock_w=1,
+                block_h=1,
+                block_w=width_per_core // 32,
+                inplace=False,
+            )
+            heads = ttnn.to_memory_config(heads, block_mc)
+            heads = norm_mod(
+                heads,
+                mode="decode",
+                in_sharded=True,
+                out_sharded=True,
+                norm_config={"sharded_program_config": prog_cfg, "sharded_output_config": block_mc},
+            )
+            heads = ttnn.to_memory_config(heads, rm)
+            return heads
+
+        # Place the QK-norm block-shard grids on free worker columns (7-10), not the default cols 1-2.
+        # Columns 1-3 are the dram_prefetcher's global-CB receiver cores; running the norm there collides
+        # with the resident global CB during trace capture. Cols 7-10 are inside the worker sub-device
+        # (cols 1-10) but carry no global CB / CCL persistent buffers. Q has n_local_heads shards (rows
+        # 0..N-1); K has n_local_kv_heads (1 shard) so it lands on a single row placed clear of Q. The
+        # reshard-in/reshard-out inside _norm_one moves the heads there and back, so the grid choice is
+        # independent of the create-head layout.
+        q_heads = _norm_one(q_heads, self.q_norm, (7, 0))
+        k_heads = _norm_one(k_heads, self.k_norm, (9, 0))
+        return q_heads, k_heads
 
     def _apply_decode_qk_norm_flat(self, q_heads, k_heads):
         """DRAM interleaved TILE RMSNorm; use reshape (not view) for TILE [1,H,B,D] -> [1,1,H*B,D]."""
@@ -525,6 +614,23 @@ class TtLlamaAttention(LightweightModule):
         x: (seq_len, 1, batch, dim)
         current_pos: (batch_size), current token position in the sequence for each user
         """
+        # fused_ccl gates the fused galaxy collectives (llama_rs_create_heads / all_gather_concat).
+        # On the BH prefetcher path (use_unfused_ccl) we keep the ring matmuls but run the stable,
+        # worker-pinned no-prefetcher collective/head/rotary path instead, gluing layouts as needed.
+        fused_ccl = self.use_prefetcher and not self.use_unfused_ccl
+
+        _ap_on = os.environ.get("QWEN_BH_PROBE", "0") == "1"
+
+        def _aprobe(tag):
+            if _ap_on:
+                logger.info(f"[attn-probe] before sync: {tag}")
+                try:
+                    ttnn.synchronize_device(self.mesh_device)
+                except Exception as e:
+                    logger.info(f"[attn-probe] sync skipped ({tag}): {str(e)[:80]}")
+                    return
+                logger.info(f"[attn-probe] after  sync: {tag}")
+
         ###
         # QKV matmuls
         # Use HiFi2 for DRAM-sharded matmuls as they are otherwise flop-bound. Loses 1 bit of activation precision.
@@ -533,11 +639,18 @@ class TtLlamaAttention(LightweightModule):
             xqkv_fused_sharded = ttnn.matmul(  # [1, 1, 32, 1280]
                 x,
                 self.wqkv,
-                program_config=self.model_config["XQKV_DECODE_RING_PROGCFG"],
+                # Unfused-CCL path emits TILE bf8 (non-untilized) so the sliced create-head input can feed
+                # the bf8-sized column all-reduce directly; the fused path untilizes to ROW_MAJOR bf16 for
+                # llama_rs_create_heads.
+                program_config=(
+                    self.model_config["XQKV_DECODE_RING_PROGCFG_TILE"]
+                    if self.use_unfused_ccl
+                    else self.model_config["XQKV_DECODE_RING_PROGCFG"]
+                ),
                 memory_config=self.model_config["SHARDED_QKV_OUT_RING_MEMCFG"],
                 compute_kernel_config=self.compute_kernel_config_hifi2,
                 global_cb=self.prefetcher_setup.global_circular_buffer,
-                dtype=ttnn.bfloat16,
+                dtype=ttnn.bfloat8_b if self.use_unfused_ccl else ttnn.bfloat16,
                 sub_device_id=self.prefetcher_setup.worker_sub_device_id,
             )
         else:
@@ -560,44 +673,58 @@ class TtLlamaAttention(LightweightModule):
             if x_in is not x:
                 ttnn.deallocate(x_in)
         ttnn.deallocate(x)
+        _aprobe("qkv_matmul")
         # xqkv_fused_sharded -> [1, 1, 32, 12288 // 8]
 
         ###
         # Reshape and rotary embeddings
         ###
-        if not self.use_prefetcher:
-            xqkv_fused_interleaved = ttnn.to_memory_config(xqkv_fused_sharded, memory_config=ttnn.L1_MEMORY_CONFIG)
-            fqkv_shape = xqkv_fused_interleaved.shape
-            if fqkv_shape[3] > self._qkv_n_local:
-                xqkv_fused_interleaved = ttnn.slice(
-                    xqkv_fused_interleaved,
-                    [0, 0, 0, 0],
-                    [fqkv_shape[0], fqkv_shape[1], fqkv_shape[2], self._qkv_n_local],
-                    memory_config=ttnn.L1_MEMORY_CONFIG,
-                )
-                fqkv_shape = xqkv_fused_interleaved.shape
-            xqkv_fused_interleaved = ttnn.reshape(
-                xqkv_fused_interleaved,
-                (1, 1, self.batch_size_per_device_group, fqkv_shape[3]),
-                (1, 1, 32, fqkv_shape[3]),
-            )
-            if xqkv_fused_interleaved.layout != ttnn.TILE_LAYOUT:
-                xqkv_fused_interleaved = ttnn.to_layout(
-                    xqkv_fused_interleaved,
-                    ttnn.TILE_LAYOUT,
-                    memory_config=ttnn.L1_MEMORY_CONFIG,
-                )
-            # nlp_create_qkv_heads_decode only honors batch_offset/slice_size in its WIDTH_SHARDED
-            # program factory; width-shard the fused tensor so batch_offset selects users
-            # [col*8:col*8+8] per column.
-            create_head_input_memcfg = self._create_head_input_memcfg_nlp
-            if create_head_input_memcfg is not None:
-                xqkv_fused_create_head_in = ttnn.to_memory_config(
-                    xqkv_fused_interleaved, memory_config=create_head_input_memcfg
-                )
-                ttnn.deallocate(xqkv_fused_interleaved)
+        if not fused_ccl:
+            if self.use_unfused_ccl:
+                # Prefetcher resident: the ring QKV matmul already emitted a width-sharded L1 tensor on
+                # the worker cores (SHARDED_QKV_OUT_RING_MEMCFG: padded N = 12288//8 over RING_SIZE
+                # cores, [32, head_dim/2] per shard). Feed it straight into the common column all-reduce
+                # + nlp_create_qkv_heads_decode below, exactly like the proven BH LB/QB tt_transformers
+                # decode path: the create-head op consumes the first (n_q + 2*n_kv)*head_dim = 1280
+                # valid columns and ignores the N padding (its width-sharded factory only requires the
+                # shard width to divide head_dim, which 64 does). This avoids any unpad ttnn.slice /
+                # sharded->interleaved bounce; those auto-pack a 32-core block from origin (0,0) that
+                # spills into the uncovered senders-column tail (cores (0,8)/(0,9)) -> "kernel group
+                # cores do not match sub device cores" fatal under the resident prefetcher manager.
+                xqkv_fused_create_head_in = xqkv_fused_sharded
             else:
-                xqkv_fused_create_head_in = xqkv_fused_interleaved
+                xqkv_fused_interleaved = ttnn.to_memory_config(xqkv_fused_sharded, memory_config=ttnn.L1_MEMORY_CONFIG)
+                fqkv_shape = xqkv_fused_interleaved.shape
+                if fqkv_shape[3] > self._qkv_n_local:
+                    xqkv_fused_interleaved = ttnn.slice(
+                        xqkv_fused_interleaved,
+                        [0, 0, 0, 0],
+                        [fqkv_shape[0], fqkv_shape[1], fqkv_shape[2], self._qkv_n_local],
+                        memory_config=ttnn.L1_MEMORY_CONFIG,
+                    )
+                    fqkv_shape = xqkv_fused_interleaved.shape
+                xqkv_fused_interleaved = ttnn.reshape(
+                    xqkv_fused_interleaved,
+                    (1, 1, self.batch_size_per_device_group, fqkv_shape[3]),
+                    (1, 1, 32, fqkv_shape[3]),
+                )
+                if xqkv_fused_interleaved.layout != ttnn.TILE_LAYOUT:
+                    xqkv_fused_interleaved = ttnn.to_layout(
+                        xqkv_fused_interleaved,
+                        ttnn.TILE_LAYOUT,
+                        memory_config=ttnn.L1_MEMORY_CONFIG,
+                    )
+                # nlp_create_qkv_heads_decode only honors batch_offset/slice_size in its WIDTH_SHARDED
+                # program factory; width-shard the fused tensor so batch_offset selects users
+                # [col*8:col*8+8] per column.
+                create_head_input_memcfg = self._create_head_input_memcfg_nlp
+                if create_head_input_memcfg is not None:
+                    xqkv_fused_create_head_in = ttnn.to_memory_config(
+                        xqkv_fused_interleaved, memory_config=create_head_input_memcfg
+                    )
+                    ttnn.deallocate(xqkv_fused_interleaved)
+                else:
+                    xqkv_fused_create_head_in = xqkv_fused_interleaved
             # Sum the K-fractured QKV partials across mesh columns on device (sum + replicate),
             # the device equivalent of the former host column-sum. This keeps the whole decode path
             # on device and trace-capturable. The width-sharded [32, head_dim]x(qkv_n_local/head_dim)
@@ -612,6 +739,31 @@ class TtLlamaAttention(LightweightModule):
                 dtype=ttnn.bfloat16,
                 use_optimal_ccl_for_llama=True,
             )
+            _aprobe("qkv_line_all_reduce")
+            if self.use_unfused_ccl:
+                # The ring QKV output + column all-reduce leave the fused tensor width-sharded on the
+                # ring cores == the prefetcher's global-CB receiver cores (cols 1-3, rows 0-7). Running
+                # nlp_create_qkv_heads_decode there while the resident dram_prefetcher is still streaming
+                # weights into the global CB on those same cores deadlocks the create-head kernels. Move
+                # the create-head input onto non-receiver worker columns (5-6) first, so create-heads
+                # (and its output) never touch the live global-CB receiver cores. One head (head_dim)
+                # per core, width-sharded, so nlp_create_qkv_heads_decode's batch_offset factory works.
+                _ch_w = int(xqkv_fused_create_head_in.shape[-1])
+                _ch_ncores = _ch_w // self.head_dim
+                _off_receiver_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 9))])
+                _ch_in_memcfg = ttnn.MemoryConfig(
+                    ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                    ttnn.BufferType.L1,
+                    ttnn.ShardSpec(
+                        ttnn.num_cores_to_corerangeset_in_subcoregrids(
+                            ttnn.CoreCoord(5, 0), _ch_ncores, _off_receiver_grid, row_wise=False
+                        ),
+                        [32, self.head_dim],
+                        ttnn.ShardOrientation.ROW_MAJOR,
+                    ),
+                )
+                xqkv_fused_create_head_in = ttnn.to_memory_config(xqkv_fused_create_head_in, _ch_in_memcfg)
+                _aprobe("create_head_input_reshard_off_receiver")
             (
                 q_heads_pre_rot_1BQD,
                 k_heads_pre_rot_1BKD,
@@ -625,6 +777,7 @@ class TtLlamaAttention(LightweightModule):
                 slice_size=self.slice_size,
             )
             ttnn.deallocate(xqkv_fused_create_head_in)
+            _aprobe("create_qkv_heads")
         else:
             (
                 q_heads_pre_rot_1BQD,
@@ -643,11 +796,12 @@ class TtLlamaAttention(LightweightModule):
             q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD = self._apply_decode_qk_norm(
                 q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD
             )
+            _aprobe("qk_norm")
 
         ttnn.deallocate(xqkv_fused_sharded)
 
         # Q, K Rotary Embeddings
-        if self.use_prefetcher:
+        if fused_ccl:
             q_heads_1BQD, k_heads_1BKD = ttnn.experimental.rotary_embedding_llama_fused_qk(
                 q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD, rot_mats[0], rot_mats[1], self.transformation_mats["decode"]
             )  # [1, 8, 8, 128], [1, 8, 8, 128]
@@ -675,29 +829,39 @@ class TtLlamaAttention(LightweightModule):
                     k_heads_pre_rot_1BKD.shape[2],
                     self.head_dim,
                 ]
+                # Prefetcher resident (unfused-CCL): pin the auto-gridding slice kernels to the worker
+                # sub-core grid. Otherwise ttnn.slice packs a 32-core block column-major from origin
+                # (0,0), spilling into the uncovered senders-column tail (cores (0,8)/(0,9)) and hitting
+                # the "kernel group cores do not match sub device cores" fatal under the split
+                # senders/worker sub-device manager. None on the WH / no-prefetcher path (no split mgr).
+                rot_slice_sub_core_grids = self._worker_sub_core_grids if self.use_unfused_ccl else None
                 q_rot_cos = ttnn.slice(
                     rot_mats[0],
                     [0, 0, 0, 0],
                     q_rot_end,
                     memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
+                    sub_core_grids=rot_slice_sub_core_grids,
                 )
                 q_rot_sin = ttnn.slice(
                     rot_mats[1],
                     [0, 0, 0, 0],
                     q_rot_end,
                     memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
+                    sub_core_grids=rot_slice_sub_core_grids,
                 )
                 k_rot_cos = ttnn.slice(
                     rot_mats[0],
                     [0, 0, 0, 0],
                     k_rot_end,
                     memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
+                    sub_core_grids=rot_slice_sub_core_grids,
                 )
                 k_rot_sin = ttnn.slice(
                     rot_mats[1],
                     [0, 0, 0, 0],
                     k_rot_end,
                     memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
+                    sub_core_grids=rot_slice_sub_core_grids,
                 )
                 q_rot_cos = ttnn.to_layout(q_rot_cos, ttnn.TILE_LAYOUT)
                 q_rot_sin = ttnn.to_layout(q_rot_sin, ttnn.TILE_LAYOUT)
@@ -719,6 +883,7 @@ class TtLlamaAttention(LightweightModule):
             )
         ttnn.deallocate(q_heads_pre_rot_1BQD)
         ttnn.deallocate(k_heads_pre_rot_1BKD)
+        _aprobe("rotary")
 
         ###
         # KV update
@@ -733,7 +898,7 @@ class TtLlamaAttention(LightweightModule):
         # k_heads, [seqlen, n_kv_heads, bsz, head_dim]
         # v_heads [seqlen, n_kv_heads, bsz, head_dim]
         # keys, [max_batch_size, n_kv_heads // configuration.num_devices, max_seq_len, head_dim]
-        if not self.use_prefetcher:
+        if not fused_ccl:
             v_update_mem_cfg = ttnn.MemoryConfig(
                 ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                 ttnn.BufferType.L1,
@@ -756,6 +921,7 @@ class TtLlamaAttention(LightweightModule):
         )
         ttnn.deallocate(k_heads_1BKD)
         ttnn.deallocate(v_heads_1BKD)
+        _aprobe("kv_update")
 
         # NOTE: Varying the batch size will result in slightly different outputs.
         # For example, a prompt w/ 1 user vs, the same prompt repeated N times for N users, will produce different outputs
@@ -786,8 +952,9 @@ class TtLlamaAttention(LightweightModule):
                 memory_config=sdpa_out_mem_cfg,  # FIXME: why not L1 height sharded e.g. SCORES_BATCHED_MM_OUTPUT_MEMCFG?
             )
         ttnn.deallocate(q_heads_1BQD)
+        _aprobe("sdpa")
 
-        if not self.use_prefetcher:
+        if not fused_ccl:
             # Device SDPA output is batch-first [1, B_local, H_local, D] (8 users/col). Order matters:
             # nlp_concat_heads_decode pads batch to 32, so gather users across cols FIRST (8 -> 32),
             # then concat heads. Mimic tt_transformers.tt_all_gather: all_gather_async with
@@ -814,6 +981,7 @@ class TtLlamaAttention(LightweightModule):
                 subdevice_id=_ccl.worker_sub_device_id,
             )
             _ccl.gather_idx[_ca] = (_gidx + 1) % _ccl.num_cbs
+            _aprobe("sdpa_all_gather_users")
             try:
                 concat_sub_core_grids = gathered_users.memory_config().shard_spec.grid
             except Exception:
@@ -824,6 +992,7 @@ class TtLlamaAttention(LightweightModule):
                 sub_core_grids=concat_sub_core_grids,
             )
             ttnn.deallocate(gathered_users)
+            _aprobe("concat_heads")
         else:
             attn_output_cat = self.tt_ccl.all_gather_concat(  # [1, 1, 32, 1024]
                 attn_output_1G4D_sharded,
@@ -839,6 +1008,13 @@ class TtLlamaAttention(LightweightModule):
         use_replicated_full_wo = (
             self.is_qwen and not self.use_prefetcher and attn_output_cat.shape[-1] == self.n_heads * self.head_dim
         )
+        if self.use_unfused_ccl:
+            # The ring WO matmul (below) expects its input in the ring layout, but the unfused concat
+            # produced the no-prefetcher layout; reshard into the ring WO input config first.
+            attn_output_cat = ttnn.to_memory_config(
+                attn_output_cat, self.model_config["SHARDED_ATTN_WO_INPUT_RING_MEMCFG"]
+            )
+            _aprobe("wo_input_reshard")
         if not self.use_prefetcher:
             # BH no-prefetch cannot use the ring WO program here: its static CB
             # allocation exceeds L1 once concat produces the correct decode shape.
@@ -865,6 +1041,7 @@ class TtLlamaAttention(LightweightModule):
                 dtype=ttnn.bfloat8_b,
                 sub_device_id=self.prefetcher_setup.worker_sub_device_id,
             )
+        _aprobe("wo_matmul")
         # [1, 1, 32, 2304]
         if use_replicated_full_wo:
             dense_out_reduced = dense_out_ttnn
@@ -882,6 +1059,7 @@ class TtLlamaAttention(LightweightModule):
                 use_optimal_ccl_for_llama=True,
             )
             ttnn.deallocate(dense_out_ttnn)
+        _aprobe("wo_line_all_reduce")
 
         return dense_out_reduced
 

--- a/models/demos/llama3_70b_galaxy/tt/llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_attention.py
@@ -419,24 +419,39 @@ class TtLlamaAttention(LightweightModule):
             memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
             sub_core_grids=rot_slice_sub_core_grids,
         )
-        k_rot_cos = ttnn.slice(
-            rot_mats[0],
-            [0, 0, 0, 0],
-            k_rot_end,
-            memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
-            sub_core_grids=rot_slice_sub_core_grids,
-        )
-        k_rot_sin = ttnn.slice(
-            rot_mats[1],
-            [0, 0, 0, 0],
-            k_rot_end,
-            memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
-            sub_core_grids=rot_slice_sub_core_grids,
-        )
         q_rot_cos = ttnn.to_layout(q_rot_cos, ttnn.TILE_LAYOUT)
         q_rot_sin = ttnn.to_layout(q_rot_sin, ttnn.TILE_LAYOUT)
-        k_rot_cos = ttnn.to_layout(k_rot_cos, ttnn.TILE_LAYOUT)
-        k_rot_sin = ttnn.to_layout(k_rot_sin, ttnn.TILE_LAYOUT)
+        # The expanded rot_mats repeat identical cos/sin rows across the heads dim (rotation
+        # depends only on position and head-dim index), and the decode rotary op validates only
+        # the batch dim and the (padded, 32-row) shard shape of cos/sin. So when the K bounds
+        # differ from Q only in the heads dim, the Q slices serve the K rotary as-is: K heads
+        # read the same per-core [32, head_dim] shard rows. Saves 2 slice + 2 to_layout ops per
+        # layer, and halves the L1 held when the slices are cached across the layer loop.
+        k_shares_q = (
+            k_rot_end[0] == q_rot_end[0]
+            and k_rot_end[1] == q_rot_end[1]
+            and k_rot_end[2] <= q_rot_end[2]
+            and k_rot_end[3] == q_rot_end[3]
+        )
+        if k_shares_q:
+            k_rot_cos, k_rot_sin = q_rot_cos, q_rot_sin
+        else:
+            k_rot_cos = ttnn.slice(
+                rot_mats[0],
+                [0, 0, 0, 0],
+                k_rot_end,
+                memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
+                sub_core_grids=rot_slice_sub_core_grids,
+            )
+            k_rot_sin = ttnn.slice(
+                rot_mats[1],
+                [0, 0, 0, 0],
+                k_rot_end,
+                memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
+                sub_core_grids=rot_slice_sub_core_grids,
+            )
+            k_rot_cos = ttnn.to_layout(k_rot_cos, ttnn.TILE_LAYOUT)
+            k_rot_sin = ttnn.to_layout(k_rot_sin, ttnn.TILE_LAYOUT)
         if store_cache:
             self.tt_ccl._decode_rot_slice_cache = (
                 (id(rot_mats[0]), id(rot_mats[1])),

--- a/models/demos/llama3_70b_galaxy/tt/llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_attention.py
@@ -130,6 +130,10 @@ class TtLlamaAttention(LightweightModule):
         # BH-prefetcher bring-up: keep the ring matmuls (gated by use_prefetcher) but route the
         # post-matmul collectives through the stable/no-prefetcher branches (gated by use_unfused_ccl).
         self.use_unfused_ccl = getattr(configuration, "use_unfused_ccl", False)
+        # BH selective re-fusion on top of the unfused-CCL path: the underlying fused ops were ported
+        # to 2D-fabric-aware routing, so they can be enabled one CCL site at a time.
+        self.use_bh_fused_qkv_rs = getattr(configuration, "use_bh_fused_qkv_rs", False)
+        self.use_bh_fused_ag_concat = getattr(configuration, "use_bh_fused_ag_concat", False)
         self.sdpa_decode_compute_kernel_config = self.model_config["SDPA_DECODE_COMPUTE_PROGCFG"]
         self.ccl_topology = configuration.ccl_topology()
         self.is_multichip = configuration.is_multichip
@@ -293,12 +297,26 @@ class TtLlamaAttention(LightweightModule):
         if f"{q_norm_str}.weight" in self.state_dict:
             self.qk_norm = True
 
-            # Memory configurations for QK norm
+            # Memory configurations for QK norm. Default (WH TG) grids live on cols 1-3; on the BH
+            # prefetcher path those columns are the dram_prefetcher's global-CB receiver cores (and
+            # the ring matmul), so static CBs there clash with the resident global CB during trace
+            # capture. Relocate to cols 7-10 (inside the worker sub-device, free of prefetcher/CCL
+            # persistent L1) when the BH fused-QKV path routes through the sharded norm.
+            if self.use_bh_fused_qkv_rs:
+                _qkn_q_int_core = ttnn.CoreCoord(7, 0)
+                _qkn_k_int_core = ttnn.CoreCoord(9, 0)
+                _qkn_q_out_range = ttnn.CoreRange(ttnn.CoreCoord(7, 0), ttnn.CoreCoord(8, 1))
+                _qkn_k_out_range = ttnn.CoreRange(ttnn.CoreCoord(9, 0), ttnn.CoreCoord(10, 1))
+            else:
+                _qkn_q_int_core = ttnn.CoreCoord(1, 0)
+                _qkn_k_int_core = ttnn.CoreCoord(3, 0)
+                _qkn_q_out_range = ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(2, 1))
+                _qkn_k_out_range = ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 3))
             self.reshape_intermediate_q_mem_cfg = ttnn.create_sharded_memory_config(
                 shape=(64, 128),  # [1, 8, 8 (32), 128] ==> *[1, 1, 64, 128]* ==> [1, 1, 64, 32 * 4 = 128]
                 core_grid=ttnn.CoreRangeSet(
                     [
-                        ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))
+                        ttnn.CoreRange(_qkn_q_int_core, _qkn_q_int_core)
                     ]  # This captures the fact that we are using 1 core (height sharded)
                 ),  # resharding tensor to 1 core
                 strategy=ttnn.ShardStrategy.HEIGHT,  # Literally stating to the device to perform height sharding
@@ -309,7 +327,7 @@ class TtLlamaAttention(LightweightModule):
                 shape=(64, 128),  # [1, 8, 8 (32), 128] ==> *[1, 1, 64, 128]* ==> [1, 1, 64, 32 * 4 = 128]
                 core_grid=ttnn.CoreRangeSet(
                     [
-                        ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(3, 0))
+                        ttnn.CoreRange(_qkn_k_int_core, _qkn_k_int_core)
                     ]  # This captures the fact that we are using 1 core (height sharded)
                 ),  # resharding tensor to 1 core
                 strategy=ttnn.ShardStrategy.HEIGHT,  # Literally stating to the device to perform height sharding
@@ -319,9 +337,7 @@ class TtLlamaAttention(LightweightModule):
 
             self.reshape_output_q_mem_cfg = ttnn.create_sharded_memory_config(
                 shape=(64, 32),  # [1, 8, 8, 128] ==> [1, 1, 64, 128] ==> *[1, 1, 64, 32 * 4 = 128]*
-                core_grid=ttnn.CoreRangeSet(
-                    [ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(2, 1))]
-                ),  # resharding tensor to cores
+                core_grid=ttnn.CoreRangeSet([_qkn_q_out_range]),  # resharding tensor to cores
                 strategy=ttnn.ShardStrategy.WIDTH,  # Literally stating to the device to perform width sharding
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,
                 use_height_and_width_as_shard_shape=True,
@@ -329,9 +345,7 @@ class TtLlamaAttention(LightweightModule):
 
             self.reshape_output_k_mem_cfg = ttnn.create_sharded_memory_config(
                 shape=(64, 32),  # [1, 8, 8, 128] ==> [1, 1, 64, 128] ==> *[1, 1, 64, 32 * 4 = 128]*
-                core_grid=ttnn.CoreRangeSet(
-                    [ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 3))]
-                ),  # resharding tensor to cores
+                core_grid=ttnn.CoreRangeSet([_qkn_k_out_range]),  # resharding tensor to cores
                 strategy=ttnn.ShardStrategy.WIDTH,  # Literally stating to the device to perform width sharding
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,
                 use_height_and_width_as_shard_shape=True,
@@ -466,7 +480,9 @@ class TtLlamaAttention(LightweightModule):
         # tensor (user-parallel), which neither the fused sharded reshard (expects the head-parallel
         # single-core layout) nor the flat path (DRAM round-trip violates single-sub-device with the
         # resident prefetcher) can consume. Normalize in place on the worker cores instead.
-        if self.use_prefetcher and self.use_unfused_ccl:
+        # With use_bh_fused_qkv_rs, llama_rs_create_heads produces the head-parallel ROW_MAJOR layout
+        # the sharded variant was written for, so route there (its grids are BH-relocated in __init__).
+        if self.use_prefetcher and self.use_unfused_ccl and not self.use_bh_fused_qkv_rs:
             return self._apply_decode_qk_norm_unfused(q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD)
         if self.use_prefetcher:
             return self._apply_decode_qk_norm_sharded(q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD)
@@ -689,6 +705,11 @@ class TtLlamaAttention(LightweightModule):
         # On the BH prefetcher path (use_unfused_ccl) we keep the ring matmuls but run the stable,
         # worker-pinned no-prefetcher collective/head/rotary path instead, gluing layouts as needed.
         fused_ccl = self.use_prefetcher and not self.use_unfused_ccl
+        # BH selective re-fusion (2D-fabric routing ports): flip individual CCL sites back to the
+        # fused ops while the rest of the path (rotary, qk-norm, KV update) stays on the unfused
+        # branches. fused_ccl itself stays False on BH so those branches are unaffected.
+        qkv_fused = fused_ccl or self.use_bh_fused_qkv_rs
+        ag_concat_fused = fused_ccl or self.use_bh_fused_ag_concat
 
         _ap_on = os.environ.get("QWEN_BH_PROBE", "0") == "1"
 
@@ -715,13 +736,13 @@ class TtLlamaAttention(LightweightModule):
                 # llama_rs_create_heads.
                 program_config=(
                     self.model_config["XQKV_DECODE_RING_PROGCFG_TILE"]
-                    if self.use_unfused_ccl
+                    if (self.use_unfused_ccl and not qkv_fused)
                     else self.model_config["XQKV_DECODE_RING_PROGCFG"]
                 ),
                 memory_config=self.model_config["SHARDED_QKV_OUT_RING_MEMCFG"],
                 compute_kernel_config=self.compute_kernel_config_hifi2,
                 global_cb=self.prefetcher_setup.global_circular_buffer,
-                dtype=ttnn.bfloat8_b if self.use_unfused_ccl else ttnn.bfloat16,
+                dtype=ttnn.bfloat8_b if (self.use_unfused_ccl and not qkv_fused) else ttnn.bfloat16,
                 sub_device_id=self.prefetcher_setup.worker_sub_device_id,
             )
         else:
@@ -750,7 +771,7 @@ class TtLlamaAttention(LightweightModule):
         ###
         # Reshape and rotary embeddings
         ###
-        if not fused_ccl:
+        if not qkv_fused:
             if self.use_unfused_ccl:
                 # Prefetcher resident: the ring QKV matmul already emitted a width-sharded L1 tensor on
                 # the worker cores (SHARDED_QKV_OUT_RING_MEMCFG: padded N = 12288//8 over RING_SIZE
@@ -872,7 +893,12 @@ class TtLlamaAttention(LightweightModule):
         ttnn.deallocate(xqkv_fused_sharded)
 
         # Q, K Rotary Embeddings
-        if fused_ccl:
+        # The fused-qk rotary is a per-core compute op (no collective), so it follows the
+        # create-heads choice: llama_rs_create_heads emits the ROW_MAJOR head layout the fused
+        # rotary consumes, while the unfused nlp_create_qkv_heads_decode path feeds the TILE
+        # non-fused rotary below. llama_model gates the rot_mats format (use_fused_rope) the
+        # same way.
+        if qkv_fused:
             q_heads_1BQD, k_heads_1BKD = ttnn.experimental.rotary_embedding_llama_fused_qk(
                 q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD, rot_mats[0], rot_mats[1], self.transformation_mats["decode"]
             )  # [1, 8, 8, 128], [1, 8, 8, 128]
@@ -957,7 +983,7 @@ class TtLlamaAttention(LightweightModule):
         # k_heads, [seqlen, n_kv_heads, bsz, head_dim]
         # v_heads [seqlen, n_kv_heads, bsz, head_dim]
         # keys, [max_batch_size, n_kv_heads // configuration.num_devices, max_seq_len, head_dim]
-        if not fused_ccl:
+        if not qkv_fused:
             v_update_mem_cfg = ttnn.MemoryConfig(
                 ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                 ttnn.BufferType.L1,
@@ -1013,7 +1039,7 @@ class TtLlamaAttention(LightweightModule):
         ttnn.deallocate(q_heads_1BQD)
         _aprobe("sdpa")
 
-        if not fused_ccl:
+        if not ag_concat_fused:
             # Device SDPA output is batch-first [1, B_local, H_local, D] (8 users/col). Order matters:
             # nlp_concat_heads_decode pads batch to 32, so gather users across cols FIRST (8 -> 32),
             # then concat heads. Mimic tt_transformers.tt_all_gather: all_gather_async with
@@ -1067,7 +1093,7 @@ class TtLlamaAttention(LightweightModule):
         use_replicated_full_wo = (
             self.is_qwen and not self.use_prefetcher and attn_output_cat.shape[-1] == self.n_heads * self.head_dim
         )
-        if self.use_unfused_ccl:
+        if self.use_unfused_ccl and not ag_concat_fused:
             # The ring WO matmul (below) expects its input in the ring layout, but the unfused concat
             # produced the no-prefetcher layout; reshard into the ring WO input config first.
             attn_output_cat = ttnn.to_memory_config(

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -162,11 +162,48 @@ class TT_CCL:
         self.reduce_scatter_buffer_idx = [0, 0]
         self.barrier_semaphore_idx = [0, 0]
 
+    def reset_global_semaphores(self):
+        """Reset all global semaphores to 0 and rotating indices, so a reused CCL behaves like a
+        freshly-created one. close() only resets the stall group and leaves semaphores intact, so
+        when a CCL is reused across repeat batches the semaphore values drift away from the
+        trace-capture-time state (which assumes fresh 0-valued semaphores), eventually hanging the
+        CCL ops. Resetting here re-establishes that clean state at each mode switch."""
+
+        def _reset(obj):
+            if isinstance(obj, (list, tuple)):
+                for item in obj:
+                    _reset(item)
+            elif obj is not None:
+                ttnn.reset_global_semaphore_value(obj, 0)
+
+        for container in (
+            self.gather_semaphore_handles,
+            self.barrier_semaphore_handles,
+            getattr(self, "from_semaphore_handles", None),
+            getattr(self, "to_semaphore_handles", None),
+            getattr(self, "reduce_semaphore_handles", None),
+        ):
+            _reset(container)
+        self.reset_gather_and_buffer_idx()
+
     def get_and_cycle_barrier_semaphore_handle(self, cluster_axis):
         semaphore_index = cluster_axis
         current_idx = self.barrier_semaphore_idx[semaphore_index]
         self.barrier_semaphore_idx[semaphore_index] = (current_idx + 1) % self.num_cbs
         return self.barrier_semaphore_handles[semaphore_index][current_idx]
+
+    def get_and_cycle_ag_semaphore_handles(self, cluster_axis):
+        # All-gather semaphore accessor for the force-argmax sampling path (Blackhole).
+        # ttnn.experimental.all_gather_async requires two global semaphores; build the pair from
+        # consecutive entries of the per-axis gather semaphore ring (same construction the internal
+        # all_gather_async path uses), then advance the rotating index.
+        current_idx = self.gather_idx[cluster_axis]
+        semaphores = [
+            self.gather_semaphore_handles[cluster_axis][current_idx],
+            self.gather_semaphore_handles[cluster_axis][(current_idx + 1) % self.num_cbs],
+        ]
+        self.gather_idx[cluster_axis] = (current_idx + 1) % self.num_cbs
+        return semaphores
 
     def get_all_gather_concat_inter_buffer(self):
         if ttnn.get_arch_name().lower() == "blackhole":

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -55,6 +55,15 @@ class TT_CCL:
         # The no-prefetcher (Blackhole) buffer-sizing and stable-CCL fallbacks below are gated on
         # this so the prefetcher (Wormhole) path stays byte-for-byte identical to main.
         self.use_prefetcher = getattr(model_args, "use_prefetcher", True)
+        # BH prefetcher bring-up: keep the prefetcher-fed ring matmuls but route every galaxy collective
+        # through the stable/standard op (worker-pinned) instead of the fused galaxy CCLs, whose
+        # 1D-multicast writers no-op on the BH 2D-torus fabric. Gated the same way as the model/attention.
+        self.use_unfused_ccl = getattr(model_args, "use_unfused_ccl", False)
+        # Blackhole galaxy exposes only 2 ethernet links between column neighbours (Wormhole has 4). The
+        # prefill ring CCLs below historically forced 4 links whenever use_prefetcher was set (previously
+        # WH-only); with the prefetcher now enabled on BH that request goes out of bounds, so cap to the
+        # mesh's real link budget on Blackhole.
+        self.is_blackhole = getattr(model_args, "is_blackhole", False)
         all_crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 9))])
 
         self.mesh_device = mesh_device
@@ -132,6 +141,20 @@ class TT_CCL:
                             ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0)
                         )
 
+        # BH prefetcher unfused-CCL decode: the stable reduce_scatter_minimal_async needs 3 within-op
+        # global semaphores per invocation. Pre-create a double-buffered pool on the full worker grid
+        # (cols 1-10; the op enumerates the whole worker sub-device, wider than sub_core_grids) so the
+        # collective is trace-safe (no per-step allocation) and every worker core can see the semaphore.
+        self.rs_min_semaphore_handles = None
+        if mode == "decode" and self.use_unfused_ccl:
+            rs_worker_crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(10, 9))])
+            self.rs_min_semaphore_handles = [[], []]
+            for i in range(2):
+                for _ in range(self.num_cbs):
+                    self.rs_min_semaphore_handles[i].append(
+                        [ttnn.create_global_semaphore(self.mesh_device, rs_worker_crs, 0) for _ in range(3)]
+                    )
+
         self.gather_idx = [0, 0]
         self.reduce_scatter_buffer_idx = [0, 0]
         self.barrier_semaphore_idx = [0, 0]
@@ -182,6 +205,7 @@ class TT_CCL:
             getattr(self, "from_semaphore_handles", None),
             getattr(self, "to_semaphore_handles", None),
             getattr(self, "reduce_semaphore_handles", None),
+            getattr(self, "rs_min_semaphore_handles", None),
         ):
             _reset(container)
         self.reset_gather_and_buffer_idx()
@@ -835,6 +859,21 @@ class TT_CCL:
                     else persistent_buffer.memory_config()
                 )
                 input_tensor_mesh = ttnn.to_memory_config(input_tensor_mesh, target_mem_cfg)
+            if os.environ.get("QWEN_BH_PROBE", "0") == "1":
+                try:
+                    _pb_grid = persistent_buffer.memory_config().shard_spec.grid
+                    _out_grid = (
+                        memory_config.shard_spec.grid
+                        if (memory_config is not None and memory_config.is_sharded())
+                        else None
+                    )
+                    logger.info(
+                        f"QWEN_BH_AR_PROBE lm_head={lm_head} cluster_axis={cluster_axis} "
+                        f"in_grid={input_tensor_mesh.memory_config().shard_spec.grid if input_tensor_mesh.memory_config().is_sharded() else None} "
+                        f"buffer_grid={_pb_grid} out_grid={_out_grid}"
+                    )
+                except Exception as _e:
+                    logger.info(f"QWEN_BH_AR_PROBE failed: {_e}")
             output_tensor_mesh = ttnn.experimental.all_reduce_async(
                 input_tensor_mesh,
                 persistent_buffer,
@@ -896,6 +935,42 @@ class TT_CCL:
             # ttnn.synchronize_device(self.mesh_device)
 
         self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
+        return output_tensor_mesh
+
+    def line_all_reduce_gather_reduce(self, input_tensor_mesh, cluster_axis, num_links, memory_config):
+        # Stable all-reduce used for the wide Blackhole lm_head logits in decode. all_reduce_async's
+        # reduction scratch CB scales as (total output pages / num_links); with only 2 fabric links on
+        # BH (vs 4 on WH) that CB grows large enough to collide with the full-worker-grid resident
+        # decode L1 on every worker column, so the async op cannot allocate. Instead gather the four
+        # per-device partials along a new leading dim and sum them locally (same pattern as the prefill
+        # lm_head path). The gather output lives in DRAM so fast_reduce_nc only needs small per-tile CBs
+        # and never touches the crowded worker-core L1.
+        gathered = ttnn.all_gather(
+            input_tensor_mesh,
+            dim=0,
+            cluster_axis=cluster_axis,
+            topology=self.model_config["CCL_TOPOLOGY"],
+            num_links=num_links,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            subdevice_id=self.worker_sub_device_id,
+        )
+        # Confine the reduce to the worker sub-core grid. Without sub_core_grids fast_reduce_nc
+        # auto-grids across the full 12-column device and hits the uncovered dispatch column (col 11)
+        # under the split senders/worker sub-device manager -> "kernel group cores do not match sub
+        # device cores". sub_core_grids is only honored for an interleaved output (a sharded output
+        # takes the divide-by-shards path and ignores it), so reduce into DRAM then reshard to the
+        # sharded lm_head output layout (its target grid is inside the worker sub-device).
+        reduced = ttnn.experimental.fast_reduce_nc(
+            gathered,
+            dims=[0],
+            output=None,
+            compute_kernel_config=None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            sub_core_grids=self.sub_device_crs,
+        )
+        ttnn.deallocate(gathered)
+        output_tensor_mesh = ttnn.to_memory_config(reduced, memory_config)
+        ttnn.deallocate(reduced)
         return output_tensor_mesh
 
     def line_all_reduce_create_heads(
@@ -1146,10 +1221,35 @@ class TT_CCL:
             self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
 
         else:
-            if not self.use_prefetcher:
+            if self.use_prefetcher and self.use_unfused_ccl:
+                # BH prefetcher unfused-CCL bring-up. The public ttnn.reduce_scatter passes the worker
+                # sub-device's bounding-box start (here (1,0), since col 0 is the prefetcher sender column)
+                # as choose_worker_cores' core_grid_offset, which is then *added* to the already-absolute
+                # worker coords -> the reduction kernels shift onto col 11, the tensix dispatch column
+                # ("Illegal kernel placement for ring_reduction"). Call the experimental
+                # reduce_scatter_minimal_async directly instead: it fixes core_grid_offset to (0,0), so the
+                # kernels stay on the real worker cores (cols 1-10). Semaphores come from the pre-created
+                # worker-grid pool. Everything is pinned to the worker sub-device so it coexists with the
+                # resident prefetcher senders.
+                idx = self.gather_idx[cluster_axis]
+                ttnn_tensor_out = ttnn.experimental.reduce_scatter_minimal_async(
+                    input_tensor_mesh,
+                    dim=dim,
+                    multi_device_global_semaphore=self.rs_min_semaphore_handles[cluster_axis][idx],
+                    barrier_semaphore=self.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+                    num_links=num_links,
+                    memory_config=memory_config,
+                    topology=self.model_config["CCL_TOPOLOGY"],
+                    subdevice_id=self.worker_sub_device_id,
+                    cluster_axis=cluster_axis,
+                )
+                self.gather_idx[cluster_axis] = (idx + 1) % self.num_cbs
+            elif not self.use_prefetcher:
                 # BH no-prefetch (Qwen and Llama): use the stable ttnn.reduce_scatter with the
-                # configured Ring topology instead of llama_reduce_scatter, which deadlocks on the
-                # 2D-torus fabric column reduction.
+                # configured Ring topology instead of llama_reduce_scatter, whose 1D-multicast writer
+                # deadlocks on the 2D-torus fabric column reduction. With the default (SubDeviceId(0))
+                # sub-device the bounding box starts at (0,0), so the core_grid_offset double-shift above
+                # does not occur.
                 ttnn_tensor_out = ttnn.reduce_scatter(
                     input_tensor_mesh,
                     dim,
@@ -1213,7 +1313,9 @@ class TT_CCL:
         persistent_buffers_list = list(persistent_buffers.values()) if persistent_buffers else None
         # Wormhole / prefetcher path keeps main's fixed link count (4); Blackhole caps to the links
         # physically available on the mesh (Blackhole Galaxy exposes 2, not 4).
-        num_links = 4 if self.use_prefetcher else min(4, self.model_config["GALAXY_NUM_LINKS"])
+        num_links = (
+            4 if (self.use_prefetcher and not self.is_blackhole) else min(4, self.model_config["GALAXY_NUM_LINKS"])
+        )
         # Seeing better performance for longer sequence lengths with num_workers_per_link = 4
         if seqlen > 128:
             num_workers_per_link = 4
@@ -1249,6 +1351,7 @@ class TT_CCL:
         use_optimal_ccl_for_llama=False,
         use_subdevice=True,
         use_experimental_all_gather=False,
+        force_stable=False,
     ):
         topology = ttnn.Topology.Linear
 
@@ -1288,7 +1391,12 @@ class TT_CCL:
             topology = self.model_config["CCL_TOPOLOGY"]
             assert buffer_key is not None, "buffer_key is None"
             persistent_buffer = self.all_gather_buffers.get(buffer_key, None)
-        if use_experimental_all_gather or self.use_prefetcher:
+        # force_stable routes through the stable public all_gather even when use_prefetcher=True.
+        # The experimental all_gather_async is not needed here and the persistent buffer (sized for the
+        # fused path) must be dropped so the stable op allocates its own output.
+        if force_stable:
+            persistent_buffer = None
+        if (use_experimental_all_gather or self.use_prefetcher) and not force_stable:
             # Wormhole / prefetcher path uses the experimental async all-gather (identical to main).
             # The Blackhole no-prefetcher bring-up uses the stable public all_gather below.
             barrier_semaphore = None
@@ -1387,7 +1495,9 @@ class TT_CCL:
 
         # Wormhole / prefetcher path keeps main's fixed link count (4); Blackhole caps to the links
         # physically available on the mesh (Blackhole Galaxy exposes 2, not 4).
-        num_links = 4 if self.use_prefetcher else min(4, self.model_config["GALAXY_NUM_LINKS"])
+        num_links = (
+            4 if (self.use_prefetcher and not self.is_blackhole) else min(4, self.model_config["GALAXY_NUM_LINKS"])
+        )
         if reverse_order:
             all_gather_function = ttnn.experimental.all_gather_async_reversed
         else:
@@ -1445,7 +1555,7 @@ class TT_CCL:
 
         div_axis = core_grid.x if force_transpose else core_grid.y
         # Wormhole / prefetcher path is unconstrained (matches main); Blackhole caps to GALAXY_NUM_LINKS.
-        max_links = 4 if self.use_prefetcher else self.model_config["GALAXY_NUM_LINKS"]
+        max_links = 4 if (self.use_prefetcher and not self.is_blackhole) else self.model_config["GALAXY_NUM_LINKS"]
         num_links = 1
         for nl in [4, 3, 2, 1]:
             if nl <= max_links and div_axis % nl == 0:
@@ -1635,6 +1745,19 @@ class TT_CCL:
         self.mesh_device.reset_sub_device_stall_group()
 
 
+def _norm_probe(mesh_device, tag):
+    # Env-gated device sync used to bracket the distributed-norm sub-ops so a hang can be attributed
+    # to the exact step (pre / all_gather / post). No-op unless QWEN_BH_PROBE=1.
+    if os.environ.get("QWEN_BH_PROBE", "0") == "1":
+        logger.info(f"[norm-probe] before sync: {tag}")
+        try:
+            ttnn.synchronize_device(mesh_device)
+        except Exception as e:
+            logger.info(f"[norm-probe] sync skipped ({tag}): {str(e)[:80]}")
+            return
+        logger.info(f"[norm-probe] after  sync: {tag}")
+
+
 def tt_distributed_rmsnorm(
     inp,
     epsilon,
@@ -1643,17 +1766,46 @@ def tt_distributed_rmsnorm(
     compute_kernel_config,
     tt_ccl=None,
     output_dtype=None,
+    force_stable_ag=False,
+    input_memcfg=None,
+    program_config=None,
+    stats_memcfg=None,
 ):
-    use_2d_grid = False
+    # When program_config is provided (BH prefetcher path), the pre/post rms ops run on the sharded
+    # LayerNorm program's core grid, which is confined to the worker sub-device (excludes the prefetcher
+    # sender column). This mirrors the proven tt_transformers sharded distributed-norm and is what keeps
+    # the local norm compute from deadlocking against the resident dram_prefetcher. use_2d_core_grid must
+    # be left unset in that case (the program config picks the grid).
+    use_2d_grid = None if program_config is not None else False
+
+    # Reshard onto the worker-safe grid before computing stats (only on the confined path).
+    if input_memcfg is not None:
+        inp = ttnn.to_memory_config(inp, memory_config=input_memcfg)
+        _norm_probe(mesh_device, "reshard inp -> worker grid")
 
     # Run distributed rmsnorm part 1
     tt_stats = ttnn.rms_norm_pre_all_gather(
-        inp, compute_kernel_config=compute_kernel_config, dtype=ttnn.bfloat16, use_2d_core_grid=use_2d_grid
+        inp,
+        compute_kernel_config=compute_kernel_config,
+        dtype=ttnn.bfloat16,
+        use_2d_core_grid=use_2d_grid,
+        program_config=program_config,
     )
+    _norm_probe(mesh_device, "rms_norm_pre_all_gather")
 
+    # On the confined path the gathered stats must be sharded (rms_norm_post_all_gather with a sharded
+    # program config asserts stats.is_sharded()); everywhere else keep the DRAM interleaved gather.
+    stats_ag_memcfg = stats_memcfg if stats_memcfg is not None else ttnn.DRAM_MEMORY_CONFIG
     tt_stats_gathered = tt_ccl.line_all_gather(
-        tt_stats, dim=3, cluster_axis=1, num_links=1, memory_config=ttnn.DRAM_MEMORY_CONFIG, buffer_key="LAYERNORM"
+        tt_stats,
+        dim=3,
+        cluster_axis=1,
+        num_links=1,
+        memory_config=stats_ag_memcfg,
+        buffer_key="LAYERNORM",
+        force_stable=force_stable_ag,
     )
+    _norm_probe(mesh_device, "line_all_gather (LAYERNORM stats)")
     tt_stats.deallocate(True)
 
     # Run distributed rmsnorm part 2. output_dtype lets the caller keep the norm output bf8 even when
@@ -1665,8 +1817,10 @@ def tt_distributed_rmsnorm(
         weight=gamma,
         compute_kernel_config=compute_kernel_config,
         use_2d_core_grid=use_2d_grid,
+        program_config=program_config,
         dtype=output_dtype,
     )
+    _norm_probe(mesh_device, "rms_norm_post_all_gather")
     # tt_stats_gathered.deallocate(True)
     # inp.deallocate(True)
 

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -63,6 +63,10 @@ class TT_CCL:
         # reduce_scatter_minimal_async via ttnn.experimental.matmul_reduce_scatter_async. See
         # qwen_model_config.py and matmul_reduce_scatter_async wrapper below.
         self.use_bh_fused_async_rs_matmul = getattr(model_args, "use_bh_fused_async_rs_matmul", False)
+        # BH 2D-fabric routing port of llama_reduce_scatter/llama_rs_matmul: when active, decode
+        # reduce-scatters can use the fused packet-worker llama_reduce_scatter (~7 us) instead of
+        # the generic reduce_scatter_minimal_async fallback (~21 us).
+        self.use_bh_fused_rs_matmul = getattr(model_args, "use_bh_fused_rs_matmul", False)
         # Blackhole galaxy exposes only 2 ethernet links between column neighbours (Wormhole has 4). The
         # prefill ring CCLs below historically forced 4 links whenever use_prefetcher was set (previously
         # WH-only); with the prefetcher now enabled on BH that request goes out of bounds, so cap to the
@@ -159,6 +163,19 @@ class TT_CCL:
                     self.rs_min_semaphore_handles[i].append(
                         [ttnn.create_global_semaphore(self.mesh_device, rs_worker_crs, 0) for _ in range(3)]
                     )
+
+        # BH prefetcher fused distributed-norm (fused_rms_minimal): the norm runs on the LN grid at
+        # column 7 (outside sub_device_crs, which only covers cols 1-3/5-6), and the op's out-ready
+        # global semaphore lives on the sender core (7,0). Allocate a dedicated double-buffered pool
+        # on the full worker grid so the semaphore address is valid on those cores.
+        self.fused_norm_semaphore_handles = None
+        self.fused_norm_idx = 0
+        self.use_bh_fused_norm = mode == "decode" and getattr(model_args, "use_bh_fused_rms", False)
+        if self.use_bh_fused_norm:
+            fused_norm_crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(10, 9))])
+            self.fused_norm_semaphore_handles = [
+                ttnn.create_global_semaphore(self.mesh_device, fused_norm_crs, 0) for _ in range(self.num_cbs)
+            ]
 
         # Dedicated semaphores for the sampling force-argmax all-gather (Blackhole). The op maps
         # its two global semaphores to the forward/backward ring directions, so the shared gather
@@ -340,7 +357,14 @@ class TT_CCL:
         persistent_buffers["SDPA"] = tt_buffer
 
         # Layernorm
-        grid_offset = ttnn.CoreCoord(1, 0)
+        # The fused RMSAllGather requires the stats shard to live on the first core of the norm's
+        # input shard grid (the op aliases the stats buffer as a CB on its sender core). On the BH
+        # prefetcher fused-norm path the LN grid starts at (7,0) (see DistributedNorm), so the
+        # persistent stats buffer must move there too. WH keeps (1,0).
+        if getattr(self.model_args, "use_bh_fused_rms", False):
+            grid_offset = ttnn.CoreCoord(7, 0)
+        else:
+            grid_offset = ttnn.CoreCoord(1, 0)
         tt_stats_sharded_config = ttnn.create_sharded_memory_config(
             shape=(32, 128),
             core_grid=ttnn.CoreRangeSet([ttnn.CoreRange(grid_offset, grid_offset)]),
@@ -475,6 +499,8 @@ class TT_CCL:
             2048 // 16 * cluster_shape[cluster_axis] if not self.is_qwen else 1280 // 10 * cluster_shape[cluster_axis]
         )  # FF2/DO
         M_axis0 = default_M
+        axis0_buffer_crs = self.sub_device_crs
+        axis0_num_cores = num_cores
         if self.is_qwen:
             # all_reduce_async validates: buffer_shard_volume >= output_shard_volume * ring_size.
             # For decode residual all-reduce on axis 0 this requires width >= output_width * mesh_rows.
@@ -487,17 +513,24 @@ class TT_CCL:
                 required_width = decode_residual_memcfg.shard_spec.shape[1] * cluster_shape[cluster_axis]
                 N_per_shard = max(N_per_shard, required_width)
                 M_axis0 = max(M_axis0, decode_residual_memcfg.shard_spec.shape[0])
+                # all_reduce_async also requires every output core to hold a buffer shard (the
+                # buffer doubles as per-output-core reduction scratch). On the BH fused-norm path
+                # the residual grid moves to cols 7-8, outside sub_core_grids, so extend the
+                # buffer grid to cover it.
+                if not axis0_buffer_crs.contains(decode_residual_memcfg.shard_spec.grid):
+                    axis0_buffer_crs = axis0_buffer_crs.merge(decode_residual_memcfg.shard_spec.grid)
+                    axis0_num_cores = axis0_buffer_crs.num_cores()
         buffer_mem_cfg = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.BufferType.L1,
             ttnn.ShardSpec(
-                self.sub_device_crs,
+                axis0_buffer_crs,
                 [M_axis0, N_per_shard],
                 ttnn.ShardOrientation.ROW_MAJOR,
             ),
         )
         tt_buffer = ttnn.from_torch(
-            torch.zeros((*cluster_shape, M_axis0, N_per_shard * num_cores)),
+            torch.zeros((*cluster_shape, M_axis0, N_per_shard * axis0_num_cores)),
             device=self.mesh_device,
             layout=ttnn.TILE_LAYOUT,
             dtype=ttnn.bfloat8_b,
@@ -1352,6 +1385,10 @@ class TT_CCL:
             self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
 
         else:
+            # NOTE: routing this through llama_reduce_scatter instead (use_bh_fused_rs_matmul-gated)
+            # was tried and measured ~1 ms/token SLOWER than reduce_scatter_minimal_async in the full
+            # model (54.2 vs 56.7 tok/s/u), despite the standalone op being faster - it serializes
+            # against the fused Matmul_RS's packet workers/interim buffers. Keep rs_minimal here.
             if self.use_prefetcher and self.use_unfused_ccl:
                 # BH prefetcher unfused-CCL bring-up. The public ttnn.reduce_scatter passes the worker
                 # sub-device's bounding-box start (here (1,0), since col 0 is the prefetcher sender column)
@@ -1972,11 +2009,20 @@ def tt_sharded_distributed_rmsnorm(
     use_noc1_only=False,
     ccl_topology=None,
 ):
-    # inp = ttnn.to_memory_config(inp, memory_config=ln_sharded_input_memcfg)
-
     # Run distributed rmsnorm part 1
     cluster_axis = 1
-    semaphore = tt_ccl.gather_semaphore_handles[cluster_axis][tt_ccl.gather_idx[cluster_axis]]
+    bh_fused_norm = getattr(tt_ccl, "use_bh_fused_norm", False)
+    if bh_fused_norm:
+        # BH prefetcher: the residual stream lives on cols 1-2 (prefetcher GCB receiver cores), where
+        # the fused op's static CBs would clash with the resident global CB under trace capture.
+        # Reshard onto the LN grid at column 7 (same confinement as the proven unfused path) and use
+        # the dedicated worker-grid semaphore pool (the shared gather pool's CRS excludes col 7).
+        inp = ttnn.to_memory_config(inp, memory_config=ln_sharded_input_memcfg)
+        semaphore = tt_ccl.fused_norm_semaphore_handles[tt_ccl.fused_norm_idx]
+        tt_ccl.fused_norm_idx = (tt_ccl.fused_norm_idx + 1) % tt_ccl.num_cbs
+    else:
+        semaphore = tt_ccl.gather_semaphore_handles[cluster_axis][tt_ccl.gather_idx[cluster_axis]]
+        tt_ccl.gather_idx[cluster_axis] = (tt_ccl.gather_idx[cluster_axis] + 1) % tt_ccl.num_cbs
     persistent_buffer = tt_ccl.all_gather_buffers.get("LAYERNORM", None)
     tt_out = ttnn.fused_rms_minimal(
         inp,
@@ -1993,5 +2039,4 @@ def tt_sharded_distributed_rmsnorm(
         memory_config=output_mem_config,
         use_noc1_only=use_noc1_only,
     )
-    tt_ccl.gather_idx[cluster_axis] = (tt_ccl.gather_idx[cluster_axis] + 1) % tt_ccl.num_cbs
     return tt_out, res

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -160,6 +160,20 @@ class TT_CCL:
                         [ttnn.create_global_semaphore(self.mesh_device, rs_worker_crs, 0) for _ in range(3)]
                     )
 
+        # Dedicated semaphores for the sampling force-argmax all-gather (Blackhole). The op maps
+        # its two global semaphores to the forward/backward ring directions, so the shared gather
+        # ring (num_cbs=2) would hand out overlapping pairs whose members swap direction roles
+        # between calls ([s0,s1] then [s1,s0]) while the same handles are simultaneously consumed
+        # as singles by the other decode CCLs. Leftover per-direction counts then desync later
+        # gathers (observed as argmax indices displaced by whole vocab chunks). Fixed-role
+        # dedicated handles avoid this.
+        self.sampling_ag_semaphore_handles = [
+            [ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0) for _ in range(2)] for _ in range(2)
+        ]
+        self.sampling_barrier_semaphore_handles = [
+            ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0) for _ in range(2)
+        ]
+
         self.gather_idx = [0, 0]
         self.reduce_scatter_buffer_idx = [0, 0]
         self.barrier_semaphore_idx = [0, 0]
@@ -215,6 +229,8 @@ class TT_CCL:
             getattr(self, "to_semaphore_handles", None),
             getattr(self, "reduce_semaphore_handles", None),
             getattr(self, "rs_min_semaphore_handles", None),
+            getattr(self, "sampling_ag_semaphore_handles", None),
+            getattr(self, "sampling_barrier_semaphore_handles", None),
         ):
             _reset(container)
         self.reset_gather_and_buffer_idx()
@@ -225,18 +241,17 @@ class TT_CCL:
         self.barrier_semaphore_idx[semaphore_index] = (current_idx + 1) % self.num_cbs
         return self.barrier_semaphore_handles[semaphore_index][current_idx]
 
+    def get_sampling_barrier_semaphore_handle(self, cluster_axis):
+        # Dedicated barrier for the force-argmax sampling all-gather (fixed role, never shared
+        # with the internal CCL barrier ring). See __init__ for why sharing corrupts.
+        return self.sampling_barrier_semaphore_handles[cluster_axis]
+
     def get_and_cycle_ag_semaphore_handles(self, cluster_axis):
         # All-gather semaphore accessor for the force-argmax sampling path (Blackhole).
-        # ttnn.experimental.all_gather_async requires two global semaphores; build the pair from
-        # consecutive entries of the per-axis gather semaphore ring (same construction the internal
-        # all_gather_async path uses), then advance the rotating index.
-        current_idx = self.gather_idx[cluster_axis]
-        semaphores = [
-            self.gather_semaphore_handles[cluster_axis][current_idx],
-            self.gather_semaphore_handles[cluster_axis][(current_idx + 1) % self.num_cbs],
-        ]
-        self.gather_idx[cluster_axis] = (current_idx + 1) % self.num_cbs
-        return semaphores
+        # ttnn.experimental.all_gather_async requires two global semaphores (one per ring
+        # direction); return the dedicated fixed-role pair (see __init__) rather than overlapping
+        # slices of the shared gather ring, whose members would swap direction roles between calls.
+        return list(self.sampling_ag_semaphore_handles[cluster_axis])
 
     def get_all_gather_concat_inter_buffer(self):
         if ttnn.get_arch_name().lower() == "blackhole":

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -59,6 +59,10 @@ class TT_CCL:
         # through the stable/standard op (worker-pinned) instead of the fused galaxy CCLs, whose
         # 1D-multicast writers no-op on the BH 2D-torus fabric. Gated the same way as the model/attention.
         self.use_unfused_ccl = getattr(model_args, "use_unfused_ccl", False)
+        # BH "prefetcher + fused op": fuse the FF1/FF3 ring matmul with the BH-working
+        # reduce_scatter_minimal_async via ttnn.experimental.matmul_reduce_scatter_async. See
+        # qwen_model_config.py and matmul_reduce_scatter_async wrapper below.
+        self.use_bh_fused_async_rs_matmul = getattr(model_args, "use_bh_fused_async_rs_matmul", False)
         # Blackhole galaxy exposes only 2 ethernet links between column neighbours (Wormhole has 4). The
         # prefill ring CCLs below historically forced 4 links whenever use_prefetcher was set (previously
         # WH-only); with the prefetcher now enabled on BH that request goes out of bounds, so cap to the
@@ -67,6 +71,7 @@ class TT_CCL:
         all_crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 9))])
 
         self.mesh_device = mesh_device
+        self.model_args = model_args
         # If no worker subdevice is provided (e.g. prefetcher disabled), keep CCL on the full core set.
         self.sub_device_crs = (
             all_crs if mode == "prefill" or worker_sub_device_id is None else model_args.sub_core_grids
@@ -165,6 +170,10 @@ class TT_CCL:
             self.all_gather_buffers = self.get_all_gather_buffers()
             self.reduce_scatter_buffers = self.get_decode_reduce_scatter_buffers()
             self.rs_create_heads_buffers = self.get_decode_rs_create_heads_buffers()
+            self.fused_rs_matmul_buffers = (
+                self.get_decode_fused_rs_matmul_buffers() if self.use_bh_fused_async_rs_matmul else None
+            )
+            self.fused_rs_matmul_buffer_idx = [0, 0]
         if mode == "prefill":
             # For some prefill seqlens we always allocate CCL buffers. Otherwise they will require barrier syncing
             self.support_seqlens = [4096, 2048, 1024, 128]
@@ -571,6 +580,57 @@ class TT_CCL:
             persistent_buffers[cluster_axis].append(tt_buffer)
 
         return persistent_buffers
+
+    def get_decode_fused_rs_matmul_buffers(self):
+        """Double-buffered persistent buffers for ttnn.experimental.matmul_reduce_scatter_async
+        (BH prefetcher + fused FF1/FF3 reduce-scatter).
+
+        The fused op requires two caller-owned tensors:
+          - persistent_intermediate: the reduce_scatter_minimal ring scratch; same per-device layout as
+            the FF ring-matmul output (SHARDED_FF12_OUT_RING_MEMCFG, [32, 3840] width-sharded on the
+            24 ring cores).
+          - persistent_output: the scattered result, returned as the op's reduce_scatter output
+            (REDUCE_SCATTER_OUT_MEMCFG, [32, 960] width-sharded on 30 cores).
+        Two of each (num_cbs) so w1 and w3 (and successive layers under trace) never alias.
+        """
+        cluster_shape = (8, 4)
+        cluster_axis = 1
+        num_col_devices = cluster_shape[cluster_axis]
+        # LOGICAL FF-hidden width per device (matmul output before the column reduce-scatter). This is the
+        # UNPADDED width (3200 for Qwen3-32B); the ring memcfg physically pads it to 3840 across 24 cores.
+        # The persistent buffers MUST carry the logical width, not the padded one: the fused op returns
+        # persistent_output verbatim as the reduce-scatter result, and the RS derives its scatter partition
+        # from the matmul output's logical width (3200 -> 800/device). Allocating at the padded width (3840 ->
+        # 960/device) misaligns the scatter and folds the 640 padding columns into the logical result,
+        # corrupting downstream (observed as a ~0.984 vs 0.9975 decode PCC drop).
+        n_logical = self.model_args.intermediate_dim_per_tp  # 3200
+        interim_memcfg = self.model_config["SHARDED_FF12_OUT_RING_MEMCFG"]
+        out_memcfg = self.model_config["REDUCE_SCATTER_OUT_MEMCFG"]
+        shard_h = out_memcfg.shard_spec.shape[0]  # decode_shard_height (32 for batch-32)
+
+        buffers = {"intermediate": [], "output": []}
+        for _ in range(self.num_cbs):
+            buffers["intermediate"].append(
+                ttnn.from_torch(
+                    torch.zeros((*cluster_shape, shard_h, n_logical)),
+                    device=self.mesh_device,
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=ttnn.bfloat8_b,
+                    memory_config=interim_memcfg,
+                    mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(0, 1), mesh_shape=cluster_shape),
+                )
+            )
+            buffers["output"].append(
+                ttnn.from_torch(
+                    torch.zeros((*cluster_shape, shard_h, n_logical // num_col_devices)),
+                    device=self.mesh_device,
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=ttnn.bfloat8_b,
+                    memory_config=out_memcfg,
+                    mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(0, 1), mesh_shape=cluster_shape),
+                )
+            )
+        return buffers
 
     def get_decode_rs_create_heads_buffers(self):
         """
@@ -1063,6 +1123,62 @@ class TT_CCL:
         self.reduce_scatter_buffer_idx[cluster_axis] = (self.reduce_scatter_buffer_idx[cluster_axis] + 1) % self.num_cbs
         # ttnn.synchronize_device(self.mesh_device, sub_device_ids=[self.worker_sub_device_id])
         return ttnn_tensor_out, w3_out
+
+    def matmul_reduce_scatter_async(
+        self,
+        matmul_input,
+        matmul_weight,
+        compute_kernel_config=None,
+        dtype=None,
+        program_config=None,
+        memory_config_mm=None,
+        memory_config_rs=None,
+        global_cb=None,
+        sub_device_id=None,
+        dim=3,
+        num_links=1,
+        cluster_axis=1,
+    ):
+        """BH prefetcher + fused op: fuse the FF1/FF3 prefetcher ring matmul (streaming global-CB
+        weights) with the BH-working reduce_scatter_minimal_async backend, using the REDUCE_SCATTER
+        OpSignaler co-design. Returns the reduce-scattered output only (the matmul partial is internal).
+
+        reduce_scatter_sub_core_grid confines the RS reader/worker cores to columns 4-10, clear of the
+        ring-matmul cores (cols 1-3), the prefetcher senders (col 0) and the dispatch column (col 11).
+        An additive core_grid_offset cannot express this: the worker grid already reaches col 10, so
+        offsetting overflows off-grid (col 13). This disjointness is required because, unlike the unfused
+        path, the matmul and reduce-scatter run in the SAME program here.
+        """
+        idx = self.gather_idx[cluster_axis]
+        buf_idx = self.fused_rs_matmul_buffer_idx[cluster_axis]
+        persistent_intermediate = self.fused_rs_matmul_buffers["intermediate"][buf_idx]
+        persistent_output = self.fused_rs_matmul_buffers["output"][buf_idx]
+        rs_sub_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(10, 9))])
+
+        _, rs_out = ttnn.experimental.matmul_reduce_scatter_async(
+            matmul_input,
+            matmul_weight,
+            persistent_intermediate_buffer=persistent_intermediate,
+            persistent_output_buffer=persistent_output,
+            dim=dim,
+            multi_device_global_semaphore=self.rs_min_semaphore_handles[cluster_axis][idx],
+            reduce_scatter_core_grid_offset=(0, 0),
+            reduce_scatter_sub_core_grid=rs_sub_core_grid,
+            barrier_semaphore=self.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+            num_links=num_links,
+            memory_config_rs=memory_config_rs,
+            memory_config_mm=memory_config_mm,
+            topology=self.model_config["CCL_TOPOLOGY"],
+            subdevice_id=sub_device_id,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+            cluster_axis=cluster_axis,
+            global_cb=global_cb,
+        )
+        self.gather_idx[cluster_axis] = (idx + 1) % self.num_cbs
+        self.fused_rs_matmul_buffer_idx[cluster_axis] = (buf_idx + 1) % self.num_cbs
+        return rs_out
 
     def matmul_line_reduce_scatter(
         self,

--- a/models/demos/llama3_70b_galaxy/tt/llama_decoder.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_decoder.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import os
 import ttnn
 from loguru import logger
 from models.demos.llama3_70b_galaxy.tt.llama_attention import TtLlamaAttention
@@ -147,6 +148,25 @@ class TtTransformerBlock(LightweightModule):
     ) -> ttnn.Tensor:
         # x contains input in layer 0 and ffout of previous layer thereafter, x should be dealocated
         # h contains 0 in layer 0 and h_prev+x_prev+attn_out_prev thereafter, h is persistent
+        # Bring-up probe: log + device-sync at each stage boundary so a device hang can be
+        # localized to a specific op (the last "[probe]" line printed is the culprit stage).
+        _probe_on = os.environ.get("QWEN_BH_PROBE", "0") == "1" and mode == "decode"
+
+        def _probe(tag):
+            if _probe_on:
+                logger.info(f"[probe] before sync: {tag}")
+                # synchronize_device is illegal during trace capture; swallow that so the probe
+                # is a no-op on the trace-capture pass and only actually syncs on the eager
+                # compile pass (where a device deadlock can be localized to the last logged tag).
+                try:
+                    ttnn.synchronize_device(self.mesh_device)
+                except Exception as e:
+                    logger.info(f"[probe] sync skipped ({tag}): {str(e)[:80]}")
+                    return
+                logger.info(f"[probe] after  sync: {tag}")
+
+        _probe("entry (flushes dram_prefetcher)")
+
         skip_mem_cfg = self.model_config["DECODE_RESIDUAL_MEMCFG"] if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG
         # On the BH no-prefetch path the residual stream defaults to bf8, so it is re-quantized on
         # every layer's residual add. Over 64 layers that accumulated bf8 error degrades the final
@@ -183,6 +203,8 @@ class TtTransformerBlock(LightweightModule):
             else:
                 attn_in_sharded, _ = self.attention_norm(x, h, mode)
 
+        _probe("attention_norm")
+
         attn_out = self.attention.forward(
             attn_in_sharded,
             current_pos,
@@ -196,6 +218,7 @@ class TtTransformerBlock(LightweightModule):
             kv_cache=kv_cache,
             batch_size=batch_size,
         )
+        _probe("attention.forward")
         if mode == "prefill":
             h = ttnn.add(x, attn_out, memory_config=skip_mem_cfg, dtype=res_dtype)  # bf16 on BH no-prefetch
             x.deallocate(True)
@@ -226,8 +249,11 @@ class TtTransformerBlock(LightweightModule):
             if h is not attn_out:
                 attn_out.deallocate(True)
 
+        _probe("ff_norm")
+
         # MLP takes replicated inputs and produces fractured outputs
         ff_out = self.feed_forward.forward(ff_in_sharded, mode, batch_size=batch_size)
+        _probe("feed_forward.forward")
         if self.layer_num == self.n_layers - 1 or mode == "prefill":
             out = ttnn.add(ff_out, h, memory_config=skip_mem_cfg, dtype=res_dtype)
             if mode == "decode":

--- a/models/demos/llama3_70b_galaxy/tt/llama_embedding.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_embedding.py
@@ -36,16 +36,26 @@ class TtLlamaEmbedding(LightweightModule):
 
     def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         x = ttnn.reshape(x, ttnn.Shape((1, 1, 1, x.shape[-2] * x.shape[-1])))
+        use_decode_memcfg = x.shape[-1] <= 32
+        # The no-prefetcher (Blackhole) decode runs on the 16-core grid where ttnn.embedding cannot
+        # reliably emit the width-sharded DECODE_RESIDUAL_MEMCFG directly, so embed to DRAM (correct
+        # values) then reshard to the residual layout the model's decode forward expects. Wormhole
+        # keeps main's direct emit onto DECODE_RESIDUAL_MEMCFG.
+        reshard_decode = use_decode_memcfg and not self.args.use_prefetcher
+        if use_decode_memcfg and not reshard_decode:
+            out_memcfg = self.args.model_config["DECODE_RESIDUAL_MEMCFG"]
+        else:
+            out_memcfg = ttnn.DRAM_MEMORY_CONFIG
         x = ttnn.embedding(
             x,
             self.weights,
             layout=ttnn.TILE_LAYOUT,
-            memory_config=(
-                self.args.model_config["DECODE_RESIDUAL_MEMCFG"] if x.shape[-1] <= 32 else ttnn.DRAM_MEMORY_CONFIG
-            ),
+            memory_config=out_memcfg,
             dtype=ttnn.bfloat8_b
             if x.shape[-1] > 32
             else ttnn.bfloat16,  # Keep bfloat16 for decode, bfloat8_b for prefill
         )
         x = ttnn.reshape(x, ttnn.Shape((1, 1, x.shape[-2], x.shape[-1])))
+        if reshard_decode:
+            x = ttnn.to_memory_config(x, self.args.model_config["DECODE_RESIDUAL_MEMCFG"])
         return x

--- a/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
@@ -49,6 +49,10 @@ class TtLlamaMLP(LightweightModule):
         self.model_config = model_config
         # Single source of truth for the prefetcher gate (Wormhole/TG True, Blackhole bring-up False).
         self.use_prefetcher = args.use_prefetcher
+        # BH prefetcher bring-up: keep the prefetcher-fed ring matmuls but unfuse the reduce_scatter
+        # (the fused llama_rs_matmul / llama_reduce_scatter 1D-multicast writers no-op on the BH
+        # 2D-torus fabric). Gated identically to the attention/model unfused-CCL flag.
+        self.use_unfused_ccl = getattr(args, "use_unfused_ccl", False)
         self.prefetcher_setup = prefetcher_setup
         self.tt_ccl = tt_ccl
         state_dict_prefix = state_dict_prefix or args.get_state_dict_prefix(self.__class__.__name__, layer_num)
@@ -163,6 +167,53 @@ class TtLlamaMLP(LightweightModule):
                 sub_device_id=None,
             )
             ttnn.deallocate(x)
+            w1_out_reduced = self.tt_ccl.line_reduce_scatter(
+                w1_out,
+                cluster_axis=1,
+                num_links=self.model_config["GALAXY_NUM_LINKS"],
+                memory_config=self.model_config["REDUCE_SCATTER_OUT_MEMCFG"],
+                use_noc1_only=False,
+            )
+            ttnn.deallocate(w1_out)
+        elif self.use_prefetcher and self.use_unfused_ccl:
+            # BH prefetcher + unfused CCL: run the FF1/FF3 ring matmuls separately so they still consume
+            # the prefetched global-CB weights (self.w1/self.w3) on the worker sub-device, but replace the
+            # fused reduce_scatter with the stable worker-pinned ttnn.reduce_scatter (via line_reduce_scatter,
+            # which now honors use_unfused_ccl). The fused double_matmul_line_reduce_scatter's 1D-multicast
+            # RS writer no-ops on the BH 2D-torus fabric and deadlocks.
+            w1_out = ttnn.linear(
+                x,
+                self.w1,
+                program_config=pc_1_3,
+                memory_config=self.model_config["SHARDED_FF12_OUT_RING_MEMCFG"],
+                compute_kernel_config=self.args.compute_kernel_config_lofi
+                if self.four_bit_mlp
+                else self.args.compute_kernel_config_hifi2,
+                dtype=ttnn.bfloat8_b,
+                global_cb=self.prefetcher_setup.global_circular_buffer,
+                sub_device_id=self.prefetcher_setup.worker_sub_device_id,
+            )
+            w3_out = ttnn.linear(
+                x,
+                self.w3,
+                program_config=pc_1_3,
+                memory_config=self.model_config["SHARDED_FF12_OUT_RING_MEMCFG"],
+                compute_kernel_config=self.args.compute_kernel_config_lofi
+                if self.four_bit_mlp
+                else self.args.compute_kernel_config_hifi2,
+                dtype=ttnn.bfloat8_b,
+                global_cb=self.prefetcher_setup.global_circular_buffer,
+                sub_device_id=self.prefetcher_setup.worker_sub_device_id,
+            )
+            ttnn.deallocate(x)
+            # The stable ttnn.reduce_scatter places its ring_reduction kernel on the input's shard grid.
+            # The ring-matmul output lives on the ring cores (columns 1-3), some of which are dispatch
+            # cores -> "Illegal kernel placement ... dispatch cores". Bring both outputs to DRAM
+            # interleaved first (like the no-prefetch path) so reduce_scatter instead picks its worker
+            # grid from subdevice_id (which excludes dispatch/prefetcher cores). The reshard reads from
+            # the worker shard cores, so it stays clear of the resident prefetcher senders.
+            w1_out = ttnn.to_memory_config(w1_out, ttnn.DRAM_MEMORY_CONFIG)
+            w3_out = ttnn.to_memory_config(w3_out, ttnn.DRAM_MEMORY_CONFIG)
             w1_out_reduced = self.tt_ccl.line_reduce_scatter(
                 w1_out,
                 cluster_axis=1,

--- a/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
@@ -204,21 +204,40 @@ class TtLlamaMLP(LightweightModule):
                 num_links=self.model_config["GALAXY_NUM_LINKS"],
                 cluster_axis=1,
             )
-            w3_out_reduced = self.tt_ccl.matmul_reduce_scatter_async(
-                x,
-                self.w3,
-                program_config=pc_1_3,
-                memory_config_mm=self.model_config["SHARDED_FF12_OUT_RING_MEMCFG"],
-                memory_config_rs=self.model_config["REDUCE_SCATTER_OUT_MEMCFG"],
-                compute_kernel_config=mm_ckc,
-                dtype=ttnn.bfloat8_b,
-                global_cb=self.prefetcher_setup.global_circular_buffer,
-                sub_device_id=self.prefetcher_setup.worker_sub_device_id,
-                num_links=self.model_config["GALAXY_NUM_LINKS"],
-                cluster_axis=1,
-            )
+            if os.environ.get("QWEN_FUSED_FF1_ONLY") == "1":
+                # Diagnostic (token-2 dispatch deadlock narrowing): fuse ONLY FF1, run FF3 through the
+                # unfused ring-matmul -> DRAM -> line_reduce_scatter path. One fused call per layer
+                # instead of two: if the hang moves proportionally later, the failure is a per-fused-call
+                # accounting leak; if it stays at the same token, it is per-program-structure.
+                # (w3_out_reduced produced by the post-branch line_reduce_scatter is intentionally not
+                # deallocated in the fused path's guard below — acceptable leak for this diagnostic.)
+                w3_out = ttnn.linear(
+                    x,
+                    self.w3,
+                    program_config=pc_1_3,
+                    memory_config=self.model_config["SHARDED_FF12_OUT_RING_MEMCFG"],
+                    compute_kernel_config=mm_ckc,
+                    dtype=ttnn.bfloat8_b,
+                    global_cb=self.prefetcher_setup.global_circular_buffer,
+                    sub_device_id=self.prefetcher_setup.worker_sub_device_id,
+                )
+                w3_out = ttnn.to_memory_config(w3_out, ttnn.DRAM_MEMORY_CONFIG)
+            else:
+                w3_out_reduced = self.tt_ccl.matmul_reduce_scatter_async(
+                    x,
+                    self.w3,
+                    program_config=pc_1_3,
+                    memory_config_mm=self.model_config["SHARDED_FF12_OUT_RING_MEMCFG"],
+                    memory_config_rs=self.model_config["REDUCE_SCATTER_OUT_MEMCFG"],
+                    compute_kernel_config=mm_ckc,
+                    dtype=ttnn.bfloat8_b,
+                    global_cb=self.prefetcher_setup.global_circular_buffer,
+                    sub_device_id=self.prefetcher_setup.worker_sub_device_id,
+                    num_links=self.model_config["GALAXY_NUM_LINKS"],
+                    cluster_axis=1,
+                )
+                w3_out = None  # already reduce-scattered; skip the post-branch line_reduce_scatter
             ttnn.deallocate(x)
-            w3_out = None  # already reduce-scattered; skip the post-branch line_reduce_scatter
             if os.environ.get("QWEN_DBG_FUSED_SYNC") == "1":
                 # Diagnostic: drain the worker sub-device after the fused ops to test whether the
                 # token-2 deadlock is an async overlap hazard (fused RS not fully ordered before the

--- a/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import torch
 import ttnn
 from models.common.lightweightmodule import LightweightModule
@@ -53,6 +55,12 @@ class TtLlamaMLP(LightweightModule):
         # (the fused llama_rs_matmul / llama_reduce_scatter 1D-multicast writers no-op on the BH
         # 2D-torus fabric). Gated identically to the attention/model unfused-CCL flag.
         self.use_unfused_ccl = getattr(args, "use_unfused_ccl", False)
+        # Narrow bring-up: route just the FF1/FF3 reduce-scatter through the fused llama_rs_matmul on
+        # Blackhole prefetcher, while leaving every other collective unfused. See qwen_model_config.py.
+        self.use_bh_fused_rs_matmul = getattr(args, "use_bh_fused_rs_matmul", False)
+        # BH prefetcher + fused op: fuse FF1/FF3 ring matmul with reduce_scatter_minimal_async via
+        # ttnn.experimental.matmul_reduce_scatter_async (see qwen_model_config.py / llama_ccl.py).
+        self.use_bh_fused_async_rs_matmul = getattr(args, "use_bh_fused_async_rs_matmul", False)
         self.prefetcher_setup = prefetcher_setup
         self.tt_ccl = tt_ccl
         state_dict_prefix = state_dict_prefix or args.get_state_dict_prefix(self.__class__.__name__, layer_num)
@@ -175,7 +183,49 @@ class TtLlamaMLP(LightweightModule):
                 use_noc1_only=False,
             )
             ttnn.deallocate(w1_out)
-        elif self.use_prefetcher and self.use_unfused_ccl:
+        elif self.use_prefetcher and self.use_bh_fused_async_rs_matmul:
+            # BH prefetcher + fused op: FF1 and FF3 each run as a single fused matmul_reduce_scatter_async
+            # (the prefetcher ring matmul streaming global-CB weights, fused with the BH-working
+            # reduce_scatter_minimal_async). Produces the reduce-scattered outputs directly, replacing
+            # the separate ring matmul -> DRAM -> reduce_scatter round-trip of the unfused path.
+            mm_ckc = (
+                self.args.compute_kernel_config_lofi if self.four_bit_mlp else self.args.compute_kernel_config_hifi2
+            )
+            w1_out_reduced = self.tt_ccl.matmul_reduce_scatter_async(
+                x,
+                self.w1,
+                program_config=pc_1_3,
+                memory_config_mm=self.model_config["SHARDED_FF12_OUT_RING_MEMCFG"],
+                memory_config_rs=self.model_config["REDUCE_SCATTER_OUT_MEMCFG"],
+                compute_kernel_config=mm_ckc,
+                dtype=ttnn.bfloat8_b,
+                global_cb=self.prefetcher_setup.global_circular_buffer,
+                sub_device_id=self.prefetcher_setup.worker_sub_device_id,
+                num_links=self.model_config["GALAXY_NUM_LINKS"],
+                cluster_axis=1,
+            )
+            w3_out_reduced = self.tt_ccl.matmul_reduce_scatter_async(
+                x,
+                self.w3,
+                program_config=pc_1_3,
+                memory_config_mm=self.model_config["SHARDED_FF12_OUT_RING_MEMCFG"],
+                memory_config_rs=self.model_config["REDUCE_SCATTER_OUT_MEMCFG"],
+                compute_kernel_config=mm_ckc,
+                dtype=ttnn.bfloat8_b,
+                global_cb=self.prefetcher_setup.global_circular_buffer,
+                sub_device_id=self.prefetcher_setup.worker_sub_device_id,
+                num_links=self.model_config["GALAXY_NUM_LINKS"],
+                cluster_axis=1,
+            )
+            ttnn.deallocate(x)
+            w3_out = None  # already reduce-scattered; skip the post-branch line_reduce_scatter
+            if os.environ.get("QWEN_DBG_FUSED_SYNC") == "1":
+                # Diagnostic: drain the worker sub-device after the fused ops to test whether the
+                # token-2 deadlock is an async overlap hazard (fused RS not fully ordered before the
+                # next op reuses its cores/buffers). If this removes the hang, the op needs a real
+                # completion barrier rather than a full host synchronize.
+                ttnn.synchronize_device(self.mesh_device, sub_device_ids=[self.prefetcher_setup.worker_sub_device_id])
+        elif self.use_prefetcher and self.use_unfused_ccl and not self.use_bh_fused_rs_matmul:
             # BH prefetcher + unfused CCL: run the FF1/FF3 ring matmuls separately so they still consume
             # the prefetched global-CB weights (self.w1/self.w3) on the worker sub-device, but replace the
             # fused reduce_scatter with the stable worker-pinned ttnn.reduce_scatter (via line_reduce_scatter,
@@ -244,14 +294,15 @@ class TtLlamaMLP(LightweightModule):
             )
             ttnn.deallocate(x)
 
-        w3_out_reduced = self.tt_ccl.line_reduce_scatter(
-            w3_out,
-            cluster_axis=1,
-            num_links=self.model_config["GALAXY_NUM_LINKS"],
-            memory_config=self.model_config["REDUCE_SCATTER_OUT_MEMCFG"],
-            use_noc1_only=False,
-        )
-        ttnn.deallocate(w3_out)
+        if w3_out is not None:
+            w3_out_reduced = self.tt_ccl.line_reduce_scatter(
+                w3_out,
+                cluster_axis=1,
+                num_links=self.model_config["GALAXY_NUM_LINKS"],
+                memory_config=self.model_config["REDUCE_SCATTER_OUT_MEMCFG"],
+                use_noc1_only=False,
+            )
+            ttnn.deallocate(w3_out)
         if return_intermediates:
             intermediates["ff1_reduced"] = w1_out_reduced
             intermediates["ff3_reduced"] = w3_out_reduced
@@ -266,7 +317,10 @@ class TtLlamaMLP(LightweightModule):
 
         if return_intermediates:
             intermediates["activation"] = ff1ff3
-        else:
+        elif not self.use_bh_fused_async_rs_matmul:
+            # In the fused-async-RS path w1/w3_out_reduced ARE the TT_CCL persistent output buffers
+            # (double-buffered, reused every layer). They were just consumed by the mul above, so they
+            # must NOT be deallocated here or the next layer's fused op finds them unallocated.
             ttnn.deallocate(w3_out_reduced)
             ttnn.deallocate(w1_out_reduced)
 

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -44,6 +44,7 @@ class TtTransformer(LightweightModule):
         self.model_config = args.get_model_config()
         self.grid_size = self.args.max_grid_size
         self.enable_prefetcher_performance_mode = enable_prefetcher_performance_mode
+        self.use_prefetcher = args.use_prefetcher
         state_dict_prefix = args.get_state_dict_prefix("", None)
         self.allocate_prefill_buffers = allocate_prefill_buffers
         self.paged_attention_config = paged_attention_config
@@ -73,6 +74,12 @@ class TtTransformer(LightweightModule):
         self.prefetcher_setup = None
         self.mesh_sub_device_manager_id_decode = None
         self.mesh_sub_device_manager_id_prefill = None
+        # Cached CCLs so the no-prefetcher path can reuse them across mode switches instead of
+        # recreating (TT_CCL.close() only resets the stall group and leaves buffers/semaphores
+        # intact, so the cached objects stay valid). Recreating a CCL on each prefill<->decode
+        # switch corrupts state on repeat batches (garbage output on batch 1+).
+        self.tt_ccl_prefill = None
+        self.tt_ccl_decode = None
 
         # First initialization of decode CCLs and prefetcher
         self.setup_decode()
@@ -111,6 +118,9 @@ class TtTransformer(LightweightModule):
             args,
             tt_ccl=self.tt_ccl,
             ccl_topology=self.model_config["CCL_TOPOLOGY"],
+            # Match the decoder layers: BH no-prefetch uses the distributed (non-sharded) decode
+            # norm path; the sharded fused decode norm is prefetcher-only.
+            use_sharded_decode=not args.blackhole_no_prefetcher,
         )
 
         state_dict_prefix = args.get_state_dict_prefix("", None)
@@ -133,7 +143,7 @@ class TtTransformer(LightweightModule):
                 self.setup_prefill()
             self.is_prefill_setup = True
 
-        if mode == "decode":
+        if mode == "decode" and self.use_prefetcher:
             self.tt_tensors = self.prefetcher_setup.get_input_tensors()
         self.tt_rot_mats_prefill = None
 
@@ -162,10 +172,32 @@ class TtTransformer(LightweightModule):
                 seq_len=int(self.args.max_seq_len),
                 scale_factor=self.args.rope_scaling_factor,
                 start_pos=0,
+                theta=self.args.rope_theta,
             )
         return self.tt_rot_mats_prefill
 
     def setup_prefill(self, mesh_sub_device_manager_id_prefill=None):
+        if not self.use_prefetcher:
+            self.prefetcher_setup = None
+            self.mesh_sub_device_manager_id_prefill = mesh_sub_device_manager_id_prefill
+            if self.tt_ccl_prefill is not None:
+                # Reuse the previously-created prefill CCL (close() leaves it intact). Recreating it
+                # on every repeat batch corrupts state and yields garbage output on batch 1+.
+                self.tt_ccl = self.tt_ccl_prefill
+            elif mesh_sub_device_manager_id_prefill is None:
+                self.tt_ccl = TT_CCL(
+                    self.mesh_device,
+                    self.args,
+                    None,
+                    mode="prefill",
+                    allocate_prefill_buffers=self.allocate_prefill_buffers,
+                    is_qwen=True if self.args.is_qwen else False,
+                )
+                self.tt_ccl_prefill = self.tt_ccl
+            else:
+                self.tt_ccl = self.tt_ccl_prefill
+            return
+
         self.prefetcher_setup = TtLlamaPrefetcherSetup(
             self.mesh_device,
             n_tensors=0,
@@ -190,6 +222,30 @@ class TtTransformer(LightweightModule):
             self.tt_ccl = self.tt_ccl_prefill
 
     def setup_decode(self, mesh_sub_device_manager_id_decode=None):
+        if not self.use_prefetcher:
+            self.prefetcher_setup = None
+            self.mesh_sub_device_manager_id_decode = mesh_sub_device_manager_id_decode
+            if self.tt_ccl_decode is not None:
+                # Reuse the previously-created decode CCL (and its SamplingGenerator); see note in
+                # setup_prefill. Avoids the recreate-per-batch corruption on repeat batches.
+                self.tt_ccl = self.tt_ccl_decode
+            elif mesh_sub_device_manager_id_decode is None:
+                self.tt_ccl = TT_CCL(
+                    self.mesh_device,
+                    self.args,
+                    None,
+                    is_qwen=True if self.args.is_qwen else False,
+                )
+                self.tt_ccl_decode = self.tt_ccl
+                self.sampling = SamplingGenerator(
+                    args=self.args,
+                    mesh_device=self.mesh_device,
+                    tt_ccl=self.tt_ccl,
+                )
+            else:
+                self.tt_ccl = self.tt_ccl_decode
+            return
+
         self.prefetcher_setup = TtLlamaPrefetcherSetup(
             self.mesh_device,
             n_tensors=5,
@@ -477,7 +533,15 @@ class TtTransformer(LightweightModule):
         rot_current_pos = torch.maximum(
             current_pos, torch.tensor(0, dtype=torch.int64)
         )  # Ensure position indices are non-negative
-        rope_idxs = self.rope_setup.get_rm_rot_idxs(rot_current_pos, on_host=True)
+        # The no-prefetcher (Blackhole) decode uses the NON-fused rotary op, which needs the simple
+        # get_rot_idxs/get_rot_mats tables. get_rm_rot_idxs/get_rm_rot_mats produce the FUSED-qk
+        # expanded layout ([1, expanded_batch, heads, head_dim]); feeding that to the non-fused op
+        # (via the slice branch in forward_decode) yields a wrong rotary at pos>0 (pos0 is rotary-
+        # independent, so it hides the bug) and collapses multi-layer decode PCC.
+        if self.use_prefetcher:
+            rope_idxs = self.rope_setup.get_rm_rot_idxs(rot_current_pos, on_host=True)
+        else:
+            rope_idxs = self.rope_setup.get_rot_idxs(rot_current_pos, on_host=True)
         cur_pos_shard_dim = 0
         if is_cur_pos_sharded:
             cur_pos_shard_dim = 1
@@ -522,7 +586,10 @@ class TtTransformer(LightweightModule):
         Get rope sin/cos
         Embed tokens
         """
-        tt_rot_mats = self.rope_setup.get_rm_rot_mats(rope_idxs)
+        if self.use_prefetcher:
+            tt_rot_mats = self.rope_setup.get_rm_rot_mats(rope_idxs)
+        else:
+            tt_rot_mats = self.rope_setup.get_rot_mats(rope_idxs)
         tt_tokens = self.embd(tokens)
         return tt_tokens, current_pos, tt_rot_mats, page_table
 
@@ -594,7 +661,7 @@ class TtTransformer(LightweightModule):
             tt_logits = self.tt_ccl.line_all_gather(
                 tt_logits[0],
                 dim=3,
-                num_links=3,
+                num_links=3 if self.use_prefetcher else self.model_config["GALAXY_NUM_LINKS"],
                 cluster_axis=0,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 buffer_key="SAMPLING",
@@ -710,7 +777,10 @@ class TtTransformer(LightweightModule):
         This method will take device tensors and any other args to run forward.
         It returns ttnn device tensors.
         """
-        rot_mats = self.rope_setup.get_rm_rot_mats(rot_mat_idxs)
+        if self.use_prefetcher:
+            rot_mats = self.rope_setup.get_rm_rot_mats(rot_mat_idxs)
+        else:
+            rot_mats = self.rope_setup.get_rot_mats(rot_mat_idxs)
         x_embd = self.embd(x)
         tt_logits = self.forward(
             x_embd,
@@ -726,7 +796,7 @@ class TtTransformer(LightweightModule):
             tt_logits = self.tt_ccl.line_all_gather(
                 tt_logits[0],
                 dim=3,
-                num_links=3,
+                num_links=3 if self.use_prefetcher else self.model_config["GALAXY_NUM_LINKS"],
                 cluster_axis=0,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 buffer_key="SAMPLING",
@@ -760,14 +830,20 @@ class TtTransformer(LightweightModule):
             if self.is_decode_setup is False:
                 self.setup_decode(self.mesh_sub_device_manager_id_decode)
                 self.is_decode_setup = True
-                # prefetch
+                # Re-point every submodule at the (new) decode CCL. The prefetcher tensor inserts
+                # inside layer.prefetch are guarded on prefetcher_setup, so this is safe for the
+                # no-prefetcher Blackhole path too (otherwise layers keep the stale prefill CCL).
                 for layer in self.layers:
                     layer.prefetch(self.prefetcher_setup, self.tt_ccl)
                 self.norm.tt_ccl = self.tt_ccl
                 self.lm_head.tt_ccl = self.tt_ccl
-                self.tt_tensors = self.prefetcher_setup.get_input_tensors()
-                # Re-create global CB for decode (if it was not already created)
-                self.prefetcher_setup.create_global_cb()
+                if self.use_prefetcher:
+                    self.tt_tensors = self.prefetcher_setup.get_input_tensors()
+                    # Re-create global CB for decode (if it was not already created)
+                    self.prefetcher_setup.create_global_cb()
+                else:
+                    # No-prefetcher path reuses the cached decode CCL; clear its semaphore drift.
+                    self.tt_ccl.reset_global_semaphores()
 
         else:
             if self.is_decode_setup:
@@ -778,10 +854,16 @@ class TtTransformer(LightweightModule):
             if self.is_prefill_setup is False:
                 self.setup_prefill(self.mesh_sub_device_manager_id_prefill)
                 self.is_prefill_setup = True
+                # Re-point every submodule at the (new) prefill CCL. Without this the no-prefetcher
+                # Blackhole layers keep the decode CCL and prefill hits the decode all_reduce_async
+                # path (which rejects DRAM input on BH).
                 for layer in self.layers:
                     layer.prefetch(self.prefetcher_setup, self.tt_ccl)
                 self.norm.tt_ccl = self.tt_ccl
                 self.lm_head.tt_ccl = self.tt_ccl
+                if not self.use_prefetcher:
+                    # No-prefetcher path reuses the cached prefill CCL; clear its semaphore drift.
+                    self.tt_ccl.reset_global_semaphores()
 
     def forward(
         self,
@@ -798,7 +880,7 @@ class TtTransformer(LightweightModule):
         kv_cache=None,
         batch_size=1,
     ):
-        if mode == "decode":
+        if mode == "decode" and self.use_prefetcher:
             self.prefetcher_setup.create_global_cb()
             garbage_tensor = ttnn.dram_prefetcher(
                 self.tt_tensors,
@@ -853,9 +935,10 @@ class TtTransformer(LightweightModule):
                 batch_size=batch_size,
             )
         # ttnn.deallocate(h)
-        if mode == "decode":
+        if mode == "decode" and self.use_prefetcher:
             ttnn.deallocate(garbage_tensor)
 
+        if mode == "decode":
             # Pre-allocated output of AllReduce in LM Head to avoid memory cloberring
             self.tt_ccl.tt_lm_head_buffer_l1 = ttnn.to_memory_config(
                 self.tt_ccl.tt_lm_head_buffer, self.tt_ccl.lm_head_buffer_mem_cfg
@@ -870,7 +953,9 @@ class TtTransformer(LightweightModule):
             x = x[:, :, get_last_token:, :]
 
         lm_head_output = self.lm_head(
-            x, None if mode == "prefill" else self.prefetcher_setup.worker_sub_device_id, mode=mode
+            x,
+            None if mode == "prefill" or not self.use_prefetcher else self.prefetcher_setup.worker_sub_device_id,
+            mode=mode,
         )
         # if mode is decode and Qwen model
         if mode == "decode" and self.args.is_qwen:
@@ -878,7 +963,10 @@ class TtTransformer(LightweightModule):
         return lm_head_output
 
     def __del__(self):
-        self.tt_ccl.close()
+        try:
+            self.tt_ccl.close()
+        except Exception:
+            pass
 
         # clear global saved addresses
         global global_tt_tensor_address

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -45,6 +45,11 @@ class TtTransformer(LightweightModule):
         self.grid_size = self.args.max_grid_size
         self.enable_prefetcher_performance_mode = enable_prefetcher_performance_mode
         self.use_prefetcher = args.use_prefetcher
+        # BH-prefetcher bring-up: with unfused CCL the attention uses the non-fused create-heads/concat
+        # path, which needs the simple (non-fused-qk) rotary tables. Select the fused-qk rope tables
+        # only when the fused collectives are actually in use.
+        self.use_unfused_ccl = getattr(args, "use_unfused_ccl", False)
+        self.use_fused_rope = self.use_prefetcher and not self.use_unfused_ccl
         state_dict_prefix = args.get_state_dict_prefix("", None)
         self.allocate_prefill_buffers = allocate_prefill_buffers
         self.paged_attention_config = paged_attention_config
@@ -177,7 +182,22 @@ class TtTransformer(LightweightModule):
         return self.tt_rot_mats_prefill
 
     def setup_prefill(self, mesh_sub_device_manager_id_prefill=None):
-        if not self.use_prefetcher:
+        # BH unfused-CCL path: prefill uses the fused all_gather_minimal_matmul + interleaved weights, never
+        # the ring matmuls or the prefetcher global CB (those are decode-only). Run prefill exactly like the
+        # no-prefetcher path (default sub-device, no custom manager). Loading the prefetcher's prefill
+        # sub-device manager here forces the prefill/sampling auto-grid ops (ttnn.untilize/ttnn.embedding,
+        # which pick the full 12-wide compute grid) through the strict sub-device validation, which fails on
+        # the dispatch column ("Kernel group cores do not match sub device cores"). The no-prefetcher path
+        # loads no custom manager, so that validation is skipped (see program.cpp: "No sub device manager,
+        # nothing to validate"). Decode still sets up the prefetcher via setup_decode.
+        if not self.use_prefetcher or self.use_unfused_ccl:
+            if self.use_prefetcher:
+                # A decode run may have left the prefetcher (worker/prefetcher) sub-device manager loaded;
+                # clear it so prefill + sampling run on the default sub-device.
+                try:
+                    self.mesh_device.clear_loaded_sub_device_manager()
+                except Exception:
+                    pass
             self.prefetcher_setup = None
             self.mesh_sub_device_manager_id_prefill = mesh_sub_device_manager_id_prefill
             if self.tt_ccl_prefill is not None:
@@ -196,6 +216,14 @@ class TtTransformer(LightweightModule):
                 self.tt_ccl_prefill = self.tt_ccl
             else:
                 self.tt_ccl = self.tt_ccl_prefill
+            if self.use_unfused_ccl:
+                # Force the prefill CCL onto the stable (no-prefetcher) collective paths. use_prefetcher is
+                # read at forward time to choose ring vs stable reduce_scatter/all_gather; on the BH 2D-torus
+                # the ring prefill collectives (ring_reduce_scatter / experimental all-gathers) deadlock, so
+                # the unfused prefill must use the exact same stable ops as the no-prefetcher path. Prefill
+                # buffer allocation keys off use_ring_*_prefill (topology), not use_prefetcher, so flipping
+                # this after construction is safe.
+                self.tt_ccl.use_prefetcher = False
             return
 
         self.prefetcher_setup = TtLlamaPrefetcherSetup(
@@ -538,7 +566,7 @@ class TtTransformer(LightweightModule):
         # expanded layout ([1, expanded_batch, heads, head_dim]); feeding that to the non-fused op
         # (via the slice branch in forward_decode) yields a wrong rotary at pos>0 (pos0 is rotary-
         # independent, so it hides the bug) and collapses multi-layer decode PCC.
-        if self.use_prefetcher:
+        if self.use_fused_rope:
             rope_idxs = self.rope_setup.get_rm_rot_idxs(rot_current_pos, on_host=True)
         else:
             rope_idxs = self.rope_setup.get_rot_idxs(rot_current_pos, on_host=True)
@@ -586,7 +614,7 @@ class TtTransformer(LightweightModule):
         Get rope sin/cos
         Embed tokens
         """
-        if self.use_prefetcher:
+        if self.use_fused_rope:
             tt_rot_mats = self.rope_setup.get_rm_rot_mats(rope_idxs)
         else:
             tt_rot_mats = self.rope_setup.get_rot_mats(rope_idxs)
@@ -661,7 +689,9 @@ class TtTransformer(LightweightModule):
             tt_logits = self.tt_ccl.line_all_gather(
                 tt_logits[0],
                 dim=3,
-                num_links=3 if self.use_prefetcher else self.model_config["GALAXY_NUM_LINKS"],
+                num_links=3
+                if (self.use_prefetcher and not getattr(self.args, "is_blackhole", False))
+                else self.model_config["GALAXY_NUM_LINKS"],
                 cluster_axis=0,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 buffer_key="SAMPLING",
@@ -777,7 +807,7 @@ class TtTransformer(LightweightModule):
         This method will take device tensors and any other args to run forward.
         It returns ttnn device tensors.
         """
-        if self.use_prefetcher:
+        if self.use_fused_rope:
             rot_mats = self.rope_setup.get_rm_rot_mats(rot_mat_idxs)
         else:
             rot_mats = self.rope_setup.get_rot_mats(rot_mat_idxs)
@@ -796,7 +826,9 @@ class TtTransformer(LightweightModule):
             tt_logits = self.tt_ccl.line_all_gather(
                 tt_logits[0],
                 dim=3,
-                num_links=3 if self.use_prefetcher else self.model_config["GALAXY_NUM_LINKS"],
+                num_links=3
+                if (self.use_prefetcher and not getattr(self.args, "is_blackhole", False))
+                else self.model_config["GALAXY_NUM_LINKS"],
                 cluster_axis=0,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 buffer_key="SAMPLING",

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -51,7 +51,12 @@ class TtTransformer(LightweightModule):
         # path, which needs the simple (non-fused-qk) rotary tables. Select the fused-qk rope tables
         # only when the fused collectives are actually in use.
         self.use_unfused_ccl = getattr(args, "use_unfused_ccl", False)
-        self.use_fused_rope = self.use_prefetcher and not self.use_unfused_ccl
+        # use_bh_fused_qkv_rs re-fuses the QKV segment (llama_rs_create_heads + fused-qk rotary)
+        # on BH even while use_unfused_ccl keeps the other collectives unfused, so it needs the
+        # fused-qk rope tables too.
+        self.use_fused_rope = self.use_prefetcher and (
+            not self.use_unfused_ccl or getattr(args, "use_bh_fused_qkv_rs", False)
+        )
         state_dict_prefix = args.get_state_dict_prefix("", None)
         self.allocate_prefill_buffers = allocate_prefill_buffers
         self.paged_attention_config = paged_attention_config

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import ttnn
 import torch
 from tqdm import tqdm
@@ -912,6 +914,27 @@ class TtTransformer(LightweightModule):
         kv_cache=None,
         batch_size=1,
     ):
+        if (
+            mode == "decode"
+            and self.use_prefetcher
+            and self.use_unfused_ccl
+            and os.environ.get("QWEN_BH_HOIST_ROT_SLICES", "0") == "1"
+            and rot_mats is not None
+            and rot_mats[0].shape[1] != 1
+        ):
+            # Pre-compute the per-step rotary cos/sin slices before any per-layer transients are
+            # allocated: the sliced tensors persist for the whole layer loop, and allocating them
+            # first places them high in L1, clear of the ring matmuls' static CB region (allocating
+            # them lazily inside layer 0 landed them at ~0x59400 on the worker cores and tripped
+            # "static circular buffers clash with L1 buffers" during trace capture). The slice
+            # bounds are recorded by the attention on the first (eager) decode run; until then the
+            # layers compute the slices themselves.
+            _rot_bounds = getattr(self.tt_ccl, "_decode_rot_slice_bounds", None)
+            if _rot_bounds is not None:
+                self.layers[0].attention.compute_decode_rot_slices(
+                    rot_mats, list(_rot_bounds[0]), list(_rot_bounds[1]), store_cache=True
+                )
+
         if mode == "decode" and self.use_prefetcher:
             self.prefetcher_setup.create_global_cb()
             garbage_tensor = ttnn.dram_prefetcher(

--- a/models/demos/llama3_70b_galaxy/tt/lm_head.py
+++ b/models/demos/llama3_70b_galaxy/tt/lm_head.py
@@ -53,6 +53,10 @@ class LMHead(LightweightModule):
             if args.dummy_weights
             else weight_cache_path / f"output_lm_head_{num_splits}_split_shard_0_dram_prefill"
         )
+        # On Blackhole (no prefetcher) decode uses a per-device matmul on the unpadded
+        # column-fractured K (matching the attention QKV no-prefetch path), so it does not
+        # require the ring-padded weight.
+        self.no_prefetcher = not args.use_prefetcher
         padded_lm_head = torch.zeros(1, 1, args.dim, self.padded_vocab_size)
         padded_lm_head[:, :, :, : self.vocab_size] = torch_output_weights
 
@@ -141,7 +145,27 @@ class LMHead(LightweightModule):
     def forward(self, x: ttnn.Tensor, worker_sub_device_id, mode):
         outputs = []
         num_links = 3
-        if mode == "decode":
+        if mode == "decode" and self.no_prefetcher:
+            num_links = self.args.model_config["GALAXY_NUM_LINKS"]
+            # Blackhole no-prefetch: per-device matmul on the unpadded column-fractured K
+            # (the ring matmul is prefetcher-only). Each column produces a partial logits tensor;
+            # the cross-column reduction is done by line_all_reduce below.
+            x_in = ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
+            for weight in self.output_weights_prefill:
+                output = ttnn.linear(
+                    x_in,
+                    weight,
+                    compute_kernel_config=self.compute_kernel_config,
+                    program_config=None,
+                    core_grid=None,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    dtype=ttnn.bfloat8_b,
+                )
+                output = ttnn.to_memory_config(output, self.args.model_config["LM_HEAD_OUT_RING_RESHARD_MEMCFG"])
+                outputs.append(output)
+            if x_in is not x:
+                ttnn.deallocate(x_in)
+        elif mode == "decode":
             num_links = self.args.model_config["GALAXY_NUM_LINKS"]
             for weight, pc in zip(self.output_weights_decode, self.program_configs):
                 x = ttnn.to_memory_config(x, self.args.model_config["SHARDED_LM_HEAD_INPUT_32_RING_MEMCFG"])

--- a/models/demos/llama3_70b_galaxy/tt/lm_head.py
+++ b/models/demos/llama3_70b_galaxy/tt/lm_head.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+import os
+
 import torch
 import ttnn
 from models.common.lightweightmodule import LightweightModule
@@ -43,10 +45,15 @@ class LMHead(LightweightModule):
         self.output_weights_decode = []
         self.output_weights_prefill = []
         num_splits = 1
+        # Blackhole stores the decode ring weight DRAM-interleaved (see memory_config_decode
+        # below); encode the layout in the cache name so the tensor never collides with a
+        # previously cached width-sharded one.
+        _is_blackhole = getattr(args, "is_blackhole", False)
+        _decode_suffix = "_dram_interleaved" if _is_blackhole else "_dram_width_sharded"
         cache_file_name_decode = (
             None
             if args.dummy_weights
-            else weight_cache_path / f"output_lm_head_{num_splits}_split_shard_0_dram_width_sharded_decode"
+            else weight_cache_path / f"output_lm_head_{num_splits}_split_shard_0{_decode_suffix}_decode"
         )
         cache_file_name_prefill = (
             None
@@ -56,13 +63,25 @@ class LMHead(LightweightModule):
         # On Blackhole (no prefetcher) decode uses a per-device matmul on the unpadded
         # column-fractured K (matching the attention QKV no-prefetch path), so it does not
         # require the ring-padded weight.
-        self.no_prefetcher = not args.use_prefetcher
+        # QWEN_BH_LMHEAD_NO_RING=1 forces this plain-matmul decode branch even when the
+        # prefetcher is on (accuracy-diagnostic: isolates the decode ring lm_head matmul).
+        self.no_prefetcher = (not args.use_prefetcher) or os.environ.get("QWEN_BH_LMHEAD_NO_RING", "0") == "1"
         padded_lm_head = torch.zeros(1, 1, args.dim, self.padded_vocab_size)
         padded_lm_head[:, :, :, : self.vocab_size] = torch_output_weights
 
         if args.is_70b:
-            memory_config_decode = args.create_dram_sharded_mem_config_lm_head(
-                k=args.dim // 4, n=self.padded_vocab_size // 8
+            # The ring matmul's DRAM-width-sharded in1 reader assigns each ring core a DRAM bank by
+            # physical y-proximity plus a ring_idx%N offset — a mapping hand-co-designed with the WH
+            # bank layout and the LM_HEAD_OUTPUT_GRID core order. On Blackhole (8 banks, 24-ring,
+            # 16-core-derived shard widths) that co-design does not hold and every core reads the
+            # wrong weight slice, garbling all logits. Store the weight DRAM-interleaved instead:
+            # the interleaved reader addresses tiles globally from the ring index
+            # (correct-by-construction), and requires LM_HEAD_OUT_RING_MEMCFG to use the input-grid
+            # core order (see qwen_model_config).
+            memory_config_decode = (
+                ttnn.DRAM_MEMORY_CONFIG
+                if _is_blackhole
+                else args.create_dram_sharded_mem_config_lm_head(k=args.dim // 4, n=self.padded_vocab_size // 8)
             )
             memory_config_prefill = ttnn.DRAM_MEMORY_CONFIG
         else:

--- a/models/demos/llama3_70b_galaxy/tt/lm_head.py
+++ b/models/demos/llama3_70b_galaxy/tt/lm_head.py
@@ -203,15 +203,29 @@ class LMHead(LightweightModule):
                 x.deallocate(True)
                 outputs.append(output)
 
+        # Blackhole galaxy has only 2 fabric links (vs Wormhole's 4), which roughly doubles the
+        # all_reduce_async reduction scratch CB. For the wide lm_head logits that CB no longer fits
+        # beside the full-worker-grid resident decode buffers on any worker column, so the async
+        # all-reduce fails to allocate. Route Blackhole through the stable all_gather + local reduce
+        # (the same pattern prefill uses): it avoids the oversized reduction CB entirely.
+        lm_head_bh_gather_reduce = mode == "decode" and getattr(self.args, "is_blackhole", False)
         outputs_reduced = []
         for output in outputs:
-            output_reduced = self.tt_ccl.line_all_reduce(
-                output,
-                cluster_axis=1,
-                num_links=num_links,
-                memory_config=output.memory_config(),
-                lm_head=True,
-                buffer_key="LM_HEAD",
-            )  # self.output_memory_config
+            if lm_head_bh_gather_reduce:
+                output_reduced = self.tt_ccl.line_all_reduce_gather_reduce(
+                    output,
+                    cluster_axis=1,
+                    num_links=num_links,
+                    memory_config=output.memory_config(),
+                )
+            else:
+                output_reduced = self.tt_ccl.line_all_reduce(
+                    output,
+                    cluster_axis=1,
+                    num_links=num_links,
+                    memory_config=output.memory_config(),
+                    lm_head=True,
+                    buffer_key="LM_HEAD",
+                )  # self.output_memory_config
             outputs_reduced.append(ttnn.sharded_to_interleaved(output_reduced, memory_config=ttnn.DRAM_MEMORY_CONFIG))
         return outputs_reduced

--- a/models/demos/llama3_70b_galaxy/tt/model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/model_config.py
@@ -68,6 +68,13 @@ PREFETCHER_NOC1_GRID = [
     (2, 9),
 ]
 
+# Blackhole galaxy prefetcher ring: 24 matmul cores = 8 DRAM readers x 3 receivers.
+# BH has a 12x10 tensix grid (x:0-11, y:0-9) and 8 DRAM banks (vs WH's 7x10 grid / 12 banks),
+# so RING_SIZE stays 24 (keeping all weight-sharding math) by widening receivers-per-reader
+# from 2 to 3. Senders live in column 0; the 24 receiver/ring cores occupy columns 1-3.
+# First-pass functional placement for bring-up; NoC1-congestion tuning is a follow-up (Step 6).
+PREFETCHER_NOC1_GRID_BH = [(x, y) for y in range(8) for x in (1, 2, 3)]
+
 LM_HEAD_16_GRID = [
     (1, 0),
     (1, 1),
@@ -121,6 +128,14 @@ LM_HEAD_32_GRID = [
     (5, 0),
     (5, 1),
 ]
+
+# Blackhole galaxy prefetcher path: the lm_head all_reduce persistent buffer lives on
+# sub_core_grids, which is capped to rows 0-7 on BH (sub_core_max_y = 7 to match the
+# 24-core ring geometry). The default LM_HEAD_32_GRID spans rows 0-9 in cols 1-3, so its
+# rows 8-9 fall outside the buffer and all_reduce_async's "output must be a subset of the
+# buffer cores" check fails. Use a 32-core layout confined to rows 0-7: cols 1-3 (24 cores)
+# plus col 5 (8 cores), all inside sub_core_grids.
+LM_HEAD_32_GRID_BH = [(x, y) for x in (1, 2, 3) for y in range(8)] + [(5, y) for y in range(8)]
 
 LM_HEAD_INPUT_GRID = [
     (6, 6),
@@ -177,10 +192,76 @@ LM_HEAD_OUTPUT_GRID = [
 ]
 
 
-def get_core_ranges(num_reader_cores, num_global_cb_receivers, is_functional_test):
+def _get_core_ranges_blackhole(num_reader_cores, num_global_cb_receivers):
+    """
+    Blackhole galaxy prefetcher core placement (first-pass functional bring-up).
+
+    Topology (measured): 12x10 tensix grid (x:0-11, y:0-9), 8 DRAM banks.
+    Layout:
+      - DRAM readers: banks 0..num_reader_cores-1.
+      - Senders: one tensix per reader in column 0 (rows 0..num_reader_cores-1);
+        remaining column-0 rows are dummy senders so the global-CB mapping stays balanced.
+      - Receivers / matmul ring: num_global_cb_receivers cores per reader in columns
+        1..num_global_cb_receivers, one reader per row. With 8 readers x 3 receivers this
+        is the 24-core ring (RING_SIZE=24), matching PREFETCHER_NOC1_GRID_BH.
+      - Workers: columns 1..11 (everything except the sender column), which includes the
+        receiver/ring cores.
+    NoC1 congestion tuning of the ring order is deferred (Step 6).
+    """
+    assert num_reader_cores <= 8, f"Blackhole galaxy has 8 DRAM banks, got num_reader_cores={num_reader_cores}"
+    grid_h = 10  # y rows
+    max_recv_col = num_global_cb_receivers  # receivers occupy columns 1..num_global_cb_receivers
+
+    all_dram_cores = [ttnn.CoreCoord(idx, 0) for idx in range(8)]
+    dram_cores = all_dram_cores[:num_reader_cores]
+
+    # Senders in column 0: active first, then dummies filling the rest of the column.
+    active_sender_cores = [ttnn.CoreCoord(0, y) for y in range(num_reader_cores)]
+    dummy_sender_cores = [ttnn.CoreCoord(0, y) for y in range(num_reader_cores, grid_h)]
+    sender_cores = list(active_sender_cores) + list(dummy_sender_cores)
+
+    # Receiver core list (flat), row-major per reader: reader y -> (1,y),(2,y),...,(recv,y).
+    active_receiver_cores_list = [(x, y) for y in range(num_reader_cores) for x in range(1, max_recv_col + 1)]
+
+    def _recv_range_set(y):
+        return ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, y), ttnn.CoreCoord(max_recv_col, y))])
+
+    all_receiver_cores = [_recv_range_set(y) for y in range(num_reader_cores)]
+    # Dummy receiver ranges paired with the dummy senders.
+    all_receiver_cores += [_recv_range_set(y) for y in range(num_reader_cores, grid_h)]
+
+    # Workers: columns 1..10 (col 0 = prefetcher senders; col 11 excluded). Empirically, folding col 11
+    # into the worker sub-device (the LB/QB `full_grid - senders` shape) regresses prefill warmup, so on
+    # this COL-dispatch galaxy col 11 is not a plain worker. cols 1..10 (100 cores) is the furthest-
+    # working decode config.
+    worker_cores_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(10, grid_h - 1))])
+
+    mm_optimised_ring_cores = PREFETCHER_NOC1_GRID_BH
+    # Hop core for the 1D ring matmul. It must (a) NOT overlap the ring/input-A shard grid
+    # (cols 1-3, rows 0..num_reader_cores-1) and (b) be a member of the global CB's cores
+    # (senders in col 0 or receivers in cols 1-3). The dummy-receiver rows (>= num_reader_cores)
+    # satisfy both, mirroring Wormhole where the hop sits on a dummy receiver.
+    hop_grid = [(max_recv_col, grid_h - 2)]  # e.g. (3, 8): a dummy-receiver core outside the ring
+
+    return (
+        active_sender_cores,
+        dram_cores,
+        sender_cores,
+        active_receiver_cores_list,
+        all_receiver_cores,
+        worker_cores_range_set,
+        mm_optimised_ring_cores,
+        hop_grid,
+    )
+
+
+def get_core_ranges(num_reader_cores, num_global_cb_receivers, is_functional_test, is_blackhole=False):
     """
     Helper function to get all the relevant core ranges for dram prefetcher + matmul configuration
     """
+
+    if is_blackhole:
+        return _get_core_ranges_blackhole(num_reader_cores, num_global_cb_receivers)
 
     all_dram_cores = [ttnn.CoreCoord(idx, 0) for idx in range(12)]  # 12 DRAM banks
 
@@ -490,8 +571,11 @@ class TtModelArgs:
             # assume Wormhole's 12 DRAM banks / wider tensix grid). Wormhole galaxy is unchanged.
             self.use_prefetcher = not self.is_blackhole
 
-        # Set up prefetcher stuff
-        _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(12, 2, False)
+        # Set up prefetcher stuff (Blackhole galaxy: 8 readers x 3 receivers; Wormhole: 12 x 2)
+        if self.is_blackhole:
+            _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(8, 3, False, is_blackhole=True)
+        else:
+            _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(12, 2, False)
 
         self.sub_core_grids = ttnn.CoreRangeSet(
             [
@@ -1384,6 +1468,18 @@ class TtModelArgs:
                 12288 // 8,  # Use padded N
                 RING_SIZE,
                 untilize_out=True,
+            )
+            # Non-untilized (TILE) variant for the Blackhole unfused-CCL bring-up: bf8 output requires TILE
+            # layout, and the unfused create-head path wants a bf8 TILE input to the column all-reduce
+            # (matching the no-prefetcher path). The fused path keeps the untilized (ROW_MAJOR) config for
+            # llama_rs_create_heads.
+            self.model_config["XQKV_DECODE_RING_PROGCFG_TILE"] = self.matmul_1d_ring_config(
+                1,
+                32,
+                8192 // 4,
+                12288 // 8,  # Use padded N
+                RING_SIZE,
+                untilize_out=False,
             )
             RS_CREATE_HEADS_PACKET_WORKER_CRS = ttnn.CoreRangeSet(
                 [

--- a/models/demos/llama3_70b_galaxy/tt/prefetcher_common.py
+++ b/models/demos/llama3_70b_galaxy/tt/prefetcher_common.py
@@ -13,6 +13,18 @@ from models.demos.llama3_70b_galaxy.tt.model_config import (
 global_tt_tensor_address = None
 
 
+def _mesh_is_blackhole(mesh_device):
+    """Best-effort Blackhole detection from the mesh device arch."""
+    try:
+        arch = mesh_device.arch()
+        return "blackhole" in str(arch).lower()
+    except Exception:
+        try:
+            return "blackhole" in ttnn.get_arch_name().lower()
+        except Exception:
+            return False
+
+
 class TtLlamaPrefetcherSetup(LightweightModule):
     def __init__(
         self,
@@ -37,8 +49,16 @@ class TtLlamaPrefetcherSetup(LightweightModule):
         self.n_layers = n_layers
 
         ###### Set up GlobalCB ######
-        num_reader_cores = 12
-        num_global_cb_receivers = 2
+        # Blackhole galaxy has 8 DRAM banks and a 12x10 tensix grid (vs Wormhole's 12 banks / 7x10),
+        # so the prefetcher ring is 8 readers x 3 receivers (=24, same RING_SIZE) instead of 12 x 2.
+        is_blackhole = _mesh_is_blackhole(mesh_device)
+        self.is_blackhole = is_blackhole
+        if is_blackhole:
+            num_reader_cores = 8
+            num_global_cb_receivers = 3
+        else:
+            num_reader_cores = 12
+            num_global_cb_receivers = 2
 
         (
             self.active_sender_cores,
@@ -49,7 +69,9 @@ class TtLlamaPrefetcherSetup(LightweightModule):
             self.worker_cores_range_set,
             self.mm_optimised_ring_cores,
             self.hop_grid,
-        ) = get_core_ranges(num_reader_cores, num_global_cb_receivers, is_functional_test=False)
+        ) = get_core_ranges(
+            num_reader_cores, num_global_cb_receivers, is_functional_test=False, is_blackhole=is_blackhole
+        )
 
         ##### Set up the input tensors #####
         self.dram_core_range_set = ttnn.CoreRangeSet(
@@ -59,7 +81,8 @@ class TtLlamaPrefetcherSetup(LightweightModule):
             [ttnn.CoreRange(core_coord, core_coord) for core_coord in self.active_sender_cores]
         )
 
-        self.all_core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 9))])
+        _grid_max = ttnn.CoreCoord(11, 9) if is_blackhole else ttnn.CoreCoord(6, 9)
+        self.all_core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), _grid_max)])
 
         ##### Setup up sub devices #####
 
@@ -78,7 +101,17 @@ class TtLlamaPrefetcherSetup(LightweightModule):
             # This ensures that back to back matmuls (for eg. in MLP) can run
             # without stalling on the weight prefetch
             # To fit entire MLP we'd need ~742 * 1088 but using block-wise prefetching and 732 tiles this is sufficient for now
-            self.global_cb_size = 728 * 1088
+            # Blackhole: the global CB is top-anchored in L1 (its top sits just below the receiver-core
+            # semaphore buffers and it grows downward). At 728 tiles its base lands at ~389 KB on the
+            # prefetcher receiver cores, which leaves only ~389 KB of contiguous low L1 for the ring
+            # matmul's static CBs (`bmm_..._gathered`, which need ~444 KB) -> during full-model trace
+            # capture (global CB + every matmul program resident at once) the matmul CBs overlap the
+            # global CB by ~55 KB ("static circular buffers clash with L1 buffers on [1-0 - 6-9]").
+            # Trimming to 656 tiles raises the global CB base to ~457 KB, clearing the matmul CB region
+            # with margin across all receiver cores. Still >2x the largest single weight block, so the
+            # weight double-buffering the prefetcher relies on is preserved. WH (2 receivers, different
+            # L1 layout) keeps the original 728.
+            self.global_cb_size = (656 if self.is_blackhole else 728) * 1088
             self.sender_receiver_mapping = list(zip(self.all_sender_cores, self.all_receiver_cores))
             # self.global_circular_buffer = ttnn.create_global_circular_buffer(
             #     self.mesh_device, self.sender_receiver_mapping, self.global_cb_size

--- a/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
@@ -231,6 +231,18 @@ class TtQwenModelArgs(TtModelArgs):
         self.use_unfused_ccl = (
             self.use_prefetcher and self.is_blackhole and os.environ.get("QWEN_BH_UNFUSED_CCL", "1") == "1"
         )
+        # Fused distributed-norm (fused_rms_minimal / RMSAllGather) on the BH prefetcher path. The
+        # writer's stats all-gather was ported to fabric-topology-aware routing (ccl_routing_utils),
+        # so it no longer no-ops on the 2D torus. This gates ONLY the decode norm chain; the other
+        # collectives stay on the unfused path (use_unfused_ccl above). On BH the fused norm runs on
+        # the LN grid at column 7 (see DistributedNorm), with the LAYERNORM stats buffer and a
+        # dedicated semaphore pool moved there to match.
+        self.use_bh_fused_rms = (
+            self.use_prefetcher
+            and self.is_blackhole
+            and self.use_unfused_ccl
+            and os.environ.get("QWEN_BH_FUSED_RMS", "1") == "1"
+        )
         # Repro harness for bringing up the FUSED matmul+reduce-scatter (llama_rs_matmul) on the
         # Blackhole prefetcher path, isolated to the MLP FF1/FF3 reduce-scatter. Enabling it routes the
         # FF matmul through the WH fused double_matmul_line_reduce_scatter unchanged. Unlike the fused
@@ -258,6 +270,20 @@ class TtQwenModelArgs(TtModelArgs):
         # Enable with QWEN_BH_FUSED_ASYNC_RS_MATMUL=1 (requires QWEN_BH_UNFUSED_CCL=1 for the semaphore pool).
         self.use_bh_fused_async_rs_matmul = (
             self.use_prefetcher and self.is_blackhole and os.environ.get("QWEN_BH_FUSED_ASYNC_RS_MATMUL", "0") == "1"
+        )
+        # Fused QKV reduce-scatter + create-heads (llama_rs_create_heads) on the BH prefetcher path.
+        # Replaces the unfused column all-reduce + off-receiver reshard + nlp_create_qkv_heads_decode.
+        # Requires the 2D-fabric routing port of llama_reduce_scatter_create_heads (done) and the
+        # RS_CREATE_HEADS packet workers off the global-CB receiver cols (handled below).
+        self.use_bh_fused_qkv_rs = (
+            self.use_prefetcher and self.is_blackhole and os.environ.get("QWEN_BH_FUSED_QKV_RS", "0") == "1"
+        )
+        # Fused SDPA-output all-gather + concat-heads (all_gather_concat) on the BH prefetcher path.
+        # Replaces all_gather_async + nlp_concat_heads_decode + the WO ring reshard; writes the WO ring
+        # input layout directly. Requires the 2D-fabric multicast routing port of
+        # all_gather_concat_heads_fused (done).
+        self.use_bh_fused_ag_concat = (
+            self.use_prefetcher and self.is_blackhole and os.environ.get("QWEN_BH_FUSED_AG_CONCAT", "0") == "1"
         )
 
         # Set up prefetcher stuff (Blackhole galaxy: 8 readers x 3 receivers; Wormhole: 12 x 2)
@@ -485,6 +511,14 @@ class TtQwenModelArgs(TtModelArgs):
             # Wormhole keeps main's fixed height (32); only the Blackhole bring-up path uses the
             # tile-padded batch rows.
             decode_shard_height = self.tile_padded_batch_rows if self.is_blackhole else 32
+            # On the BH fused-norm path the fused RMSAllGather runs on the LN grid at cols 7-8
+            # (clear of the prefetcher GCB receiver cols 1-3). Keeping the residual stream on the
+            # same grid makes the per-norm reshard-in a no-op (129 reshards/token saved); all other
+            # consumers (residual adds, attn/MLP output reshards, embedding) are grid-agnostic.
+            if self.use_bh_fused_rms:
+                residual_core_range = ttnn.CoreRange(ttnn.CoreCoord(7, 0), ttnn.CoreCoord(8, 4))
+            else:
+                residual_core_range = core_range
             # Always use Galaxy configuration
             self.model_config["DECODE_RESIDUAL_MEMCFG"] = ttnn.create_sharded_memory_config(
                 shape=(
@@ -495,7 +529,7 @@ class TtQwenModelArgs(TtModelArgs):
                 ),
                 core_grid=ttnn.CoreRangeSet(
                     [
-                        core_range,
+                        residual_core_range,
                         # ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(3, 0)),
                         # ttnn.CoreRange(ttnn.CoreCoord(3, 3), ttnn.CoreCoord(3, 5)),  # use 16 + 4 = 20 cores here
                     ]
@@ -1028,11 +1062,16 @@ class TtQwenModelArgs(TtModelArgs):
             # the resident global CB during full-model trace capture. With dynamic chunking (k_chunk=0)
             # the K/V CBs are sized for max_dynamic_chunk_size (dst_size = 8 tiles) -> ~256 KB, which
             # overflows the ~423 KB of L1 left free below the global CB on the receiver cores by ~25 KB
-            # ("static circular buffers clash with L1 buffers on [1-0 - 3-7]"). Pin k_chunk_size to the
-            # paged KV block_size (64 tokens = 2 tiles): page-aligned so each chunk is exactly one page,
-            # and Sk_chunk_t=2 shrinks the K/V CBs to ~64 KB, clearing the clash. Flash-decode's online
-            # softmax makes the fixed smaller chunk numerically identical, just a few more K iterations.
-            paged_sdpa_k_chunk = 64 if (self.is_blackhole and self.use_prefetcher and self.use_unfused_ccl) else 0
+            # ("static circular buffers clash with L1 buffers on [1-0 - 3-7]"). Pin k_chunk_size to a
+            # fixed 128 tokens (2 paged KV blocks = 4 tiles): page-aligned, and Sk_chunk_t=4 keeps the
+            # K/V CBs at ~128 KB, ~100 KB under the clash threshold, while halving the flash-decode
+            # K-iteration count vs the earlier 64-token chunk (SDPA was 17.8 us/layer vs WH's 12.9 us).
+            # Flash-decode's online softmax makes the fixed smaller chunk numerically identical.
+            paged_sdpa_k_chunk = (
+                int(os.environ.get("QWEN_BH_SDPA_K_CHUNK", "128"))
+                if (self.is_blackhole and self.use_prefetcher and self.use_unfused_ccl)
+                else 0
+            )
             self.model_config["PAGED_SDPA_DECODE_PROGCFG"] = ttnn.SDPAProgramConfig(
                 compute_with_storage_grid_size=paged_sdpa_grid,
                 sub_core_grids=paged_sdpa_sub_core_grids,
@@ -1232,12 +1271,23 @@ class TtQwenModelArgs(TtModelArgs):
             self.model_config["SHARDED_QKV_OUT_PER_DEVICE_MEMCFG"] = self.create_dram_sharded_mem_config(
                 self.tile_padded_batch_rows, self.qkv_n_local
             )
-            RS_CREATE_HEADS_PACKET_WORKER_CRS = ttnn.CoreRangeSet(
-                [
-                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 0)),
-                    ttnn.CoreRange(ttnn.CoreCoord(1, 1), ttnn.CoreCoord(2, 1)),
-                ]
-            )
+            if self.use_prefetcher:
+                # Prefetcher resident: cols 1-3 are live global-CB receiver cores (and the QKV ring),
+                # so the RS packet workers must stay off them (same conflict as PACKET_WORKER_CRS for
+                # the fused MLP reduce-scatter). 5 cores on cols 5-6, off the CCL sender row 3.
+                RS_CREATE_HEADS_PACKET_WORKER_CRS = ttnn.CoreRangeSet(
+                    [
+                        ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 1)),
+                        ttnn.CoreRange(ttnn.CoreCoord(5, 2), ttnn.CoreCoord(5, 2)),
+                    ]
+                )
+            else:
+                RS_CREATE_HEADS_PACKET_WORKER_CRS = ttnn.CoreRangeSet(
+                    [
+                        ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 0)),
+                        ttnn.CoreRange(ttnn.CoreCoord(1, 1), ttnn.CoreCoord(2, 1)),
+                    ]
+                )
             # Match main width (512). The Blackhole no-prefetch path re-widens this to 1280 in TT_CCL
             # (interim-shard guard) where the all_reduce_create_qkv_heads buffer minimum requires it.
             self.model_config["RS_CREATE_HEADS_INTERIM_MEMCFG"] = ttnn.create_sharded_memory_config(
@@ -1611,12 +1661,25 @@ class TtQwenModelArgs(TtModelArgs):
             # {1,0}-{2,0}, {1,4}-{2,5}, {1,9}-{2,9}, {5,0}-{6,2}, {5,4}-{6,7}, {5,9}-{6,9} (Matmul)
             # {0,0}-{0,9}, {4,0}-{4,9} (Prefetcher)
             # {3,6} (Matmul hop core)
-            PACKET_WORKER_CRS = ttnn.CoreRangeSet(
-                [
-                    ttnn.CoreRange(ttnn.CoreCoord(1, 1), ttnn.CoreCoord(3, 2)),
-                    ttnn.CoreRange(ttnn.CoreCoord(1, 3), ttnn.CoreCoord(2, 3)),
-                ]
-            )
+            if self.is_blackhole:
+                # BH ring matmul occupies cols 1-3 rows 0-7 + hop (3,8). The fused llama_rs_matmul
+                # subtracts the RS cores from the matmul worker set (restricted_cores), so any
+                # packet-worker core inside the ring silently drops that ring core's matmul kernel
+                # and the in0 ring gather deadlocks. Keep packet workers on cols 5-6, off the CCL
+                # sender row 3 ((5,3),(6,3)).
+                PACKET_WORKER_CRS = ttnn.CoreRangeSet(
+                    [
+                        ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 2)),
+                        ttnn.CoreRange(ttnn.CoreCoord(5, 4), ttnn.CoreCoord(6, 4)),
+                    ]
+                )
+            else:
+                PACKET_WORKER_CRS = ttnn.CoreRangeSet(
+                    [
+                        ttnn.CoreRange(ttnn.CoreCoord(1, 1), ttnn.CoreCoord(3, 2)),
+                        ttnn.CoreRange(ttnn.CoreCoord(1, 3), ttnn.CoreCoord(2, 3)),
+                    ]
+                )
 
             self.model_config["REDUCE_SCATTER_INTERIM_MEMCFG"] = ttnn.create_sharded_memory_config(
                 shape=(32, 512),

--- a/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
@@ -281,6 +281,17 @@ class TtQwenModelArgs(TtModelArgs):
                     ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(10, 9)),
                 ]
             )
+            # Force-argmax sampling: argmax is a scalar-RISC compare loop over the full gathered
+            # padded vocab (32 x 155648), so runtime scales ~1/num_cores. The default
+            # sub_core_grids is only 40 cores (2.1 ms/token); use the whole worker sub-device
+            # (cols 1-10, rows 0-9 = 100 cores, matching prefetcher_common's worker_cores_range_set)
+            # for the sampling untilize/argmax. Argmax/untilize CBs are tiny, so unlike top-k they
+            # coexist with the resident global CB on the receiver columns 1-3.
+            self.force_argmax_sub_core_grids = ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(10, 9)),
+                ]
+            )
         else:
             self.sub_core_grid_topk = ttnn.CoreRangeSet(
                 [

--- a/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
@@ -35,7 +35,9 @@ from models.demos.llama3_70b_galaxy.tt.model_config import (
     CheckpointType,
     get_core_ranges,
     PREFETCHER_NOC1_GRID,
+    PREFETCHER_NOC1_GRID_BH,
     LM_HEAD_32_GRID,
+    LM_HEAD_32_GRID_BH,
     LM_HEAD_16_GRID,
     LM_HEAD_INPUT_GRID,
     LM_HEAD_OUTPUT_GRID,
@@ -215,17 +217,48 @@ class TtQwenModelArgs(TtModelArgs):
 
         if self.num_devices == 32:
             self.use_prefetcher = not self.is_blackhole
+            # Opt-in bring-up of the Blackhole galaxy prefetcher (off by default so the working
+            # no-prefetcher path is untouched). Enable with QWEN_BH_PREFETCHER=1.
+            if self.is_blackhole and os.environ.get("QWEN_BH_PREFETCHER", "0") == "1":
+                self.use_prefetcher = True
 
-        # Set up prefetcher stuff
-        _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(12, 2, False)
+        # On Blackhole galaxy the fused galaxy CCLs (fused_rms_minimal, llama_rs_create_heads,
+        # all_gather_concat, llama_rs_matmul, llama_reduce_scatter) use 1D-multicast writers that no-op
+        # on the 2D-torus fabric, so with the prefetcher on we keep the ring matmuls (they must consume
+        # the prefetched global-CB weights) but route every collective through the stable/standard ops
+        # the no-prefetcher path already uses, each pinned to the worker sub-device. use_prefetcher
+        # still gates the matmuls; use_unfused_ccl gates the post-matmul collective/head/rotary logic.
+        self.use_unfused_ccl = (
+            self.use_prefetcher and self.is_blackhole and os.environ.get("QWEN_BH_UNFUSED_CCL", "1") == "1"
+        )
+
+        # Set up prefetcher stuff (Blackhole galaxy: 8 readers x 3 receivers; Wormhole: 12 x 2)
+        if self.is_blackhole:
+            _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(8, 3, False, is_blackhole=True)
+        else:
+            _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(12, 2, False)
 
         self.sub_core_max_y = 7 if self.is_blackhole else 9
         self.sub_core_grids = _build_galaxy_sub_core_grids(self.sub_core_max_y)
-        self.sub_core_grid_topk = ttnn.CoreRangeSet(
-            [
-                ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, self.sub_core_max_y)),
-            ]
-        )
+        if self.use_prefetcher and self.is_blackhole:
+            # The sampling top-k allocates large static circular buffers (padded vocab = 32768) on its
+            # sub-core grid. On Blackhole the prefetcher keeps a big resident global circular buffer
+            # (728*1088 ~= 774 KB) on the receiver columns 1-3, plus other worker-core buffers, so the
+            # 24-core top-k footprint no longer leaves enough contiguous L1 there ("static circular buffers
+            # clash with L1 buffers ... region ends at 809536"). Spread top-k across a much wider grid
+            # (columns 4-10, all 10 rows = 70 cores, clear of the prefetcher's global-CB columns 0-3 and
+            # the dispatch column 11) so the per-core static CB shrinks well below the resident buffers.
+            self.sub_core_grid_topk = ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(10, 9)),
+                ]
+            )
+        else:
+            self.sub_core_grid_topk = ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, self.sub_core_max_y)),
+                ]
+            )
         self.start_core = ttnn.CoreCoord(1, 0)
 
         HF_MODEL = os.getenv("HF_MODEL")
@@ -944,14 +977,27 @@ class TtQwenModelArgs(TtModelArgs):
 
             paged_sdpa_num_cores = 40 if self.is_blackhole else 48
             paged_sdpa_grid = (8, 5) if self.is_blackhole else (8, 6)
+            paged_sdpa_sub_core_grids = ttnn.num_cores_to_corerangeset_in_subcoregrids(
+                self.start_core, paged_sdpa_num_cores, self.sub_core_grids, row_wise=True
+            )
+            # SDPA decode must run on the same cores its Q/KV/output shards live on (the reducer/worker
+            # readers pull each core's Q shard in place), so its compute grid is pinned to sub_core_grids
+            # (cols 1-3, 5-6) and cannot be relocated off the dram_prefetcher global-CB receiver cores
+            # (cols 1-3) without deadlocking. Instead shrink the K/V circular buffers so they fit under
+            # the resident global CB during full-model trace capture. With dynamic chunking (k_chunk=0)
+            # the K/V CBs are sized for max_dynamic_chunk_size (dst_size = 8 tiles) -> ~256 KB, which
+            # overflows the ~423 KB of L1 left free below the global CB on the receiver cores by ~25 KB
+            # ("static circular buffers clash with L1 buffers on [1-0 - 3-7]"). Pin k_chunk_size to the
+            # paged KV block_size (64 tokens = 2 tiles): page-aligned so each chunk is exactly one page,
+            # and Sk_chunk_t=2 shrinks the K/V CBs to ~64 KB, clearing the clash. Flash-decode's online
+            # softmax makes the fixed smaller chunk numerically identical, just a few more K iterations.
+            paged_sdpa_k_chunk = 64 if (self.is_blackhole and self.use_prefetcher and self.use_unfused_ccl) else 0
             self.model_config["PAGED_SDPA_DECODE_PROGCFG"] = ttnn.SDPAProgramConfig(
                 compute_with_storage_grid_size=paged_sdpa_grid,
-                sub_core_grids=ttnn.num_cores_to_corerangeset_in_subcoregrids(
-                    self.start_core, paged_sdpa_num_cores, self.sub_core_grids, row_wise=True
-                ),
+                sub_core_grids=paged_sdpa_sub_core_grids,
                 exp_approx_mode=False,
                 q_chunk_size=0,
-                k_chunk_size=0,
+                k_chunk_size=paged_sdpa_k_chunk,
             )
 
             # TODO: Need to uplift UpdateCache to support dynamic chunk sizes if non-paged
@@ -1064,13 +1110,14 @@ class TtQwenModelArgs(TtModelArgs):
             ##### Prefetcher stuff #####
             self.model_config["USE_PREFETCHER"] = self.use_prefetcher
             RING_SIZE = 24
+            prefetcher_ring_grid = PREFETCHER_NOC1_GRID_BH if self.is_blackhole else PREFETCHER_NOC1_GRID
             ring_core_range_set = ttnn.CoreRangeSet(
                 [
                     ttnn.CoreRange(
                         ttnn.CoreCoord(x, y),
                         ttnn.CoreCoord(x, y),
                     )
-                    for x, y in PREFETCHER_NOC1_GRID
+                    for x, y in prefetcher_ring_grid
                 ]
             )
             pf_mm_out_core_range_set = ttnn.CoreRangeSet(
@@ -1114,6 +1161,18 @@ class TtQwenModelArgs(TtModelArgs):
                 self.qkv_n_ring,
                 RING_SIZE,
                 untilize_out=True,
+            )
+            # Non-untilized (TILE) variant for the Blackhole unfused-CCL bring-up: bf8 output requires TILE
+            # layout, and the unfused create-head path feeds a bf8 TILE input to the column all-reduce
+            # (matching the no-prefetcher path). The fused path keeps the untilized config for
+            # llama_rs_create_heads.
+            self.model_config["XQKV_DECODE_RING_PROGCFG_TILE"] = self.matmul_1d_ring_config(
+                1,
+                32,
+                self.qkv_k_ring,
+                self.qkv_n_ring,
+                RING_SIZE,
+                untilize_out=False,
             )
             # BH no-prefetch: L1 column-sharded act @ DRAM width-sharded wqkv (test_galaxy_nd pattern).
             qkv_k_per_device = self.dim // self.cluster_shape[1]
@@ -1277,13 +1336,16 @@ class TtQwenModelArgs(TtModelArgs):
             # self.lm_head_shape = (self.dim // 4, 151936 // 8)
             self.lm_head_shape = (6144 // 4, 155648 // 8)
 
+            # On BH the lm_head all_reduce buffer (sub_core_grids) is capped to rows 0-7, so the
+            # resharded output grid must fit inside rows 0-7 too (see LM_HEAD_32_GRID_BH).
+            lm_head_32_grid = LM_HEAD_32_GRID_BH if self.is_blackhole else LM_HEAD_32_GRID
             lm_head_ring_core_range_set = ttnn.CoreRangeSet(
                 [
                     ttnn.CoreRange(
                         ttnn.CoreCoord(x, y),
                         ttnn.CoreCoord(x, y),
                     )
-                    for x, y in LM_HEAD_32_GRID
+                    for x, y in lm_head_32_grid
                 ]
             )
 
@@ -2073,7 +2135,9 @@ class TtQwenModelArgs(TtModelArgs):
             out_subblock_w -= 1
 
         # DRAM-sharded in1 still needs hop core without runtime prefetcher (see test_matmul_1d_ring_qwen).
-        hop_grid = [(3, 6)]
+        # Blackhole ring occupies cols 1-3 rows 0-7; the hop core must be outside that grid AND be a
+        # member of the global CB (a dummy-receiver core at (3,8)), mirroring WH's hop on a dummy receiver.
+        hop_grid = [(3, 8)] if self.is_blackhole else [(3, 6)]
         hop_core_range_set = ttnn.CoreRangeSet(
             {
                 ttnn.CoreRange(
@@ -2097,7 +2161,7 @@ class TtQwenModelArgs(TtModelArgs):
             mcast_in0=False,
             gather_in0=True,
             hop_cores=hop_core_range_set,
-            num_global_cb_receivers=2 if prefetch else 1,
+            num_global_cb_receivers=(3 if self.is_blackhole else 2) if prefetch else 1,
             untilize_out=untilize_out,
         )
 
@@ -2132,7 +2196,7 @@ class TtQwenModelArgs(TtModelArgs):
         while out_block_w % out_subblock_w != 0:
             out_subblock_w -= 1
 
-        hop_grid = [(3, 6)]
+        hop_grid = [(3, 8)] if self.is_blackhole else [(3, 6)]
         hop_core_range_set = ttnn.CoreRangeSet(
             {
                 ttnn.CoreRange(

--- a/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
@@ -389,9 +389,11 @@ class TtQwenModelArgs(TtModelArgs):
         # through it (with correct sub_core_grids), so force-argmax must stay disabled there.
         self.model_config["SAMPLING_AG_CONFIG"] = {
             "allow_force_argmax": self.is_blackhole,
-            "num_links": self.model_config["GALAXY_NUM_LINKS"],
-            "chunks_per_sync": 10,
-            "topology": ttnn.Topology.Ring,
+            "num_links": int(os.getenv("QWEN_SAMPLING_AG_LINKS", str(self.model_config["GALAXY_NUM_LINKS"]))),
+            "chunks_per_sync": int(os.getenv("QWEN_SAMPLING_AG_CHUNKS_PER_SYNC", "10")),
+            "topology": ttnn.Topology.Linear
+            if os.getenv("QWEN_SAMPLING_AG_TOPOLOGY", "ring").lower() == "linear"
+            else ttnn.Topology.Ring,
         }
         if device is not None:
             self.n_local_heads = self.n_heads // self.cluster_shape[1]
@@ -1423,7 +1425,13 @@ class TtQwenModelArgs(TtModelArgs):
             self.model_config["LM_HEAD_OUT_RING_MEMCFG"] = ttnn.create_sharded_memory_config(
                 # shape=(32, 16896 // LM_HEAD_RING_SIZE),  # padded shape
                 shape=(32, 19968 // LM_HEAD_RING_SIZE),  # padded shape
-                core_grid=lm_head_ring_core_output_range_set,
+                # LM_HEAD_OUTPUT_GRID's permuted order encodes the WH DRAM-sharded in1 bank mapping.
+                # Blackhole reads the decode weight DRAM-interleaved (see lm_head.py): ring core i
+                # computes global N slice i, so the output shard order must follow the INPUT ring
+                # order instead.
+                core_grid=lm_head_ring_core_input_range_set
+                if self.is_blackhole
+                else lm_head_ring_core_output_range_set,
                 strategy=ttnn.ShardStrategy.WIDTH,
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,
                 use_height_and_width_as_shard_shape=True,

--- a/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
@@ -231,6 +231,34 @@ class TtQwenModelArgs(TtModelArgs):
         self.use_unfused_ccl = (
             self.use_prefetcher and self.is_blackhole and os.environ.get("QWEN_BH_UNFUSED_CCL", "1") == "1"
         )
+        # Repro harness for bringing up the FUSED matmul+reduce-scatter (llama_rs_matmul) on the
+        # Blackhole prefetcher path, isolated to the MLP FF1/FF3 reduce-scatter. Enabling it routes the
+        # FF matmul through the WH fused double_matmul_line_reduce_scatter unchanged. Unlike the fused
+        # all-gather CCLs, the RS writer is unicast (fabric_set_unicast_route, no to_chip_multicast) and
+        # num_links=2 places its senders at cores {5,3},{6,3} (clear of the prefetcher columns 0-3 and
+        # dispatch column 11), so it is NOT a core-placement or multicast problem.
+        # STATUS (2026-08): still DEADLOCKS on BH. The stall is inside llama_reduce_scatter's own
+        # internal reduce-scatter (device freezes immediately after the fused gathered matmul dispatches,
+        # before any downstream collective). Captured via TT_METAL_WATCHER=1 TT_METAL_WATCHER_DISABLE_ETH=1
+        # TT_METAL_WATCHER_DISABLE_ASSERT=1 (plain watcher trips a benign watcher-only ASSERT in the norm
+        # all_gather first, and the fabric firmware does not fit on BH ACTIVE_ETH with watcher). Root cause
+        # is llama_reduce_scatter's ring/fabric-hop setup on BH's 2-link fabric vs the working standalone
+        # reduce_scatter_minimal_async; needs CCL-op-level fabric debugging. Off by default.
+        # Enable with QWEN_BH_FUSED_RS_MATMUL=1.
+        self.use_bh_fused_rs_matmul = (
+            self.use_prefetcher and self.is_blackhole and os.environ.get("QWEN_BH_FUSED_RS_MATMUL", "0") == "1"
+        )
+        # BH "prefetcher + fused op" path for the MLP FF1/FF3 reduce-scatter. Unlike use_bh_fused_rs_matmul
+        # (which routes through the WH llama_rs_matmul / llama_reduce_scatter that deadlocks on BH's
+        # 2D-torus fabric), this uses ttnn.experimental.matmul_reduce_scatter_async, which fuses the
+        # prefetcher's 1D gathered ring matmul (streaming the global-CB weights) with the BH-working
+        # reduce_scatter_minimal_async backend. The ring matmul signals the RS reader via the
+        # REDUCE_SCATTER OpSignaler protocol added to reader_bmm_tile_layout_in1_ring_all_gather.cpp.
+        # Keeps the prefetcher AND removes the matmul->DRAM->RS round-trip. Off by default.
+        # Enable with QWEN_BH_FUSED_ASYNC_RS_MATMUL=1 (requires QWEN_BH_UNFUSED_CCL=1 for the semaphore pool).
+        self.use_bh_fused_async_rs_matmul = (
+            self.use_prefetcher and self.is_blackhole and os.environ.get("QWEN_BH_FUSED_ASYNC_RS_MATMUL", "0") == "1"
+        )
 
         # Set up prefetcher stuff (Blackhole galaxy: 8 readers x 3 receivers; Wormhole: 12 x 2)
         if self.is_blackhole:

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -222,6 +222,18 @@
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
 
+- name: Qwen3-32B e2e tests (Blackhole Galaxy)
+  cmd: |
+    export HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B
+    pytest --timeout 1000 models/demos/llama3_70b_galaxy/tests/test_qwen_accuracy.py
+  model: qwen3-32b-galaxy
+  skus:
+    bh_galaxy:
+      timeout: 15
+      tier: 1
+  owner_id: U053W15B6JF # Djordje Ivanovic
+  team: models
+
 - name: Qwen2.5-32B e2e tests
   cmd: |
     export HF_MODEL=Qwen/Qwen2.5-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen2.5-32B-Instruct

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -219,17 +219,8 @@
     wh_galaxy_perf:
       timeout: 30
       tier: 1
-  owner_id: U053W15B6JF # Djordje Ivanovic
-  team: models
-
-- name: Qwen3-32B e2e tests (Blackhole Galaxy)
-  cmd: |
-    export HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B
-    pytest --timeout 1000 models/demos/llama3_70b_galaxy/tests/test_qwen_accuracy.py
-  model: qwen3-32b-galaxy
-  skus:
     bh_galaxy:
-      timeout: 15
+      timeout: 30
       tier: 1
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -485,12 +485,15 @@
   cmd: |
     export HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B
     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp.py
+    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp_prefill.py
     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_attention.py
+    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_attention_prefill.py
     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder.py
+    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder_prefill.py
   model: qwen3-32b-galaxy
   skus:
     bh_galaxy:
-      timeout: 25
+      timeout: 45
       tier: 1
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -478,20 +478,6 @@
     wh_galaxy_perf:
       timeout: 10
       tier: 1
-  owner_id: U053W15B6JF # Djordje Ivanovic
-  team: models
-
-- name: Qwen3-32B unit tests (Blackhole Galaxy)
-  cmd: |
-    export HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B
-    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp.py
-    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp_prefill.py
-    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_attention.py
-    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_attention_prefill.py
-    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder.py
-    pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder_prefill.py
-  model: qwen3-32b-galaxy
-  skus:
     bh_galaxy:
       timeout: 45
       tier: 1

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_1d_gather_in0.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_1d_gather_in0.py
@@ -15,6 +15,7 @@ from tracy import signpost
 
 from models.demos.llama3_70b_galaxy.tt.model_config import (
     PREFETCHER_NOC1_GRID,
+    PREFETCHER_NOC1_GRID_BH,
 )
 
 
@@ -1240,4 +1241,69 @@ def test_matmul_1d_ring_llama_lm_head(
         hop_grid=hop_grid,
         in1_is_dram_interleaved=in1_is_dram_interleaved,
         in1_is_in_dram=in1_is_in_dram,
+    )
+
+
+# Intra-chip gather_in0 ring matmul on the Blackhole ring geometry (cols 1-3, rows 0-7,
+# hop core (3,8)) with in1 in L1, covering the four decoder matmul shapes. No CCL and no
+# DRAM-prefetcher global CB, so this exercises the ring NoC routing in isolation.
+@pytest.mark.parametrize("has_bias", [False], ids=["no_bias"])
+@pytest.mark.parametrize(
+    "B, M, K, N, in0_dtype, in1_dtype, output_dtype, fidelity, packer_l1_acc, fp32_acc_mode",
+    [
+        (1, 32, 1280, 1280, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.MathFidelity.HiFi2, True, True),
+        (1, 32, 1024, 1280, ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2, True, True),
+        (1, 32, 1280, 3200, ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi, True, False),
+        (1, 32, 3200, 1280, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2, True, True),
+    ],
+    ids=["qkv", "do", "ff13", "ff2"],
+)
+@pytest.mark.parametrize("num_iters", [10])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
+def test_matmul_1d_ring_qwen_bh(
+    device,
+    in0_dtype,
+    in1_dtype,
+    output_dtype,
+    fidelity,
+    has_bias,
+    fp32_acc_mode,
+    packer_l1_acc,
+    B,
+    M,
+    K,
+    N,
+    num_iters,
+    function_level_defaults,
+):
+    torch.manual_seed(0)
+    device_grid = (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y)
+    if device_grid != (12, 10):
+        pytest.skip(f"BH ring isolation harness expects a 12x10 grid, got {device_grid}")
+
+    run_multi_core_matmul_1d(
+        device,
+        in0_dtype,
+        in1_dtype,
+        fidelity,
+        has_bias,
+        fp32_acc_mode,
+        packer_l1_acc,
+        B,
+        M,
+        K,
+        N,
+        None,  # activation
+        PREFETCHER_NOC1_GRID_BH,
+        True,  # use_arbitrary_cores
+        num_iters,
+        output_dtype=output_dtype,
+        use_physical_to_logical_mapping=False,
+        hop_grid=[(3, 8)],
+        in1_is_dram_interleaved=False,
+        in1_is_in_dram=False,
     )

--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_create_heads_async_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_create_heads_async_TG.py
@@ -81,7 +81,12 @@ def run_reduce_scatter_test(
     output_grid=None,
     dtype=ttnn.bfloat8_b,
     profiler=BenchmarkProfiler(),
+    topology=None,
 ):
+    # Default keeps the original module-level topology (Linear) for the WH TG tests;
+    # BH-galaxy callers pass Ring to match the 2D-torus fabric.
+    if topology is None:
+        topology = TOPOLOGY
     num_pages_per_packet = 4
     cyclic_buffer_size = 8
 
@@ -261,7 +266,7 @@ def run_reduce_scatter_test(
                 worker_sub_device_id,
                 cluster_axis=1,
                 mesh_device=mesh_device,
-                topology=TOPOLOGY,
+                topology=topology,
                 num_links=num_links,
                 num_heads=8,
                 num_kv_heads=1,

--- a/tools/tracy/__main__.py
+++ b/tools/tracy/__main__.py
@@ -214,7 +214,9 @@ def main():
             sys.exit(1)
 
     if options.processLogsOnly:
-        generate_report(generate_logs_folder(outputFolder), binaryFolder, "", None, options.collect_noc_traces)
+        # generate_report derives the logs folder itself (generate_logs_folder), so pass the output
+        # folder as-is; wrapping it here doubled the path to <out>/.logs/.logs and broke reprocessing.
+        generate_report(outputFolder, binaryFolder, "", None, options.collect_noc_traces)
         sys.exit(0)
 
     if options.port:

--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -685,10 +685,15 @@ def _enrich_ops_from_perf_csv(
                     if cand_op_id == op_id:
                         candidates.extend(rows)
 
-            assert candidates, (
-                f"Device data missing: Op {op_id} not present in {PROFILER_CPP_DEVICE_PERF_REPORT} "
-                f"for device {device_id} (trace_id={host_trace_id})"
-            )
+            if not candidates:
+                # Device markers can legitimately be missing when the device profiler DRAM buffers
+                # overflowed mid-run (e.g. long multi-user prefill before a drain point). Skip the op
+                # instead of aborting the whole report.
+                logger.warning(
+                    f"Device data missing: Op {op_id} not present in {PROFILER_CPP_DEVICE_PERF_REPORT} "
+                    f"for device {device_id} (trace_id={host_trace_id}); skipping"
+                )
+                continue
 
             # Create one enriched op per ProgramExecutionUID row in the C++ report.
             for perf_row in candidates:

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1764,13 +1764,21 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
             }
         }
         if (lowest_address.has_value() and lowest_address.value() < cb_region_end) {
+            std::string kernel_names;
+            for (size_t ki = 0; ki < this->num_kernels(); ki++) {
+                auto k = this->get_kernel(ki);
+                if (k) {
+                    kernel_names += (kernel_names.empty() ? "" : ", ") + k->name();
+                }
+            }
             TT_THROW(
                 "Statically allocated circular buffers in program {} clash with L1 buffers on core range {}. L1 buffer "
-                "allocated at {} and static circular buffer region ends at {}",
+                "allocated at {} and static circular buffer region ends at {}. Kernels: [{}]",
                 this->id,
                 cb_allocator.core_range.str(),
                 lowest_address.value(),
-                cb_region_end);
+                cb_region_end,
+                kernel_names);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
@@ -300,4 +300,19 @@ struct ReduceScatterOpReceiver {
         ASSERT(this->initialized);
         Semaphore<>(this->signal_op_semaphore_id).wait_min(batch_idx + 1);
     }
+
+    // The signal semaphore uses a cumulative wait_min (batch_idx + 1) and is created once at program
+    // build (CreateSemaphore(..., 0)). Under program caching the same program is re-dispatched every
+    // decode iteration, so the L1 value persists and keeps accumulating across invocations. Left unreset,
+    // the next invocation's wait_min(1) is satisfied by the stale value before this iteration's matmul has
+    // actually produced its output -> the matmul/reduce-scatter handshake desyncs (RS races ahead reading
+    // stale tiles) and eventually corrupts shared-core state. Zero it after the batch loop has consumed all
+    // matmul signals so the next dispatch starts fresh. Safe because matmul + reduce-scatter are a single
+    // fused program serialized on the command queue: by the last batch's wait the matmul has emitted every
+    // signal, and the next invocation cannot begin until this program (including this reset) completes.
+    void reset() {
+        if (this->initialized) {
+            Semaphore<>(this->signal_op_semaphore_id).set(0);
+        }
+    }
 };

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_program_factory.cpp
@@ -135,7 +135,8 @@ ReduceScatterDeviceOperation::ReduceScatterProgram::create_at(
         operation_attributes.num_workers_per_link,
         operation_attributes.num_buffers_per_channel,
         first_coord,  // first core in the subdevice is our offset as we don't use this version for fusions
-        operation_attributes.compute_kernel_config);
+        operation_attributes.compute_kernel_config,
+        std::nullopt);
 
     shared_variables_t shared_vars{
         .multidevice_semaphores = multidevice_semaphores,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -225,8 +225,6 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
 
-    IDevice* device = a.device();
-
     // input shard spec
     auto shard_spec_unpadded = a.shard_spec().value();
     uint32_t shard_height_unpadded = shard_spec_unpadded.shape[0];
@@ -264,10 +262,11 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     log_debug(tt::LogOp, "all_cores_unpadded: {}", all_cores_unpadded);
     log_debug(tt::LogOp, "num_cores_unpadded: {}", num_cores_unpadded);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    // CBs must only be placed on cores this program actually uses (the input/output shard
+    // grids). Covering the full compute grid would multicast CB configs onto cores that may
+    // belong to another sub-device (e.g. DRAM-prefetcher sender cores on Galaxy), corrupting
+    // whatever that sub-device has loaded at the worker kernel-config addresses.
+    CoreRangeSet cb_cores = all_cores_unpadded.merge(all_cores_padded);
 
     Buffer* src_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
@@ -280,7 +279,7 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     {
         CBDescriptor cb_src0;
         cb_src0.total_size = shard_height_unpadded * stick_size_unpadded;
-        cb_src0.core_ranges = total_cores;
+        cb_src0.core_ranges = cb_cores;
         cb_src0.format_descriptors.push_back(CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(src0_cb_index),
             .data_format = cb_data_format,
@@ -295,7 +294,7 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     {
         CBDescriptor cb_output;
         cb_output.total_size = shard_height_padded * stick_size_padded;
-        cb_output.core_ranges = total_cores;
+        cb_output.core_ranges = cb_cores;
         cb_output.format_descriptors.push_back(CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(output_cb_index),
             .data_format = dst_cb_data_format,
@@ -310,7 +309,7 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     uint32_t src1_cb_index = 1;
     desc.cbs.push_back(CBDescriptor{
         .total_size = stick_size_padded,
-        .core_ranges = total_cores,
+        .core_ranges = cb_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(src1_cb_index),
             .data_format = cb_data_format,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
@@ -36,8 +36,6 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
     auto unpadded_stick_bytes = W * input_tensor.element_size();
     auto padded_stick_bytes = W_padded * input_tensor.element_size();
 
-    IDevice* device = input_tensor.device();
-
     // input shard spec
     auto input_shard_spec = input_tensor.shard_spec().value();
     uint32_t shard_height_unpadded = input_shard_spec.shape[0];
@@ -49,10 +47,11 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
     const auto& ordered_cores_with_data = get_optimal_worker_cores_for_sharded_tensor(output);
     auto all_cores_padded = CoreRangeSet(ttsl::Span<const CoreCoord>(ordered_cores_with_data));
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    // CBs must only be placed on cores this program actually uses (the input/output shard
+    // grids). Covering the full compute grid would multicast CB configs onto cores that may
+    // belong to another sub-device (e.g. DRAM-prefetcher sender cores on Galaxy), corrupting
+    // whatever that sub-device has loaded at the worker kernel-config addresses.
+    CoreRangeSet cb_cores = input_shard_spec.grid.merge(all_cores_padded);
 
     Buffer* input_buffer = input_tensor.buffer();
     Buffer* output_buffer = output.buffer();
@@ -66,7 +65,7 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
         // patches the CB address on cache hits via cb.buffer.
         CBDescriptor cb_input;
         cb_input.total_size = shard_height_unpadded * unpadded_stick_bytes;
-        cb_input.core_ranges = total_cores;
+        cb_input.core_ranges = cb_cores;
         cb_input.format_descriptors.push_back(CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(input_shard_cb_index),
             .data_format = input_cb_data_format,
@@ -82,7 +81,7 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
         // Sharded output CB — globally allocated to the output buffer.
         CBDescriptor cb_output;
         cb_output.total_size = shard_height_padded * padded_stick_bytes;
-        cb_output.core_ranges = total_cores;
+        cb_output.core_ranges = cb_cores;
         cb_output.format_descriptors.push_back(CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(output_shard_cb_index),
             .data_format = output_cb_data_format,
@@ -97,7 +96,7 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
     uint32_t pad_val_cb_index = tt::CBIndex::c_1;
     desc.cbs.push_back(CBDescriptor{
         .total_size = padded_stick_bytes,
-        .core_ranges = total_cores,
+        .core_ranges = cb_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(pad_val_cb_index),
             .data_format = pad_val_cb_data_format,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program_factory.cpp
@@ -127,6 +127,41 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
     auto [num_targets_forward, num_targets_backward, dynamic_alternate] =
         ::ttnn::ccl::get_forward_backward_configuration(
             operation_attributes.ring_size, ring_index, operation_attributes.topology);
+    // On 2D fabrics the multicast routes are direction-specific (dst mesh/chip id + per-direction
+    // hops), so the dynamic-alternate trick of swapping the forward/backward packet headers between
+    // packets would send packets with the wrong route. Disable it there; 1D fabrics keep it.
+    if (tt::tt_fabric::is_2d_fabric_config(tt::tt_fabric::GetFabricConfig())) {
+        dynamic_alternate = false;
+    }
+    // Fabric-topology-aware multicast route info. The legacy writer built raw 1D
+    // MulticastRoutingCommandHeaders, which no-op on 2D fabrics (e.g. the Blackhole galaxy 2D
+    // torus, where PACKET_HEADER_TYPE is HybridMeshPacketHeader and routes need dst mesh/chip ids
+    // plus per-direction hop counts). Emit host-computed route info the same way the proven
+    // all_gather_async writers do; ccl_routing_utils picks the encoding per fabric type (1D
+    // low-latency headers keep the exact old behavior).
+    const auto& forward_device_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+        input_tensor, mesh_coordinate, 1, operation_attributes.topology, operation_attributes.cluster_axis);
+    const auto& backward_device_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+        input_tensor, mesh_coordinate, -1, operation_attributes.topology, operation_attributes.cluster_axis);
+    auto [mcast_forward_args, mcast_backward_args] = ttnn::ccl::get_forward_backward_line_mcast_configuration(
+        mesh_coordinate,
+        forward_device_coord,
+        backward_device_coord,
+        num_targets_forward,
+        num_targets_backward,
+        mesh_device);
+    // The output-ready-semaphore mcast uses max(num_targets) when dynamic_alternate is on; emit a
+    // dedicated route pair for it so the kernel does not rebuild headers from hop counts.
+    const uint32_t num_max_targets = std::max(num_targets_forward, num_targets_backward);
+    const uint32_t num_sync_targets_forward = dynamic_alternate ? num_max_targets : num_targets_forward;
+    const uint32_t num_sync_targets_backward = dynamic_alternate ? num_max_targets : num_targets_backward;
+    auto [sync_mcast_forward_args, sync_mcast_backward_args] = ttnn::ccl::get_forward_backward_line_mcast_configuration(
+        mesh_coordinate,
+        forward_device_coord,
+        backward_device_coord,
+        num_sync_targets_forward,
+        num_sync_targets_backward,
+        mesh_device);
 
     // To overlap NLP local data with all gather, we divide the batches for each device into:
     //      - local batch (starts with start_local)
@@ -243,6 +278,20 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
         }
     }
     const auto& q_cores_updated = CoreRangeSet(q_cores_vector);
+    // Semaphore-multicast ranges for signaling the concat cores. The former hardcoded ranges
+    // (cols 5-6 rows {9, 0-2, 4-7}) match the WH-TG prefetcher-ring order, where the first 16 ring
+    // cores happen to be exactly those; on other ring orders (e.g. the BH galaxy ring, which starts
+    // at cols 1-3) the hardcoded rectangles signal cores that do not run the concat kernels (hang)
+    // while 3 real concat cores were skipped by a stale worker-core exclusion (crash in
+    // override_runtime_arguments). Derive the ranges + destination counts from the actual concat
+    // core ranges instead.
+    std::vector<CoreRange> sem_mcast_ranges_vec;
+    std::vector<uint32_t> sem_mcast_dest_counts;
+    for (const auto& cr : q_cores_vector) {
+        sem_mcast_ranges_vec.push_back(cr);
+        sem_mcast_dest_counts.push_back(cr.size());
+    }
+    const uint32_t num_semaphore_ranges = sem_mcast_ranges_vec.size();
     std::vector<CoreRange> sem_cores_vector;
     sem_cores_vector.push_back(CoreRange(sender_worker_cores[0], sender_worker_cores[0]));
     range_count = 0;
@@ -362,8 +411,17 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
         num_targets_forward,              // num_targets_forward_direction
         num_targets_backward,             // num_targets_backward_direction
         dynamic_alternate,                // alternate
-        llama_configuration.num_semaphore_ranges,
+        num_semaphore_ranges,
         out_ready_sem_wait_value};
+    // Host-computed fabric multicast route info (2D-fabric aware): data fwd/bwd, then sync fwd/bwd.
+    all_gather_writer_ct_args.insert(
+        all_gather_writer_ct_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
+    all_gather_writer_ct_args.insert(
+        all_gather_writer_ct_args.end(), mcast_backward_args.begin(), mcast_backward_args.end());
+    all_gather_writer_ct_args.insert(
+        all_gather_writer_ct_args.end(), sync_mcast_forward_args.begin(), sync_mcast_forward_args.end());
+    all_gather_writer_ct_args.insert(
+        all_gather_writer_ct_args.end(), sync_mcast_backward_args.begin(), sync_mcast_backward_args.end());
 
     auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -490,13 +548,12 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
             concat_semaphore_id2,
         };
 
-        auto sem_mcast_ranges = CoreRangeSet(llama_configuration.semaphore_mcast_ranges);
         std::vector<uint32_t> mcast_start_x;
         std::vector<uint32_t> mcast_start_y;
         std::vector<uint32_t> mcast_end_x;
         std::vector<uint32_t> mcast_end_y;
 
-        for (const auto& range : sem_mcast_ranges.ranges()) {
+        for (const auto& range : sem_mcast_ranges_vec) {
             auto start_core = mesh_device->worker_core_from_logical_core(range.start_coord);
             auto end_core = mesh_device->worker_core_from_logical_core(range.end_coord);
             if (writer_noc == tt::tt_metal::NOC::NOC_1) {
@@ -514,6 +571,9 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
         writer_rt_args.insert(writer_rt_args.end(), mcast_start_y.begin(), mcast_start_y.end());
         writer_rt_args.insert(writer_rt_args.end(), mcast_end_x.begin(), mcast_end_x.end());
         writer_rt_args.insert(writer_rt_args.end(), mcast_end_y.begin(), mcast_end_y.end());
+        // Per-range multicast destination counts (formerly hardcoded 2/6/8 in the kernel, which
+        // only matched the WH-TG concat grid).
+        writer_rt_args.insert(writer_rt_args.end(), sem_mcast_dest_counts.begin(), sem_mcast_dest_counts.end());
 
         log_trace(tt::LogOp, "Writer Runtime Args:");
         for ([[maybe_unused]] const auto& arg : writer_rt_args) {
@@ -537,6 +597,19 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
     }
 
     /* rt for concat kernels*/
+    // Virtual NOC coords of the input-tensor shard cores, for the local-batch copy. The kernel
+    // used to hardcode the WH-TG virtual coords ({19,20,21}x{18,19,20}); on other archs (e.g.
+    // Blackhole) the logical->virtual mapping differs, so the local users were read from the
+    // wrong cores (silently: the guarding TT_ASSERT is compiled out in release builds). Pass
+    // the host-computed coords as runtime args instead.
+    std::vector<uint32_t> input_cores_x;
+    std::vector<uint32_t> input_cores_y;
+    for (uint32_t k = 0; k < llama_configuration.num_cores_input_tensor; k++) {
+        auto this_core = mesh_device->worker_core_from_logical_core(input_cores_vec[k]);
+        input_cores_x.push_back(this_core.x);
+        input_cores_y.push_back(this_core.y);
+    }
+    std::vector<CoreCoord> concat_arg_cores;
     uint32_t q_start_addr = temp_tensor.buffer()->address();
     for (uint32_t i = 0; i < llama_configuration.concat_num_cores; ++i) {
         uint32_t second_half_core = 1;
@@ -546,24 +619,16 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
         // in_tile_offset_by_batch is the start address of each batch in the input tile. The first face_h batches are in
         // the upper half of the tile and rest are in the lower half of tile.
         const auto& core = cores[i];
-        std::vector<uint32_t> input_cores_x;
-        std::vector<uint32_t> input_cores_y;
-        std::array<uint32_t, 8> kernel_core_noc_x = {19, 20, 21, 19, 20, 21, 19, 20};
-        std::array<uint32_t, 8> kernel_core_noc_y = {18, 18, 18, 19, 19, 19, 20, 20};
-        for (uint32_t k = 0; k < llama_configuration.num_cores_input_tensor; k++) {
-            auto this_core = mesh_device->worker_core_from_logical_core(input_cores_vec[k]);
-            input_cores_x.push_back(this_core.x);
-            input_cores_y.push_back(this_core.y);
-            TT_ASSERT(
-                this_core.x == kernel_core_noc_x[k] && this_core.y == kernel_core_noc_y[k],
-                "This op should run on a TG machine");
-        }
-        bool is_worker_core = core.x == 1 && core.y == 0;
-        is_worker_core = is_worker_core || (core.x == 2 && core.y == 0);
-        is_worker_core = is_worker_core || (core.x == 3 && core.y == 0);
+        // Skip cores doubling as AG sender workers (they run the AG reader/writer kernels instead).
+        // This used to be a hardcoded {(1,0),(2,0),(3,0)} check: vestigial on the WH-TG grid (the
+        // first 16 ring cores are on cols 5-6) but wrong on ring orders that start at cols 1-3
+        // (BH galaxy): 3 real concat cores were skipped, leaving their kernels without runtime args.
+        bool is_worker_core =
+            std::find(sender_worker_cores.begin(), sender_worker_cores.end(), core) != sender_worker_cores.end();
         if (is_worker_core == 0) {
+            concat_arg_cores.push_back(core);
             std::vector<uint32_t> reader_runtime_args;
-            reader_runtime_args.reserve(6 + (2 * in_num_cores));
+            reader_runtime_args.reserve(6 + (2 * in_num_cores) + input_cores_x.size() + input_cores_y.size());
             reader_runtime_args = {
                 q_start_addr, input_tensor.buffer()->address(), concat_semaphore_id, concat_semaphore_id2};
 
@@ -571,6 +636,9 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
             reader_runtime_args.insert(reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
             reader_runtime_args.push_back(second_half_core);
             reader_runtime_args.push_back(i / 2);
+            // Local-batch input shard core coords (see comment above).
+            reader_runtime_args.insert(reader_runtime_args.end(), input_cores_x.begin(), input_cores_x.end());
+            reader_runtime_args.insert(reader_runtime_args.end(), input_cores_y.begin(), input_cores_y.end());
 
             tt::tt_metal::SetRuntimeArgs(program, concat_reader_kernel_id, core, reader_runtime_args);
         }
@@ -582,6 +650,7 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
         .num_concat_worker_cores = num_concat_worker_cores,
         .cb_q_output = cb_q_output,
         .cores = cores,
+        .concat_arg_cores = concat_arg_cores,
         .worker_sender_reader_kernel_id = worker_sender_reader_kernel_id,
         .worker_sender_writer_kernel_id = worker_sender_writer_kernel_id,
         .concat_reader_kernel_id = concat_reader_kernel_id,
@@ -626,8 +695,8 @@ void AllGatherConcatMeshWorkloadFactory::override_runtime_arguments(
             worker_writer_sender_runtime_args[1] = semaphore.address();
         }
 
-        for (uint32_t i = 0; i < shared_vars.num_concat_worker_cores; ++i) {
-            const auto& core = shared_vars.cores[i];
+        // Only touch cores that received args at create time (AG sender-worker cores are excluded).
+        for (const auto& core : shared_vars.concat_arg_cores) {
             auto& concat_reader_runtime_args = GetRuntimeArgs(program, shared_vars.concat_reader_kernel_id, core);
             concat_reader_runtime_args[0] = q_start_addr;
             concat_reader_runtime_args[1] = input.buffer()->address();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program_factory.hpp
@@ -15,6 +15,8 @@ struct AllGatherConcatSharedVariables {
     uint32_t num_concat_worker_cores = 0;
     tt::tt_metal::CBHandle cb_q_output{};
     std::vector<tt::tt_metal::CoreCoord> cores;
+    // Concat-reader cores that actually received runtime args (excludes AG sender-worker overlap).
+    std::vector<tt::tt_metal::CoreCoord> concat_arg_cores;
     tt::tt_metal::KernelHandle worker_sender_reader_kernel_id{};
     tt::tt_metal::KernelHandle worker_sender_writer_kernel_id{};
     tt::tt_metal::KernelHandle concat_reader_kernel_id{};

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -10,6 +10,7 @@
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
+#include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 #include <cstdint>
 #include <utility>
 #include <array>
@@ -34,6 +35,16 @@ constexpr uint32_t out_ready_sem_wait_value = get_compile_time_arg_val(10);
 constexpr uint32_t num_max_targets = std::max(num_targets_forward_direction, num_targets_backward_direction);
 constexpr uint32_t num_sync_targets_forward = dynamic_alternate ? num_max_targets : num_targets_forward_direction;
 constexpr uint32_t num_sync_targets_backward = dynamic_alternate ? num_max_targets : num_targets_backward_direction;
+// Host-computed fabric multicast routes (2D-fabric aware; 1D keeps hop-based behavior):
+// data fwd/bwd, then output-ready-semaphore sync fwd/bwd.
+constexpr ccl_routing_utils::line_multicast_route_info_t forward_multicast_route_info =
+    ccl_routing_utils::get_line_multicast_route_info_from_args<11>();
+constexpr ccl_routing_utils::line_multicast_route_info_t backward_multicast_route_info =
+    ccl_routing_utils::get_line_multicast_route_info_from_args<11 + ccl_routing_utils::num_line_multicast_args>();
+constexpr ccl_routing_utils::line_multicast_route_info_t sync_forward_multicast_route_info =
+    ccl_routing_utils::get_line_multicast_route_info_from_args<11 + 2 * ccl_routing_utils::num_line_multicast_args>();
+constexpr ccl_routing_utils::line_multicast_route_info_t sync_backward_multicast_route_info =
+    ccl_routing_utils::get_line_multicast_route_info_from_args<11 + 3 * ccl_routing_utils::num_line_multicast_args>();
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -73,6 +84,10 @@ void kernel_main() {
     arg_idx += num_sem_ranges;
     tt_l1_ptr uint32_t* mcast_dest_noc_end_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += num_sem_ranges;
+    // Per-range destination counts (host-derived from the actual concat core ranges; formerly
+    // hardcoded 2/6/8 which only matched the WH-TG concat grid).
+    tt_l1_ptr uint32_t* mcast_dest_counts = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_sem_ranges;
 
     size_t arg_for_fab = arg_idx;
     constexpr bool connect_to_fabric_when_creating = true;
@@ -100,10 +115,8 @@ void kernel_main() {
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
     volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
-    pkt_hdr_forward->to_chip_multicast(
-        tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
-    pkt_hdr_backward->to_chip_multicast(
-        tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+    ccl_routing_utils::fabric_set_line_multicast_route(pkt_hdr_forward, forward_multicast_route_info);
+    ccl_routing_utils::fabric_set_line_multicast_route(pkt_hdr_backward, backward_multicast_route_info);
 
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.open_finish();
@@ -152,15 +165,13 @@ void kernel_main() {
     // Write the mcast packet (forward)
     if (fabric_connection.has_forward_connection()) {
         fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-        pkt_hdr->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_sync_targets_forward)});
+        ccl_routing_utils::fabric_set_line_multicast_route(pkt_hdr, sync_forward_multicast_route_info);
         fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
     // Write the mcast packet (backward)
     if (fabric_connection.has_backward_connection()) {
-        pkt_hdr->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_sync_targets_backward)});
+        ccl_routing_utils::fabric_set_line_multicast_route(pkt_hdr, sync_backward_multicast_route_info);
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
@@ -183,13 +194,8 @@ void kernel_main() {
     }
 
     if (wait_output_semaphore) {
-        for (uint32_t i = 0; i < 3; i++) {
-            uint32_t mcast_dest_num = 2;
-            if (i == 1) {
-                mcast_dest_num = 6;
-            } else if (i == 2) {
-                mcast_dest_num = 8;
-            }
+        for (uint32_t i = 0; i < num_sem_ranges; i++) {
+            uint32_t mcast_dest_num = mcast_dest_counts[i];
             concat_sem.set_multicast(
                 noc_obj,
                 mcast_dest_noc_start_x[i],

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_concat_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_concat_reader.cpp
@@ -139,8 +139,16 @@ void kernel_main() {
     uint32_t second_half_core = get_arg_val<uint32_t>(arg_idx++);
     uint32_t start_row = get_arg_val<uint32_t>(arg_idx++);
 
-    std::array<uint32_t, 8> core_noc_x = {19, 20, 21, 19, 20, 21, 19, 20};
-    std::array<uint32_t, 8> core_noc_y = {18, 18, 18, 19, 19, 19, 20, 20};
+    // Virtual NOC coords of the input shard cores for the local-batch copy. Host-computed:
+    // the previous hardcoded values were the WH-TG virtual coords and broke other archs (BH).
+    std::array<uint32_t, 8> core_noc_x;
+    std::array<uint32_t, 8> core_noc_y;
+    for (uint32_t k = 0; k < 8; k++) {
+        core_noc_x[k] = get_arg_val<uint32_t>(arg_idx++);
+    }
+    for (uint32_t k = 0; k < 8; k++) {
+        core_noc_y[k] = get_arg_val<uint32_t>(arg_idx++);
+    }
 
     Noc noc_obj;
     CircularBuffer cb_q_out(cb_id_q_out);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
@@ -12,6 +12,7 @@
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
+#include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 constexpr bool flush = false;
 
 template <bool ring_topology>
@@ -104,6 +105,9 @@ void kernel_main() {
         // Set up packet headers once
         constexpr uint8_t device_order[other_devices] =
             DEVICE_ORDER;  // this is code gen'd in the program factory using the defines
+        // Per-target fabric route info, same order as device_order (code gen'd in the program
+        // factory): {mesh_id, chip_id} on 2D fabrics, {0, num_hops} on 1D fabrics.
+        constexpr uint16_t unicast_routes[other_devices][2] = UNICAST_ROUTES;
         constexpr uint8_t packet_worker_cores[num_packet_worker_cores][2] = PACKET_WORKER_CORES;
         const auto packet_header_buffer_addr = cb_packet_header.get_read_ptr();
         auto* unicast_packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr);
@@ -123,10 +127,12 @@ void kernel_main() {
         if (fabric_connection.is_logically_connected()) {
             fabric_connection.open_finish();
         }
-        for (uint32_t target_device_id : device_order) {
-            // Calculate device-specific constants once per device
-            const uint32_t num_hops = distance<ring_topology>(chip_id, target_device_id, num_devices);
-            fabric_set_unicast_route<false>(unicast_packet_header, num_hops);
+        for (uint32_t target_idx = 0; target_idx < other_devices; target_idx++) {
+            const uint32_t target_device_id = device_order[target_idx];
+            // Fabric-topology-aware route (host-computed): on 2D fabrics the routers need the
+            // target's {mesh_id, chip_id}; the old hop-count-only route never resolved there.
+            ccl_routing_utils::fabric_set_line_unicast_route(
+                unicast_packet_header, {unicast_routes[target_idx][0], unicast_routes[target_idx][1]});
             auto& fabric_conn =
                 get_fabric_connection<ring_topology>(fabric_connection, chip_id, target_device_id, num_devices);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -20,7 +20,8 @@ namespace ttnn::operations::experimental::ccl {
 
 namespace detail {
 
-std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, tt::tt_fabric::Topology topology) {
+ttsl::SmallVector<uint32_t> device_order_vector(
+    uint32_t ring_size, uint32_t ring_index, tt::tt_fabric::Topology topology) {
     ttsl::SmallVector<uint32_t> device_order;
     device_order.reserve(ring_size - 1);
     // Add all indices except ring_index
@@ -58,7 +59,11 @@ std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, t
             return a < b;
         });
     }
+    return device_order;
+}
 
+std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, tt::tt_fabric::Topology topology) {
+    const auto device_order = device_order_vector(ring_size, ring_index, topology);
     // Convert to string format
     std::string result = "{";
     for (size_t i = 0; i < device_order.size(); i++) {
@@ -66,6 +71,37 @@ std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, t
         if (i < device_order.size() - 1) {
             result += ", ";
         }
+    }
+    result += "}";
+    return result;
+}
+
+// Per-target fabric unicast route info, in the same order as device_order_array_string. Each entry
+// feeds ccl_routing_utils::fabric_set_line_unicast_route in the writer: on 2D fabrics (e.g. the BH
+// galaxy torus) that requires the target's {mesh_id, chip_id} (hop counts are meaningless to the 2D
+// routers - using them is why this op used to deadlock there); on 1D fabrics it stays {0, num_hops},
+// preserving the original behavior.
+std::string unicast_route_array_string(
+    uint32_t ring_size,
+    uint32_t ring_index,
+    tt::tt_fabric::Topology topology,
+    const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids) {
+    const auto device_order = device_order_vector(ring_size, ring_index, topology);
+    const bool is_2d_fabric = tt::tt_fabric::is_2d_fabric_config(tt::tt_fabric::GetFabricConfig());
+    std::string result = "{";
+    for (size_t i = 0; i < device_order.size(); i++) {
+        const uint32_t target = device_order[i];
+        uint32_t mesh_id = 0;
+        uint32_t chip_or_hops = 0;
+        if (is_2d_fabric) {
+            const auto& node_id = fabric_node_ids.at(target);
+            mesh_id = *node_id.mesh_id;
+            chip_or_hops = node_id.chip_id;
+        } else {
+            const uint32_t diff = std::abs(static_cast<int>(target) - static_cast<int>(ring_index));
+            chip_or_hops = (topology == tt::tt_fabric::Topology::Ring) ? std::min(diff, ring_size - diff) : diff;
+        }
+        result += "{" + std::to_string(mesh_id) + ", " + std::to_string(chip_or_hops) + "}, ";
     }
     result += "}";
     return result;
@@ -705,6 +741,10 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_proc
         topology == tt::tt_fabric::Topology::Ring ? 1u : 0u};
 
     auto writer_defines = reader_defines;
+    // Fabric-topology-aware unicast routes (indexed in DEVICE_ORDER order); see
+    // detail::unicast_route_array_string for why hop counts alone break on 2D fabrics.
+    writer_defines["UNICAST_ROUTES"] =
+        detail::unicast_route_array_string(ring_size, ring_index, topology, fabric_node_ids);
     bool skip_write_back = output_cores == packet_worker_cores and num_pages_per_packet == output_tiles_per_core_width;
     if (skip_write_back) {
         writer_defines["SKIP_WRITE_BACK"] = "1";

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
@@ -15,6 +15,7 @@
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
+#include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 
 constexpr bool flush = false;
 void kernel_main() {
@@ -89,6 +90,9 @@ void kernel_main() {
         // Set up packet headers once
         constexpr uint8_t device_order[other_devices] =
             DEVICE_ORDER;  // this is code gen'd in the program factory using the defines
+        // Per-target fabric route info, same order as device_order (code gen'd in the program
+        // factory): {mesh_id, chip_id} on 2D fabrics, {0, num_hops} on 1D fabrics.
+        constexpr uint16_t unicast_routes[other_devices][2] = UNICAST_ROUTES;
         constexpr uint8_t packet_worker_cores[num_packet_worker_cores][2] = PACKET_WORKER_CORES;
         cb_packet_header.reserve_back(buffering_factor * num_packet_headers_storable);
         const auto packet_header_buffer_addr = cb_packet_header.get_read_ptr();
@@ -107,10 +111,21 @@ void kernel_main() {
 
         ASSERT(fabric_connection.is_logically_connected());
         fabric_connection.open_finish();
-        for (uint32_t target_device_id : device_order) {
+        for (uint32_t target_idx = 0; target_idx < other_devices; target_idx++) {
+            const uint32_t target_device_id = device_order[target_idx];
             // Calculate device-specific constants once per device
             bool forward_connection = true;
-            if constexpr (RING_TOPOLOGY) {
+            constexpr bool is_2d_fabric = std::is_same_v<PACKET_HEADER_TYPE, tt::tt_fabric::HybridMeshPacketHeader>;
+            if constexpr (is_2d_fabric && RING_TOPOLOGY) {
+                // 2D fabric: fabric_set_unicast_route encodes the full hop-by-hop route into the
+                // header from the sender's routing table, so the packet MUST be injected into the
+                // EDM connection matching the table's first hop: shortest path, forward on ties
+                // (the parity-based load balancing below injects half the 2-hop packets backward
+                // with a forward route program - they are never delivered and wedge the routers).
+                const uint32_t right_distance = (target_device_id - chip_id + num_devices) % num_devices;
+                const uint32_t left_distance = (chip_id - target_device_id + num_devices) % num_devices;
+                forward_connection = right_distance <= left_distance;
+            } else if constexpr (RING_TOPOLOGY) {
                 const int diff = int(target_device_id) - int(chip_id);
                 const uint32_t num_hops = std::abs(diff) == 2 ? 2 : 1;
                 // To evenly distribute the load, we use the following logic:
@@ -119,12 +134,13 @@ void kernel_main() {
                 } else {
                     forward_connection = false;
                 }
-                fabric_set_unicast_route<false>(unicast_packet_header, num_hops);
             } else {
-                const uint32_t num_hops = std::abs(int(target_device_id) - int(chip_id));
-                fabric_set_unicast_route<false>(unicast_packet_header, num_hops);
                 forward_connection = target_device_id > chip_id;
             }
+            // Fabric-topology-aware route (host-computed): on 2D fabrics the routers need the
+            // target's {mesh_id, chip_id}; the old hop-count-only route never resolved there.
+            ccl_routing_utils::fabric_set_line_unicast_route(
+                unicast_packet_header, {unicast_routes[target_idx][0], unicast_routes[target_idx][1]});
             auto& fabric_conn = forward_connection ? fabric_connection.get_forward_connection()
                                                    : fabric_connection.get_backward_connection();
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
@@ -19,7 +19,8 @@ namespace ttnn::operations::experimental::ccl {
 
 namespace detail::rs_heads_fusion {
 
-std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, tt::tt_fabric::Topology topology) {
+ttsl::SmallVector<uint32_t> device_order_vector(
+    uint32_t ring_size, uint32_t ring_index, tt::tt_fabric::Topology topology) {
     ttsl::SmallVector<uint32_t> device_order;
     device_order.reserve(ring_size - 1);
     // Add all indices except ring_index
@@ -57,7 +58,11 @@ std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, t
             return a < b;
         });
     }
+    return device_order;
+}
 
+std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, tt::tt_fabric::Topology topology) {
+    const auto device_order = device_order_vector(ring_size, ring_index, topology);
     // Convert to string format
     std::string result = "{";
     for (size_t i = 0; i < device_order.size(); i++) {
@@ -65,6 +70,37 @@ std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, t
         if (i < device_order.size() - 1) {
             result += ", ";
         }
+    }
+    result += "}";
+    return result;
+}
+
+// Per-target fabric unicast route info, in the same order as device_order_array_string. Each entry
+// feeds ccl_routing_utils::fabric_set_line_unicast_route in the writer: on 2D fabrics (e.g. the BH
+// galaxy torus) that requires the target's {mesh_id, chip_id} (hop counts are meaningless to the 2D
+// routers - using them is why this op used to deadlock there); on 1D fabrics it stays {0, num_hops},
+// preserving the original behavior.
+std::string unicast_route_array_string(
+    uint32_t ring_size,
+    uint32_t ring_index,
+    tt::tt_fabric::Topology topology,
+    const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids) {
+    const auto device_order = device_order_vector(ring_size, ring_index, topology);
+    const bool is_2d_fabric = tt::tt_fabric::is_2d_fabric_config(tt::tt_fabric::GetFabricConfig());
+    std::string result = "{";
+    for (size_t i = 0; i < device_order.size(); i++) {
+        const uint32_t target = device_order[i];
+        uint32_t mesh_id = 0;
+        uint32_t chip_or_hops = 0;
+        if (is_2d_fabric) {
+            const auto& node_id = fabric_node_ids.at(target);
+            mesh_id = *node_id.mesh_id;
+            chip_or_hops = node_id.chip_id;
+        } else {
+            const uint32_t diff = std::abs(static_cast<int>(target) - static_cast<int>(ring_index));
+            chip_or_hops = (topology == tt::tt_fabric::Topology::Ring) ? std::min(diff, ring_size - diff) : diff;
+        }
+        result += "{" + std::to_string(mesh_id) + ", " + std::to_string(chip_or_hops) + "}, ";
     }
     result += "}";
     return result;
@@ -683,6 +719,10 @@ LlamaReduceScatterCreateHeadsDeviceOperation::LlamaReduceScatterCreateHeads::cre
         operation_attributes.topology == ttnn::ccl::Topology::Linear ? 0 : 1};
 
     auto writer_defines = reader_defines;
+    // Fabric-topology-aware unicast routes (indexed in DEVICE_ORDER order); see
+    // detail::rs_heads_fusion::unicast_route_array_string for why hop counts break on 2D fabrics.
+    writer_defines["UNICAST_ROUTES"] = detail::rs_heads_fusion::unicast_route_array_string(
+        ring_size, ring_index, operation_attributes.topology, fabric_node_ids);
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.cpp
@@ -38,11 +38,19 @@ void MatmulReduceScatterAsyncDeviceOperation::validate_on_program_cache_miss(
         std::visit(
             [&](const auto& config) {
                 using ProgramConfigType = std::decay_t<decltype(config)>;
+                // 2D multicast matmul (DRAM weights) is the default fused front-end. The 1D gathered ring
+                // matmul (MatmulMultiCoreReuseMultiCast1DProgramConfig) is also supported and is the path
+                // used with the prefetcher's global circular buffer: the ring matmul streams weights from
+                // the GCB and signals the reduce_scatter_minimal_async reader via the OpSignaler protocol.
                 if (not(std::is_same_v<
-                        ProgramConfigType,
-                        operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>)) {
+                            ProgramConfigType,
+                            operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                        std::is_same_v<
+                            ProgramConfigType,
+                            operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>)) {
                     TT_THROW(
-                        "Unsupported MatmulProgramConfig type for MatmulReduceScatterAsync. Needs to be 2D Multicast.");
+                        "Unsupported MatmulProgramConfig type for MatmulReduceScatterAsync. Needs to be 2D Multicast "
+                        "or 1D Multicast (gathered).");
                 }
             },
             args.matmul_struct.program_config.value());
@@ -141,9 +149,17 @@ ttnn::experimental::prim::MatmulReduceScatterAsyncDeviceOperation::tensor_return
     const std::optional<const operations::matmul::MatmulProgramConfig>& program_config,
     const std::optional<const std::string>& activation,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const ttnn::CoreGrid> core_grid) {
+    const std::optional<const ttnn::CoreGrid> core_grid,
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const std::optional<CoreRangeSet>& reduce_scatter_sub_core_grid) {
     using OperationType = ttnn::experimental::prim::MatmulReduceScatterAsyncDeviceOperation;
     std::vector<IDevice*> devices = ttnn::ccl::get_active_physical_devices(input_tensor);
+
+    // Ring size is the number of devices participating in the reduce-scatter. When a cluster_axis is
+    // provided (e.g. galaxy column RS on cluster_axis=1) this is the mesh extent along that axis, not
+    // the whole mesh. Mirrors ttnn::experimental::reduce_scatter_minimal_async.
+    uint32_t rs_ring_size = ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
 
     /* Matmul setup */
     bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.logical_shape());
@@ -169,7 +185,9 @@ ttnn::experimental::prim::MatmulReduceScatterAsyncDeviceOperation::tensor_return
             transpose_a,
             transpose_b,
             /*output_tile=*/std::nullopt,
-            /*global_cb=*/std::nullopt},
+            /*global_cb=*/
+            (global_cb.has_value() ? std::optional<tt::tt_metal::experimental::GlobalCircularBuffer>(*global_cb)
+                                   : std::nullopt)},
         {});
 
     // Not using persistent buffers not currently supported by the RSMM API
@@ -180,7 +198,7 @@ ttnn::experimental::prim::MatmulReduceScatterAsyncDeviceOperation::tensor_return
     ttnn::experimental::prim::ReduceScatterMinimalAsyncParams reduce_scatter_params{
         .dim = dim,
         .num_links = num_links,
-        .ring_size = static_cast<uint32_t>(devices.size()),
+        .ring_size = rs_ring_size,
         .output_mem_config = memory_config_rs.value_or(input_tensor.memory_config()),
         .optional_intermediate_mem_config = intermediate_memory_config_rs.value_or(input_tensor.memory_config()),
         .topology = topology,
@@ -188,14 +206,14 @@ ttnn::experimental::prim::MatmulReduceScatterAsyncDeviceOperation::tensor_return
         .barrier_semaphore = barrier_semaphore,
         .using_persistent_buffers = using_persistent_buffers,
         .sub_device_id = sub_device_id,
-        .cluster_axis = std::nullopt,
+        .cluster_axis = cluster_axis,
         .chunks_per_sync = std::nullopt,
         .num_workers_per_link = DEFAULT_WORKERS_PER_LINK,
         .num_buffers_per_channel = std::nullopt,
     };
 
     auto operation_attributes = OperationType::operation_attributes_t(
-        reduce_scatter_params, matmul_struct, reduce_scatter_core_grid_offset, devices);
+        reduce_scatter_params, matmul_struct, reduce_scatter_core_grid_offset, reduce_scatter_sub_core_grid, devices);
     auto tensor_args = OperationType::tensor_args_t{
         .input = input_tensor,
         .weight = weight_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.hpp
@@ -68,6 +68,9 @@ ttnn::experimental::prim::MatmulReduceScatterAsyncDeviceOperation::tensor_return
     const std::optional<const operations::matmul::MatmulProgramConfig>& program_config = std::nullopt,
     const std::optional<const std::string>& activation = std::nullopt,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    std::optional<const ttnn::CoreGrid> core_grid = std::nullopt);
+    std::optional<const ttnn::CoreGrid> core_grid = std::nullopt,
+    std::optional<uint32_t> cluster_axis = std::nullopt,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb = std::nullopt,
+    const std::optional<CoreRangeSet>& reduce_scatter_sub_core_grid = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation_types.hpp
@@ -20,6 +20,11 @@ struct MatmulReduceScatterAsyncParams {
     ReduceScatterMinimalAsyncParams reduce_scatter_params;
     ttnn::prim::MatmulParams matmul_struct;
     CoreCoord reduce_scatter_core_grid_offset;
+    // Optional grid confining the reduce-scatter worker cores. Unlike reduce_scatter_core_grid_offset
+    // (which is *added* to every enumerated worker core, and so overflows a grid that already reaches the
+    // last column), this restricts choose_worker_cores to a sub-set of the worker sub-device. Used by the
+    // BH prefetcher fused path to keep the reduce-scatter off the ring-matmul columns (1-3).
+    std::optional<CoreRangeSet> reduce_scatter_sub_core_grid;
     std::vector<IDevice*> devices;
 
     // Constructor required because operation structs are not default constructible.
@@ -27,10 +32,12 @@ struct MatmulReduceScatterAsyncParams {
         ReduceScatterMinimalAsyncParams reduce_scatter_params,
         ttnn::prim::MatmulParams matmul_struct,
         CoreCoord reduce_scatter_core_grid_offset,
+        std::optional<CoreRangeSet> reduce_scatter_sub_core_grid,
         std::vector<IDevice*> devices) :
         reduce_scatter_params(std::move(reduce_scatter_params)),
         matmul_struct(std::move(matmul_struct)),
         reduce_scatter_core_grid_offset(reduce_scatter_core_grid_offset),
+        reduce_scatter_sub_core_grid(std::move(reduce_scatter_sub_core_grid)),
         devices(std::move(devices)) {}
 
     static constexpr auto attribute_names = std::forward_as_tuple("matmul_struct", "reduce_scatter_core_grid_offset");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_program_factory.cpp
@@ -100,7 +100,8 @@ MatmulReduceScatterAsyncProgramFactory::cached_program_t MatmulReduceScatterAsyn
         std::nullopt,
         std::nullopt,
         args.reduce_scatter_core_grid_offset,
-        std::nullopt);
+        std::nullopt,
+        args.reduce_scatter_sub_core_grid);
 
     // Create a matmul signal info object that gets populated by the matmul kernel
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> matmul_fused_op_signaler =
@@ -112,7 +113,48 @@ MatmulReduceScatterAsyncProgramFactory::cached_program_t MatmulReduceScatterAsyn
         reduce_scatter_fused_op_signaler->fused_op_receiver_signal_semaphores,
         reduce_scatter_fused_op_signaler->fused_op_signaler_mode);
 
-    // Matmul
+    // Matmul front-end. The 1D gathered ring matmul is selected when the program config is 1D multicast
+    // (the prefetcher path with a global circular buffer). It runs on the ring worker cores and is
+    // restricted away from the reduce-scatter reader cores so the two do not clash; the ring matmul
+    // signals the RS reader via the OpSignaler REDUCE_SCATTER protocol wired above. Otherwise the 2D
+    // multicast matmul (DRAM weights) is used.
+    const bool is_1d_matmul =
+        std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(program_config);
+
+    if (is_1d_matmul) {
+        // Keep the ring matmul off the reduce-scatter reader cores (mirrors llama_rs_matmul, which passes
+        // its rs_cores as restricted_cores). The RS artifacts expose their cores as a flat list; wrap each
+        // as a single-core range to build the CoreRangeSet the 1D helper expects.
+        std::vector<CoreRange> rs_core_ranges;
+        rs_core_ranges.reserve(reduce_scatter_artifacts.all_cores.size());
+        for (const auto& c : reduce_scatter_artifacts.all_cores) {
+            rs_core_ranges.emplace_back(c, c);
+        }
+        std::optional<CoreRangeSet> rs_restricted_cores = CoreRangeSet(rs_core_ranges);
+
+        auto matmul_1d_shared_variables = ttnn::prim::matmul_multi_core_reuse_mcast_1d_optimized_helper(
+            program,
+            tensor_args.input,
+            {tensor_args.weight},
+            /*bias=*/std::nullopt,
+            {output_tensors.mm},
+            bcast_batch,
+            compute_kernel_config,
+            program_config,
+            untilize_out,
+            matmul_fused_op_signaler,
+            args.matmul_struct.global_cb,
+            sub_device_id,
+            tt::CBIndex::c_6 /*start cb index*/,
+            rs_restricted_cores /*keep matmul off the RS reader cores*/);
+
+        return cached_program_t{
+            std::move(program),
+            {.reduce_scatter_artifacts = std::move(reduce_scatter_artifacts),
+             .is_1d_matmul = true,
+             .matmul_1d_shared_variables = std::move(matmul_1d_shared_variables)}};
+    }
+
     auto matmul_cached_program = ttnn::prim::matmul_multi_core_reuse_mcast_2d_optimized_helper(
         program,
         tensor_args.input,
@@ -128,6 +170,7 @@ MatmulReduceScatterAsyncProgramFactory::cached_program_t MatmulReduceScatterAsyn
     return cached_program_t{
         std::move(matmul_cached_program.program),
         {.reduce_scatter_artifacts = std::move(reduce_scatter_artifacts),
+         .is_1d_matmul = false,
          .matmul_shared_variables = std::move(matmul_cached_program.shared_variables)}};
 }
 
@@ -140,14 +183,24 @@ void MatmulReduceScatterAsyncProgramFactory::override_runtime_arguments(
         auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
 
         std::vector<Tensor> matmul_output_tensors = {output_tensors.mm};
-        ttnn::prim::MatmulMultiCoreReuseMcast2DProgramFactory::override_runtime_arguments(
-            program,
-            shared_vars.matmul_shared_variables,
-            args.matmul_struct,
-            {.input_tensors = {tensor_args.input, tensor_args.weight},
-             .optional_input_tensors = {tensor_args.bias},
-             .optional_output_tensors = {output_tensors.mm}},
-            matmul_output_tensors);
+        if (shared_vars.is_1d_matmul) {
+            // 1D gathered matmul override refreshes the (global-CB-backed) matmul addresses in place.
+            ttnn::prim::reuse_mcast_1d_optimized_helpers::override_program_parameters(
+                shared_vars.matmul_1d_shared_variables.value(),
+                args.matmul_struct.global_cb,
+                program,
+                {{tensor_args.input, tensor_args.weight}, {}},
+                {output_tensors.mm});
+        } else {
+            ttnn::prim::MatmulMultiCoreReuseMcast2DProgramFactory::override_runtime_arguments(
+                program,
+                shared_vars.matmul_shared_variables.value(),
+                args.matmul_struct,
+                {.input_tensors = {tensor_args.input, tensor_args.weight},
+                 .optional_input_tensors = {tensor_args.bias},
+                 .optional_output_tensors = {output_tensors.mm}},
+                matmul_output_tensors);
+        }
 
         // Call reduce scatter runtime arguments override directly using artifacts
         ttnn::experimental::prim::ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_program_factory.hpp
@@ -10,12 +10,17 @@
 #include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_ring_program_factory.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_line_program_factory.hpp"
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp"
+#include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp"
 
 namespace ttnn::experimental::prim {
 
 struct MatmulReduceScatterAsyncSharedVariables {
     ttnn::experimental::prim::ReduceScatterProgramArtifacts reduce_scatter_artifacts;
-    ttnn::prim::MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t matmul_shared_variables;
+    // The fused matmul front-end is either the 2D multicast matmul (DRAM weights) or the 1D gathered ring
+    // matmul (prefetcher global circular buffer). Exactly one of the two shared-variable sets is populated.
+    bool is_1d_matmul = false;
+    std::optional<ttnn::prim::MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t> matmul_shared_variables;
+    std::optional<ttnn::prim::MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t> matmul_1d_shared_variables;
 };
 
 struct MatmulReduceScatterAsyncProgramFactory {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/matmul_reduce_scatter_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/matmul_reduce_scatter_async.cpp
@@ -31,12 +31,15 @@ std::vector<ttnn::Tensor> matmul_reduce_scatter_async(
     const std::optional<const operations::matmul::MatmulProgramConfig>& program_config,
     const std::optional<const std::string>& activation,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const ttnn::CoreGrid> core_grid) {
+    const std::optional<const ttnn::CoreGrid> core_grid,
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::CoreRangeSet>& reduce_scatter_sub_core_grid) {
     auto* mesh_device = input_tensor.device();
     TT_FATAL(mesh_device != nullptr, "Mesh device is required for matmul_reduce_scatter_async operation");
     uint32_t resolved_num_links =
-        num_links.value_or(ttnn::operations::ccl::common::get_num_links(*mesh_device, std::nullopt));
-    tt::tt_fabric::Topology usable_topology = ::ttnn::ccl::get_usable_topology(input_tensor, topology, std::nullopt);
+        num_links.value_or(ttnn::operations::ccl::common::get_num_links(*mesh_device, cluster_axis));
+    tt::tt_fabric::Topology usable_topology = ::ttnn::ccl::get_usable_topology(input_tensor, topology, cluster_axis);
     auto output_tensors = ttnn::prim::matmul_reduce_scatter_async(
         input_tensor,
         weight_tensor,
@@ -59,7 +62,10 @@ std::vector<ttnn::Tensor> matmul_reduce_scatter_async(
         program_config,
         activation,
         compute_kernel_config,
-        core_grid);
+        core_grid,
+        cluster_axis,
+        global_cb,
+        reduce_scatter_sub_core_grid);
     return {output_tensors.mm, output_tensors.reduce_scatter};
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/matmul_reduce_scatter_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/matmul_reduce_scatter_async.hpp
@@ -16,6 +16,7 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/matmul/device/config/matmul_program_config_types.hpp"
 #include "ttnn/types.hpp"
+#include <tt-metalium/global_circular_buffer.hpp>
 
 namespace ttnn::experimental {
 
@@ -41,6 +42,9 @@ std::vector<ttnn::Tensor> matmul_reduce_scatter_async(
     const std::optional<const operations::matmul::MatmulProgramConfig>& program_config = std::nullopt,
     const std::optional<const std::string>& activation = std::nullopt,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    std::optional<const ttnn::CoreGrid> core_grid = std::nullopt);
+    std::optional<const ttnn::CoreGrid> core_grid = std::nullopt,
+    std::optional<uint32_t> cluster_axis = std::nullopt,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb = std::nullopt,
+    const std::optional<tt::tt_metal::CoreRangeSet>& reduce_scatter_sub_core_grid = std::nullopt);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/matmul_reduce_scatter_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/matmul_reduce_scatter_async_nanobind.cpp
@@ -48,7 +48,10 @@ std::vector<ttnn::Tensor> matmul_reduce_scatter_async_wrapper(
     const std::optional<const operations::matmul::MatmulProgramConfig>& program_config,
     const std::optional<const std::string>& activation,
     const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const ttnn::CoreGrid> core_grid) {
+    const std::optional<const ttnn::CoreGrid> core_grid,
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::CoreRangeSet>& reduce_scatter_sub_core_grid) {
     return ttnn::experimental::matmul_reduce_scatter_async(
         input_tensor,
         weight_tensor,
@@ -71,7 +74,10 @@ std::vector<ttnn::Tensor> matmul_reduce_scatter_async_wrapper(
         program_config,
         activation,
         compute_kernel_config,
-        core_grid);
+        core_grid,
+        cluster_axis,
+        global_cb,
+        reduce_scatter_sub_core_grid);
 }
 
 }  // namespace
@@ -125,7 +131,10 @@ void bind_matmul_reduce_scatter_async(nb::module_& mod) {
         nb::arg("program_config") = nb::none(),
         nb::arg("activation") = nb::none(),
         nb::arg("compute_kernel_config") = nb::none(),
-        nb::arg("core_grid") = nb::none());
+        nb::arg("core_grid") = nb::none(),
+        nb::arg("cluster_axis") = nb::none(),
+        nb::arg("global_cb") = nb::none(),
+        nb::arg("reduce_scatter_sub_core_grid") = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
@@ -426,4 +426,10 @@ void kernel_main() {
     }
     // Reset my output ready semaphore
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
+
+    if constexpr (fuse_op) {
+        // Zero the matmul->RS signal semaphore so a program-cached re-dispatch starts fresh (see
+        // ReduceScatterOpReceiver::reset for the full rationale).
+        matmul_receiver.reset();
+    }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -304,4 +304,10 @@ void kernel_main() {
         sem_target = 0;
         sem2_target = 0;
     }
+
+    if constexpr (fuse_op) {
+        // Zero the matmul->RS signal semaphore now that every batch has been consumed, so the next
+        // (program-cached) dispatch of this fused op does not inherit a stale accumulated value.
+        matmul_receiver.reset();
+    }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_line_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_line_program_factory.hpp
@@ -62,7 +62,8 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     std::optional<uint32_t> num_workers_per_direction_opt,
     std::optional<uint32_t> num_buffers_per_channel,
     CoreCoord core_grid_offset,
-    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config);
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
 
 // Override runtime arguments helper for line topology
 void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -357,7 +357,8 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     std::optional<uint32_t> num_workers_per_direction_opt,
     std::optional<uint32_t> num_buffers_per_channel,
     const CoreCoord core_grid_offset,
-    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    const std::optional<CoreRangeSet>& sub_core_grid) {
     auto* mesh_device = input_tensor.device();
     [[maybe_unused]] bool is_first_chip = ring_index == 0;
     [[maybe_unused]] bool is_last_chip = ring_index == ring_size - 1;
@@ -407,7 +408,7 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
         sender_device_coord, forward_coord, backward_coord, ring_size - 1, ring_size - 1, mesh_device);
 
     const auto [all_core_range, all_cores] =
-        choose_worker_cores(num_links, num_cores_per_link, mesh_device, sub_device_id, core_grid_offset);
+        choose_worker_cores(num_links, num_cores_per_link, mesh_device, sub_device_id, core_grid_offset, sub_core_grid);
 
     const auto mux_connection_valid = [&backward_coord, &forward_coord](const uint32_t dir) {
         return (!dir && backward_coord.has_value()) || (dir && forward_coord.has_value());
@@ -1630,7 +1631,8 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     std::optional<uint32_t> num_workers_per_direction_opt,
     std::optional<uint32_t> num_buffers_per_channel,
     CoreCoord core_grid_offset,
-    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    const std::optional<CoreRangeSet>& sub_core_grid) {
     return ::ttnn::build_ring_reduce_scatter_minimal_async_program_artifacts(
         program,
         input_tensor,
@@ -1653,7 +1655,8 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
         num_workers_per_direction_opt,
         num_buffers_per_channel,
         core_grid_offset,
-        compute_kernel_config);
+        compute_kernel_config,
+        sub_core_grid);
 }
 
 ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_artifacts(
@@ -1678,7 +1681,8 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     std::optional<uint32_t> num_workers_per_direction_opt,
     std::optional<uint32_t> num_buffers_per_channel,
     CoreCoord core_grid_offset,
-    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    [[maybe_unused]] const std::optional<CoreRangeSet>& sub_core_grid) {
     return ::ttnn::build_line_reduce_scatter_minimal_async_program_artifacts(
         program,
         input_tensor,
@@ -1833,7 +1837,8 @@ RingReduceScatterMeshWorkloadFactory::create_at(
         operation_attributes.num_workers_per_link,
         operation_attributes.num_buffers_per_channel,
         CoreCoord(0, 0),
-        operation_attributes.compute_kernel_config);
+        operation_attributes.compute_kernel_config,
+        std::nullopt);
 
     return {std::move(program), std::move(shared_vars)};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_ring_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_ring_program_factory.hpp
@@ -62,7 +62,8 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     std::optional<uint32_t> num_workers_per_direction_opt,
     std::optional<uint32_t> num_buffers_per_channel,
     CoreCoord core_grid_offset,
-    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config);
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
 
 // Override runtime arguments helper for ring topology
 void ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
@@ -14,6 +14,7 @@
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
+#include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "reshard_writer.hpp"
@@ -57,7 +58,12 @@ void kernel_main() {
     // worker count). The NoC ack counter must be credited against the
     // rectangle size or noc_async_write_barrier() will wait forever.
     constexpr uint32_t num_mcast_dests = get_compile_time_arg_val(24);
-    constexpr auto gamma_args = TensorAccessorArgs<25>();
+    // Host-computed fabric multicast route info (2D-fabric aware; see program factory).
+    constexpr ccl_routing_utils::line_multicast_route_info_t forward_multicast_route_info =
+        ccl_routing_utils::get_line_multicast_route_info_from_args<25>();
+    constexpr ccl_routing_utils::line_multicast_route_info_t backward_multicast_route_info =
+        ccl_routing_utils::get_line_multicast_route_info_from_args<25 + ccl_routing_utils::num_line_multicast_args>();
+    constexpr auto gamma_args = TensorAccessorArgs<25 + 2 * ccl_routing_utils::num_line_multicast_args>();
 
     Noc noc_obj;
     CircularBuffer cb_packet_header(reserved_packet_header_cb_id);
@@ -142,10 +148,8 @@ void kernel_main() {
             reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
         volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
             reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
-        pkt_hdr_forward->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
-        pkt_hdr_backward->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+        ccl_routing_utils::fabric_set_line_multicast_route(pkt_hdr_forward, forward_multicast_route_info);
+        ccl_routing_utils::fabric_set_line_multicast_route(pkt_hdr_backward, backward_multicast_route_info);
         fabric_connection.open_finish();
         // 1. mcast via fabric to remote tensor addresses
         uint32_t tiles_read = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
@@ -125,6 +125,24 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
         }
     }
 
+    // Fabric-topology-aware multicast route info for the stats all-gather. The legacy writer built raw
+    // 1D MulticastRoutingCommandHeaders, which are no-ops on 2D fabrics (e.g. the Blackhole galaxy
+    // 2D torus, where PACKET_HEADER_TYPE is HybridMeshPacketHeader and routes need dst mesh/chip ids
+    // plus per-direction hop counts). Emit host-computed route info the same way the proven
+    // all_gather_async writers do, and let ccl_routing_utils pick the encoding per fabric type
+    // (1D low-latency headers keep the exact old behavior).
+    const auto& forward_device_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+        a, mesh_coord, 1, topology, operation_attributes.cluster_axis);
+    const auto& backward_device_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+        a, mesh_coord, -1, topology, operation_attributes.cluster_axis);
+    auto [mcast_forward_args, mcast_backward_args] = ttnn::ccl::get_forward_backward_line_mcast_configuration(
+        mesh_coord,
+        forward_device_coord,
+        backward_device_coord,
+        num_targets_forward,
+        num_targets_backward,
+        mesh_device);
+
     // Get worker cores, assuming 1 worker per link
     ShardSpec shard_spec = a.shard_spec().value();
     CoreRangeSet all_cores = shard_spec.grid;
@@ -692,6 +710,11 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
     writer_compile_time_args.push_back(signaling_cb);
     writer_compile_time_args.push_back(num_blocks);
     writer_compile_time_args.push_back(num_mcast_dests);
+    // Multicast route info (6 args per direction), consumed by ccl_routing_utils in the writer.
+    writer_compile_time_args.insert(
+        writer_compile_time_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
+    writer_compile_time_args.insert(
+        writer_compile_time_args.end(), mcast_backward_args.begin(), mcast_backward_args.end());
     tt::tt_metal::TensorAccessorArgs(gamma ? gamma->buffer() : nullptr).append_to(writer_compile_time_args);
 
     tt::tt_metal::NOC reader_noc = NOC::NOC_1;

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_nanobind.cpp
@@ -24,9 +24,15 @@ ttnn::Tensor fast_reduce_nc_wrapper(
     const ttsl::SmallVector<int32_t>& dims,
     const std::optional<const ttnn::Tensor>& output,
     const ttnn::MemoryConfig& memory_config,
-    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
+    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids) {
     return ttnn::experimental::reduction::fast_reduce_nc(
-        input, ttsl::Span<const int32_t>(dims.data(), dims.size()), output, memory_config, compute_kernel_config);
+        input,
+        ttsl::Span<const int32_t>(dims.data(), dims.size()),
+        output,
+        memory_config,
+        compute_kernel_config,
+        sub_core_grids);
 }
 
 }  // namespace
@@ -43,7 +49,8 @@ void bind_fast_reduce_nc(nb::module_& mod) {
         nb::arg("dims").noconvert() = ttsl::SmallVector<int32_t>(),
         nb::arg("output").noconvert() = nb::none(),
         nb::arg("memory_config").noconvert() = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        nb::arg("compute_kernel_config").noconvert() = nb::none());
+        nb::arg("compute_kernel_config").noconvert() = nb::none(),
+        nb::arg("sub_core_grids").noconvert() = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::reduction::detail

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -2278,6 +2278,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
         (std::uint32_t)in1_block_width_num_pages,
         (std::uint32_t)in1_shard_width_in_dram,
         (std::uint32_t)fused_op_signaler.has_value(),
+        (std::uint32_t)(fused_op_signaler.has_value() && fused_op_signaler->is_reduce_scatter()),
     };
     tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
 
@@ -2346,6 +2347,16 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
                 resident_blocks);
             mm_in1_kernel_defines["STREAMING_IN1"] = "1";
             mm_kernel_defines["STREAMING_IN1"] = "1";
+            // Fused reduce_scatter_minimal_async: on the streaming path the compute kernel otherwise
+            // has no way to tell the in1 reader that this batch's output is fully packed (the
+            // non-streaming compute->reader cb_sync handshake is compiled out). Without it the reader
+            // would signal the reduce-scatter off the in1 drain alone, letting RS read output tiles the
+            // packer has not written yet (systematic PCC loss). Re-enable a per-batch cb_sync push in
+            // compute, matched by a wait in the reader, only for the RS fusion so the plain prefetcher
+            // path is untouched.
+            if (fused_op_signaler.has_value() && fused_op_signaler->is_reduce_scatter()) {
+                mm_kernel_defines["RS_STREAMING_SYNC"] = "1";
+            }
         }
     } else {
         TT_FATAL(!stream_in1, "stream_in1 requires a DRAM-sender global circular buffer (use_global_cb)");
@@ -2385,8 +2396,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     tt_metal::NOC_MODE noc_mode =
         use_dedicated_noc ? tt_metal::NOC_MODE::DM_DEDICATED_NOC : tt_metal::NOC_MODE::DM_DYNAMIC_NOC;
 
-    // Init the signaler
-    if (fused_op_signaler.has_value()) {
+    // Init the signaler. The llama reduce-scatter path initializes here (it signals from all matmul cores
+    // via a privileged core). The reduce_scatter_minimal_async path (is_reduce_scatter) instead uses the
+    // OpSignaler worker-sync protocol and is initialized below once the worker core list is known.
+    if (fused_op_signaler.has_value() && !fused_op_signaler->is_reduce_scatter()) {
         ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
         signaler.init_llama_rs_cores_mm(all_cores, program, device, 0);
     }
@@ -2435,6 +2448,14 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     auto all_cores_vec = corerange_to_cores(all_cores, std::nullopt, row_major);
     auto worker_cores_vec = corerange_to_cores(all_worker_cores, std::nullopt, row_major);
     auto hop_cores_vec = corerange_to_cores(hop_cores, std::nullopt, row_major);
+
+    // For the reduce_scatter_minimal_async fusion, initialize the OpSignaler protocol now that the matmul
+    // worker cores are known: the workers sync among themselves and the master signals the RS reader. The
+    // worker sync semaphore is created over the worker bounding box (extra cores in the box are harmless).
+    if (fused_op_signaler.has_value() && fused_op_signaler->is_reduce_scatter()) {
+        ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
+        signaler.init_fused_op(program, device, all_worker_cores.bounding_box(), worker_cores_vec);
+    }
     for (auto core : all_cores_vec) {
         auto all_worker_cores_iter = std::find(worker_cores_vec.begin(), worker_cores_vec.end(), core);
         auto hop_cores_iter = std::find(hop_cores_vec.begin(), hop_cores_vec.end(), core);
@@ -2454,7 +2475,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
             // in1
             std::vector<uint32_t> mm_kernel_in1_sender_writer_args;
             mm_kernel_in1_sender_writer_args.push_back((std::uint32_t)core_type);
-            if (fused_op_signaler.has_value()) {
+            // Idle cores participate in the llama privileged-core signaling, but are NOT matmul workers in
+            // the reduce_scatter_minimal_async OpSignaler protocol, so they push no signaling args there.
+            if (fused_op_signaler.has_value() && !fused_op_signaler->is_reduce_scatter()) {
                 ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
                 signaler.push_llama_rs_rt_args_for_mm(mm_kernel_in1_sender_writer_args, core, in1_noc, device);
             }
@@ -2648,7 +2671,12 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
         }
         if (fused_op_signaler.has_value()) {
             ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
-            signaler.push_llama_rs_rt_args_for_mm(mm_in1_args, core, in1_noc, device);
+            if (signaler.is_reduce_scatter()) {
+                // OpSignaler args: match this worker to its index in matmul_worker_cores via (y, x).
+                signaler.push_matmul_fused_op_rt_args(mm_in1_args, core.y, core.x);
+            } else {
+                signaler.push_llama_rs_rt_args_for_mm(mm_in1_args, core, in1_noc, device);
+            }
         }
         tt_metal::SetRuntimeArgs(program, mm_kernel_in1_sender_writer_id, core, mm_in1_args);
 
@@ -2691,7 +2719,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
         // in1
         std::vector<uint32_t> mm_kernel_in1_sender_writer_args;
         mm_kernel_in1_sender_writer_args.push_back((std::uint32_t)core_type);
-        if (fused_op_signaler.has_value()) {
+        // Hop cores relay the ring but are not matmul workers; they do not signal in the RS-minimal protocol.
+        if (fused_op_signaler.has_value() && !fused_op_signaler->is_reduce_scatter()) {
             ttnn::experimental::ccl::MatmulFusedOpSignaler& signaler = fused_op_signaler.value();
             signaler.push_llama_rs_rt_args_for_mm(mm_kernel_in1_sender_writer_args, core, in1_noc, device);
         }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -512,5 +512,13 @@ void kernel_main() {
         UNPACK((update_rd_ptr_to_ring_index(
             in1_cb_id, in1_block_size_bytes, ring_size, in1_tensor_split)));  // update to next tensor addr
 #endif
+#if defined(ENABLE_GLOBAL_CB) && defined(STREAMING_IN1) && defined(RS_STREAMING_SYNC)
+        // Fused reduce_scatter handshake (streaming path): the whole batch's output is now packed into
+        // mm_out_cb, so publish a cb_sync credit to the in1 reader. The reader waits on this before it
+        // increments the reduce_scatter reader's semaphore, guaranteeing RS never reads output tiles the
+        // packer has not written. Mirrors the non-streaming release above.
+        sync_buf.reserve_back(1);
+        sync_buf.push_back(1);
+#endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -15,6 +15,7 @@
 #include "api/tensor/noc_traits.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 
 enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 
@@ -85,9 +86,13 @@ void kernel_main() {
 
     uint32_t rt_args_idx = 0;
     constexpr bool needs_signaler = get_compile_time_arg_val(11) == 1;
+    // When set, the fused reduce-scatter uses the reduce_scatter_minimal_async OpSignaler protocol
+    // (worker cores sync, master increments the RS reader's semaphore) instead of the llama do_signaling
+    // multicast. Idle/hop cores are not matmul workers and do not participate in that sync.
+    constexpr bool fuse_op_reduce_scatter = get_compile_time_arg_val(12) == 1;
     uint32_t core_type = get_arg_val<uint32_t>(rt_args_idx++);
     if (core_type == (uint32_t)CORE_TYPE::IDLE_CORE || core_type == (uint32_t)CORE_TYPE::HOP_CORE) {
-        if constexpr (needs_signaler) {
+        if constexpr (needs_signaler && !fuse_op_reduce_scatter) {
             Noc early_noc;
             do_signaling(early_noc, rt_args_idx);
             early_noc.async_write_barrier();
@@ -110,7 +115,7 @@ void kernel_main() {
     constexpr uint32_t sync_cb = get_named_compile_time_arg_val("cb_sync");
     constexpr uint32_t sync_cb2 = get_named_compile_time_arg_val("cb_sync2");
     constexpr uint32_t remote_cb_id = get_named_compile_time_arg_val("cb_remote");
-    constexpr auto in1_args = TensorAccessorArgs<12>();
+    constexpr auto in1_args = TensorAccessorArgs<13>();
 
     const uint32_t in1_block_num_tiles = in1_block_height_in_tiles * in1_block_width_in_tiles;
 
@@ -134,6 +139,14 @@ void kernel_main() {
         in1_shard_width_offset_bytes = in1_shard_width_in_dram * in1_single_tile_size_bytes;
         in1_dram_shard_block_size_bytes = in1_shard_width_offset_bytes * in1_block_height_in_tiles;
         dram_read_offset_bytes = dram_read_offset * in1_block_width_in_tiles * in1_single_tile_size_bytes;
+    }
+
+    // Fused reduce_scatter_minimal_async signaler (worker cores only; idle/hop returned early). Its
+    // runtime args follow the normal per-worker args. Constructed once here, then the matmul workers
+    // sync and the master increments the RS reader's semaphore once per batch (wait_for_matmul_batch).
+    OpSignaler op_signaler;
+    if constexpr (needs_signaler && fuse_op_reduce_scatter) {
+        op_signaler = OpSignaler(rt_args_idx);
     }
 
     for (uint32_t b = 0; b < batch; ++b) {
@@ -186,7 +199,15 @@ void kernel_main() {
             experimental::remote_cb_pop_front(remote_cb_id, 1);
         }
         if constexpr (needs_signaler) {
-            if (b == 0) {
+            if constexpr (fuse_op_reduce_scatter) {
+                // Wait for compute to publish "batch output fully packed" (cb_sync) before releasing the
+                // reduce_scatter, otherwise RS could read output tiles the packer has not written yet.
+                // On the streaming path the compute kernel emits this credit only under RS_STREAMING_SYNC,
+                // which the factory sets exactly when this fused-RS reader is active.
+                cb_sync.wait_front(1);
+                cb_sync.pop_front(1);
+                op_signaler.synchronize_workers_and_signal_op(0);
+            } else if (b == 0) {
                 do_signaling(noc, rt_args_idx);
             }
         }
@@ -259,7 +280,9 @@ void kernel_main() {
 #endif
         // Signal Here
         if constexpr (needs_signaler) {
-            if (b == 0) {
+            if constexpr (fuse_op_reduce_scatter) {
+                op_signaler.synchronize_workers_and_signal_op(0);
+            } else if (b == 0) {
                 do_signaling(noc, rt_args_idx);
             }
         }

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -355,7 +355,9 @@ void kernel_main() {
     for (uint32_t k = 0; k < outer_dim_units; ++k) {
         if (is_reduce_core) {
             // done_sem is zero-initialized by the dispatcher before the kernel
-            // launches, so the k == 0 iteration needs no reset. Resetting it here
+            // launches (and restored to zero at the end of this kernel so trace
+            // replays see the same state), so the k == 0 iteration needs no
+            // reset. Resetting it here
             // at k == 0 would race the worker cores' done_sem.up() increments:
             // those increments are ungated at k == 0 (the start_sem handshake
             // below only orders k > 0), so a reset could clobber an increment that
@@ -502,4 +504,25 @@ void kernel_main() {
             noc.async_write_barrier();
         }
     }  // if constexpr (reduce_all)
+
+    // Restore both semaphores to their initial (zero) state for the next launch. The k == 0
+    // iteration relies on done_sem starting at 0, but that only holds on a fresh enqueue: trace
+    // replay does not re-run the dispatcher's semaphore initialization, so without this reset the
+    // previous run's final count (num_cores) is still present, the reducer's k == 0 wait passes
+    // immediately, and it collates stale partials (observed as argmax indices from the wrong
+    // core's slice on the first outer row). These resets are race-free: the final done_sem.wait
+    // above guarantees every worker's increment for the last iteration has landed, and workers
+    // never read start_sem again after their final wait.
+    if (is_reduce_core) {
+        done_sem.set(0);
+        start_sem.set(0);
+        if constexpr (num_cores > 1) {
+            start_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
+                noc, start_core_x0, start_core_y0, end_core_x0, end_core_y0, num_cores0);
+            if (num_cores1 > 0) {
+                start_sem.set_multicast(noc, start_core_x1, start_core_y1, end_core_x1, end_core_y1, num_cores1);
+            }
+            noc.async_write_barrier();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Brings the Qwen3-32B Blackhole Galaxy decode path from the no-fused-op prefetcher baseline to **56.92 tok/s/user** (batch 32, 17.57 ms/token) by porting the fused galaxy CCL ops to the BH 2D-torus fabric and fixing the BH-specific accuracy/placement issues along the way. Accuracy is verified at **93% Top-1 / 99% Top-5** on the 511-token teacher-forcing test with all fused ops enabled.

The fused-CCL enablement is gated behind env flags (`QWEN_BH_FUSED_RS_MATMUL`, `QWEN_BH_FUSED_QKV_RS`, `QWEN_BH_FUSED_AG_CONCAT`) on top of the stable `use_unfused_ccl` prefetcher path; Wormhole behavior is unchanged.

## Optimizations and measured impact

Decode, batch 32, steady state. Each row was measured with a full demo run on a BH Galaxy; accuracy re-verified at every checkpoint.

| # | Optimization | tok/s/user |
|---|---|---|
| 0 | Baseline: dram_prefetcher decode + unfused CCLs | 44.8 |
| 1 | lm_head DRAM sharding + sampling gather sub-device race fix (accuracy 27% -> 89% Top-1) | 47.6 |
| 2 | Force-argmax sampling grid widened to the full 100-core worker sub-device | 50.7 |
| 3 | Distributed force-argmax (per-device argmax + tiny cross-column combine) | 52.8 |
| 4 | `rms_allgather` (fused distributed norm) ported to 2D fabric + residual grid moved to LN cols | 54.4 |
| 5 | FF1/FF3 via fused `llama_rs_matmul` (2D-fabric port + packet workers moved off the ring) | 56.4 |
| 6 | QKV via `llama_reduce_scatter_create_heads` + fused-qk rotary; SDPA output via `all_gather_concat` (both ported to 2D fabric) | 56.7 |
| 7 | Paged SDPA k_chunk 64 -> 128 (halves flash-decode K iterations, K/V CBs still clear the global-CB L1 clash) | **56.9** |

## Key technical changes

- **2D-fabric routing ports** (`rms_allgather`, `llama_reduce_scatter`, `llama_reduce_scatter_create_heads`, `all_gather_concat_heads_fused`): the writers used 1D hop-count unicast / 1D multicast headers that no-op or deadlock on the BH 2D-torus fabric (`HybridMeshPacketHeader`). Factories now pass host-computed `{mesh_id, chip_id}` line-unicast/multicast route args (`ccl_routing_utils`) to the kernels.
- **Injection-direction fix** (create-heads writer): on 2D fabrics the source-computed route must match the EDM connection it is injected into; direction is now shortest-path-forward-on-ties (matching the routing table) instead of chip-parity load balancing, which silently dropped half the 2-hop packets and wedged the eth routers.
- **`all_gather_concat` factory generalization**: dynamic concat-arg cores, sender-worker exclusion by actual cores, runtime-arg NOC coordinates and mcast dest counts (previously hardcoded WH virtual coords), dynamic semaphore mcast ranges.
- **BH core placement**: RS packet workers moved to cols 5-6 (off the ring-matmul cores), sharded qk-norm grids to cols 7-10 (clear of the resident global CB), residual/LN grids aligned.
- Unit tests for all four ported ops (eager + trace) under `models/demos/llama3_70b_galaxy/tests/unit_tests/`.

## Negative result (documented in-code)

Routing the standalone w3 reduce-scatter through the ported `llama_reduce_scatter` measured ~1 ms/token *slower* than `reduce_scatter_minimal_async` in the full model (it serializes against the fused `Matmul_RS` packet workers), despite the standalone op being ~3x faster. Kept `rs_minimal`; note left in `llama_ccl.py`.

## Where the remaining time goes

Traced-decode Tracy profile (all fused ops): worker sub-device is ~94% busy. The ring matmuls (~6.3 ms/token) are paced by the prefetcher stream rate (~134 GB/s effective vs >500 GB/s DRAM), and the CCLs are at their 2-link fabric floors. The next big lever is BH `dram_prefetcher` streaming throughput, tracked in `BH_FUSED_RS_MATMUL_WIP.md`.

## Test plan

- [x] Demo perf: batch-32, 64 tokens -> 17.57 ms @ 56.92 tok/s/user
- [x] Accuracy: 511-token teacher forcing -> 93% Top-1 / 99% Top-5 (all fused ops), 92%/100% with k_chunk 128
- [x] Unit tests (eager + trace): `test_bh_fused_rms_allgather`, `test_bh_llama_reduce_scatter`, `test_bh_llama_rs_matmul`, `test_bh_llama_rs_create_heads`, `test_bh_all_gather_concat`
- [ ] WH TG regression run (fused ops untouched on 1D fabric, but worth a CI pass)

Made with [Cursor](https://cursor.com)