### PR TITLE
tests: skip nightly fabric UDM suite before initialization

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -287,10 +287,28 @@ protected:
 };
 
 class NightlyFabric2DUDMModeFixture : public Fabric2DUDMModeFixture {
+private:
+    inline static bool insufficient_devices_ = false;
+
 protected:
+    static void SetUpTestSuite() {
+        insufficient_devices_ = tt::tt_metal::GetNumAvailableDevices() < 8;
+        if (insufficient_devices_) {
+            return;
+        }
+        Fabric2DUDMModeFixture::SetUpTestSuite();
+    }
+
+    static void TearDownTestSuite() {
+        if (!insufficient_devices_) {
+            Fabric2DUDMModeFixture::TearDownTestSuite();
+        }
+    }
+
     void SetUp() override {
-        if (devices_.size() < 8) {
-            GTEST_SKIP() << "Test requires at least 8 devices (2x4 mesh), found " << devices_.size();
+        if (insufficient_devices_) {
+            GTEST_SKIP() << "Test requires at least 8 devices (2x4 mesh), found "
+                         << tt::tt_metal::GetNumAvailableDevices();
         }
         Fabric2DUDMModeFixture::SetUp();
     }


### PR DESCRIPTION
### PR Category
Bug fix in test

### Summary
Skip fabrit init if fewer than 8 devices are present. Doesn't fix any failures, but reduces overhead before the tests are skipped anyway.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=micah/fabric-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:micah/fabric-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=micah/fabric-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:micah/fabric-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=micah/fabric-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:micah/fabric-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=micah/fabric-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:micah/fabric-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=micah/fabric-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:micah/fabric-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=micah/fabric-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:micah/fabric-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=micah/fabric-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:micah/fabric-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=micah/fabric-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:micah/fabric-fixes)