### PR TITLE
[Feature] Ring joint SDPA and the LTX-2.3 distilled AV pipeline

### DIFF
--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -336,9 +336,7 @@ class ColParallelLinear(Module):
             M, K, N = x.padded_shape[-2], weight.padded_shape[-2], weight.padded_shape[-1]
             full_grid = self.mesh_device.compute_with_storage_grid_size()
 
-            # Fabric-bound path: known shapes route to the optimized strided all-gather-matmul op.
-            # Restricted (for now) to the plain chunks==1 / no-swiglu case; other shapes fall
-            # through to the current all_gather_minimal_matmul_async path below.
+            # Fabric-bound path: known shapes route to the optimized strided all-gather-matmul op
             fabric_cfg = get_fabric_agmm_config(K, N, (self.chunks or 1), full_grid)
             if fabric_cfg is not None and self.chunks in (None, 1) and not self.fuse_swiglu:
                 return self._forward_fabric_agmm(x, weight, fabric_cfg, parallel_config, compute_kernel_config, dtype)

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 from models.common.utility_functions import is_blackhole
 
-from ..utils.matmul import get_fused_mmrs_config, get_matmul_config, get_matmul_core_grid
+from ..utils.matmul import get_fabric_agmm_config, get_fused_mmrs_config, get_matmul_config, get_matmul_core_grid
 from ..utils.tensor import prepare_for_fused_swiglu
 from .module import Module, Parameter
 
@@ -174,6 +174,7 @@ class ColParallelLinear(Module):
         fsdp_mesh_axis=None,
         ccl_manager=None,
         chunks=None,
+        chunk_sizes=None,
         activation_dtype=None,
         pin_output_bf16=False,
     ):
@@ -198,6 +199,8 @@ class ColParallelLinear(Module):
         self.fsdp_mesh_axis = fsdp_mesh_axis
         self.ccl_manager = ccl_manager
         self.chunks = chunks
+        # Per-chunk output widths in ELEMENTS (global, pre-TP-shard); None => uniform N/chunks.
+        self.chunk_sizes = chunk_sizes
 
         if self.fsdp_mesh_axis is not None:
             assert self.mesh_axis != self.fsdp_mesh_axis
@@ -264,6 +267,49 @@ class ColParallelLinear(Module):
                 bias = permute_for_swiglu(bias)
             state["bias"] = bias
 
+    def _forward_fabric_agmm(self, x, weight, fabric_cfg, parallel_config, compute_kernel_config, dtype) -> ttnn.Tensor:
+        """Optimized fabric-bound TP all-gather-matmul via strided_all_gather_minimal_matmul_async.
+
+        The matmul runs on ``fabric_cfg.mm_core_grid`` (lower rows); the strided all-gather workers
+        run on the rows starting at ``fabric_cfg.ag_core_grid_offset`` (disjoint region). Returns the
+        single (chunks==1) matmul output; the op's first output is the gathered-K scratch.
+        """
+        mesh_axis = parallel_config.tensor_parallel.mesh_axis
+        matmul_config = ttnn.MinimalMatmulConfig(
+            M_block_size=fabric_cfg.M_block_size,
+            K_block_size=fabric_cfg.K_block_size,
+            N_block_size=fabric_cfg.N_block_size,
+            subblock_h=fabric_cfg.subblock_h,
+            subblock_w=fabric_cfg.subblock_w,
+            compute_with_storage_grid_size=fabric_cfg.mm_core_grid,
+        )
+        ag_persistent_buffer = self.ccl_manager.get_ag_ping_pong_buffer(x.shape, 3, mesh_axis, dtype=x.get_dtype())
+        ag_global_semaphores = self.ccl_manager.get_strided_ag_mm_semaphore(mesh_axis, fabric_cfg.num_workers_per_link)
+        dram = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+        outputs = ttnn.experimental.strided_all_gather_minimal_matmul_async(
+            x,
+            weight,
+            persistent_output_buffer=ag_persistent_buffer,
+            dim=3,
+            multi_device_global_semaphore=ag_global_semaphores,
+            strided_all_gather_core_grid_offset=fabric_cfg.ag_core_grid_offset,
+            num_links=self.ccl_manager.num_links,
+            memory_config_ag=dram,
+            topology=self.ccl_manager.topology,
+            cluster_axis=mesh_axis,
+            bias=self.bias.data if self.bias is not None else None,
+            fused_activation=self.fused_activation_fn,
+            config=matmul_config,
+            memory_config_mm=dram,
+            compute_kernel_config=compute_kernel_config or self.compute_config,
+            num_workers_per_link=fabric_cfg.num_workers_per_link,
+            num_buffers_per_channel=fabric_cfg.num_buffers_per_channel,
+            read_local_slice_from_input=True,
+            chunks=1,
+        )
+        # Op returns [all_gather_output, matmul_chunk_0]; take the single matmul chunk.
+        return _apply_activation_fn(outputs[1], self.activation_fn)
+
     def forward(
         self, x: ttnn.Tensor, compute_kernel_config=None, default_block_size=None, parallel_config=None, dtype=None
     ) -> ttnn.Tensor | list[ttnn.Tensor]:
@@ -289,6 +335,14 @@ class ColParallelLinear(Module):
         if parallel_config is not None and parallel_config.tensor_parallel.factor > 1:
             M, K, N = x.padded_shape[-2], weight.padded_shape[-2], weight.padded_shape[-1]
             full_grid = self.mesh_device.compute_with_storage_grid_size()
+
+            # Fabric-bound path: known shapes route to the optimized strided all-gather-matmul op.
+            # Restricted (for now) to the plain chunks==1 / no-swiglu case; other shapes fall
+            # through to the current all_gather_minimal_matmul_async path below.
+            fabric_cfg = get_fabric_agmm_config(K, N, (self.chunks or 1), full_grid)
+            if fabric_cfg is not None and self.chunks in (None, 1) and not self.fuse_swiglu:
+                return self._forward_fabric_agmm(x, weight, fabric_cfg, parallel_config, compute_kernel_config, dtype)
+
             core_grid = ttnn.CoreCoord(full_grid.x, full_grid.y - 1)
             matmul_config = get_matmul_config(M, K, N, core_grid, default_block_size)
 
@@ -315,6 +369,10 @@ class ColParallelLinear(Module):
                 num_workers_per_link=full_grid.x // self.ccl_manager.num_links,
                 num_buffers_per_channel=48 if not is_blackhole() else 24,
                 chunks=self.chunks if self.chunks is not None else 1,
+                # Op's N is per-device, so pass per-device widths (each global width is % TP == 0).
+                chunk_sizes=(
+                    [w // parallel_config.tensor_parallel.factor for w in self.chunk_sizes] if self.chunk_sizes else []
+                ),
                 dtype=dtype,
                 fuse_swiglu=self.fuse_swiglu,
             )

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -581,6 +581,7 @@ class RowParallelLinear(Module):
             addcmul_input_tensor1=addcmul_a,
             addcmul_input_tensor2=addcmul_b,
             dtype=dtype,
+            mm_progress_counters=self.ccl_manager.get_mm_progress_counters_buffer(),
         )
         if needs_reshape:
             output = ttnn.squeeze(output, 0)

--- a/models/tt_dit/models/transformers/ltx/attention_ltx.py
+++ b/models/tt_dit/models/transformers/ltx/attention_ltx.py
@@ -139,8 +139,7 @@ class LTXAttention(Module):
         # kwargs forward through LoRAColParallelLinear's **kwargs to the base linear.
         ColCls = LoRAColParallelLinear if lora_enabled else ColParallelLinear
 
-        # Fuse the per-head gate into the QKV/Q matmul via variable-width chunks; only the fused AGMM
-        # path (TP>1 on Ring) honours them, so fall back to a standalone gate op elsewhere.
+        # Fuse the per-head gate into the QKV/Q matmul via variable-width chunks
         tp_factor = parallel_config.tensor_parallel.factor
         uses_fused_agmm = tp_factor > 1 and ccl_manager is not None and ccl_manager.topology == ttnn.Topology.Ring
         # A fused linear carries a single weight dtype, but the quant profile holds the gate at bf16
@@ -189,8 +188,7 @@ class LTXAttention(Module):
             **qk("out"),
         )
 
-        # Per-head gate, sharded on num_heads to match the SDPA-output head layout (bf16, sigmoid and
-        # the ×2 stay standalone ops).
+        # Per-head gate, sharded on num_heads to match the SDPA-output head layout
         self.apply_gated_attention = apply_gated_attention
         if apply_gated_attention and not self.fuse_gate:
             # Standalone gate weight stays bf16 (the model's working dtype) while consuming the shared
@@ -457,8 +455,7 @@ class LTXAttention(Module):
             M, K, N_out = x.padded_shape[-2], weight.padded_shape[-2], weight.padded_shape[-1]
             full_grid = self.mesh_device.compute_with_storage_grid_size()
 
-            # Known shapes route the addcmul to_out to the strided AG-matmul (out = a + scalar*matmul*b);
-            # a miss falls through to the all_gather_minimal_matmul_async addcmul path below.
+            # Known shapes route the addcmul to_out to the strided AG-matmul (out = a + scalar*matmul*b)
             fabric_cfg = get_fabric_agmm_config(K, N_out, 1, full_grid)
             if fabric_cfg is not None:
                 tp_axis = parallel_config.tensor_parallel.mesh_axis

--- a/models/tt_dit/models/transformers/ltx/attention_ltx.py
+++ b/models/tt_dit/models/transformers/ltx/attention_ltx.py
@@ -546,8 +546,12 @@ class LTXAttention(Module):
         return output
 
     def _gate_is_live(self) -> bool:
-        """True when the gate projection will actually run (and so will gather its input)."""
-        return self.apply_gated_attention and self.to_gate_logits.weight._data is not None
+        """True when the gate projection will actually run (and so will gather its input).
+
+        A fused gate has no projection of its own — it falls out of the QKV/Q matmul — so it neither
+        runs nor gathers, and ``to_gate_logits`` is never built.
+        """
+        return self.apply_gated_attention and not self.fuse_gate and self.to_gate_logits.weight._data is not None
 
     def _compute_gate(
         self, spatial_1BND: ttnn.Tensor, qkv_parallel_config: DiTParallelConfig | None

--- a/models/tt_dit/models/transformers/ltx/attention_ltx.py
+++ b/models/tt_dit/models/transformers/ltx/attention_ltx.py
@@ -16,7 +16,7 @@ from ....layers.module import Module
 from ....layers.normalization import DistributedRMSNorm
 from ....parallel.config import DiTParallelConfig
 from ....parallel.manager import CCLManager
-from ....utils.matmul import get_matmul_config
+from ....utils.matmul import get_fabric_agmm_config, get_matmul_config
 from ....utils.substate import pop_substate, rename_substate
 from ....utils.tensor import bf16_tensor
 from .quant_config import LtxQuantProfile
@@ -139,10 +139,43 @@ class LTXAttention(Module):
         # kwargs forward through LoRAColParallelLinear's **kwargs to the base linear.
         ColCls = LoRAColParallelLinear if lora_enabled else ColParallelLinear
 
+        # Fuse the per-head gate into the QKV/Q matmul via variable-width chunks; only the fused AGMM
+        # path (TP>1 on Ring) honours them, so fall back to a standalone gate op elsewhere.
+        tp_factor = parallel_config.tensor_parallel.factor
+        uses_fused_agmm = tp_factor > 1 and ccl_manager is not None and ccl_manager.topology == ttnn.Topology.Ring
+        # A fused linear carries a single weight dtype, but the quant profile holds the gate at bf16
+        # while quantizing qkv/q, so the two cannot share one matmul: fusion is bf16-only.
+        self.fuse_gate = apply_gated_attention and uses_fused_agmm and quant_config is None
+
+        # Gate is num_heads/TP columns per device (sub-tile); pad to a whole tile so it's a legal chunk.
+        self.gate_width_per_device = self.n_local_heads
+        self.gate_padded_per_device = ((self.n_local_heads + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+        gate_fused_width = self.gate_padded_per_device * tp_factor
+
         if is_self:
-            self.to_qkv = ColCls(dim, 3 * dim, chunks=3, **col_parallel_kwargs, **qk("qkv"))
+            if self.fuse_gate:
+                self.to_qkv = ColCls(
+                    dim,
+                    3 * dim + gate_fused_width,
+                    chunks=4,
+                    chunk_sizes=[dim, dim, dim, gate_fused_width],
+                    **col_parallel_kwargs,
+                    **qk("qkv"),
+                )
+            else:
+                self.to_qkv = ColCls(dim, 3 * dim, chunks=3, **col_parallel_kwargs, **qk("qkv"))
         else:
-            self.to_q = ColCls(self.query_input_dim, dim, **col_parallel_kwargs, **qk("q"))
+            if self.fuse_gate:
+                self.to_q = ColCls(
+                    self.query_input_dim,
+                    dim + gate_fused_width,
+                    chunks=2,
+                    chunk_sizes=[dim, gate_fused_width],
+                    **col_parallel_kwargs,
+                    **qk("q"),
+                )
+            else:
+                self.to_q = ColCls(self.query_input_dim, dim, **col_parallel_kwargs, **qk("q"))
             self.to_kv = ColCls(self.kv_input_dim, 2 * dim, chunks=2, **col_parallel_kwargs, **qk("kv"))
 
         self.to_out = ColCls(
@@ -156,13 +189,11 @@ class LTXAttention(Module):
             **qk("out"),
         )
 
-        # Per-head gate, sharded on num_heads to match the SDPA-output head layout. bf16 matches the
-        # reference (which runs the gate in the model's working dtype). Sigmoid is a standalone op:
-        # fusing it into the matmul trips minimal_matmul's sigmoid VecMode assert (needs C/RC). The
-        # ×2 stays a separate multiply (2·sigmoid is nonlinear, can't fold).
+        # Per-head gate, sharded on num_heads to match the SDPA-output head layout (bf16, sigmoid and
+        # the ×2 stay standalone ops).
         self.apply_gated_attention = apply_gated_attention
-        if apply_gated_attention:
-            # Gate weight stays bf16 (runs in the model's working dtype), but it consumes the shared
+        if apply_gated_attention and not self.fuse_gate:
+            # Standalone gate weight stays bf16 (the model's working dtype) while consuming the shared
             # bf8 activation, so its output is pinned back to bf16 like the quantized projections.
             self.to_gate_logits = ColParallelLinear(
                 in_features=self.query_input_dim,
@@ -171,6 +202,7 @@ class LTXAttention(Module):
                 dtype=ttnn.bfloat16,
                 mesh_device=mesh_device,
                 mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+                fsdp_mesh_axis=fsdp_mesh_axis,
                 ccl_manager=ccl_manager,
                 **qk("gate"),
             )
@@ -298,6 +330,38 @@ class LTXAttention(Module):
             merged = merged.reshape(merged.shape[0], len(tensors) * self.num_heads * self.head_dim)
             return merged.T
 
+        def _pad_gate_to_tile(t: torch.Tensor) -> torch.Tensor:
+            """Zero-pad each device's gate block from n_local_heads up to a whole tile (device-major)."""
+            n_dev = self.parallel_config.tensor_parallel.factor
+            pad = self.gate_padded_per_device - self.n_local_heads
+            if pad == 0:
+                return t
+            blocks = []
+            for d in range(n_dev):
+                blocks.append(t[d * self.n_local_heads : (d + 1) * self.n_local_heads])
+                blocks.append(torch.zeros(pad, *t.shape[1:], dtype=t.dtype))
+            return torch.cat(blocks, dim=0)
+
+        def _gate_state_or_zeros(reference: torch.Tensor, want_bias: bool) -> dict[str, torch.Tensor]:
+            """Gate substate, zero-filled when the checkpoint has none (zeros -> identity gating)."""
+            g = pop_substate(state, "to_gate_logits")
+            if "weight" not in g:
+                g["weight"] = torch.zeros(self.num_heads, reference.shape[1], dtype=reference.dtype)
+            if want_bias and "bias" not in g:
+                g["bias"] = torch.zeros(self.num_heads, dtype=reference.dtype)
+            return g
+
+        def _interleave_device_major(tensors: list[torch.Tensor]):
+            """Like _interleave_heads but for per-device widths that differ (q/k/v head_dim vs gate)."""
+            n_dev = self.parallel_config.tensor_parallel.factor
+            reshaped = []
+            for t in tensors:
+                t = t.T  # [in, out]
+                assert t.shape[1] % n_dev == 0, f"projection width {t.shape[1]} not divisible by TP={n_dev}"
+                reshaped.append(t.reshape(t.shape[0], n_dev, t.shape[1] // n_dev))
+            merged = torch.cat(reshaped, dim=2)
+            return merged.reshape(merged.shape[0], -1).T
+
         if self.is_self:
             q_state = pop_substate(state, "to_q")
             k_state = pop_substate(state, "to_k")
@@ -310,12 +374,30 @@ class LTXAttention(Module):
             if "bias" in k_state:
                 k_state["bias"] = _permute_qk(k_state["bias"])
 
-            state["to_qkv.weight"] = _interleave_heads([q_state["weight"], k_state["weight"], v_state["weight"]])
-            if "bias" in q_state:
-                bias = _interleave_heads(
-                    [q_state["bias"].unsqueeze(-1), k_state["bias"].unsqueeze(-1), v_state["bias"].unsqueeze(-1)]
+            if self.fuse_gate:
+                # Fold the gate in as a 4th chunk, device-major: device d holds [q_d | k_d | v_d | gate_d].
+                g_state = _gate_state_or_zeros(q_state["weight"], "bias" in q_state)
+                g_state = {k: _pad_gate_to_tile(v) for k, v in g_state.items()}
+                state["to_qkv.weight"] = _interleave_device_major(
+                    [q_state["weight"], k_state["weight"], v_state["weight"], g_state["weight"]]
                 )
-                state["to_qkv.bias"] = bias.squeeze(-1)
+                if "bias" in q_state:
+                    bias = _interleave_device_major(
+                        [
+                            q_state["bias"].unsqueeze(-1),
+                            k_state["bias"].unsqueeze(-1),
+                            v_state["bias"].unsqueeze(-1),
+                            g_state["bias"].unsqueeze(-1),
+                        ]
+                    )
+                    state["to_qkv.bias"] = bias.squeeze(-1)
+            else:
+                state["to_qkv.weight"] = _interleave_heads([q_state["weight"], k_state["weight"], v_state["weight"]])
+                if "bias" in q_state:
+                    bias = _interleave_heads(
+                        [q_state["bias"].unsqueeze(-1), k_state["bias"].unsqueeze(-1), v_state["bias"].unsqueeze(-1)]
+                    )
+                    state["to_qkv.bias"] = bias.squeeze(-1)
         else:
             k_state = pop_substate(state, "to_k")
             v_state = pop_substate(state, "to_v")
@@ -328,6 +410,15 @@ class LTXAttention(Module):
                 state["to_q.weight"] = _permute_qk(state["to_q.weight"])
             if "to_q.bias" in state:
                 state["to_q.bias"] = _permute_qk(state["to_q.bias"])
+
+            if self.fuse_gate and "to_q.weight" in state:
+                # Cross-attn: gate rides along with Q as a 2nd chunk.
+                g_state = _gate_state_or_zeros(state["to_q.weight"], "to_q.bias" in state)
+                g_state = {k: _pad_gate_to_tile(v) for k, v in g_state.items()}
+                state["to_q.weight"] = _interleave_device_major([state["to_q.weight"], g_state["weight"]])
+                if "to_q.bias" in state and "bias" in g_state:
+                    bias = _interleave_device_major([state["to_q.bias"].unsqueeze(-1), g_state["bias"].unsqueeze(-1)])
+                    state["to_q.bias"] = bias.squeeze(-1)
 
             state["to_kv.weight"] = _interleave_heads([k_state["weight"], v_state["weight"]])
             if "bias" in k_state:
@@ -365,6 +456,51 @@ class LTXAttention(Module):
         if parallel_config is not None and parallel_config.tensor_parallel.factor > 1:
             M, K, N_out = x.padded_shape[-2], weight.padded_shape[-2], weight.padded_shape[-1]
             full_grid = self.mesh_device.compute_with_storage_grid_size()
+
+            # Known shapes route the addcmul to_out to the strided AG-matmul (out = a + scalar*matmul*b);
+            # a miss falls through to the all_gather_minimal_matmul_async addcmul path below.
+            fabric_cfg = get_fabric_agmm_config(K, N_out, 1, full_grid)
+            if fabric_cfg is not None:
+                tp_axis = parallel_config.tensor_parallel.mesh_axis
+                dram = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+                fabric_matmul_config = ttnn.MinimalMatmulConfig(
+                    M_block_size=fabric_cfg.M_block_size,
+                    K_block_size=fabric_cfg.K_block_size,
+                    N_block_size=fabric_cfg.N_block_size,
+                    subblock_h=fabric_cfg.subblock_h,
+                    subblock_w=fabric_cfg.subblock_w,
+                    compute_with_storage_grid_size=fabric_cfg.mm_core_grid,
+                )
+                outputs = ttnn.experimental.strided_all_gather_minimal_matmul_async(
+                    x,
+                    weight,
+                    persistent_output_buffer=self.ccl_manager.get_ag_ping_pong_buffer(
+                        x.shape, 3, tp_axis, dtype=x.get_dtype()
+                    ),
+                    dim=3,
+                    multi_device_global_semaphore=self.ccl_manager.get_strided_ag_mm_semaphore(
+                        tp_axis, fabric_cfg.num_workers_per_link
+                    ),
+                    strided_all_gather_core_grid_offset=fabric_cfg.ag_core_grid_offset,
+                    num_links=self.ccl_manager.num_links,
+                    memory_config_ag=dram,
+                    topology=self.ccl_manager.topology,
+                    cluster_axis=tp_axis,
+                    bias=to_out.bias.data if to_out.bias is not None else None,
+                    config=fabric_matmul_config,
+                    memory_config_mm=dram,
+                    compute_kernel_config=compute_kernel_config or to_out.compute_config,
+                    num_workers_per_link=fabric_cfg.num_workers_per_link,
+                    num_buffers_per_channel=fabric_cfg.num_buffers_per_channel,
+                    read_local_slice_from_input=True,
+                    fused_ternary_input_a=addcmul_residual,
+                    fused_ternary_input_b=addcmul_gate,
+                    fused_ternary_scalar=1.0,
+                    chunks=1,
+                )
+                # Op returns [all_gather_output, matmul_chunk_0]; take the single matmul chunk.
+                return outputs[1]
+
             core_grid = ttnn.CoreCoord(full_grid.x, full_grid.y - 1)
             matmul_config = get_matmul_config(M, K, N_out, core_grid)
 
@@ -424,13 +560,23 @@ class LTXAttention(Module):
             return None
 
         gate_logits = self.to_gate_logits(spatial_1BND, parallel_config=qkv_parallel_config)
-        gate = ttnn.multiply(ttnn.sigmoid(gate_logits), 2.0)
+        return self._gate_from_logits(gate_logits)
 
-        # (1, B, N, H_local) -> (B, H_local, N, 1) in one pass: the N<->H_local swap is the real
-        # data movement, and the leading unit axis is parked into the trailing broadcast slot (over
-        # E). Replaces squeeze+transpose+unsqueeze (the unsqueeze was a retile, not a free view).
-        gate = ttnn.permute(gate, (1, 3, 2, 0))
-        return gate
+    def _unpad_gate_logits(self, gate_logits: ttnn.Tensor) -> ttnn.Tensor:
+        """Drop the tile padding from the fused gate chunk, leaving n_local_heads real columns."""
+        if self.gate_padded_per_device == self.gate_width_per_device:
+            return gate_logits
+        shape = gate_logits.shape
+        return ttnn.slice(
+            gate_logits,
+            [0, 0, 0, 0],
+            [shape[0], shape[1], shape[2], self.gate_width_per_device],
+        )
+
+    def _gate_from_logits(self, gate_logits: ttnn.Tensor) -> ttnn.Tensor:
+        """2 * sigmoid(logits) as (B, H_local, N, 1); shared by the fused and unfused paths."""
+        gate = ttnn.multiply(ttnn.sigmoid(gate_logits), 2.0)
+        return ttnn.permute(gate, (1, 3, 2, 0))
 
     def forward(
         self,
@@ -478,15 +624,23 @@ class LTXAttention(Module):
 
         qkv_parallel_config = None if (use_nonfused_agmm or dedup_gate_gather) else self.parallel_config
 
-        # Per-head gate, computed before QKV consumes spatial_1BND.
-        gate_bhne = self._compute_gate(spatial_1BND, qkv_parallel_config)
+        # When fused, the gate falls out of the QKV/Q matmul below; otherwise it's its own projection.
+        gate_bhne = None if self.fuse_gate else self._compute_gate(spatial_1BND, qkv_parallel_config)
 
         if self.is_self:
-            q_1BNF, k_1BNF, v_1BNF = self.to_qkv(
-                spatial_1BND,
-                compute_kernel_config=self.mm_compute_kernel_config,
-                parallel_config=qkv_parallel_config,
-            )
+            if self.fuse_gate:
+                q_1BNF, k_1BNF, v_1BNF, gate_logits = self.to_qkv(
+                    spatial_1BND,
+                    compute_kernel_config=self.mm_compute_kernel_config,
+                    parallel_config=qkv_parallel_config,
+                )
+                gate_bhne = self._gate_from_logits(self._unpad_gate_logits(gate_logits))
+            else:
+                q_1BNF, k_1BNF, v_1BNF = self.to_qkv(
+                    spatial_1BND,
+                    compute_kernel_config=self.mm_compute_kernel_config,
+                    parallel_config=qkv_parallel_config,
+                )
         else:
             kv_input = prompt_1BLP if prompt_1BLP is not None else spatial_1BND
             # Cross K/V: gather TP-sharded context for to_kv (replicated text prompt is already full).
@@ -501,11 +655,19 @@ class LTXAttention(Module):
                         )
                     else:
                         kv_parallel_config = self.parallel_config
-            q_1BNF = self.to_q(
-                spatial_1BND,
-                compute_kernel_config=self.mm_compute_kernel_config,
-                parallel_config=qkv_parallel_config,
-            )
+            if self.fuse_gate:
+                q_1BNF, gate_logits = self.to_q(
+                    spatial_1BND,
+                    compute_kernel_config=self.mm_compute_kernel_config,
+                    parallel_config=qkv_parallel_config,
+                )
+                gate_bhne = self._gate_from_logits(self._unpad_gate_logits(gate_logits))
+            else:
+                q_1BNF = self.to_q(
+                    spatial_1BND,
+                    compute_kernel_config=self.mm_compute_kernel_config,
+                    parallel_config=qkv_parallel_config,
+                )
             k_1BNF, v_1BNF = self.to_kv(
                 kv_input,
                 compute_kernel_config=self.mm_compute_kernel_config,

--- a/models/tt_dit/models/vae/vae_ltx.py
+++ b/models/tt_dit/models/vae/vae_ltx.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import time
 from typing import TYPE_CHECKING, Sequence
 
 import torch
@@ -18,7 +19,6 @@ from safetensors import safe_open
 from safetensors.torch import load_file
 
 import ttnn
-from models.common.utility_functions import is_blackhole
 
 from ...layers.module import Module, ModuleList, Parameter
 from ...layers.normalization import RMSNorm
@@ -37,6 +37,8 @@ from ...utils.conv3d import (
 )
 from ...utils.ltx import pad_hw_replicate
 from ...utils.tensor import fast_device_to_host, float_to_uint8, typed_tensor, typed_tensor_2dshard
+from ...utils.tracing import traced_function
+from ...utils.yuv_d2h import fast_device_to_host_yuv
 
 if TYPE_CHECKING:
     from ..upsampler.latent_upsampler_ltx import LTXLatentUpsampler
@@ -57,6 +59,35 @@ def _get_w_mask(cache, x_BTHWC, logical_w, parallel_config, mesh_device, dtype):
             mesh_axis=parallel_config.width_parallel.mesh_axis,
             shard_dim=3,
             dtype=dtype,
+        )
+    return cache[key]
+
+
+def _get_pad_offset(cache, x_BTHWC, parallel_config, mesh_device, sub_h=0, sub_w=0):
+    """Per-device [h_start, w_start] global spatial offset for conv3d's in-kernel logical-pad mask.
+    Sharded so device (hi, wi) reads its own pair [hi*H_dev, wi*W_dev]; H_dev/W_dev are uniform per
+    device because conv_pad_* pads to a multiple of the mesh factor. Lets the halo path mask pad
+    positions inside the conv3d read instead of a full-tensor pre-mul. sub_h/sub_w: subtract from the
+    per-device dims when x is a PADDED buffer (copy-free path) so h_start/w_start stay INTERIOR-based."""
+    hf = parallel_config.height_parallel.factor
+    wf = parallel_config.width_parallel.factor
+    h_dev, w_dev = x_BTHWC.shape[2] - 2 * sub_h, x_BTHWC.shape[3] - 2 * sub_w
+    key = (hf, wf, h_dev, w_dev)
+    if key not in cache:
+        off = torch.zeros(hf, wf, 2, dtype=torch.int32)
+        for hi in range(hf):
+            for wi in range(wf):
+                off[hi, wi, 0] = hi * h_dev
+                off[hi, wi, 1] = wi * w_dev
+        cache[key] = typed_tensor_2dshard(
+            off,
+            mesh_device,
+            shard_mapping={
+                parallel_config.height_parallel.mesh_axis: 0,
+                parallel_config.width_parallel.mesh_axis: 1,
+            },
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.uint32,
         )
     return cache[key]
 
@@ -146,11 +177,33 @@ class LTXCausalConv3d(Module):
             W=dims_W,
         )
 
+        # Hybrid dispatch: the fused neighbor_pad+conv3d op wins only on conv-heavy shapes where the
+        # interior conv pass hides the halo exchange. get_conv3d_config marks exactly those shapes with
+        # halo_last (interior-then-boundary two-pass) or force_spatial_parallel; that per-shape table IS
+        # the calibrated threshold (a flat T cutoff can't separate the winners — every VAE stage has
+        # T >= 21). NP-light / tiny-conv shapes (conv_in, s0/s1/s2 res, upsamplers, conv_out) carry
+        # neither flag and stay on the standalone NP+conv3d path, which is faster there.
+        self._needs_halo = (self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1) or (
+            self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1
+        )
+        # Halo-aware two-dispatch (neighbor_pad_halo -> conv3d halo mode): for the NP-light shapes that skip
+        # the fused op, avoid the full-pad interior copy by feeding conv3d the compact halo buffer directly.
+        # Valid only when ALL spatial padding is external (halo-exchanged) — i.e. both spatial axes' internal
+        # padding is 0 — so every conv boundary read maps to a halo section. Off via NP_NO_HALO_CONV.
+        self._use_halo_conv = (
+            self._needs_halo
+            and self.internal_padding[1] == 0
+            and self.internal_padding[2] == 0
+            and os.environ.get("NP_NO_HALO_CONV") is None
+        )
+
+        from models.common.utility_functions import is_blackhole
+
         self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
             self.mesh_device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi4
-            if (is_blackhole() and dtype == ttnn.float32)
-            else ttnn.MathFidelity.HiFi2,  # Do not use HiFi3/4 with fp32_dest_acc on WH due to accuracy issues.
+            math_fidelity=(
+                ttnn.MathFidelity.HiFi4 if (is_blackhole() and dtype == ttnn.float32) else ttnn.MathFidelity.HiFi2
+            ),  # Do not use HiFi3/4 with fp32_dest_acc on WH due to accuracy issues.
             math_approx_mode=False,
             fp32_dest_acc_en=True,
             packer_l1_acc=False,
@@ -161,6 +214,12 @@ class LTXCausalConv3d(Module):
         self.bias = Parameter(total_shape=[1, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
 
         self._w_mask_cache: dict[tuple, ttnn.Tensor] = {}
+        self._pad_offset_cache: dict[tuple, ttnn.Tensor] = {}
+        # Persistent-padded path (default on): neighbor_pad_halo -> compact -> halo_scatter into a padded
+        # buffer -> plain (pad=0) conv with in-kernel logical masking, instead of conv3d halo-read mode.
+        # Validated PCC=1.0 and ~6% faster e2e on BH 4x8 1080p (448ms vs 477ms halo-read). Opt out with
+        # TT_LTX_NO_PERSIST_PAD for the halo-read path.
+        self._persist_pad = os.environ.get("TT_LTX_NO_PERSIST_PAD") is None
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
         # LTX-2 stores weights under "conv.weight" and "conv.bias"
@@ -207,9 +266,14 @@ class LTXCausalConv3d(Module):
         causal: bool = True,
         logical_h: int = 0,
         logical_w: int = 0,
+        cf_input_padded: bool = False,
+        cf_output_padded: bool = False,
     ) -> ttnn.Tensor:
         # x_BTHWC: (B, T, H_per_device, W_per_device, C) ROW_MAJOR, H/W fractured on the mesh.
         # logical_h/logical_w: pre-pad full spatial dims for pad masking (0 = no masking).
+        # cf_input_padded: x is already a padded [.,Hp,Wp,.] buffer (copy-free; halo reads interior
+        #   strided + border-scatter in place, no interior copy). cf_output_padded: conv writes a padded
+        #   output (output_pad) so the next conv can consume it copy-free. Both require the persist-pad path.
         assert x_BTHWC.layout == ttnn.ROW_MAJOR_LAYOUT
 
         # Temporal padding (T is not sharded — local op on every device).
@@ -230,51 +294,153 @@ class LTXCausalConv3d(Module):
         h_pad_needed = self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1
         w_pad_needed = self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1
 
-        # Width pre-conv mul-mask: zero pad columns before the halo (neighbor_pad has no W-mask).
-        if (
-            logical_w > 0
-            and self.parallel_config.width_parallel.factor > 1
-            and x_BTHWC.shape[3] * self.parallel_config.width_parallel.factor > logical_w
-        ):
+        # H-row masking (zeroing rows at/beyond logical_h) is fused into neighbor_pad via logical_h on the
+        # standalone path. The fused neighbor_pad_conv3d op has no logical_h argument, so a call that
+        # actually needs H masking must fall back to standalone to stay correct. For the production
+        # 1080p config every logical dim divides the mesh factor, so this is never triggered there.
+        h_mask_active = (
+            h_pad_needed
+            and logical_h > 0
+            and x_BTHWC.shape[2] * self.parallel_config.height_parallel.factor > logical_h
+        )
+
+        # Pre-conv pad masking. W pad columns must be zeroed on the input in BOTH paths (neighbor_pad has
+        # no W-mask). The full-pad path masks H pad rows inside neighbor_pad (logical_h=...); the compact
+        # neighbor_pad_halo op has no logical_h, so the halo path must mask H here too — folded into the
+        # SAME mul as W (one combined H&W mask) so it pays a single pre-conv mask op, not two full-tensor
+        # muls. Fires only where the physical dim exceeds the logical (e.g. 4x8's s0 pad 34->36 that
+        # propagates through the upsamples); a no-op when every logical dim divides the mesh factor (2x4).
+        wf = self.parallel_config.width_parallel.factor
+        hf = self.parallel_config.height_parallel.factor
+        w_needed = logical_w > 0 and wf > 1 and x_BTHWC.shape[3] * wf > logical_w
+        h_needed = logical_h > 0 and hf > 1 and x_BTHWC.shape[2] * hf > logical_h
+        # Halo path defers pad masking INTO conv3d (in-kernel, per-position on the interior read) via
+        # logical_h/w + a per-device offset — no full-tensor pre-mul. The full-pad path keeps its W
+        # pre-mul (neighbor_pad masks H via logical_h but has no W mask). See _get_pad_offset / conv3d.
+        conv_logical_h = 0
+        conv_logical_w = 0
+        pad_offset_tensor = None
+        if self._use_halo_conv:
+            conv_logical_h = logical_h if h_needed else 0
+            conv_logical_w = logical_w if w_needed else 0
+            if conv_logical_h or conv_logical_w:
+                pad_offset_tensor = _get_pad_offset(
+                    self._pad_offset_cache, x_BTHWC, self.parallel_config, self.mesh_device
+                )
+        elif w_needed:
             x_BTHWC = ttnn.mul(
                 x_BTHWC,
                 _get_w_mask(self._w_mask_cache, x_BTHWC, logical_w, self.parallel_config, self.mesh_device, self.dtype),
             )
 
+        # conv3d args set by the dispatch below (halo path fills halo_buffer + spatial conv_padding).
+        halo_buffer = None
+        conv_padding = self.internal_padding
         if h_pad_needed or w_pad_needed:
             dims, pad_left, pad_right = [], [], []
             axes, neighbor_sems, links = [], [], []
+            sem_getter = self.ccl_manager.get_np_ping_pong_semaphore
             if h_pad_needed:
                 dims.append(2)
                 pad_left.append(self.external_padding[1])
                 pad_right.append(self.external_padding[1])
                 axes.append(self.parallel_config.height_parallel.mesh_axis)
-                neighbor_sems.append(
-                    self.ccl_manager.get_np_ping_pong_semaphore(self.parallel_config.height_parallel.mesh_axis)
-                )
+                neighbor_sems.append(sem_getter(self.parallel_config.height_parallel.mesh_axis))
                 links.append(_neighbor_pad_num_links(self.ccl_manager, x_BTHWC, 2))
             if w_pad_needed:
                 dims.append(3)
                 pad_left.append(self.external_padding[2])
                 pad_right.append(self.external_padding[2])
                 axes.append(self.parallel_config.width_parallel.mesh_axis)
-                neighbor_sems.append(
-                    self.ccl_manager.get_np_ping_pong_semaphore(self.parallel_config.width_parallel.mesh_axis)
-                )
+                neighbor_sems.append(sem_getter(self.parallel_config.width_parallel.mesh_axis))
                 links.append(_neighbor_pad_num_links(self.ccl_manager, x_BTHWC, 3))
 
-            x_BTHWC = self.ccl_manager.neighbor_pad_persistent_buffer(
-                x_BTHWC,
-                dims=dims,
-                pad_left=pad_left,
-                pad_right=pad_right,
-                padding_mode="zeros",
-                axes=axes,
-                neighbor_sems=neighbor_sems,
-                num_links=links,
-                logical_h=(logical_h if h_pad_needed else 0),
-                t_front_pad=0,
-            )
+            if self._use_halo_conv and self._persist_pad and h_pad_needed and w_pad_needed:
+                # Persistent-padded: neighbor_pad_halo -> compact -> halo_scatter into a padded buffer ->
+                # plain (pad=0) conv. Logical-pad masking is done IN-KERNEL by the plain conv (logical+pad
+                # threshold + per-device interior offset). cf_input_padded: x is already padded -> read its
+                # interior halo (strided) + border-scatter in place (copy-free, no interior copy).
+                # cf_output_padded: conv writes a padded output so the next conv consumes it copy-free.
+                pHe, pWe = self.external_padding[1], self.external_padding[2]
+                # Interior per-device dims (x carries the padded border when cf_input_padded).
+                ih = x_BTHWC.shape[2] - (2 * pHe if cf_input_padded else 0)
+                iw = x_BTHWC.shape[3] - (2 * pWe if cf_input_padded else 0)
+                cf_h_needed = logical_h > 0 and hf > 1 and ih * hf > logical_h
+                cf_w_needed = logical_w > 0 and wf > 1 and iw * wf > logical_w
+                pp_logical_h = (logical_h + pHe) if cf_h_needed else 0
+                pp_logical_w = (logical_w + pWe) if cf_w_needed else 0
+                pp_pad_offset = None
+                if pp_logical_h or pp_logical_w:
+                    pp_pad_offset = _get_pad_offset(
+                        self._pad_offset_cache,
+                        x_BTHWC,
+                        self.parallel_config,
+                        self.mesh_device,
+                        sub_h=(pHe if cf_input_padded else 0),
+                        sub_w=(pWe if cf_input_padded else 0),
+                    )
+                # Fused exchange+scatter. cf_input_padded: x already carries the padded interior (prev
+                # conv's padded output) -> border-only in place. Else: allocate padded, fill interior+border.
+                padded = self.ccl_manager.neighbor_pad_halo_scatter(
+                    x_BTHWC,
+                    dims=dims,
+                    pad_left=pad_left,
+                    pad_right=pad_right,
+                    axes=axes,
+                    neighbor_sems=neighbor_sems,
+                    num_links=links,
+                    padding_mode="zeros",
+                    input_pad_h=(pHe if cf_input_padded else 0),
+                    input_pad_w=(pWe if cf_input_padded else 0),
+                    border_only=cf_input_padded,
+                )
+                return ttnn.experimental.conv3d(
+                    input_tensor=padded,
+                    weight_tensor=self.weight.data,
+                    bias_tensor=self.bias.data,
+                    device=self.mesh_device,
+                    config=self.conv_config,
+                    output_channels=self.out_channels,
+                    kernel_size=self.kernel_size,
+                    stride=self.stride,
+                    padding=(self.internal_padding[0], 0, 0),
+                    padding_mode="zeros",
+                    dtype=self.dtype,
+                    compute_kernel_config=self.compute_kernel_config,
+                    logical_h_mask=pp_logical_h,
+                    logical_w_mask=pp_logical_w,
+                    pad_offset_tensor=pp_pad_offset,
+                    output_pad_h=(pHe if cf_output_padded else 0),
+                    output_pad_w=(pWe if cf_output_padded else 0),
+                )
+
+            if self._use_halo_conv:
+                # Compact halo -> conv3d halo mode: conv does the spatial (external) padding by reading the
+                # neighbor's pixels from the halo buffer, skipping the full-pad interior copy.
+                halo_buffer = self.ccl_manager.neighbor_pad_halo_only(
+                    x_BTHWC,
+                    dims=dims,
+                    pad_left=pad_left,
+                    pad_right=pad_right,
+                    axes=axes,
+                    neighbor_sems=neighbor_sems,
+                    num_links=links,
+                    padding_mode="zeros",
+                )
+                conv_padding = (self.internal_padding[0], self.external_padding[1], self.external_padding[2])
+            else:
+                x_BTHWC = self.ccl_manager.neighbor_pad_persistent_buffer(
+                    x_BTHWC,
+                    dims=dims,
+                    pad_left=pad_left,
+                    pad_right=pad_right,
+                    padding_mode="zeros",
+                    axes=axes,
+                    neighbor_sems=neighbor_sems,
+                    num_links=links,
+                    logical_h=(logical_h if h_pad_needed else 0),
+                    t_front_pad=0,
+                )
 
         x_BTHWC = ttnn.experimental.conv3d(
             input_tensor=x_BTHWC,
@@ -285,10 +451,14 @@ class LTXCausalConv3d(Module):
             output_channels=self.out_channels,
             kernel_size=self.kernel_size,
             stride=self.stride,
-            padding=self.internal_padding,
+            padding=conv_padding,
             padding_mode="zeros",
             dtype=self.dtype,
             compute_kernel_config=self.compute_kernel_config,
+            halo_buffer=halo_buffer,
+            logical_h_mask=conv_logical_h,
+            logical_w_mask=conv_logical_w,
+            pad_offset_tensor=pad_offset_tensor,
         )
 
         return x_BTHWC
@@ -409,26 +579,22 @@ class LTXResnetBlock3D(Module):
         logical_h: int = 0,
         logical_w: int = 0,
     ) -> ttnn.Tensor:
+        # Copy-free: conv1 writes a PADDED output, norm2 runs on it (per-position; border is garbage),
+        # and conv2 reads it copy-free (halo interior read + border-scatter in place) — no interior copy
+        # between the two convs. norm outputs TILE; conv3d needs ROW_MAJOR.
         residual = x_BTHWC
-
-        # Main path: (norm+silu fused) → conv → (norm+silu fused) → conv. The fused norm outputs
-        # TILE; conv3d needs ROW_MAJOR.
         h = self.norm1(x_BTHWC, compute_kernel_config=self.norm_compute_kernel_config)
         h = ttnn.to_layout(h, ttnn.ROW_MAJOR_LAYOUT)
-        h = self.conv1(h, causal=causal, logical_h=logical_h, logical_w=logical_w)
+        h = self.conv1(h, causal=causal, logical_h=logical_h, logical_w=logical_w, cf_output_padded=True)
 
         h = self.norm2(h, compute_kernel_config=self.norm_compute_kernel_config)
         h = ttnn.to_layout(h, ttnn.ROW_MAJOR_LAYOUT)
-        h = self.conv2(h, causal=causal, logical_h=logical_h, logical_w=logical_w)
+        h = self.conv2(h, causal=causal, logical_h=logical_h, logical_w=logical_w, cf_input_padded=True)
 
-        # Skip connection
         if self.has_shortcut:
             residual = ttnn.layer_norm(residual, weight=self.norm3_weight.data, bias=self.norm3_bias.data)
-            residual = (
-                ttnn.to_layout(residual, ttnn.ROW_MAJOR_LAYOUT)
-                if residual.layout != ttnn.ROW_MAJOR_LAYOUT
-                else residual
-            )
+            if residual.layout != ttnn.ROW_MAJOR_LAYOUT:
+                residual = ttnn.to_layout(residual, ttnn.ROW_MAJOR_LAYOUT)
             residual = self.conv_shortcut(residual, causal=causal, logical_h=logical_h, logical_w=logical_w)
 
         return ttnn.add(residual, h)
@@ -543,6 +709,8 @@ class LTXDepthToSpaceUpsample(Module):
         """Upsample by `stride`; returns (out, new_logical_h, new_logical_w) scaled by p2/p3."""
         B, T, H, W, _ = x_BTHWC.shape
         p1, p2, p3 = self.stride
+        new_logical_h = logical_h * p2 if logical_h else 0
+        new_logical_w = logical_w * p3 if logical_w else 0
 
         # Residual path: depth-to-space the input, repeat channels to match conv output.
         if self.residual:
@@ -565,8 +733,6 @@ class LTXDepthToSpaceUpsample(Module):
         if self.residual:
             x = ttnn.add(x, x_in)
 
-        new_logical_h = logical_h * p2 if logical_h else 0
-        new_logical_w = logical_w * p3 if logical_w else 0
         return x, new_logical_h, new_logical_w
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
@@ -658,6 +824,9 @@ class LTXVideoDecoder(Module):
         self.mesh_device = mesh_device
         self.parallel_config = parallel_config
         self.ccl_manager = ccl_manager
+        # Set True by the pipeline after warmup so the first real decode captures a ttnn trace of
+        # decode_device and later decodes replay it (removing host-dispatch overhead).
+        self._vae_traced = False
         out_channels_with_patch = out_channels * patch_size**2  # 3 * 16 = 48
 
         feature_channels = base_channels * 8  # 1024
@@ -789,6 +958,36 @@ class LTXVideoDecoder(Module):
         for k in keys_to_remove:
             del state[k]
 
+    @traced_function(device=lambda self: self.mesh_device, prep_run=True, clone_prep_inputs=True)
+    def decode_device(self, sample_tt, logical_h: int, logical_w: int):
+        """Device-only decode: denorm → conv_in → up_blocks → norm_out → conv_out, on an already-sharded
+        input, returning the device output before the host gather. Split out from forward() so it can be
+        captured as a single ttnn trace (the host upload/gather must stay outside the trace).
+
+        Pass ``traced=True`` (plus a stable ``tracer_trace_key``) to capture/replay it as a ttnn trace."""
+        # Denormalize: x = x * std + mean (per-channel stats replicated on the mesh).
+        mean = self.per_channel_mean.data
+        std = self.per_channel_std.data
+        sample_tt = ttnn.add(ttnn.multiply(sample_tt, std), mean)
+        sample_tt = ttnn.to_layout(sample_tt, ttnn.ROW_MAJOR_LAYOUT)
+
+        # logical_h/logical_w scale up through each upsample so later convs mask the right region.
+        sample_tt = self.conv_in(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
+        for up_block in self.up_blocks:
+            if isinstance(up_block, LTXDepthToSpaceUpsample):
+                sample_tt, logical_h, logical_w = up_block(
+                    sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w
+                )
+            else:
+                sample_tt = up_block(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
+
+        sample_tt = self.norm_out(sample_tt, compute_kernel_config=self.norm_out_compute_kernel_config)
+        sample_tt = ttnn.to_layout(sample_tt, ttnn.ROW_MAJOR_LAYOUT)
+        out = self.conv_out(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
+        # logical_h/logical_w have grown through the upsample blocks (e.g. 34 -> 272); the caller needs
+        # these post-upsample dims to crop mesh padding, not the pre-upsample ones it passed in.
+        return out, logical_h, logical_w
+
     def forward(self, sample_BCTHW: torch.Tensor, *, output_type: str = "float") -> torch.Tensor:
         """Decode latent (B, 128, F', H', W') → video.
 
@@ -810,25 +1009,20 @@ class LTXVideoDecoder(Module):
             dtype=ttnn.bfloat16,
         )
 
-        # Denormalize: x = x * std + mean (per-channel stats replicated on the mesh).
-        mean = self.per_channel_mean.data
-        std = self.per_channel_std.data
-        sample_tt = ttnn.add(ttnn.multiply(sample_tt, std), mean)
-        sample_tt = ttnn.to_layout(sample_tt, ttnn.ROW_MAJOR_LAYOUT)
-
-        # logical_h/logical_w scale up through each upsample so later convs mask the right region.
-        sample_tt = self.conv_in(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
-        for up_block in self.up_blocks:
-            if isinstance(up_block, LTXDepthToSpaceUpsample):
-                sample_tt, logical_h, logical_w = up_block(
-                    sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w
-                )
-            else:
-                sample_tt = up_block(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
-
-        sample_tt = self.norm_out(sample_tt, compute_kernel_config=self.norm_out_compute_kernel_config)
-        sample_tt = ttnn.to_layout(sample_tt, ttnn.ROW_MAJOR_LAYOUT)
-        sample_tt = self.conv_out(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
+        _time = os.environ.get("LTX_VAE_TIME")
+        if _time:
+            ttnn.synchronize_device(self.mesh_device)
+            _t0 = time.time()
+        sample_tt, logical_h, logical_w = self.decode_device(
+            sample_tt,
+            logical_h,
+            logical_w,
+            traced=self._vae_traced,
+            tracer_trace_key=(tuple(sample_tt.shape), int(logical_h), int(logical_w)),
+        )
+        if _time:
+            ttnn.synchronize_device(self.mesh_device)
+            _t_dec = time.time()
 
         # Depth-to-space unpatch on device, output BCTHW so the gather's innermost dim stays large
         # (channels-last would gather a length-3 innermost). conv_out channels are ordered (c, p, r, q).
@@ -837,6 +1031,27 @@ class LTXVideoDecoder(Module):
         sample_tt = ttnn.reshape(sample_tt, (B_, T_, H4, W4, 3, p, r, q))
         sample_tt = ttnn.permute(sample_tt, (0, 4, 1, 5, 2, 7, 3, 6))
         sample_tt = ttnn.reshape(sample_tt, (B_, 3, T_ * p, H4 * q, W4 * r))  # (B, 3, T, H, W)
+        if _time:
+            ttnn.synchronize_device(self.mesh_device)
+            logger.info(
+                f"VAE_TIME decode_device(traced={self._vae_traced})={(_t_dec - _t0) * 1000:.1f}ms "
+                f"d2s={(time.time() - _t_dec) * 1000:.1f}ms"
+            )
+
+        if output_type == "yuv":
+            # On-device YUV 4:2:0 + fast d2h -> ffmpeg yuv420p planar uint8.
+            # logical_h/logical_w crop the global-tail mesh padding post-gather in the host planar kernel.
+            h_out, w_out = logical_h * q, logical_w * r
+            planar = fast_device_to_host_yuv(
+                sample_tt,
+                self.mesh_device,
+                ccl_manager=self.ccl_manager,
+                logical_h=h_out,
+                logical_w=w_out,
+            )
+            # Reshape flat (T, H*W*3//2) -> self-describing (T, H*3//2, W) so the exporter can
+            # recover H/W from the array alone — this IS PyAV's yuv420p ndarray layout.
+            return planar.reshape(planar.shape[0], h_out * 3 // 2, w_out)
 
         concat_dims = [None, None]
         concat_dims[self.parallel_config.height_parallel.mesh_axis] = 3

--- a/models/tt_dit/models/vae/vae_ltx.py
+++ b/models/tt_dit/models/vae/vae_ltx.py
@@ -955,6 +955,11 @@ class LTXVideoDecoder(Module):
         # logical_h/logical_w have grown through the upsample blocks
         return out, logical_h, logical_w
 
+    def release_trace(self) -> None:
+        """Free all captured decode traces (call on shutdown or before re-warming)."""
+        for tracer in type(self).decode_device._tracers_keyed.get(self, {}).values():
+            tracer.release_trace()
+
     def forward(self, sample_BCTHW: torch.Tensor, *, output_type: str = "float") -> torch.Tensor:
         """Decode latent (B, 128, F', H', W') → video.
 

--- a/models/tt_dit/models/vae/vae_ltx.py
+++ b/models/tt_dit/models/vae/vae_ltx.py
@@ -281,13 +281,6 @@ class LTXCausalConv3d(Module):
         h_pad_needed = self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1
         w_pad_needed = self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1
 
-        # H-row masking (zeroing rows at/beyond logical_h) is fused into neighbor_pad via logical_h on the standalone
-        h_mask_active = (
-            h_pad_needed
-            and logical_h > 0
-            and x_BTHWC.shape[2] * self.parallel_config.height_parallel.factor > logical_h
-        )
-
         # Pre-conv pad masking
         wf = self.parallel_config.width_parallel.factor
         hf = self.parallel_config.height_parallel.factor

--- a/models/tt_dit/models/vae/vae_ltx.py
+++ b/models/tt_dit/models/vae/vae_ltx.py
@@ -177,19 +177,11 @@ class LTXCausalConv3d(Module):
             W=dims_W,
         )
 
-        # Hybrid dispatch: the fused neighbor_pad+conv3d op wins only on conv-heavy shapes where the
-        # interior conv pass hides the halo exchange. get_conv3d_config marks exactly those shapes with
-        # halo_last (interior-then-boundary two-pass) or force_spatial_parallel; that per-shape table IS
-        # the calibrated threshold (a flat T cutoff can't separate the winners — every VAE stage has
-        # T >= 21). NP-light / tiny-conv shapes (conv_in, s0/s1/s2 res, upsamplers, conv_out) carry
-        # neither flag and stay on the standalone NP+conv3d path, which is faster there.
+        # Hybrid dispatch: the fused neighbor_pad+conv3d op wins only on conv-heavy shapes where the interior conv
         self._needs_halo = (self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1) or (
             self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1
         )
         # Halo-aware two-dispatch (neighbor_pad_halo -> conv3d halo mode): for the NP-light shapes that skip
-        # the fused op, avoid the full-pad interior copy by feeding conv3d the compact halo buffer directly.
-        # Valid only when ALL spatial padding is external (halo-exchanged) — i.e. both spatial axes' internal
-        # padding is 0 — so every conv boundary read maps to a halo section. Off via NP_NO_HALO_CONV.
         self._use_halo_conv = (
             self._needs_halo
             and self.internal_padding[1] == 0
@@ -215,10 +207,7 @@ class LTXCausalConv3d(Module):
 
         self._w_mask_cache: dict[tuple, ttnn.Tensor] = {}
         self._pad_offset_cache: dict[tuple, ttnn.Tensor] = {}
-        # Persistent-padded path (default on): neighbor_pad_halo -> compact -> halo_scatter into a padded
-        # buffer -> plain (pad=0) conv with in-kernel logical masking, instead of conv3d halo-read mode.
-        # Validated PCC=1.0 and ~6% faster e2e on BH 4x8 1080p (448ms vs 477ms halo-read). Opt out with
-        # TT_LTX_NO_PERSIST_PAD for the halo-read path.
+        # Persistent-padded path (default on): neighbor_pad_halo -> compact -> halo_scatter into a padded buffer ->
         self._persist_pad = os.environ.get("TT_LTX_NO_PERSIST_PAD") is None
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
@@ -271,9 +260,7 @@ class LTXCausalConv3d(Module):
     ) -> ttnn.Tensor:
         # x_BTHWC: (B, T, H_per_device, W_per_device, C) ROW_MAJOR, H/W fractured on the mesh.
         # logical_h/logical_w: pre-pad full spatial dims for pad masking (0 = no masking).
-        # cf_input_padded: x is already a padded [.,Hp,Wp,.] buffer (copy-free; halo reads interior
-        #   strided + border-scatter in place, no interior copy). cf_output_padded: conv writes a padded
-        #   output (output_pad) so the next conv can consume it copy-free. Both require the persist-pad path.
+        # cf_input_padded: x is already a padded [.,Hp,Wp,.] buffer
         assert x_BTHWC.layout == ttnn.ROW_MAJOR_LAYOUT
 
         # Temporal padding (T is not sharded — local op on every device).
@@ -294,29 +281,19 @@ class LTXCausalConv3d(Module):
         h_pad_needed = self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1
         w_pad_needed = self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1
 
-        # H-row masking (zeroing rows at/beyond logical_h) is fused into neighbor_pad via logical_h on the
-        # standalone path. The fused neighbor_pad_conv3d op has no logical_h argument, so a call that
-        # actually needs H masking must fall back to standalone to stay correct. For the production
-        # 1080p config every logical dim divides the mesh factor, so this is never triggered there.
+        # H-row masking (zeroing rows at/beyond logical_h) is fused into neighbor_pad via logical_h on the standalone
         h_mask_active = (
             h_pad_needed
             and logical_h > 0
             and x_BTHWC.shape[2] * self.parallel_config.height_parallel.factor > logical_h
         )
 
-        # Pre-conv pad masking. W pad columns must be zeroed on the input in BOTH paths (neighbor_pad has
-        # no W-mask). The full-pad path masks H pad rows inside neighbor_pad (logical_h=...); the compact
-        # neighbor_pad_halo op has no logical_h, so the halo path must mask H here too — folded into the
-        # SAME mul as W (one combined H&W mask) so it pays a single pre-conv mask op, not two full-tensor
-        # muls. Fires only where the physical dim exceeds the logical (e.g. 4x8's s0 pad 34->36 that
-        # propagates through the upsamples); a no-op when every logical dim divides the mesh factor (2x4).
+        # Pre-conv pad masking
         wf = self.parallel_config.width_parallel.factor
         hf = self.parallel_config.height_parallel.factor
         w_needed = logical_w > 0 and wf > 1 and x_BTHWC.shape[3] * wf > logical_w
         h_needed = logical_h > 0 and hf > 1 and x_BTHWC.shape[2] * hf > logical_h
-        # Halo path defers pad masking INTO conv3d (in-kernel, per-position on the interior read) via
-        # logical_h/w + a per-device offset — no full-tensor pre-mul. The full-pad path keeps its W
-        # pre-mul (neighbor_pad masks H via logical_h but has no W mask). See _get_pad_offset / conv3d.
+        # Halo path defers pad masking INTO conv3d (in-kernel, per-position on the interior read) via logical_h/w +
         conv_logical_h = 0
         conv_logical_w = 0
         pad_offset_tensor = None
@@ -356,11 +333,7 @@ class LTXCausalConv3d(Module):
                 links.append(_neighbor_pad_num_links(self.ccl_manager, x_BTHWC, 3))
 
             if self._use_halo_conv and self._persist_pad and h_pad_needed and w_pad_needed:
-                # Persistent-padded: neighbor_pad_halo -> compact -> halo_scatter into a padded buffer ->
-                # plain (pad=0) conv. Logical-pad masking is done IN-KERNEL by the plain conv (logical+pad
-                # threshold + per-device interior offset). cf_input_padded: x is already padded -> read its
-                # interior halo (strided) + border-scatter in place (copy-free, no interior copy).
-                # cf_output_padded: conv writes a padded output so the next conv consumes it copy-free.
+                # Persistent-padded: neighbor_pad_halo -> compact -> halo_scatter into a padded buffer -> plain
                 pHe, pWe = self.external_padding[1], self.external_padding[2]
                 # Interior per-device dims (x carries the padded border when cf_input_padded).
                 ih = x_BTHWC.shape[2] - (2 * pHe if cf_input_padded else 0)
@@ -379,8 +352,7 @@ class LTXCausalConv3d(Module):
                         sub_h=(pHe if cf_input_padded else 0),
                         sub_w=(pWe if cf_input_padded else 0),
                     )
-                # Fused exchange+scatter. cf_input_padded: x already carries the padded interior (prev
-                # conv's padded output) -> border-only in place. Else: allocate padded, fill interior+border.
+                # Fused exchange+scatter
                 padded = self.ccl_manager.neighbor_pad_halo_scatter(
                     x_BTHWC,
                     dims=dims,
@@ -415,8 +387,7 @@ class LTXCausalConv3d(Module):
                 )
 
             if self._use_halo_conv:
-                # Compact halo -> conv3d halo mode: conv does the spatial (external) padding by reading the
-                # neighbor's pixels from the halo buffer, skipping the full-pad interior copy.
+                # Compact halo -> conv3d halo mode: conv does the spatial
                 halo_buffer = self.ccl_manager.neighbor_pad_halo_only(
                     x_BTHWC,
                     dims=dims,
@@ -579,9 +550,7 @@ class LTXResnetBlock3D(Module):
         logical_h: int = 0,
         logical_w: int = 0,
     ) -> ttnn.Tensor:
-        # Copy-free: conv1 writes a PADDED output, norm2 runs on it (per-position; border is garbage),
-        # and conv2 reads it copy-free (halo interior read + border-scatter in place) — no interior copy
-        # between the two convs. norm outputs TILE; conv3d needs ROW_MAJOR.
+        # Copy-free: conv1 writes a PADDED output, norm2 runs on it
         residual = x_BTHWC
         h = self.norm1(x_BTHWC, compute_kernel_config=self.norm_compute_kernel_config)
         h = ttnn.to_layout(h, ttnn.ROW_MAJOR_LAYOUT)
@@ -824,8 +793,7 @@ class LTXVideoDecoder(Module):
         self.mesh_device = mesh_device
         self.parallel_config = parallel_config
         self.ccl_manager = ccl_manager
-        # Set True by the pipeline after warmup so the first real decode captures a ttnn trace of
-        # decode_device and later decodes replay it (removing host-dispatch overhead).
+        # Set True by the pipeline after warmup so the first real decode captures a ttnn trace of decode_device
         self._vae_traced = False
         out_channels_with_patch = out_channels * patch_size**2  # 3 * 16 = 48
 
@@ -984,8 +952,7 @@ class LTXVideoDecoder(Module):
         sample_tt = self.norm_out(sample_tt, compute_kernel_config=self.norm_out_compute_kernel_config)
         sample_tt = ttnn.to_layout(sample_tt, ttnn.ROW_MAJOR_LAYOUT)
         out = self.conv_out(sample_tt, causal=self.causal, logical_h=logical_h, logical_w=logical_w)
-        # logical_h/logical_w have grown through the upsample blocks (e.g. 34 -> 272); the caller needs
-        # these post-upsample dims to crop mesh padding, not the pre-upsample ones it passed in.
+        # logical_h/logical_w have grown through the upsample blocks
         return out, logical_h, logical_w
 
     def forward(self, sample_BCTHW: torch.Tensor, *, output_type: str = "float") -> torch.Tensor:
@@ -1039,8 +1006,7 @@ class LTXVideoDecoder(Module):
             )
 
         if output_type == "yuv":
-            # On-device YUV 4:2:0 + fast d2h -> ffmpeg yuv420p planar uint8.
-            # logical_h/logical_w crop the global-tail mesh padding post-gather in the host planar kernel.
+            # On-device YUV 4:2:0 + fast d2h -> ffmpeg yuv420p planar uint8
             h_out, w_out = logical_h * q, logical_w * r
             planar = fast_device_to_host_yuv(
                 sample_tt,
@@ -1049,8 +1015,7 @@ class LTXVideoDecoder(Module):
                 logical_h=h_out,
                 logical_w=w_out,
             )
-            # Reshape flat (T, H*W*3//2) -> self-describing (T, H*3//2, W) so the exporter can
-            # recover H/W from the array alone — this IS PyAV's yuv420p ndarray layout.
+            # Reshape flat (T, H*W*3//2) -> self-describing
             return planar.reshape(planar.shape[0], h_out * 3 // 2, w_out)
 
         concat_dims = [None, None]

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -36,6 +36,11 @@ class CCLManager:
         # keyed by the caller's shape/config key. See get_fused_norm_stats_buffer.
         self._fused_norm_stats_buffer_cache = {}
 
+        # Lazily-allocated ping-pong pool of semaphore lists for the strided all-gather-matmul op,
+        # keyed by (mesh_axis, num_workers_per_link). See get_strided_ag_mm_semaphore.
+        self._strided_ag_mm_sem_cache = {}
+        self._strided_ag_mm_sem_idx = {}
+
         # Setup semaphores
         self._init_subdevice()
 
@@ -52,8 +57,10 @@ class CCLManager:
         self.ag_ping_pong_idx = [0, 0]
         self.exp_ring_ping_pong_idx = [0, 0]
         self.np_ping_pong_idx = [0, 0]
+        self.np_fused_ping_pong_idx = [0, 0]
         self.sr_ping_pong_idx = [0, 0]
         self.barrier_idx = [0, 0]
+        self.barrier_fused_idx = [0, 0]
 
     def _init_subdevice(self):
         compute_grid_size = self.mesh_device.compute_with_storage_grid_size()
@@ -61,11 +68,6 @@ class CCLManager:
             {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
         )
 
-        _worker_sub_device = ttnn.SubDevice(
-            [
-                self.ccl_cores,
-            ]
-        )
         self.ccl_sub_device_id = ttnn.SubDeviceId(0)
 
     def _init_semaphores(self):
@@ -96,7 +98,7 @@ class CCLManager:
             1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(exp_ring_n_sems)],
         }
 
-        # Initialize neighbor pad semaphores
+        # Initialize neighbor pad semaphores (standalone NP path)
         np_n_sems = 1 * 2
         self.np_ping_pong_semaphores = {
             0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(np_n_sems)],
@@ -115,6 +117,32 @@ class CCLManager:
         self.barrier_semaphores = {
             0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
             1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
+        }
+
+        # Separate semaphores for fused NP+Conv3d path to avoid state conflicts
+        # when standalone NP and fused ops alternate in the same pipeline
+        self.np_fused_ping_pong_semaphores = {
+            0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(np_n_sems)],
+            1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(np_n_sems)],
+        }
+        self.barrier_fused_semaphores = {
+            0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
+            1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
+        }
+
+        # Per-(region,link) progress sems for fused NP+Conv3d overlap: 4 face regions
+        # {H-top, H-bot, W-left, W-right} × num_links links, indexed [region*num_links + link].
+        # That is exactly 8 on BH-LB (num_links=2); up to 16 at num_links=4 (4x8). Single bank, no host
+        # reset: the consuming kernels self-reset their own copies on-device after their final wait, so
+        # the op is trace-safe and the static addresses are baked once by the factory.
+        self._np_region_n_sems = 4 * self.num_links
+        self.np_region_progress_semaphores = {
+            0: [
+                ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(self._np_region_n_sems)
+            ],
+            1: [
+                ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(self._np_region_n_sems)
+            ],
         }
 
     def get_rs_ping_pong_buffer(self, shape, dim, mesh_axis):
@@ -253,6 +281,37 @@ class CCLManager:
         self.ag_ping_pong_idx[mesh_axis] = (cur_idx + 1) % 2
         return self.ag_ping_pong_semaphores[mesh_axis][cur_idx * n_sems : (cur_idx + 1) * n_sems]
 
+    def get_strided_ag_mm_semaphore(self, mesh_axis, num_workers_per_link):
+        """
+        Get semaphores for the strided all-gather-matmul op (strided_all_gather_minimal_matmul_async).
+
+        Unlike the 2-semaphore all-gather path, the strided op needs 2 out-ready semaphores plus
+        2 * num_links * num_workers_per_link per-worker aggregator semaphores (incremented over the
+        fabric by writer workers on the receiving device), all in a single list. A 2-deep ping-pong
+        pool is allocated lazily per (mesh_axis, num_workers_per_link) and rotated on each call.
+
+        Args:
+            mesh_axis: The mesh axis (0 or 1) to get semaphores for
+            num_workers_per_link: The op's num_workers_per_link (sets the aggregator-sem count)
+
+        Returns:
+            List of (2 + 2 * num_links * num_workers_per_link) GlobalSemaphores for this cycle
+        """
+        cache_key = (mesh_axis, num_workers_per_link)
+        if cache_key not in self._strided_ag_mm_sem_cache:
+            ttnn.synchronize_device(self.mesh_device)
+            n_sems = 2 + 2 * self.num_links * num_workers_per_link
+            self._strided_ag_mm_sem_cache[cache_key] = [
+                [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(n_sems)]
+                for _ in range(2)
+            ]
+            self._strided_ag_mm_sem_idx[cache_key] = 0
+            ttnn.synchronize_device(self.mesh_device)
+
+        cur_idx = self._strided_ag_mm_sem_idx[cache_key]
+        self._strided_ag_mm_sem_idx[cache_key] = 1 - cur_idx
+        return self._strided_ag_mm_sem_cache[cache_key][cur_idx]
+
     def get_fused_norm_stats_buffer(self, key, create_buffer):
         """Own the ping-pong pool + lifetime of the fused distributed-norm op's persistent
         stats (all-gather scratch) buffer.
@@ -302,12 +361,26 @@ class CCLManager:
 
     def get_np_ping_pong_semaphore(self, mesh_axis):
         """
-        Get semaphores for neighbor pad operations.
+        Get semaphores for standalone neighbor pad operations.
         """
         cur_idx = self.np_ping_pong_idx[mesh_axis]
         n_sems = 1
         self.np_ping_pong_idx[mesh_axis] = (cur_idx + 1) % 2
         return self.np_ping_pong_semaphores[mesh_axis][cur_idx]
+
+    def get_np_fused_ping_pong_semaphore(self, mesh_axis):
+        """
+        Get semaphores for fused NP+Conv3d operations (separate pool from standalone NP).
+        """
+        cur_idx = self.np_fused_ping_pong_idx[mesh_axis]
+        self.np_fused_ping_pong_idx[mesh_axis] = (cur_idx + 1) % 2
+        return self.np_fused_ping_pong_semaphores[mesh_axis][cur_idx]
+
+    def get_barrier_fused_semaphore(self, mesh_axis):
+        """Get barrier semaphore for fused NP+Conv3d (separate pool from standalone NP)."""
+        cur_idx = self.barrier_fused_idx[mesh_axis]
+        self.barrier_fused_idx[mesh_axis] = (cur_idx + 1) % 2
+        return self.barrier_fused_semaphores[mesh_axis][cur_idx]
 
     def get_sr_ping_pong_semaphore(self, mesh_axis):
         """
@@ -317,6 +390,182 @@ class CCLManager:
         n_sems = 1
         self.sr_ping_pong_idx[mesh_axis] = (cur_idx + 1) % 2
         return self.sr_ping_pong_semaphores[mesh_axis][cur_idx]
+
+    def get_np_region_progress_semaphores(self, mesh_axis):
+        """Get the 4*num_links per-(region,link) progress sems (static, single bank), indexed [region*num_links + link]."""
+        return self.np_region_progress_semaphores[mesh_axis]
+
+    def get_np_halo_buffer(self, input_shape, dim, padding, dtype=ttnn.bfloat16, dim2=None, padding2=0):
+        """
+        Get or create a ping-pong compact halo buffer for fabric-only NeighborPad.
+        Handles H halo and optionally W halo.
+
+        Layout: [H-top | H-bot | W-left | W-right] where H sections are
+        outer_dim × padding_h × W_dev sticks, and W sections are
+        outer_dim × padding_w × (H_dev + 2*padding_h) sticks (extended for corner fix).
+        """
+        import torch
+
+        outer_dim_size = 1
+        for d in range(dim):
+            outer_dim_size *= input_shape[d]
+        # H sticks per halo row = product of dims after dim (excluding last C dim)
+        h_sticks = 1
+        for d in range(dim + 1, len(input_shape) - 1):
+            h_sticks *= input_shape[d]
+        # W sticks per halo col = H_dev + 2*padding_h (extended to include H-padded rows for corner fix)
+        w_sticks = (input_shape[dim] + 2 * padding) if dim2 is not None else 0
+
+        h_halo_total = outer_dim_size * 2 * padding * h_sticks
+        w_halo_total = outer_dim_size * 2 * padding2 * w_sticks if dim2 is not None else 0
+        total_sticks = h_halo_total + w_halo_total
+        # Each "stick" = C channels × 2 bytes (BF16). The compact buffer must have shape
+        # [total_sticks, C] so that each 2D row = C elements = one stick page (= C×2 bytes),
+        # matching the input tensor's aligned_page_size used as stick_size in the NP factory.
+        C = input_shape[-1]  # channel dimension
+
+        cache_key = ("np_halo", tuple(input_shape), dim, padding, dim2, padding2, dtype)
+        if cache_key not in self._ping_pong_buffer_cache:
+            bufs = []
+            for _ in range(2):
+                buf = ttnn.from_torch(
+                    torch.zeros([total_sticks, C], dtype=torch.bfloat16),
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    dtype=dtype,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    device=self.mesh_device,
+                )
+                bufs.append(buf)
+            self._ping_pong_buffer_cache[cache_key] = bufs
+            self._ping_pong_buffer_indices[cache_key] = 0
+
+        cur = self._ping_pong_buffer_indices[cache_key]
+        self._ping_pong_buffer_indices[cache_key] = 1 - cur
+        return self._ping_pong_buffer_cache[cache_key][cur]
+
+    def neighbor_pad_halo_only(
+        self,
+        tensor: ttnn.Tensor,
+        *,
+        dims: list,
+        pad_left: list,
+        pad_right: list,
+        axes: list,
+        neighbor_sems: list,
+        num_links: list,
+        padding_mode: str = "zeros",
+        input_pad_h: int = 0,
+        input_pad_w: int = 0,
+        padded_output: ttnn.Tensor = None,
+    ) -> ttnn.Tensor:
+        """Fill and return the compact [H-top|H-bot|W-left|W-right] halo buffer via the standalone
+        neighbor_pad_halo op. Pair with ttnn.experimental.conv3d(halo_buffer=...) for the two-dispatch
+        halo-aware path (no full-pad interior copy). Halo-only variant of the neighbor-pad exchange.
+
+        input_pad_h/w > 0: `tensor` is a padded [.,H+2*ipad_h,W+2*ipad_w,C] buffer; exchange the halo of
+        its INTERIOR (copy-free path). The compact buffer is sized for the interior dims.
+
+        padded_output: fused mode — the op ALSO copies the interior (tensor -> padded_output) on free
+        cores CONCURRENTLY with the fabric exchange. Returns the compact buffer (still needed for the
+        border scatter); the padded interior is filled as a side effect."""
+        barrier_sem = self.get_barrier_semaphore(axes[0])
+        dim2 = dims[1] if len(dims) > 1 else None
+        padding2 = pad_left[1] if dim2 is not None else 0
+        # Compact buffer is sized from the INTERIOR shape (input_pad strips the padded border).
+        halo_shape = list(tensor.shape)
+        if input_pad_h:
+            halo_shape[dims[0]] -= 2 * input_pad_h
+        if input_pad_w and dim2 is not None:
+            halo_shape[dim2] -= 2 * input_pad_w
+        halo_buf = self.get_np_halo_buffer(
+            halo_shape, dims[0], pad_left[0], dtype=tensor.get_dtype(), dim2=dim2, padding2=padding2
+        )
+        pw = pad_left[1] if dim2 is not None and len(pad_left) > 1 else 0
+        w_sem = neighbor_sems[1] if len(neighbor_sems) > 1 else neighbor_sems[0]
+        np_pad2_left = pad_left[1] if dim2 is not None and len(pad_left) > 1 else 0
+        np_pad2_right = pad_right[1] if dim2 is not None and len(pad_right) > 1 else 0
+        np_pad_dim2_val = dim2 if dim2 is not None else 0
+        np_pad2_cluster_axis_val = axes[1] if dim2 is not None and len(axes) > 1 else 0
+        np_pad2_num_links = num_links[1] if dim2 is not None and len(num_links) > 1 else 1
+        ttnn.experimental.neighbor_pad_halo(
+            tensor,
+            halo_buf,
+            np_padding_h=pad_left[0],
+            np_padding_w=pw,
+            np_cluster_axis=axes[0],
+            np_num_links=num_links[0],
+            np_topology=self.topology,
+            h_neighbor_semaphore=neighbor_sems[0],
+            barrier_semaphore=barrier_sem,
+            w_neighbor_semaphore=w_sem,
+            np_pad_dim2=np_pad_dim2_val,
+            np_pad2_left=np_pad2_left,
+            np_pad2_right=np_pad2_right,
+            np_pad2_cluster_axis=np_pad2_cluster_axis_val,
+            np_pad2_num_links=np_pad2_num_links,
+            padding_mode=padding_mode,
+            input_pad_h=input_pad_h,
+            input_pad_w=input_pad_w,
+            padded_output=padded_output,
+        )
+        return halo_buf
+
+    def neighbor_pad_halo_scatter(
+        self,
+        tensor: ttnn.Tensor,
+        *,
+        dims: list,
+        pad_left: list,
+        pad_right: list,
+        axes: list,
+        neighbor_sems: list,
+        num_links: list,
+        padding_mode: str = "zeros",
+        input_pad_h: int = 0,
+        input_pad_w: int = 0,
+        border_only: bool = False,
+    ) -> ttnn.Tensor:
+        """Fused halo op: fabric halo exchange (into the compact buffer) then local scatter into a padded
+        [.,H+2pH,W+2pW,C] buffer, returned ready for a plain (pad=0) conv3d. Folds neighbor_pad_halo_only
+        + halo_scatter into one call.
+
+        border_only: `tensor` already carries a padded interior (previous conv's padded output), so only
+        the border is written in place (copy-free). Otherwise (repack) the padded buffer is allocated and
+        the interior copy is FUSED into the exchange op (runs concurrently on free cores), then the border
+        is scattered — overlapping the interior copy with the fabric transport instead of serializing it."""
+        pH = pad_left[0]
+        pW = pad_left[1] if len(pad_left) > 1 else 0
+        if border_only:
+            compact = self.neighbor_pad_halo_only(
+                tensor,
+                dims=dims,
+                pad_left=pad_left,
+                pad_right=pad_right,
+                axes=axes,
+                neighbor_sems=neighbor_sems,
+                num_links=num_links,
+                padding_mode=padding_mode,
+                input_pad_h=input_pad_h,
+                input_pad_w=input_pad_w,
+            )
+            return ttnn.experimental.halo_scatter(compact, tensor, np_padding_h=pH, np_padding_w=pW, border_only=True)
+
+        # Repack: allocate the padded output; the exchange op copies the interior into it concurrently.
+        padded = self.get_np_ping_pong_buffer(list(tensor.shape), dims, pad_left, pad_right, dtype=tensor.get_dtype())
+        compact = self.neighbor_pad_halo_only(
+            tensor,
+            dims=dims,
+            pad_left=pad_left,
+            pad_right=pad_right,
+            axes=axes,
+            neighbor_sems=neighbor_sems,
+            num_links=num_links,
+            padding_mode=padding_mode,
+            input_pad_h=input_pad_h,
+            input_pad_w=input_pad_w,
+            padded_output=padded,
+        )
+        return ttnn.experimental.halo_scatter(compact, padded, np_padding_h=pH, np_padding_w=pW, border_only=True)
 
     def get_barrier_semaphore(self, mesh_axis):
         """
@@ -452,11 +701,17 @@ class CCLManager:
         for axis in [0, 1]:
             for sem in self.np_ping_pong_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
+            for sem in self.np_fused_ping_pong_semaphores[axis]:
+                ttnn.reset_global_semaphore_value(sem, 0)
+            for sem in self.barrier_fused_semaphores[axis]:
+                ttnn.reset_global_semaphore_value(sem, 0)
             for sem in self.sr_ping_pong_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
             for sem in self.rs_ping_pong_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
             for sem in self.ag_ping_pong_semaphores[axis]:
+                ttnn.reset_global_semaphore_value(sem, 0)
+            for sem in self.np_region_progress_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
 
     def all_gather_persistent_buffer(

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -120,26 +120,16 @@ class CCLManager:
             1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
         }
 
-        # Separate semaphores for fused NP+Conv3d path to avoid state conflicts when standalone NP and fused ops
-        self.np_fused_ping_pong_semaphores = {
-            0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(np_n_sems)],
-            1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(np_n_sems)],
-        }
-        self.barrier_fused_semaphores = {
-            0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
-            1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
-        }
-
-        # Per-(region,link) progress sems for fused NP+Conv3d overlap: 4 face regions {H-top, H-bot, W-left
+        # Separate semaphores for fused NP+Conv3d path to avoid state conflicts when standalone NP and fused ops.
+        # Per-(region,link) progress sems cover 4 face regions {H-top, H-bot, W-left, W-right} per link.
+        # These three pools allocate on first use: nothing selects the fused path yet, and a global
+        # semaphore is a device resource held for the lifetime of every CCLManager.
+        self._np_fused_n_sems = np_n_sems
+        self._barrier_fused_n_sems = barrier_n_sems
         self._np_region_n_sems = 4 * self.num_links
-        self.np_region_progress_semaphores = {
-            0: [
-                ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(self._np_region_n_sems)
-            ],
-            1: [
-                ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(self._np_region_n_sems)
-            ],
-        }
+        self.np_fused_ping_pong_semaphores = None
+        self.barrier_fused_semaphores = None
+        self.np_region_progress_semaphores = None
 
     def get_rs_ping_pong_buffer(self, shape, dim, mesh_axis):
         """
@@ -391,16 +381,27 @@ class CCLManager:
         self.np_ping_pong_idx[mesh_axis] = (cur_idx + 1) % 2
         return self.np_ping_pong_semaphores[mesh_axis][cur_idx]
 
+    def _make_semaphore_pool(self, n_sems):
+        """Allocate a per-axis bank of `n_sems` global semaphores."""
+        return {
+            axis: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(n_sems)]
+            for axis in (0, 1)
+        }
+
     def get_np_fused_ping_pong_semaphore(self, mesh_axis):
         """
         Get semaphores for fused NP+Conv3d operations (separate pool from standalone NP).
         """
+        if self.np_fused_ping_pong_semaphores is None:
+            self.np_fused_ping_pong_semaphores = self._make_semaphore_pool(self._np_fused_n_sems)
         cur_idx = self.np_fused_ping_pong_idx[mesh_axis]
         self.np_fused_ping_pong_idx[mesh_axis] = (cur_idx + 1) % 2
         return self.np_fused_ping_pong_semaphores[mesh_axis][cur_idx]
 
     def get_barrier_fused_semaphore(self, mesh_axis):
         """Get barrier semaphore for fused NP+Conv3d (separate pool from standalone NP)."""
+        if self.barrier_fused_semaphores is None:
+            self.barrier_fused_semaphores = self._make_semaphore_pool(self._barrier_fused_n_sems)
         cur_idx = self.barrier_fused_idx[mesh_axis]
         self.barrier_fused_idx[mesh_axis] = (cur_idx + 1) % 2
         return self.barrier_fused_semaphores[mesh_axis][cur_idx]
@@ -416,6 +417,8 @@ class CCLManager:
 
     def get_np_region_progress_semaphores(self, mesh_axis):
         """Get the 4*num_links per-(region,link) progress sems (static, single bank), indexed [region*num_links + link]."""
+        if self.np_region_progress_semaphores is None:
+            self.np_region_progress_semaphores = self._make_semaphore_pool(self._np_region_n_sems)
         return self.np_region_progress_semaphores[mesh_axis]
 
     def get_np_halo_buffer(self, input_shape, dim, padding, dtype=ttnn.bfloat16, dim2=None, padding2=0):
@@ -722,18 +725,21 @@ class CCLManager:
         for axis in [0, 1]:
             for sem in self.np_ping_pong_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
-            for sem in self.np_fused_ping_pong_semaphores[axis]:
-                ttnn.reset_global_semaphore_value(sem, 0)
-            for sem in self.barrier_fused_semaphores[axis]:
-                ttnn.reset_global_semaphore_value(sem, 0)
             for sem in self.sr_ping_pong_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
             for sem in self.rs_ping_pong_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
             for sem in self.ag_ping_pong_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
-            for sem in self.np_region_progress_semaphores[axis]:
-                ttnn.reset_global_semaphore_value(sem, 0)
+            # Lazily-allocated fused NP+Conv3d pools; skipped entirely until something asks for them.
+            for pool in (
+                self.np_fused_ping_pong_semaphores,
+                self.barrier_fused_semaphores,
+                self.np_region_progress_semaphores,
+            ):
+                if pool is not None:
+                    for sem in pool[axis]:
+                        ttnn.reset_global_semaphore_value(sem, 0)
 
     def all_gather_persistent_buffer(
         self, tensor: ttnn.Tensor, /, *, dim: int, mesh_axis: int | None, use_hyperparams: bool = False

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -40,6 +40,8 @@ class CCLManager:
         # keyed by (mesh_axis, num_workers_per_link). See get_strided_ag_mm_semaphore.
         self._strided_ag_mm_sem_cache = {}
         self._strided_ag_mm_sem_idx = {}
+        # Single shared MM->RS progress counter array. See get_mm_progress_counters_buffer.
+        self._mm_progress_counters_buffer = None
 
         # Setup semaphores
         self._init_subdevice()
@@ -343,6 +345,33 @@ class CCLManager:
         buf = bufs[entry["idx"]]
         entry["idx"] = (entry["idx"] + 1) % len(bufs)
         return buf
+
+    def get_mm_progress_counters_buffer(self):
+        """Own the progress-counter array for the fused matmul -> strided reduce-scatter op's
+        per-core MM->RS signaling: one uint32 slot per matmul core, one row per core.
+
+        Same per-core row as the array the op allocates for itself, over the whole compute grid
+        rather than just the RS worker cores, and allocated once here instead of per compiled
+        program. The op's own copy is retained for as long as the program stays cached, and because
+        L1 is handed out top-down each of those small permanent blocks pins the freed space above it,
+        which eventually leaves a later op (the VAE's ring joint SDPA) short of contiguous L1 for its
+        circular buffers.
+        """
+        if self._mm_progress_counters_buffer is None:
+            grid = self.mesh_device.compute_with_storage_grid_size()
+            slots = grid.x * grid.y
+            self._mm_progress_counters_buffer = ttnn.allocate_tensor_on_device(
+                ttnn.Shape([slots, slots]),
+                ttnn.uint32,
+                ttnn.ROW_MAJOR_LAYOUT,
+                self.mesh_device,
+                ttnn.MemoryConfig(
+                    ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                    ttnn.BufferType.L1,
+                    ttnn.ShardSpec(self.ccl_cores, [1, slots], ttnn.ShardOrientation.ROW_MAJOR),
+                ),
+            )
+        return self._mm_progress_counters_buffer
 
     def get_exp_ring_ping_pong_semaphore(self, mesh_axis):
         """

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -36,8 +36,7 @@ class CCLManager:
         # keyed by the caller's shape/config key. See get_fused_norm_stats_buffer.
         self._fused_norm_stats_buffer_cache = {}
 
-        # Lazily-allocated ping-pong pool of semaphore lists for the strided all-gather-matmul op,
-        # keyed by (mesh_axis, num_workers_per_link). See get_strided_ag_mm_semaphore.
+        # Lazily-allocated ping-pong pool of semaphore lists for the strided all-gather-matmul op
         self._strided_ag_mm_sem_cache = {}
         self._strided_ag_mm_sem_idx = {}
         # Single shared MM->RS progress counter array. See get_mm_progress_counters_buffer.
@@ -121,8 +120,7 @@ class CCLManager:
             1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
         }
 
-        # Separate semaphores for fused NP+Conv3d path to avoid state conflicts
-        # when standalone NP and fused ops alternate in the same pipeline
+        # Separate semaphores for fused NP+Conv3d path to avoid state conflicts when standalone NP and fused ops
         self.np_fused_ping_pong_semaphores = {
             0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(np_n_sems)],
             1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(np_n_sems)],
@@ -132,11 +130,7 @@ class CCLManager:
             1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(barrier_n_sems)],
         }
 
-        # Per-(region,link) progress sems for fused NP+Conv3d overlap: 4 face regions
-        # {H-top, H-bot, W-left, W-right} × num_links links, indexed [region*num_links + link].
-        # That is exactly 8 on BH-LB (num_links=2); up to 16 at num_links=4 (4x8). Single bank, no host
-        # reset: the consuming kernels self-reset their own copies on-device after their final wait, so
-        # the op is trace-safe and the static addresses are baked once by the factory.
+        # Per-(region,link) progress sems for fused NP+Conv3d overlap: 4 face regions {H-top, H-bot, W-left
         self._np_region_n_sems = 4 * self.num_links
         self.np_region_progress_semaphores = {
             0: [
@@ -448,9 +442,7 @@ class CCLManager:
         h_halo_total = outer_dim_size * 2 * padding * h_sticks
         w_halo_total = outer_dim_size * 2 * padding2 * w_sticks if dim2 is not None else 0
         total_sticks = h_halo_total + w_halo_total
-        # Each "stick" = C channels × 2 bytes (BF16). The compact buffer must have shape
-        # [total_sticks, C] so that each 2D row = C elements = one stick page (= C×2 bytes),
-        # matching the input tensor's aligned_page_size used as stick_size in the NP factory.
+        # Each "stick" = C channels × 2 bytes (BF16)
         C = input_shape[-1]  # channel dimension
 
         cache_key = ("np_halo", tuple(input_shape), dim, padding, dim2, padding2, dtype)

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx.py
@@ -814,6 +814,8 @@ class LTXPipeline:
 
         with Watchdog("vae decode"):
             video = self.vae_decoder(latent_spatial, output_type=output_type)
+        if output_type == "yuv":
+            return video  # already a numpy (T, H*3//2, W) uint8 yuv420p planar array
         if output_type != "float":
             return video.numpy()
         return video

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx.py
@@ -342,6 +342,8 @@ class LTXPipeline:
             self.tt_vocoder_with_bwe.release_trace()
         if self.tt_mel_decoder is not None:
             self.tt_mel_decoder.release_trace()
+        if self.vae_decoder is not None:
+            self.vae_decoder.release_trace()
         self._trace_state.clear()
         self._prompt_v = StateTensor()
         self._prompt_a = StateTensor()

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx_distilled.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx_distilled.py
@@ -21,7 +21,7 @@ from ...models.vae.vae_ltx import upsample_latent
 from ...utils.ltx import load_conditioning_image
 from ...utils.patchifiers import AudioLatentShape, VideoPixelShape
 from ...utils.tensor import bf16_tensor
-from ...utils.video import export_video_audio
+from ...utils.video import export_video_audio, export_video_audio_yuv
 from .pipeline_ltx import SPATIAL_COMPRESSION, TEMPORAL_COMPRESSION, LTXPipeline, LTXTransformerState, latent_grid
 
 # Distilled sigma schedules for the two stages.
@@ -185,6 +185,11 @@ class LTXDistilledPipeline(LTXPipeline):
 
             # Compile VAE decode at full-res (only s2 feeds decode in generate).
             self._warmup_decode(num_frames, height, width)
+
+            # Programs are now compiled; let the first real decode capture a ttnn trace of
+            # decode_device and later decodes replay it (removes host-dispatch overhead).
+            if self._traced and self.vae_decoder is not None:
+                self.vae_decoder._vae_traced = True
 
             # Warm the on-device audio decode eagerly at the real latent shape: compiles kernels,
             # initializes lazy device state, and frees back to a deterministic allocator free-list,
@@ -696,8 +701,12 @@ class LTXDistilledPipeline(LTXPipeline):
             logger.info(f"VAE prepare: {time.time() - t0:.1f}s")
 
         latent_h, latent_w = height // SPATIAL_COMPRESSION, width // SPATIAL_COMPRESSION
+        # LTX_YUV_EXPORT routes the mp4 path through the on-device YUV 4:2:0 fast gather
+        # (the mp4 is yuv420p either way — this only moves the color conversion onto the device
+        # and shrinks the d2h ~8x). Off → the float RGB gather feeding host-side conversion.
+        yuv_export = output_path is not None and os.environ.get("LTX_YUV_EXPORT", "0") != "0"
         # export_video_audio needs float [-1,1]; the frame-return path uses the requested output_type.
-        decode_type = "float" if output_path is not None else output_type
+        decode_type = ("yuv" if yuv_export else "float") if output_path is not None else output_type
         t0 = time.time()
         video_pixels = self.decode_latents(s2_video, latent_frames, latent_h, latent_w, output_type=decode_type)
         t_vae_decode = time.time() - t0
@@ -716,7 +725,10 @@ class LTXDistilledPipeline(LTXPipeline):
             return video_pixels, audio_obj
 
         t0 = time.time()
-        export_video_audio(video_pixels, output_path, fps=fps, audio=audio_obj)
+        if yuv_export:
+            export_video_audio_yuv(video_pixels, output_path, fps=fps, audio=audio_obj)
+        else:
+            export_video_audio(video_pixels, output_path, fps=fps, audio=audio_obj)
         logger.info(f"Video export: {time.time() - t0:.1f}s")
         logger.info(f"Total (compute): {sum(s for _, s in timings):.1f}s | Output: {output_path}")
         return output_path

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx_distilled.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx_distilled.py
@@ -186,8 +186,7 @@ class LTXDistilledPipeline(LTXPipeline):
             # Compile VAE decode at full-res (only s2 feeds decode in generate).
             self._warmup_decode(num_frames, height, width)
 
-            # Programs are now compiled; let the first real decode capture a ttnn trace of
-            # decode_device and later decodes replay it (removes host-dispatch overhead).
+            # Programs are now compiled
             if self._traced and self.vae_decoder is not None:
                 self.vae_decoder._vae_traced = True
 
@@ -702,8 +701,6 @@ class LTXDistilledPipeline(LTXPipeline):
 
         latent_h, latent_w = height // SPATIAL_COMPRESSION, width // SPATIAL_COMPRESSION
         # LTX_YUV_EXPORT routes the mp4 path through the on-device YUV 4:2:0 fast gather
-        # (the mp4 is yuv420p either way — this only moves the color conversion onto the device
-        # and shrinks the d2h ~8x). Off → the float RGB gather feeding host-side conversion.
         yuv_export = output_path is not None and os.environ.get("LTX_YUV_EXPORT", "0") != "0"
         # export_video_audio needs float [-1,1]; the frame-return path uses the requested output_type.
         decode_type = ("yuv" if yuv_export else "float") if output_path is not None else output_type

--- a/models/tt_dit/tests/models/ltx/ltx_mesh_params.py
+++ b/models/tt_dit/tests/models/ltx/ltx_mesh_params.py
@@ -94,6 +94,9 @@ LTX_ONE_STAGE_MESH_PARAMS_DL = [
     for p in LTX_PIPELINE_MESH_PARAMS_DL
 ]
 
+# Two-stages (Pro) drives the same audio vocoder, so it needs the same pool for the same reason.
+LTX_TWO_STAGES_MESH_PARAMS_DL = LTX_ONE_STAGE_MESH_PARAMS_DL
+
 
 # ---------------------------------------------------------------------------
 # Distilled AV pipeline mesh params. Same geometry as the pipeline configs, but the audio

--- a/models/tt_dit/tests/models/ltx/ltx_mesh_params.py
+++ b/models/tt_dit/tests/models/ltx/ltx_mesh_params.py
@@ -7,7 +7,11 @@ import os
 import pytest
 
 import ttnn
-from models.tt_dit.utils.test import line_params_req_exact_devices, ring_params_req_exact_devices
+from models.tt_dit.utils.test import (
+    line_params_req_exact_devices,
+    ring_params_8k_req_exact_devices,
+    ring_params_req_exact_devices,
+)
 
 _line = line_params_req_exact_devices
 _ring = ring_params_req_exact_devices
@@ -111,7 +115,10 @@ LTX_ONE_STAGE_MESH_PARAMS_DL = [
 _line_l1small = {**_line, "l1_small_size": 32768}
 _ring_worker_l1 = {"worker_l1_size": 1344544, **_ring}
 _line_trace = {**_line, "trace_region_size": 500_000_000, "l1_small_size": 32768}
-_ring_trace = {**_ring, "trace_region_size": 500_000_000, "l1_small_size": 32768}
+#   fabric_router_config (8 KB payload): the strided all-gather packs up to 4 bf16 tiles per
+#     fabric packet (scatter-write, 4 distinct dest NoC addresses). That cap degrades to
+#     whatever the payload holds, so a smaller packet silently halves it to 2 tiles.
+_ring_trace = {**ring_params_8k_req_exact_devices, "trace_region_size": 500_000_000, "l1_small_size": 32768}
 
 LTX_DISTILLED_MESH_PARAMS_DL = [
     _with_dynamic_load(_2x2sp0tp1nl2_line_is_fsdp1, False),

--- a/models/tt_dit/tests/models/ltx/ltx_mesh_params.py
+++ b/models/tt_dit/tests/models/ltx/ltx_mesh_params.py
@@ -118,9 +118,7 @@ LTX_TWO_STAGES_MESH_PARAMS_DL = LTX_ONE_STAGE_MESH_PARAMS_DL
 _line_l1small = {**_line, "l1_small_size": 32768}
 _ring_worker_l1 = {"worker_l1_size": 1344544, **_ring}
 _line_trace = {**_line, "trace_region_size": 500_000_000, "l1_small_size": 32768}
-#   fabric_router_config (8 KB payload): the strided all-gather packs up to 4 bf16 tiles per
-#     fabric packet (scatter-write, 4 distinct dest NoC addresses). That cap degrades to
-#     whatever the payload holds, so a smaller packet silently halves it to 2 tiles.
+# fabric_router_config (8 KB payload): the strided all-gather packs up to 4 bf16 tiles per fabric packet
 _ring_trace = {**ring_params_8k_req_exact_devices, "trace_region_size": 500_000_000, "l1_small_size": 32768}
 
 LTX_DISTILLED_MESH_PARAMS_DL = [

--- a/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
+++ b/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
@@ -57,8 +57,9 @@ def _ltx_checkpoint_cached(filename: str) -> bool:
         except (LocalEntryNotFoundError, EntryNotFoundError, FileNotFoundError):
             return False
     return False
-from models.tt_dit.utils.vbench import assert_vbench_quality
 
+
+from models.tt_dit.utils.vbench import assert_vbench_quality
 
 
 # Default-off: full AV gen needs the real LTX checkpoint + Gemma, so it skips without one.

--- a/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
+++ b/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
@@ -59,9 +59,6 @@ def _ltx_checkpoint_cached(filename: str) -> bool:
     return False
 
 
-from models.tt_dit.utils.vbench import assert_vbench_quality
-
-
 # Default-off: full AV gen needs the real LTX checkpoint + Gemma, so it skips without one.
 @pytest.mark.skipif(
     not _ltx_checkpoint_cached("ltx-2.3-22b-distilled-1.1.safetensors"),

--- a/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
+++ b/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
@@ -57,11 +57,11 @@ def _ltx_checkpoint_cached(filename: str) -> bool:
         except (LocalEntryNotFoundError, EntryNotFoundError, FileNotFoundError):
             return False
     return False
+from models.tt_dit.utils.vbench import assert_vbench_quality
 
 
-# Default-off: full AV gen needs the real LTX checkpoint + Gemma, so it skips in the default suite
-# (no checkpoint present). Runs the same prompt as the girl audio fixture (DEFAULT_LTX_PROMPT — the
-# "young woman with a guitar sings Doo-be-doo" clip the audio tests use), so e2e and audio stay aligned.
+
+# Default-off: full AV gen needs the real LTX checkpoint + Gemma, so it skips without one.
 @pytest.mark.skipif(
     not _ltx_checkpoint_cached("ltx-2.3-22b-distilled-1.1.safetensors"),
     reason="needs the LTX checkpoint (set LTX_CHECKPOINT to a local .safetensors)",

--- a/models/tt_dit/tests/models/ltx/test_pipeline_ltx_two_stages.py
+++ b/models/tt_dit/tests/models/ltx/test_pipeline_ltx_two_stages.py
@@ -18,7 +18,7 @@ from models.tt_dit.utils.ltx import (
 )
 from models.tt_dit.utils.test import skip_if_unsupported_num_links
 
-from .ltx_mesh_params import LTX_PIPELINE_MESH_PARAMS_DL, LTX_TWO_STAGES_I2V_MESH_PARAMS_DL
+from .ltx_mesh_params import LTX_TWO_STAGES_I2V_MESH_PARAMS_DL, LTX_TWO_STAGES_MESH_PARAMS_DL
 
 
 def _default_distilled_lora() -> str:
@@ -43,7 +43,7 @@ def _default_distilled_lora() -> str:
 )
 @pytest.mark.parametrize(
     "mesh_device, sp_axis, tp_axis, num_links, device_params, topology, is_fsdp, dynamic_load",
-    LTX_PIPELINE_MESH_PARAMS_DL,
+    LTX_TWO_STAGES_MESH_PARAMS_DL,
     indirect=["mesh_device", "device_params"],
 )
 def test_pipeline_two_stages(

--- a/models/tt_dit/tests/models/ltx/test_transformer_ltx.py
+++ b/models/tt_dit/tests/models/ltx/test_transformer_ltx.py
@@ -1506,10 +1506,7 @@ def test_ltx_per_token_timestep_nonuniform(
     assert_quality(ref_video, out_tt, pcc=0.99, relative_rmse=0.03)
 
 
-# ---------------------------------------------------------------------------
-# Trace-based perf: VIDEO stage-2 ring only (measures StridedAllGatherMinimalMatmulAsync
-# and block wall-clock at steady state under a ttnn trace). Perf-only: no PCC.
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- Trace-based perf: VIDEO stage-2 ring
 def _build_video_trace_setup(
     *,
     mesh_device,
@@ -1835,8 +1832,7 @@ def test_ltx_transformer_trace_perf(
         checkpoint_variant=checkpoint_variant,
     )
 
-    # AV emits far more markers than video; keep warm/replay counts low (overridable via env) so the
-    # per-core profiler buffer doesn't overflow before the post-capture drain below.
+    # AV emits far more markers than video
     n_warm = int(os.environ.get("LTX_PERF_N_WARM", "1" if has_audio else "2"))
     n_replay = int(os.environ.get("LTX_PERF_N_REPLAY", "3" if has_audio else "5"))
 
@@ -1867,8 +1863,7 @@ def test_ltx_transformer_trace_perf(
     signpost("stop")
     logger.info(f"trace replay ({n_replay}x): {replay_s:.3f}s → {replay_s / n_replay * 1e3:.2f} ms/step")
 
-    # Perf-only: crop SP-padding tail, assert shape + finiteness (no PCC).
-    # AV mode returns (video, audio); video-only returns a single tensor.
+    # Perf-only: crop SP-padding tail, assert shape + finiteness (no PCC)
     video_out = result[0] if isinstance(result, tuple) else result
     tt_video = LTXTransformerModel.device_to_host(video_out).squeeze(0)[:, :video_N_real, :]
     assert tt_video.shape == (1, video_N_real, OUT_CHANNELS), f"video shape {tt_video.shape}"
@@ -1891,8 +1886,7 @@ def _build_block_trace_setup(
     """
     checkpoint_22b = _resolve_checkpoint_22b(checkpoint_variant)
     sp_factor = tuple(mesh_device.shape)[sp_axis]
-    # Real latent grid → SP-padded sequence (mirrors LTXPipeline). video_N is the padded device
-    # length; video_N_real is the logical token count fed to SDPA's logical_n / padding masks.
+    # Real latent grid → SP-padded sequence (mirrors LTXPipeline)
     video_N_real = F * H * W
     video_N = _sp_pad_len(video_N_real, sp_factor)
     audio_N, audio_N_real = _audio_seq_lens(F, sp_factor)
@@ -1932,8 +1926,7 @@ def _build_block_trace_setup(
     temb = torch.randn(1, 1, 9 * DIM, dtype=torch.float32)  # 9 adaln params
     prompt_temb = torch.randn(1, 1, 2 * DIM, dtype=torch.float32)  # 2 adaln params for prompt
 
-    # TT video tensors. Sequence SP-padded to video_N; rope pads with identity rotation; video_N_real
-    # (logical) goes to the block for SDPA masking.
+    # TT video tensors
     spatial = _pad_seq_dim(x, video_N, dim=1).unsqueeze(0)
     tt_spatial = bf16_tensor_2dshard(spatial, device=mesh_device, shard_mapping={sp_axis: 2, tp_axis: 3})
     tt_prompt = bf16_tensor(context.unsqueeze(0), device=mesh_device)
@@ -2025,8 +2018,7 @@ def _build_block_trace_setup(
 
 @pytest.mark.parametrize(
     ("mesh_device", "sp_axis", "tp_axis", "num_links", "device_params", "topology", "is_fsdp"),
-    # Same ring stage-2 8k config as test_ltx_transformer_trace_perf (ring_params_8k = FABRIC_1D_RING
-    # + 8192-B fabric router payload). Do NOT add other-mesh params here.
+    # Same ring stage-2 8k config as test_ltx_transformer_trace_perf
     [pytest.param((4, 8), 1, 0, 2, ring_params_8k, ttnn.Topology.Ring, False, id="ring_bh_4x8sp1tp0_8k")],
     indirect=["mesh_device", "device_params"],
 )
@@ -2070,14 +2062,10 @@ def test_ltx_transformer_block_trace_perf(
         checkpoint_variant=checkpoint_variant,
     )
 
-    # Trace the block forward with the same Tracer settings inner_step uses (prep_run=False:
-    # kernels are precompiled by the eager warm calls below; clone_prep_inputs=False).
+    # Trace the block forward with the same Tracer settings inner_step uses
     tracer = Tracer(tt_block.forward, device=mesh_device, prep_run=False, clone_prep_inputs=False)
 
-    # AV runs many more ops than video (audio self/cross + a2v/v2a + audio ff/RS). The per-core
-    # 12000-marker profiler DRAM buffer is drained only at end-of-run, so warm + capture + replay
-    # markers pile up and overflow. We drain the profiler after capture (below) so only the
-    # signposted replays count against the budget; AV also uses fewer warm/replays for headroom.
+    # AV runs many more ops than video (audio self/cross + a2v/v2a + audio ff/RS)
     n_warm = 1 if has_audio else 2
     n_replay = 3 if has_audio else 5
 
@@ -2095,7 +2083,6 @@ def test_ltx_transformer_block_trace_perf(
     logger.info(f"trace capture: {time.time() - t0:.1f}s")
 
     # Drain warm+capture markers so ONLY the signposted replays occupy the profiler DRAM buffer
-    # (the AV profiler-overflow fix, mirroring test_ltx_transformer_trace_perf).
     ttnn.ReadDeviceProfiler(mesh_device)
 
     # Steady-state replay under the signpost bracket for tt-perf-report --start/end-signpost.
@@ -2109,8 +2096,7 @@ def test_ltx_transformer_block_trace_perf(
     signpost("stop")
     logger.info(f"trace replay ({n_replay}x): {replay_s:.3f}s → {replay_s / n_replay * 1e3:.2f} ms/step")
 
-    # Perf-only: crop SP-padding tail, assert shape + finiteness (no PCC).
-    # AV mode returns (video, audio); video-only returns a single tensor.
+    # Perf-only: crop SP-padding tail, assert shape + finiteness (no PCC)
     tt_v = result[0] if isinstance(result, tuple) else result
     concat_dims = [None, None]
     concat_dims[sp_axis] = 2

--- a/models/tt_dit/tests/models/ltx/test_transformer_ltx.py
+++ b/models/tt_dit/tests/models/ltx/test_transformer_ltx.py
@@ -34,7 +34,13 @@ from models.tt_dit.utils.check import assert_quality
 from models.tt_dit.utils.mochi import get_rot_transformation_mat
 from models.tt_dit.utils.patchifiers import AudioLatentShape, VideoPixelShape
 from models.tt_dit.utils.tensor import bf16_tensor, bf16_tensor_2dshard
-from models.tt_dit.utils.test import line_params_req_exact_devices, skip_if_unsupported_num_links
+from models.tt_dit.utils.test import (
+    line_params_req_exact_devices,
+    ring_params_4k,
+    ring_params_8k,
+    skip_if_unsupported_num_links,
+)
+from models.tt_dit.utils.tracing import Tracer
 
 from .ltx_mesh_params import LTX_TRANSFORMER_MESH_PARAMS, _4x8sp1tp0nl2_ring_is_fsdp0
 
@@ -1498,3 +1504,624 @@ def test_ltx_per_token_timestep_nonuniform(
     logger.info(f"non-uniform per-token (TT vs oracle): all={pcc_all:.5f} frame0={pcc_f0:.5f} rest={pcc_rest:.5f}")
 
     assert_quality(ref_video, out_tt, pcc=0.99, relative_rmse=0.03)
+
+
+# ---------------------------------------------------------------------------
+# Trace-based perf: VIDEO stage-2 ring only (measures StridedAllGatherMinimalMatmulAsync
+# and block wall-clock at steady state under a ttnn trace). Perf-only: no PCC.
+# ---------------------------------------------------------------------------
+def _build_video_trace_setup(
+    *,
+    mesh_device,
+    sp_axis,
+    tp_axis,
+    num_links,
+    topology,
+    is_fsdp,
+    F,
+    H,
+    W,
+    has_audio=False,
+    checkpoint_variant="fast",
+    num_layers=1,
+):
+    """Build the TT model + device-only ``inner_step`` kwargs for the trace-perf test.
+
+    Mirrors the TT setup in ``_run_inner_step`` and reproduces ``LTXTransformerModel.forward``'s
+    host→device upload preamble (which ``inner_step`` normally receives), so the returned ttnn
+    kwargs can be captured/replayed directly under ttnn trace. Returns
+    ``(tt_model, inner_kwargs, video_N_real)``. Perf-only; no PCC.
+
+    Video mode uses random scaled weights. AV mode (``has_audio=True``) loads the 22B checkpoint
+    (``strict=False``) like the AV PCC path and adds the audio device tensors (audio latent,
+    audio/cross-modal rope, video pad mask) so a2v / audio shapes actually fire under the trace.
+    """
+    sp_factor = tuple(mesh_device.shape)[sp_axis]
+    video_N_real = F * H * W
+    video_N = _sp_pad_len(video_N_real, sp_factor)
+    assert video_N % (32 * sp_factor) == 0
+    audio_N = AUDIO_N
+    if has_audio:
+        assert audio_N % (32 * sp_factor) == 0
+
+    if has_audio:
+        # AV weights come from the 22B checkpoint (strict=False), same as the AV PCC path.
+        checkpoint_22b = _resolve_checkpoint_22b(checkpoint_variant)
+        state_dict = _load_22b_state_dict(num_layers=num_layers, checkpoint_path=checkpoint_22b)
+        if state_dict is None:
+            pytest.skip(f"22B checkpoint not found at {checkpoint_22b}")
+    else:
+        # Random scaled weights from the diffusers 3D video model — the video PCC path.
+        torch_model = _make_diffusers_video_model(num_layers=num_layers)
+        torch_model.eval()
+        _scale_init_(torch_model)
+        state_dict = _convert_diffusers_video_model_to_tt(
+            torch_model.state_dict(), num_heads=NUM_HEADS, head_dim=HEAD_DIM
+        )
+        state_dict = {k: v.detach().clone() for k, v in state_dict.items()}
+        del torch_model
+
+    # Real-grid latent; the TT side gets a zero-padded copy (video_N).
+    torch.manual_seed(INPUT_SEED)
+    video_lat_real = torch.randn(1, video_N_real, IN_CHANNELS, dtype=torch.float32)
+    video_lat = _pad_seq_dim(video_lat_real, video_N, dim=1)
+    video_prompt = torch.randn(1, PROMPT_LEN, CTX_DIM, dtype=torch.float32)
+    sigma_val = 0.5 if has_audio else TIMESTEP_VAL  # AV path uses production sigma=0.5
+    timestep_torch = torch.tensor([sigma_val])
+
+    audio_lat = None
+    audio_prompt = None
+    if has_audio:
+        audio_lat = torch.randn(1, audio_N, AUDIO_IN_CHANNELS, dtype=torch.float32)
+        audio_prompt = torch.randn(1, PROMPT_LEN, AUDIO_CTX_DIM, dtype=torch.float32)
+
+    ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
+    parallel_config = _make_parallel_config(mesh_device, sp_axis, tp_axis)
+    tt_model = _make_tt_model(
+        mesh_device=mesh_device,
+        ccl_manager=ccl_manager,
+        parallel_config=parallel_config,
+        is_fsdp=is_fsdp,
+        has_audio=has_audio,
+        num_layers=num_layers,
+    )
+    t0 = time.time()
+    tt_model.load_torch_state_dict(state_dict, strict=not has_audio)
+    logger.info(f"state-dict load: {time.time() - t0:.1f}s")
+
+    # Stage-constant device tensors (INTERLEAVED rope + trans_mat + prompt).
+    tt_video_prompt = bf16_tensor(video_prompt.unsqueeze(0), device=mesh_device)
+    tt_vc, tt_vs = _tt_rope(
+        _video_rope_freqs, F, H, W, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, pad_to=video_N
+    )
+    tt_trans_mat = bf16_tensor(get_rot_transformation_mat(), device=mesh_device)
+
+    # Per-step device inputs — reproduce LTXTransformerModel.forward's upload for the video path.
+    video_1BNI_torch = video_lat.unsqueeze(0)  # (1, B=1, video_N, IN_CHANNELS)
+    B_size = video_1BNI_torch.shape[1]
+    video_1BNI = bf16_tensor(video_1BNI_torch, device=mesh_device, mesh_axis=sp_axis, shard_dim=-2)
+    timestep = bf16_tensor(timestep_torch.reshape(1, 1, B_size, 1) * 1000.0, device=mesh_device)
+
+    # inner_step is keyword-only; these are exactly the device tensors it consumes.
+    inner_kwargs = dict(
+        video_1BNI=video_1BNI,
+        timestep=timestep,
+        video_prompt_1BLP=tt_video_prompt,
+        video_rope_cos=tt_vc,
+        video_rope_sin=tt_vs,
+        video_N=video_N_real,
+        trans_mat=tt_trans_mat,
+    )
+
+    if has_audio:
+        # Audio + cross-modal device tensors, mirroring the AV branch of _run_inner_step.
+        a_cos, a_sin = _tt_rope(_audio_rope_freqs, audio_N, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis)
+        vx_cos, vx_sin = _tt_rope(
+            _video_cross_pe_freqs, F, H, W, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, pad_to=video_N
+        )
+        ax_cos, ax_sin = _tt_rope(
+            _audio_cross_pe_freqs, audio_N, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis
+        )
+        ax_cos_full, ax_sin_full = _tt_rope_full(
+            _audio_cross_pe_freqs, audio_N, mesh_device=mesh_device, tp_axis=tp_axis
+        )
+        v_pad_sp = build_video_pad_mask(video_N, video_N_real, mesh_device=mesh_device, sp_axis=sp_axis)
+        audio_1BNI = bf16_tensor(audio_lat.unsqueeze(0), device=mesh_device, mesh_axis=sp_axis, shard_dim=-2)
+        inner_kwargs.update(
+            audio_1BNI=audio_1BNI,
+            audio_prompt_1BLP=bf16_tensor(audio_prompt.unsqueeze(0), device=mesh_device),
+            audio_rope_cos=a_cos,
+            audio_rope_sin=a_sin,
+            audio_N=audio_N,
+            video_cross_pe_cos=vx_cos,
+            video_cross_pe_sin=vx_sin,
+            audio_cross_pe_cos=ax_cos,
+            audio_cross_pe_sin=ax_sin,
+            audio_cross_pe_cos_full=ax_cos_full,
+            audio_cross_pe_sin_full=ax_sin_full,
+            video_padding_mask=v_pad_sp,
+        )
+    return tt_model, inner_kwargs, video_N_real
+
+
+def _build_trace_inner_kwargs(*, mesh_device, sp_axis, tp_axis, F, H, W, has_audio):
+    """Build ONLY the device inner_step kwargs for a given (F,H,W) — no model / CCLManager.
+
+    Split out so ONE model + CCLManager can be driven at multiple shapes (e.g. stage-1 then
+    stage-2) to reproduce the e2e's cross-stage device/semaphore-pool state. Mirrors the per-shape
+    tensor setup inside _build_video_trace_setup. Returns (inner_kwargs, video_N_real).
+    """
+    sp_factor = tuple(mesh_device.shape)[sp_axis]
+    video_N_real = F * H * W
+    video_N = _sp_pad_len(video_N_real, sp_factor)
+    assert video_N % (32 * sp_factor) == 0
+    audio_N = AUDIO_N
+    if has_audio:
+        assert audio_N % (32 * sp_factor) == 0
+
+    torch.manual_seed(INPUT_SEED)
+    video_lat_real = torch.randn(1, video_N_real, IN_CHANNELS, dtype=torch.float32)
+    video_lat = _pad_seq_dim(video_lat_real, video_N, dim=1)
+    video_prompt = torch.randn(1, PROMPT_LEN, CTX_DIM, dtype=torch.float32)
+    sigma_val = 0.5 if has_audio else TIMESTEP_VAL
+    timestep_torch = torch.tensor([sigma_val])
+
+    audio_lat = None
+    audio_prompt = None
+    if has_audio:
+        audio_lat = torch.randn(1, audio_N, AUDIO_IN_CHANNELS, dtype=torch.float32)
+        audio_prompt = torch.randn(1, PROMPT_LEN, AUDIO_CTX_DIM, dtype=torch.float32)
+
+    tt_video_prompt = bf16_tensor(video_prompt.unsqueeze(0), device=mesh_device)
+    tt_vc, tt_vs = _tt_rope(
+        _video_rope_freqs, F, H, W, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, pad_to=video_N
+    )
+    tt_trans_mat = bf16_tensor(get_rot_transformation_mat(), device=mesh_device)
+
+    video_1BNI_torch = video_lat.unsqueeze(0)
+    B_size = video_1BNI_torch.shape[1]
+    video_1BNI = bf16_tensor(video_1BNI_torch, device=mesh_device, mesh_axis=sp_axis, shard_dim=-2)
+    timestep = bf16_tensor(timestep_torch.reshape(1, 1, B_size, 1) * 1000.0, device=mesh_device)
+
+    inner_kwargs = dict(
+        video_1BNI=video_1BNI,
+        timestep=timestep,
+        video_prompt_1BLP=tt_video_prompt,
+        video_rope_cos=tt_vc,
+        video_rope_sin=tt_vs,
+        video_N=video_N_real,
+        trans_mat=tt_trans_mat,
+    )
+    if has_audio:
+        a_cos, a_sin = _tt_rope(_audio_rope_freqs, audio_N, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis)
+        vx_cos, vx_sin = _tt_rope(
+            _video_cross_pe_freqs, F, H, W, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, pad_to=video_N
+        )
+        ax_cos, ax_sin = _tt_rope(
+            _audio_cross_pe_freqs, audio_N, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis
+        )
+        ax_cos_full, ax_sin_full = _tt_rope_full(
+            _audio_cross_pe_freqs, audio_N, mesh_device=mesh_device, tp_axis=tp_axis
+        )
+        v_pad_sp = build_video_pad_mask(video_N, video_N_real, mesh_device=mesh_device, sp_axis=sp_axis)
+        audio_1BNI = bf16_tensor(audio_lat.unsqueeze(0), device=mesh_device, mesh_axis=sp_axis, shard_dim=-2)
+        inner_kwargs.update(
+            audio_1BNI=audio_1BNI,
+            audio_prompt_1BLP=bf16_tensor(audio_prompt.unsqueeze(0), device=mesh_device),
+            audio_rope_cos=a_cos,
+            audio_rope_sin=a_sin,
+            audio_N=audio_N,
+            video_cross_pe_cos=vx_cos,
+            video_cross_pe_sin=vx_sin,
+            audio_cross_pe_cos=ax_cos,
+            audio_cross_pe_sin=ax_sin,
+            audio_cross_pe_cos_full=ax_cos_full,
+            audio_cross_pe_sin_full=ax_sin_full,
+            video_padding_mask=v_pad_sp,
+        )
+    return inner_kwargs, video_N_real
+
+
+@pytest.mark.parametrize(
+    ("mesh_device", "sp_axis", "tp_axis", "num_links", "device_params", "topology", "is_fsdp"),
+    [
+        pytest.param((4, 8), 1, 0, 2, ring_params_4k, ttnn.Topology.Ring, False, id="ring_bh_4x8sp1tp0_4k"),
+        # 8k fabric payload variant (where stage-2 wedges at depth).
+        pytest.param((4, 8), 1, 0, 2, ring_params_8k, ttnn.Topology.Ring, False, id="ring_bh_4x8sp1tp0_8k"),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("has_audio", [pytest.param(False, id="video"), pytest.param(True, id="av")])
+@pytest.mark.parametrize("checkpoint_variant", [pytest.param("fast", id="ckpt_fast")])
+def test_ltx_transformer_crossstage_hang(
+    mesh_device,
+    sp_axis,
+    tp_axis,
+    num_links,
+    topology,
+    is_fsdp,
+    has_audio,
+    checkpoint_variant,
+    reset_seeds,
+) -> None:
+    """FAST cross-stage repro of the e2e stage-2 deadlock: drive ONE model+CCLManager through
+    stage-1 then stage-2 (eager, no VAE/Gemma), so stage-2 reuses the shared strided-AGMM pool
+    that stage-1 left mid-rotation. PASSES -> not cross-stage; HANGS -> confirmed.
+    """
+    # Stage-2 shape; full depth (env-overridable) to stack many back-to-back strided ops per forward.
+    tt_model, kwargs_s2, vN2 = _build_video_trace_setup(
+        mesh_device=mesh_device,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+        topology=topology,
+        is_fsdp=is_fsdp,
+        F=19,
+        H=34,
+        W=60,
+        has_audio=has_audio,
+        checkpoint_variant=checkpoint_variant,
+        num_layers=int(os.environ.get("CROSSSTAGE_NUM_LAYERS", "48")),
+    )
+    # Stage-1 shape (half spatial res, like the e2e's height//2,width//2) on the SAME model.
+    kwargs_s1, vN1 = _build_trace_inner_kwargs(
+        mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, F=19, H=17, W=30, has_audio=has_audio
+    )
+    logger.info(f"cross-stage: stage-1 vN={vN1} then stage-2 vN={vN2} (shared CCLManager)")
+
+    # CROSSSTAGE_SKIP_S1=1 -> run only stage-2, isolating the stage transition from full-depth big-M.
+    skip_s1 = os.environ.get("CROSSSTAGE_SKIP_S1", "0") != "0"
+    if not skip_s1:
+        # Stage 1 first (eager) — populate/rotate the shared strided-AGMM semaphore pool at stage-1 M.
+        for i in range(3):
+            _ = tt_model.inner_step(**kwargs_s1)
+            ttnn.synchronize_device(mesh_device)
+            logger.info(f"stage-1 forward {i} done")
+        logger.info("stage-1 complete; entering STAGE-2 (the e2e hang point) ...")
+    else:
+        logger.info("SKIP_S1: entering STAGE-2 directly (48 layers, no stage-1) ...")
+
+    # Stage 2 (eager) — reuses the same pool. This is where the e2e deadlocks.
+    for i in range(3):
+        _ = tt_model.inner_step(**kwargs_s2)
+        ttnn.synchronize_device(mesh_device)
+        logger.info(f"stage-2 forward {i} done")
+
+    logger.info("PASSED cross-stage: stage-1 -> stage-2 completed without deadlock")
+    del tt_model
+
+
+@pytest.mark.parametrize(
+    ("mesh_device", "sp_axis", "tp_axis", "num_links", "device_params", "topology", "is_fsdp"),
+    # VIDEO stage-2 ring config only (8k fabric payload); do NOT add AV/other-mesh params here.
+    [pytest.param((4, 8), 1, 0, 2, ring_params_8k, ttnn.Topology.Ring, False, id="ring_bh_4x8sp1tp0_8k")],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(("F", "H", "W"), [pytest.param(19, 34, 60, id="stage_2")])
+@pytest.mark.parametrize("has_audio", [pytest.param(False, id="video"), pytest.param(True, id="av")])
+@pytest.mark.parametrize("checkpoint_variant", [pytest.param("fast", id="ckpt_fast")])
+def test_ltx_transformer_trace_perf(
+    mesh_device,
+    sp_axis,
+    tp_axis,
+    num_links,
+    topology,
+    is_fsdp,
+    F,
+    H,
+    W,
+    has_audio,
+    checkpoint_variant,
+    reset_seeds,
+) -> None:
+    """Trace-based perf for LTXTransformerModel.inner_step (VIDEO stage-2 ring).
+
+    Measures StridedAllGatherMinimalMatmulAsync device time and block wall-clock at steady state
+    under a ttnn trace (gap-free replay), which the eager op-by-op path can't expose. Perf-only:
+    asserts shape/finiteness, no PCC. inner_step is @traced_function(prep_run=False), so kernels
+    are precompiled with a couple of eager warm calls before trace capture.
+    """
+    tt_model, inner_kwargs, video_N_real = _build_video_trace_setup(
+        mesh_device=mesh_device,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+        topology=topology,
+        is_fsdp=is_fsdp,
+        F=F,
+        H=H,
+        W=W,
+        has_audio=has_audio,
+        checkpoint_variant=checkpoint_variant,
+    )
+
+    # AV emits far more markers than video; keep warm/replay counts low (overridable via env) so the
+    # per-core profiler buffer doesn't overflow before the post-capture drain below.
+    n_warm = int(os.environ.get("LTX_PERF_N_WARM", "1" if has_audio else "2"))
+    n_replay = int(os.environ.get("LTX_PERF_N_REPLAY", "3" if has_audio else "5"))
+
+    # Warm / compile: eager (untraced) calls precompile kernels (prep_run=False on inner_step).
+    t0 = time.time()
+    for _ in range(n_warm):
+        _ = tt_model.inner_step(**inner_kwargs)
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"eager warm/compile ({n_warm}x): {time.time() - t0:.1f}s")
+
+    # Capture: first traced call captures the trace (and executes it once).
+    t0 = time.time()
+    _ = tt_model.inner_step(**inner_kwargs, traced=True)
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"trace capture: {time.time() - t0:.1f}s")
+
+    # Drain warm+capture markers so only the signposted replays occupy the profiler buffer.
+    ttnn.ReadDeviceProfiler(mesh_device)
+
+    # Steady-state replay under the signpost bracket for tt-perf-report --start/end-signpost.
+    signpost("start")
+    t0 = time.time()
+    result = None
+    for _ in range(n_replay):
+        result = tt_model.inner_step(**inner_kwargs, traced=True)
+    ttnn.synchronize_device(mesh_device)
+    replay_s = time.time() - t0
+    signpost("stop")
+    logger.info(f"trace replay ({n_replay}x): {replay_s:.3f}s → {replay_s / n_replay * 1e3:.2f} ms/step")
+
+    # Perf-only: crop SP-padding tail, assert shape + finiteness (no PCC).
+    # AV mode returns (video, audio); video-only returns a single tensor.
+    video_out = result[0] if isinstance(result, tuple) else result
+    tt_video = LTXTransformerModel.device_to_host(video_out).squeeze(0)[:, :video_N_real, :]
+    assert tt_video.shape == (1, video_N_real, OUT_CHANNELS), f"video shape {tt_video.shape}"
+    assert torch.isfinite(tt_video).all(), "NaN/Inf in traced video output"
+    logger.info(f"PASSED trace-perf: video {tuple(tt_video.shape)} has_audio={has_audio}")
+
+    del tt_model
+
+
+# Trace-based perf for a SINGLE transformer block (isolates one block's program order).
+def _build_block_trace_setup(
+    *, mesh_device, sp_axis, tp_axis, num_links, topology, is_fsdp, F, H, W, has_audio, checkpoint_variant="fast"
+):
+    """Build an ``LTXTransformerBlock`` + device ``forward`` kwargs for the block trace-perf test.
+
+    Mirrors the non-PCC setup of ``test_ltx_transformer_block``: AV loads the 22B checkpoint
+    (``strict=False``) and builds the full video+audio+cross-modal device tensors; video harvests
+    random scaled weights from a throwaway diffusers block. Returns
+    ``(tt_block, forward_kwargs, video_N_real, audio_N_real)``. Perf-only; no PCC.
+    """
+    checkpoint_22b = _resolve_checkpoint_22b(checkpoint_variant)
+    sp_factor = tuple(mesh_device.shape)[sp_axis]
+    # Real latent grid → SP-padded sequence (mirrors LTXPipeline). video_N is the padded device
+    # length; video_N_real is the logical token count fed to SDPA's logical_n / padding masks.
+    video_N_real = F * H * W
+    video_N = _sp_pad_len(video_N_real, sp_factor)
+    audio_N, audio_N_real = _audio_seq_lens(F, sp_factor)
+    assert video_N % (32 * sp_factor) == 0, f"video_N={video_N} not sp/tile-aligned for sp={sp_factor}"
+    assert audio_N % (32 * sp_factor) == 0, f"audio_N={audio_N} not sp/tile-aligned for sp={sp_factor}"
+
+    ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
+    parallel_config = _make_parallel_config(mesh_device, sp_axis, tp_axis)
+    tt_block = _make_tt_block(
+        mesh_device=mesh_device,
+        ccl_manager=ccl_manager,
+        parallel_config=parallel_config,
+        is_fsdp=is_fsdp,
+        has_audio=has_audio,
+    )
+
+    if has_audio:
+        sd = _load_22b_state_dict(num_layers=1, checkpoint_path=checkpoint_22b)
+        if sd is None:
+            pytest.skip(f"22B checkpoint not found at {checkpoint_22b}")
+        block_sd = {
+            k[len("transformer_blocks.0.") :]: v for k, v in sd.items() if k.startswith("transformer_blocks.0.")
+        }
+        tt_block.load_torch_state_dict(block_sd, strict=False)
+    else:
+        # video mode — harvest a shape-matching state dict from a throwaway block (perf-only).
+        dummy = _make_diffusers_video_block()
+        _scale_init_(dummy)
+        conv = _convert_diffusers_video_block_to_tt(dummy.state_dict(), num_heads=NUM_HEADS, head_dim=HEAD_DIM)
+        tt_block.load_torch_state_dict({k: v.detach().clone() for k, v in conv.items()})
+        del dummy
+
+    # Inputs (real-grid token count; the TT side gets a zero-padded copy below).
+    torch.manual_seed(INPUT_SEED)
+    x = torch.randn(1, video_N_real, DIM, dtype=torch.float32)
+    context = torch.randn(1, PROMPT_LEN, CTX_DIM, dtype=torch.float32)
+    temb = torch.randn(1, 1, 9 * DIM, dtype=torch.float32)  # 9 adaln params
+    prompt_temb = torch.randn(1, 1, 2 * DIM, dtype=torch.float32)  # 2 adaln params for prompt
+
+    # TT video tensors. Sequence SP-padded to video_N; rope pads with identity rotation; video_N_real
+    # (logical) goes to the block for SDPA masking.
+    spatial = _pad_seq_dim(x, video_N, dim=1).unsqueeze(0)
+    tt_spatial = bf16_tensor_2dshard(spatial, device=mesh_device, shard_mapping={sp_axis: 2, tp_axis: 3})
+    tt_prompt = bf16_tensor(context.unsqueeze(0), device=mesh_device)
+    tt_temb = bf16_tensor(
+        temb.reshape(9, DIM).unsqueeze(1).unsqueeze(1), device=mesh_device, mesh_axis=tp_axis, shard_dim=3
+    )
+    tt_prompt_temb = bf16_tensor(prompt_temb.reshape(2, DIM).unsqueeze(1).unsqueeze(1), device=mesh_device)
+    tt_cos, tt_sin = _tt_rope(
+        _video_rope_freqs, F, H, W, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, pad_to=video_N
+    )
+    tt_trans_mat = bf16_tensor(get_rot_transformation_mat(), device=mesh_device)
+
+    forward_kwargs = dict(
+        video_1BND=tt_spatial,
+        video_prompt=tt_prompt,
+        video_temb=tt_temb,
+        video_N=video_N_real,
+        video_rope_cos=tt_cos,
+        video_rope_sin=tt_sin,
+        trans_mat=tt_trans_mat,
+        video_prompt_temb=tt_prompt_temb,
+    )
+    if has_audio:
+        # Real tokens in [:audio_N_real], zeros in the padded tail (matches the padded audio latent).
+        a_x = torch.zeros(1, audio_N, AUDIO_DIM, dtype=torch.float32)
+        a_x[:, :audio_N_real, :] = torch.randn(1, audio_N_real, AUDIO_DIM, dtype=torch.float32)
+        a_ctx = torch.randn(1, PROMPT_LEN, AUDIO_CTX_DIM, dtype=torch.float32)
+        a_temb = torch.randn(1, 1, 9 * AUDIO_DIM, dtype=torch.float32)
+        a_prompt_temb = torch.randn(1, 1, 2 * AUDIO_DIM, dtype=torch.float32)
+        av_ca_v = torch.randn(1, 1, 5 * DIM, dtype=torch.float32)  # 4 scale-shift + 1 gate
+        av_ca_a = torch.randn(1, 1, 5 * AUDIO_DIM, dtype=torch.float32)
+
+        a_cos, a_sin = _tt_rope(_audio_rope_freqs, audio_N, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis)
+        vx_cos, vx_sin = _tt_rope(
+            _video_cross_pe_freqs, F, H, W, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis, pad_to=video_N
+        )
+        ax_cos, ax_sin = _tt_rope(
+            _audio_cross_pe_freqs, audio_N, mesh_device=mesh_device, sp_axis=sp_axis, tp_axis=tp_axis
+        )
+        ax_cos_full, ax_sin_full = _tt_rope_full(
+            _audio_cross_pe_freqs, audio_N, mesh_device=mesh_device, tp_axis=tp_axis
+        )
+
+        # Padding masks, same construction as the fast pipeline (audio padded, video aligned).
+        a_attn_mask, a_pad_sp, a_pad_full = build_audio_masks(
+            audio_N, audio_N_real, mesh_device=mesh_device, sp_axis=sp_axis
+        )
+        v_pad_sp = build_video_pad_mask(video_N, video_N_real, mesh_device=mesh_device, sp_axis=sp_axis)
+
+        forward_kwargs.update(
+            audio_1BND=bf16_tensor_2dshard(
+                a_x.unsqueeze(0), device=mesh_device, shard_mapping={sp_axis: 2, tp_axis: 3}
+            ),
+            audio_prompt=bf16_tensor(a_ctx.unsqueeze(0), device=mesh_device),
+            audio_temb=bf16_tensor(
+                a_temb.reshape(9, AUDIO_DIM).unsqueeze(1).unsqueeze(1),
+                device=mesh_device,
+                mesh_axis=tp_axis,
+                shard_dim=3,
+            ),
+            audio_prompt_temb=bf16_tensor(
+                a_prompt_temb.reshape(2, AUDIO_DIM).unsqueeze(1).unsqueeze(1), device=mesh_device
+            ),
+            av_ca_temb=bf16_tensor(
+                av_ca_v.reshape(5, DIM).unsqueeze(1).unsqueeze(1), device=mesh_device, mesh_axis=tp_axis, shard_dim=3
+            ),
+            av_ca_audio_temb=bf16_tensor(
+                av_ca_a.reshape(5, AUDIO_DIM).unsqueeze(1).unsqueeze(1),
+                device=mesh_device,
+                mesh_axis=tp_axis,
+                shard_dim=3,
+            ),
+            audio_N=audio_N,
+            audio_rope_cos=a_cos,
+            audio_rope_sin=a_sin,
+            video_cross_pe_cos=vx_cos,
+            video_cross_pe_sin=vx_sin,
+            audio_cross_pe_cos=ax_cos,
+            audio_cross_pe_sin=ax_sin,
+            audio_cross_pe_cos_full=ax_cos_full,
+            audio_cross_pe_sin_full=ax_sin_full,
+            audio_attn_mask=a_attn_mask,
+            audio_padding_mask=a_pad_sp,
+            audio_padding_mask_full=a_pad_full,
+            video_padding_mask=v_pad_sp,
+        )
+    return tt_block, forward_kwargs, video_N_real, audio_N_real
+
+
+@pytest.mark.parametrize(
+    ("mesh_device", "sp_axis", "tp_axis", "num_links", "device_params", "topology", "is_fsdp"),
+    # Same ring stage-2 8k config as test_ltx_transformer_trace_perf (ring_params_8k = FABRIC_1D_RING
+    # + 8192-B fabric router payload). Do NOT add other-mesh params here.
+    [pytest.param((4, 8), 1, 0, 2, ring_params_8k, ttnn.Topology.Ring, False, id="ring_bh_4x8sp1tp0_8k")],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(("F", "H", "W"), [pytest.param(19, 34, 60, id="stage_2")])
+@pytest.mark.parametrize("has_audio", [pytest.param(False, id="video"), pytest.param(True, id="av")])
+@pytest.mark.parametrize("checkpoint_variant", [pytest.param("fast", id="ckpt_fast")])
+def test_ltx_transformer_block_trace_perf(
+    mesh_device,
+    sp_axis,
+    tp_axis,
+    num_links,
+    topology,
+    is_fsdp,
+    F,
+    H,
+    W,
+    has_audio,
+    checkpoint_variant,
+    reset_seeds,
+) -> None:
+    """Trace-based perf for a SINGLE ``LTXTransformerBlock`` forward (AV stage-2 ring).
+
+    Isolates one block's program order — no model-level patch-embed / proj-out / tilize /
+    untilize / mesh-partition ops, and no multi-block scrambling — so tt-perf-report shows a clean
+    one-block, program-ordered view. Captures the block forward under a ttnn trace (via the same
+    ``Tracer`` machinery that backs ``inner_step``'s ``traced=True`` path) and replays it under the
+    same "start"/"stop" signpost bracket used by ``test_ltx_transformer_trace_perf``. Perf-only:
+    asserts shape/finiteness, no PCC.
+    """
+    tt_block, forward_kwargs, video_N_real, _audio_N_real = _build_block_trace_setup(
+        mesh_device=mesh_device,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+        topology=topology,
+        is_fsdp=is_fsdp,
+        F=F,
+        H=H,
+        W=W,
+        has_audio=has_audio,
+        checkpoint_variant=checkpoint_variant,
+    )
+
+    # Trace the block forward with the same Tracer settings inner_step uses (prep_run=False:
+    # kernels are precompiled by the eager warm calls below; clone_prep_inputs=False).
+    tracer = Tracer(tt_block.forward, device=mesh_device, prep_run=False, clone_prep_inputs=False)
+
+    # AV runs many more ops than video (audio self/cross + a2v/v2a + audio ff/RS). The per-core
+    # 12000-marker profiler DRAM buffer is drained only at end-of-run, so warm + capture + replay
+    # markers pile up and overflow. We drain the profiler after capture (below) so only the
+    # signposted replays count against the budget; AV also uses fewer warm/replays for headroom.
+    n_warm = 1 if has_audio else 2
+    n_replay = 3 if has_audio else 5
+
+    # Warm / compile: eager (untraced) calls precompile kernels before trace capture.
+    t0 = time.time()
+    for _ in range(n_warm):
+        _ = tt_block(**forward_kwargs)
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"eager warm/compile ({n_warm}x): {time.time() - t0:.1f}s")
+
+    # Capture: first traced call captures the trace (and executes it once).
+    t0 = time.time()
+    _ = tracer(**forward_kwargs, traced=True)
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"trace capture: {time.time() - t0:.1f}s")
+
+    # Drain warm+capture markers so ONLY the signposted replays occupy the profiler DRAM buffer
+    # (the AV profiler-overflow fix, mirroring test_ltx_transformer_trace_perf).
+    ttnn.ReadDeviceProfiler(mesh_device)
+
+    # Steady-state replay under the signpost bracket for tt-perf-report --start/end-signpost.
+    signpost("start")
+    t0 = time.time()
+    result = None
+    for _ in range(n_replay):
+        result = tracer(**forward_kwargs, traced=True)
+    ttnn.synchronize_device(mesh_device)
+    replay_s = time.time() - t0
+    signpost("stop")
+    logger.info(f"trace replay ({n_replay}x): {replay_s:.3f}s → {replay_s / n_replay * 1e3:.2f} ms/step")
+
+    # Perf-only: crop SP-padding tail, assert shape + finiteness (no PCC).
+    # AV mode returns (video, audio); video-only returns a single tensor.
+    tt_v = result[0] if isinstance(result, tuple) else result
+    concat_dims = [None, None]
+    concat_dims[sp_axis] = 2
+    concat_dims[tp_axis] = 3
+    tt_v_torch = ttnn.to_torch(
+        tt_v,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=concat_dims, mesh_shape=tuple(mesh_device.shape)),
+    ).squeeze(0)[:, :video_N_real, :]
+    assert tt_v_torch.shape == (1, video_N_real, DIM), f"video shape {tt_v_torch.shape}"
+    assert torch.isfinite(tt_v_torch).all(), "NaN/Inf in traced video output"
+    logger.info(f"PASSED block trace-perf: video {tuple(tt_v_torch.shape)} has_audio={has_audio}")
+
+    tracer.release_trace()
+    del tt_block

--- a/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
+++ b/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
@@ -161,8 +161,7 @@ def run_test_linear_impl(
         if activation == "gelu":
             torch_output = torch.nn.functional.gelu(torch_output)
 
-        # Variable-width chunks split at the given per-device widths; uniform chunks are the
-        # equal-width case. torch_output is [M_global, N_per_device].
+        # Variable-width chunks split at the given per-device widths
         if chunk_sizes:
             torch_output = torch.split(torch_output, list(chunk_sizes), dim=-1)
         else:
@@ -325,8 +324,7 @@ def run_test_linear_impl(
             for i in range(device.shape[sp_axis]):
                 for j in range(device.shape[tp_axis]):
                     m_slice = slice(i * per_device_M, (i + 1) * per_device_M)
-                    # For chunk c the concatenated tensor is [M_global, width_c * TP], so each
-                    # device's slice is this chunk's own width -- not a shared N // chunks.
+                    # For chunk c the concatenated tensor is [M_global, width_c * TP]
                     chunk_width = chunk_sizes[c] if chunk_sizes else (N // chunks)
                     n_slice = slice(j * chunk_width, (j + 1) * chunk_width)
 

--- a/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
+++ b/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
@@ -70,6 +70,7 @@ def run_test_linear_impl(
     torch_addcmul_b=None,
     addcmul_scalar=1.0,
     chunks=1,
+    chunk_sizes=None,
     broadcast_gate=True,
     fuse_swiglu=False,
 ):
@@ -160,7 +161,12 @@ def run_test_linear_impl(
         if activation == "gelu":
             torch_output = torch.nn.functional.gelu(torch_output)
 
-        torch_output = torch.chunk(torch_output, chunks, dim=-1)
+        # Variable-width chunks split at the given per-device widths; uniform chunks are the
+        # equal-width case. torch_output is [M_global, N_per_device].
+        if chunk_sizes:
+            torch_output = torch.split(torch_output, list(chunk_sizes), dim=-1)
+        else:
+            torch_output = torch.chunk(torch_output, chunks, dim=-1)
 
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
@@ -253,6 +259,7 @@ def run_test_linear_impl(
                 addcmul_input_tensor1=tt_addcmul_a,
                 addcmul_input_tensor2=tt_addcmul_b,
                 chunks=chunks,
+                chunk_sizes=list(chunk_sizes) if chunk_sizes else [],
                 fuse_swiglu=fuse_swiglu,
             )
 
@@ -318,7 +325,10 @@ def run_test_linear_impl(
             for i in range(device.shape[sp_axis]):
                 for j in range(device.shape[tp_axis]):
                     m_slice = slice(i * per_device_M, (i + 1) * per_device_M)
-                    n_slice = slice(j * (N // chunks), (j + 1) * (N // chunks))
+                    # For chunk c the concatenated tensor is [M_global, width_c * TP], so each
+                    # device's slice is this chunk's own width -- not a shared N // chunks.
+                    chunk_width = chunk_sizes[c] if chunk_sizes else (N // chunks)
+                    n_slice = slice(j * chunk_width, (j + 1) * chunk_width)
 
                     if use_non_fused:
                         idx = (slice(None), slice(None), m_slice, n_slice)
@@ -383,6 +393,7 @@ def run_test_linear(
     fuse_addcmul=False,
     addcmul_scalar=1.0,
     chunks=1,
+    chunk_sizes=None,
     broadcast_gate=True,
     fuse_swiglu=False,
 ):
@@ -492,6 +503,7 @@ def run_test_linear(
         torch_addcmul_b=torch_addcmul_b,
         addcmul_scalar=addcmul_scalar,
         chunks=chunks,
+        chunk_sizes=chunk_sizes,
         broadcast_gate=broadcast_gate,
         fuse_swiglu=fuse_swiglu,
     )

--- a/models/tt_dit/tests/unit/test_planar_concat.py
+++ b/models/tt_dit/tests/unit/test_planar_concat.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-side coverage for the YUV 4:2:0 planar assembly.
+
+The C++/AVX2 scatter is checked byte-for-byte against a NumPy port of the torch
+fallback in ``yuv_d2h._yuv_planar_d2h``, so the two assembly paths cannot drift.
+Cases cover both source layouts, every tile-tail branch in the CHWT transpose,
+and logical crops (including one that drops a whole shard column).
+"""
+
+import numpy as np
+import pytest
+
+from ...utils.planar_concat import HAS_CPP_PLANAR_CONCAT, planar_concat_cpp
+from ...utils.yuv_d2h import fast_device_to_host_yuv
+
+_SENTINEL = 0xAA
+
+
+def _reference_planar_concat(y_shards, u_shards, v_shards, dim_order, mesh_shape, out_H, out_W, T, fill=_SENTINEL):
+    """NumPy port of the torch scatter fallback: the byte layout both paths must produce."""
+    _, SP = mesh_shape
+    out_Hu, out_Wu = out_H // 2, out_W // 2
+    out_hw, out_uv = out_H * out_W, out_Hu * out_Wu
+    out = np.full((T, out_hw + 2 * out_uv), fill, dtype=np.uint8)
+
+    planes = [
+        (out[:, :out_hw].reshape(T, out_H, out_W), y_shards, out_H, out_W),
+        (out[:, out_hw : out_hw + out_uv].reshape(T, out_Hu, out_Wu), u_shards, out_Hu, out_Wu),
+        (out[:, out_hw + out_uv :].reshape(T, out_Hu, out_Wu), v_shards, out_Hu, out_Wu),
+    ]
+    for view, shards, bound_h, bound_w in planes:
+        for idx, shard in enumerate(shards):
+            r, c = idx // SP, idx % SP
+            s = shard[0]
+            if dim_order == "CHWT":
+                s = np.transpose(s, (2, 0, 1))  # (h, w, T) -> (T, h, w)
+            h_per, w_per = s.shape[1], s.shape[2]
+            r0, c0 = r * h_per, c * w_per
+            vh, vw = min(h_per, bound_h - r0), min(w_per, bound_w - c0)
+            if vh <= 0 or vw <= 0:
+                continue  # shard lies entirely in the padded tail
+            view[:, r0 : r0 + vh, c0 : c0 + vw] = s[:, :vh, :vw]
+    return out
+
+
+def _make_shards(rng, n, h_per, w_per, T, dim_order):
+    shape = (1, h_per, w_per, T) if dim_order == "CHWT" else (1, T, h_per, w_per)
+    return [np.ascontiguousarray(rng.integers(0, 256, size=shape, dtype=np.uint8)) for _ in range(n)]
+
+
+# (dim_order, TP, SP, h_per, w_per, T, crop_h, crop_w)
+_CASES = [
+    pytest.param("CHWT", 2, 2, 32, 32, 32, None, None, id="chwt_clean_tiles"),
+    pytest.param("CHWT", 2, 2, 32, 48, 32, None, None, id="chwt_wtail16"),
+    pytest.param("CHWT", 2, 2, 32, 40, 32, None, None, id="chwt_wtail_generic"),
+    pytest.param("CHWT", 2, 2, 32, 32, 40, None, None, id="chwt_ttail"),
+    pytest.param("CHWT", 2, 2, 32, 48, 40, None, None, id="chwt_wtail16_ttail"),
+    pytest.param("CHWT", 2, 2, 32, 40, 40, None, None, id="chwt_wtail_ttail"),
+    pytest.param("CHWT", 2, 2, 32, 32, 8, None, None, id="chwt_t_under_tile"),
+    pytest.param("CHWT", 4, 8, 16, 32, 33, None, None, id="chwt_4x8_mesh"),
+    pytest.param("CHWT", 2, 2, 32, 32, 32, 50, 54, id="chwt_crop"),
+    pytest.param("CHWT", 2, 4, 32, 32, 32, 40, 34, id="chwt_crop_drops_shard_col"),
+    pytest.param("CTHW", 2, 2, 32, 32, 32, None, None, id="cthw_clean_tiles"),
+    pytest.param("CTHW", 2, 2, 24, 40, 17, None, None, id="cthw_ragged"),
+    pytest.param("CTHW", 2, 2, 32, 32, 16, 50, 54, id="cthw_crop"),
+]
+
+
+@pytest.mark.skipif(not HAS_CPP_PLANAR_CONCAT, reason="planar concat extension not built (models/tt_dit/utils/cpp)")
+@pytest.mark.parametrize("dim_order, TP, SP, h_per, w_per, T, crop_h, crop_w", _CASES)
+def test_planar_concat_matches_reference(dim_order, TP, SP, h_per, w_per, T, crop_h, crop_w):
+    rng = np.random.default_rng(0xC0FFEE)
+    n = TP * SP
+    y = _make_shards(rng, n, h_per, w_per, T, dim_order)
+    u = _make_shards(rng, n, h_per // 2, w_per // 2, T, dim_order)
+    v = _make_shards(rng, n, h_per // 2, w_per // 2, T, dim_order)
+
+    out_H = h_per * TP if crop_h is None else crop_h
+    out_W = w_per * SP if crop_w is None else crop_w
+    expected = _reference_planar_concat(y, u, v, dim_order, (TP, SP), out_H, out_W, T)
+
+    got = np.full(expected.shape, _SENTINEL, dtype=np.uint8)
+    planar_concat_cpp(y, u, v, dim_order, (TP, SP), out=got, out_H=out_H, out_W=out_W)
+
+    assert np.array_equal(got, expected), f"{int((got != expected).sum())} bytes differ from the scatter reference"
+
+
+@pytest.mark.skipif(not HAS_CPP_PLANAR_CONCAT, reason="planar concat extension not built (models/tt_dit/utils/cpp)")
+@pytest.mark.parametrize("crop_h, crop_w", [(None, None), (50, 54)], ids=["full", "cropped"])
+def test_planar_concat_writes_every_output_byte(crop_h, crop_w):
+    """Two different fills must produce identical output; any byte that differs was never written.
+
+    Comparing against the reference alone cannot catch this — both leave the same gaps.
+    """
+    rng = np.random.default_rng(11)
+    TP, SP, h_per, w_per, T = 2, 2, 34, 34, 9
+    y = _make_shards(rng, TP * SP, h_per, w_per, T, "CHWT")
+    u = _make_shards(rng, TP * SP, h_per // 2, w_per // 2, T, "CHWT")
+    v = _make_shards(rng, TP * SP, h_per // 2, w_per // 2, T, "CHWT")
+
+    out_H = h_per * TP if crop_h is None else crop_h
+    out_W = w_per * SP if crop_w is None else crop_w
+    row = out_H * out_W + 2 * (out_H // 2) * (out_W // 2)
+
+    outs = []
+    for fill in (0xAA, 0x55):
+        buf = np.full((T, row), fill, dtype=np.uint8)
+        planar_concat_cpp(y, u, v, "CHWT", (TP, SP), out=buf, out_H=out_H, out_W=out_W)
+        outs.append(buf)
+
+    assert np.array_equal(outs[0], outs[1]), f"{int((outs[0] != outs[1]).sum())} output bytes were never written"
+
+
+class _ShapeOnly:
+    """Stands in for a ttnn tensor / mesh device: the crop check runs before any device call."""
+
+    def __init__(self, shape):
+        self.shape = shape
+
+
+@pytest.mark.parametrize(
+    "logical_h, logical_w",
+    [(63, 64), (64, 63), (66, 64), (64, 66), (0, 64), (-2, 64), (64, 0)],
+    ids=["odd_h", "odd_w", "h_over_H", "w_over_W", "zero_h", "negative_h", "zero_w"],
+)
+def test_fast_device_to_host_yuv_rejects_invalid_crop(logical_h, logical_w, expect_error):
+    """An oversized crop leaves the tail of the buffer uninitialized and an odd one desyncs
+    the chroma planes from the luma plane; both must fail before any device work."""
+    with expect_error(ValueError, "logical_"):
+        fast_device_to_host_yuv(
+            _ShapeOnly((1, 3, 8, 32, 32)),
+            _ShapeOnly((2, 2)),
+            coefficients=object(),  # skip the ttnn BT.601 default
+            logical_h=logical_h,
+            logical_w=logical_w,
+        )

--- a/models/tt_dit/utils/conv3d.py
+++ b/models/tt_dit/utils/conv3d.py
@@ -419,7 +419,13 @@ _BLOCKINGS = {
     (2, 4, 512, 512, (3, 3, 3), 75, 68, 60): (64, 256, 1, 8, 4),  # ltx_s2_res — 60810us
     (2, 4, 256, 256, (3, 3, 3), 147, 68, 60): (64, 256, 1, 8, 4),  # ltx_s3_res — 25688us
     (2, 4, 256, 512, (3, 3, 3), 147, 68, 60): (64, 256, 1, 8, 4),  # ltx_s3_chg — 48772us
-    (2, 4, 128, 128, (3, 3, 3), 147, 136, 120): (64, 128, 6, 4, 8),  # ltx_s4_res — 22798us
+    (2, 4, 128, 128, (3, 3, 3), 147, 136, 120): (
+        64,
+        128,
+        12,
+        4,
+        8,
+    ),  # ltx_s4_res — fused halo_last 23.1ms (T_out_block 12: fewer larger matmuls; beats force_spatial -4.9%)
     (2, 4, 128, 48, (3, 3, 3), 147, 136, 120): (128, 64, 6, 4, 8),  # ltx_s4_out — 13833us
     # LTX-2.3 spatial latent upsampler (x2), 2x4 BH-LB, 1080p.
     (2, 4, 128, 1024, (3, 3, 3), 21, 9, 8): (64, 256, 1, 2, 8),  # initial_conv
@@ -439,7 +445,9 @@ _BLOCKINGS = {
     (4, 8, 512, 512, (3, 3, 3), 75, 34, 30): (64, 256, 1, 8, 4),  # ltx_s2_res — 13752us
     (4, 8, 256, 256, (3, 3, 3), 147, 34, 30): (64, 256, 1, 8, 4),  # ltx_s3_res — 6145us
     (4, 8, 256, 512, (3, 3, 3), 147, 34, 30): (64, 256, 1, 8, 4),  # ltx_s3_chg — 12013us
-    (4, 8, 128, 128, (3, 3, 3), 147, 68, 60): (128, 64, 6, 2, 16),  # ltx_s4_res — 5647us
+    # This table feeds standalone conv3d (LTX VAE). Keep standalone-optimal blocking here:
+    # the fused halo_last win needs finer H3W2 (128,64,6,3,2), which regresses standalone (~6629 vs 5407us).
+    (4, 8, 128, 128, (3, 3, 3), 147, 68, 60): (128, 64, 6, 2, 16),  # ltx_s4_res — 5647us standalone
     (4, 8, 128, 48, (3, 3, 3), 147, 68, 60): (128, 64, 6, 2, 16),  # ltx_s4_out — 2914us
     # LTX-2.3 spatial latent upsampler (x2), BH Galaxy 4x8, 1080p.
     # Regenerate via bruteforce_conv3d_sweep.py -k "sweep_all and h4w8"
@@ -573,6 +581,38 @@ def register_conv3d_configs(configs: dict) -> None:
         })
     """
     _DEFAULT_BLOCKINGS.update({(c_in, c_out, _ntuple(ks, 3)): tuple(v) for (c_in, c_out, ks), v in configs.items()})
+
+
+# Shapes that run fastest with force_spatial_parallel
+_FORCE_SPATIAL_KEYS = {
+    (2, 4, 128, 48, (3, 3, 3), 147, 136, 120),  # ltx_s4_out (128->48): light C_out matmul
+    # s4_res (4x8): force_spatial beats halo_last at the fused-only finer block 6,4,4 (below); the
+    # H3W2 blocking that made halo_last win on this shape lives only in the perf-test mock and never
+    # reaches production, so production s4_res 4x8 is routed to force_spatial.
+    (4, 8, 128, 128, (3, 3, 3), 147, 68, 60),  # ltx_s4_res (4x8)
+}
+
+
+# Fused shapes fastest with halo_last (bulk-core two-phase: each conv core does its interior blocks
+# first to overlap NP, then its boundary blocks after the NP gate). The win is where conv >> NP so the
+# interior pass fully hides NP. Measured device wins vs standalone: 2x4-s3 23.3->20.5, 4x8-s3 8.5->6.8
+# (-20%), 4x8-s2 14.9->14.3. s1/s4_out do NOT win (conv too small / NP-bound + fused-op overhead).
+_HALO_LAST_KEYS = {
+    # s4_res_2x4 (large per-dev 136x120): halo_last 23100us vs force_spatial 24282us (-4.9%, MIN FW).
+    # The big interior fraction fully hides NP in the first pass; the boundary pass is a small tail.
+    (2, 4, 128, 128, (3, 3, 3), 147, 136, 120),  # ltx_s4_res (2x4)
+    (2, 4, 256, 256, (3, 3, 3), 147, 68, 60),  # ltx_s3_res (2x4)
+    (2, 4, 256, 512, (3, 3, 3), 147, 68, 60),  # ltx_s3_chg (2x4)
+    (4, 8, 512, 512, (3, 3, 3), 75, 34, 30),  # ltx_s2_res (4x8)
+    (4, 8, 256, 256, (3, 3, 3), 147, 34, 30),  # ltx_s3_res (4x8)
+    (4, 8, 256, 512, (3, 3, 3), 147, 34, 30),  # ltx_s3_chg (4x8)
+    # ltx_s1_up (512->4096): the fused conv pipeline runs ~250us faster than standalone conv on the small
+    # 4x8 per-dev (17x15) AND hides the 369us NP → fused 16.4ms vs standalone 17.1ms (-3.8%). Win holds on
+    # every fused scheme (default/halo_last/force_spatial all ~16.4ms); routed via halo_last to match the
+    # sibling 4x8 routes. Standalone-optimal blocking (128,64,5,4,8) is also fused-optimal → no override.
+    # The 2x4 variant (per-dev 34x30) is NP-light (NP 0.7ms << +10ms fused-conv overhead) and stays standalone.
+    (4, 8, 512, 4096, (3, 3, 3), 39, 17, 15),  # ltx_s1_up (4x8)
+}
 
 
 def get_conv3d_config(

--- a/models/tt_dit/utils/conv3d.py
+++ b/models/tt_dit/utils/conv3d.py
@@ -445,8 +445,7 @@ _BLOCKINGS = {
     (4, 8, 512, 512, (3, 3, 3), 75, 34, 30): (64, 256, 1, 8, 4),  # ltx_s2_res — 13752us
     (4, 8, 256, 256, (3, 3, 3), 147, 34, 30): (64, 256, 1, 8, 4),  # ltx_s3_res — 6145us
     (4, 8, 256, 512, (3, 3, 3), 147, 34, 30): (64, 256, 1, 8, 4),  # ltx_s3_chg — 12013us
-    # This table feeds standalone conv3d (LTX VAE). Keep standalone-optimal blocking here:
-    # the fused halo_last win needs finer H3W2 (128,64,6,3,2), which regresses standalone (~6629 vs 5407us).
+    # This table feeds standalone conv3d (LTX VAE)
     (4, 8, 128, 128, (3, 3, 3), 147, 68, 60): (128, 64, 6, 2, 16),  # ltx_s4_res — 5647us standalone
     (4, 8, 128, 48, (3, 3, 3), 147, 68, 60): (128, 64, 6, 2, 16),  # ltx_s4_out — 2914us
     # LTX-2.3 spatial latent upsampler (x2), BH Galaxy 4x8, 1080p.
@@ -586,31 +585,21 @@ def register_conv3d_configs(configs: dict) -> None:
 # Shapes that run fastest with force_spatial_parallel
 _FORCE_SPATIAL_KEYS = {
     (2, 4, 128, 48, (3, 3, 3), 147, 136, 120),  # ltx_s4_out (128->48): light C_out matmul
-    # s4_res (4x8): force_spatial beats halo_last at the fused-only finer block 6,4,4 (below); the
-    # H3W2 blocking that made halo_last win on this shape lives only in the perf-test mock and never
-    # reaches production, so production s4_res 4x8 is routed to force_spatial.
+    # s4_res (4x8): force_spatial beats halo_last at the fused-only finer block 6,4,4 (below)
     (4, 8, 128, 128, (3, 3, 3), 147, 68, 60),  # ltx_s4_res (4x8)
 }
 
 
-# Fused shapes fastest with halo_last (bulk-core two-phase: each conv core does its interior blocks
-# first to overlap NP, then its boundary blocks after the NP gate). The win is where conv >> NP so the
-# interior pass fully hides NP. Measured device wins vs standalone: 2x4-s3 23.3->20.5, 4x8-s3 8.5->6.8
-# (-20%), 4x8-s2 14.9->14.3. s1/s4_out do NOT win (conv too small / NP-bound + fused-op overhead).
+# Fused shapes fastest with halo_last
 _HALO_LAST_KEYS = {
-    # s4_res_2x4 (large per-dev 136x120): halo_last 23100us vs force_spatial 24282us (-4.9%, MIN FW).
-    # The big interior fraction fully hides NP in the first pass; the boundary pass is a small tail.
+    # s4_res_2x4 (large per-dev 136x120): halo_last 23100us vs force_spatial 24282us (-4.9%, MIN FW)
     (2, 4, 128, 128, (3, 3, 3), 147, 136, 120),  # ltx_s4_res (2x4)
     (2, 4, 256, 256, (3, 3, 3), 147, 68, 60),  # ltx_s3_res (2x4)
     (2, 4, 256, 512, (3, 3, 3), 147, 68, 60),  # ltx_s3_chg (2x4)
     (4, 8, 512, 512, (3, 3, 3), 75, 34, 30),  # ltx_s2_res (4x8)
     (4, 8, 256, 256, (3, 3, 3), 147, 34, 30),  # ltx_s3_res (4x8)
     (4, 8, 256, 512, (3, 3, 3), 147, 34, 30),  # ltx_s3_chg (4x8)
-    # ltx_s1_up (512->4096): the fused conv pipeline runs ~250us faster than standalone conv on the small
-    # 4x8 per-dev (17x15) AND hides the 369us NP → fused 16.4ms vs standalone 17.1ms (-3.8%). Win holds on
-    # every fused scheme (default/halo_last/force_spatial all ~16.4ms); routed via halo_last to match the
-    # sibling 4x8 routes. Standalone-optimal blocking (128,64,5,4,8) is also fused-optimal → no override.
-    # The 2x4 variant (per-dev 34x30) is NP-light (NP 0.7ms << +10ms fused-conv overhead) and stays standalone.
+    # ltx_s1_up (512->4096): the fused conv pipeline runs ~250us faster than standalone conv on the small 4x8 per-dev
     (4, 8, 512, 4096, (3, 3, 3), 39, 17, 15),  # ltx_s1_up (4x8)
 }
 

--- a/models/tt_dit/utils/cpp/build.sh
+++ b/models/tt_dit/utils/cpp/build.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Builds the optional _planar_concat extension consumed by
+# models/tt_dit/utils/planar_concat.py. Absence of the .so is not an error:
+# the caller falls back to the torch scatter path.
+
+set -euo pipefail
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SRC_DIR}/build"
+PYTHON="${PYTHON:-python3}"
+
+if ! grep -q '\bavx2\b' /proc/cpuinfo; then
+    echo "build.sh: this CPU reports no AVX2 support; the extension would fault at runtime" >&2
+    exit 1
+fi
+
+PY_INCLUDE="$("${PYTHON}" -c 'import sysconfig; print(sysconfig.get_paths()["include"])')"
+NUMPY_INCLUDE="$("${PYTHON}" -c 'import numpy; print(numpy.get_include())')"
+EXT_SUFFIX="$("${PYTHON}" -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')"
+
+mkdir -p "${BUILD_DIR}"
+OUT="${BUILD_DIR}/_planar_concat${EXT_SUFFIX}"
+
+# -mavx2 covers the streaming stores in planar_concat.cpp as well as the transposes.
+${CXX:-g++} -O3 -std=c++17 -fPIC -shared -mavx2 -fvisibility=hidden \
+    -I"${SRC_DIR}" -I"${PY_INCLUDE}" -I"${NUMPY_INCLUDE}" \
+    "${SRC_DIR}/transpose_avx2.cpp" \
+    "${SRC_DIR}/planar_concat.cpp" \
+    "${SRC_DIR}/planar_concat_bindings.cpp" \
+    -o "${OUT}"
+
+echo "build.sh: wrote ${OUT}"

--- a/models/tt_dit/utils/cpp/planar_concat.cpp
+++ b/models/tt_dit/utils/cpp/planar_concat.cpp
@@ -1,0 +1,436 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Outer scatter loop + persistent std::thread pool for the C++ planar
+// concat path.  Inner SIMD work lives in transpose_avx2.cpp.
+
+#include "planar_concat.hpp"
+#include "transpose_avx2.hpp"
+
+#include <atomic>
+#include <condition_variable>
+#include <cstring>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include <emmintrin.h>  // SSE2 (_mm_stream_si128, _mm_sfence)
+#include <immintrin.h>  // AVX2 (_mm256_stream_si256)
+
+namespace tt_dit_planar {
+
+// ---------------------------------------------------------------------------
+// Static thread pool — created lazily on first use, kept alive for the rest
+// of the process lifetime.  Matches the warm-pool semantics of the Python
+// `_get_default_reassemble_pool()` it replaces.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+class ThreadPool {
+public:
+    explicit ThreadPool(int n_threads) : n_threads_(n_threads), stop_(false) {
+        workers_.reserve(n_threads);
+        for (int i = 0; i < n_threads; ++i) {
+            workers_.emplace_back([this] { run_worker(); });
+        }
+    }
+
+    ~ThreadPool() {
+        {
+            std::unique_lock<std::mutex> lock(mu_);
+            stop_ = true;
+        }
+        cv_.notify_all();
+        for (auto& w : workers_) {
+            w.join();
+        }
+    }
+
+    // Submit `n_tasks` tasks; each task is `fn(task_idx)`.  Blocks until all
+    // complete.  Re-entrant calls are supported but rare (the planar path
+    // doesn't recurse).
+    template <typename Fn>
+    void run(int n_tasks, Fn fn) {
+        if (n_tasks <= 0) {
+            return;
+        }
+        std::atomic<int> remaining(n_tasks);
+        std::atomic<int> next_idx(0);
+        std::mutex done_mu;
+        std::condition_variable done_cv;
+
+        {
+            std::unique_lock<std::mutex> lock(mu_);
+            for (int i = 0; i < n_tasks; ++i) {
+                tasks_.emplace([&, this] {
+                    int idx;
+                    while ((idx = next_idx.fetch_add(1, std::memory_order_relaxed)) < n_tasks) {
+                        fn(idx);
+                    }
+                    if (remaining.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+                        std::lock_guard<std::mutex> lk(done_mu);
+                        done_cv.notify_one();
+                    }
+                });
+            }
+        }
+        cv_.notify_all();
+
+        std::unique_lock<std::mutex> lk(done_mu);
+        done_cv.wait(lk, [&] { return remaining.load() == 0; });
+    }
+
+    int n_threads() const { return n_threads_; }
+
+private:
+    void run_worker() {
+        for (;;) {
+            std::function<void()> task;
+            {
+                std::unique_lock<std::mutex> lock(mu_);
+                cv_.wait(lock, [this] { return stop_ || !tasks_.empty(); });
+                if (stop_ && tasks_.empty()) {
+                    return;
+                }
+                task = std::move(tasks_.front());
+                tasks_.pop();
+            }
+            task();
+        }
+    }
+
+    int n_threads_;
+    std::vector<std::thread> workers_;
+    std::queue<std::function<void()>> tasks_;
+    std::mutex mu_;
+    std::condition_variable cv_;
+    bool stop_;
+};
+
+// Process-wide singleton.  Configured via set_thread_pool_size() before
+// first use; otherwise defaults to min(8, hardware_concurrency()).
+static int g_requested_threads = 0;
+static std::once_flag g_init_flag;
+static ThreadPool* g_pool = nullptr;
+
+ThreadPool& get_pool() {
+    std::call_once(g_init_flag, [] {
+        int n = g_requested_threads > 0 ? g_requested_threads : static_cast<int>(std::thread::hardware_concurrency());
+        if (n <= 0) {
+            n = 1;
+        }
+        if (n > 8) {
+            n = 8;
+        }
+        g_pool = new ThreadPool(n);
+    });
+    return *g_pool;
+}
+
+}  // namespace
+
+void set_thread_pool_size(int n_threads) {
+    if (n_threads > 0) {
+        g_requested_threads = n_threads;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Inner per-shard scatter kernels.
+//
+// Both kernels write a (T, h_per, w_per) destination region for one shard.
+// The dest pointer (`out_plane_base`) is the byte address of plane row 0,
+// pixel (r * h_per, c * w_per) — i.e. the upper-left of this shard's
+// rectangle in the plane.  The dest stride between successive `t` rows is
+// `row_stride` bytes; between successive `h_g` rows of one frame it's
+// `plane_W` bytes; W stride is 1 byte.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Non-temporal copy of `n` bytes: writes via SSE/AVX streaming stores so the
+// destination cache lines aren't pulled into L1/L2 (skipping read-for-
+// ownership traffic).  Caller must `_mm_sfence()` before any later read of
+// the destination region.
+//
+// Path selection by alignment:
+//   - dst & 31 == 0 and n % 32 == 0  → AVX2 32-byte streams.
+//   - dst & 15 == 0 and n % 16 == 0  → SSE2 16-byte streams.
+//   - otherwise                       → libc memcpy (fallback).
+//
+// Loads are unaligned (`loadu`) — sources come from arbitrary torch tensor
+// allocations whose alignment we don't control.  All our actual call sites
+// hit the AVX2 path (Y plane, w_per=160, dst always 32-aligned) or the SSE2
+// path (UV plane, w_per=80, dst at least 16-aligned for any c).
+static inline void stream_copy_n(uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
+    const uintptr_t addr = reinterpret_cast<uintptr_t>(dst);
+    if ((addr & 31u) == 0 && (n & 31u) == 0) {
+        for (size_t i = 0; i < n; i += 32) {
+            __m256i v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + i));
+            _mm256_stream_si256(reinterpret_cast<__m256i*>(dst + i), v);
+        }
+        return;
+    }
+    if ((addr & 15u) == 0 && (n & 15u) == 0) {
+        for (size_t i = 0; i < n; i += 16) {
+            __m128i v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i));
+            _mm_stream_si128(reinterpret_cast<__m128i*>(dst + i), v);
+        }
+        return;
+    }
+    std::memcpy(dst, src, n);
+}
+
+// CTHW: src layout is (T, h_per, w_per), W innermost (stride 1).  For each
+// (t, h), we have w_per contiguous source bytes that go to w_per
+// contiguous dest bytes — a straight copy.  We use non-temporal stores so the
+// 112 MB output buffer doesn't displace useful data from L2/L3 and so we
+// don't pay the read-for-ownership tax on every cache line written.
+void scatter_one_cthw(
+    const uint8_t* src,
+    uint8_t* dst,
+    int T,
+    int src_h_per,
+    int src_w_per,
+    int valid_h,
+    int valid_w,
+    int plane_W,
+    int row_stride) {
+    for (int t = 0; t < T; ++t) {
+        for (int h = 0; h < valid_h; ++h) {
+            stream_copy_n(
+                dst + t * static_cast<std::ptrdiff_t>(row_stride) + h * static_cast<std::ptrdiff_t>(plane_W),
+                src + (t * static_cast<std::ptrdiff_t>(src_h_per) + h) * static_cast<std::ptrdiff_t>(src_w_per),
+                static_cast<size_t>(valid_w));
+        }
+    }
+    // Drain WC buffers so subsequent readers (other threads, the Python
+    // caller) see the data.  Cheap when no streaming stores were issued
+    // (i.e. fallback memcpy path).
+    _mm_sfence();
+}
+
+// CHWT: src layout is (h_per, w_per, T), T innermost (stride 1).  Dest has
+// W innermost (stride 1) and T at stride row_stride.  Per-h slice is a
+// (w_per, T) → (T, w_per) byte transpose, tiled in 32×32 blocks.
+//
+// w_per for our case is in {160, 80}.  T is 81 (2 full 32-T tiles + a
+// 17-T tail).  We handle both:
+//   - w_chunks of 32 (Y: 5 chunks; UV: 2 full chunks + 1 tail of 16).
+//   - t_chunks of 32 (full: 2; tail: 1 of 17).
+void scatter_one_chwt(
+    const uint8_t* src,
+    uint8_t* dst,
+    int T,
+    int src_h_per,
+    int src_w_per,
+    int valid_h,
+    int valid_w,
+    int plane_W,
+    int row_stride) {
+    (void)src_h_per;  // CHWT source h-stride is src_w_per*T; h_per only bounds the loop (valid_h).
+    const std::ptrdiff_t src_w_stride = static_cast<std::ptrdiff_t>(T);  // bytes between adjacent w in source
+
+    const int n_w_full_tiles = valid_w / 32;
+    const int w_tail = valid_w - n_w_full_tiles * 32;  // padded tail cols are never written
+
+    const int n_t_full_tiles = T / 32;
+    const int t_tail = T - n_t_full_tiles * 32;
+
+    for (int h = 0; h < valid_h; ++h) {
+        const uint8_t* src_h = src + static_cast<std::ptrdiff_t>(h) * src_w_per * T;
+        uint8_t* dst_h = dst + static_cast<std::ptrdiff_t>(h) * plane_W;
+
+        // Full 32×32 (W × T) tiles.
+        for (int w_tile = 0; w_tile < n_w_full_tiles; ++w_tile) {
+            const uint8_t* src_w = src_h + static_cast<std::ptrdiff_t>(w_tile) * 32 * T;
+            uint8_t* dst_w = dst_h + static_cast<std::ptrdiff_t>(w_tile) * 32;
+
+            for (int t_tile = 0; t_tile < n_t_full_tiles; ++t_tile) {
+                const uint8_t* src_tile = src_w + t_tile * 32;
+                uint8_t* dst_tile = dst_w + static_cast<std::ptrdiff_t>(t_tile) * 32 * row_stride;
+                transpose_32x32_u8(src_tile, src_w_stride, dst_tile, row_stride);
+            }
+            if (t_tail > 0) {
+                const uint8_t* src_tile = src_w + n_t_full_tiles * 32;
+                uint8_t* dst_tile = dst_w + static_cast<std::ptrdiff_t>(n_t_full_tiles) * 32 * row_stride;
+                transpose_32xN_u8(src_tile, src_w_stride, dst_tile, row_stride, t_tail);
+            }
+        }
+
+        // W-tail (when w_per % 32 != 0).
+        //
+        // Fast path for w_tail == 16 (UV plane, w_per_uv = 80 = 2*32 + 16):
+        // 16 W-source rows × 32 T-source cols → 32 T-dest rows × 16 W-dest
+        // cols, done with two back-to-back 16×16 SSE transposes.  No bounce
+        // buffer, no zero-padding pass.
+        //
+        // General path (w_tail in [1, 31] \ {16}): zero-pad source into a
+        // 32×32 stack temp, transpose, copy only the valid w_tail cols from
+        // each output row.  Slower but covers every shape we might see.
+        // (Currently only triggered if w_tail != 16, which doesn't happen for
+        // 720p Y/UV; kept for safety.)
+        if (w_tail > 0) {
+            const uint8_t* src_w = src_h + static_cast<std::ptrdiff_t>(n_w_full_tiles) * 32 * T;
+            uint8_t* dst_w = dst_h + static_cast<std::ptrdiff_t>(n_w_full_tiles) * 32;
+
+            if (w_tail == 16) {
+                for (int t_tile = 0; t_tile < n_t_full_tiles; ++t_tile) {
+                    transpose_32x16_u8(
+                        src_w + t_tile * 32,
+                        src_w_stride,
+                        dst_w + static_cast<std::ptrdiff_t>(t_tile) * 32 * row_stride,
+                        row_stride);
+                }
+                if (t_tail > 0) {
+                    // T-tail × 16 W-cols: small enough to keep the bounce
+                    // buffer; reduces case explosion in this code path.
+                    alignas(32) uint8_t tmp_src[32 * 32];
+                    alignas(32) uint8_t tmp_dst[32 * 32];
+                    std::memset(tmp_src, 0, sizeof(tmp_src));
+                    for (int i = 0; i < 16; ++i) {
+                        std::memcpy(tmp_src + i * 32, src_w + i * src_w_stride + n_t_full_tiles * 32, t_tail);
+                    }
+                    transpose_32x32_u8(tmp_src, 32, tmp_dst, 32);
+                    uint8_t* dst_tile = dst_w + static_cast<std::ptrdiff_t>(n_t_full_tiles) * 32 * row_stride;
+                    for (int i = 0; i < t_tail; ++i) {
+                        std::memcpy(dst_tile + i * row_stride, tmp_dst + i * 32, 16);
+                    }
+                }
+            } else {
+                alignas(32) uint8_t tmp_src[32 * 32];
+                alignas(32) uint8_t tmp_dst[32 * 32];
+
+                for (int t_tile = 0; t_tile < n_t_full_tiles; ++t_tile) {
+                    std::memset(tmp_src, 0, sizeof(tmp_src));
+                    for (int i = 0; i < w_tail; ++i) {
+                        std::memcpy(tmp_src + i * 32, src_w + i * src_w_stride + t_tile * 32, 32);
+                    }
+                    transpose_32x32_u8(tmp_src, 32, tmp_dst, 32);
+                    uint8_t* dst_tile = dst_w + static_cast<std::ptrdiff_t>(t_tile) * 32 * row_stride;
+                    for (int i = 0; i < 32; ++i) {
+                        std::memcpy(dst_tile + i * row_stride, tmp_dst + i * 32, w_tail);
+                    }
+                }
+                if (t_tail > 0) {
+                    std::memset(tmp_src, 0, sizeof(tmp_src));
+                    for (int i = 0; i < w_tail; ++i) {
+                        std::memcpy(tmp_src + i * 32, src_w + i * src_w_stride + n_t_full_tiles * 32, t_tail);
+                    }
+                    transpose_32x32_u8(tmp_src, 32, tmp_dst, 32);
+                    uint8_t* dst_tile = dst_w + static_cast<std::ptrdiff_t>(n_t_full_tiles) * 32 * row_stride;
+                    for (int i = 0; i < t_tail; ++i) {
+                        std::memcpy(dst_tile + i * row_stride, tmp_dst + i * 32, w_tail);
+                    }
+                }
+            }
+        }
+    }
+}
+
+}  // namespace
+
+void scatter_component(
+    const std::vector<ShardView>& shards,
+    DimOrder dim_order,
+    uint8_t* out,
+    int T,
+    int plane_offset,
+    int plane_W,
+    int row_stride,
+    int h_per,
+    int w_per) {
+    auto& pool = get_pool();
+    const int n = static_cast<int>(shards.size());
+
+    pool.run(n, [&](int idx) {
+        const ShardView& sv = shards[idx];
+        uint8_t* dst_base = out + static_cast<std::ptrdiff_t>(plane_offset) +
+                            static_cast<std::ptrdiff_t>(sv.r) * h_per * plane_W +
+                            static_cast<std::ptrdiff_t>(sv.c) * w_per;
+
+        if (dim_order == DimOrder::CTHW) {
+            scatter_one_cthw(sv.data, dst_base, T, h_per, w_per, h_per, w_per, plane_W, row_stride);
+        } else {
+            scatter_one_chwt(sv.data, dst_base, T, h_per, w_per, h_per, w_per, plane_W, row_stride);
+        }
+    });
+}
+
+void planar_concat(
+    const std::vector<ShardView>& y_shards,
+    int y_h_per,
+    int y_w_per,
+    const std::vector<ShardView>& cb_shards,
+    int uv_h_per,
+    int uv_w_per,
+    const std::vector<ShardView>& cr_shards,
+    DimOrder dim_order,
+    int T,
+    int H,
+    int W,
+    int out_H,
+    int out_W,
+    uint8_t* out) {
+    (void)H;
+    (void)W;
+    // Output geometry is the logical (cropped) frame; sources keep the padded per-shard dims.
+    const int out_Hu = out_H / 2;
+    const int out_Wu = out_W / 2;
+    const int out_hw = out_H * out_W;
+    const int out_uv = out_Hu * out_Wu;
+    const int row_stride = out_hw + 2 * out_uv;
+
+    // Build a flat task list across all 3 components so the thread pool can
+    // load-balance Y (4× the bytes of UV) against UV.  Each entry is a
+    // resolved per-shard task.  ``bound_h``/``bound_w`` are the logical plane
+    // extents used to clamp each shard's write.
+    struct Task {
+        const ShardView* shard;
+        int plane_offset;
+        int plane_W;
+        int h_per;
+        int w_per;
+        int bound_h;
+        int bound_w;
+    };
+
+    std::vector<Task> tasks;
+    tasks.reserve(y_shards.size() + cb_shards.size() + cr_shards.size());
+
+    auto add_component =
+        [&](const std::vector<ShardView>& s, int plane_off, int plane_w_arg, int h_p, int w_p, int bnd_h, int bnd_w) {
+            for (const auto& sv : s) {
+                tasks.push_back({&sv, plane_off, plane_w_arg, h_p, w_p, bnd_h, bnd_w});
+            }
+        };
+    add_component(y_shards, 0, out_W, y_h_per, y_w_per, out_H, out_W);
+    add_component(cb_shards, out_hw, out_Wu, uv_h_per, uv_w_per, out_Hu, out_Wu);
+    add_component(cr_shards, out_hw + out_uv, out_Wu, uv_h_per, uv_w_per, out_Hu, out_Wu);
+
+    auto& pool = get_pool();
+    pool.run(static_cast<int>(tasks.size()), [&](int idx) {
+        const Task& tk = tasks[idx];
+        const ShardView& sv = *tk.shard;
+        const int r0 = sv.r * tk.h_per;
+        const int c0 = sv.c * tk.w_per;
+        const int valid_h = (tk.h_per < tk.bound_h - r0) ? tk.h_per : (tk.bound_h - r0);
+        const int valid_w = (tk.w_per < tk.bound_w - c0) ? tk.w_per : (tk.bound_w - c0);
+        if (valid_h <= 0 || valid_w <= 0) {
+            return;  // shard lies entirely in the padded tail
+        }
+        uint8_t* dst_base = out + static_cast<std::ptrdiff_t>(tk.plane_offset) +
+                            static_cast<std::ptrdiff_t>(r0) * tk.plane_W + c0;
+
+        if (dim_order == DimOrder::CTHW) {
+            scatter_one_cthw(sv.data, dst_base, T, tk.h_per, tk.w_per, valid_h, valid_w, tk.plane_W, row_stride);
+        } else {
+            scatter_one_chwt(sv.data, dst_base, T, tk.h_per, tk.w_per, valid_h, valid_w, tk.plane_W, row_stride);
+        }
+    });
+}
+
+}  // namespace tt_dit_planar

--- a/models/tt_dit/utils/cpp/planar_concat.cpp
+++ b/models/tt_dit/utils/cpp/planar_concat.cpp
@@ -21,11 +21,7 @@
 
 namespace tt_dit_planar {
 
-// ---------------------------------------------------------------------------
-// Static thread pool — created lazily on first use, kept alive for the rest
-// of the process lifetime.  Matches the warm-pool semantics of the Python
-// `_get_default_reassemble_pool()` it replaces.
-// ---------------------------------------------------------------------------
+// --------------------------------------------------------------------------- Static thread pool
 
 namespace {
 
@@ -49,9 +45,7 @@ public:
         }
     }
 
-    // Submit `n_tasks` tasks; each task is `fn(task_idx)`.  Blocks until all
-    // complete.  Re-entrant calls are supported but rare (the planar path
-    // doesn't recurse).
+    // Submit `n_tasks` tasks
     template <typename Fn>
     void run(int n_tasks, Fn fn) {
         if (n_tasks <= 0) {
@@ -110,8 +104,7 @@ private:
     bool stop_;
 };
 
-// Process-wide singleton.  Configured via set_thread_pool_size() before
-// first use; otherwise defaults to min(8, hardware_concurrency()).
+// Process-wide singleton
 static int g_requested_threads = 0;
 static std::once_flag g_init_flag;
 static ThreadPool* g_pool = nullptr;
@@ -138,33 +131,11 @@ void set_thread_pool_size(int n_threads) {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Inner per-shard scatter kernels.
-//
-// Both kernels write a (T, h_per, w_per) destination region for one shard.
-// The dest pointer (`out_plane_base`) is the byte address of plane row 0,
-// pixel (r * h_per, c * w_per) — i.e. the upper-left of this shard's
-// rectangle in the plane.  The dest stride between successive `t` rows is
-// `row_stride` bytes; between successive `h_g` rows of one frame it's
-// `plane_W` bytes; W stride is 1 byte.
-// ---------------------------------------------------------------------------
+// --------------------------------------------------------------------------- Inner per-shard scatter kernels
 
 namespace {
 
-// Non-temporal copy of `n` bytes: writes via SSE/AVX streaming stores so the
-// destination cache lines aren't pulled into L1/L2 (skipping read-for-
-// ownership traffic).  Caller must `_mm_sfence()` before any later read of
-// the destination region.
-//
-// Path selection by alignment:
-//   - dst & 31 == 0 and n % 32 == 0  → AVX2 32-byte streams.
-//   - dst & 15 == 0 and n % 16 == 0  → SSE2 16-byte streams.
-//   - otherwise                       → libc memcpy (fallback).
-//
-// Loads are unaligned (`loadu`) — sources come from arbitrary torch tensor
-// allocations whose alignment we don't control.  All our actual call sites
-// hit the AVX2 path (Y plane, w_per=160, dst always 32-aligned) or the SSE2
-// path (UV plane, w_per=80, dst at least 16-aligned for any c).
+// Non-temporal copy of `n` bytes: writes via SSE/AVX streaming stores so the destination cache lines aren't pulled
 static inline void stream_copy_n(uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
     const uintptr_t addr = reinterpret_cast<uintptr_t>(dst);
     if ((addr & 31u) == 0 && (n & 31u) == 0) {
@@ -184,11 +155,7 @@ static inline void stream_copy_n(uint8_t* __restrict dst, const uint8_t* __restr
     std::memcpy(dst, src, n);
 }
 
-// CTHW: src layout is (T, h_per, w_per), W innermost (stride 1).  For each
-// (t, h), we have w_per contiguous source bytes that go to w_per
-// contiguous dest bytes — a straight copy.  We use non-temporal stores so the
-// 112 MB output buffer doesn't displace useful data from L2/L3 and so we
-// don't pay the read-for-ownership tax on every cache line written.
+// CTHW: src layout is (T, h_per, w_per), W innermost (stride 1)
 void scatter_one_cthw(
     const uint8_t* src,
     uint8_t* dst,
@@ -207,20 +174,11 @@ void scatter_one_cthw(
                 static_cast<size_t>(valid_w));
         }
     }
-    // Drain WC buffers so subsequent readers (other threads, the Python
-    // caller) see the data.  Cheap when no streaming stores were issued
-    // (i.e. fallback memcpy path).
+    // Drain WC buffers so subsequent readers (other threads, the Python caller) see the data
     _mm_sfence();
 }
 
-// CHWT: src layout is (h_per, w_per, T), T innermost (stride 1).  Dest has
-// W innermost (stride 1) and T at stride row_stride.  Per-h slice is a
-// (w_per, T) → (T, w_per) byte transpose, tiled in 32×32 blocks.
-//
-// w_per for our case is in {160, 80}.  T is 81 (2 full 32-T tiles + a
-// 17-T tail).  We handle both:
-//   - w_chunks of 32 (Y: 5 chunks; UV: 2 full chunks + 1 tail of 16).
-//   - t_chunks of 32 (full: 2; tail: 1 of 17).
+// CHWT: src layout is (h_per, w_per, T), T innermost (stride 1)
 void scatter_one_chwt(
     const uint8_t* src,
     uint8_t* dst,
@@ -261,18 +219,7 @@ void scatter_one_chwt(
             }
         }
 
-        // W-tail (when w_per % 32 != 0).
-        //
-        // Fast path for w_tail == 16 (UV plane, w_per_uv = 80 = 2*32 + 16):
-        // 16 W-source rows × 32 T-source cols → 32 T-dest rows × 16 W-dest
-        // cols, done with two back-to-back 16×16 SSE transposes.  No bounce
-        // buffer, no zero-padding pass.
-        //
-        // General path (w_tail in [1, 31] \ {16}): zero-pad source into a
-        // 32×32 stack temp, transpose, copy only the valid w_tail cols from
-        // each output row.  Slower but covers every shape we might see.
-        // (Currently only triggered if w_tail != 16, which doesn't happen for
-        // 720p Y/UV; kept for safety.)
+        // W-tail (when w_per % 32 != 0)
         if (w_tail > 0) {
             const uint8_t* src_w = src_h + static_cast<std::ptrdiff_t>(n_w_full_tiles) * 32 * T;
             uint8_t* dst_w = dst_h + static_cast<std::ptrdiff_t>(n_w_full_tiles) * 32;
@@ -286,8 +233,7 @@ void scatter_one_chwt(
                         row_stride);
                 }
                 if (t_tail > 0) {
-                    // T-tail × 16 W-cols: small enough to keep the bounce
-                    // buffer; reduces case explosion in this code path.
+                    // T-tail × 16 W-cols: small enough to keep the bounce buffer
                     alignas(32) uint8_t tmp_src[32 * 32];
                     alignas(32) uint8_t tmp_dst[32 * 32];
                     std::memset(tmp_src, 0, sizeof(tmp_src));
@@ -384,10 +330,7 @@ void planar_concat(
     const int out_uv = out_Hu * out_Wu;
     const int row_stride = out_hw + 2 * out_uv;
 
-    // Build a flat task list across all 3 components so the thread pool can
-    // load-balance Y (4× the bytes of UV) against UV.  Each entry is a
-    // resolved per-shard task.  ``bound_h``/``bound_w`` are the logical plane
-    // extents used to clamp each shard's write.
+    // Build a flat task list across all 3 components so the thread pool can load-balance Y
     struct Task {
         const ShardView* shard;
         int plane_offset;

--- a/models/tt_dit/utils/cpp/planar_concat.hpp
+++ b/models/tt_dit/utils/cpp/planar_concat.hpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace tt_dit_planar {
+
+// Per-shard view of an input shard.  `data` is the raw uint8 byte pointer;
+// `h_per`, `w_per`, `T` are the per-shard logical dimensions.  Mesh
+// coordinates `(r, c)` index the shard into the destination plane.
+struct ShardView {
+    const uint8_t* data;
+    int r;
+    int c;
+};
+
+enum class DimOrder {
+    CHWT,  // shard memory layout: (h_per, w_per, T) — T innermost
+    CTHW,  // shard memory layout: (T, h_per, w_per) — W innermost
+};
+
+// Scatter all shards of one component into one plane region of `out`.
+//
+// `plane_offset` is the byte offset into each output frame's row at which
+// this component's plane begins (Y: 0; Cb: H*W; Cr: H*W + (H/2)*(W/2)).
+// `plane_W` is the full destination width of this plane (W for Y, W/2 for UV).
+// `row_stride` is the bytes per output frame row (= H*W + 2*(H/2)*(W/2)).
+// `T` is the temporal extent (= number of output rows).
+// `h_per`, `w_per` are per-shard heights and widths of THIS component.
+//
+// Tasks are dispatched across the static thread pool.  Returns when all
+// scatters of this component are complete.
+void scatter_component(
+    const std::vector<ShardView>& shards,
+    DimOrder dim_order,
+    uint8_t* out,
+    int T,
+    int plane_offset,
+    int plane_W,
+    int row_stride,
+    int h_per,
+    int w_per);
+
+// Top-level entry: schedule Y/Cb/Cr scatters in one batch for maximum
+// thread-pool parallelism (96 tasks for a 4×8 mesh).  Blocks until all
+// tasks finish.
+// ``out_H``/``out_W`` are the logical output dims. When the VAE pads a global
+// right/bottom tail (``out_H < H`` and/or ``out_W < W``), each shard's write
+// extent is clamped to the logical bound while its source is still addressed
+// with the full padded per-shard dims — so the padded tail is never written
+// and ``out`` is sized for the logical (cropped) frame, no separate trim pass.
+void planar_concat(
+    const std::vector<ShardView>& y_shards,
+    int y_h_per,
+    int y_w_per,
+    const std::vector<ShardView>& cb_shards,
+    int uv_h_per,
+    int uv_w_per,
+    const std::vector<ShardView>& cr_shards,
+    DimOrder dim_order,
+    int T,
+    int H,
+    int W,
+    int out_H,
+    int out_W,
+    uint8_t* out);
+
+// Optional knob — set the size of the static thread pool.  No-op after the
+// pool has been created (first call to scatter_component / planar_concat).
+void set_thread_pool_size(int n_threads);
+
+}  // namespace tt_dit_planar

--- a/models/tt_dit/utils/cpp/planar_concat.hpp
+++ b/models/tt_dit/utils/cpp/planar_concat.hpp
@@ -8,9 +8,7 @@
 
 namespace tt_dit_planar {
 
-// Per-shard view of an input shard.  `data` is the raw uint8 byte pointer;
-// `h_per`, `w_per`, `T` are the per-shard logical dimensions.  Mesh
-// coordinates `(r, c)` index the shard into the destination plane.
+// Per-shard view of an input shard
 struct ShardView {
     const uint8_t* data;
     int r;
@@ -22,17 +20,7 @@ enum class DimOrder {
     CTHW,  // shard memory layout: (T, h_per, w_per) — W innermost
 };
 
-// Scatter all shards of one component into one plane region of `out`.
-//
-// `plane_offset` is the byte offset into each output frame's row at which
-// this component's plane begins (Y: 0; Cb: H*W; Cr: H*W + (H/2)*(W/2)).
-// `plane_W` is the full destination width of this plane (W for Y, W/2 for UV).
-// `row_stride` is the bytes per output frame row (= H*W + 2*(H/2)*(W/2)).
-// `T` is the temporal extent (= number of output rows).
-// `h_per`, `w_per` are per-shard heights and widths of THIS component.
-//
-// Tasks are dispatched across the static thread pool.  Returns when all
-// scatters of this component are complete.
+// Scatter all shards of one component into one plane region of `out`
 void scatter_component(
     const std::vector<ShardView>& shards,
     DimOrder dim_order,
@@ -44,14 +32,7 @@ void scatter_component(
     int h_per,
     int w_per);
 
-// Top-level entry: schedule Y/Cb/Cr scatters in one batch for maximum
-// thread-pool parallelism (96 tasks for a 4×8 mesh).  Blocks until all
-// tasks finish.
-// ``out_H``/``out_W`` are the logical output dims. When the VAE pads a global
-// right/bottom tail (``out_H < H`` and/or ``out_W < W``), each shard's write
-// extent is clamped to the logical bound while its source is still addressed
-// with the full padded per-shard dims — so the padded tail is never written
-// and ``out`` is sized for the logical (cropped) frame, no separate trim pass.
+// Top-level entry: schedule Y/Cb/Cr scatters in one batch for maximum thread-pool parallelism
 void planar_concat(
     const std::vector<ShardView>& y_shards,
     int y_h_per,
@@ -68,8 +49,7 @@ void planar_concat(
     int out_W,
     uint8_t* out);
 
-// Optional knob — set the size of the static thread pool.  No-op after the
-// pool has been created (first call to scatter_component / planar_concat).
+// Optional knob — set the size of the static thread pool
 void set_thread_pool_size(int n_threads);
 
 }  // namespace tt_dit_planar

--- a/models/tt_dit/utils/cpp/planar_concat_bindings.cpp
+++ b/models/tt_dit/utils/cpp/planar_concat_bindings.cpp
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// CPython extension module `_planar_concat`. Written against the bare CPython
+// and NumPy C APIs so build.sh needs no dependency beyond a compiler and the
+// NumPy headers already required to import the caller.
+
+#define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+#include <Python.h>
+#include <numpy/arrayobject.h>
+
+#include <string>
+#include <vector>
+
+#include "planar_concat.hpp"
+
+namespace {
+
+using tt_dit_planar::DimOrder;
+using tt_dit_planar::ShardView;
+
+struct ComponentShards {
+    std::vector<ShardView> views;
+    int h_per = 0;
+    int w_per = 0;
+    int T = 0;
+};
+
+// Shards arrive pre-sorted by (mesh_row, mesh_col), so list order alone fixes
+// each shard's placement in the mesh.
+bool parse_component(PyObject* seq, DimOrder dim_order, int TP, int SP, const char* name, ComponentShards* out) {
+    PyObject* fast = PySequence_Fast(seq, "shard container must be a sequence");
+    if (fast == nullptr) {
+        return false;
+    }
+    const Py_ssize_t n = PySequence_Fast_GET_SIZE(fast);
+    if (n != static_cast<Py_ssize_t>(TP) * SP) {
+        PyErr_Format(PyExc_ValueError, "%s: expected %d shards for a %dx%d mesh, got %zd", name, TP * SP, TP, SP, n);
+        Py_DECREF(fast);
+        return false;
+    }
+
+    out->views.reserve(static_cast<size_t>(n));
+    for (Py_ssize_t i = 0; i < n; ++i) {
+        PyObject* item = PySequence_Fast_GET_ITEM(fast, i);
+        if (!PyArray_Check(item)) {
+            PyErr_Format(PyExc_TypeError, "%s[%zd]: expected a numpy.ndarray", name, i);
+            Py_DECREF(fast);
+            return false;
+        }
+        PyArrayObject* arr = reinterpret_cast<PyArrayObject*>(item);
+        if (PyArray_TYPE(arr) != NPY_UINT8 || !PyArray_IS_C_CONTIGUOUS(arr) || PyArray_NDIM(arr) != 4) {
+            PyErr_Format(PyExc_ValueError, "%s[%zd]: expected a C-contiguous 4-D uint8 array", name, i);
+            Py_DECREF(fast);
+            return false;
+        }
+
+        int h_per, w_per, T;
+        if (dim_order == DimOrder::CHWT) {
+            h_per = static_cast<int>(PyArray_DIM(arr, 1));
+            w_per = static_cast<int>(PyArray_DIM(arr, 2));
+            T = static_cast<int>(PyArray_DIM(arr, 3));
+        } else {
+            T = static_cast<int>(PyArray_DIM(arr, 1));
+            h_per = static_cast<int>(PyArray_DIM(arr, 2));
+            w_per = static_cast<int>(PyArray_DIM(arr, 3));
+        }
+        if (i == 0) {
+            out->h_per = h_per;
+            out->w_per = w_per;
+            out->T = T;
+        } else if (h_per != out->h_per || w_per != out->w_per || T != out->T) {
+            PyErr_Format(PyExc_ValueError, "%s[%zd]: shard shape differs from shard 0", name, i);
+            Py_DECREF(fast);
+            return false;
+        }
+
+        ShardView sv;
+        sv.data = static_cast<const uint8_t*>(PyArray_DATA(arr));
+        sv.r = static_cast<int>(i) / SP;
+        sv.c = static_cast<int>(i) % SP;
+        out->views.push_back(sv);
+    }
+    Py_DECREF(fast);
+    return true;
+}
+
+PyObject* py_planar_concat(PyObject* /*self*/, PyObject* args) {
+    PyObject *y_obj, *u_obj, *v_obj, *mesh_obj, *out_obj;
+    const char* dim_order_str;
+    int out_H, out_W;
+    if (!PyArg_ParseTuple(
+            args, "OOOsOOii", &y_obj, &u_obj, &v_obj, &dim_order_str, &mesh_obj, &out_obj, &out_H, &out_W)) {
+        return nullptr;
+    }
+
+    DimOrder dim_order;
+    if (std::string(dim_order_str) == "CHWT") {
+        dim_order = DimOrder::CHWT;
+    } else if (std::string(dim_order_str) == "CTHW") {
+        dim_order = DimOrder::CTHW;
+    } else {
+        PyErr_Format(PyExc_ValueError, "dim_order must be 'CHWT' or 'CTHW', got '%s'", dim_order_str);
+        return nullptr;
+    }
+
+    int TP, SP;
+    {
+        PyObject* fast = PySequence_Fast(mesh_obj, "mesh_shape must be a sequence");
+        if (fast == nullptr) {
+            return nullptr;
+        }
+        if (PySequence_Fast_GET_SIZE(fast) != 2) {
+            PyErr_SetString(PyExc_ValueError, "mesh_shape must be a 2-element sequence");
+            Py_DECREF(fast);
+            return nullptr;
+        }
+        TP = static_cast<int>(PyLong_AsLong(PySequence_Fast_GET_ITEM(fast, 0)));
+        SP = static_cast<int>(PyLong_AsLong(PySequence_Fast_GET_ITEM(fast, 1)));
+        Py_DECREF(fast);
+        if (PyErr_Occurred()) {
+            return nullptr;
+        }
+    }
+    if (TP <= 0 || SP <= 0) {
+        PyErr_SetString(PyExc_ValueError, "mesh_shape entries must be positive");
+        return nullptr;
+    }
+
+    ComponentShards y, cb, cr;
+    if (!parse_component(y_obj, dim_order, TP, SP, "y_shards", &y) ||
+        !parse_component(u_obj, dim_order, TP, SP, "u_shards", &cb) ||
+        !parse_component(v_obj, dim_order, TP, SP, "v_shards", &cr)) {
+        return nullptr;
+    }
+    if (cb.h_per != cr.h_per || cb.w_per != cr.w_per) {
+        PyErr_SetString(PyExc_ValueError, "Cb and Cr shard dims differ");
+        return nullptr;
+    }
+    if (y.T != cb.T || y.T != cr.T) {
+        PyErr_SetString(PyExc_ValueError, "Y and chroma shards disagree on T");
+        return nullptr;
+    }
+
+    if (!PyArray_Check(out_obj)) {
+        PyErr_SetString(PyExc_TypeError, "out must be a numpy.ndarray");
+        return nullptr;
+    }
+    PyArrayObject* out_arr = reinterpret_cast<PyArrayObject*>(out_obj);
+    if (PyArray_TYPE(out_arr) != NPY_UINT8 || !PyArray_IS_C_CONTIGUOUS(out_arr) || PyArray_NDIM(out_arr) != 2) {
+        PyErr_SetString(PyExc_ValueError, "out must be a C-contiguous 2-D uint8 array");
+        return nullptr;
+    }
+    if (out_H <= 0 || out_W <= 0 || (out_H & 1) || (out_W & 1)) {
+        PyErr_Format(PyExc_ValueError, "out_H/out_W must be positive and even, got %d/%d", out_H, out_W);
+        return nullptr;
+    }
+
+    const int H = y.h_per * TP;
+    const int W = y.w_per * SP;
+    if (out_H > H || out_W > W) {
+        PyErr_Format(PyExc_ValueError, "logical crop %dx%d exceeds the assembled %dx%d frame", out_H, out_W, H, W);
+        return nullptr;
+    }
+
+    const npy_intp row_stride =
+        static_cast<npy_intp>(out_H) * out_W + 2 * (static_cast<npy_intp>(out_H / 2) * (out_W / 2));
+    if (PyArray_DIM(out_arr, 0) != y.T || PyArray_DIM(out_arr, 1) != row_stride) {
+        PyErr_Format(
+            PyExc_ValueError,
+            "out must have shape (%d, %zd); got (%zd, %zd)",
+            y.T,
+            row_stride,
+            PyArray_DIM(out_arr, 0),
+            PyArray_DIM(out_arr, 1));
+        return nullptr;
+    }
+
+    uint8_t* out_ptr = static_cast<uint8_t*>(PyArray_DATA(out_arr));
+    Py_BEGIN_ALLOW_THREADS;
+    tt_dit_planar::planar_concat(
+        y.views, y.h_per, y.w_per, cb.views, cb.h_per, cb.w_per, cr.views, dim_order, y.T, H, W, out_H, out_W, out_ptr);
+    Py_END_ALLOW_THREADS;
+
+    Py_RETURN_NONE;
+}
+
+PyObject* py_set_thread_pool_size(PyObject* /*self*/, PyObject* arg) {
+    const long n = PyLong_AsLong(arg);
+    if (n == -1 && PyErr_Occurred()) {
+        return nullptr;
+    }
+    tt_dit_planar::set_thread_pool_size(static_cast<int>(n));
+    Py_RETURN_NONE;
+}
+
+PyMethodDef g_methods[] = {
+    {"planar_concat", py_planar_concat, METH_VARARGS, "Scatter YUV 4:2:0 shards into a planar frame buffer."},
+    {"set_thread_pool_size",
+     py_set_thread_pool_size,
+     METH_O,
+     "Set the worker pool size; takes effect before first use."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
+PyModuleDef g_module = {
+    PyModuleDef_HEAD_INIT,
+    "_planar_concat",
+    "AVX2 planar YUV concat.",
+    -1,
+    g_methods,
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
+};
+
+}  // namespace
+
+PyMODINIT_FUNC PyInit__planar_concat(void) {
+    import_array();
+    return PyModule_Create(&g_module);
+}

--- a/models/tt_dit/utils/cpp/transpose_avx2.cpp
+++ b/models/tt_dit/utils/cpp/transpose_avx2.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// SIMD byte-tile transposes backing the CHWT scatter in planar_concat.cpp.
+
+#include "transpose_avx2.hpp"
+
+#include <cstring>
+
+#include <emmintrin.h>
+#include <immintrin.h>
+#include <tmmintrin.h>
+
+namespace tt_dit_planar {
+
+namespace {
+
+// 16x16 byte transpose via the standard four-stage unpack network: each stage
+// doubles the element width, so after epi8/16/32/64 every output lane holds one
+// source column. This is the only primitive; the wider tiles compose from it.
+inline void transpose_16x16_u8(const uint8_t* src, std::ptrdiff_t ss, uint8_t* dst, std::ptrdiff_t ds) {
+    __m128i r[16];
+    for (int i = 0; i < 16; ++i) {
+        r[i] = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i * ss));
+    }
+
+    __m128i a[16];
+    for (int i = 0; i < 8; ++i) {
+        a[2 * i] = _mm_unpacklo_epi8(r[2 * i], r[2 * i + 1]);
+        a[2 * i + 1] = _mm_unpackhi_epi8(r[2 * i], r[2 * i + 1]);
+    }
+
+    __m128i b[16];
+    for (int g = 0; g < 4; ++g) {
+        const int s = g * 4;
+        b[s + 0] = _mm_unpacklo_epi16(a[s + 0], a[s + 2]);
+        b[s + 1] = _mm_unpackhi_epi16(a[s + 0], a[s + 2]);
+        b[s + 2] = _mm_unpacklo_epi16(a[s + 1], a[s + 3]);
+        b[s + 3] = _mm_unpackhi_epi16(a[s + 1], a[s + 3]);
+    }
+
+    __m128i c[16];
+    for (int g = 0; g < 2; ++g) {
+        const int s = g * 8;
+        for (int i = 0; i < 4; ++i) {
+            c[s + 2 * i] = _mm_unpacklo_epi32(b[s + i], b[s + 4 + i]);
+            c[s + 2 * i + 1] = _mm_unpackhi_epi32(b[s + i], b[s + 4 + i]);
+        }
+    }
+
+    for (int i = 0; i < 8; ++i) {
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + (2 * i) * ds), _mm_unpacklo_epi64(c[i], c[8 + i]));
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + (2 * i + 1) * ds), _mm_unpackhi_epi64(c[i], c[8 + i]));
+    }
+}
+
+}  // namespace
+
+void transpose_32x32_u8(const uint8_t* src, std::ptrdiff_t src_stride, uint8_t* dst, std::ptrdiff_t dst_stride) {
+    // Off-diagonal quadrants swap position under transposition.
+    transpose_16x16_u8(src, src_stride, dst, dst_stride);
+    transpose_16x16_u8(src + 16 * src_stride, src_stride, dst + 16, dst_stride);
+    transpose_16x16_u8(src + 16, src_stride, dst + 16 * dst_stride, dst_stride);
+    transpose_16x16_u8(src + 16 * src_stride + 16, src_stride, dst + 16 * dst_stride + 16, dst_stride);
+}
+
+void transpose_32xN_u8(const uint8_t* src, std::ptrdiff_t src_stride, uint8_t* dst, std::ptrdiff_t dst_stride, int n) {
+    if (n <= 0) {
+        return;
+    }
+    // Staging keeps the partial tile off the strided source/destination; the
+    // padded lanes are never copied back out.
+    alignas(32) uint8_t tmp_src[32 * 32];
+    alignas(32) uint8_t tmp_dst[32 * 32];
+    std::memset(tmp_src, 0, sizeof(tmp_src));
+    for (int i = 0; i < 32; ++i) {
+        std::memcpy(tmp_src + i * 32, src + i * src_stride, static_cast<size_t>(n));
+    }
+    transpose_32x32_u8(tmp_src, 32, tmp_dst, 32);
+    for (int i = 0; i < n; ++i) {
+        std::memcpy(dst + i * dst_stride, tmp_dst + i * 32, 32);
+    }
+}
+
+void transpose_32x16_u8(const uint8_t* src, std::ptrdiff_t src_stride, uint8_t* dst, std::ptrdiff_t dst_stride) {
+    // 16 source rows x 32 source cols: the two 16x16 halves stack vertically in dst.
+    transpose_16x16_u8(src, src_stride, dst, dst_stride);
+    transpose_16x16_u8(src + 16, src_stride, dst + 16 * dst_stride, dst_stride);
+}
+
+}  // namespace tt_dit_planar

--- a/models/tt_dit/utils/cpp/transpose_avx2.hpp
+++ b/models/tt_dit/utils/cpp/transpose_avx2.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace tt_dit_planar {
+
+// All three routines write dst[i][j] = src[j][i]; `src` is indexed by the CHWT
+// source's W axis and `dst` by its T axis, so the caller's "rows" swap meaning
+// across the call.
+
+// 32 source rows x 32 source cols.
+void transpose_32x32_u8(const uint8_t* src, std::ptrdiff_t src_stride, uint8_t* dst, std::ptrdiff_t dst_stride);
+
+// 32 source rows x `n` source cols, n in [1, 32]. Reads only `n` bytes per
+// source row, so a short trailing source is never over-read.
+void transpose_32xN_u8(const uint8_t* src, std::ptrdiff_t src_stride, uint8_t* dst, std::ptrdiff_t dst_stride, int n);
+
+// 16 source rows x 32 source cols.
+void transpose_32x16_u8(const uint8_t* src, std::ptrdiff_t src_stride, uint8_t* dst, std::ptrdiff_t dst_stride);
+
+}  // namespace tt_dit_planar

--- a/models/tt_dit/utils/matmul.py
+++ b/models/tt_dit/utils/matmul.py
@@ -256,11 +256,7 @@ class FusedMMRSConfig(NamedTuple):
     subblock_w: int
     num_buffers_per_channel: int | None
     chunk_width_in_mm_blocks: int
-    # Optional explicit reduce-scatter worker count. When None (default) it is derived from the
-    # RS-zone geometry below. Set it to pin the value to an op-test-tuned count so the model and
-    # the ccl op test (tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py)
-    # agree exactly -- the geometry derivation and the op test's explicit num_workers_per_link do
-    # not otherwise match (e.g. LTX ff2: derived 5 vs op-test-validated 3).
+    # Optional explicit reduce-scatter worker count
     num_workers_per_link: int | None = None
 
     def get_params(self, core_grid, num_links):
@@ -295,11 +291,7 @@ fused_mmrs_configs = {
     ttnn.CoreCoord(12, 10): {
         (9472, 3456, 5120): FusedMMRSConfig(ttnn.CoreCoord(12, 8), 8, 4, 8, 2, 1, None, 1),
         (9472 // 4, 3456, 5120): FusedMMRSConfig(ttnn.CoreCoord(12, 8), 4, 4, 8, 2, 2, None, 1),
-        # LTX video FFN ff2 (RowParallel): per-device [4864,4096]@[4096,4096]. (12,8)=96-core MM grid
-        # with op-test-tuned b756 blocking: 7x5x6 tiles (224/160/192 elem), subblock 1x3, chunk=1,
-        # RS workers on rows 8-9. num_workers_per_link pinned to 3 (geometry would derive 5) to match
-        # ltx_ff2_4864_4096_4096_x12_y8_b756 in
-        # tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py.
+        # LTX video FFN ff2 (RowParallel): per-device [4864,4096]@[4096,4096]
         (4864, 4096, 4096): FusedMMRSConfig(ttnn.CoreCoord(12, 8), 7, 5, 6, 1, 3, None, 1, 3),
     },
 }
@@ -371,16 +363,7 @@ def register_fused_mmrs_configs(configs: dict) -> None:
         fused_mmrs_configs.setdefault(core_grid, {}).update(entries)
 
 
-# =====================================================================
-# Fabric-bound all-gather-matmul (strided AGMM) configs
-# =====================================================================
-# The optimized fabric-bound op ``ttnn.experimental.strided_all_gather_minimal_matmul_async``
-# partitions the worker grid: the matmul runs on ``mm_core_grid`` (the lower rows) and the
-# strided all-gather workers run on the rows starting at ``ag_core_grid_offset`` (which must
-# start at ``mm_core_grid.y`` to keep the two regions disjoint). Only shapes registered here
-# take the fabric path; everything else falls through to the current
-# ``all_gather_minimal_matmul_async`` op. This is the seam for the eventual 3-path
-# (fabric / dram / compute) router.
+# ===================================================================== Fabric-bound all-gather-matmul
 class FabricAGMMConfig(NamedTuple):
     mm_core_grid: ttnn.CoreCoord
     ag_core_grid_offset: tuple
@@ -393,42 +376,16 @@ class FabricAGMMConfig(NamedTuple):
     num_buffers_per_channel: int
 
 
-# Keyed by device core-grid (``ttnn.CoreCoord``) then ``(K, N, chunks)``. K is the full (gathered)
-# contraction dim, N the per-TP-device output width, chunks the output-split count. M (the per-SP-
-# device sequence length) is intentionally NOT part of the key: the tuned block sizes are
-# M-independent across every LTX entry, and the model's real M for the audio/kv rows differs from
-# the video-seq proxy the op test sweeps -- keying on M would stop those shapes from ever matching.
-# Seeded from the LTX stage-1/stage-2 video + audio blocks on the Blackhole galaxy 12x10 grid.
+# Keyed by device core-grid (``ttnn.CoreCoord``) then ``(K, N, chunks)``
 fabric_agmm_configs: dict[ttnn.CoreCoord, dict[tuple, FabricAGMMConfig]] = {
     ttnn.CoreCoord(12, 10): {
-        # (K, N, chunks) -> FabricAGMMConfig(mm_core_grid, ag_core_grid_offset,
-        #                                    M_block, K_block, N_block, sub_h, sub_w, num_w/link, num_buf/chan)
-        # video to_q (cross) / to_out(plain) / to_out addcmul: N = video_dim/tp = 1024.
-        # DEVICE-VALIDATED: stage-2 video block, 3x StridedAllGatherMinimalMatmulAsync, PCC pass.
+        # (K, N, chunks) -> FabricAGMMConfig
         (4096, 1024, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 4, 2, 2, 3, 8),
-        # ---------------------------------------------------------------------------------------
-        # Remaining uncommented shapes from test_strided_all_gather_minimal_matmul_ltx_configs.
-        # Block shapes below MIRROR that op test exactly (it is the tuning source of truth) --
-        # (M_block, K_block, N_block, subblock_h, subblock_w). Validate on device via that test.
-        # ---------------------------------------------------------------------------------------
-        # video to_gate_logits: per-device N = num_heads/tp = 8, tile-padded to 32 (1 tile).
+        # --------------------------------------------------------------------------------------- Remaining
         (4096, 32, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 1, 2, 1, 3, 8),
-        # audio to_gate_logits: per-device N = num_heads/tp = 8, tile-padded to 32 (1 tile).
-        # DISABLED under global IN0_SUB_CHUNKS=2 banding: audio seq is tiny (AUDIO_N/sp = 1 M-tile),
-        # so last_m_block_tiles=1 < in0_sub_chunks=2 -> the banded path hard-asserts
-        # (minimal_matmul_fabric_bound_program_factory.cpp:522). Audio M=1 tile is also perf-negligible
-        # and can't overlap-band regardless, so keep it on the old op. Re-enable only once in0_sub_chunks
-        # is a per-config field (set to 1 for audio) rather than a global env var.
-        # (2048, 32, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 1, 2, 1, 3, 8),
-        # audio_to_video_attn.to_q (a2v cross): K = video_dim = 4096, N = audio_dim/tp = 512 (16 tiles).
-        # transpose grid -> N across grid.y=8 => 2 tiles/core. N_block MUST be 2 (subblock_w=2) so
-        # N_blocks_per_core = ceil(2/2) = 1; N_block=1 gives 2 blocks/core -> split-write DEADLOCK
-        # (device-confirmed hang at "Waiting for op"). This differs from the op test's stale value.
+        # audio to_gate_logits: per-device N = num_heads/tp = 8, tile-padded to 32 (1 tile)
         (4096, 512, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 2, 2, 2, 3, 8),
-        # audio a_kv (chunks=1 in the op test): K = audio_dim = 2048, N = 1024. Inert in-model (real
-        # to_kv is chunks=2 -> old op). Also DISABLED for the same reason as the audio gate above:
-        # in-model audio M = AUDIO_N/sp = 1 tile, which can't band under global IN0_SUB_CHUNKS=2.
-        # (2048, 1024, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 4, 2, 2, 3, 8),
+        # audio a_kv (chunks=1 in the op test): K = audio_dim = 2048, N = 1024
     },
 }
 

--- a/models/tt_dit/utils/matmul.py
+++ b/models/tt_dit/utils/matmul.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+import os
 from typing import NamedTuple
 
 from loguru import logger
@@ -255,13 +256,24 @@ class FusedMMRSConfig(NamedTuple):
     subblock_w: int
     num_buffers_per_channel: int | None
     chunk_width_in_mm_blocks: int
+    # Optional explicit reduce-scatter worker count. When None (default) it is derived from the
+    # RS-zone geometry below. Set it to pin the value to an op-test-tuned count so the model and
+    # the ccl op test (tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py)
+    # agree exactly -- the geometry derivation and the op test's explicit num_workers_per_link do
+    # not otherwise match (e.g. LTX ff2: derived 5 vs op-test-validated 3).
+    num_workers_per_link: int | None = None
 
     def get_params(self, core_grid, num_links):
-        rs_zone_capacity = (core_grid.y - self.compute_with_storage_grid_size.y) * core_grid.x
-        num_workers_per_link = rs_zone_capacity // (2 * num_links) - 1
         config_dict = self._asdict()
         num_buffers_per_channel = config_dict.pop("num_buffers_per_channel")
         chunk_width_in_mm_blocks = config_dict.pop("chunk_width_in_mm_blocks")
+        num_workers_override = config_dict.pop("num_workers_per_link")
+
+        if num_workers_override is not None:
+            num_workers_per_link = num_workers_override
+        else:
+            rs_zone_capacity = (core_grid.y - self.compute_with_storage_grid_size.y) * core_grid.x
+            num_workers_per_link = rs_zone_capacity // (2 * num_links) - 1
 
         # Order is important. Guaranteed for python 3.7+
         return {
@@ -283,6 +295,12 @@ fused_mmrs_configs = {
     ttnn.CoreCoord(12, 10): {
         (9472, 3456, 5120): FusedMMRSConfig(ttnn.CoreCoord(12, 8), 8, 4, 8, 2, 1, None, 1),
         (9472 // 4, 3456, 5120): FusedMMRSConfig(ttnn.CoreCoord(12, 8), 4, 4, 8, 2, 2, None, 1),
+        # LTX video FFN ff2 (RowParallel): per-device [4864,4096]@[4096,4096]. (12,8)=96-core MM grid
+        # with op-test-tuned b756 blocking: 7x5x6 tiles (224/160/192 elem), subblock 1x3, chunk=1,
+        # RS workers on rows 8-9. num_workers_per_link pinned to 3 (geometry would derive 5) to match
+        # ltx_ff2_4864_4096_4096_x12_y8_b756 in
+        # tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py.
+        (4864, 4096, 4096): FusedMMRSConfig(ttnn.CoreCoord(12, 8), 7, 5, 6, 1, 3, None, 1, 3),
     },
 }
 
@@ -351,3 +369,101 @@ def register_fused_mmrs_configs(configs: dict) -> None:
     """
     for core_grid, entries in configs.items():
         fused_mmrs_configs.setdefault(core_grid, {}).update(entries)
+
+
+# =====================================================================
+# Fabric-bound all-gather-matmul (strided AGMM) configs
+# =====================================================================
+# The optimized fabric-bound op ``ttnn.experimental.strided_all_gather_minimal_matmul_async``
+# partitions the worker grid: the matmul runs on ``mm_core_grid`` (the lower rows) and the
+# strided all-gather workers run on the rows starting at ``ag_core_grid_offset`` (which must
+# start at ``mm_core_grid.y`` to keep the two regions disjoint). Only shapes registered here
+# take the fabric path; everything else falls through to the current
+# ``all_gather_minimal_matmul_async`` op. This is the seam for the eventual 3-path
+# (fabric / dram / compute) router.
+class FabricAGMMConfig(NamedTuple):
+    mm_core_grid: ttnn.CoreCoord
+    ag_core_grid_offset: tuple
+    M_block_size: int
+    K_block_size: int
+    N_block_size: int
+    subblock_h: int
+    subblock_w: int
+    num_workers_per_link: int
+    num_buffers_per_channel: int
+
+
+# Keyed by device core-grid (``ttnn.CoreCoord``) then ``(K, N, chunks)``. K is the full (gathered)
+# contraction dim, N the per-TP-device output width, chunks the output-split count. M (the per-SP-
+# device sequence length) is intentionally NOT part of the key: the tuned block sizes are
+# M-independent across every LTX entry, and the model's real M for the audio/kv rows differs from
+# the video-seq proxy the op test sweeps -- keying on M would stop those shapes from ever matching.
+# Seeded from the LTX stage-1/stage-2 video + audio blocks on the Blackhole galaxy 12x10 grid.
+fabric_agmm_configs: dict[ttnn.CoreCoord, dict[tuple, FabricAGMMConfig]] = {
+    ttnn.CoreCoord(12, 10): {
+        # (K, N, chunks) -> FabricAGMMConfig(mm_core_grid, ag_core_grid_offset,
+        #                                    M_block, K_block, N_block, sub_h, sub_w, num_w/link, num_buf/chan)
+        # video to_q (cross) / to_out(plain) / to_out addcmul: N = video_dim/tp = 1024.
+        # DEVICE-VALIDATED: stage-2 video block, 3x StridedAllGatherMinimalMatmulAsync, PCC pass.
+        (4096, 1024, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 4, 2, 2, 3, 8),
+        # ---------------------------------------------------------------------------------------
+        # Remaining uncommented shapes from test_strided_all_gather_minimal_matmul_ltx_configs.
+        # Block shapes below MIRROR that op test exactly (it is the tuning source of truth) --
+        # (M_block, K_block, N_block, subblock_h, subblock_w). Validate on device via that test.
+        # ---------------------------------------------------------------------------------------
+        # video to_gate_logits: per-device N = num_heads/tp = 8, tile-padded to 32 (1 tile).
+        (4096, 32, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 1, 2, 1, 3, 8),
+        # audio to_gate_logits: per-device N = num_heads/tp = 8, tile-padded to 32 (1 tile).
+        # DISABLED under global IN0_SUB_CHUNKS=2 banding: audio seq is tiny (AUDIO_N/sp = 1 M-tile),
+        # so last_m_block_tiles=1 < in0_sub_chunks=2 -> the banded path hard-asserts
+        # (minimal_matmul_fabric_bound_program_factory.cpp:522). Audio M=1 tile is also perf-negligible
+        # and can't overlap-band regardless, so keep it on the old op. Re-enable only once in0_sub_chunks
+        # is a per-config field (set to 1 for audio) rather than a global env var.
+        # (2048, 32, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 1, 2, 1, 3, 8),
+        # audio_to_video_attn.to_q (a2v cross): K = video_dim = 4096, N = audio_dim/tp = 512 (16 tiles).
+        # transpose grid -> N across grid.y=8 => 2 tiles/core. N_block MUST be 2 (subblock_w=2) so
+        # N_blocks_per_core = ceil(2/2) = 1; N_block=1 gives 2 blocks/core -> split-write DEADLOCK
+        # (device-confirmed hang at "Waiting for op"). This differs from the op test's stale value.
+        (4096, 512, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 2, 2, 2, 3, 8),
+        # audio a_kv (chunks=1 in the op test): K = audio_dim = 2048, N = 1024. Inert in-model (real
+        # to_kv is chunks=2 -> old op). Also DISABLED for the same reason as the audio gate above:
+        # in-model audio M = AUDIO_N/sp = 1 tile, which can't band under global IN0_SUB_CHUNKS=2.
+        # (2048, 1024, 1): FabricAGMMConfig(ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 4, 2, 2, 3, 8),
+    },
+}
+
+
+def get_fabric_agmm_config(K, N, chunks, device_core_grid) -> FabricAGMMConfig | None:
+    """Return the tuned fabric-bound strided-AGMM config for this shape, or ``None``.
+
+    ``None`` means the shape is not (known to be) fabric-bound; the caller keeps the current
+    ``all_gather_minimal_matmul_async`` path. Keyed on ``(K, N, chunks)`` only (M-independent).
+
+    A/B switch: set ``DISABLE_FABRIC_AGMM=1`` to force a miss for every shape, routing the whole
+    model back onto the old ``all_gather_minimal_matmul_async`` op. Used to get an apples-to-apples
+    old-agmm-vs-strided-sagmm baseline under the same trace/fabric config.
+    """
+    if os.environ.get("DISABLE_FABRIC_AGMM") in ("1", "true", "True"):
+        return None
+    return fabric_agmm_configs.get(device_core_grid, {}).get((K, N, chunks))
+
+
+def register_fabric_agmm_configs(configs: dict) -> None:
+    """Register additional fabric-bound strided-AGMM configs from external models.
+
+    Args:
+        configs: Mapping from ``ttnn.CoreCoord`` (device core-grid) to dict of
+            ``(K, N, chunks)`` -> :class:`FabricAGMMConfig`.
+
+    Example::
+
+        register_fabric_agmm_configs({
+            ttnn.CoreCoord(12, 10): {
+                (4096, 1024, 1): FabricAGMMConfig(
+                    ttnn.CoreCoord(12, 8), (0, 8), 16, 8, 4, 2, 2, 3, 8
+                ),
+            },
+        })
+    """
+    for core_grid, entries in configs.items():
+        fabric_agmm_configs.setdefault(core_grid, {}).update(entries)

--- a/models/tt_dit/utils/planar_concat.py
+++ b/models/tt_dit/utils/planar_concat.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python wrapper around the C++ planar concat extension.
+
+The C++ source lives in ``models/tt_dit/utils/cpp/`` and produces
+``cpp/build/_planar_concat<abi>.so`` when built via ``cpp/build.sh``.  This
+module loads it via ``importlib.util`` so callers don't need to put the
+build directory on ``sys.path``.
+
+If the ``.so`` isn't built (or fails to import), :data:`HAS_CPP_PLANAR_CONCAT`
+is False and :func:`planar_concat_cpp` is None.  The benchmark harness in
+``test_fast_device_to_host.py`` already has a ``HAS_*`` skip pattern that
+this slots into.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from typing import TYPE_CHECKING, Sequence
+
+import numpy as np
+
+if TYPE_CHECKING:
+    pass
+
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_BUILD_DIR = os.path.join(_THIS_DIR, "cpp", "build")
+
+
+def _try_load_extension():
+    if not os.path.isdir(_BUILD_DIR):
+        return None
+    candidates = [f for f in os.listdir(_BUILD_DIR) if f.startswith("_planar_concat") and f.endswith(".so")]
+    if not candidates:
+        return None
+    so_path = os.path.join(_BUILD_DIR, candidates[0])
+    spec = importlib.util.spec_from_file_location("_planar_concat", so_path)
+    if spec is None or spec.loader is None:
+        return None
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        return None
+    return mod
+
+
+_ext = _try_load_extension()
+HAS_CPP_PLANAR_CONCAT: bool = _ext is not None
+
+
+def _to_numpy(shard) -> np.ndarray:
+    """Convert a torch tensor to a contiguous numpy uint8 array (zero-copy when possible)."""
+    if isinstance(shard, np.ndarray):
+        if not shard.flags.c_contiguous:
+            shard = np.ascontiguousarray(shard)
+        return shard
+    # torch.Tensor or anything else with .numpy()
+    if hasattr(shard, "contiguous") and hasattr(shard, "numpy"):
+        t = shard.contiguous()
+        return t.numpy()
+    raise TypeError(f"unsupported shard type: {type(shard)!r}")
+
+
+if HAS_CPP_PLANAR_CONCAT:
+
+    def planar_concat_cpp(
+        y_shards: Sequence,
+        u_shards: Sequence,
+        v_shards: Sequence,
+        dim_order: str,
+        mesh_shape: tuple[int, int] = (4, 8),
+        out: np.ndarray | None = None,
+        out_H: int | None = None,
+        out_W: int | None = None,
+    ) -> np.ndarray:
+        """Vectorized YUV 4:2:0 planar concat — C++/AVX2 implementation.
+
+        Equivalent in output to the ``planar_concat_torch_threaded``
+        reference in ``test_fast_device_to_host.py`` but runs in C++ with a
+        persistent ``std::thread`` pool and AVX2 byte-tile transposes for
+        the CHWT path.
+
+        Args:
+            y_shards, u_shards, v_shards: lists of ``TP*SP`` per-shard
+                tensors/arrays.  Per-shard shape:
+                  * CHWT: ``(1, h_per, w_per, T)`` uint8 contiguous.
+                  * CTHW: ``(1, T, h_per, w_per)`` uint8 contiguous.
+                UV shards must have ``h_per/2`` and ``w_per/2`` of the Y
+                shards' dims (4:2:0 subsampling).
+            dim_order: ``"CHWT"`` or ``"CTHW"``.
+            mesh_shape: ``(TP, SP)``.  Defaults to ``(4, 8)``.
+            out: Optional pre-allocated output buffer of shape
+                ``(T, H*W + 2*(H/2 * W/2))`` uint8.  When ``None``, a fresh
+                ``np.empty`` is allocated each call (matches the convention
+                of the other variants in the test harness).  Reusing a
+                buffer across calls eliminates ~50 ms of first-touch page
+                faults per call on systems without THP=always.
+
+        Returns:
+            ``np.ndarray`` of shape ``(T, H*W + 2*(H/2 * W/2))``, dtype
+            ``uint8``.  Per-frame layout: ``[Y plane | Cb plane | Cr plane]``.
+        """
+        y_np = [_to_numpy(s) for s in y_shards]
+        u_np = [_to_numpy(s) for s in u_shards]
+        v_np = [_to_numpy(s) for s in v_shards]
+
+        TP, SP = int(mesh_shape[0]), int(mesh_shape[1])
+        if dim_order == "CHWT":
+            _, h_per, w_per, T = y_np[0].shape
+        elif dim_order == "CTHW":
+            _, T, h_per, w_per = y_np[0].shape
+        else:
+            raise ValueError(f"dim_order must be 'CHWT' or 'CTHW', got {dim_order!r}")
+        H, W = h_per * TP, w_per * SP
+        # Logical (cropped) output: when the VAE pads a global tail, write only the valid frame.
+        oH = H if out_H is None else out_H
+        oW = W if out_W is None else out_W
+        oHu, oWu = oH // 2, oW // 2
+        row_stride = oH * oW + 2 * oHu * oWu
+
+        if out is None:
+            out = np.empty((T, row_stride), dtype=np.uint8)
+        elif out.shape != (T, row_stride) or out.dtype != np.uint8 or not out.flags.c_contiguous:
+            raise ValueError(
+                f"out must be C-contiguous uint8 with shape ({T}, {row_stride}); "
+                f"got shape {out.shape} dtype {out.dtype} c_contig={out.flags.c_contiguous}"
+            )
+
+        _ext.planar_concat(y_np, u_np, v_np, dim_order, mesh_shape, out, oH, oW)
+        return out
+
+    def set_thread_pool_size(n_threads: int) -> None:
+        """Set the C++ thread pool size.  Must be called BEFORE first scatter."""
+        _ext.set_thread_pool_size(int(n_threads))
+
+else:
+    planar_concat_cpp = None  # type: ignore[assignment]
+
+    def set_thread_pool_size(n_threads: int) -> None:  # noqa: D401
+        """No-op fallback when the C++ extension isn't built."""

--- a/models/tt_dit/utils/test.py
+++ b/models/tt_dit/utils/test.py
@@ -7,9 +7,9 @@ import pytest
 import ttnn
 
 
-def create_fabric_router_config(max_payload_size: int = 8192):
+def create_fabric_router_config(max_packet_payload_size_bytes=8192):
     config = ttnn.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = max_payload_size
+    config.max_packet_payload_size_bytes = max_packet_payload_size_bytes
     return config
 
 
@@ -31,7 +31,6 @@ line_params = {"fabric_config": ttnn.FabricConfig.FABRIC_1D}
 ring_params = {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}
 line_params_8k = {**line_params, "fabric_router_config": create_fabric_router_config()}
 ring_params_8k = {**ring_params, "fabric_router_config": create_fabric_router_config()}
-# 4 KB payload (2 tiles/packet for the strided AG): A/B control against the 8k variant.
 ring_params_4k = {**ring_params, "fabric_router_config": create_fabric_router_config(4096)}
 line_params_req_exact_devices = {**line_params, "require_exact_physical_num_devices": True}
 ring_params_req_exact_devices = {**ring_params, "require_exact_physical_num_devices": True}

--- a/models/tt_dit/utils/test.py
+++ b/models/tt_dit/utils/test.py
@@ -7,9 +7,9 @@ import pytest
 import ttnn
 
 
-def create_fabric_router_config():
+def create_fabric_router_config(max_payload_size: int = 8192):
     config = ttnn.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = 8192
+    config.max_packet_payload_size_bytes = max_payload_size
     return config
 
 
@@ -31,6 +31,8 @@ line_params = {"fabric_config": ttnn.FabricConfig.FABRIC_1D}
 ring_params = {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}
 line_params_8k = {**line_params, "fabric_router_config": create_fabric_router_config()}
 ring_params_8k = {**ring_params, "fabric_router_config": create_fabric_router_config()}
+# 4 KB payload (2 tiles/packet for the strided AG): A/B control against the 8k variant.
+ring_params_4k = {**ring_params, "fabric_router_config": create_fabric_router_config(4096)}
 line_params_req_exact_devices = {**line_params, "require_exact_physical_num_devices": True}
 ring_params_req_exact_devices = {**ring_params, "require_exact_physical_num_devices": True}
 ring_params_8k_req_exact_devices = {**ring_params_8k, "require_exact_physical_num_devices": True}

--- a/models/tt_dit/utils/video.py
+++ b/models/tt_dit/utils/video.py
@@ -93,6 +93,99 @@ def export_to_video(
     return output_video_path
 
 
+def _add_audio_stream(container, audio: Audio | None):
+    """Add an AAC audio stream to an open write container. Must run before any packet is muxed
+    (PyAV forbids adding streams once muxing starts). Returns the stream, or None if no audio."""
+    if audio is None:
+        return None
+    audio_stream = container.add_stream("aac", rate=audio.sampling_rate)
+    audio_stream.codec_context.sample_rate = audio.sampling_rate
+    audio_stream.codec_context.layout = "stereo"
+    audio_stream.codec_context.time_base = Fraction(1, audio.sampling_rate)
+    return audio_stream
+
+
+def _mux_audio(container, audio_stream, audio: Audio) -> None:
+    """Encode + mux the decoded waveform into ``audio_stream`` (created by ``_add_audio_stream``)."""
+    import av
+
+    samples = audio.waveform
+    if samples.ndim == 1:
+        samples = samples[:, None]
+    if samples.shape[1] != 2 and samples.shape[0] == 2:
+        samples = samples.T
+    if samples.shape[1] != 2:
+        logger.warning(f"Audio has {samples.shape[1]} channels, expected 2 — duplicating mono")
+        samples = samples[:, :1].repeat(1, 2)
+
+    if samples.dtype != torch.int16:
+        samples = torch.clip(samples, -1.0, 1.0)
+        samples = (samples * 32767.0).to(torch.int16)
+
+    frame_in = av.AudioFrame.from_ndarray(
+        samples.contiguous().reshape(1, -1).cpu().numpy(),
+        format="s16",
+        layout="stereo",
+    )
+    frame_in.sample_rate = audio.sampling_rate
+
+    cc = audio_stream.codec_context
+    resampler = av.audio.resampler.AudioResampler(
+        format=cc.format or "fltp",
+        layout=cc.layout or "stereo",
+        rate=cc.sample_rate or audio.sampling_rate,
+    )
+    for resampled in resampler.resample(frame_in):
+        for packet in audio_stream.encode(resampled):
+            container.mux(packet)
+    for packet in audio_stream.encode():
+        container.mux(packet)
+
+
+def export_video_audio_yuv(yuv_planar, output_path: str, fps: int = 24, audio: Audio | None = None) -> None:
+    """Export a pre-computed yuv420p planar video (+ optional audio) to MP4 — fast-path
+    counterpart to :func:`export_video_audio`.
+
+    The RGB->YUV 4:2:0 conversion already ran on-device (``fast_device_to_host_yuv``), so we
+    hand libx264 native yuv420p frames and skip both the host-side color conversion and the
+    3x-larger float/RGB device->host gather. The encoded MP4 is yuv420p either way, so this is
+    not a fidelity change — only the conversion's location moves.
+
+    Args:
+        yuv_planar: ``(T, H*3//2, W)`` uint8 — PyAV yuv420p ndarray layout, one entry per frame.
+        output_path: output .mp4 path
+        fps: frame rate
+        audio: decoded ``Audio``, or None
+    """
+    import av
+
+    t, h32, width = yuv_planar.shape
+    height = h32 * 2 // 3
+
+    container = av.open(output_path, mode="w")
+    stream = container.add_stream("libx264", rate=int(fps))
+    stream.width = width
+    stream.height = height
+    stream.pix_fmt = "yuv420p"
+    stream.options = {"preset": "veryfast", "crf": "23"}
+    stream.thread_type = "AUTO"
+
+    audio_stream = _add_audio_stream(container, audio)
+
+    for frame_array in yuv_planar:
+        frame = av.VideoFrame.from_ndarray(frame_array, format="yuv420p")
+        for packet in stream.encode(frame):
+            container.mux(packet)
+    for packet in stream.encode():
+        container.mux(packet)
+
+    if audio is not None and audio_stream is not None:
+        _mux_audio(container, audio_stream, audio)
+
+    container.close()
+    logger.info(f"Saved: {output_path} ({t}f @ {fps}fps, yuv420p fast path)")
+
+
 def export_video_audio(video_pixels: torch.Tensor, output_path: str, fps: int = 24, audio: Audio | None = None) -> None:
     """Export decoded video (and optionally audio) to MP4.
 
@@ -131,13 +224,8 @@ def export_video_audio(video_pixels: torch.Tensor, output_path: str, fps: int = 
     stream.options = {"preset": "veryfast", "crf": "23"}
     stream.thread_type = "AUTO"
 
-    # Prepare audio stream if provided
-    audio_stream = None
-    if audio is not None:
-        audio_stream = container.add_stream("aac", rate=audio.sampling_rate)
-        audio_stream.codec_context.sample_rate = audio.sampling_rate
-        audio_stream.codec_context.layout = "stereo"
-        audio_stream.codec_context.time_base = Fraction(1, audio.sampling_rate)
+    # Prepare audio stream if provided (must be added before any packet is muxed)
+    audio_stream = _add_audio_stream(container, audio)
 
     # Write video frames
     for frame_array in frames:
@@ -151,38 +239,7 @@ def export_video_audio(video_pixels: torch.Tensor, output_path: str, fps: int = 
 
     # Write audio if provided
     if audio is not None and audio_stream is not None:
-        samples = audio.waveform
-        if samples.ndim == 1:
-            samples = samples[:, None]
-        if samples.shape[1] != 2 and samples.shape[0] == 2:
-            samples = samples.T
-        if samples.shape[1] != 2:
-            logger.warning(f"Audio has {samples.shape[1]} channels, expected 2 — duplicating mono")
-            samples = samples[:, :1].repeat(1, 2)
-
-        if samples.dtype != torch.int16:
-            samples = torch.clip(samples, -1.0, 1.0)
-            samples = (samples * 32767.0).to(torch.int16)
-
-        frame_in = av.AudioFrame.from_ndarray(
-            samples.contiguous().reshape(1, -1).cpu().numpy(),
-            format="s16",
-            layout="stereo",
-        )
-        frame_in.sample_rate = audio.sampling_rate
-
-        # Resample to encoder format and write
-        cc = audio_stream.codec_context
-        resampler = av.audio.resampler.AudioResampler(
-            format=cc.format or "fltp",
-            layout=cc.layout or "stereo",
-            rate=cc.sample_rate or audio.sampling_rate,
-        )
-        for resampled in resampler.resample(frame_in):
-            for packet in audio_stream.encode(resampled):
-                container.mux(packet)
-        for packet in audio_stream.encode():
-            container.mux(packet)
+        _mux_audio(container, audio_stream, audio)
 
     container.close()
     logger.info(f"Saved: {output_path} ({frames.shape[0]}f @ {fps}fps)")

--- a/models/tt_dit/utils/yuv_d2h.py
+++ b/models/tt_dit/utils/yuv_d2h.py
@@ -22,8 +22,7 @@ from .planar_concat import HAS_CPP_PLANAR_CONCAT
 from .planar_concat import planar_concat_cpp as _planar_concat_cpp_impl
 from .tensor import _get_inter_host_axis, _host_buffer_to_torch, _to_torch_zero_copy
 
-# Persistent host-side reassembly pool — strided uint8 copies release the GIL,
-# so a few threads scale near-linearly; persistence avoids per-call startup.
+# Persistent host-side reassembly pool — strided uint8 copies release the GIL, so a few threads scale near-linearly
 _DEFAULT_REASSEMBLE_POOL: ThreadPoolExecutor | None = None
 _DEFAULT_REASSEMBLE_WORKERS = min(8, os.cpu_count() or 8)
 
@@ -38,10 +37,7 @@ def _get_default_reassemble_pool() -> ThreadPoolExecutor:
     return _DEFAULT_REASSEMBLE_POOL
 
 
-# Persistent output buffer for the C++ planar-concat fast path — fresh np.empty
-# pays first-touch page-fault overhead per call that dwarfs the kernel; reuse
-# eliminates it. The returned buffer is reused across calls (copy out / feed
-# ffmpeg before the next call). Shape changes reallocate lazily.
+# Persistent output buffer for the C++ planar-concat fast path
 _PLANAR_OUT_BUF: np.ndarray | None = None
 _PLANAR_OUT_SHAPE: tuple[int, int] | None = None
 
@@ -110,9 +106,7 @@ def _yuv_planar_d2h(
     uv = Hu * Wu
     row_stride = hw + 2 * uv
 
-    # Logical output dims: when the VAE pads (global right/bottom tail, e.g. LTX W 1920->2048),
-    # the scatter writes each shard's valid columns/rows straight into a logical-sized buffer —
-    # no separate trim copy. Defaults to the padded H/W (no crop).
+    # Logical output dims: when the VAE pads
     out_H = H if out_H is None else out_H
     out_W = W if out_W is None else out_W
 
@@ -179,17 +173,7 @@ def _yuv_planar_d2h(
         Cb_shards = _extract(host_Cb)  # each (1, h_per_uv, w_per_uv, T)
         Cr_shards = _extract(host_Cr)
 
-    # --- C++/AVX2 fast path ---------------------------------------------
-    #
-    # Drop-in replacement for the torch_threaded scatter below: same byte
-    # layout, ~2× faster with the persistent output buffer.  The C++
-    # binding assumes shards are passed in row-major (r, c) order, so we
-    # sort by coord first.  The fast path requires a complete TP_eff ×
-    # SP_eff rectangular submesh; if the local coords are sparse (could
-    # happen on irregular multi-host topologies), we fall through to the
-    # Python path which handles arbitrary coord sets.
-    # C++ path: needs a complete TP_eff x SP_eff rectangular submesh; it clamps each shard's
-    # write to out_H/out_W (the padded global tail is never written) and sizes out logically.
+    # --- C++/AVX2 fast path --------------------------------------------- Drop-in replacement for the torch_threaded
     if HAS_CPP_PLANAR_CONCAT and len(mesh_coords) == TP_eff * SP_eff:
         triples = sorted(
             zip(mesh_coords, Y_shards, Cb_shards, Cr_shards),
@@ -209,9 +193,7 @@ def _yuv_planar_d2h(
             out_W=out_W,
         )
 
-    # --- Python fallback (torch_threaded scatter) ------------------------
-    # Assemble directly into the logical-sized planar buffer; each shard's scatter is clamped to
-    # the logical bound so padded tail rows/cols are simply not written (no separate trim pass).
+    # --- Python fallback (torch_threaded scatter) ------------------------ Assemble directly into the logical-sized
     out_Hu, out_Wu = out_H // 2, out_W // 2
     out_hw, out_uv = out_H * out_W, out_Hu * out_Wu
     out_row = out_hw + 2 * out_uv
@@ -328,13 +310,7 @@ def fast_device_to_host_yuv(
     if coefficients is None:
         coefficients = _bt601_yuv_coefficients()
 
-    # NOTE: ttnn ``.shape`` on a multi-device sharded tensor returns the
-    # per-shard (local) shape, not the global logical shape.  We derive the
-    # global H, W from the mesh shape, assuming H is sharded on axis 0 and W
-    # on axis 1 (the convention this function documents).  All on-device ops
-    # (permute, reshape, yuv_conversion) operate on per-shard semantics, so
-    # we use ``h_per, w_per`` for the reshape target; ``_yuv_planar_d2h``
-    # then takes the global ``H, W`` to size the output buffer.
+    # NOTE: ttnn ``.shape`` on a multi-device sharded tensor returns the per-shard (local) shape
     mesh_shape = tuple(mesh_device.shape)
     B, C, T, h_per, w_per = tt_video_BCTHW.shape
     assert B == 1, f"fast_device_to_host_yuv requires B=1, got {B}"
@@ -364,10 +340,7 @@ def fast_device_to_host_yuv(
 
         inter_dim = concat_dims[inter_host_axis]
         if inter_dim is not None and mesh_shape[inter_host_axis] > 1:
-            # Move the gather dim out of the tile dims (last two) to position 2
-            # (dim=-3). This avoids the composite_all_gather path's tile-padded
-            # check and makes any concat fallback a cheap outer-dim memcpy.
-            # BCTHW dims: B=0 C=1 T=2 H=3 W=4. inter_dim is 3 (H) or 4 (W).
+            # Move the gather dim out of the tile dims (last two) to position 2 (dim=-3)
             if inter_dim == 4:
                 pre_dims = (0, 1, 4, 2, 3)  # BCTHW -> BCWTH
                 post_dims = (0, 1, 3, 4, 2)  # BCWTH -> BCTHW
@@ -385,8 +358,7 @@ def fast_device_to_host_yuv(
                 use_hyperparams=True,
                 use_persistent_buffer=True,
             )
-            # Drop back to ROW_MAJOR before repeat/mesh_partition so ttnn.repeat
-            # doesn't wrap itself in an Untilize → Repeat → Tilize roundtrip.
+            # Drop back to ROW_MAJOR before repeat/mesh_partition so ttnn.repeat doesn't wrap itself in an Untilize →
             tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.ROW_MAJOR_LAYOUT)
             n_hosts = int(ttnn.distributed_context_get_size())
             if n_hosts > 1:
@@ -426,9 +398,7 @@ def fast_device_to_host_yuv(
         print(f"  [yuv-d2h]   Cb: {list(tt_Cb.shape)}")
         print(f"  [yuv-d2h]   Cr: {list(tt_Cr.shape)}")
 
-    # 3+4. Batched D2H + planar concat, assembled straight into the logical-sized buffer.
-    # The VAE pads a global right/bottom tail (LTX pads W 1920->2048 on 4x8); passing
-    # out_H/out_W clamps each shard's scatter so the padded tail is never written — no trim copy.
+    # 3+4
     new_H = logical_h if logical_h is not None else H
     new_W = logical_w if logical_w is not None else W
     out = _yuv_planar_d2h(tt_Y, tt_Cb, tt_Cr, mesh_device, H, W, T, out_H=new_H, out_W=new_W, view=d2h_view, pool=pool)

--- a/models/tt_dit/utils/yuv_d2h.py
+++ b/models/tt_dit/utils/yuv_d2h.py
@@ -297,15 +297,20 @@ def fast_device_to_host_yuv(
             the planar buffer on host (Y -> top ``logical_h`` rows; Cb/Cr ->
             top ``logical_h/2`` rows).  Must be even and ``<= H``.  Defaults to
             ``None`` (no trim).
+        logical_w: Optional logical (un-padded) width of the output, trimming
+            the right columns of each plane exactly as ``logical_h`` trims the
+            bottom rows.  Must be even and ``<= W``.  Defaults to ``None``.
 
     Returns:
-        ``np.ndarray`` of shape ``(T, H'*W + 2*(H'/2 * W/2))``, dtype uint8,
-        where ``H' = logical_h if logical_h is not None else H``.
+        ``np.ndarray`` of shape ``(T, H'*W' + 2*(H'/2 * W'/2))``, dtype uint8,
+        where ``H'``/``W'`` are ``logical_h``/``logical_w`` when set and
+        ``H``/``W`` otherwise.
         Returns ``None`` for non-root ranks when ``root`` is set.
 
     Raises:
         AssertionError: if ``B != 1``, ``C != 3``, or H/W are not even.
-        ValueError: if ``logical_h`` is set and is greater than ``H`` or odd.
+        ValueError: if ``logical_h``/``logical_w`` is non-positive, odd, or
+            exceeds ``H``/``W``.
     """
     if coefficients is None:
         coefficients = _bt601_yuv_coefficients()
@@ -318,6 +323,23 @@ def fast_device_to_host_yuv(
 
     TP, SP = mesh_shape
     H, W = h_per * TP, w_per * SP
+
+    # The shards only ever cover HxW, so an oversized crop leaves the tail rows/columns
+    # of the planar buffer untouched; an odd one halves to a chroma plane that no longer
+    # matches its luma plane. Both surface far downstream, as corrupt video or an opaque
+    # reshape failure.
+    for name, value, bound_name, bound in (
+        ("logical_h", logical_h, "H", H),
+        ("logical_w", logical_w, "W", W),
+    ):
+        if value is None:
+            continue
+        if value <= 0 or value % 2 != 0:
+            msg = f"{name} must be positive and even for 4:2:0, got {value}"
+            raise ValueError(msg)
+        if value > bound:
+            msg = f"{name}={value} exceeds the assembled {bound_name}={bound}"
+            raise ValueError(msg)
 
     if debug:
         print(f"  [yuv-d2h] input per-shard: {list(tt_video_BCTHW.shape)}")

--- a/models/tt_dit/utils/yuv_d2h.py
+++ b/models/tt_dit/utils/yuv_d2h.py
@@ -1,0 +1,436 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""On-device YUV 4:2:0 conversion + fast device-to-host into ffmpeg yuv420p planar bytes.
+
+Isolated from ``tensor.py`` so the LTX wiring stays decoupled from that module's
+d2h internals; reuses the shard-extraction primitives it already exposes.
+"""
+
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import torch
+
+import ttnn
+
+from .planar_concat import HAS_CPP_PLANAR_CONCAT
+from .planar_concat import planar_concat_cpp as _planar_concat_cpp_impl
+from .tensor import _get_inter_host_axis, _host_buffer_to_torch, _to_torch_zero_copy
+
+# Persistent host-side reassembly pool — strided uint8 copies release the GIL,
+# so a few threads scale near-linearly; persistence avoids per-call startup.
+_DEFAULT_REASSEMBLE_POOL: ThreadPoolExecutor | None = None
+_DEFAULT_REASSEMBLE_WORKERS = min(8, os.cpu_count() or 8)
+
+
+def _get_default_reassemble_pool() -> ThreadPoolExecutor:
+    global _DEFAULT_REASSEMBLE_POOL
+    if _DEFAULT_REASSEMBLE_POOL is None:
+        _DEFAULT_REASSEMBLE_POOL = ThreadPoolExecutor(
+            max_workers=_DEFAULT_REASSEMBLE_WORKERS,
+            thread_name_prefix="tt_dit_yuv_reassemble",
+        )
+    return _DEFAULT_REASSEMBLE_POOL
+
+
+# Persistent output buffer for the C++ planar-concat fast path — fresh np.empty
+# pays first-touch page-fault overhead per call that dwarfs the kernel; reuse
+# eliminates it. The returned buffer is reused across calls (copy out / feed
+# ffmpeg before the next call). Shape changes reallocate lazily.
+_PLANAR_OUT_BUF: np.ndarray | None = None
+_PLANAR_OUT_SHAPE: tuple[int, int] | None = None
+
+
+def _get_planar_out_buf(T: int, row_stride: int) -> np.ndarray:
+    global _PLANAR_OUT_BUF, _PLANAR_OUT_SHAPE
+    shape = (T, row_stride)
+    if _PLANAR_OUT_SHAPE != shape:
+        _PLANAR_OUT_BUF = np.empty(shape, dtype=np.uint8)
+        _PLANAR_OUT_SHAPE = shape
+    return _PLANAR_OUT_BUF
+
+
+def _bt601_yuv_coefficients():
+    """BT.601 coefficients for input in [-1, 1] -> limited-range uint8 (Y 16-235, CbCr 16-240)."""
+    return ttnn.experimental.yuv_bt601_coefficients()
+
+
+def _yuv_planar_d2h(
+    tt_Y: ttnn.Tensor,
+    tt_Cb: ttnn.Tensor,
+    tt_Cr: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    H: int,
+    W: int,
+    T: int,
+    *,
+    out_H: int | None = None,
+    out_W: int | None = None,
+    view=None,
+    pool: ThreadPoolExecutor | None = None,
+) -> np.ndarray:
+    """Batched D2H of three YUV ttnn tensors into ffmpeg yuv420p planar uint8.
+
+    Per-shard input shapes (kernel-native BHWT with C=1):
+
+      * tt_Y:        ``(1, h_per_y, w_per_y, T)``
+      * tt_Cb/tt_Cr: ``(1, h_per_uv, w_per_uv, T)``
+
+    Output: ``(T, H*W + 2*(H/2 * W/2))`` numpy uint8 — per-frame
+    ``[Y plane | Cb plane | Cr plane]`` in row-major.
+
+    Kicks off all three ``cpu(blocking=False)`` calls before a single
+    ``synchronize_device`` so the reads overlap.  Per-shard scatters then
+    take one of two paths:
+
+      * **C++/AVX2 fast path** (when ``HAS_CPP_PLANAR_CONCAT`` is True and
+        the local mesh is rectangular): one ``planar_concat_cpp`` call into
+        a module-level persistent output buffer.  ~2× faster than the
+        Python path on warm calls, but the returned buffer is **reused
+        across calls** — copy out (or feed ffmpeg) before the next call.
+      * **Python fallback**: per-shard ``_write`` tasks on the shared
+        reassembly ThreadPoolExecutor (torch's strided-copy backend).
+        Each scatter is a strided->strided copy; allocates a fresh output
+        per call.
+
+    Either way, the byte layout is identical.
+
+    Args:
+        view: Optional mesh device view for multi-host environments.
+            When provided, uses ``host_buffer()`` / ``get_shard()`` with
+            ``view.is_local()`` filtering instead of ``get_device_tensors()``.
+    """
+    Hu, Wu = H // 2, W // 2
+    hw = H * W
+    uv = Hu * Wu
+    row_stride = hw + 2 * uv
+
+    # Logical output dims: when the VAE pads (global right/bottom tail, e.g. LTX W 1920->2048),
+    # the scatter writes each shard's valid columns/rows straight into a logical-sized buffer —
+    # no separate trim copy. Defaults to the padded H/W (no crop).
+    out_H = H if out_H is None else out_H
+    out_W = W if out_W is None else out_W
+
+    # Async D2H all 3 outputs, single sync — overlaps three D2H reads.
+    host_Y = tt_Y.cpu(blocking=False)
+    host_Cb = tt_Cb.cpu(blocking=False)
+    host_Cr = tt_Cr.cpu(blocking=False)
+    ttnn.synchronize_device(mesh_device)
+
+    if view is not None:
+        # --- Multi-host: extract local shards via host_buffer/get_shard ---
+        def _extract_local(host_tensor):
+            host_mesh_coords = list(host_tensor.tensor_topology().mesh_coords())
+            distributed_buf = host_tensor.host_buffer()
+            tt_dtype = host_tensor.dtype
+            padded_shape = list(host_tensor.padded_shape)
+            logical_shape = list(host_tensor.shape)
+            trim = tuple(slice(0, d) for d in logical_shape)
+
+            coords_and_shards = []
+            for c in host_mesh_coords:
+                if not view.is_local(c):
+                    continue
+                buf = distributed_buf.get_shard(c)
+                if buf is not None:
+                    coords_and_shards.append((c, _host_buffer_to_torch(buf, padded_shape, tt_dtype)[trim]))
+            return coords_and_shards
+
+        Y_coords_shards = _extract_local(host_Y)
+        Cb_coords_shards = _extract_local(host_Cb)
+        Cr_coords_shards = _extract_local(host_Cr)
+
+        # Remap global mesh coordinates to 0-based local coordinates.
+        all_local_coords = [c for c, _ in Y_coords_shards]
+        local_row_positions = sorted({int(c[0]) for c in all_local_coords})
+        local_col_positions = sorted({int(c[1]) for c in all_local_coords})
+        row_remap = {pos: i for i, pos in enumerate(local_row_positions)}
+        col_remap = {pos: i for i, pos in enumerate(local_col_positions)}
+        TP_eff = len(local_row_positions)
+        SP_eff = len(local_col_positions)
+
+        h_per_y, w_per_y = H // TP_eff, W // SP_eff
+        h_per_uv, w_per_uv = Hu // TP_eff, Wu // SP_eff
+
+        mesh_coords = [(row_remap[int(c[0])], col_remap[int(c[1])]) for c in all_local_coords]
+        Y_shards = [s for _, s in Y_coords_shards]
+        Cb_shards = [s for _, s in Cb_coords_shards]
+        Cr_shards = [s for _, s in Cr_coords_shards]
+    else:
+        # --- Single-host: extract all shards via get_device_tensors ---
+        TP_eff, SP_eff = tuple(mesh_device.shape)
+        h_per_y, w_per_y = H // TP_eff, W // SP_eff
+        h_per_uv, w_per_uv = Hu // TP_eff, Wu // SP_eff
+
+        mesh_coords = list(tt_Y.tensor_topology().mesh_coords())
+
+        def _extract(host_tensor):
+            host_shards = ttnn.get_device_tensors(host_tensor)
+            logical_shape = list(host_shards[0].shape)
+            trim = tuple(slice(0, d) for d in logical_shape)
+            return [_to_torch_zero_copy(s)[trim] for s in host_shards]
+
+        Y_shards = _extract(host_Y)  # each (1, h_per_y, w_per_y, T)
+        Cb_shards = _extract(host_Cb)  # each (1, h_per_uv, w_per_uv, T)
+        Cr_shards = _extract(host_Cr)
+
+    # --- C++/AVX2 fast path ---------------------------------------------
+    #
+    # Drop-in replacement for the torch_threaded scatter below: same byte
+    # layout, ~2× faster with the persistent output buffer.  The C++
+    # binding assumes shards are passed in row-major (r, c) order, so we
+    # sort by coord first.  The fast path requires a complete TP_eff ×
+    # SP_eff rectangular submesh; if the local coords are sparse (could
+    # happen on irregular multi-host topologies), we fall through to the
+    # Python path which handles arbitrary coord sets.
+    # C++ path: needs a complete TP_eff x SP_eff rectangular submesh; it clamps each shard's
+    # write to out_H/out_W (the padded global tail is never written) and sizes out logically.
+    if HAS_CPP_PLANAR_CONCAT and len(mesh_coords) == TP_eff * SP_eff:
+        triples = sorted(
+            zip(mesh_coords, Y_shards, Cb_shards, Cr_shards),
+            key=lambda t: (int(t[0][0]), int(t[0][1])),
+        )
+        out_Hu, out_Wu = out_H // 2, out_W // 2
+        out_row = out_H * out_W + 2 * out_Hu * out_Wu
+        out = _get_planar_out_buf(T, out_row)
+        return _planar_concat_cpp_impl(
+            [t[1] for t in triples],
+            [t[2] for t in triples],
+            [t[3] for t in triples],
+            "CHWT",
+            (TP_eff, SP_eff),
+            out=out,
+            out_H=out_H,
+            out_W=out_W,
+        )
+
+    # --- Python fallback (torch_threaded scatter) ------------------------
+    # Assemble directly into the logical-sized planar buffer; each shard's scatter is clamped to
+    # the logical bound so padded tail rows/cols are simply not written (no separate trim pass).
+    out_Hu, out_Wu = out_H // 2, out_W // 2
+    out_hw, out_uv = out_H * out_W, out_Hu * out_Wu
+    out_row = out_hw + 2 * out_uv
+
+    out = np.empty((T, out_row), dtype=np.uint8)
+    out_t = torch.from_numpy(out)
+    y_view = out_t.as_strided((T, out_H, out_W), (out_row, out_W, 1), 0)
+    u_view = out_t.as_strided((T, out_Hu, out_Wu), (out_row, out_Wu, 1), out_hw)
+    v_view = out_t.as_strided((T, out_Hu, out_Wu), (out_row, out_Wu, 1), out_hw + out_uv)
+
+    if pool is None:
+        pool = _get_default_reassemble_pool()
+
+    def _write(view, shard, r, c, h_per, w_per, bound_h, bound_w):
+        r0, c0 = r * h_per, c * w_per
+        vh = min(h_per, bound_h - r0)
+        vw = min(w_per, bound_w - c0)
+        if vh <= 0 or vw <= 0:
+            return  # shard lies entirely in the padded tail
+        # shard (1, h_per, w_per, T) -> squeeze(0).permute(2, 0, 1) -> (T, h_per, w_per).
+        src = shard.squeeze(0).permute(2, 0, 1)[:, :vh, :vw]
+        view[:, r0 : r0 + vh, c0 : c0 + vw].copy_(src)
+
+    futures = []
+    for coord, shard in zip(mesh_coords, Y_shards):
+        r, c = int(coord[0]), int(coord[1])
+        futures.append(pool.submit(_write, y_view, shard, r, c, h_per_y, w_per_y, out_H, out_W))
+    for coord, shard in zip(mesh_coords, Cb_shards):
+        r, c = int(coord[0]), int(coord[1])
+        futures.append(pool.submit(_write, u_view, shard, r, c, h_per_uv, w_per_uv, out_Hu, out_Wu))
+    for coord, shard in zip(mesh_coords, Cr_shards):
+        r, c = int(coord[0]), int(coord[1])
+        futures.append(pool.submit(_write, v_view, shard, r, c, h_per_uv, w_per_uv, out_Hu, out_Wu))
+    for f in futures:
+        f.result()
+
+    return out
+
+
+def fast_device_to_host_yuv(
+    tt_video_BCTHW: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    *,
+    ccl_manager=None,
+    root: int | None = None,
+    coefficients=None,
+    pool: ThreadPoolExecutor | None = None,
+    debug: bool = False,
+    logical_h: int | None = None,
+    logical_w: int | None = None,
+) -> np.ndarray | None:
+    """On-device YUV 4:2:0 conversion + batched D2H + planar uint8 concat.
+
+    Takes a sharded BCTHW bf16 row-major tensor with values in ``[-1, 1]`` —
+    typically the output of the Wan VAE — and returns a single numpy uint8
+    array in ffmpeg ``AV_PIX_FMT_YUV420P`` layout.
+
+    On a single-host system, reads all per-device shards concurrently with
+    async DMA, converts each shard's YUV planes, and scatters into the
+    planar output on host.
+
+    On a multi-host (distributed) system, uses a hybrid approach: an
+    on-device all_gather for the inter-host axis only, then re-shards with
+    repeat + mesh_partition so each local device holds unique data, runs the
+    YUV conversion on the gathered data, and performs fast async DMA + planar
+    concat for local shards only.
+
+    Pipeline:
+      1. (Multi-host only) ``all_gather`` + ``repeat`` + ``mesh_partition``
+         on the inter-host axis of the bf16 BCTHW input.
+      2. Permute BCTHW -> BCHWT (T moves to the last position) and reshape to
+         drop the B=1 dim, landing in CHWT — the layout the YUV kernel expects.
+      3. ``ttnn.experimental.rgb_to_yuv`` runs on each device's local shard,
+         producing 3 uint8 outputs (Y full-res, Cb/Cr 4:2:0 subsampled).
+      4. Async ``cpu(blocking=False)`` on all three outputs followed by a
+         single ``synchronize_device`` so the D2H reads overlap.
+      5. Per-shard scatters are dispatched across the shared reassembly thread
+         pool using torch's strided-copy backend.
+
+    Output shape: ``(T, H*W + 2*(H/2 * W/2))`` numpy uint8 — one row per frame,
+    ``[Y plane | Cb plane | Cr plane]`` in row-major.
+
+    Args:
+        tt_video_BCTHW: Sharded ttnn tensor with shape ``(1, 3, T, H, W)``,
+            bfloat16, ROW_MAJOR_LAYOUT, sharded ``{axis 0: dim 3 (H), axis 1: dim 4 (W)}``.
+            Values must lie in ``[-1, 1]`` — the YUV kernel's expected range.
+        mesh_device: The mesh device.
+        ccl_manager: Optional :class:`CCLManager` instance.  Required for
+            multi-host environments where only local devices are accessible.
+        root: If set, only the host with this MPI rank performs the D2H
+            transfer and returns the assembled array; all other ranks return
+            ``None``.  If ``None`` (default), all ranks perform D2H.
+        coefficients: ``ttnn.experimental.YUVCoefficients`` to use for the
+            per-channel weights and offsets.  Defaults to BT.601 limited range.
+        pool: Optional ``ThreadPoolExecutor`` for the host-side reassembly.
+            If ``None``, the module-level lazy default pool is used.
+        debug: If ``True``, print diagnostic shape information.
+        logical_h: Optional logical (un-padded) height of the output.  When
+            the VAE pads ``H`` to a coarser size, pass the true logical height
+            here and the function will trim the bottom rows of each plane in
+            the planar buffer on host (Y -> top ``logical_h`` rows; Cb/Cr ->
+            top ``logical_h/2`` rows).  Must be even and ``<= H``.  Defaults to
+            ``None`` (no trim).
+
+    Returns:
+        ``np.ndarray`` of shape ``(T, H'*W + 2*(H'/2 * W/2))``, dtype uint8,
+        where ``H' = logical_h if logical_h is not None else H``.
+        Returns ``None`` for non-root ranks when ``root`` is set.
+
+    Raises:
+        AssertionError: if ``B != 1``, ``C != 3``, or H/W are not even.
+        ValueError: if ``logical_h`` is set and is greater than ``H`` or odd.
+    """
+    if coefficients is None:
+        coefficients = _bt601_yuv_coefficients()
+
+    # NOTE: ttnn ``.shape`` on a multi-device sharded tensor returns the
+    # per-shard (local) shape, not the global logical shape.  We derive the
+    # global H, W from the mesh shape, assuming H is sharded on axis 0 and W
+    # on axis 1 (the convention this function documents).  All on-device ops
+    # (permute, reshape, yuv_conversion) operate on per-shard semantics, so
+    # we use ``h_per, w_per`` for the reshape target; ``_yuv_planar_d2h``
+    # then takes the global ``H, W`` to size the output buffer.
+    mesh_shape = tuple(mesh_device.shape)
+    B, C, T, h_per, w_per = tt_video_BCTHW.shape
+    assert B == 1, f"fast_device_to_host_yuv requires B=1, got {B}"
+    assert C == 3, f"fast_device_to_host_yuv requires C=3 (RGB), got {C}"
+
+    TP, SP = mesh_shape
+    H, W = h_per * TP, w_per * SP
+
+    if debug:
+        print(f"  [yuv-d2h] input per-shard: {list(tt_video_BCTHW.shape)}")
+        print(f"  [yuv-d2h] global H={H}, W={W}, T={T}  (mesh TP={TP}, SP={SP})")
+
+    # Sharding convention: axis 0 -> dim 3 (H), axis 1 -> dim 4 (W).
+    concat_dims: list[int | None] = [3, 4]
+
+    # --- Multi-host: hybrid on-device collective + fast local DMA -----------
+    d2h_view = None
+    if ttnn.using_distributed_env():
+        if ccl_manager is None:
+            msg = "fast_device_to_host_yuv requires ccl_manager in a distributed (multi-host) environment"
+            raise ValueError(msg)
+
+        d2h_view = mesh_device.get_view()
+        rank = int(ttnn.distributed_context_get_rank())
+
+        inter_host_axis = _get_inter_host_axis(mesh_device, d2h_view, mesh_shape)
+
+        inter_dim = concat_dims[inter_host_axis]
+        if inter_dim is not None and mesh_shape[inter_host_axis] > 1:
+            # Move the gather dim out of the tile dims (last two) to position 2
+            # (dim=-3). This avoids the composite_all_gather path's tile-padded
+            # check and makes any concat fallback a cheap outer-dim memcpy.
+            # BCTHW dims: B=0 C=1 T=2 H=3 W=4. inter_dim is 3 (H) or 4 (W).
+            if inter_dim == 4:
+                pre_dims = (0, 1, 4, 2, 3)  # BCTHW -> BCWTH
+                post_dims = (0, 1, 3, 4, 2)  # BCWTH -> BCTHW
+            else:  # inter_dim == 3
+                pre_dims = (0, 1, 3, 2, 4)  # BCTHW -> BCHTW
+                post_dims = (0, 1, 3, 2, 4)  # BCHTW -> BCTHW (same swap)
+            ag_dim = 2
+
+            tt_video_BCTHW = ttnn.permute(tt_video_BCTHW, pre_dims)
+            tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.TILE_LAYOUT)
+            tt_video_BCTHW = ccl_manager.all_gather(
+                tt_video_BCTHW,
+                dim=ag_dim,
+                mesh_axis=inter_host_axis,
+                use_hyperparams=True,
+                use_persistent_buffer=True,
+            )
+            # Drop back to ROW_MAJOR before repeat/mesh_partition so ttnn.repeat
+            # doesn't wrap itself in an Untilize → Repeat → Tilize roundtrip.
+            tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.ROW_MAJOR_LAYOUT)
+            n_hosts = int(ttnn.distributed_context_get_size())
+            if n_hosts > 1:
+                repeat_dims = [1] * len(tt_video_BCTHW.shape)
+                repeat_dims[ag_dim] = n_hosts
+                tt_video_BCTHW = ttnn.repeat(tt_video_BCTHW, repeat_dims)
+                tt_video_BCTHW = ttnn.mesh_partition(tt_video_BCTHW, dim=ag_dim, cluster_axis=inter_host_axis)
+            tt_video_BCTHW = ttnn.permute(tt_video_BCTHW, post_dims)
+
+        # Recompute per-shard dims after gather — they may have grown.
+        B, C, T, h_per, w_per = tt_video_BCTHW.shape
+
+        if debug:
+            print(f"  [yuv-d2h] (distributed) post-gather per-shard: {list(tt_video_BCTHW.shape)}")
+
+        if root is not None and rank != root:
+            return None
+
+    assert (
+        h_per % 2 == 0 and w_per % 2 == 0
+    ), f"per-shard H and W must be even for 4:2:0 (got h_per={h_per}, w_per={w_per})"
+
+    # 1. Reorder BCTHW -> CHWT for the YUV kernel.  Shapes here are per-shard.
+    tt_BCHWT = ttnn.permute(tt_video_BCTHW, (0, 1, 3, 4, 2))
+    if debug:
+        print(f"  [yuv-d2h] after permute(0,1,3,4,2) per-shard: {list(tt_BCHWT.shape)}")
+
+    tt_CHWT = ttnn.reshape(tt_BCHWT, (C, h_per, w_per, T))
+    if debug:
+        print(f"  [yuv-d2h] after reshape to (C,h_per,w_per,T) per-shard: {list(tt_CHWT.shape)}")
+
+    # 2. On-device YUV 4:2:0 -> 3 uint8 tensors.
+    tt_Y, tt_Cb, tt_Cr = ttnn.experimental.rgb_to_yuv(tt_CHWT, coefficients=coefficients)
+    if debug:
+        print(f"  [yuv-d2h] yuv outputs per-shard:")
+        print(f"  [yuv-d2h]   Y : {list(tt_Y.shape)}")
+        print(f"  [yuv-d2h]   Cb: {list(tt_Cb.shape)}")
+        print(f"  [yuv-d2h]   Cr: {list(tt_Cr.shape)}")
+
+    # 3+4. Batched D2H + planar concat, assembled straight into the logical-sized buffer.
+    # The VAE pads a global right/bottom tail (LTX pads W 1920->2048 on 4x8); passing
+    # out_H/out_W clamps each shard's scatter so the padded tail is never written — no trim copy.
+    new_H = logical_h if logical_h is not None else H
+    new_W = logical_w if logical_w is not None else W
+    out = _yuv_planar_d2h(tt_Y, tt_Cb, tt_Cr, mesh_device, H, W, T, out_H=new_H, out_W=new_W, view=d2h_view, pool=pool)
+
+    return out

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -304,6 +304,46 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
         )
     )
 
+    # LTX-2.3 distilled video self-attention (spatial, non-causal). video_dim=4096, 32 heads ->
+    # 8 local heads on TP=4, head_dim=128. seq_len is per-device (SP-padded total / sp_size); the two
+    # distilled stages use N=9728 (s1) and N=38912 (s2). Chunk sizes match attention_ltx's
+    # ring_sdpa_chunk_by_n for (blackhole, sp=8, tp=4).
+    if mesh_config.is_galaxy:
+        configs.append(
+            ModelConfig(
+                name="ltx_s1",
+                nhq=8,
+                nhk=8,
+                nhv=8,
+                d_q=128,
+                d_k=128,
+                d_v=128,
+                is_causal=False,
+                q_dtype=ttnn.bfloat16,
+                kv_dtype=ttnn.bfloat16,
+                q_chunk_sizes=[96],
+                k_chunk_sizes=[256],
+                seq_len=1216,
+            )
+        )
+        configs.append(
+            ModelConfig(
+                name="ltx_s2",
+                nhq=8,
+                nhk=8,
+                nhv=8,
+                d_q=128,
+                d_k=128,
+                d_v=128,
+                is_causal=False,
+                q_dtype=ttnn.bfloat16,
+                kv_dtype=ttnn.bfloat16,
+                q_chunk_sizes=[192],
+                k_chunk_sizes=[512],
+                seq_len=4864,
+            )
+        )
+
     return {config.name: config for config in configs}
 
 

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -304,10 +304,7 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
         )
     )
 
-    # LTX-2.3 distilled video self-attention (spatial, non-causal). video_dim=4096, 32 heads ->
-    # 8 local heads on TP=4, head_dim=128. seq_len is per-device (SP-padded total / sp_size); the two
-    # distilled stages use N=9728 (s1) and N=38912 (s2). Chunk sizes match attention_ltx's
-    # ring_sdpa_chunk_by_n for (blackhole, sp=8, tp=4).
+    # LTX-2.3 distilled video self-attention (spatial, non-causal)
     if mesh_config.is_galaxy:
         configs.append(
             ModelConfig(

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa_cross_padded.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa_cross_padded.py
@@ -1,0 +1,54 @@
+"""Padded V2A cross configs so the large transport-bound shapes RUN on the ring8 (SP=8) mesh.
+
+The committed cross test skips stage2_1080p_6s / _14s on SP=8 because their global q/kv dims
+are not multiples of SP*32 (=256). Here we round q_global/kv_global UP to the nearest SP*32
+while keeping the true logical_n, so the op attends only real keys (PCC unchanged) and we can
+measure device kernel duration for the split-forward optimization on the exposed-transport case.
+"""
+import pytest
+
+from tests.nightly.blackhole.sdpa.test_ring_joint_sdpa import (
+    MESH_CONFIG,
+    Topology,
+    run_ring_joint_sdpa_cross,
+    CROSS_PCC_THRESHOLD,
+    CROSS_RMSE_THRESHOLD,
+)
+
+
+def _round_up(x, m):
+    return ((x + m - 1) // m) * m
+
+
+# Round to the SP=8 tile-shard granularity (8*32=256). q/kv padded; logical_n = true key count.
+_SP = 8
+_M = _SP * 32
+# (id, nhq_total, head_dim, q_true, kv_true, logical_n)
+_RAW = [
+    ("ltx_v2a_stage1_6s", 32, 64, 256, 9728, 9690),
+    ("ltx_v2a_stage2_1080p_6s", 32, 64, 256, 38784, 38760),
+    ("ltx_v2a_stage2_1080p_14s", 32, 64, 384, 87808, 87720),
+]
+PADDED_CONFIGS = [
+    pytest.param(nhq, d, _round_up(q, _M), _round_up(kv, _M), logical_n, id=name)
+    for (name, nhq, d, q, kv, logical_n) in _RAW
+]
+
+
+@pytest.mark.parametrize("nhq_total, head_dim, q_global, kv_global, logical_n", PADDED_CONFIGS)
+def test_cross_padded_ring8(nhq_total, head_dim, q_global, kv_global, logical_n):
+    """is_cross ring SDPA at padded V2A shapes on the ring8 mesh (split-forward active)."""
+    run_ring_joint_sdpa_cross(
+        MESH_CONFIG,
+        nhq_total,
+        head_dim,
+        q_global,
+        kv_global,
+        logical_n,
+        q_chunk_sizes=[64, 128],
+        tp_size=4,
+        sp_size=8,
+        topology=Topology.Ring,
+        pcc_threshold=CROSS_PCC_THRESHOLD,
+        rmse_threshold=CROSS_RMSE_THRESHOLD,
+    )

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa_cross_padded.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa_cross_padded.py
@@ -39,6 +39,7 @@ PADDED_CONFIGS = [
 ]
 
 
+@pytest.mark.timeout(600)
 @pytest.mark.parametrize("nhq_total, head_dim, q_global, kv_global, logical_n", PADDED_CONFIGS)
 def test_cross_padded_ring8(nhq_total, head_dim, q_global, kv_global, logical_n):
     """is_cross ring SDPA at padded V2A shapes on the ring8 mesh (split-forward active)."""

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa_cross_padded.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa_cross_padded.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 """Padded V2A cross configs so the large transport-bound shapes RUN on the ring8 (SP=8) mesh.
 
 The committed cross test skips stage2_1080p_6s / _14s on SP=8 because their global q/kv dims

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -185,6 +185,17 @@ void kernel_main() {
         }
     }
 
+    // Mirror the writer's split-forwarding (see ring_attention_all_gather_writer.cpp): on an even ring
+    // the diametric slice is relayed in halves across both links. Direction 1 receives one extra slice
+    // (its own diametric shard's second half, signaled but never relayed) and relays one extra (the
+    // second half of its downstream neighbor's diametric shard). Gated on ring geometry only so the
+    // writer and the SDPA op receiver make the identical decision.
+    const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    if (split_forwarding_enabled && direction == 1) {
+        slices_expected++;
+        writes_expected++;
+    }
+
     while (slices_received < slices_expected) {
         // Do i expect more from the backward direction?
         // In the linear case, I expect num_targets_backward_direction slices from the left
@@ -224,16 +235,34 @@ void kernel_main() {
         // In the ring case, if I have received on the right less than my targets on the left, forward
         if ((topology == Topology::Linear && writes_expected > 0) ||
             (topology == Topology::Ring && (slices_received < (writes_expected + 1)))) {
+            // The last slice we relay is the diametric shard of our downstream neighbor; relay only
+            // this link's half so the paired writer pops a matching cb_output count.
+            const bool is_split_forwarded_slice = split_forwarding_enabled && (slices_received == writes_expected);
             for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-                uint32_t tiles_read = input_tile_id_start[input_idx];
-                uint32_t tiles_to_read = input_tile_id_end[input_idx];
-
-                uint32_t output_tile_id_start = 0;
-                uint32_t pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
-                uint32_t row_offset =
-                    (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
                 uint32_t slice_Wt = input_tensor_Wt[input_idx];
                 uint32_t stride_Wt = output_tensor_Wt[input_idx];
+
+                // Packet-aligned midpoint of this input's per-batch-head page range (matches the
+                // writer). Direction 0 relays [start, mid); direction 1 relays [mid, end).
+                const uint32_t total_pages = input_tile_id_end[input_idx] - input_tile_id_start[input_idx];
+                const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
+                const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;
+                const bool split_this_input = is_split_forwarded_slice;
+                uint32_t relay_start = input_tile_id_start[input_idx];
+                uint32_t relay_end = input_tile_id_end[input_idx];
+                if (split_this_input) {
+                    if (direction == 0) {
+                        relay_end = input_tile_id_start[input_idx] + first_half_pages;
+                    } else {
+                        relay_start = input_tile_id_start[input_idx] + first_half_pages;
+                    }
+                }
+
+                uint32_t tiles_read = relay_start;
+                uint32_t tiles_to_read = relay_end;
+                uint32_t output_tile_id_start = 0;
+                uint32_t pages_read_in_row = relay_start % slice_Wt;
+                uint32_t row_offset = (relay_start / slice_Wt) * stride_Wt;
                 if (gather_dim == 3) {
                     output_tile_id_start = actual_sender_chip_id * input_tensor_Wt[input_idx];
                 } else {
@@ -262,11 +291,10 @@ void kernel_main() {
                             }
                             return pid;
                         });
-                    pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
-                    row_offset =
-                        (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
-                    tiles_read = input_tile_id_start[input_idx];
-                    tiles_to_read = input_tile_id_end[input_idx];
+                    pages_read_in_row = relay_start % slice_Wt;
+                    row_offset = (relay_start / slice_Wt) * stride_Wt;
+                    tiles_read = relay_start;
+                    tiles_to_read = relay_end;
                     output_tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -185,11 +185,7 @@ void kernel_main() {
         }
     }
 
-    // Mirror the writer's split-forwarding (see ring_attention_all_gather_writer.cpp): on an even ring
-    // the diametric slice is relayed in halves across both links. Direction 1 receives one extra slice
-    // (its own diametric shard's second half, signaled but never relayed) and relays one extra (the
-    // second half of its downstream neighbor's diametric shard). Gated on ring geometry only so the
-    // writer and the SDPA op receiver make the identical decision.
+    // Mirror the writer's split-forwarding (see ring_attention_all_gather_writer.cpp): on an even ring the diametric
     const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
     if (split_forwarding_enabled && direction == 1) {
         slices_expected++;
@@ -235,15 +231,13 @@ void kernel_main() {
         // In the ring case, if I have received on the right less than my targets on the left, forward
         if ((topology == Topology::Linear && writes_expected > 0) ||
             (topology == Topology::Ring && (slices_received < (writes_expected + 1)))) {
-            // The last slice we relay is the diametric shard of our downstream neighbor; relay only
-            // this link's half so the paired writer pops a matching cb_output count.
+            // The last slice we relay is the diametric shard of our downstream neighbor
             const bool is_split_forwarded_slice = split_forwarding_enabled && (slices_received == writes_expected);
             for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
                 uint32_t slice_Wt = input_tensor_Wt[input_idx];
                 uint32_t stride_Wt = output_tensor_Wt[input_idx];
 
-                // Packet-aligned midpoint of this input's per-batch-head page range (matches the
-                // writer). Direction 0 relays [start, mid); direction 1 relays [mid, end).
+                // Packet-aligned midpoint of this input's per-batch-head page range (matches the writer)
                 const uint32_t total_pages = input_tile_id_end[input_idx] - input_tile_id_start[input_idx];
                 const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
                 const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -294,12 +294,7 @@ void kernel_main() {
         }
     }
 
-    // On an even ring the terminal relayed slice (its receiver's diametric shard, N/2 hops away on
-    // both links) would otherwise traverse its final hop on one link while the other idles. Relay its
-    // first half on direction 0 and its second half on direction 1 so both links share that hop;
-    // direction 1 gains one relay to carry the second half. Gated on ring geometry only so the paired
-    // reader and the SDPA op receiver make the identical decision without shape info; a single-packet
-    // range degenerates to first_half_pages == 0 (direction 0 relays nothing).
+    // On an even ring the terminal relayed slice
     const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
     if (split_forwarding_enabled && direction == 1) {
         writes_expected++;
@@ -343,9 +338,7 @@ void kernel_main() {
                 tile_id_start = actual_slice_chip_id * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
             }
 
-            // Packet-aligned midpoint of this input's per-batch-head page range. On the split slice
-            // direction 0 relays [start, mid) and direction 1 relays [mid, end); the skipped half's
-            // cursor still advances so cb_output pops match the pages the paired reader pushed.
+            // Packet-aligned midpoint of this input's per-batch-head page range
             const uint32_t total_pages = tiles_to_read - input_tile_id_start[input_idx];
             const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
             const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -294,6 +294,17 @@ void kernel_main() {
         }
     }
 
+    // On an even ring the terminal relayed slice (its receiver's diametric shard, N/2 hops away on
+    // both links) would otherwise traverse its final hop on one link while the other idles. Relay its
+    // first half on direction 0 and its second half on direction 1 so both links share that hop;
+    // direction 1 gains one relay to carry the second half. Gated on ring geometry only so the paired
+    // reader and the SDPA op receiver make the identical decision without shape info; a single-packet
+    // range degenerates to first_half_pages == 0 (direction 0 relays nothing).
+    const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    if (split_forwarding_enabled && direction == 1) {
+        writes_expected++;
+    }
+
     while (slice_writes < writes_expected) {
         // Direction == backward
         // Did I get something from my left to send to my right?
@@ -315,6 +326,7 @@ void kernel_main() {
             slice_chip_id = my_chip_id - slice_writes - 1;
             actual_slice_chip_id = (slice_chip_id < 0) ? ring_size + slice_chip_id : slice_chip_id;
         }
+        const bool is_split_forwarded_slice = split_forwarding_enabled && (slice_writes == writes_expected - 1);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             uint32_t tiles_read = input_tile_id_start[input_idx];
             uint32_t tiles_to_read = input_tile_id_end[input_idx];
@@ -330,47 +342,65 @@ void kernel_main() {
             } else {
                 tile_id_start = actual_slice_chip_id * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
             }
+
+            // Packet-aligned midpoint of this input's per-batch-head page range. On the split slice
+            // direction 0 relays [start, mid) and direction 1 relays [mid, end); the skipped half's
+            // cursor still advances so cb_output pops match the pages the paired reader pushed.
+            const uint32_t total_pages = tiles_to_read - input_tile_id_start[input_idx];
+            const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
+            const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;
+            const bool split_this_input = is_split_forwarded_slice;
+
             for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
                 while (tiles_read < tiles_to_read) {
                     uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
-                    cb_output.wait_front(packet_size_in_pages);
-                    size_t l1_read_addr = cb_output.get_read_ptr();
+                    uint32_t page_in_bh = tiles_read - input_tile_id_start[input_idx];
+                    bool relay_this_packet =
+                        !split_this_input ||
+                        (direction == 0 ? (page_in_bh < first_half_pages) : (page_in_bh >= first_half_pages));
+
                     uint32_t first_tile_id = tile_id_start + row_offset + pages_read_in_row;
                     pages_read_in_row++;
                     if (pages_read_in_row >= slice_Wt) {
                         row_offset += stride_Wt;
                         pages_read_in_row = 0;
                     }
-
+                    uint32_t second_tile_id = 0;
                     if (num_pages_to_read == 2) {
-                        uint32_t second_tile_id = tile_id_start + row_offset + pages_read_in_row;
+                        second_tile_id = tile_id_start + row_offset + pages_read_in_row;
                         pages_read_in_row++;
                         if (pages_read_in_row >= slice_Wt) {
                             row_offset += stride_Wt;
                             pages_read_in_row = 0;
                         }
+                    }
 
-                        scatter_fabric_write_unidir(
-                            first_tile_id,
-                            second_tile_id,
-                            output_addrgens[input_idx],
-                            pkt_hdr,
-                            *fabric_direction_connection,
-                            l1_read_addr,
-                            output_page_size);
-                    } else {
-                        ASSERT(num_pages_to_read == 1);
-                        fabric_write_unidir(
-                            first_tile_id,
-                            output_addrgens[input_idx],
-                            pkt_hdr,
-                            *fabric_direction_connection,
-                            l1_read_addr,
-                            output_page_size);
+                    if (relay_this_packet) {
+                        cb_output.wait_front(packet_size_in_pages);
+                        size_t l1_read_addr = cb_output.get_read_ptr();
+                        if (num_pages_to_read == 2) {
+                            scatter_fabric_write_unidir(
+                                first_tile_id,
+                                second_tile_id,
+                                output_addrgens[input_idx],
+                                pkt_hdr,
+                                *fabric_direction_connection,
+                                l1_read_addr,
+                                output_page_size);
+                        } else {
+                            ASSERT(num_pages_to_read == 1);
+                            fabric_write_unidir(
+                                first_tile_id,
+                                output_addrgens[input_idx],
+                                pkt_hdr,
+                                *fabric_direction_connection,
+                                l1_read_addr,
+                                output_page_size);
+                        }
+                        cb_output.pop_front(packet_size_in_pages);
                     }
 
                     tiles_read += num_pages_to_read;
-                    cb_output.pop_front(packet_size_in_pages);
                 }
                 tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
                 tiles_read = input_tile_id_start[input_idx];

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
@@ -16,6 +16,13 @@ struct RingSDPAOpReceiver {
     std::array<uint32_t, 2> signal_op_semaphore_ids = {0, 0};
     bool initialized = false;
 
+    // Even-ring split-forwarding: the diametric shard arrives split across both links and is signaled
+    // on both direction semaphores. Its second half is the extra increment on direction 1's all-gather
+    // semaphore (index 0); the step that releases the split shard must wait for it before compute reads.
+    bool split_forwarding_enabled = false;
+    uint32_t split_shard_id = 0;
+    uint32_t split_second_half_wait = 0;
+
     RingSDPAOpReceiver() {}
 
     RingSDPAOpReceiver(bool wait_for_op_signal, uint32_t& rt_args_idx) : wait_for_op_signal(wait_for_op_signal) {
@@ -29,6 +36,9 @@ struct RingSDPAOpReceiver {
             signal_op_semaphore_ids[1] = get_arg_val<uint32_t>(rt_args_idx++);
             // Second is AllGather's FWD semaphore. It belongs to direction 0.
             signal_op_semaphore_ids[0] = get_arg_val<uint32_t>(rt_args_idx++);
+            split_forwarding_enabled = get_arg_val<uint32_t>(rt_args_idx++) == 1;
+            split_shard_id = get_arg_val<uint32_t>(rt_args_idx++);
+            split_second_half_wait = get_arg_val<uint32_t>(rt_args_idx++);
         }
 
         seq = RingIdSequencer(ring_index, ring_size, backward_writes_expected, forward_writes_expected);
@@ -37,11 +47,17 @@ struct RingSDPAOpReceiver {
 
     uint32_t get_next_ring_id_and_sync() {
         ASSERT(initialized);
-        return seq.get_next_ring_id([&](uint32_t dir, uint32_t val) {
+        uint32_t ring_id = seq.get_next_ring_id([&](uint32_t dir, uint32_t val) {
             if (this->wait_for_op_signal) {
                 Semaphore<>(this->signal_op_semaphore_ids[dir]).wait_min(val);
             }
         });
+        // The split shard's second half lands via direction 1 (all-gather semaphore index 0). The
+        // sequencer only waits one direction per step, so wait the second half here explicitly.
+        if (this->wait_for_op_signal && this->split_forwarding_enabled && ring_id == this->split_shard_id) {
+            Semaphore<>(this->signal_op_semaphore_ids[0]).wait_min(this->split_second_half_wait);
+        }
+        return ring_id;
     }
 
     uint32_t get_next_ring_id_and_consume_one_signal() {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
@@ -16,9 +16,7 @@ struct RingSDPAOpReceiver {
     std::array<uint32_t, 2> signal_op_semaphore_ids = {0, 0};
     bool initialized = false;
 
-    // Even-ring split-forwarding: the diametric shard arrives split across both links and is signaled
-    // on both direction semaphores. Its second half is the extra increment on direction 1's all-gather
-    // semaphore (index 0); the step that releases the split shard must wait for it before compute reads.
+    // Even-ring split-forwarding: the diametric shard arrives split across both links and is signaled on both
     bool split_forwarding_enabled = false;
     uint32_t split_shard_id = 0;
     uint32_t split_second_half_wait = 0;
@@ -52,8 +50,7 @@ struct RingSDPAOpReceiver {
                 Semaphore<>(this->signal_op_semaphore_ids[dir]).wait_min(val);
             }
         });
-        // The split shard's second half lands via direction 1 (all-gather semaphore index 0). The
-        // sequencer only waits one direction per step, so wait the second half here explicitly.
+        // The split shard's second half lands via direction 1 (all-gather semaphore index 0)
         if (this->wait_for_op_signal && this->split_forwarding_enabled && ring_id == this->split_shard_id) {
             Semaphore<>(this->signal_op_semaphore_ids[0]).wait_min(this->split_second_half_wait);
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
@@ -69,5 +69,17 @@ void RingSDPAFusedOpSignaler::push_ring_sdpa_fused_op_rt_args(std::vector<uint32
     out_rt_args.push_back(static_cast<uint32_t>(this->backward_writes_expected));
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[0]));
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[1]));
+
+    // Even-ring split-forwarding: the diametric shard S arrives split across both links. Direction 1
+    // (all-gather semaphore index 0) carries its second half as one extra signal, so the SDPA reader
+    // must wait backward_writes_expected + 1 on that semaphore at S's step. S is direction 1's
+    // terminal received shard: ring_index + backward_writes_expected + 1 (== ring_index - num_targets
+    // _forward, mod ring_size). Values are ignored downstream when split_forwarding_enabled is false.
+    const uint32_t split_shard_id =
+        this->ring_size ? ((this->ring_index + this->backward_writes_expected + 1) % this->ring_size) : 0;
+    const uint32_t split_second_half_wait = this->backward_writes_expected + 1;
+    out_rt_args.push_back(static_cast<uint32_t>(this->split_forwarding_enabled ? 1 : 0));
+    out_rt_args.push_back(static_cast<uint32_t>(split_shard_id));
+    out_rt_args.push_back(static_cast<uint32_t>(split_second_half_wait));
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
@@ -70,11 +70,7 @@ void RingSDPAFusedOpSignaler::push_ring_sdpa_fused_op_rt_args(std::vector<uint32
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[0]));
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[1]));
 
-    // Even-ring split-forwarding: the diametric shard S arrives split across both links. Direction 1
-    // (all-gather semaphore index 0) carries its second half as one extra signal, so the SDPA reader
-    // must wait backward_writes_expected + 1 on that semaphore at S's step. S is direction 1's
-    // terminal received shard: ring_index + backward_writes_expected + 1 (== ring_index - num_targets
-    // _forward, mod ring_size). Values are ignored downstream when split_forwarding_enabled is false.
+    // Even-ring split-forwarding: the diametric shard S arrives split across both links
     const uint32_t split_shard_id =
         this->ring_size ? ((this->ring_index + this->backward_writes_expected + 1) % this->ring_size) : 0;
     const uint32_t split_second_half_wait = this->backward_writes_expected + 1;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
@@ -24,6 +24,11 @@ struct RingSDPAFusedOpSignaler {
     uint32_t forward_writes_expected = 0;
     uint32_t backward_writes_expected = 0;
 
+    // Set by the program factory when the all-gather relays the diametric slice split across both
+    // links (even ring, size > 2). Must match the all-gather kernels' gate exactly. Drives the SDPA
+    // reader's dual-half wait on the split shard.
+    bool split_forwarding_enabled = false;
+
     bool initialized_all_gather = false;
     bool initialized_fused_op = false;
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
@@ -24,9 +24,7 @@ struct RingSDPAFusedOpSignaler {
     uint32_t forward_writes_expected = 0;
     uint32_t backward_writes_expected = 0;
 
-    // Set by the program factory when the all-gather relays the diametric slice split across both
-    // links (even ring, size > 2). Must match the all-gather kernels' gate exactly. Drives the SDPA
-    // reader's dual-half wait on the split shard.
+    // Set by the program factory when the all-gather relays the diametric slice split across both links
     bool split_forwarding_enabled = false;
 
     bool initialized_all_gather = false;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -1182,6 +1182,13 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         sdpa_fused_op_signaler->initialized_fused_op = true;
     }
 
+    // Must match the all-gather kernels' split-forwarding gate exactly (ring geometry only) so the
+    // SDPA reader's dual-half wait and the kernels agree on whether the diametric slice is split.
+    sdpa_fused_op_signaler->split_forwarding_enabled =
+        (args.all_gather_operation_attributes.topology == ttnn::ccl::Topology::Ring) &&
+        (args.all_gather_operation_attributes.ring_size % 2 == 0) &&
+        (args.all_gather_operation_attributes.ring_size > 2);
+
     log_debug(tt::LogOp, "num_cores: {}", num_cores);
     log_debug(
         tt::LogOp, "mesh_device->compute_with_storage_grid_size(): {}", mesh_device->compute_with_storage_grid_size());

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -1182,8 +1182,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         sdpa_fused_op_signaler->initialized_fused_op = true;
     }
 
-    // Must match the all-gather kernels' split-forwarding gate exactly (ring geometry only) so the
-    // SDPA reader's dual-half wait and the kernels agree on whether the diametric slice is split.
+    // Must match the all-gather kernels' split-forwarding gate exactly
     sdpa_fused_op_signaler->split_forwarding_enabled =
         (args.all_gather_operation_attributes.topology == ttnn::ccl::Topology::Ring) &&
         (args.all_gather_operation_attributes.ring_size % 2 == 0) &&


### PR DESCRIPTION
# [Feature] Ring joint SDPA and the LTX-2.3 distilled AV pipeline

### PR Category

Feature

---

> **Stacked PR 3 of 3.** Base: PR 2 (`nwoodall/ltx-neighbor-pad-halo-conv3d`, #52514),
> which is itself based on PR 1 (#52513, merged). This PR is the model-side wiring
> and **genuinely depends on both**: the VAE calls `neighbor_pad_halo` /
> `halo_scatter` from PR 2, and the transformer calls the MMRS and strided-AGMM ops
> from PR 1. It must merge last.
>
> Until #52514 lands, this PR's diff against `main` also contains PR 2's commits.
> The delta that is *this* PR's own work is **15 commits, 27 files changed,
> 2830 insertions(+), 196 deletions(-)**. Commits are referenced by subject below
> rather than by hash, since the stack is rebased as the lower PRs land.

## Summary

Brings the LTX-2.3 distilled two-stage audio-video pipeline up on a Blackhole
4x8 galaxy (32 chips, `FABRIC_1D_RING`, `num_links=2`) at **6.1 s end-to-end
compute** for a 6 s 1920x1088 video, by routing the model onto the ops added in
PRs 1 and 2.

### Ring-attention all-gather and cross-padded joint SDPA

Cross-padded joint ring SDPA, plus even-ring split-forwarding for the
ring-attention all-gather (the diametric slice is split across both links, with
direction 1 receiving and relaying one extra half). This lets the VAE's joint
attention run on the same ring topology as the rest of the pipeline instead of
falling back to a different collective shape.

*Commits:* `sdpa: ring-attention all-gather and cross-padded joint SDPA` ·
`test: coverage for ring joint SDPA including cross-padded`

### LTX model wiring

VAE conv3d routes through `neighbor_pad_halo` + `halo_scatter` into a standalone
conv3d. `get_conv3d_config` carries a per-shape table marking shapes `halo_last`
(interior-then-boundary two-pass) or `force_spatial_parallel`, so the interior
conv pass hides the halo exchange. Those entries carry their measured numbers
in-comment.

The per-head attention gate folds into the QKV/Q matmul via variable-width
chunks, honored only on the fused AGMM path (TP>1 on Ring) with a standalone gate
op elsewhere; the gate is `num_heads/TP` columns per device (sub-tile), padded to
a whole tile so it is a legal chunk.

`CCLManager` gains halo-buffer geometry derivation, per-call halo buffer
addressing, and a fixed 16-slot region/link config array
(`[region * num_links + link]`, zero-padded). It also allocates the shared MMRS
L1 progress counter once and hands it to every MMRS call — PR 1 added the op-side
optional parameter; this is the caller that turns it on. The motivation is L1
fragmentation: per-program counter arrays are retained for each program's cached
life, and because L1 is handed out top-down each small permanent block pins the
freed space above it. After enough cached MMRS programs the VAE's ring joint SDPA
has no contiguous L1 left for its circular buffers.

`LTX_YUV_EXPORT` routes the mp4 path through a device-side gather built on the
existing `ttnn.experimental.rgb_to_yuv`, keeping the color conversion off the
host; the mp4 is `yuv420p` either way.

*Commits:* `ltx: route VAE conv3d through halo CCL ops` · `ltx: fold the per-head
attention gate into the QKV/Q matmul` · `ltx: on-device YUV export and planar
concat for the decode path` · `ltx: wire the distilled AV pipeline to the fast
decode path` · `ltx: parallel-config plumbing for halo and fabric-bound ops` ·
`ltx: allocate the shared MMRS progress counter in CCLManager` · `ltx: restore the
8 KB fabric payload on the traced 4x8 ring config` · `ltx: give the two-stages Pro
test the vocoder's L1_SMALL pool` · `comments: collapse multi-line explanatory
blocks to one line` · `ltx: keep the gather dedup off the fused-gate path`

---

## Test results

Blackhole galaxy, 32 chips, 4x8 mesh, 12x10 compute grid, `FABRIC_1D_RING`,
`num_links=2`, `l1_small_size=32768`, `trace_region_size=500M`.

**LTX distilled 4x8 ring**, `LTX_TRACED=1 RUN_WARMUP=1 LTX_YUV_EXPORT=1`:

| | cold | warm (traced) |
|---|---|---|
| Stage 1 denoise (544x960, 8 steps) | 15.6 s | 2.3 s |
| Stage 2 denoise (1088x1920, 3 steps) | 15.1 s | 2.6 s |
| **Total (compute)** | 45.1 s | **6.1 s** |

`pytest models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py -k
"4x8sp1tp0nl2_ring_is_fsdp0 and not i2v"` — 1 passed.

New LTX pipeline and transformer coverage, plus wan2_2 neighbor-pad / conv3d /
AGMM coverage.

*Commits:* `test: ltx pipeline and transformer coverage` · `test: wan2_2
neighbor-pad, conv3d and AGMM coverage`

---

## Notes for reviewers

**This PR cannot be reviewed standalone.** Its value is the integration; the
machinery it calls is in PRs 1 and 2. Reviewing the model wiring against those
two op PRs is the intended reading order.

**`run_safe_pytest.sh` configurability** (shipped in PR 1) is what makes the 4x8
galaxy runs viable: the 5 s dispatch-timeout default false-trips on full-mesh
fabric ops, and a galaxy needs `tt-smi -glx_reset` rather than `tt-smi -r`.

---

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nwoodall/ltx-sdpa-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nwoodall/ltx-sdpa-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nwoodall/ltx-sdpa-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nwoodall/ltx-sdpa-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nwoodall/ltx-sdpa-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nwoodall/ltx-sdpa-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nwoodall/ltx-sdpa-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nwoodall/ltx-sdpa-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nwoodall/ltx-sdpa-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nwoodall/ltx-sdpa-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nwoodall/ltx-sdpa-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nwoodall/ltx-sdpa-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nwoodall/ltx-sdpa-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nwoodall/ltx-sdpa-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nwoodall/ltx-sdpa-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nwoodall/ltx-sdpa-pipeline)
