### PR TITLE
tests: gate fixed-topology fabric cases by cluster requirements

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_custom_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_custom_routing_tables.cpp
@@ -38,7 +38,15 @@ std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::files
 
 namespace tt::tt_fabric::fabric_router_tests {
 
+static bool has_n300_2x2_topology() {
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() ==
+           tt::tt_metal::ClusterType::N300_2x2;
+}
+
 TEST_F(ControlPlaneFixture, TestCustom2x2ControlPlaneInit) {
+    if (!has_n300_2x2_topology()) {
+        GTEST_SKIP() << "Test requires a four-chip N300 2x2 cluster";
+    }
     const std::filesystem::path mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/n300_2x2_mesh_graph_descriptor.textproto";
@@ -48,6 +56,9 @@ TEST_F(ControlPlaneFixture, TestCustom2x2ControlPlaneInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestCustom2x2MeshAPIs) {
+    if (!has_n300_2x2_topology()) {
+        GTEST_SKIP() << "Test requires a four-chip N300 2x2 cluster";
+    }
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto user_meshes = control_plane.get_user_physical_mesh_ids();
     EXPECT_EQ(user_meshes.size(), 1);
@@ -58,6 +69,9 @@ TEST_F(ControlPlaneFixture, TestCustom2x2MeshAPIs) {
 }
 
 TEST_F(ControlPlaneFixture, TestCustom2x2ControlPlaneInitMGD2) {
+    if (!has_n300_2x2_topology()) {
+        GTEST_SKIP() << "Test requires a four-chip N300 2x2 cluster";
+    }
     const std::filesystem::path mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/n300_2x2_mesh_graph_descriptor.textproto";

--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -37,6 +37,10 @@ using tt::tt_fabric::fabric_router_tests::expect_mesh_graph_host_topology_matche
 
 namespace tt::tt_fabric::multi_host_tests {
 
+static bool has_multiple_world_ranks() {
+    return *tt::tt_metal::MetalContext::instance().full_world_distributed_context().size() > 1;
+}
+
 std::vector<std::pair<FabricNodeId, FabricNodeId>> get_all_intermesh_connections(const ControlPlane& control_plane) {
     std::vector<std::pair<FabricNodeId, FabricNodeId>> all_intermesh_connections;
     const auto& inter_conn = control_plane.get_mesh_graph().get_inter_mesh_connectivity();
@@ -533,6 +537,9 @@ TEST(MultiHost, TestDual2x4Fabric1DSanity) {
 }
 
 TEST(MultiHost, TestSplit2x2ControlPlaneInit) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Split 2x2 topology requires a multi-host rank layout";
+    }
     const std::filesystem::path split_2x2_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.textproto";
@@ -547,6 +554,9 @@ TEST(MultiHost, TestSplit2x2ControlPlaneInit) {
 }
 
 TEST(MultiHost, TestSplit2x2Fabric2DSanity) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Split 2x2 topology requires a multi-host rank layout";
+    }
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
     tt::tt_metal::MetalContext::instance().initialize_fabric_config();
@@ -592,6 +602,9 @@ TEST(MultiHost, TestSplit2x2Fabric1DSanity) {
 }
 
 TEST(MultiHost, TestBigMesh2x4ControlPlaneInit) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Big-mesh 2x4 topology requires a multi-host rank layout";
+    }
     const std::filesystem::path big_mesh_2x4_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.textproto";
@@ -606,6 +619,9 @@ TEST(MultiHost, TestBigMesh2x4ControlPlaneInit) {
 }
 
 TEST(MultiHost, TestBigMesh2x4Fabric2DSanity) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Big-mesh 2x4 topology requires a multi-host rank layout";
+    }
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
     tt::tt_metal::MetalContext::instance().initialize_fabric_config();
@@ -628,6 +644,9 @@ TEST(MultiHost, TestBigMesh2x4Fabric2DSanity) {
 }
 
 TEST(MultiHost, TestBigMesh2x4Fabric1DSanity) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Big-mesh 2x4 topology requires a multi-host rank layout";
+    }
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_1D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
     tt::tt_metal::MetalContext::instance().initialize_fabric_config();
@@ -1022,6 +1041,9 @@ TEST(MultiHost, TestBHQB4x4Fabric1DSanity) {
 }
 
 TEST(MultiHost, TestClosetBox3PodTTSwitchControlPlaneInit) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Closet-box topology requires a multi-host rank layout";
+    }
     const std::filesystem::path mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_closetbox_3pod_ttswitch_mgd.textproto";
@@ -1053,6 +1075,9 @@ TEST(MultiHost, TestBHQB4x4RelaxedControlPlaneInit) {
 }
 
 TEST(MultiHost, TestClosetBox3PodTTSwitchAPIs) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Closet-box topology requires a multi-host rank layout";
+    }
     const std::filesystem::path mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_closetbox_3pod_ttswitch_mgd.textproto";
@@ -1635,6 +1660,9 @@ TEST(MultiHost, BHDualGalaxyFabric2DSanity) {
 }
 
 TEST(MultiHost, T3K2x2AssignZDirectionControlPlaneInit) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "T3K split-2x2 topology requires a multi-host rank layout";
+    }
     const std::filesystem::path t3k_2x2_assign_z_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_assign_z_direction_mesh_graph_descriptor.textproto";
@@ -1665,6 +1693,9 @@ TEST(MultiHost, T3KAssignZConflictFatal) {
 }
 
 TEST(MultiHost, T3K2x2AssignZDirectionFabric2DSanity) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "T3K split-2x2 topology requires a multi-host rank layout";
+    }
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
     tt::tt_metal::MetalContext::instance().initialize_fabric_config();
@@ -1789,6 +1820,9 @@ TEST(MultiHost, TestDual4x8ZDirectionFallbackControlPlaneInit) {
 }
 
 TEST(MultiHost, TestBHBlitzPipelineControlPlaneInit) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Blitz pipeline topology requires a multi-host rank layout";
+    }
     const std::filesystem::path bh_blitz_pipeline_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/bh_glx_split_4x2.textproto";
@@ -1813,6 +1847,9 @@ TEST(MultiHost, TestBHBlitzPipelineControlPlaneInit) {
 }
 
 TEST(MultiHost, TestBlitzSuperpodAutoMapperControlPlaneInit) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Blitz superpod topology requires a multi-host rank layout";
+    }
     auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
     std::filesystem::path blitz_superpod_mesh_graph_desc_path =
         std::filesystem::path(rtoptions.get_root_dir()) /
@@ -1844,6 +1881,9 @@ TEST(MultiHost, TestBlitzSuperpodAutoMapperControlPlaneInit) {
 }
 
 TEST(MultiHost, TestBHBlitzPipelineFabric2DSanity) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Blitz pipeline topology requires a multi-host rank layout";
+    }
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
     tt::tt_metal::MetalContext::instance().initialize_fabric_config();
@@ -1864,6 +1904,9 @@ TEST(MultiHost, TestBHBlitzPipelineFabric2DSanity) {
 }
 
 TEST(MultiHost, TestBHBlitzPipelineFabric1DSanity) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Blitz pipeline topology requires a multi-host rank layout";
+    }
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_1D, tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
     tt::tt_metal::MetalContext::instance().initialize_fabric_config();
@@ -1884,6 +1927,9 @@ TEST(MultiHost, TestBHBlitzPipelineFabric1DSanity) {
 }
 
 TEST(MultiHost, TestTriplePod32x4QuadBHGalaxyControlPlaneInit) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Triple-pod topology requires a multi-host rank layout";
+    }
     const std::filesystem::path triple_pod_32x4_quad_bh_galaxy_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/triple_pod_32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto";
@@ -1900,6 +1946,9 @@ TEST(MultiHost, TestTriplePod32x4QuadBHGalaxyControlPlaneInit) {
 }
 
 TEST(MultiHost, TestTriplePod32x4QuadBHGalaxyFabric2DSanity) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Triple-pod topology requires a multi-host rank layout";
+    }
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
@@ -1921,6 +1970,9 @@ TEST(MultiHost, TestTriplePod32x4QuadBHGalaxyFabric2DSanity) {
 }
 
 TEST(MultiHost, TestTriplePod32x4QuadBHGalaxyFabric1DSanity) {
+    if (!has_multiple_world_ranks()) {
+        GTEST_SKIP() << "Triple-pod topology requires a multi-host rank layout";
+    }
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_1D_RING,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -148,6 +148,23 @@ namespace tt::tt_fabric::fabric_router_tests {
 
 using ::testing::ElementsAre;
 
+static bool has_cluster_type(tt::tt_metal::ClusterType required_type) {
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == required_type;
+}
+
+static bool has_galaxy_topology() {
+    const auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+    return cluster_type == tt::tt_metal::ClusterType::GALAXY ||
+           cluster_type == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY;
+}
+
+static bool has_single_galaxy_topology() {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& world = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    return has_cluster_type(tt::tt_metal::ClusterType::GALAXY) &&
+           cluster.get_cluster_desc()->get_all_chips().size() == 32 && *world->size() == 1;
+}
+
 TEST(MeshGraphValidation, TestMGDConnections) {
     // TODO: This test is currently not implemented completely connection types currently cannot be mixed
     // Skip for now
@@ -195,6 +212,9 @@ TEST_F(ControlPlaneFixture, TestControlPlaneInitNoMGD) {
 // checks for shapes 1x1, 1x2, 2x2, 2x4, 2x8, 4x4 (two-tray), 4x8, 4x16, 4x32, 8x16 (rank 0 only in multihost).
 // Four-tray 4x4 split-host layouts use TestGalaxy4x4SplitHostLayoutCheck instead.
 TEST_F(ControlPlaneFixture, TestGalaxyLayoutCheck) {
+    if (!has_cluster_type(tt::tt_metal::ClusterType::GALAXY)) {
+        GTEST_SKIP() << "Test requires a Galaxy topology";
+    }
     tt::tt_metal::MetalContext::instance().set_default_fabric_topology();
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
@@ -225,6 +245,9 @@ TEST_F(ControlPlaneFixture, TestGalaxy4x4SplitHostLayoutCheck) {
 
 // Galaxy corner folding: mesh endpoints (first/last logical chips) must map to tray-corner ASICs.
 TEST_F(ControlPlaneFixture, TestGalaxyCornerPins) {
+    if (!has_galaxy_topology()) {
+        GTEST_SKIP() << "Test requires a Galaxy topology";
+    }
     tt::tt_metal::MetalContext::instance().set_default_fabric_topology();
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
@@ -286,6 +309,9 @@ TEST(MeshGraphValidation, Test2x2StageRingPortReservationByTorusOrigin) {
 }
 
 TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
+    if (!has_cluster_type(tt::tt_metal::ClusterType::T3K)) {
+        GTEST_SKIP() << "Test requires a T3K topology";
+    }
     // Reset MetalContext's control plane to ensure it doesn't interfere with the test's custom control plane
     tt::tt_metal::MetalContext::instance().set_default_fabric_topology();
 
@@ -311,6 +337,9 @@ TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
+    if (!has_cluster_type(tt::tt_metal::ClusterType::T3K)) {
+        GTEST_SKIP() << "Test requires a T3K topology";
+    }
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto";
@@ -331,6 +360,9 @@ TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
 }
 
 TEST_F(ControlPlaneFixture, TestT3k1x8FabricRoutes) {
+    if (!has_cluster_type(tt::tt_metal::ClusterType::T3K)) {
+        GTEST_SKIP() << "Test requires a T3K topology";
+    }
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.textproto";
@@ -359,6 +391,9 @@ TEST_F(ControlPlaneFixture, TestT3k1x8FabricRoutes) {
 }
 
 TEST_F(ControlPlaneFixture, TestSingleGalaxy1x32ControlPlaneInit) {
+    if (!has_single_galaxy_topology()) {
+        GTEST_SKIP() << "Test requires a single-rank, 32-chip Galaxy topology";
+    }
     const std::filesystem::path galaxy_6u_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto";
@@ -368,6 +403,9 @@ TEST_F(ControlPlaneFixture, TestSingleGalaxy1x32ControlPlaneInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestSingleGalaxy1x32FabricRoutes) {
+    if (!has_single_galaxy_topology()) {
+        GTEST_SKIP() << "Test requires a single-rank, 32-chip Galaxy topology";
+    }
     const std::filesystem::path galaxy_6u_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto";
@@ -443,7 +481,15 @@ TEST_F(ControlPlaneFixture, TestSingleGalaxy1x16FabricRoutes) {
 
 class T3kCustomMeshGraphControlPlaneFixture
     : public ControlPlaneFixture,
-      public testing::WithParamInterface<std::tuple<std::string, std::vector<std::vector<EthCoord>>>> {};
+      public testing::WithParamInterface<std::tuple<std::string, std::vector<std::vector<EthCoord>>>> {
+protected:
+    void SetUp() override {
+        if (!has_cluster_type(tt::tt_metal::ClusterType::T3K)) {
+            GTEST_SKIP() << "Test requires a T3K topology";
+        }
+        ControlPlaneFixture::SetUp();
+    }
+};
 
 TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kMeshGraphInit) {
     auto [mesh_graph_desc_path, _] = GetParam();
@@ -538,6 +584,9 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
 }
 
 TEST_F(ControlPlaneFixture, TestT3kDisjointFabricRoutes) {
+    if (!has_cluster_type(tt::tt_metal::ClusterType::T3K)) {
+        GTEST_SKIP() << "Test requires a T3K topology";
+    }
     auto [mesh_graph_desc_path, mesh_graph_eth_coords] = t3k_disjoint_mesh_descriptor_chip_mappings[0];
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
@@ -572,6 +621,9 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(t3k_mesh_descriptor_chip_mappings));
 
 TEST_F(ControlPlaneFixture, TestSingleGalaxyControlPlaneInit) {
+    if (!has_single_galaxy_topology()) {
+        GTEST_SKIP() << "Test requires a single-rank, 32-chip Galaxy topology";
+    }
     const std::filesystem::path single_galaxy_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.textproto";
@@ -671,6 +723,9 @@ TEST_F(ControlPlaneFixture, ProbeWormholeSingleGalaxyAutoDiscoveryFullCoverage) 
 }
 
 TEST_F(ControlPlaneFixture, TestSingleGalaxyMeshAPIs) {
+    if (!has_single_galaxy_topology()) {
+        GTEST_SKIP() << "Test requires a single-rank, 32-chip Galaxy topology";
+    }
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto user_meshes = control_plane.get_user_physical_mesh_ids();
     EXPECT_EQ(user_meshes.size(), 1);
@@ -918,6 +973,9 @@ TEST(MeshGraphValidation, TestSingleGalaxyMesh) {
 }
 
 TEST(RoutingTableValidation, TestSingleGalaxyMesh) {
+    if (!has_single_galaxy_topology()) {
+        GTEST_SKIP() << "Test requires a single-rank, 32-chip Galaxy topology";
+    }
     using namespace single_galaxy_constants;
     // Testing XY dimension order routing, if algorithm changes we can remove this test
     const std::filesystem::path mesh_graph_desc_path =
@@ -992,6 +1050,9 @@ TEST(MeshGraphValidation, TestSingleGalaxyTorusXY) {
 }
 
 TEST(RoutingTableValidation, TestSingleGalaxyTorusXY) {
+    if (!has_single_galaxy_topology()) {
+        GTEST_SKIP() << "Test requires a single-rank, 32-chip Galaxy topology";
+    }
     using namespace single_galaxy_constants;
     // Testing XY dimension order routing, if algorithm changes we can remove this test
     const std::filesystem::path mesh_graph_desc_path =
@@ -1078,6 +1139,9 @@ TEST(MeshGraphValidation, TestSingleGalaxyTorusX) {
 }
 
 TEST(RoutingTableValidation, TestSingleGalaxyTorusX) {
+    if (!has_single_galaxy_topology()) {
+        GTEST_SKIP() << "Test requires a single-rank, 32-chip Galaxy topology";
+    }
     using namespace single_galaxy_constants;
     // Testing XY dimension order routing, if algorithm changes we can remove this test
     const std::filesystem::path mesh_graph_desc_path =
@@ -1165,6 +1229,9 @@ TEST(MeshGraphValidation, TestSingleGalaxyTorusY) {
 }
 
 TEST(RoutingTableValidation, TestSingleGalaxyTorusY) {
+    if (!has_single_galaxy_topology()) {
+        GTEST_SKIP() << "Test requires a single-rank, 32-chip Galaxy topology";
+    }
     using namespace single_galaxy_constants;
     // Testing XY dimension order routing, if algorithm changes we can remove this test
     const std::filesystem::path mesh_graph_desc_path =
@@ -1286,6 +1353,9 @@ TEST(MeshGraphValidation, TestP150X8BlackHoleMeshGraph) {
 }
 
 TEST_F(ControlPlaneFixture, TestP150X8BlackHoleControlPlaneInit) {
+    if (!has_cluster_type(tt::tt_metal::ClusterType::P150_X8)) {
+        GTEST_SKIP() << "Test requires a P150 x8 topology";
+    }
     const std::filesystem::path p150_x8_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/p150_x8_mesh_graph_descriptor.textproto";
@@ -1293,6 +1363,9 @@ TEST_F(ControlPlaneFixture, TestP150X8BlackHoleControlPlaneInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestP150X8BlackHoleFabricRoutes) {
+    if (!has_cluster_type(tt::tt_metal::ClusterType::P150_X8)) {
+        GTEST_SKIP() << "Test requires a P150 x8 topology";
+    }
     const std::filesystem::path p150_x8_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/p150_x8_mesh_graph_descriptor.textproto";
@@ -1355,6 +1428,9 @@ TEST(MeshGraphValidation, TestFabricConfigInvalidMeshToTorus) {
 }
 
 TEST_F(ControlPlaneFixture, TestSerializeEthCoordinatesToFile) {
+    if (!has_cluster_type(tt::tt_metal::ClusterType::T3K)) {
+        GTEST_SKIP() << "Test requires a T3K topology";
+    }
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto";
@@ -2208,6 +2284,10 @@ void validate_sp5_blitz_decode_pipeline_stages(
 }  // namespace
 
 TEST_F(ControlPlaneFixture, TestBlitzDecodePipelineBuilder) {
+    if (!has_galaxy_topology() ||
+        !tt::tt_metal::MetalContext::instance().rtoptions().is_custom_fabric_mesh_graph_desc_path_specified()) {
+        GTEST_SKIP() << "Test requires a Galaxy cluster with an explicit multi-mesh graph descriptor";
+    }
     tt::tt_metal::MetalContext::instance().set_default_fabric_topology();
 
     tt::tt_metal::MetalContext::instance().set_fabric_config(


### PR DESCRIPTION
### PR Category
bug fix in tests

### Summary

Fabric router tests for fixed hardware topologies previously ran unconditionally,
failing with confusing control-plane or mesh-graph errors when executed against a
cluster they weren't written for. This gates each fixed-topology case behind an
explicit cluster requirement so it skips with a clear reason instead.

### Changes

**Cluster-requirement predicates.** Added small helpers so the requirement for each
test is stated once and reused:

- `has_cluster_type(ClusterType)` — exact-match gate (T3K, P150_X8, N300_2x2)
- `has_galaxy_topology()` — matches both `GALAXY` and `BLACKHOLE_GALAXY`
- `has_single_galaxy_topology()` — Galaxy + 32 chips + single rank
- `has_multiple_world_ranks()` — multi-host rank layouts in `test_multi_host.cpp`

**Gated tests.** T3K, Galaxy, single-Galaxy, N300 2x2, and P150 x8 cases now skip
with a message naming the topology they need. The T3K parameterized fixture gates in
`SetUp` so every instantiation is covered.

**Consistency fix.** `TestSplit2x2Fabric1DSanity` carried a stale guard requiring
`ClusterType::N300_2x2`, while its two siblings assert the same
`intermesh_connections.size() == 8` against the same 8-chip mock T3K descriptor on the
same CI line. N300_2x2 is a 4-chip single-host layout, so that guard could never hold
in this job — the test was silently skipping. All three now use
`has_multiple_world_ranks()`.

### Notes for reviewers

The main risk is over-gating: a predicate stricter than reality disables a test without
any signal. Two spots worth a careful look:

- `has_galaxy_topology()` vs `has_cluster_type(GALAXY)` — BH Galaxy mocks declare
  `ubb_blackhole` boards, which resolve to `BLACKHOLE_GALAXY`, a distinct enum value.
  Cases exercised by `bh_*` descriptors need the broader predicate.
- The topology-mapper prefix table is keyed on test names, so a renamed or newly-added
  test silently falls through to "no requirements" and runs unguarded.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=micah/cluster-reqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:micah/cluster-reqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=micah/cluster-reqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:micah/cluster-reqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=micah/cluster-reqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:micah/cluster-reqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=micah/cluster-reqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:micah/cluster-reqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=micah/cluster-reqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:micah/cluster-reqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=micah/cluster-reqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:micah/cluster-reqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=micah/cluster-reqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:micah/cluster-reqs)