### PR TITLE
Scope ttnn-core CODEOWNERS to core tests, not op tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -361,7 +361,6 @@ ttnn/cpp/ttnn/operations/experimental/rgb_to_yuv/ @cglagovichTT @jonathansuTT @t
 ttnn/cpp/ttnn/operations/experimental/rgb_to_yuv/**/CMakeLists.txt @cglagovichTT @jonathansuTT @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/quasar/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/quasar/**/CMakeLists.txt @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
-tests/ttnn/nightly/unit_tests/operations/experimental/quasar/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/slice_write/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/slice_write/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/padded_slice/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
@@ -419,6 +418,9 @@ tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py @tensto
 
 
 tests/ttnn/ @tenstorrent/metalium-developers-ttnn-core @razorback3 @dongjin-na @bbradelTT @tenstorrent/codeowner-bypass
+# op tests follow op ownership, mirroring ttnn/cpp/ttnn/operations/
+tests/ttnn/**/operations/ @tenstorrent/metalium-developers-ops-leads @tenstorrent/codeowner-bypass
+tests/ttnn/python_api_testing/ @tenstorrent/metalium-developers-ops-leads @tenstorrent/codeowner-bypass
 tests/ttnn/**/*realtime_profiler* @tenstorrent/metalium-developers-ttnn-core @mo-tenstorrent @yusufbashiTT @razorback3 @dongjin-na @bbradelTT @tenstorrent/codeowner-bypass
 tests/ttnn/tracy/ @tenstorrent/metalium-developers-ttnn-core @mo-tenstorrent @yusufbashiTT @razorback3 @dongjin-na @bbradelTT @tenstorrent/codeowner-bypass
 tests/ttnn/**/CMakeLists.txt @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-developers-infra
@@ -450,6 +452,7 @@ tests/ttnn/nightly/unit_tests/operations/reduction/ @tenstorrent/metalium-develo
 tests/ttnn/nightly/unit_tests/operations/transformers/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/sdpa/ @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/sdpa/ @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
+tests/ttnn/nightly/unit_tests/operations/experimental/quasar/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/ @tenstorrent/metalium-developers-ds-prefill @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass


### PR DESCRIPTION
### Problem

`tests/ttnn/` is owned by `metalium-developers-ttnn-core`, so ttnn-core is added as a required
reviewer on any PR that touches a test under `tests/ttnn`, including op PRs it does not own.
#52377 is a recent example: the op source is owned by ops-data-movement, but the test file
`tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py` pulled
in ttnn-core.

Note the `tests/ttnn/` catch-all cannot simply be deleted: `ttnn/` has no internal slash, so under
gitignore semantics it matches a `ttnn` directory at any depth, including `tests/ttnn/`. Removing
the catch-all would leave those files falling back to ttnn-core one rule up.

### Change

Op tests now follow op ownership, mirroring the existing fallback for op source
(`ttnn/cpp/ttnn/operations/`, `ttnn/ttnn/operations/`):

- `tests/ttnn/**/operations/` and `tests/ttnn/python_api_testing/` -> `metalium-developers-ops-leads`
- `tests/ttnn/nightly/unit_tests/operations/experimental/quasar/` moved from the ttnn source block
  into the tests block, where it is no longer shadowed by `tests/ttnn/` (it was ttnn-core, now
  mmfusedreduce, as intended)

ttnn-core keeps the core test suites: `base_functionality`, `tensor`, `gtests`,
`per_core_allocation`, `light_metal`, `distributed`, plus tracy/profiler and CMake rules unchanged.

### Verification

Ownership was resolved per file (last matching rule wins) over `git ls-files`, before vs after:

- tracked files owned by ttnn-core: 1090 -> 685 (347 `python_api_testing`, 50 `**/operations/`, 8 quasar)
- files with no owner: 0 before, 0 after
- files that newly gained ttnn-core: 0
- every existing per-op test rule still takes precedence (eltwise, ccl, sdpa, conv, pool, matmul,
  moreh, data_movement, fused, reduce, udm, deepseek_prefill, transformers)
- `codeowners-validator` constraints hold: no duplicate patterns, and each new pattern matches at
  least one tracked file

### Follow-ups (not in this PR)

Still ttnn-core, and arguably not core tests either: `tests/ttnn/integration_tests/` (model tests)
and `tests/ttnn/**/CMakeLists.txt` (shared with infra).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/codeowners-ttnn-core-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/codeowners-ttnn-core-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/codeowners-ttnn-core-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/codeowners-ttnn-core-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/codeowners-ttnn-core-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/codeowners-ttnn-core-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/codeowners-ttnn-core-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/codeowners-ttnn-core-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/codeowners-ttnn-core-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/codeowners-ttnn-core-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/codeowners-ttnn-core-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/codeowners-ttnn-core-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/codeowners-ttnn-core-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/codeowners-ttnn-core-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/codeowners-ttnn-core-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/codeowners-ttnn-core-tests)