### PR TITLE
Close stale PRs: upgrade actions/stale to v11, scan oldest-first, raise operations budget

### DIFF
--- a/.github/workflows/close-stale-prs.yaml
+++ b/.github/workflows/close-stale-prs.yaml
@@ -31,9 +31,13 @@ jobs:
             to reopen it or open a new PR whenever you're ready to continue.
           stale-pr-label: "stale"
           exempt-draft-pr: false
-          # Each closed PR costs ~5 operations (fetch events, fetch comments,
-          # label, comment, close), so 450 closes roughly 85 PRs per run. Closing
-          # a PR issues 3 content-generating API requests, and GitHub's secondary
-          # rate limit allows ~500 of those per hour -- 450 keeps us under it.
-          operations-per-run: 450
+          # Sized to close at most ~150 PRs per run. Closing one PR costs 5
+          # operations: GET list-events, GET list-comments, POST add-label,
+          # POST create-comment, PATCH close. The three POST/PATCH calls count
+          # against GitHub's secondary rate limit of 500 content-generating
+          # requests per hour, so 150 PRs x 3 = 450 -- 90% of the ceiling,
+          # leaving headroom for other automation acting on this repo.
+          # Paging through open PRs costs a further ~1 operation per 100
+          # scanned, so 750 lands just under the 150-PR cap rather than over.
+          operations-per-run: 750
           remove-stale-when-updated: true

--- a/.github/workflows/close-stale-prs.yaml
+++ b/.github/workflows/close-stale-prs.yaml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'tenstorrent/tt-metal'
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-pr-stale: 32
@@ -31,5 +31,9 @@ jobs:
             to reopen it or open a new PR whenever you're ready to continue.
           stale-pr-label: "stale"
           exempt-draft-pr: false
-          operations-per-run: 100
+          # Each closed PR costs ~5 operations (fetch events, fetch comments,
+          # label, comment, close), so 450 closes roughly 85 PRs per run. Closing
+          # a PR issues 3 content-generating API requests, and GitHub's secondary
+          # rate limit allows ~500 of those per hour -- 450 keeps us under it.
+          operations-per-run: 450
           remove-stale-when-updated: true

--- a/.github/workflows/close-stale-prs.yaml
+++ b/.github/workflows/close-stale-prs.yaml
@@ -31,13 +31,25 @@ jobs:
             to reopen it or open a new PR whenever you're ready to continue.
           stale-pr-label: "stale"
           exempt-draft-pr: false
-          # Sized to close at most ~150 PRs per run. Closing one PR costs 5
-          # operations: GET list-events, GET list-comments, POST add-label,
-          # POST create-comment, PATCH close. The three POST/PATCH calls count
-          # against GitHub's secondary rate limit of 500 content-generating
-          # requests per hour, so 150 PRs x 3 = 450 -- 90% of the ceiling,
-          # leaving headroom for other automation acting on this repo.
-          # Paging through open PRs costs a further ~1 operation per 100
-          # scanned, so 750 lands just under the 150-PR cap rather than over.
+          # Scan oldest PRs first. The action defaults to descending, i.e.
+          # newest-created first, which is the least likely to be stale: the
+          # newest 485 open PRs here contain zero stale candidates, so the
+          # scan wasted 13 pages before finding anything. Ascending reaches
+          # 150 stale PRs in ~11 pages instead of ~19, and closes genuinely
+          # abandoned PRs first rather than newer ones that happen to qualify.
+          ascending: true
+          # This is a budget of API operations, NOT a count of PRs. Closing one
+          # PR costs 5 operations: GET list-events, GET list-comments, POST
+          # add-label, POST create-comment, PATCH close. Paging costs 1 more per
+          # 100 items scanned; PRs that turn out not to be stale cost nothing.
+          #
+          # The 3 POST/PATCH calls count against GitHub's secondary rate limit
+          # of 500 content-generating requests per hour, which is not raised by
+          # our enterprise plan. Capping at 150 PRs per run gives 150 x 3 = 450
+          # writes, 90% of that ceiling, leaving headroom for other automation.
+          #
+          # The action breaks out of its loop only once consumed >= this value,
+          # so it can overrun by up to 4 operations. 750 therefore closes at
+          # most 150 PRs for any page count, and ~148 in practice.
           operations-per-run: 750
           remove-stale-when-updated: true


### PR DESCRIPTION
Follow-up to #52343 and #52546, addressing findings from the first two runs.

## 1. Node 20 deprecation

`actions/stale` v9.1.0 declares `using: node20`, which is deprecated and was force-run on Node 24. Bumped to **v11.0.0** (`using: node24`).

- Only breaking change between v9 and v11 is the Node 24 requirement from v10.0.0, needing runner `v2.327.1+`. Runs are on `2.336.0`.
- v11.0.0 is an ESM migration plus dependency updates; no config-facing changes.
- All inputs used here were verified present in the v11.0.0 `action.yml`.

## 2. Scan order was backwards

`actions/stale` defaults to `ascending: false` with `sort-by: created`, so it fetches **newest-created PRs first** — the least likely to be stale.

Measured against this repo (open PRs, staleness threshold 32 days):

| Scan order | Pages to reach 150 stale PRs | Precision |
|---|---|---|
| `created` desc — **current default** | ~19 | 150 / ~700 scanned (~21%) |
| `created` asc — **this PR** | ~11 | 144 / 152 scanned (~95%) |
| `updated` asc | ~12 | 100%, but 6 pages wasted on issues first |

The newest **485** open PRs contain **zero** stale candidates, so the default order burned 13 pages before finding anything. `updated` ascending has perfect precision but this repo has 4,286 open issues whose `updated_at` predates the PRs, so it wastes 6 pages on issues that are skipped anyway (`days-before-issue-stale: -1`).

`ascending: true` is the single-line fix. Beyond saving operations, it closes genuinely abandoned PRs first rather than newer ones that happen to qualify while older ones linger.

## 3. Operations budget

`operations-per-run` was 100. The run stats show why that yielded only 19 closures:

```
Processed PRs: 526      Fetched items: 600
Closed PRs: 19          Operations performed: 101
```

**`operations-per-run` budgets API operations, not PRs.** Traced against the v11.0.0 source, closing one PR costs **5 operations**:

| Call | Method | Content-generating |
|---|---|---|
| `issues.listEvents` | GET | No |
| `issues.listComments` | GET | No |
| `issues.addLabels` (`stale`) | POST | **Yes** |
| `issues.createComment` (close message) | POST | **Yes** |
| `issues.update` (`state: closed`) | PATCH | **Yes** |

Paging costs 1 operation per 100 items (`getIssues` calls `consumeOperation`). PRs that are not stale cost **nothing** — no operation is consumed unless the action acts. That reconciles the log exactly: 6 pages + 19 x 5 = **101**.

Four other mutating calls are ruled out by this config: the *stale* comment (`skipMessage` is true because `stale-pr-message` is empty), `close-pr-label` (never set), `git.deleteRef` (`delete-branch` off), and `pulls.get` (only under `exempt-draft-pr: true` or the delete-branch path).

### Sizing to 150 PRs

Target is **150 PRs per run = 450 write requests**, 90% of GitHub's secondary limit of 500 content-generating requests/hour. That limit is separate from the primary limit and is **not** raised by our enterprise plan.

150 x 5 = 750. The loop guard is `consumed < operationsPerRun` evaluated before each PR, so a run can overrun by up to 4 operations but never by a whole PR. **750 therefore closes at most 150 PRs at any page count, and ~148 in practice.**

For reference, neither other limit binds: 750 requests against 15,000/hour primary for `GITHUB_TOKEN` on enterprise-owned resources, and 17 points/PR against 900/minute.

## Expected result

~148 PRs per run, 4 runs/week, against ~1,068 currently-stale PRs — backlog clears in about two weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)