### PR TITLE
fix: improve tanh bf16 performance

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -94,20 +94,19 @@ constexpr float TANH_POLY_C1 = 0.999004364013671875f;
 constexpr float TANH_POLY_C2 = 3.0897438526153564453125e-2f;
 constexpr float TANH_POLY_C3 = -0.4890659749507904052734375f;
 
-// The same three as vectors, for scalar callers with LRegs to spare. calculate_tanh has none left
-// (its pairs need six)
-struct TanhPolyConsts {
-    sfpi::vFloat c1 = TANH_POLY_C1;
-    sfpi::vFloat c2 = TANH_POLY_C2;
-    sfpi::vFloat c3 = TANH_POLY_C3;
-};
-
-sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x, const TanhPolyConsts& k) {
+sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // For negative numbers, we compute tanh(-x) = -tanh(x)
     sfpi::vFloat val = sfpi::abs(x);  // set positive
 
     sfpi::vFloat result = PolynomialEvaluator::eval(
-        val, 0.0f, k.c1, k.c2, k.c3, sfpi::vConstFloatPrgm2, sfpi::vConstFloatPrgm1, sfpi::vConstFloatPrgm0);
+        val,
+        0.0f,
+        TANH_POLY_C1,
+        TANH_POLY_C2,
+        TANH_POLY_C3,
+        sfpi::vConstFloatPrgm2,
+        sfpi::vConstFloatPrgm1,
+        sfpi::vConstFloatPrgm0);
 
     // For larger x, the polynomial approximation may exceed 1.0.
     // Since tanh(x) is bounded by [-1, 1], we clamp output to 1.0.
@@ -117,8 +116,6 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x, const TanhPolyCo
 
     return result;
 }
-
-sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) { return _sfpu_tanh_polynomial_(x, TanhPolyConsts()); }
 
 // Two datums through the polynomial in lockstep, so each fills the other's SFPMAD stall slots.
 // Only WH stalls; BH comes out even either way, so both arches run this shape. Only c1 can be
@@ -172,7 +169,9 @@ inline void calculate_tanh() {
         l_reg[sfpi::LRegs::LReg2] = l2;
     } else if constexpr (is_fp32_dest_acc_en) {  // APPROXIMATION_MODE is false
         for (int d = 0; d < ITERATIONS; d++) {
-            sfpi::dst_reg[0] = _sfpu_tanh_fp32_accurate_(sfpi::dst_reg[0]);
+            sfpi::vFloat val = sfpi::dst_reg[0];
+            sfpi::vFloat result = _sfpu_tanh_fp32_accurate_(val);
+            sfpi::dst_reg[0] = result;
             sfpi::dst_reg++;
         }
     } else {
@@ -180,7 +179,7 @@ inline void calculate_tanh() {
 
         // Walk dst_reg rather than index by d: a uniform body is what the replay buffer records
         // once, and a runtime index makes sfpi build each SFPLOAD/SFPSTORE in scalar registers.
-#pragma GCC unroll 8
+#pragma GCC unroll 4
         for (int d = 0; d < ITERATIONS / 2; d++) {
             sfpi::vFloat r0, r1;
             _sfpu_tanh_polynomial_x2_(r0, r1, sfpi::dst_reg[0], sfpi::dst_reg[1], c1);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -85,23 +85,29 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat x) {
     return sfpi::copysgn(y, x);
 }
 
-sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
+// Sollya coefficients. tanh_init has programmable CRegs for the top three only, so these three
+// cost an SFPLOADI pair per use unless the caller keeps them in an LReg.
+// val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *
+// (0.281917631626129150390625 + val * (-6.6649019718170166015625e-2 + val *
+// (5.876733921468257904052734375e-3))))));
+constexpr float TANH_POLY_C1 = 0.999004364013671875f;
+constexpr float TANH_POLY_C2 = 3.0897438526153564453125e-2f;
+constexpr float TANH_POLY_C3 = -0.4890659749507904052734375f;
+
+// The same three as vectors, for scalar callers with LRegs to spare. calculate_tanh has none left
+// (its pairs need six)
+struct TanhPolyConsts {
+    sfpi::vFloat c1 = TANH_POLY_C1;
+    sfpi::vFloat c2 = TANH_POLY_C2;
+    sfpi::vFloat c3 = TANH_POLY_C3;
+};
+
+sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x, const TanhPolyConsts& k) {
     // For negative numbers, we compute tanh(-x) = -tanh(x)
     sfpi::vFloat val = sfpi::abs(x);  // set positive
 
-    // Polynomial coefficients found using Sollya
-    // val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *
-    // (0.281917631626129150390625 + val * (-6.6649019718170166015625e-2 + val *
-    // (5.876733921468257904052734375e-3))))));
     sfpi::vFloat result = PolynomialEvaluator::eval(
-        val,
-        0.0f,
-        0.999004364013671875,
-        3.0897438526153564453125e-2,
-        -0.4890659749507904052734375,
-        sfpi::vConstFloatPrgm2,
-        sfpi::vConstFloatPrgm1,
-        sfpi::vConstFloatPrgm0);
+        val, 0.0f, k.c1, k.c2, k.c3, sfpi::vConstFloatPrgm2, sfpi::vConstFloatPrgm1, sfpi::vConstFloatPrgm0);
 
     // For larger x, the polynomial approximation may exceed 1.0.
     // Since tanh(x) is bounded by [-1, 1], we clamp output to 1.0.
@@ -110,6 +116,38 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     result = sfpi::copysgn(result, x);  // restore sign (i.e. tanh(-x) = -tanh(x))
 
     return result;
+}
+
+sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) { return _sfpu_tanh_polynomial_(x, TanhPolyConsts()); }
+
+// Two datums through the polynomial in lockstep, so each fills the other's SFPMAD stall slots.
+// Only WH stalls; BH comes out even either way, so both arches run this shape. Only c1 can be
+// hoisted on top of it: six vectors are already live for the data, and an eighth spills.
+sfpi_inline void _sfpu_tanh_polynomial_x2_(
+    sfpi::vFloat& y0, sfpi::vFloat& y1, sfpi::vFloat x0, sfpi::vFloat x1, sfpi::vFloat c1) {
+    sfpi::vFloat a0 = sfpi::abs(x0);
+    sfpi::vFloat a1 = sfpi::abs(x1);
+
+    sfpi::vFloat r0 = sfpi::vConstFloatPrgm0;
+    sfpi::vFloat r1 = sfpi::vConstFloatPrgm0;
+    r0 = r0 * a0 + sfpi::vConstFloatPrgm1;
+    r1 = r1 * a1 + sfpi::vConstFloatPrgm1;
+    r0 = r0 * a0 + sfpi::vConstFloatPrgm2;
+    r1 = r1 * a1 + sfpi::vConstFloatPrgm2;
+    // One local each, else sfpi emits the SFPLOADI pair per MAD. Both die after their second use.
+    sfpi::vFloat c3 = TANH_POLY_C3;
+    r0 = r0 * a0 + c3;
+    r1 = r1 * a1 + c3;
+    sfpi::vFloat c2 = TANH_POLY_C2;
+    r0 = r0 * a0 + c2;
+    r1 = r1 * a1 + c2;
+    r0 = r0 * a0 + c1;
+    r1 = r1 * a1 + c1;
+    r0 = r0 * a0;
+    r1 = r1 * a1;
+
+    y0 = sfpi::copysgn(sfpi::min(r0, 1.0f), x0);
+    y1 = sfpi::copysgn(sfpi::min(r1, 1.0f), x1);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
@@ -132,19 +170,32 @@ inline void calculate_tanh() {
         l_reg[sfpi::LRegs::LReg0] = l0;
         l_reg[sfpi::LRegs::LReg1] = l1;
         l_reg[sfpi::LRegs::LReg2] = l2;
-    } else {  // APPROXIMATION_MODE is false
-
+    } else if constexpr (is_fp32_dest_acc_en) {  // APPROXIMATION_MODE is false
         for (int d = 0; d < ITERATIONS; d++) {
-            sfpi::vFloat val = sfpi::dst_reg[0];
+            sfpi::dst_reg[0] = _sfpu_tanh_fp32_accurate_(sfpi::dst_reg[0]);
+            sfpi::dst_reg++;
+        }
+    } else {
+        sfpi::vFloat c1 = TANH_POLY_C1;  // inline it and every datum pays an SFPLOADI pair
 
-            sfpi::vFloat result;
+        // Walk dst_reg rather than index by d: a uniform body is what the replay buffer records
+        // once, and a runtime index makes sfpi build each SFPLOAD/SFPSTORE in scalar registers.
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS / 2; d++) {
+            sfpi::vFloat r0, r1;
+            _sfpu_tanh_polynomial_x2_(r0, r1, sfpi::dst_reg[0], sfpi::dst_reg[1], c1);
+            // Round into a vFloat; storing the vFloat16b expression pins SFPSTORE to FP16B.
+            r0 = sfpi::convert<sfpi::vFloat16b>(r0, sfpi::RoundMode::Nearest);
+            r1 = sfpi::convert<sfpi::vFloat16b>(r1, sfpi::RoundMode::Nearest);
 
-            if constexpr (is_fp32_dest_acc_en) {
-                result = _sfpu_tanh_fp32_accurate_(val);
-            } else {
-                result = _sfpu_tanh_polynomial_(val);
-                result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
-            }
+            sfpi::dst_reg[0] = r0;
+            sfpi::dst_reg[1] = r1;
+            sfpi::dst_reg += 2;
+        }
+
+        if constexpr (ITERATIONS % 2 != 0) {
+            sfpi::vFloat result = _sfpu_tanh_polynomial_(sfpi::dst_reg[0]);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
 
             sfpi::dst_reg[0] = result;
             sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -97,20 +97,19 @@ constexpr float TANH_POLY_C1 = 0.999004364013671875f;
 constexpr float TANH_POLY_C2 = 3.0897438526153564453125e-2f;
 constexpr float TANH_POLY_C3 = -0.4890659749507904052734375f;
 
-// The same three as vectors, for scalar callers with LRegs to spare. calculate_tanh has none left
-// (its pairs need six)
-struct TanhPolyConsts {
-    sfpi::vFloat c1 = TANH_POLY_C1;
-    sfpi::vFloat c2 = TANH_POLY_C2;
-    sfpi::vFloat c3 = TANH_POLY_C3;
-};
-
-sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x, const TanhPolyConsts& k) {
+sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // For negative numbers, we compute tanh(-x) = -tanh(x)
     sfpi::vFloat val = sfpi::abs(x);  // set positive
 
     sfpi::vFloat result = PolynomialEvaluator::eval(
-        val, 0.0f, k.c1, k.c2, k.c3, sfpi::vConstFloatPrgm2, sfpi::vConstFloatPrgm1, sfpi::vConstFloatPrgm0);
+        val,
+        0.0f,
+        TANH_POLY_C1,
+        TANH_POLY_C2,
+        TANH_POLY_C3,
+        sfpi::vConstFloatPrgm2,
+        sfpi::vConstFloatPrgm1,
+        sfpi::vConstFloatPrgm0);
 
     // For larger x, the polynomial approximation may exceed 1.0.
     // Since tanh(x) is bounded by [-1, 1], we clamp output to 1.0.
@@ -120,8 +119,6 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x, const TanhPolyCo
 
     return result;
 }
-
-sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) { return _sfpu_tanh_polynomial_(x, TanhPolyConsts()); }
 
 // Two datums through the polynomial in lockstep, so each fills the other's SFPMAD stall slots.
 // Only WH stalls; BH comes out even either way, so both arches run this shape. Only c1 can be
@@ -185,7 +182,7 @@ inline void calculate_tanh() {
 
         // Walk dst_reg rather than index by d: a uniform body is what the replay buffer records
         // once, and a runtime index makes sfpi build each SFPLOAD/SFPSTORE in scalar registers.
-#pragma GCC unroll 8
+#pragma GCC unroll 4
         for (int d = 0; d < ITERATIONS / 2; d++) {
             sfpi::vFloat r0, r1;
             _sfpu_tanh_polynomial_x2_(r0, r1, sfpi::dst_reg[0], sfpi::dst_reg[1], c1);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -88,23 +88,29 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat x) {
     return sfpi::copysgn(y, x);
 }
 
-sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
+// Sollya coefficients. tanh_init has programmable CRegs for the top three only, so these three
+// cost an SFPLOADI pair per use unless the caller keeps them in an LReg.
+// val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *
+// (0.281917631626129150390625 + val * (-6.6649019718170166015625e-2 + val *
+// (5.876733921468257904052734375e-3))))));
+constexpr float TANH_POLY_C1 = 0.999004364013671875f;
+constexpr float TANH_POLY_C2 = 3.0897438526153564453125e-2f;
+constexpr float TANH_POLY_C3 = -0.4890659749507904052734375f;
+
+// The same three as vectors, for scalar callers with LRegs to spare. calculate_tanh has none left
+// (its pairs need six)
+struct TanhPolyConsts {
+    sfpi::vFloat c1 = TANH_POLY_C1;
+    sfpi::vFloat c2 = TANH_POLY_C2;
+    sfpi::vFloat c3 = TANH_POLY_C3;
+};
+
+sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x, const TanhPolyConsts& k) {
     // For negative numbers, we compute tanh(-x) = -tanh(x)
     sfpi::vFloat val = sfpi::abs(x);  // set positive
 
-    // Polynomial coefficients found using Sollya
-    // val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *
-    // (0.281917631626129150390625 + val * (-6.6649019718170166015625e-2 + val *
-    // (5.876733921468257904052734375e-3))))));
     sfpi::vFloat result = PolynomialEvaluator::eval(
-        val,
-        0.0f,
-        0.999004364013671875,
-        3.0897438526153564453125e-2,
-        -0.4890659749507904052734375,
-        sfpi::vConstFloatPrgm2,
-        sfpi::vConstFloatPrgm1,
-        sfpi::vConstFloatPrgm0);
+        val, 0.0f, k.c1, k.c2, k.c3, sfpi::vConstFloatPrgm2, sfpi::vConstFloatPrgm1, sfpi::vConstFloatPrgm0);
 
     // For larger x, the polynomial approximation may exceed 1.0.
     // Since tanh(x) is bounded by [-1, 1], we clamp output to 1.0.
@@ -113,6 +119,38 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     result = sfpi::copysgn(result, x);  // restore sign (i.e. tanh(-x) = -tanh(x))
 
     return result;
+}
+
+sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) { return _sfpu_tanh_polynomial_(x, TanhPolyConsts()); }
+
+// Two datums through the polynomial in lockstep, so each fills the other's SFPMAD stall slots.
+// Only WH stalls; BH comes out even either way, so both arches run this shape. Only c1 can be
+// hoisted on top of it: six vectors are already live for the data, and an eighth spills.
+sfpi_inline void _sfpu_tanh_polynomial_x2_(
+    sfpi::vFloat& y0, sfpi::vFloat& y1, sfpi::vFloat x0, sfpi::vFloat x1, sfpi::vFloat c1) {
+    sfpi::vFloat a0 = sfpi::abs(x0);
+    sfpi::vFloat a1 = sfpi::abs(x1);
+
+    sfpi::vFloat r0 = sfpi::vConstFloatPrgm0;
+    sfpi::vFloat r1 = sfpi::vConstFloatPrgm0;
+    r0 = r0 * a0 + sfpi::vConstFloatPrgm1;
+    r1 = r1 * a1 + sfpi::vConstFloatPrgm1;
+    r0 = r0 * a0 + sfpi::vConstFloatPrgm2;
+    r1 = r1 * a1 + sfpi::vConstFloatPrgm2;
+    // One local each, else sfpi emits the SFPLOADI pair per MAD. Both die after their second use.
+    sfpi::vFloat c3 = TANH_POLY_C3;
+    r0 = r0 * a0 + c3;
+    r1 = r1 * a1 + c3;
+    sfpi::vFloat c2 = TANH_POLY_C2;
+    r0 = r0 * a0 + c2;
+    r1 = r1 * a1 + c2;
+    r0 = r0 * a0 + c1;
+    r1 = r1 * a1 + c1;
+    r0 = r0 * a0;
+    r1 = r1 * a1;
+
+    y0 = sfpi::copysgn(sfpi::min(r0, 1.0f), x0);
+    y1 = sfpi::copysgn(sfpi::min(r1, 1.0f), x1);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
@@ -135,23 +173,37 @@ inline void calculate_tanh() {
         l_reg[sfpi::LRegs::LReg0] = l0;
         l_reg[sfpi::LRegs::LReg1] = l1;
         l_reg[sfpi::LRegs::LReg2] = l2;
-    } else {  // APPROXIMATION_MODE is false
-        if constexpr (is_fp32_dest_acc_en) {
-            for (int d = 0; d < ITERATIONS; d++) {
-                sfpi::vFloat val = sfpi::dst_reg[0];
-                sfpi::vFloat result = _sfpu_tanh_fp32_accurate_(val);
-                sfpi::dst_reg[0] = result;
-                sfpi::dst_reg++;
-            }
-        } else {
+    } else if constexpr (is_fp32_dest_acc_en) {  // APPROXIMATION_MODE is false
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat val = sfpi::dst_reg[0];
+            sfpi::vFloat result = _sfpu_tanh_fp32_accurate_(val);
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
+        }
+    } else {
+        sfpi::vFloat c1 = TANH_POLY_C1;  // inline it and every datum pays an SFPLOADI pair
+
+        // Walk dst_reg rather than index by d: a uniform body is what the replay buffer records
+        // once, and a runtime index makes sfpi build each SFPLOAD/SFPSTORE in scalar registers.
 #pragma GCC unroll 8
-            for (int d = 0; d < ITERATIONS; d++) {
-                sfpi::vFloat val = sfpi::dst_reg[0];
-                sfpi::vFloat result = _sfpu_tanh_polynomial_(val);
-                result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
-                sfpi::dst_reg[0] = result;
-                sfpi::dst_reg++;
-            }
+        for (int d = 0; d < ITERATIONS / 2; d++) {
+            sfpi::vFloat r0, r1;
+            _sfpu_tanh_polynomial_x2_(r0, r1, sfpi::dst_reg[0], sfpi::dst_reg[1], c1);
+            // Round into a vFloat; storing the vFloat16b expression pins SFPSTORE to FP16B.
+            r0 = sfpi::convert<sfpi::vFloat16b>(r0, sfpi::RoundMode::Nearest);
+            r1 = sfpi::convert<sfpi::vFloat16b>(r1, sfpi::RoundMode::Nearest);
+
+            sfpi::dst_reg[0] = r0;
+            sfpi::dst_reg[1] = r1;
+            sfpi::dst_reg += 2;
+        }
+
+        if constexpr (ITERATIONS % 2 != 0) {
+            sfpi::vFloat result = _sfpu_tanh_polynomial_(sfpi::dst_reg[0]);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
         }
     }
 }


### PR DESCRIPTION
### PR Category
Performance

### Summary
#### Improve bf16 tanh performance on Wormhole and Blackhole
The bf16 `tanh` polynomial path re-materialised its three non-CReg Sollya coefficients with an `SFPLOADI` pair per datum, and on Wormhole the six-deep Horner chain also stalled a slot between every dependent `SFPMAD`.
`_sfpu_tanh_polynomial_x2_` now runs two datums through the polynomial in lockstep, so each fills the other's stall slots, with one coefficient hoisted above the loop and the other two shared per pair via short-lived locals. Both architectures use this one implementation; Wormhole is where it pays, Blackhole comes out even on issue count and gains the shared shape.

| | before | after | delta |
|---|---|---|---|
| Blackhole | 20 issues/datum | 14.75 | −26% |
| Wormhole | 22 issues/datum | 14.75 | −33% |

Results are bit-identical: same coefficients, same Horner order, same per-datum instruction sequence, only reordered across independent datums. No golden or tolerance changes. The fp32-accurate and LUT approximation paths are untouched and assemble identically. The loop steps in pairs, so odd `ITERATIONS` falls back
to a scalar tail.
Counts are SFPU issue slots per face call, taken from disassembly rather than a hardware benchmark.

#### Test plan
- [ ] LLK SFPU `tanh` tests on WH and BH, all three modes (bf16, fp32 dest, approx)
- [ ] `ttnn` `tanh` unit tests / sweeps on both arches

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/tanh-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/tanh-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=filip/tanh-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:filip/tanh-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=filip/tanh-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:filip/tanh-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/tanh-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/tanh-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=filip/tanh-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:filip/tanh-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/tanh-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/tanh-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/tanh-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/tanh-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/tanh-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/tanh-update)