### PR TITLE
Fix curl URL-globbing failure on bot PR authors in codeowners ping

### DIFF
--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -1028,7 +1028,7 @@ jobs:
                     for member in "${MEMBERS_ARRAY[@]}"; do
                       member_name="$member"
                       if [ -n "$member" ] && [ "$member" != " " ]; then
-                        USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/users/$member" 2>/dev/null)
+                        USER_DATA=$(curl -s -g -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/users/$member" 2>/dev/null)
                         USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
                         [ -n "$USER_NAME" ] && [ "$USER_NAME" != "null" ] && member_name="$USER_NAME"
                       fi
@@ -1173,7 +1173,7 @@ jobs:
                 IFS=',' read -ra DIRECT_ARRAY <<< "$direct_approvers_set"
                 for member in "${DIRECT_ARRAY[@]}"; do
                   [ -z "$member" ] && continue
-                  USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/users/$member" 2>/dev/null)
+                  USER_DATA=$(curl -s -g -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/users/$member" 2>/dev/null)
                   USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
                   [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ] && USER_NAME="$member"
                   direct_approved="$direct_approved$USER_NAME, "
@@ -1185,7 +1185,7 @@ jobs:
                 IFS=',' read -ra SHARED_ARRAY <<< "$shared_approvers_set"
                 for member in "${SHARED_ARRAY[@]}"; do
                   [ -z "$member" ] && continue
-                  USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/users/$member" 2>/dev/null)
+                  USER_DATA=$(curl -s -g -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/users/$member" 2>/dev/null)
                   USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
                   [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ] && USER_NAME="$member"
                   shared_approved="$shared_approved$USER_NAME, "
@@ -1489,7 +1489,7 @@ jobs:
           if [ -n "$REQUESTER_LOGIN" ] && [ "$REQUESTER_LOGIN" != "$PR_AUTHOR_LOGIN" ]; then
             echo "DEBUG: Requester and PR author are different users"
             REQUESTER_USER_API="https://api.github.com/users/$REQUESTER_LOGIN"
-            REQUESTER_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+            REQUESTER_USER_DATA=$(curl -s -g -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                                    -H "Accept: application/vnd.github.v3+json" \
                                    "$REQUESTER_USER_API" 2>/dev/null)
             REQUESTER_FULL_NAME=$(echo "$REQUESTER_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
@@ -1574,7 +1574,7 @@ jobs:
           PR_AUTHOR_FULL_NAME="$PR_AUTHOR_NAME"
           if [ "$PR_AUTHOR_FULL_NAME" = "$PR_AUTHOR_LOGIN" ] || [ -z "$PR_AUTHOR_FULL_NAME" ] || [ "$PR_AUTHOR_FULL_NAME" = "null" ]; then
             AUTHOR_USER_API="https://api.github.com/users/$PR_AUTHOR_LOGIN"
-            AUTHOR_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+            AUTHOR_USER_DATA=$(curl -s -g -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                                    -H "Accept: application/vnd.github.v3+json" \
                                    "$AUTHOR_USER_API" 2>/dev/null)
             AUTHOR_FULL_NAME=$(echo "$AUTHOR_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
@@ -1716,7 +1716,7 @@ jobs:
                   # This is an individual user
                   # Get full name from GitHub API
                   USER_API="https://api.github.com/users/$clean_item"
-                  USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                  USER_DATA=$(curl -s -g -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                                  -H "Accept: application/vnd.github.v3+json" \
                                  "$USER_API" 2>/dev/null)
                   USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
@@ -1788,7 +1788,7 @@ jobs:
                   fi
 
                   USER_API="https://api.github.com/users/$clean_username"
-                  USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                  USER_DATA=$(curl -s -g -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                                  -H "Accept: application/vnd.github.v3+json" \
                                  "$USER_API" 2>/dev/null)
                   USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
@@ -2490,7 +2490,7 @@ jobs:
               if [ -n "$owner" ]; then
                 # Get user info
                 USER_API="https://api.github.com/users/$owner"
-                USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                USER_DATA=$(curl -s -g -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                                -H "Accept: application/vnd.github.v3+json" \
                                "$USER_API" 2>/dev/null)
                 USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
@@ -2512,7 +2512,7 @@ jobs:
             if [ "$PR_AUTHOR_FULL_NAME" = "$PR_AUTHOR_LOGIN" ] || [ -z "$PR_AUTHOR_FULL_NAME" ] || [ "$PR_AUTHOR_FULL_NAME" = "null" ]; then
               # Try to fetch full name from GitHub API
               AUTHOR_USER_API="https://api.github.com/users/$PR_AUTHOR_LOGIN"
-              AUTHOR_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+              AUTHOR_USER_DATA=$(curl -s -g -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                                      -H "Accept: application/vnd.github.v3+json" \
                                      "$AUTHOR_USER_API" 2>/dev/null)
               AUTHOR_FULL_NAME=$(echo "$AUTHOR_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
@@ -2714,7 +2714,7 @@ jobs:
                 if [ -n "$owner" ]; then
                   # Get full name for this owner
                   USER_API="https://api.github.com/users/$owner"
-                  USER_RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                  USER_RESPONSE=$(curl -s -g -w '\n%{http_code}' -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                                  -H "Accept: application/vnd.github.v3+json" \
                                  "$USER_API" 2>/dev/null)
                   USER_HTTP_CODE=$(echo "$USER_RESPONSE" | tail -n1)
@@ -2745,7 +2745,7 @@ jobs:
             PR_AUTHOR_FULL_NAME="$PR_AUTHOR_NAME"
             if [ "$PR_AUTHOR_FULL_NAME" = "$PR_AUTHOR_LOGIN" ] || [ -z "$PR_AUTHOR_FULL_NAME" ] || [ "$PR_AUTHOR_FULL_NAME" = "null" ]; then
               AUTHOR_USER_API="https://api.github.com/users/$PR_AUTHOR_LOGIN"
-              AUTHOR_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+              AUTHOR_USER_DATA=$(curl -s -g -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                                      -H "Accept: application/vnd.github.v3+json" \
                                      "$AUTHOR_USER_API" 2>/dev/null)
               AUTHOR_FULL_NAME=$(echo "$AUTHOR_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
@@ -2767,7 +2767,7 @@ jobs:
             if [ -n "$REQUESTER_LOGIN" ] && [ "$REQUESTER_LOGIN" != "$PR_AUTHOR_LOGIN" ]; then
               # Get full name for requester if available
               REQUESTER_USER_API="https://api.github.com/users/$REQUESTER_LOGIN"
-              REQUESTER_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+              REQUESTER_USER_DATA=$(curl -s -g -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                                      -H "Accept: application/vnd.github.v3+json" \
                                      "$REQUESTER_USER_API" 2>/dev/null)
               REQUESTER_FULL_NAME=$(echo "$REQUESTER_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
@@ -2836,7 +2836,7 @@ jobs:
 
                     # Get full name from GitHub API
                     USER_API="https://api.github.com/users/$clean_username"
-                    USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                    USER_DATA=$(curl -s -g -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                                    -H "Accept: application/vnd.github.v3+json" \
                                    "$USER_API" 2>/dev/null)
                     USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)


### PR DESCRIPTION
## What
Adds `-g` (`--globoff`) to the 13 `curl` calls in `codeowners-group-analysis.yaml` that resolve a GitHub login to a display name via `https://api.github.com/users/$LOGIN`.

## Why
`curl` treats `[` and `]` in a URL as glob range syntax unless `--globoff` is passed. Bot logins such as `github-actions[bot]` or `dependabot[bot]` spliced unescaped into the users-API URL trip this, and curl exits 3 ("URL malformed") without making any request:

```
$ curl -s -o /dev/null -w "%{http_code}\n" "https://api.github.com/users/github-actions[bot]"
exit=3
```

Every one of these lookups runs inside a `set -e` shell, so the failure kills the step immediately. In practice this means `/codeowners ping` silently fails to notify anyone whenever the PR author, the comment author, or a selected reviewer resolves to a bot login — which is routine on agentic-workflow-authored PRs, but doesn't show up on ordinary human-authored PRs since normal GitHub usernames can't contain `[` or `]`.

## Verification
- Purely additive flag (`-g`) on existing `curl` invocations; no control-flow or output-format change for the non-bot case.
- Confirmed the failure mode locally with the repro above (exit 3, matches the observed step failure).
- All 13 sites in the file that build a `/users/$VAR` URL from a variable login were updated; verified via `grep -n '/users/\$'` that no site was missed.
- `yaml.safe_load` confirms the file is still valid YAML.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/codeowners-ping-bot-author-url)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/codeowners-ping-bot-author-url)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/codeowners-ping-bot-author-url)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/codeowners-ping-bot-author-url)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix/codeowners-ping-bot-author-url)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix/codeowners-ping-bot-author-url)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/codeowners-ping-bot-author-url)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/codeowners-ping-bot-author-url)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/codeowners-ping-bot-author-url)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/codeowners-ping-bot-author-url)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/codeowners-ping-bot-author-url)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/codeowners-ping-bot-author-url)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/codeowners-ping-bot-author-url)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/codeowners-ping-bot-author-url)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/codeowners-ping-bot-author-url)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/codeowners-ping-bot-author-url)