### PR TITLE
#52630: Don't dequantize an already-dequantized Kimi checkpoint

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -40,7 +40,7 @@ from models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_2 import GLM52Adapte
 
 TEST_VARIANTS["glm_5_2"] = GLM52Adapter()
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
-from models.demos.deepseek_v3_d_p.utils.test_utils import dequantize_state_dict, detect_language_model_prefix
+from models.demos.deepseek_v3_d_p.utils.test_utils import convert_state_dict, detect_language_model_prefix
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import download_infinitebench_subset
 
 # Shared FABRIC_2D parametrize entries for the prefill block + transformer tests.
@@ -863,7 +863,7 @@ def pretrained_transformer_weights(variant, model_path, hf_config, state_dict, r
     Dequantized pretrained weights for N-layer transformer in TT state_dict format.
 
     Extracts embed, norm, and per-layer weights (attention, FFN/MoE) using
-    sub_state_dict() + dequantize_state_dict(), matching the format produced
+    sub_state_dict() + convert_state_dict(), matching the format produced
     by extract_tt_state_dict() in transformer_helpers.py.
 
     Parametrize with num_layers (default 6) via indirect fixture or marker:
@@ -894,14 +894,14 @@ def pretrained_transformer_weights(variant, model_path, hf_config, state_dict, r
 
     # Embed tokens
     embed_sd = sub_state_dict(state_dict, f"{prefix}model.embed_tokens.")
-    embed_dequant = dequantize_state_dict(embed_sd, hf_config)
+    embed_dequant = convert_state_dict(embed_sd, hf_config)
     result = {
         "embed_weight": embed_dequant["weight"].float(),
     }
 
     # Final norm
     norm_sd = sub_state_dict(state_dict, f"{prefix}model.norm.")
-    norm_dequant = dequantize_state_dict(norm_sd, hf_config)
+    norm_dequant = convert_state_dict(norm_sd, hf_config)
     result["norm_weight"] = norm_dequant["weight"]
 
     # Per-layer weights
@@ -909,7 +909,7 @@ def pretrained_transformer_weights(variant, model_path, hf_config, state_dict, r
     for i in range(num_layers):
         logger.info(f"Loading layer {i} weights...")
         layer_sd = sub_state_dict(state_dict, f"{prefix}model.layers.{i}.")
-        layer_dequant = dequantize_state_dict(layer_sd, hf_config)
+        layer_dequant = convert_state_dict(layer_sd, hf_config)
 
         layer_dict = {
             "attn_norm_weight": layer_dequant["input_layernorm.weight"],

--- a/models/demos/deepseek_v3_d_p/tests/test_dequant_utils.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_dequant_utils.py
@@ -21,6 +21,7 @@ import torch
 from models.demos.deepseek_v3_d_p.utils.test_utils import (
     _dequantize_packed_int4_weight,
     _pack_quant_params,
+    convert_state_dict,
     dequantize_state_dict,
     is_pack_quantized_int4,
 )
@@ -123,3 +124,69 @@ def test_dequantize_state_dict_int4_pack_quant_round_trip():
     # fp32 passthrough must NOT be downcast to bf16 (router-bias precision).
     assert out[bias].dtype == torch.float32
     torch.testing.assert_close(out[bias], bias_val, rtol=0, atol=0)
+
+
+def test_convert_state_dict_passes_through_dequantized_checkpoint():
+    """A dequantized checkpoint has no `quantization_config`, so nothing may reach the dequantizer --
+    it reads quantization metadata up front and would raise (the Kimi prefill-block CI failure)."""
+    weight = torch.tensor([[1.25, -0.75]], dtype=torch.bfloat16)
+    bias = torch.tensor([1.5, -2.5], dtype=torch.float32)  # router bias -- must stay fp32
+    hf_config = SimpleNamespace()  # no quantization_config at all
+
+    out = convert_state_dict({"mlp.gate.weight": weight, "mlp.gate.e_score_correction_bias": bias}, hf_config)
+
+    assert set(out) == {"mlp.gate.weight", "mlp.gate.e_score_correction_bias"}
+    assert out["mlp.gate.weight"].dtype == torch.bfloat16
+    torch.testing.assert_close(out["mlp.gate.weight"], weight, rtol=0, atol=0)
+    # Source dtype preserved, matching the INT4 path's passthrough (no bf16 downcast of the router bias).
+    assert out["mlp.gate.e_score_correction_bias"].dtype == torch.float32
+    torch.testing.assert_close(out["mlp.gate.e_score_correction_bias"], bias, rtol=0, atol=0)
+
+
+def test_convert_state_dict_dequantizes_int4_pack_quantized_checkpoint():
+    """With a `quantization_config` present, convert_state_dict must take the INT4 dequant path."""
+    levels = torch.tensor([[-8, -1, 0, 7, 3, -4, 5, -2]], dtype=torch.int64)
+    group_size = 8
+    scale = torch.tensor([[0.25]], dtype=torch.float32)
+
+    weight = "model.layers.0.mlp.experts.0.gate_proj.weight"
+    state_dict = {
+        f"{weight}_packed": _pack_int4_offset_binary(levels),
+        f"{weight}_scale": scale,
+        f"{weight}_shape": torch.tensor([levels.shape[0], levels.shape[1]]),
+    }
+    hf_config = SimpleNamespace(quantization_config=_int4_quant_config(group_size))
+
+    out = convert_state_dict(state_dict, hf_config, dtype=torch.bfloat16)
+
+    assert set(out) == {weight}
+    expected = (levels.to(torch.float32) * scale.repeat_interleave(group_size, dim=1)).to(torch.bfloat16)
+    torch.testing.assert_close(out[weight], expected, rtol=0, atol=0)
+
+
+def test_convert_state_dict_reads_quantization_config_nested_under_text_config():
+    """Kimi's multimodal checkpoint nests the LM config; missing it would pass INT4 payload through raw."""
+    levels = torch.tensor([[-8, -1, 0, 7, 3, -4, 5, -2]], dtype=torch.int64)
+    group_size = 8
+    weight = "model.layers.0.mlp.experts.0.gate_proj.weight"
+    state_dict = {
+        f"{weight}_packed": _pack_int4_offset_binary(levels),
+        f"{weight}_scale": torch.tensor([[0.25]], dtype=torch.float32),
+        f"{weight}_shape": torch.tensor([levels.shape[0], levels.shape[1]]),
+    }
+    hf_config = SimpleNamespace(text_config=SimpleNamespace(quantization_config=_int4_quant_config(group_size)))
+
+    out = convert_state_dict(state_dict, hf_config, dtype=torch.bfloat16)
+
+    assert set(out) == {weight}  # dequantized, not passed through as raw _packed/_scale/_shape
+
+
+def test_convert_state_dict_rejects_quantized_payload_without_quantization_config(expect_error):
+    """Quantized weights whose config lost its metadata must fail loudly, not pass through as garbage."""
+    hf_config = SimpleNamespace()
+
+    with expect_error(ValueError, "no `quantization_config`"):
+        convert_state_dict({"w.weight_packed": torch.zeros(1, 1, dtype=torch.int32)}, hf_config)
+
+    with expect_error(ValueError, "no `quantization_config`"):
+        convert_state_dict({"w.weight": torch.zeros(1, 1).to(torch.float8_e4m3fn)}, hf_config)

--- a/models/demos/deepseek_v3_d_p/utils/test_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/test_utils.py
@@ -360,3 +360,81 @@ def dequantize_state_dict(
     if is_pack_quantized_int4(quant_cfg):
         return _dequantize_pack_quantized_state_dict(state_dict, quant_cfg, dtype=dtype)
     return _fp8_dequantize_state_dict(state_dict, hf_config, dtype)
+
+
+def passthrough_state_dict(state_dict: Mapping[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Materialize an already-dequantized (sub-)state_dict, preserving each tensor's source dtype.
+
+    Both dequantizers need quantization metadata before they can touch a single tensor (fp8 reads
+    `weight_block_size`, INT4 reads its config group), so a checkpoint that carries none needs this
+    separate route rather than a no-op trip through `dequantize_state_dict`.
+
+    Source dtypes are preserved for the same reason `_dequantize_pack_quantized_state_dict` preserves
+    them on its non-quantized tensors: the fp32 `e_score_correction_bias` feeding the router top-k must
+    not be downcast to bf16. A dequantized checkpoint already stores the dtypes the model expects
+    (Kimi K2.6: bf16 weights, fp32 router bias), so there is nothing to convert.
+    """
+    out: dict[str, torch.Tensor] = {}
+    for name in sorted(state_dict.keys()):
+        # A dequantized checkpoint carries no quantized payload. If one turns up, the weights are
+        # quantized but config.json lost its metadata -- say so instead of emitting garbage tensors.
+        if name.endswith(("_scale_inv", "_packed")):
+            raise ValueError(
+                f"Found quantized tensor '{name}' in a checkpoint whose config has no `quantization_config`. "
+                "The dequantization metadata is missing from config.json."
+            )
+        tensor = state_dict[name]
+        if tensor is None:
+            raise ValueError(f"Expected tensor {name} to exist in state_dict but it was None")
+        if tensor.dtype == torch.float8_e4m3fn:
+            raise ValueError(
+                f"Found float8 tensor '{name}' in a checkpoint whose config has no `quantization_config`. "
+                "The dequantization metadata is missing from config.json."
+            )
+        out[name] = tensor.contiguous().clone()  # passthrough: preserve source dtype
+    return out
+
+
+_LOGGED_CONVERSION_MODES: set[str] = set()
+
+
+def _log_conversion_mode(message: str) -> None:
+    """Log the quantized/dequantized conclusion once per process; repeats drop to debug.
+
+    `convert_state_dict` runs per module and per layer (60+ times for a full checkpoint), so logging at
+    info every time would bury the rest of the weight-load output.
+    """
+    if message in _LOGGED_CONVERSION_MODES:
+        logger.debug(message)
+        return
+    _LOGGED_CONVERSION_MODES.add(message)
+    logger.info(message)
+
+
+def convert_state_dict(
+    state_dict: Mapping[str, torch.Tensor],
+    hf_config: Any,
+    dtype: torch.dtype = torch.bfloat16,
+) -> dict[str, torch.Tensor]:
+    """Convert an HF (sub-)state_dict, dequantizing only when the checkpoint is actually quantized.
+
+    Every model here ships as both a quantized and a dequantized checkpoint behind one loading path,
+    and only `hf_config.quantization_config` tells them apart: present means quantized weights, so hand
+    off to `dequantize_state_dict` (Kimi INT4 pack-quant or DeepSeek fp8 block-wise); absent means the
+    checkpoint is already dequantized, so pass the weights through untouched.
+    """
+    quant_cfg = _get_quantization_config_dict(hf_config)
+
+    if quant_cfg is None:
+        _log_conversion_mode(
+            "No `quantization_config` found in hf_config -> checkpoint is already dequantized; "
+            "passing weights through without dequantization."
+        )
+        return passthrough_state_dict(state_dict)
+
+    quant_method = quant_cfg.get("quant_method") if isinstance(quant_cfg, dict) else None
+    _log_conversion_mode(
+        f"Found `quantization_config` in hf_config (quant_method={quant_method!r}) -> checkpoint is "
+        "quantized; dequantizing weights."
+    )
+    return dequantize_state_dict(state_dict, hf_config, dtype)

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -480,7 +480,7 @@ def load_and_compute_layer_by_layer(
     from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
     from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
     from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TtPrefillBlock
-    from models.demos.deepseek_v3_d_p.utils.test_utils import dequantize_state_dict, detect_language_model_prefix
+    from models.demos.deepseek_v3_d_p.utils.test_utils import convert_state_dict, detect_language_model_prefix
 
     if gate_fallback_mode is None:
         gate_fallback_mode = GateComputeMode.HOST_ALL
@@ -531,7 +531,7 @@ def load_and_compute_layer_by_layer(
     # --- Process Embeddings ---
     logger.info("Processing embeddings...")
     embed_sd = sub_state_dict(lazy_sd, f"{prefix}model.embed_tokens.")
-    embed_dequant = dequantize_state_dict(embed_sd, config)
+    embed_dequant = convert_state_dict(embed_sd, config)
 
     if compute_reference:
         embed_with_prefix = {f"embed_tokens.{k}": v for k, v in embed_dequant.items()}
@@ -572,7 +572,7 @@ def load_and_compute_layer_by_layer(
         logger.info(f"Processing layer {i}/{num_layers}...")
 
         layer_sd = sub_state_dict(lazy_sd, f"{prefix}model.layers.{i}.")
-        layer_dequant = dequantize_state_dict(layer_sd, config)
+        layer_dequant = convert_state_dict(layer_sd, config)
 
         if compute_reference:
             layer_with_prefix = {f"layers.{i}.{k}": v for k, v in layer_dequant.items()}
@@ -691,7 +691,7 @@ def load_and_compute_layer_by_layer(
     # --- Process Norm ---
     logger.info("Processing norm...")
     norm_sd = sub_state_dict(lazy_sd, f"{prefix}model.norm.")
-    norm_dequant = dequantize_state_dict(norm_sd, config)
+    norm_dequant = convert_state_dict(norm_sd, config)
 
     if compute_reference:
         norm_with_prefix = {f"norm.{k}": v for k, v in norm_dequant.items()}
@@ -720,7 +720,7 @@ def load_and_compute_layer_by_layer(
     # --- Process LM Head ---
     logger.info("Processing lm_head...")
     lm_head_sd = sub_state_dict(lazy_sd, f"{prefix}lm_head.")
-    lm_head_dequant = dequantize_state_dict(lm_head_sd, config)
+    lm_head_dequant = convert_state_dict(lm_head_sd, config)
 
     if compute_reference:
         # Apply lm_head projection: logits = h_ref @ lm_head_weight.T


### PR DESCRIPTION
### Ticket

Closes #52630

### Problem description

The `Blaze - Kimi Prefill Block` job ([failing run](https://github.com/tenstorrent/tt-metal/actions/runs/31241236255/job/93073764769)) dies during weight loading with:

```
ValueError: Missing DeepSeek quantization_config.weight_block_size.
The source checkpoint config must retain the original quantization metadata.
```

The job points `KIMI_K2_6_HF_MODEL` at `/mnt/models/Kimi-K2_6-dequantized`, whose `config.json` has no `quantization_config` at all — the weights are already bf16. But the loader called `dequantize_state_dict` unconditionally, and both dequantizers read quantization metadata before touching a single tensor (fp8 reads `weight_block_size`, INT4 reads its config group). So a checkpoint that needs no dequantization has no way through.

Every model here ships as both a quantized and a dequantized checkpoint behind one loading path, and only the checkpoint's own config distinguishes them.

### What's changed

All within `models/demos/deepseek_v3_d_p/`:

- **`utils/test_utils.py`**
  - `passthrough_state_dict` — materializes an already-dequantized state dict, preserving source dtypes. It preserves them for the same reason `_dequantize_pack_quantized_state_dict` already does on its non-quantized tensors: the fp32 `e_score_correction_bias` feeding the router top-k must not be downcast to bf16. Quantized payload (`_packed` / `_scale_inv` / float8) raises here, since that means quantized weights whose config lost its metadata — better a clear error than garbage tensors.
  - `convert_state_dict` — dequantizes when `quantization_config` is present, passes through when it isn't, and logs which conclusion it reached (once per process; it runs per module and per layer, 60+ times for a full checkpoint). Detection reuses the existing `_get_quantization_config_dict`, so a Kimi checkpoint nesting its config under `text_config` is still correctly read as quantized.
- **`utils/transformer_helpers.py`** — the four `load_and_compute_layer_by_layer` call sites (embed / layer / norm / lm_head) now go through `convert_state_dict`.
- **`tests/conftest.py`** — same swap in `pretrained_transformer_weights` (used by `test_mla` and `test_kv_cache_table`), which had the identical bug against the same checkpoint.
- **`tests/test_dequant_utils.py`** — four new unit tests.

The quantized path is untouched: with a `quantization_config` present, `convert_state_dict` forwards to exactly the dequantizer that ran before.

This PR is self-contained — nothing outside `deepseek_v3_d_p/` changes, and it does not depend on #52744.

### Checklist

Verified on a Blackhole Galaxy (8x4), running the CI job's own commands against the CI model path:

| Test | main | this branch |
| --- | --- | --- |
| `test_kimi_prefill_block` · `pcc-prompt_5k` (dense + moe_gate_device) | 2 failed — `ValueError: Missing DeepSeek quantization_config.weight_block_size` | **2 passed** |
| `test_kimi_prefill_block` · `pcc-prompt_25k` (dense + moe_gate_device) | 2 failed — same | **2 passed** |
| `test_ds_prefill_block` · DeepSeek fp8, quantized path (regression) | 6 passed | **6 passed** |
| `tests/test_dequant_utils.py` | 3 passed | **7 passed** (4 new) |

Block PCC on the Kimi runs: dense 0.9998, moe 0.9995 — both above threshold, at 5k and 25k alike.

Both branches confirmed from the logs:

```
Kimi dequantized:  No `quantization_config` found in hf_config -> checkpoint is already
                   dequantized; passing weights through without dequantization.
DeepSeek fp8:      Found `quantization_config` in hf_config (quant_method='fp8') ->
                   checkpoint is quantized; dequantizing weights.
```

- CI: [Blaze Models Prefill tests — `kimi_prefill_block` on this branch](https://github.com/tenstorrent/tt-metal/actions/runs/31413877062)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
