### PR TITLE
[LLK] silu: honour the caller's APPROXIMATION_MODE

### DIFF
--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_experts_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_experts_matmul.hpp
@@ -331,7 +331,7 @@ struct DRAMStreamingExpertsMatmul {
                                 DST_SYNC_MODE,
                                 DST_ACCUM_MODE,
                                 calculate_silu,
-                                (CTArgs::fp32_dest_acc_en, 2 /*ITERATIONS*/),
+                                (false /*APPROXIMATION_MODE*/, CTArgs::fp32_dest_acc_en, 2 /*ITERATIONS*/),
                                 0 /*dst_index*/,
                                 VectorMode::R));
                         } else if constexpr (CTArgs::tile_r_dim == 8) {
@@ -339,7 +339,7 @@ struct DRAMStreamingExpertsMatmul {
                                 DST_SYNC_MODE,
                                 DST_ACCUM_MODE,
                                 calculate_silu,
-                                (CTArgs::fp32_dest_acc_en, 4 /*ITERATIONS*/),
+                                (false /*APPROXIMATION_MODE*/, CTArgs::fp32_dest_acc_en, 4 /*ITERATIONS*/),
                                 0 /*dst_index*/,
                                 VectorMode::R));
                         } else {
@@ -347,7 +347,7 @@ struct DRAMStreamingExpertsMatmul {
                                 DST_SYNC_MODE,
                                 DST_ACCUM_MODE,
                                 calculate_silu,
-                                (CTArgs::fp32_dest_acc_en, 8 /*ITERATIONS*/),
+                                (false /*APPROXIMATION_MODE*/, CTArgs::fp32_dest_acc_en, 8 /*ITERATIONS*/),
                                 0 /*dst_index*/,
                                 VectorMode::R));
                         }

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
@@ -329,7 +329,7 @@ struct DRAMStreamingMatmul {
                                 DST_SYNC_MODE,
                                 DST_ACCUM_MODE,
                                 calculate_silu,
-                                (false /*is_fp32_dest_acc_en*/, 2 /*ITERATIONS*/),
+                                (false /*APPROXIMATION_MODE*/, false /*is_fp32_dest_acc_en*/, 2 /*ITERATIONS*/),
                                 0 /*dst_index*/,
                                 VectorMode::R));
                         } else if constexpr (CTArgs::tile_r_dim == 8) {
@@ -337,7 +337,7 @@ struct DRAMStreamingMatmul {
                                 DST_SYNC_MODE,
                                 DST_ACCUM_MODE,
                                 calculate_silu,
-                                (false /*is_fp32_dest_acc_en*/, 4 /*ITERATIONS*/),
+                                (false /*APPROXIMATION_MODE*/, false /*is_fp32_dest_acc_en*/, 4 /*ITERATIONS*/),
                                 0 /*dst_index*/,
                                 VectorMode::R));
                         } else {
@@ -345,7 +345,7 @@ struct DRAMStreamingMatmul {
                                 DST_SYNC_MODE,
                                 DST_ACCUM_MODE,
                                 calculate_silu,
-                                (false /*is_fp32_dest_acc_en*/, 8 /*ITERATIONS*/),
+                                (false /*APPROXIMATION_MODE*/, false /*is_fp32_dest_acc_en*/, 8 /*ITERATIONS*/),
                                 0 /*dst_index*/,
                                 VectorMode::R));
                         }

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
@@ -183,7 +183,7 @@ struct Matmul {
                             DST_SYNC_MODE,
                             DST_ACCUM_MODE,
                             calculate_silu,
-                            (false /*is_fp32_dest_acc_en*/, 2 /*ITERATIONS*/),
+                            (false /*APPROXIMATION_MODE*/, false /*is_fp32_dest_acc_en*/, 2 /*ITERATIONS*/),
                             0 /*dst_index*/,
                             VectorMode::R));
                     }

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_dram.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_dram.hpp
@@ -987,7 +987,7 @@ struct MatmulExpertCompressedDRAM {
                             DST_SYNC_MODE,
                             DST_ACCUM_MODE,
                             calculate_silu,
-                            (DST_ACCUM_MODE, silu_iterations),
+                            (false /*APPROXIMATION_MODE*/, DST_ACCUM_MODE, silu_iterations),
                             0 /*dst_index*/,
                             VectorMode::R));
                         tile_regs_commit();
@@ -1089,7 +1089,7 @@ struct MatmulExpertCompressedDRAM {
                                     DST_SYNC_MODE,
                                     DST_ACCUM_MODE,
                                     calculate_silu,
-                                    (false /*is_fp32_dest_acc_en*/, 2 /*ITERATIONS*/),
+                                    (false /*APPROXIMATION_MODE*/, false /*is_fp32_dest_acc_en*/, 2 /*ITERATIONS*/),
                                     sn /*dst_index*/,
                                     VectorMode::R));
                             }

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
@@ -440,6 +440,75 @@ def test_linear_swiglu(device, gate_is_first, use_bias):
     assert result["pcc"] > 0.9999, f"PCC {result['pcc']:.7f}"
 
 
+def test_linear_swiglu_math_approx_mode(device):
+    """fuse_swiglu runs silu on the MATH thread, and it honours math_approx_mode.
+
+    The fused matmul activation reaches silu from the PACK thread (silu_tile_pack, covered by
+    test_linear_fused_silu_math_approx_mode in tests/ttnn/unit_tests/operations/matmul/test_linear.py).
+    fuse_swiglu reaches silu_tile from MATH instead, which is a second forwarding site and can
+    regress on its own. Both halves of the blast radius are asserted here: math_approx_mode picks
+    the cheaper sigmoid lowering only when DST accumulates in fp32, so without fp32_dest_acc_en it
+    has to be a no-op.
+    """
+    M, K, out_N = 256, 256, 256  # weight is [K, 2*out_N]; output is [M, out_N]
+    two_N = 2 * out_N
+    torch.manual_seed(0)
+
+    torch_input = torch.randn((M, K), dtype=torch.float32)
+    weight_input = torch.randn((K, two_N), dtype=torch.float32)
+
+    with torch.no_grad():
+        up, gate = torch.chunk(torch_input @ weight_input, 2, dim=-1)
+        golden = torch.nn.functional.silu(gate) * up
+
+    weight_il = prepare_for_fused_swiglu(weight_input, ndev=1, gate_is_first=False)
+    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_weight = ttnn.from_torch(weight_il, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+
+    matmul_config = ttnn.MinimalMatmulConfig(
+        M_block_size=8,
+        K_block_size=8,
+        N_block_size=8,
+        subblock_h=2,
+        subblock_w=2,
+        compute_with_storage_grid_size=ttnn.CoreCoord(4, 4),
+    )
+
+    outputs = {}
+    for fp32_dest_acc_en in [False, True]:
+        for math_approx_mode in [False, True]:
+            tt_output = ttnn.experimental.minimal_matmul(
+                tt_input,
+                tt_weight,
+                compute_kernel_config=ttnn.init_device_compute_kernel_config(
+                    device.arch(),
+                    math_fidelity=ttnn.MathFidelity.HiFi2,
+                    math_approx_mode=math_approx_mode,
+                    fp32_dest_acc_en=fp32_dest_acc_en,
+                    packer_l1_acc=True,
+                ),
+                config=matmul_config,
+                fuse_swiglu=True,
+            )
+            outputs[(fp32_dest_acc_en, math_approx_mode)] = ttnn.to_torch(tt_output)
+
+    for (fp32_dest_acc_en, math_approx_mode), tt_output in outputs.items():
+        _, pcc = comp_pcc(golden, tt_output)
+        logger.info(
+            f"fp32_dest_acc_en={fp32_dest_acc_en} math_approx_mode={math_approx_mode}: "
+            f"PCC against torch fp32 = {pcc}"
+        )
+        assert pcc > 0.9995, f"PCC {pcc:.7f}"
+
+    assert torch.equal(
+        outputs[(False, False)], outputs[(False, True)]
+    ), "without fp32_dest_acc_en the accurate sigmoid is unreachable, so math_approx_mode must be a no-op"
+
+    assert not torch.equal(
+        outputs[(True, False)], outputs[(True, True)]
+    ), "with fp32_dest_acc_en, math_approx_mode must actually select the approximate sigmoid on MATH"
+
+
 def test_run_performance(device):
     core_grid = ttnn.CoreCoord(8, 8)
     M, K, N = 4096, 4096, 4096

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -15,7 +15,11 @@ from models.common.utility_functions import (
     is_llk_assert_enabled,
     skip_for_slow_dispatch,
 )
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_numeric_metrics
+from tests.ttnn.utils_for_testing import (
+    assert_with_pcc,
+    assert_numeric_metrics,
+    check_with_pcc_without_tensor_printout,
+)
 from tests.ttnn.unit_tests.operations.matmul.test_matmul import is_tiny_tile_combo_supported
 
 
@@ -350,6 +354,60 @@ def test_linear_fp32_acc(device, m_size, k_size, n_size):
         pcc_threshold=0.997,
         check_ulp=False,
     )
+
+
+@pytest.mark.parametrize("m_size, k_size, n_size", [(512, 1024, 1024)])
+def test_linear_fused_silu_math_approx_mode(device, m_size, k_size, n_size):
+    """The fused silu activation honours math_approx_mode, and only where it can.
+
+    math_approx_mode selects the cheaper sigmoid lowering inside silu (exp_21f plus a single
+    reciprocal iteration, instead of the accurate exp plus two). That choice only exists when DST
+    accumulates in fp32: without fp32_dest_acc_en the accurate path is unreachable anyway, so
+    math_approx_mode must be a no-op there. Both halves are asserted below, which is the whole
+    numerical blast radius of the flag.
+    """
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = torch.randn((1, m_size, k_size), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.randn((k_size, n_size), dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.silu(torch_input_tensor_a.float() @ torch_input_tensor_b.float())
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    outputs = {}
+    for fp32_dest_acc_en in [False, True]:
+        for math_approx_mode in [False, True]:
+            output_tensor = ttnn.linear(
+                input_tensor_a,
+                input_tensor_b,
+                activation="silu",
+                core_grid=device.core_grid,
+                compute_kernel_config=ttnn.init_device_compute_kernel_config(
+                    device.arch(),
+                    math_fidelity=ttnn.MathFidelity.HiFi4,
+                    math_approx_mode=math_approx_mode,
+                    fp32_dest_acc_en=fp32_dest_acc_en,
+                    packer_l1_acc=True,
+                ),
+            )
+            outputs[(fp32_dest_acc_en, math_approx_mode)] = ttnn.to_torch(output_tensor)
+
+    for (fp32_dest_acc_en, math_approx_mode), output_tensor in outputs.items():
+        _, pcc = check_with_pcc_without_tensor_printout(torch_output_tensor, output_tensor, pcc=0.99)
+        logger.info(
+            f"fp32_dest_acc_en={fp32_dest_acc_en} math_approx_mode={math_approx_mode}: "
+            f"PCC against torch fp32 = {pcc}"
+        )
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.99)
+
+    assert torch.equal(
+        outputs[(False, False)], outputs[(False, True)]
+    ), "without fp32_dest_acc_en the accurate sigmoid is unreachable, so math_approx_mode must be a no-op"
+
+    assert not torch.equal(
+        outputs[(True, False)], outputs[(True, True)]
+    ), "with fp32_dest_acc_en, math_approx_mode must actually select the approximate sigmoid"
 
 
 def test_bloom_ff2_linear(device):

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -10,14 +10,18 @@
 
 namespace ckernel::sfpu {
 
-template <bool is_fp32_dest_acc_en, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_silu() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
 
         // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+        // _sfpu_sigmoid_'s parameter selects the accurate exp plus a 2-iteration reciprocal; false
+        // selects exp_21f (~1 ULP on bfloat16) plus a single iteration. Take the accurate path only
+        // when DST is fp32 and the caller has not asked for approximate math.
+        constexpr bool accurate_sigmoid = is_fp32_dest_acc_en && !APPROXIMATION_MODE;
+        sfpi::vFloat result = x * _sfpu_sigmoid_<accurate_sigmoid>(x);
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
@@ -32,7 +36,9 @@ inline void calculate_silu() {
 template <bool APPROXIMATION_MODE>
 inline void silu_init() {
     math::reset_counters(p_setrwc::SET_ABD_F);
-    // calculate_silu uses the non-approx sigmoid path via _sfpu_sigmoid_, so we must use non-approx sigmoid_init
+    // Both of calculate_silu's paths go through _sfpu_sigmoid_, never the approximate sigmoid LUT, and
+    // they differ only in the reciprocal iteration count. sigmoid_init<false> sets up that reciprocal,
+    // so it is the correct init for either value of APPROXIMATION_MODE.
     sigmoid_init<false>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -10,14 +10,18 @@
 
 namespace ckernel::sfpu {
 
-template <bool is_fp32_dest_acc_en, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_silu() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
 
         // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+        // _sfpu_sigmoid_'s parameter selects the accurate exp plus a 2-iteration reciprocal; false
+        // selects exp_21f (~1 ULP on bfloat16) plus a single iteration. Take the accurate path only
+        // when DST is fp32 and the caller has not asked for approximate math.
+        constexpr bool accurate_sigmoid = is_fp32_dest_acc_en && !APPROXIMATION_MODE;
+        sfpi::vFloat result = x * _sfpu_sigmoid_<accurate_sigmoid>(x);
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
@@ -32,8 +36,9 @@ inline void calculate_silu() {
 template <bool APPROXIMATION_MODE>
 inline void silu_init() {
     math::reset_counters(p_setrwc::SET_ABD_F);
-    // calculate_silu always uses the non-approx sigmoid path via _sfpu_sigmoid_, so we must
-    // use non-approx sigmoid_init regardless of APPROXIMATION_MODE.
+    // Both of calculate_silu's paths go through _sfpu_sigmoid_, never the approximate sigmoid LUT, and
+    // they differ only in the reciprocal iteration count. sigmoid_init<false> sets up that reciprocal,
+    // so it is the correct init for either value of APPROXIMATION_MODE.
     sigmoid_init<false>();
 }
 

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -165,7 +165,12 @@ ALWI void silu_tile(uint32_t idst) {
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_silu, (8 /*ITERATIONS*/), idst, ::ckernel::VectorMode::RC));
 #else
     MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_silu, (DST_ACCUM_MODE, 8 /* ITERATIONS */), idst, VectorMode::RC));
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_silu,
+        (APPROX, DST_ACCUM_MODE, 8 /* ITERATIONS */),
+        idst,
+        VectorMode::RC));
 #endif
 }
 
@@ -664,7 +669,12 @@ ALWI void expm1_tile_init() {
 
 ALWI void silu_tile_pack(uint32_t idst) {
     PACK(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_silu, (DST_ACCUM_MODE, 8 /* ITERATIONS */), idst, VectorMode::RC));
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_silu,
+        (APPROX, DST_ACCUM_MODE, 8 /* ITERATIONS */),
+        idst,
+        VectorMode::RC));
 }
 ALWI void silu_tile_init_pack() { PACK(SFPU_UNARY_INIT_FN(silu, sfpu::silu_init, (APPROX))); }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -60,14 +60,14 @@ inline void pack_compute_activation<ttnn::experimental::prim::detail::MoEActivat
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
         calculate_silu,
-        (false /*is_fp32_dest_acc_en*/, 8 /*ITERATIONS*/),
+        (false /*APPROXIMATION_MODE*/, false /*is_fp32_dest_acc_en*/, 8 /*ITERATIONS*/),
         0 /*DST_IDX*/,
         ::ckernel::VectorMode::RC));
     PACK(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
         calculate_silu,
-        (false /*is_fp32_dest_acc_en*/, 8 /*ITERATIONS*/),
+        (false /*APPROXIMATION_MODE*/, false /*is_fp32_dest_acc_en*/, 8 /*ITERATIONS*/),
         2 /*DST_IDX*/,
         ::ckernel::VectorMode::RC));
 


### PR DESCRIPTION
## What's wrong

`silu_tile` passes `APPROX` to `silu_tile_init` but not to `calculate_silu`: two adjacent functions in
`compute_kernel_api.h` disagree, and `silu_init<APPROXIMATION_MODE>` discards the parameter it was
handed.

`calculate_silu` was the only activation in `llk_api/llk_sfpu/` not declared to take
`APPROXIMATION_MODE`; gelu, tanh and sigmoid all have it. So a caller setting `math_approx_mode=true`
still gets the accurate sigmoid (`_sfpu_exp_fp32_accurate_` plus `sfpu_reciprocal_iter<2>`). The
neighbouring `expm1_tile` shows the idiom being violated.

Relates to #37896, which observed that `calculate_silu` always uses the non-approx sigmoid and made
`silu_init` consistent with that. This adds the missing path.

## The fix

`calculate_silu` takes `APPROXIMATION_MODE`, and `silu_tile` / `silu_tile_pack` forward it. The
approximate path is `_sfpu_sigmoid_<false>` (exp_21f, ~1 ULP on bfloat16, plus a single reciprocal
iteration), not the sigmoid LUT.

`silu_init` keeps calling `sigmoid_init<false>()`; only its comment changed. The two `_sfpu_sigmoid_`
branches differ only in which exp they call and in `sfpu_reciprocal_iter<2>` vs `<1>`, and
`sigmoid_init<false>()` is exactly the reciprocal init both need (`sfpu_reciprocal_init<false>()` on
blackhole, `recip_init<false, false>()` on wormhole_b0). `_sfpu_exp_21f_bf16_` is pure sfpi arithmetic
with no init of its own, unlike `calculate_sigmoid_appx`, which loads LUT coefficients into LReg0-2 and
needs `sigmoid_appx_init`. So #37896's conclusion still holds either way.

Both arches take the same change: after this patch `ckernel_sfpu_silu.h` is byte-identical between them,
`_sfpu_sigmoid_`'s body is identical, and `_sfpu_exp_21f_bf16_` is present on both. Quasar's
`calculate_silu` calls the legacy piecewise-linear `_calculate_silu_` LLK instead and is left alone.

## Blast radius

Only call sites with `fp32_dest_acc_en=true` **and** `math_approx_mode=true` change numerics, and that
is statically checkable.

**Unaffected**, because they never set `math_approx_mode=true`:

- `ttnn.silu` and the rest of the `unary` chain: `unary_program_factory.cpp:419` hardcodes
  `const bool math_approx_mode = false` and feeds it to the `ComputeConfigDescriptor` at `:517`; those
  are the only two `math_approx_mode` references in `ttnn/cpp/ttnn/operations/eltwise/`. SILU reaches
  `silu_tile` from `unary/common/unary_op_utils.cpp:881`.
- `experimental/deepseek_prefill/unified_routed_expert_ffn`, which hardcodes `.math_approx_mode = false`.
- The eleven direct LLK callers in `models/demos/deepseek_v3_b1/unified_kernels/` and
  `ttnn/.../moe_compute/`, which this PR updates to pass `false`.
  `unified_kernels/matmul.hpp:154` already threads `CTArgs::fused_activation_approx_mode` into
  `silu_init` where it is currently discarded, so its owners can opt in with a one-word change.

**Reachable**, because they forward the caller's `math_approx_mode` — these change only if the caller
also sets `fp32_dest_acc_en=true`:

- the matmul fused-activation path (`bmm_large_block_zm_fused_bias_activation`), which is what the new
  test exercises;
- `ttnn.experimental.minimal_matmul` (`minimal_matmul_program_factory.cpp:165` -> `:668`);
- `all_gather_minimal_matmul_async` (`:238` -> `:1055`).

For reviewers: #41949 attempted the same fix with a LUT fast path and also made `get_op_approx_mode()`
return true for `UnaryOpType::SILU`, silently changing numerics for every caller of a public op. (That
function no longer exists on `main`.) This PR changes no ttnn default.

## Accuracy

New `test_linear_fused_silu_math_approx_mode`: `ttnn.linear(activation="silu")`, 512x1024x1024, bf16,
HiFi4, Blackhole p150. PCC against torch fp32:

| `fp32_dest_acc_en` | `math_approx_mode` | PCC |
|---|---|---|
| false | false | 0.999934545716436 |
| false | true | 0.999934545716436 |
| true | false | 0.9999979026187754 |
| true | true | 0.99999790799465 |

The two `fp32_dest_acc_en=false` rows are bit-identical, and the test asserts it: without fp32 dest
accumulation the accurate path is unreachable, so the flag must be a no-op there. Existing
`tests/ttnn/unit_tests/operations/eltwise/test_silu.py`: 34 passed, 32 skipped.

## Perf

`bmm_large_block_zm_fused_bias_activation` at 512x1024x4096, fused `activation="silu"`,
`fp32_dest_acc_en=true`, HiFi4, warm, 200 reps, Blackhole p150. The fused activation runs on the pack
core, so the SFPU instructions are in `trisc2.elf`:

- SFPU instructions **171 -> 67**, ratio 2.55 (832 -> 727 total in that ELF; `trisc0`/`trisc1` have none)
- wall per call **77.71 us -> 69.65 us** (1.116x), and **79.04 -> 69.83** (1.132x) on a second card in a
  separate session. The two arms build different kernels, proving the flag reaches the compute kernel.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=moritztng/silu-approximation-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:moritztng/silu-approximation-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=moritztng/silu-approximation-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:moritztng/silu-approximation-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=moritztng/silu-approximation-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:moritztng/silu-approximation-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=moritztng/silu-approximation-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:moritztng/silu-approximation-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=moritztng/silu-approximation-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:moritztng/silu-approximation-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=moritztng/silu-approximation-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:moritztng/silu-approximation-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=moritztng/silu-approximation-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:moritztng/silu-approximation-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=moritztng/silu-approximation-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:moritztng/silu-approximation-mode)