### PR TITLE
[Quasar] Fence the TILE_SHAPE_IDX GPR write with sync_regfile_write

### DIFF
--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
@@ -166,6 +166,7 @@ inline void _set_tile_shape_idx_gpr_(const std::uint32_t num_rows_per_tile)
             ? 6
             : ((num_rows_per_tile == 32) ? 5 : ((num_rows_per_tile == 16) ? 4 : ((num_rows_per_tile == 8) ? 3 : ((num_rows_per_tile == 4) ? 2 : 1))));
     ckernel::regfile[p_gpr_math::TILE_SHAPE_IDX] = tile_shape_idx;
+    ckernel::sync_regfile_write(p_gpr_math::TILE_SHAPE_IDX);
 }
 
 /**


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`_set_tile_shape_idx_gpr_` (`common/inc/cmath_common.h`) caches the tile-shape shift exponent
in a Tensix GPR with a raw MMIO store:
`ckernel::regfile[p_gpr_math::TILE_SHAPE_IDX] = tile_shape_idx;`

`_set_dst_write_addr_by_rows_` reads that GPR back on every per-tile call to compute the
Dest reg base. A raw `regfile[]` store is not ordered against a later read, and there was no fence between
them. 


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/gpr_write_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/gpr_write_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/gpr_write_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/gpr_write_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amokan/gpr_write_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amokan/gpr_write_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/gpr_write_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/gpr_write_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/gpr_write_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/gpr_write_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/gpr_write_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/gpr_write_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/gpr_write_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/gpr_write_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/gpr_write_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/gpr_write_sync)