### PR TITLE
#52630: Split state-dict conversion from dequantization in hf_model_utils

### DIFF
--- a/models/demos/deepseek_v3/tests/test_hf_model_utils.py
+++ b/models/demos/deepseek_v3/tests/test_hf_model_utils.py
@@ -15,6 +15,7 @@ import torch
 
 from models.demos.deepseek_v3.utils.hf_model_utils import (
     _default_quad_ring_shard_maps,
+    convert_state_dict,
     default_quad_ring_model_path,
     default_stacked_dequantized_model_path,
     index_model_weights,
@@ -412,7 +413,7 @@ def test_save_dequantized_hf_checkpoint_rewrites_dequantized_shards_when_stackin
     )
 
 
-def test_save_dequantized_hf_checkpoint_rejects_incomplete_stacked_expert_groups(tmp_path: Path):
+def test_save_dequantized_hf_checkpoint_rejects_incomplete_stacked_expert_groups(tmp_path: Path, expect_error):
     source_dir = tmp_path / "deepseek-source"
     output_dir = default_stacked_dequantized_model_path(source_dir)
     source_dir.mkdir(parents=True, exist_ok=True)
@@ -427,11 +428,11 @@ def test_save_dequantized_hf_checkpoint_rejects_incomplete_stacked_expert_groups
     safetensors.torch.save_file(expert_tensors, str(shard))
     _write_index(source_dir, {key: shard.name for key in expert_tensors})
 
-    with pytest.raises(ValueError, match="do not match n_routed_experts=2"):
+    with expect_error(ValueError, "do not match n_routed_experts=2"):
         save_dequantized_hf_checkpoint(source_dir, output_model_path=output_dir, stack_experts=True)
 
 
-def test_save_dequantized_hf_checkpoint_rejects_missing_required_moe_projection_groups(tmp_path: Path):
+def test_save_dequantized_hf_checkpoint_rejects_missing_required_moe_projection_groups(tmp_path: Path, expect_error):
     source_dir = tmp_path / "deepseek-source"
     output_dir = default_stacked_dequantized_model_path(source_dir)
     source_dir.mkdir(parents=True, exist_ok=True)
@@ -460,7 +461,7 @@ def test_save_dequantized_hf_checkpoint_rejects_missing_required_moe_projection_
     safetensors.torch.save_file(expert_tensors, str(shard))
     _write_index(source_dir, {key: shard.name for key in expert_tensors})
 
-    with pytest.raises(ValueError, match="missing required expert projections"):
+    with expect_error(ValueError, "missing required expert projections"):
         save_dequantized_hf_checkpoint(source_dir, output_model_path=output_dir, stack_experts=True)
 
 
@@ -521,6 +522,75 @@ def test_dequantize_state_dict_compat_shim_handles_quantized_inputs():
     assert torch.equal(dequantized["plain.weight"], plain_weight.to(torch.bfloat16))
 
 
+def test_convert_state_dict_passes_through_dequantized_checkpoint():
+    # A dequantized checkpoint's config.json carries no `quantization_config`, so nothing may reach the
+    # dequantizer -- it would raise on the missing `weight_block_size` (the Kimi prefill-block failure).
+    hf_config = SimpleNamespace()
+    weight = torch.tensor([[1.25, -0.75]], dtype=torch.float32)
+    token_ids = torch.tensor([3, 7], dtype=torch.int64)
+
+    def _must_not_run(*args, **kwargs):
+        raise AssertionError("dequantizer must not be called for an unquantized checkpoint")
+
+    converted = convert_state_dict(
+        {"layer.weight": weight, "embed.ids": token_ids},
+        hf_config,
+        dequantizer=_must_not_run,
+    )
+
+    assert set(converted) == {"layer.weight", "embed.ids"}
+    assert converted["layer.weight"].dtype == torch.bfloat16
+    assert torch.equal(converted["layer.weight"], weight.to(torch.bfloat16))
+    assert converted["embed.ids"].dtype == torch.int64
+    assert torch.equal(converted["embed.ids"], token_ids)
+
+
+def test_convert_state_dict_dequantizes_quantized_checkpoint():
+    quantized_weight = torch.tensor([[1.0, -2.0], [3.0, -4.0]], dtype=torch.float32).to(torch.float8_e4m3fn)
+    inverse_scale = torch.tensor([[0.5]], dtype=torch.float32)
+    hf_config = SimpleNamespace(quantization_config={"weight_block_size": [2, 2]})
+
+    converted = convert_state_dict(
+        {"layer.weight": quantized_weight, "layer.weight_scale_inv": inverse_scale},
+        hf_config,
+    )
+
+    assert set(converted) == {"layer.weight"}
+    assert torch.equal(
+        converted["layer.weight"],
+        _dequantize_reference_tensor(quantized_weight, inverse_scale, (2, 2)).to(torch.bfloat16),
+    )
+
+
+def test_convert_state_dict_reads_quantization_config_nested_under_text_config():
+    # Kimi's multimodal checkpoint nests the LM config; missing it would pass fp8 weights through raw.
+    quantized_weight = torch.tensor([[1.0, -2.0], [3.0, -4.0]], dtype=torch.float32).to(torch.float8_e4m3fn)
+    inverse_scale = torch.tensor([[0.5]], dtype=torch.float32)
+    hf_config = SimpleNamespace(text_config=SimpleNamespace(quantization_config={"weight_block_size": [2, 2]}))
+
+    seen = {}
+
+    def _record(state_dict, config, dtype):
+        seen["called"] = True
+        return {"layer.weight": torch.zeros(1)}
+
+    convert_state_dict(
+        {"layer.weight": quantized_weight, "layer.weight_scale_inv": inverse_scale},
+        hf_config,
+        dequantizer=_record,
+    )
+
+    assert seen.get("called") is True
+
+
+def test_convert_state_dict_rejects_float8_without_quantization_config(expect_error):
+    hf_config = SimpleNamespace()
+    quantized_weight = torch.tensor([[1.0, -2.0]], dtype=torch.float32).to(torch.float8_e4m3fn)
+
+    with expect_error(ValueError, "no `quantization_config`"):
+        convert_state_dict({"layer.weight": quantized_weight}, hf_config)
+
+
 def test_prepare_model_state_dict_returns_lazy_state_dict_for_hf_weights(tmp_path: Path):
     model_dir = tmp_path / "deepseek-dequantized"
     model_dir.mkdir(parents=True, exist_ok=True)
@@ -551,7 +621,7 @@ def test_prepare_model_state_dict_returns_lazy_state_dict_for_hf_weights(tmp_pat
     assert torch.equal(state_dict["lm_head.weight"], lm_head)
 
 
-def test_prepare_model_state_dict_rejects_quantized_hf_weights(tmp_path: Path):
+def test_prepare_model_state_dict_rejects_quantized_hf_weights(tmp_path: Path, expect_error):
     model_dir = tmp_path / "deepseek-quantized"
     model_dir.mkdir(parents=True, exist_ok=True)
 
@@ -573,7 +643,7 @@ def test_prepare_model_state_dict_rejects_quantized_hf_weights(tmp_path: Path):
         },
     )
 
-    with pytest.raises(RuntimeError, match="Detected quantized HF tensors"):
+    with expect_error(RuntimeError, "Detected quantized HF tensors"):
         prepare_model_state_dict(SimpleNamespace(), random_weights=False, model_path=str(model_dir))
 
 
@@ -667,7 +737,7 @@ def test_materialized_stacked_checkpoint_load_hooks_resolve_expert_aliases(tmp_p
     assert target_tensor.numel() == 0
 
 
-def test_load_weight_from_weights_dict_rejects_mixed_expert_checkpoint():
+def test_load_weight_from_weights_dict_rejects_mixed_expert_checkpoint(expect_error):
     expert_key = "model.layers.3.mlp.experts.1.gate_proj.weight"
     stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
     weights_dict = {
@@ -678,7 +748,7 @@ def test_load_weight_from_weights_dict_rejects_mixed_expert_checkpoint():
     load_weight = load_weight_from_weights_dict(weights_dict)
     unload_weight = unload_weight_from_weights_dict(weights_dict)
 
-    with pytest.raises(RuntimeError, match="mixes legacy expert tensor"):
+    with expect_error(RuntimeError, "mixes legacy expert tensor"):
         load_weight(expert_key, torch.empty((2, 4), dtype=torch.bfloat16))
-    with pytest.raises(RuntimeError, match="mixes legacy expert tensor"):
+    with expect_error(RuntimeError, "mixes legacy expert tensor"):
         unload_weight(expert_key, torch.empty((2, 4), dtype=torch.bfloat16))

--- a/models/demos/deepseek_v3/utils/hf_model_utils.py
+++ b/models/demos/deepseek_v3/utils/hf_model_utils.py
@@ -174,8 +174,22 @@ def _get_weight_block_shape_from_quant_config(quantization_config: Any) -> tuple
     return tuple(int(dim) for dim in block_shape)
 
 
+def get_quantization_config(hf_config: Any) -> Any | None:
+    """Return the checkpoint's `quantization_config`, or `None` when the checkpoint is already dequantized.
+
+    Multimodal checkpoints (Kimi) nest the language-model config under `text_config`, so look there too --
+    otherwise a quantized checkpoint reads as dequantized and its weights are passed through raw.
+    """
+    quantization_config = getattr(hf_config, "quantization_config", None)
+    if quantization_config is None:
+        text_config = getattr(hf_config, "text_config", None)
+        if text_config is not None:
+            quantization_config = getattr(text_config, "quantization_config", None)
+    return quantization_config
+
+
 def get_weight_block_shape(hf_config: PretrainedConfig) -> tuple[int, ...]:
-    return _get_weight_block_shape_from_quant_config(getattr(hf_config, "quantization_config", None))
+    return _get_weight_block_shape_from_quant_config(get_quantization_config(hf_config))
 
 
 def get_weight_block_shape_from_model_path(model_path: str | Path) -> tuple[int, ...]:
@@ -241,6 +255,42 @@ def dequantize_weight_tensor(
     return out[original_slices].to(dtype).contiguous()
 
 
+def _cast_unquantized_tensor(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    """Materialize an already-dequantized tensor: floats are cast to `dtype`, everything else is copied."""
+    return tensor.to(dtype).contiguous() if tensor.is_floating_point() else tensor.clone()
+
+
+def _iter_weight_names(state_dict: Mapping[str, torch.Tensor]) -> list[str]:
+    """Weight keys of a (sub-)state_dict in a stable order, excluding the `_scale_inv` companions."""
+    return sorted(key for key in state_dict.keys() if not key.endswith("_scale_inv"))
+
+
+def passthrough_state_dict(
+    state_dict: Mapping[str, torch.Tensor],
+    dtype: torch.dtype = torch.bfloat16,
+) -> dict[str, torch.Tensor]:
+    """Convert an already-dequantized (sub-)state_dict without touching quantization metadata.
+
+    This is the no-scale half of `dequantize_state_dict`, split out so a checkpoint that ships without a
+    `quantization_config` never enters the dequantization path -- that path needs
+    `quantization_config.weight_block_size` and raises when the config does not carry it.
+    """
+    converted_state_dict: dict[str, torch.Tensor] = {}
+
+    for name in _iter_weight_names(state_dict):
+        tensor = state_dict[name]
+        if tensor is None:
+            raise ValueError(f"Expected tensor {name} to exist in state_dict but it was None")
+        if tensor.dtype == torch.float8_e4m3fn:
+            raise ValueError(
+                f"Found float8 tensor '{name}' in a checkpoint whose config has no `quantization_config`. "
+                "The weights are quantized but the dequantization metadata is missing from config.json."
+            )
+        converted_state_dict[name] = _cast_unquantized_tensor(tensor, dtype)
+
+    return converted_state_dict
+
+
 def dequantize_state_dict(
     state_dict: Mapping[str, torch.Tensor],
     hf_config: PretrainedConfig,
@@ -249,7 +299,7 @@ def dequantize_state_dict(
     dequantized_state_dict: dict[str, torch.Tensor] = {}
     block_shape = get_weight_block_shape(hf_config)
 
-    for name in sorted(key for key in state_dict.keys() if not key.endswith("_scale_inv")):
+    for name in _iter_weight_names(state_dict):
         tensor = state_dict[name]
         if tensor is None:
             raise ValueError(f"Expected tensor {name} to exist in state_dict but it was None")
@@ -263,9 +313,56 @@ def dequantize_state_dict(
 
         if tensor.dtype == torch.float8_e4m3fn:
             raise ValueError(f"Found float8 tensor '{name}' without matching inverse scale '{scale_name}'.")
-        dequantized_state_dict[name] = tensor.to(dtype).contiguous() if tensor.is_floating_point() else tensor.clone()
+        dequantized_state_dict[name] = _cast_unquantized_tensor(tensor, dtype)
 
     return dequantized_state_dict
+
+
+_LOGGED_CONVERSION_MODES: set[str] = set()
+
+
+def _log_conversion_mode(message: str) -> None:
+    """Log the quantized/dequantized conclusion once per process; repeats drop to debug.
+
+    `convert_state_dict` runs per module and per layer (60+ times for a full checkpoint), so logging at
+    info every time would bury the rest of the weight-load output.
+    """
+    if message in _LOGGED_CONVERSION_MODES:
+        logger.debug(message)
+        return
+    _LOGGED_CONVERSION_MODES.add(message)
+    logger.info(message)
+
+
+def convert_state_dict(
+    state_dict: Mapping[str, torch.Tensor],
+    hf_config: PretrainedConfig,
+    dtype: torch.dtype = torch.bfloat16,
+    dequantizer: Callable[..., dict[str, torch.Tensor]] | None = None,
+) -> dict[str, torch.Tensor]:
+    """Bring a (sub-)state_dict into `dtype`, dequantizing only when the checkpoint is actually quantized.
+
+    Every model ships in a quantized and a dequantized variant behind the same loading path, and only the
+    checkpoint's config tells them apart: a `quantization_config` means quantized weights, so we hand off
+    to `dequantizer` (default `dequantize_state_dict`); its absence means the checkpoint is already
+    dequantized, so the weights are passed through untouched. Callers with their own dequantizer -- e.g.
+    the d_p pipeline, which owns Kimi's INT4 pack-quant path -- inject it through `dequantizer`.
+    """
+    quantization_config = get_quantization_config(hf_config)
+
+    if quantization_config is None:
+        _log_conversion_mode(
+            "No `quantization_config` found in hf_config -> checkpoint is already dequantized; "
+            "passing weights through without dequantization."
+        )
+        return passthrough_state_dict(state_dict, dtype)
+
+    quant_method = quantization_config.get("quant_method") if isinstance(quantization_config, dict) else None
+    _log_conversion_mode(
+        f"Found `quantization_config` in hf_config (quant_method={quant_method!r}) -> checkpoint is "
+        "quantized; dequantizing weights."
+    )
+    return (dequantizer or dequantize_state_dict)(state_dict, hf_config, dtype)
 
 
 def _load_model_weight_map(model_path: Path) -> tuple[dict[str, str], dict[str, Any]]:


### PR DESCRIPTION
### Ticket

Related to #52630 (the CI fix itself is #52743, which does not depend on this PR).

### Problem description

`dequantize_state_dict` has always done two jobs: dequantize tensors that carry a `_scale_inv` companion, and pass everything else through with a dtype cast. But it reads `quantization_config.weight_block_size` up front, before it looks at a single tensor:

```python
def dequantize_state_dict(state_dict, hf_config, dtype=torch.bfloat16):
    block_shape = get_weight_block_shape(hf_config)   # raises here
    ...
```

So the pass-through half is unreachable for a checkpoint whose config carries no quantization metadata at all — the function raises before it can discover that there was nothing to dequantize:

```
ValueError: Missing DeepSeek quantization_config.weight_block_size.
```

Every model here ships as both a quantized and a dequantized variant, and only the config distinguishes them, so callers can't know in advance which function to reach for. This surfaced as a Kimi CI failure (#52630, fixed independently in #52743); this PR addresses the shared helper so any consumer of `hf_model_utils` can load either variant.

### What's changed

`models/demos/deepseek_v3/utils/hf_model_utils.py`:

- **`passthrough_state_dict`** — the no-scale half of `dequantize_state_dict`, extracted verbatim. Raises on a float8 tensor, which means quantized weights whose config lost its metadata.
- **`convert_state_dict`** — dequantizes when `quantization_config` is present, passes through when it isn't, and logs which conclusion it reached (once per process, since callers invoke it per module and per layer). An optional `dequantizer` hook lets a caller substitute its own dequantizer.
- **`get_quantization_config`** — resolves the config, also looking under `text_config` for multimodal checkpoints (Kimi K2.5/K2.6) that nest the LM config there. Without this a quantized Kimi reads as dequantized and its fp8 weights would be passed through raw.

No existing caller changes behavior:

- `dequantize_state_dict` keeps its signature and semantics; only its two shared bodies are factored into `_cast_unquantized_tensor` / `_iter_weight_names`.
- `get_weight_block_shape` only gains the `text_config` fallback — a strict widening of what it already accepted.

The pre-existing `pytest.raises` calls in `test_hf_model_utils.py` are converted to the `expect_error` fixture, since the `prefer-expect-error` pre-commit hook blocks any commit touching that file otherwise.

### Checklist

- `models/demos/deepseek_v3/tests/test_hf_model_utils.py` — **24 passed** (20 before, 4 new covering pass-through, dequantize, `text_config` nesting, and the float8-without-config error).

The four new tests pin both branches of the decision and the nesting case; the existing 20 pin that nothing else moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/52630-convert-state-dict)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/52630-convert-state-dict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/52630-convert-state-dict)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/52630-convert-state-dict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kgrujcic/52630-convert-state-dict)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kgrujcic/52630-convert-state-dict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/52630-convert-state-dict)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/52630-convert-state-dict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/52630-convert-state-dict)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/52630-convert-state-dict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/52630-convert-state-dict)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/52630-convert-state-dict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/52630-convert-state-dict)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/52630-convert-state-dict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/52630-convert-state-dict)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/52630-convert-state-dict)