### PR TITLE
[emule] populate per-CB face geometry at CB/DFB setup (tt-emule-blaze#191)

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2847,7 +2847,16 @@ static void init_core_cb_sync(
             uint32_t page_size = cb_impl->page_size(idx);
             uint32_t num_pages = (page_size > 0) ? cb_impl->num_pages(idx) : 0;
             uint8_t* base = (page_size > 0) ? core->l1_ptr(cb_addr) : nullptr;
-            core->init_cb_sync(idx, base, page_size, num_pages, cb_impl->globally_allocated());
+            // Carry the faced-tile geometry silicon's pack/unpack init reads off the
+            // CB when the config sets it, else the full-tile default (16/4).
+            uint32_t cb_face_r_dim = 16, cb_num_faces = 4;
+            const auto& cb_fg = cb_impl->unpack_face_geometry(idx);
+            if (cb_fg.has_value()) {
+                cb_face_r_dim = cb_fg->face_r_dim;
+                cb_num_faces  = cb_fg->num_faces;
+            }
+            core->init_cb_sync(idx, base, page_size, num_pages, cb_impl->globally_allocated(),
+                               cb_face_r_dim, cb_num_faces);
             configured[idx] = true;
             log_debug(
                 tt::LogMetal,
@@ -2962,8 +2971,15 @@ static std::vector<DFBAllocInfo> allocate_dfbs_on_core(
 
         // Also populate CB sync state for this DFB so compute ops (pack_tile,
         // matmul_tiles) can reuse the same L1 buffer via cb_read_ptr/cb_write_ptr.
+        // Same faced-tile geometry carry as the CB pass above, else full-tile 16/4.
         if (device_slot < EMULE_NUM_CBS) {
-            core->init_cb_sync(static_cast<uint8_t>(device_slot), base, cfg.entry_size, cfg.num_entries);
+            uint32_t dfb_face_r_dim = 16, dfb_num_faces = 4;
+            if (cfg.unpack_face_geometry.has_value()) {
+                dfb_face_r_dim = cfg.unpack_face_geometry->face_r_dim;
+                dfb_num_faces  = cfg.unpack_face_geometry->num_faces;
+            }
+            core->init_cb_sync(static_cast<uint8_t>(device_slot), base, cfg.entry_size, cfg.num_entries,
+                               /*globally_allocated=*/false, dfb_face_r_dim, dfb_num_faces);
         }
 
         // Initialize tile counters for this DFB.


### PR DESCRIPTION
## What

Threads each CB / DFB's faced-tile geometry (`face_r_dim` / `num_faces`) into the
emule `CBSyncState` at `init_cb_sync` time, at both configure sites in
`emulated_program_runner.cpp`:

- **`init_core_cb_sync`** (the `CircularBufferImpl` pass) — reads
  `cb_impl->unpack_face_geometry(idx)`.
- **`allocate_dfbs_on_core`** (the DFB pass) — reads
  `cfg.unpack_face_geometry_metadata` off the `DataflowBufferSpec`.

Both fall back to the full-tile default (16 rows/face, 4 faces) when the config
carries no geometry, so this is **behavior-preserving** for every existing caller.

## Why

This is the value silicon's pack/unpack init reads off the output CB
(`get_output_num_faces` / `get_output_face_r_dim`). emule previously had no per-CB
source for it, so `pack_untilize_dest` could not model a short faced tile and always
packed a hardcoded 32×32 — over-writing L1 that follows a CB sized for a short faced
tile on the `<32`-row untilize / sdpa-reduce / compressor paths (tt-emule-blaze
#189/#191).

## Companion — required to activate (matched pair)

This is the tt-metal runtime half. The consumer side lives in **tt-emule-blaze
PR #240** (`xchin/pack-untilize-face-geometry-191`): the `CBSyncState.face_r_dim /
num_faces` fields, the extended `init_cb_sync(..., face_r_dim, num_faces)` signature
this PR calls, the `cb_num_faces` / `cb_face_r_dim` accessors, and the
`pack_untilize_dest` / `pack_untilize_dest_init` consumers.

Neither half changes behavior alone — this PR only populates fields that default to
the full tile, and #240 only reads a source that, without this PR, is always the
default. **They must be pinned together** (this SHA in `tt-metal-pin.txt`, #240 in
`tt-blaze-pin.txt`) to take effect.

## Relationship to the fork branch

The original companion commit sat on `xchin/emule-cb-face-geometry-191`, which is
built on the entire `emule-blaze-metal-fork` lineage (~50 commits). This PR
cherry-picks **only** that one commit onto `main`, adapted to main's naming
(`device_slot`, `DataflowBufferSpec::unpack_face_geometry_metadata`); the fork field
was `unpack_face_geometry`.

Refs: `tenstorrent/tt-emule-blaze#189`, `tenstorrent/tt-emule-blaze#191`,
`tenstorrent/tt-emule-blaze#240`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/emule-cb-face-geometry-191-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/emule-cb-face-geometry-191-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/emule-cb-face-geometry-191-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/emule-cb-face-geometry-191-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=xchin/emule-cb-face-geometry-191-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:xchin/emule-cb-face-geometry-191-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/emule-cb-face-geometry-191-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/emule-cb-face-geometry-191-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/emule-cb-face-geometry-191-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/emule-cb-face-geometry-191-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/emule-cb-face-geometry-191-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/emule-cb-face-geometry-191-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/emule-cb-face-geometry-191-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/emule-cb-face-geometry-191-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/emule-cb-face-geometry-191-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/emule-cb-face-geometry-191-main)