### PR TITLE
emule: bind per-core CB config by core_ranges membership (tt-emule-blaze#153)

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2837,7 +2837,8 @@ extern "C" void __emule_fabric_teleport(const void* packet_header, const void* p
 // ---------------------------------------------------------------------------
 // setup_core_state: Configure CBs and semaphores per core, build CoreSetup list.
 // ---------------------------------------------------------------------------
-// Initialize CB-sync state on a core from the program's circular buffer list.
+// Initialize a core's CB-sync state: configure each cb_id from the CB that owns
+// it locally (a CB whose core_ranges() contain this core).
 static void init_core_cb_sync(
     tt_emule::Core* core,
     detail::ProgramImpl& impl,
@@ -2845,9 +2846,8 @@ static void init_core_cb_sync(
     std::vector<uint64_t>& persistent_cb_ranges) {
     core->reset_cb_sync();
     // Record this core's globally-allocated (persistent) CB extents so Object-Intent
-    // exempts the kernel's writes anywhere in them (see §12). Its own pass — not folded
-    // into the configure lambda below, which also walks remote pass-2 CBs — to keep the
-    // exempt set exactly the local ones.
+    // exempts kernel writes anywhere in them (§12). Separate pass so the exempt set
+    // stays exactly the local CBs.
     for (auto& cb_impl : impl.circular_buffers_on_core(logical_core)) {
         if (cb_impl->globally_allocated()) {
             uint32_t start = cb_impl->address();
@@ -2873,16 +2873,10 @@ static void init_core_cb_sync(
                 lc.x, lc.y, idx, cb_addr, page_size, num_pages, (void*)base);
         }
     };
-    // Pass 1: CBs allocated on this core take precedence (own addresses).
+    // core_ranges-scoped, no global fill: blaze shares one cb_id across CBs on disjoint
+    // grids, so binding a CB whose grid excludes this core would install the wrong
+    // (addr, num_pages) for that shared cb_id.
     for (auto& cb_impl : impl.circular_buffers_on_core(logical_core)) {
-        configure(cb_impl, logical_core);
-    }
-    // Pass 2: register the remaining program CBs at their global L1 address so a
-    // kernel can get_write_ptr() a CB allocated only on a remote core (silicon CB
-    // addresses are program-global). Needed for multi-core topk, where local cores
-    // NOC-write into the final core's final_*_cb. Used only as cross-core NOC
-    // targets here; the masked L1 offset is what __emule_resolve_noc_addr routes.
-    for (auto& cb_impl : impl.circular_buffers()) {
         configure(cb_impl, logical_core);
     }
 }


### PR DESCRIPTION
## What

Fixes the emule per-core circular-buffer mis-binding (`tt-emule-blaze#153`).

`init_core_cb_sync` (`tt_metal/impl/emulation/emulated_program_runner.cpp`)
configured each core's `cb_id → (addr, page_size, num_pages)` in two passes:

1. **pass 1** over `impl.circular_buffers_on_core(logical_core)` — CBs whose
   `core_ranges()` contain the core (correct);
2. **pass 2** over **all** `impl.circular_buffers()`, first-wins-filling any
   still-unconfigured index from *any* program CB — **including CBs whose grid
   excludes the core**.

blaze legitimately shares one `cb_id` (buffer index) across multiple CBs on
**disjoint grids** with different `(address, num_pages, page_size)` (via
`_try_reuse_cb_id`). Pass 2's first-wins therefore bound the **wrong** config on
non-owning cores — a wrong `get_write_ptr` offset and a wrong
`cb_reserve_back` / `setup_sharded_buffer` capacity for the shared `cb_id`,
surfacing as `CB Reservation Overflow` aborts / hangs (e.g. `test_dflash_postsdpa`).
This passes on real silicon, so it is an emule modeling gap, not a blaze bug.

## Fix

Remove pass 2. A core is now configured for a `cb_id` **iff a CB whose
`core_ranges()` contains it owns that index locally**. This matches:

- **silicon** — `CircularBufferCommandGenerator::construct_commands`
  (`tt_metal/impl/program/dispatch.cpp`) writes a CB's config only to cores in its
  `core_range_set`; there is no first-wins fill of unrelated indices;
- **blaze** — its per-grid `_cb_descriptors` (one `buffer_index` legitimately spans
  multiple entries on disjoint `core_ranges`).

blaze packs disjoint-grid same-`cb_id` CBs so at most one contains a given core →
the binding is unambiguous. Legitimate cross-core `get_write_ptr` users (multi-core
topk gather, mcast) declare the target CB on **every** core that writes it, so those
cores are already in the CB's grid and covered by pass 1 — which is why pass 2 is
removable without regressing them.

## Verification (emule build)

- **Curated p150 gate** (20 files, 483 tests): **481 passed, 2 skipped, 0 failed**;
  zero `num_pages=0` / CB-overflow / lost-wakeup signatures.
- **`test_cross_core_topk_merge`** (p150, the path pass 2 existed for): 9 passed
  (4 pre-existing blaze-side build-time failures, **identical on a pristine build**).
- **`test_mcast`** (loudbox): 3 passed.
- On the `dflash_postsdpa` program this removes **20,632** wrong first-wins installs
  with **no** newly-unconfigured index (no `num_pages=0` abort), confirming the
  removed bindings were unused.

## Note — does not fully unblock `test_dflash_postsdpa`

`#153` framed this as blocking `test_dflash_postsdpa`. This PR fixes the CB
mis-binding, but the test is **additionally** blocked by a separate, pre-existing
cross-core arrival-semaphore lost-wakeup, isolated and filed as
`tenstorrent/tt-emule-blaze#159` (same class as `#124`/`#72`). That is out of scope
here.

## Relationship to #51293

`#51293` carries this same one-commit fix onto the `emule-blaze-metal-fork` branch
(the emule lineage's home). This PR targets **`main`**, where the emulated runner
also still carries the buggy pass-2 code.

Refs: `tenstorrent/tt-emule-blaze#153`, `tenstorrent/tt-emule-blaze#159`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/emule-153-cb-core-ranges-binding-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/emule-153-cb-core-ranges-binding-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/emule-153-cb-core-ranges-binding-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/emule-153-cb-core-ranges-binding-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=xchin/emule-153-cb-core-ranges-binding-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:xchin/emule-153-cb-core-ranges-binding-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/emule-153-cb-core-ranges-binding-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/emule-153-cb-core-ranges-binding-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/emule-153-cb-core-ranges-binding-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/emule-153-cb-core-ranges-binding-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/emule-153-cb-core-ranges-binding-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/emule-153-cb-core-ranges-binding-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/emule-153-cb-core-ranges-binding-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/emule-153-cb-core-ranges-binding-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/emule-153-cb-core-ranges-binding-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/emule-153-cb-core-ranges-binding-main)