### PR TITLE
[TEN-4746] Disarm TDMA guard on single-tile llk_pack

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
@@ -86,6 +86,7 @@ inline std::uint32_t get_output_tile_index(std::uint8_t output_id, std::uint32_t
 template <bool out_of_order_output = false>
 inline void llk_pack(
     const std::uint32_t tile_index, const std::uint32_t pack_output, const std::uint32_t output_tile_index = 0) {
+    LLK_TDMA_GUARD_NOTE_TDMA(pack_output);  // TEN-4746: real pack (PACR) disarms this dfb
     const std::uint8_t output_id = get_output_id(pack_output);
     const std::uint32_t l1_tile_index = get_output_tile_index<out_of_order_output, false>(output_id, output_tile_index);
     const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);


### PR DESCRIPTION
The Quasar per-DFB TDMA guard was only disarmed on llk_pack_block and llk_pack_untilize, so the common cb_reserve_back -> pack_tile -> cb_push_back path stayed armed and falsely asserted in LLK-assert builds. Add the missing LLK_TDMA_GUARD_NOTE_TDMA notification to the single-tile llk_pack path, matching the block pack path.

Validated with the Quasar SFPU single-core compute suite (unit_tests_llk, SingleCoreSfpuCompute/*) on emu-quasar-1x3: 42 passed, 4 skipped.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/ten4746-llk-pack-tdma-disarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/ten4746-llk-pack-tdma-disarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rtawfik/ten4746-llk-pack-tdma-disarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rtawfik/ten4746-llk-pack-tdma-disarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=rtawfik/ten4746-llk-pack-tdma-disarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:rtawfik/ten4746-llk-pack-tdma-disarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/ten4746-llk-pack-tdma-disarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/ten4746-llk-pack-tdma-disarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rtawfik/ten4746-llk-pack-tdma-disarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rtawfik/ten4746-llk-pack-tdma-disarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/ten4746-llk-pack-tdma-disarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/ten4746-llk-pack-tdma-disarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/ten4746-llk-pack-tdma-disarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/ten4746-llk-pack-tdma-disarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/ten4746-llk-pack-tdma-disarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/ten4746-llk-pack-tdma-disarm)