### PR TITLE
[Cleanup] Migrate dit_fused_distributed_rmsnorm kernels to the Device 2.0 kernel API

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_program_factory.cpp
@@ -394,7 +394,7 @@ DitFusedDistributedRmsnormMeshWorkloadFactory::create_at(
     // Per-token weight/bias: shape [N, H] (or [B,1,N,H]) instead of broadcast
     // [1, H]. Detected by checking the second-to-last logical dim — broadcast
     // weight has 1 there. When set, the reader reads per-row tiles using
-    // noc_async_read_tile (full 4 KB/tile) and compute uses mul_tiles instead
+    // a full-page noc.async_read (4 KB/tile) and compute uses mul_tiles instead
     // of mul_tiles_bcast_rows.
     const bool per_token_weight = has_weight && (weight->logical_shape()[-2] > 1);
     const bool per_token_bias = has_bias && (bias->logical_shape()[-2] > 1);
@@ -550,7 +550,7 @@ for (uint32_t f = 0; f < num_forwarders; f++) {
     // Grid-wide set: the packet CB + sync semaphores are created here so their
     // L1 address is identical on every worker and forwarder core — a worker
     // learns its forwarder's packet base / sem addr from its OWN
-    // get_write_ptr(packet_cb) / get_semaphore(id), no cross-core address args.
+    // CircularBuffer(packet_cb).get_write_ptr() / Semaphore(id), no cross-core address args.
     const CoreRangeSet all_core_set({core_grid});
 
     // Partition helpers: worker w -> forwarder (w / wpf), slot (w % wpf);
@@ -740,7 +740,7 @@ for (uint32_t f = 0; f < num_forwarders; f++) {
     // The resident LayerNorm POST now clamps its sub-phases to the per-block tail count,
     // so non-divisible num_tile_cols is supported there (e.g. SD3.5: dim 2432 -> 38/19
     // tile-cols at TP2/TP4). The block-major LayerNorm POST, however, streams input and
-    // its PRE waits cb_wait_front(input_cb, block_size) per block — the shared reader
+    // its PRE waits input_cb.wait_front(block_size) per block — the shared reader
     // pushes only the tail count on the last block, so a non-divisible width would hang
     // that path. block-major LN needs num_tile_cols wide enough to stream (>=56) and is
     // only reached by divisible shapes today; keep a fail-fast guard for it until it gets
@@ -824,9 +824,9 @@ for (uint32_t f = 0; f < num_forwarders; f++) {
     constexpr uint32_t welford_zero_cb_id = tt::CBIndex::c_21;
 
     // Double-buffer input_cb: reader can fill chunk N+1 while compute is in
-    // chunk N's post phase. The cumulative cb_wait_front in compute pairs
+    // chunk N's post phase. The cumulative wait_front in compute pairs
     // naturally with this — compute uses absolute indices within the
-    // current chunk, and cb_pop_front at end of chunk frees that chunk's slots
+    // current chunk, and pop_front at end of chunk frees that chunk's slots
     // back to the reader.
     //
     // Streaming low-L1: input_cb holds only a handful of block_size-tile blocks
@@ -941,7 +941,7 @@ for (uint32_t f = 0; f < num_forwarders; f++) {
         // Size the cos/sin CBs to match the actual cos/sin tensor dtype rather
         // than assuming fp32. LTX feeds bf16 cos/sin (its standalone RoPE op is
         // all-bf16); accepting bf16 here halves the rope-table DRAM reads and L1
-        // footprint. The reader derives tile bytes from get_tile_size(rope_cos_cb)
+        // footprint. The reader derives tile bytes from rope_cos_cb.get_tile_size()
         // and the compute reconfigs the unpacker via reconfig_data_format(), so
         // both follow this format automatically.
         const tt::DataFormat rope_format = datatype_to_dataformat_converter(rope_cos->dtype());
@@ -1012,7 +1012,7 @@ for (uint32_t f = 0; f < num_forwarders; f++) {
     create_cb(
         rotated_input_cb_id, program, worker_core_set, intermediate_tile_size, rotated_cb_tiles, intermediate_format);
     // output_cb sized to 2 full padded rows so the writer can deep-drain a
-    // whole row under ONE noc_async_writes_flushed() (instead of flushing every
+    // whole row under ONE noc.async_writes_flushed() (instead of flushing every
     // block_size=2 tiles) while compute produces the next row. The shallow
     // 4-tile CB capped write concurrency at block_size, leaving the output
     // drain at ~22% of POST as back-pressure (P_ADD's 5.9× core-to-core spread
@@ -1043,8 +1043,8 @@ for (uint32_t f = 0; f < num_forwarders; f++) {
     // Sync semaphores for the worker<->forwarder handshake. arrival (workers inc,
     // forwarder waits) + go (forwarder incs, workers wait) are on-chip; created on
     // the WHOLE grid so their L1 address is identical across workers + forwarders
-    // (kernels resolve via get_semaphore(id)). out_ready is the caller's
-    // GlobalSemaphore, fabric-inc'd by peer forwarders (resolved later).
+    // (kernels resolve via Semaphore(id)). out_ready is the caller's GlobalSemaphore,
+    // fabric-inc'd by peer forwarders (resolved later).
     const uint32_t arrival_sem_id = use_mux ? tt::tt_metal::CreateSemaphore(program, all_core_set, 0u) : 0u;
     const uint32_t go_sem_id = use_mux ? tt::tt_metal::CreateSemaphore(program, all_core_set, 0u) : 0u;
 
@@ -1289,7 +1289,7 @@ for (uint32_t f = 0; f < num_forwarders; f++) {
         // tiles straight into stats_gathered_cb (sized for num_heads) and consume
         // them locally in POST. With the old (ring_size==1)-only form, per_head
         // ring>1 routed PRE to stats_local_cb (sized 1 tile, no consumer) and
-        // wedged on the 2nd head's cb_reserve_back.
+        // wedged on the 2nd head's reserve_back.
         /*is_tp_1=*/static_cast<uint32_t>(is_tp_1 ? 1u : 0u),
         // Packed AG CBs (all-gather path). For is_tp_1 the compute kernel
         // sidesteps the packed path entirely (pushes col-0 stats straight into

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/compute/dit_layernorm_fused_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/compute/dit_layernorm_fused_compute.cpp
@@ -93,6 +93,19 @@ void kernel_main() {
     constexpr uint32_t per_batch_bias = get_compile_time_arg_val(42);
     constexpr uint32_t rows_per_batch_tiles = get_compile_time_arg_val(43);
 
+    CircularBuffer cb_input(input_cb);
+    CircularBuffer cb_mean(mean_cb);
+    CircularBuffer cb_invstd(invstd_cb);
+    CircularBuffer cb_combine(combine_cb);
+    CircularBuffer cb_weight(weight_cb);
+    CircularBuffer cb_bias(bias_cb);
+    CircularBuffer cb_output(output_cb);
+    CircularBuffer cb_xmm(xmm_cb);
+    CircularBuffer cb_stats_local(stats_local_cb);
+    CircularBuffer cb_stats_gathered(stats_gathered_cb);
+    CircularBuffer cb_recip_lut(recip_lut_cb);
+    CircularBuffer cb_welford_zero(welford_zero_cb);
+
     // Welford reduces over the local shard: num_tile_cols * TILE_WIDTH features.
     constexpr uint32_t tile_width = 32u;
     constexpr uint32_t reduce_width = num_tile_cols * tile_width;  // = feat_local
@@ -105,7 +118,7 @@ void kernel_main() {
     // SFPU as the per-sample 1/(N+1) lookup; see dit_rmsnorm_fused_reader.cpp.
     const std::array<uint32_t, reduce_width>* p_recip = nullptr;
     if constexpr (use_recip_lut != 0) {
-        cb_wait_front(recip_lut_cb, 1);
+        cb_recip_lut.wait_front(1);
         p_recip = norm::kernel_util::compute::memory::get_pointer_to_cb_data<std::array<uint32_t, reduce_width>>(
             recip_lut_cb, 0);
     }
@@ -132,6 +145,8 @@ void kernel_main() {
     // has_bias implies has_weight (enforced in validate).
     constexpr uint32_t norm_result_cb = (has_weight != 0) ? intermediate_cb : output_cb;
     constexpr uint32_t weight_result_cb = (has_bias != 0) ? intermediate_cb : output_cb;
+    CircularBuffer cb_norm_result(norm_result_cb);
+    CircularBuffer cb_weight_result(weight_result_cb);
 
     const uint32_t num_tile_rows = get_arg_val<uint32_t>(0);
     // Worker's first GLOBAL tile-row (RT arg 1): maps each local row to its batch for per-batch
@@ -149,15 +164,15 @@ void kernel_main() {
         welford_init();
         welford_save_state(mean_dst);  // LREG4/5 (cleared) -> mean_dst / var_dst
         tile_regs_commit();
-        cb_reserve_back(welford_zero_cb, 2);
+        cb_welford_zero.reserve_back(2);
         tile_regs_wait();
         pack_reconfig_data_format(welford_zero_cb);
         pack_tile(mean_dst, welford_zero_cb);
         pack_tile(var_dst, welford_zero_cb);
         tile_regs_release();
-        cb_push_back(welford_zero_cb, 2);
+        cb_welford_zero.push_back(2);
     }
-    cb_wait_front(welford_zero_cb, 2);  // resident for the whole kernel (never popped)
+    cb_welford_zero.wait_front(2);  // resident for the whole kernel (never popped)
 
     for (uint32_t row = 0; row < num_tile_rows; row++) {
         // Per-batch adaLN (per_batch_weight/bias): the reader streams THIS row's batch slice to
@@ -167,7 +182,7 @@ void kernel_main() {
         // Resident layout: whole row stays in L1 (Welford PRE + POST re-read).
         // Streaming layout (wide shards): each pass waits/pops per block instead.
         if constexpr (streaming_low_l1 == 0) {
-            cb_wait_front(input_cb, num_tile_cols);
+            cb_input.wait_front(num_tile_cols);
         }
 
         // -------- PHASE 1: PRE — local per-token Welford (mean, var) over the shard --------
@@ -194,13 +209,13 @@ void kernel_main() {
                 // Streamed 1st pass: wait + Welford + pop each block; LREG4/5 accumulate
                 // across blocks. The reader re-pushes the row for the POST 2nd pass.
                 for (uint32_t col = 0; col < num_tile_cols; col += block_size) {
-                    cb_wait_front(input_cb, block_size);
+                    cb_input.wait_front(block_size);
                     for (uint32_t i = 0; i < block_size; i++) {
                         transpose_tile(input_cb, i, welford_in_dst);
                         wf_update(welford_in_dst, start_n);
                         start_n += tile_width;
                     }
-                    cb_pop_front(input_cb, block_size);
+                    cb_input.pop_front(block_size);
                 }
             } else {
                 for (uint32_t col = 0; col < num_tile_cols; col++) {
@@ -214,34 +229,34 @@ void kernel_main() {
 
             if constexpr (is_tp_1 != 0) {
                 // Local stat IS the full mean/var: stash row 0 for the transpose below.
-                cb_reserve_back(mean_cb, 1);
-                cb_reserve_back(invstd_cb, 1);
+                cb_mean.reserve_back(1);
+                cb_invstd.reserve_back(1);
                 tile_regs_wait();
                 pack_reconfig_data_format(mean_cb);
                 pack_tile(mean_dst, mean_cb);
                 pack_reconfig_data_format(invstd_cb);
                 pack_tile(var_dst, invstd_cb);
                 tile_regs_release();
-                cb_push_back(mean_cb, 1);
-                cb_push_back(invstd_cb, 1);
+                cb_mean.push_back(1);
+                cb_invstd.push_back(1);
             } else {
                 // Push the local (mean, var) partial (row 0) for the worker writer to
                 // ring-gather. stats_local_cb holds [mean, var] for this shard.
-                cb_reserve_back(stats_local_cb, 2);
+                cb_stats_local.reserve_back(2);
                 tile_regs_wait();
                 pack_reconfig_data_format(stats_local_cb);
                 pack_tile(mean_dst, stats_local_cb);
                 pack_tile(var_dst, stats_local_cb);
                 tile_regs_release();
-                cb_push_back(stats_local_cb, 2);
+                cb_stats_local.push_back(2);
             }
         }
 
         // -------- Produce per-token mean (col 0) + 1/std (col 0) into mean_cb / invstd_cb --------
         if constexpr (is_tp_1 != 0) {
             // Transpose row 0 -> col 0; 1/std = rsqrt(var + eps).
-            cb_wait_front(mean_cb, 1);
-            cb_wait_front(invstd_cb, 1);
+            cb_mean.wait_front(1);
+            cb_invstd.wait_front(1);
             reconfig_data_format_srca(mean_cb);
             transpose_init(mean_cb);
             tile_regs_acquire();
@@ -255,18 +270,18 @@ void kernel_main() {
             rsqrt_tile<true>(var_dst);
             tile_regs_commit();
 
-            cb_pop_front(mean_cb, 1);
-            cb_pop_front(invstd_cb, 1);
-            cb_reserve_back(mean_cb, 1);
-            cb_reserve_back(invstd_cb, 1);
+            cb_mean.pop_front(1);
+            cb_invstd.pop_front(1);
+            cb_mean.reserve_back(1);
+            cb_invstd.reserve_back(1);
             tile_regs_wait();
             pack_reconfig_data_format(mean_cb);
             pack_tile(mean_dst, mean_cb);
             pack_reconfig_data_format(invstd_cb);
             pack_tile(var_dst, invstd_cb);
             tile_regs_release();
-            cb_push_back(mean_cb, 1);
-            cb_push_back(invstd_cb, 1);
+            cb_mean.push_back(1);
+            cb_invstd.push_back(1);
         } else {
             // Equal-count Welford (Chan) combine. All ring_size shards have identical count
             // n_i == reduce_width, so the exact parallel-Welford combine collapses in closed
@@ -285,7 +300,7 @@ void kernel_main() {
             constexpr uint32_t DT = 3;   // scratch
             constexpr uint32_t two_ring = 2u * ring_size;
             constexpr uint32_t recip_k_bits = __builtin_bit_cast(uint32_t, 1.0f / static_cast<float>(ring_size));
-            cb_wait_front(stats_gathered_cb, two_ring);
+            cb_stats_gathered.wait_front(two_ring);
             reconfig_data_format(stats_gathered_cb, stats_gathered_cb);
             pack_reconfig_data_format(combine_cb);
             tile_regs_acquire();
@@ -329,37 +344,37 @@ void kernel_main() {
             rsqrt_tile_init<true>();
             rsqrt_tile<true>(DV);  // DV = 1/std (legacy, matches baseline)
             tile_regs_commit();
-            cb_reserve_back(combine_cb, 2);
+            cb_combine.reserve_back(2);
             tile_regs_wait();
             pack_tile(DM, combine_cb);  // mean_g -> tile 0
             pack_tile(DV, combine_cb);  // 1/std  -> tile 1
             tile_regs_release();
-            cb_pop_front(stats_gathered_cb, two_ring);
-            cb_push_back(combine_cb, 2);
+            cb_stats_gathered.pop_front(two_ring);
+            cb_combine.push_back(2);
 
             // Transpose merged mean / 1/std row 0 -> col 0.
-            cb_wait_front(combine_cb, 2);
+            cb_combine.wait_front(2);
             reconfig_data_format_srca(combine_cb);
             transpose_init(combine_cb);
             tile_regs_acquire();
             transpose_tile(combine_cb, 0, mean_dst);
             transpose_tile(combine_cb, 1, var_dst);
             tile_regs_commit();
-            cb_pop_front(combine_cb, 2);
-            cb_reserve_back(mean_cb, 1);
-            cb_reserve_back(invstd_cb, 1);
+            cb_combine.pop_front(2);
+            cb_mean.reserve_back(1);
+            cb_invstd.reserve_back(1);
             tile_regs_wait();
             pack_reconfig_data_format(mean_cb);
             pack_tile(mean_dst, mean_cb);
             pack_reconfig_data_format(invstd_cb);
             pack_tile(var_dst, invstd_cb);
             tile_regs_release();
-            cb_push_back(mean_cb, 1);
-            cb_push_back(invstd_cb, 1);
+            cb_mean.push_back(1);
+            cb_invstd.push_back(1);
         }
 
-        cb_wait_front(mean_cb, 1);
-        cb_wait_front(invstd_cb, 1);
+        cb_mean.wait_front(1);
+        cb_invstd.wait_front(1);
 
         // -------- PHASE 2: POST — (x - mean) * (1/std) [* weight] [+ bias] --------
         if constexpr (block_major_post != 0) {
@@ -370,11 +385,11 @@ void kernel_main() {
             // (col 0) and weight_cb / bias_cb (whole-row) stay resident.
             for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
                 // (x - mean) -> xmm_cb
-                cb_wait_front(input_cb, block_size);
+                cb_input.wait_front(block_size);
                 reconfig_data_format(input_cb, mean_cb);
                 pack_reconfig_data_format(xmm_cb);
                 sub_bcast_cols_init(input_cb, mean_cb);
-                cb_reserve_back(xmm_cb, block_size);
+                cb_xmm.reserve_back(block_size);
                 tile_regs_acquire();
                 for (uint32_t i = 0; i < block_size; i++) {
                     sub_tiles_bcast_cols(input_cb, mean_cb, i, 0, i);
@@ -385,32 +400,32 @@ void kernel_main() {
                     pack_tile(i, xmm_cb);
                 }
                 tile_regs_release();
-                cb_push_back(xmm_cb, block_size);
-                cb_pop_front(input_cb, block_size);
+                cb_xmm.push_back(block_size);
+                cb_input.pop_front(block_size);
 
                 // (x - mean) * (1/std) -> norm_result_cb
-                cb_wait_front(xmm_cb, block_size);
+                cb_xmm.wait_front(block_size);
                 reconfig_data_format(xmm_cb, invstd_cb);
                 pack_reconfig_data_format(norm_result_cb);
                 mul_bcast_cols_init(xmm_cb, invstd_cb);
-                cb_reserve_back(norm_result_cb, block_size);
+                cb_norm_result.reserve_back(block_size);
                 tile_regs_acquire();
                 for (uint32_t i = 0; i < block_size; i++) {
                     mul_tiles_bcast_cols(xmm_cb, invstd_cb, i, 0, i);
                 }
                 tile_regs_commit();
-                cb_pop_front(xmm_cb, block_size);
+                cb_xmm.pop_front(block_size);
                 tile_regs_wait();
                 for (uint32_t i = 0; i < block_size; i++) {
                     pack_tile(i, norm_result_cb);
                 }
                 tile_regs_release();
-                cb_push_back(norm_result_cb, block_size);
+                cb_norm_result.push_back(block_size);
 
                 // * weight
                 if constexpr (has_weight != 0) {
-                    cb_wait_front(weight_cb, col_tile + block_size);
-                    cb_wait_front(norm_result_cb, block_size);
+                    cb_weight.wait_front(col_tile + block_size);
+                    cb_norm_result.wait_front(block_size);
                     reconfig_data_format(norm_result_cb, weight_cb);
                     pack_reconfig_data_format(weight_result_cb);
                     if constexpr (per_token_weight != 0) {
@@ -418,7 +433,7 @@ void kernel_main() {
                     } else {
                         mul_bcast_rows_init(norm_result_cb, weight_cb);
                     }
-                    cb_reserve_back(weight_result_cb, block_size);
+                    cb_weight_result.reserve_back(block_size);
                     tile_regs_acquire();
                     for (uint32_t i = 0; i < block_size; i++) {
                         if constexpr (per_token_weight != 0) {
@@ -428,19 +443,19 @@ void kernel_main() {
                         }
                     }
                     tile_regs_commit();
-                    cb_pop_front(norm_result_cb, block_size);
+                    cb_norm_result.pop_front(block_size);
                     tile_regs_wait();
                     for (uint32_t i = 0; i < block_size; i++) {
                         pack_tile(i, weight_result_cb);
                     }
                     tile_regs_release();
-                    cb_push_back(weight_result_cb, block_size);
+                    cb_weight_result.push_back(block_size);
                 }
 
                 // + bias
                 if constexpr (has_bias != 0) {
-                    cb_wait_front(bias_cb, col_tile + block_size);
-                    cb_wait_front(weight_result_cb, block_size);
+                    cb_bias.wait_front(col_tile + block_size);
+                    cb_weight_result.wait_front(block_size);
                     reconfig_data_format(weight_result_cb, bias_cb);
                     pack_reconfig_data_format(output_cb);
                     if constexpr (per_token_bias != 0) {
@@ -448,7 +463,7 @@ void kernel_main() {
                     } else {
                         add_bcast_rows_init(weight_result_cb, bias_cb);
                     }
-                    cb_reserve_back(output_cb, block_size);
+                    cb_output.reserve_back(block_size);
                     tile_regs_acquire();
                     for (uint32_t i = 0; i < block_size; i++) {
                         if constexpr (per_token_bias != 0) {
@@ -458,13 +473,13 @@ void kernel_main() {
                         }
                     }
                     tile_regs_commit();
-                    cb_pop_front(weight_result_cb, block_size);
+                    cb_weight_result.pop_front(block_size);
                     tile_regs_wait();
                     for (uint32_t i = 0; i < block_size; i++) {
                         pack_tile(i, output_cb);
                     }
                     tile_regs_release();
-                    cb_push_back(output_cb, block_size);
+                    cb_output.push_back(block_size);
                 }
             }
             // Per-row affine (per-token OR per-batch adaLN): the reader pushes row r's slice; pop
@@ -472,10 +487,10 @@ void kernel_main() {
             // divisible num_tile_cols, so the whole row's num_tile_cols was consumed above).
             // Broadcast weight/bias stays resident (never popped).
             if constexpr (per_token_weight != 0 || per_batch_weight != 0) {
-                cb_pop_front(weight_cb, num_tile_cols);
+                cb_weight.pop_front(num_tile_cols);
             }
             if constexpr (per_token_bias != 0 || per_batch_bias != 0) {
-                cb_pop_front(bias_cb, num_tile_cols);
+                cb_bias.pop_front(num_tile_cols);
             }
         } else {
             // ===== Resident POST (shard fits L1) =====
@@ -485,7 +500,7 @@ void kernel_main() {
             // slot is stale and dropped by the writer, which also drains in block_size units).
             // This keeps the resident POST + the worker writer divisibility-agnostic. The
             // whole-row weight_cb / bias_cb instead hold exactly num_tile_cols and use a
-            // cumulative (col + n) wait. CBs are sized div_up(num_tile_cols, block_size).
+            // cumulative (col + n) wait_front. CBs are sized div_up(num_tile_cols, block_size).
             // Sub-phase A: x - mean (broadcast mean over feature cols) -> xmm_cb.
             {
                 reconfig_data_format(input_cb, mean_cb);
@@ -493,7 +508,7 @@ void kernel_main() {
                 sub_bcast_cols_init(input_cb, mean_cb);
                 for (uint32_t col = 0; col < num_tile_cols; col += block_size) {
                     const uint32_t n = (col + block_size <= num_tile_cols) ? block_size : (num_tile_cols - col);
-                    cb_reserve_back(xmm_cb, block_size);
+                    cb_xmm.reserve_back(block_size);
                     tile_regs_acquire();
                     for (uint32_t i = 0; i < n; i++) {
                         sub_tiles_bcast_cols(input_cb, mean_cb, col + i, 0, i);
@@ -504,7 +519,7 @@ void kernel_main() {
                         pack_tile(i, xmm_cb);
                     }
                     tile_regs_release();
-                    cb_push_back(xmm_cb, block_size);
+                    cb_xmm.push_back(block_size);
                 }
             }
 
@@ -515,8 +530,8 @@ void kernel_main() {
                 mul_bcast_cols_init(xmm_cb, invstd_cb);
                 for (uint32_t col = 0; col < num_tile_cols; col += block_size) {
                     const uint32_t n = (col + block_size <= num_tile_cols) ? block_size : (num_tile_cols - col);
-                    cb_wait_front(xmm_cb, block_size);
-                    cb_reserve_back(norm_result_cb, block_size);
+                    cb_xmm.wait_front(block_size);
+                    cb_norm_result.reserve_back(block_size);
                     tile_regs_acquire();
                     for (uint32_t i = 0; i < n; i++) {
                         mul_tiles_bcast_cols(xmm_cb, invstd_cb, i, 0, i);
@@ -527,8 +542,8 @@ void kernel_main() {
                         pack_tile(i, norm_result_cb);
                     }
                     tile_regs_release();
-                    cb_push_back(norm_result_cb, block_size);
-                    cb_pop_front(xmm_cb, block_size);
+                    cb_norm_result.push_back(block_size);
+                    cb_xmm.pop_front(block_size);
                 }
             }
 
@@ -543,10 +558,10 @@ void kernel_main() {
                 }
                 for (uint32_t col = 0; col < num_tile_cols; col += block_size) {
                     const uint32_t n = (col + block_size <= num_tile_cols) ? block_size : (num_tile_cols - col);
-                    // whole-row weight: cumulative wait; per-batch offsets into this batch's
+                    // whole-row weight: cumulative wait_front; per-batch offsets into this batch's
                     // resident num_tile_cols slice (w_off==0 for broadcast/per-token).
-                    cb_wait_front(weight_cb, col + n);
-                    cb_wait_front(norm_result_cb, block_size);
+                    cb_weight.wait_front(col + n);
+                    cb_norm_result.wait_front(block_size);
                     tile_regs_acquire();
                     for (uint32_t i = 0; i < n; i++) {
                         if constexpr (per_token_weight != 0) {
@@ -556,20 +571,20 @@ void kernel_main() {
                         }
                     }
                     tile_regs_commit();
-                    cb_pop_front(norm_result_cb, block_size);
-                    cb_reserve_back(weight_result_cb, block_size);
+                    cb_norm_result.pop_front(block_size);
+                    cb_weight_result.reserve_back(block_size);
                     tile_regs_wait();
                     for (uint32_t i = 0; i < n; i++) {
                         pack_tile(i, weight_result_cb);
                     }
                     tile_regs_release();
-                    cb_push_back(weight_result_cb, block_size);
+                    cb_weight_result.push_back(block_size);
                 }
                 // Per-row affine (per-token OR per-batch adaLN): weight is pushed fresh per row by
                 // the reader (row r's slice at the front); pop this row's num_tile_cols so row
                 // r+1's slice is at the front next iteration. Broadcast weight stays resident.
                 if constexpr (per_token_weight != 0 || per_batch_weight != 0) {
-                    cb_pop_front(weight_cb, num_tile_cols);
+                    cb_weight.pop_front(num_tile_cols);
                 }
             }
 
@@ -584,9 +599,9 @@ void kernel_main() {
                 }
                 for (uint32_t col = 0; col < num_tile_cols; col += block_size) {
                     const uint32_t n = (col + block_size <= num_tile_cols) ? block_size : (num_tile_cols - col);
-                    // whole-row bias: cumulative wait; per-batch offsets into this batch's slice.
-                    cb_wait_front(bias_cb, col + n);
-                    cb_wait_front(weight_result_cb, block_size);
+                    // whole-row bias: cumulative wait_front; per-batch offsets into this batch's slice.
+                    cb_bias.wait_front(col + n);
+                    cb_weight_result.wait_front(block_size);
                     tile_regs_acquire();
                     for (uint32_t i = 0; i < n; i++) {
                         if constexpr (per_token_bias != 0) {
@@ -596,27 +611,27 @@ void kernel_main() {
                         }
                     }
                     tile_regs_commit();
-                    cb_pop_front(weight_result_cb, block_size);
-                    cb_reserve_back(output_cb, block_size);
+                    cb_weight_result.pop_front(block_size);
+                    cb_output.reserve_back(block_size);
                     tile_regs_wait();
                     for (uint32_t i = 0; i < n; i++) {
                         pack_tile(i, output_cb);
                     }
                     tile_regs_release();
-                    cb_push_back(output_cb, block_size);
+                    cb_output.push_back(block_size);
                 }
                 // Per-row affine bias (per-token OR per-batch adaLN): pop this row's slice.
                 if constexpr (per_token_bias != 0 || per_batch_bias != 0) {
-                    cb_pop_front(bias_cb, num_tile_cols);
+                    cb_bias.pop_front(num_tile_cols);
                 }
             }
         }  // end resident POST (else of block_major_post)
 
-        cb_pop_front(mean_cb, 1);
-        cb_pop_front(invstd_cb, 1);
+        cb_mean.pop_front(1);
+        cb_invstd.pop_front(1);
         if constexpr (block_major_post == 0) {
             // Resident path holds the row through POST; block-major popped per block.
-            cb_pop_front(input_cb, num_tile_cols);
+            cb_input.pop_front(num_tile_cols);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/compute/dit_rmsnorm_fused_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/compute/dit_rmsnorm_fused_compute.cpp
@@ -39,6 +39,7 @@
 #include "api/compute/matmul.h"
 #include "api/compute/transpose.h"
 #include "api/compute/transpose_dest.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 void kernel_main() {
@@ -143,12 +144,33 @@ void kernel_main() {
     matmul_init(intermediate_cb, transformation_mat_cb);
     compute_kernel_hw_startup(input_cb, input_cb, input_cb);
 
+    CircularBuffer cb_input(input_cb);
+    CircularBuffer cb_stats_local(stats_local_cb);
+    CircularBuffer cb_stats_gathered(stats_gathered_cb);
+    CircularBuffer cb_weight(weight_cb);
+    CircularBuffer cb_bias(bias_cb);
+    CircularBuffer cb_reduce_scalar_sum(reduce_scalar_sum_cb);
+    CircularBuffer cb_reduce_scalar_avg(reduce_scalar_avg_cb);
+    CircularBuffer cb_epsilon(epsilon_cb);
+    CircularBuffer cb_reduce_result(reduce_result_cb);
+    CircularBuffer cb_intermediate(intermediate_cb);
+    CircularBuffer cb_pre_intermediate(pre_intermediate_cb);
+    CircularBuffer cb_output(output_cb);
+    CircularBuffer cb_transformation_mat(transformation_mat_cb);
+    CircularBuffer cb_rope_cos(rope_cos_cb);
+    CircularBuffer cb_rope_sin(rope_sin_cb);
+    CircularBuffer cb_rotated_input(rotated_input_cb);
+    CircularBuffer cb_stats_transposed_local(stats_transposed_local_cb);
+    CircularBuffer cb_stats_transposed_gathered(stats_transposed_gathered_cb);
+    // Aliases the packed-AG or the plain gathered CB, per stats_reduce_src_cb above.
+    CircularBuffer cb_stats_reduce_src(stats_reduce_src_cb);
+
     // One-time waits for reader-produced singletons.
-    cb_wait_front(reduce_scalar_sum_cb, 1);
-    cb_wait_front(reduce_scalar_avg_cb, 1);
-    cb_wait_front(epsilon_cb, 1);
+    cb_reduce_scalar_sum.wait_front(1);
+    cb_reduce_scalar_avg.wait_front(1);
+    cb_epsilon.wait_front(1);
     if constexpr (fuse_rope) {
-        cb_wait_front(transformation_mat_cb, 1);
+        cb_transformation_mat.wait_front(1);
     }
 
     constexpr uint32_t mul_rms_result_cb = (fuse_rope || has_weight) ? intermediate_cb : output_cb;
@@ -156,6 +178,10 @@ void kernel_main() {
     // in intermediate when bias or rope follows.
     constexpr uint32_t mul_weight_result_cb = (fuse_rope || has_bias) ? intermediate_cb : output_cb;
     constexpr uint32_t add_bias_result_cb = fuse_rope ? intermediate_cb : output_cb;
+
+    CircularBuffer cb_mul_rms_result(mul_rms_result_cb);
+    CircularBuffer cb_mul_weight_result(mul_weight_result_cb);
+    CircularBuffer cb_add_bias_result(add_bias_result_cb);
 
     // Process the core's tile rows one at a time (chunk size is always 1).
     // per_head_norm produces num_heads_per_device stats per row (one per
@@ -166,10 +192,10 @@ void kernel_main() {
         const uint32_t chunk_stats_tiles = per_row_stats_count;
 
         // -------- PHASE 1: PRE — sum(x**2) per row --------
-        // Cumulative input wait: instead of one cb_wait_front for the whole
+        // Cumulative input wait: instead of one wait_front for the whole
         // chunk, wait per col-block. Lets the reader push block N+1 while
         // compute is processing block N. Counter resets per chunk because we
-        // cb_pop_front(input_cb, chunk_input_tiles) at the end.
+        // cb_input.pop_front(chunk_input_tiles) at the end.
         // Per-head norm: inner reduce spans head_dim_tiles columns per head;
         // we run num_heads_per_device reduces per row. Whole-row norm: single
         // reduce over num_tile_cols per row.
@@ -200,11 +226,11 @@ void kernel_main() {
                     PACK((llk_pack_reconfig_l1_acc(0)));
                     mul_init(input_cb, input_cb);
 
-                    cb_reserve_back(pre_intermediate_cb, 1);
+                    cb_pre_intermediate.reserve_back(1);
                     for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
                         const uint32_t tiles_in_block =
                             ((num_tile_cols - col_tile) >= block_size) ? block_size : (num_tile_cols - col_tile);
-                        cb_wait_front(input_cb, tiles_in_block);
+                        cb_input.wait_front(tiles_in_block);
                         tile_regs_acquire();
                         for (uint32_t i = 0; i < tiles_in_block; i++) {
                             mul_tiles(input_cb, input_cb, i, i, i);
@@ -218,9 +244,9 @@ void kernel_main() {
                             }
                         }
                         tile_regs_release();
-                        cb_pop_front(input_cb, tiles_in_block);
+                        cb_input.pop_front(tiles_in_block);
                     }
-                    cb_push_back(pre_intermediate_cb, 1);
+                    cb_pre_intermediate.push_back(1);
                     PACK((llk_pack_reconfig_l1_acc(0)));
 
                     compute_kernel_lib::reduce<
@@ -243,7 +269,7 @@ void kernel_main() {
                         PACK((llk_pack_reconfig_l1_acc(0)));
                         mul_init(input_cb, input_cb);
 
-                        cb_reserve_back(pre_intermediate_cb, 1);
+                        cb_pre_intermediate.reserve_back(1);
 
                         for (uint32_t col_tile = 0; col_tile < pre_group_width; col_tile += block_size) {
                             const uint32_t tiles_in_block = ((pre_group_width - col_tile) >= block_size)
@@ -256,7 +282,7 @@ void kernel_main() {
                             // next reader push regardless.
                             const uint32_t need = group_base + col_tile + tiles_in_block;
                             if (need > input_tiles_waited) {
-                                cb_wait_front(input_cb, need);
+                                cb_input.wait_front(need);
                                 input_tiles_waited = need;
                             }
 
@@ -276,7 +302,7 @@ void kernel_main() {
                             }
                             tile_regs_release();
                         }
-                        cb_push_back(pre_intermediate_cb, 1);
+                        cb_pre_intermediate.push_back(1);
                         PACK((llk_pack_reconfig_l1_acc(0)));
 
                         // Row/head reduce → 1 stat tile. SUM (col 0 = sum). Post phase
@@ -301,16 +327,16 @@ void kernel_main() {
             transpose_init(stats_local_cb);
             pack_reconfig_data_format(stats_transposed_local_cb);
             {  // single row per iteration (chunk size is 1)
-                cb_wait_front(stats_local_cb, 1);
-                cb_reserve_back(stats_transposed_local_cb, 1);
+                cb_stats_local.wait_front(1);
+                cb_stats_transposed_local.reserve_back(1);
                 tile_regs_acquire();
                 transpose_tile(stats_local_cb, 0, 0);
                 tile_regs_commit();
                 tile_regs_wait();
                 pack_tile(0, stats_transposed_local_cb);
                 tile_regs_release();
-                cb_push_back(stats_transposed_local_cb, 1);
-                cb_pop_front(stats_local_cb, 1);
+                cb_stats_transposed_local.push_back(1);
+                cb_stats_local.pop_front(1);
             }
         }
 
@@ -318,7 +344,7 @@ void kernel_main() {
         {
             // Packed-AG path: the worker writer lands the ring gather in row-0 of the
             // transposed gathered CB; is_tp_1 fills the plain col-0 gathered CB locally.
-            cb_wait_front(stats_reduce_src_cb, chunk_stats_tiles);
+            cb_stats_reduce_src.wait_front(chunk_stats_tiles);
         }
 
         // -------- PHASE 3: POST — finalize normalization --------
@@ -397,7 +423,7 @@ void kernel_main() {
                                     // tile IN DST (row 0 -> col 0) with transpose_dest — no CB
                                     // round-trip — then *1/H + eps + rsqrt on col 0. One transpose
                                     // total (deferred past the sum) vs one per gathered tile.
-                                    cb_wait_front(stats_transposed_gathered_cb, stats_tiles_cols);
+                                    cb_stats_transposed_gathered.wait_front(stats_tiles_cols);
                                     reconfig_data_format(stats_transposed_gathered_cb, stats_transposed_gathered_cb);
                                     pack_reconfig_data_format(reduce_result_cb);
                                     tile_regs_acquire();
@@ -420,14 +446,14 @@ void kernel_main() {
                                     rsqrt_tile<use_legacy_rsqrt>(0);
                                     tile_regs_commit();
                                     tile_regs_wait();
-                                    cb_reserve_back(reduce_result_cb, 1);
+                                    cb_reduce_result.reserve_back(1);
                                     pack_tile(0, reduce_result_cb);
-                                    cb_push_back(reduce_result_cb, 1);
+                                    cb_reduce_result.push_back(1);
                                     tile_regs_release();
-                                    cb_pop_front(stats_transposed_gathered_cb, stats_tiles_cols);
+                                    cb_stats_transposed_gathered.pop_front(stats_tiles_cols);
                                 } else {
                                     // Non-packed path: gathered tiles are in COL 0.
-                                    cb_wait_front(stats_gathered_cb, stats_tiles_cols);
+                                    cb_stats_gathered.wait_front(stats_tiles_cols);
                                     reconfig_data_format(stats_gathered_cb, stats_gathered_cb);
                                     pack_reconfig_data_format(reduce_result_cb);
                                     tile_regs_acquire();
@@ -448,11 +474,11 @@ void kernel_main() {
                                     rsqrt_tile<use_legacy_rsqrt>(0);
                                     tile_regs_commit();
                                     tile_regs_wait();
-                                    cb_reserve_back(reduce_result_cb, 1);
+                                    cb_reduce_result.reserve_back(1);
                                     pack_tile(0, reduce_result_cb);
-                                    cb_push_back(reduce_result_cb, 1);
+                                    cb_reduce_result.push_back(1);
                                     tile_regs_release();
-                                    cb_pop_front(stats_gathered_cb, stats_tiles_cols);
+                                    cb_stats_gathered.pop_front(stats_tiles_cols);
                                 }
                             } else {
                                 // TP=1: a single gathered tile; the matmul reduce is fine
@@ -469,7 +495,7 @@ void kernel_main() {
                                     eps_rsqrt);
                             }
 
-                            cb_wait_front(reduce_result_cb, 1);
+                            cb_reduce_result.wait_front(1);
                         }  // P_NRED
 
                         // block_major_post fuses mul-rms into the single per-block POST loop
@@ -489,8 +515,8 @@ void kernel_main() {
                                 // single group with post_group_width == num_tile_cols, and
                                 // num_tile_cols % block_size == 0 (host TT_FATAL invariant).
                                 for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
-                                    cb_wait_front(input_cb, block_size);
-                                    cb_reserve_back(mul_rms_result_cb, block_size);
+                                    cb_input.wait_front(block_size);
+                                    cb_mul_rms_result.reserve_back(block_size);
                                     tile_regs_acquire();
                                     for (uint32_t i = 0; i < block_size; i++) {
                                         mul_tiles_bcast_cols(input_cb, reduce_result_cb, i, 0, i);
@@ -501,8 +527,8 @@ void kernel_main() {
                                         pack_tile(i, mul_rms_result_cb);
                                     }
                                     tile_regs_release();
-                                    cb_push_back(mul_rms_result_cb, block_size);
-                                    cb_pop_front(input_cb, block_size);
+                                    cb_mul_rms_result.push_back(block_size);
+                                    cb_input.pop_front(block_size);
                                 }
                             } else {
                                 for (uint32_t col_tile = 0; col_tile < post_group_width; col_tile += block_size) {
@@ -516,7 +542,7 @@ void kernel_main() {
                                                                                ? block_size
                                                                                : (post_group_width - col_tile))
                                                                         : block_size;
-                                    cb_reserve_back(mul_rms_result_cb, tiles_in_block);
+                                    cb_mul_rms_result.reserve_back(tiles_in_block);
                                     tile_regs_acquire();
                                     for (uint32_t i = 0; i < block_size && col_tile + i < post_group_width; i++) {
                                         const uint32_t abs_idx = group_abs_base + col_tile + i;
@@ -528,11 +554,11 @@ void kernel_main() {
                                         pack_tile(i, mul_rms_result_cb);
                                     }
                                     tile_regs_release();
-                                    cb_push_back(mul_rms_result_cb, tiles_in_block);
+                                    cb_mul_rms_result.push_back(tiles_in_block);
                                 }
                             }
 
-                            cb_pop_front(reduce_result_cb, 1);
+                            cb_reduce_result.pop_front(1);
                         }  // !block_major_post
 
                         if constexpr (block_major_post && per_head_norm != 0) {
@@ -552,7 +578,7 @@ void kernel_main() {
                                 reconfig_data_format(input_cb, reduce_result_cb);
                                 pack_reconfig_data_format(mul_rms_result_cb);
                                 mul_bcast_cols_init(input_cb, reduce_result_cb);
-                                cb_reserve_back(mul_rms_result_cb, block_size);
+                                cb_mul_rms_result.reserve_back(block_size);
                                 tile_regs_acquire();
                                 for (uint32_t i = 0; i < tiles_in_block; i++) {
                                     mul_tiles_bcast_cols(
@@ -564,12 +590,12 @@ void kernel_main() {
                                     pack_tile(i, mul_rms_result_cb);
                                 }
                                 tile_regs_release();
-                                cb_push_back(mul_rms_result_cb, block_size);
+                                cb_mul_rms_result.push_back(block_size);
 
                                 // ---- * weight (resident, absolute col index) ----
                                 if constexpr (has_weight) {
-                                    cb_wait_front(weight_cb, group_abs_base + col_tile + tiles_in_block);
-                                    cb_wait_front(mul_rms_result_cb, block_size);
+                                    cb_weight.wait_front(group_abs_base + col_tile + tiles_in_block);
+                                    cb_mul_rms_result.wait_front(block_size);
                                     reconfig_data_format(mul_rms_result_cb, weight_cb);
                                     pack_reconfig_data_format(mul_weight_result_cb);
                                     if constexpr (per_token_weight != 0) {
@@ -577,7 +603,7 @@ void kernel_main() {
                                     } else {
                                         mul_bcast_rows_init(mul_rms_result_cb, weight_cb);
                                     }
-                                    cb_reserve_back(mul_weight_result_cb, block_size);
+                                    cb_mul_weight_result.reserve_back(block_size);
                                     tile_regs_acquire();
                                     for (uint32_t i = 0; i < tiles_in_block; i++) {
                                         if constexpr (per_token_weight != 0) {
@@ -589,18 +615,18 @@ void kernel_main() {
                                         }
                                     }
                                     tile_regs_commit();
-                                    cb_pop_front(mul_rms_result_cb, block_size);
+                                    cb_mul_rms_result.pop_front(block_size);
                                     tile_regs_wait();
                                     for (uint32_t i = 0; i < tiles_in_block; i++) {
                                         pack_tile(i, mul_weight_result_cb);
                                     }
                                     tile_regs_release();
-                                    cb_push_back(mul_weight_result_cb, block_size);
+                                    cb_mul_weight_result.push_back(block_size);
                                 }
                                 // ---- + bias ----
                                 if constexpr (has_bias) {
-                                    cb_wait_front(bias_cb, group_abs_base + col_tile + tiles_in_block);
-                                    cb_wait_front(mul_weight_result_cb, block_size);
+                                    cb_bias.wait_front(group_abs_base + col_tile + tiles_in_block);
+                                    cb_mul_weight_result.wait_front(block_size);
                                     reconfig_data_format(mul_weight_result_cb, bias_cb);
                                     pack_reconfig_data_format(add_bias_result_cb);
                                     if constexpr (per_token_bias != 0) {
@@ -608,7 +634,7 @@ void kernel_main() {
                                     } else {
                                         add_bcast_rows_init(mul_weight_result_cb, bias_cb);
                                     }
-                                    cb_reserve_back(add_bias_result_cb, block_size);
+                                    cb_add_bias_result.reserve_back(block_size);
                                     tile_regs_acquire();
                                     for (uint32_t i = 0; i < tiles_in_block; i++) {
                                         if constexpr (per_token_bias != 0) {
@@ -620,21 +646,21 @@ void kernel_main() {
                                         }
                                     }
                                     tile_regs_commit();
-                                    cb_pop_front(mul_weight_result_cb, block_size);
+                                    cb_mul_weight_result.pop_front(block_size);
                                     tile_regs_wait();
                                     for (uint32_t i = 0; i < tiles_in_block; i++) {
                                         pack_tile(i, add_bias_result_cb);
                                     }
                                     tile_regs_release();
-                                    cb_push_back(add_bias_result_cb, block_size);
+                                    cb_add_bias_result.push_back(block_size);
                                 }
                                 // ---- matmul-rotate + RoPE finalize, else block already output ----
                                 if constexpr (fuse_rope) {
                                     reconfig_data_format(transformation_mat_cb, intermediate_cb);
                                     pack_reconfig_data_format(rotated_input_cb);
                                     matmul_block_init(intermediate_cb, transformation_mat_cb, 0, 1, block_size, 1);
-                                    cb_wait_front(intermediate_cb, block_size);
-                                    cb_reserve_back(rotated_input_cb, block_size);
+                                    cb_intermediate.wait_front(block_size);
+                                    cb_rotated_input.reserve_back(block_size);
                                     tile_regs_acquire();
                                     matmul_block(intermediate_cb, transformation_mat_cb, 0, 0, 0, 0, 1, block_size, 1);
                                     tile_regs_commit();
@@ -643,20 +669,20 @@ void kernel_main() {
                                         pack_tile(i, rotated_input_cb);
                                     }
                                     tile_regs_release();
-                                    cb_push_back(rotated_input_cb, block_size);
+                                    cb_rotated_input.push_back(block_size);
                                     // cos/sin: per-head RoPE uses this head's absolute cols (popped
                                     // per head); broadcast holds head_dim_tiles resident, indexed
                                     // by the column within the head (popped once after the head loop).
                                     if constexpr (per_head_rope != 0) {
-                                        cb_wait_front(rope_cos_cb, group_abs_base + col_tile + tiles_in_block);
-                                        cb_wait_front(rope_sin_cb, group_abs_base + col_tile + tiles_in_block);
+                                        cb_rope_cos.wait_front(group_abs_base + col_tile + tiles_in_block);
+                                        cb_rope_sin.wait_front(group_abs_base + col_tile + tiles_in_block);
                                     } else {
-                                        cb_wait_front(rope_cos_cb, head_dim_tiles);
-                                        cb_wait_front(rope_sin_cb, head_dim_tiles);
+                                        cb_rope_cos.wait_front(head_dim_tiles);
+                                        cb_rope_sin.wait_front(head_dim_tiles);
                                     }
-                                    cb_wait_front(intermediate_cb, block_size);
-                                    cb_wait_front(rotated_input_cb, block_size);
-                                    cb_reserve_back(output_cb, block_size);
+                                    cb_intermediate.wait_front(block_size);
+                                    cb_rotated_input.wait_front(block_size);
+                                    cb_output.reserve_back(block_size);
                                     reconfig_data_format(intermediate_cb, rope_cos_cb);
                                     pack_reconfig_data_format(output_cb);
                                     tile_regs_acquire();
@@ -680,25 +706,25 @@ void kernel_main() {
                                         pack_tile(i, output_cb);
                                     }
                                     tile_regs_release();
-                                    cb_push_back(output_cb, block_size);
-                                    cb_pop_front(intermediate_cb, block_size);
-                                    cb_pop_front(rotated_input_cb, block_size);
+                                    cb_output.push_back(block_size);
+                                    cb_intermediate.pop_front(block_size);
+                                    cb_rotated_input.pop_front(block_size);
                                     if constexpr (per_head_rope != 0) {
-                                        cb_pop_front(rope_cos_cb, tiles_in_block);
-                                        cb_pop_front(rope_sin_cb, tiles_in_block);
+                                        cb_rope_cos.pop_front(tiles_in_block);
+                                        cb_rope_sin.pop_front(tiles_in_block);
                                     }
                                 }
                                 // !fuse_rope: the last affine sub-phase already wrote output_cb.
                             }
-                            cb_pop_front(reduce_result_cb, 1);  // this head's 1/rms
+                            cb_reduce_result.pop_front(1);  // this head's 1/rms
                         }
                     }
                 }  // P_NORM
 
                 if constexpr (block_major_post && per_head_norm != 0 && fuse_rope && per_head_rope == 0) {
                     // Broadcast cos/sin were held resident across all heads; drain once.
-                    cb_pop_front(rope_cos_cb, head_dim_tiles);
-                    cb_pop_front(rope_sin_cb, head_dim_tiles);
+                    cb_rope_cos.pop_front(head_dim_tiles);
+                    cb_rope_sin.pop_front(head_dim_tiles);
                 }
 
                 if constexpr (block_major_post && per_head_norm == 0) {
@@ -714,11 +740,11 @@ void kernel_main() {
                     uint32_t rope_cursor = 0;  // broadcast cos/sin cyclic index (mod head_dim_tiles)
                     for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
                         // ---- x * (1/rms): input 2nd-pass block (streamed) -> mul_rms_result_cb ----
-                        cb_wait_front(input_cb, block_size);
+                        cb_input.wait_front(block_size);
                         reconfig_data_format(input_cb, reduce_result_cb);
                         pack_reconfig_data_format(mul_rms_result_cb);
                         mul_bcast_cols_init(input_cb, reduce_result_cb);
-                        cb_reserve_back(mul_rms_result_cb, block_size);
+                        cb_mul_rms_result.reserve_back(block_size);
                         tile_regs_acquire();
                         for (uint32_t i = 0; i < block_size; i++) {
                             mul_tiles_bcast_cols(input_cb, reduce_result_cb, i, 0, i);
@@ -729,13 +755,13 @@ void kernel_main() {
                             pack_tile(i, mul_rms_result_cb);
                         }
                         tile_regs_release();
-                        cb_push_back(mul_rms_result_cb, block_size);
-                        cb_pop_front(input_cb, block_size);
+                        cb_mul_rms_result.push_back(block_size);
+                        cb_input.pop_front(block_size);
 
                         // ---- * weight ----
                         if constexpr (has_weight) {
-                            cb_wait_front(weight_cb, col_tile + block_size);
-                            cb_wait_front(mul_rms_result_cb, block_size);
+                            cb_weight.wait_front(col_tile + block_size);
+                            cb_mul_rms_result.wait_front(block_size);
                             reconfig_data_format(mul_rms_result_cb, weight_cb);
                             pack_reconfig_data_format(mul_weight_result_cb);
                             if constexpr (per_token_weight != 0) {
@@ -743,7 +769,7 @@ void kernel_main() {
                             } else {
                                 mul_bcast_rows_init(mul_rms_result_cb, weight_cb);
                             }
-                            cb_reserve_back(mul_weight_result_cb, block_size);
+                            cb_mul_weight_result.reserve_back(block_size);
                             tile_regs_acquire();
                             for (uint32_t i = 0; i < block_size; i++) {
                                 if constexpr (per_token_weight != 0) {
@@ -753,19 +779,19 @@ void kernel_main() {
                                 }
                             }
                             tile_regs_commit();
-                            cb_pop_front(mul_rms_result_cb, block_size);
+                            cb_mul_rms_result.pop_front(block_size);
                             tile_regs_wait();
                             for (uint32_t i = 0; i < block_size; i++) {
                                 pack_tile(i, mul_weight_result_cb);
                             }
                             tile_regs_release();
-                            cb_push_back(mul_weight_result_cb, block_size);
+                            cb_mul_weight_result.push_back(block_size);
                         }
 
                         // ---- + bias ----
                         if constexpr (has_bias) {
-                            cb_wait_front(bias_cb, col_tile + block_size);
-                            cb_wait_front(mul_weight_result_cb, block_size);
+                            cb_bias.wait_front(col_tile + block_size);
+                            cb_mul_weight_result.wait_front(block_size);
                             reconfig_data_format(mul_weight_result_cb, bias_cb);
                             pack_reconfig_data_format(add_bias_result_cb);
                             if constexpr (per_token_bias != 0) {
@@ -773,7 +799,7 @@ void kernel_main() {
                             } else {
                                 add_bcast_rows_init(mul_weight_result_cb, bias_cb);
                             }
-                            cb_reserve_back(add_bias_result_cb, block_size);
+                            cb_add_bias_result.reserve_back(block_size);
                             tile_regs_acquire();
                             for (uint32_t i = 0; i < block_size; i++) {
                                 if constexpr (per_token_bias != 0) {
@@ -783,13 +809,13 @@ void kernel_main() {
                                 }
                             }
                             tile_regs_commit();
-                            cb_pop_front(mul_weight_result_cb, block_size);
+                            cb_mul_weight_result.pop_front(block_size);
                             tile_regs_wait();
                             for (uint32_t i = 0; i < block_size; i++) {
                                 pack_tile(i, add_bias_result_cb);
                             }
                             tile_regs_release();
-                            cb_push_back(add_bias_result_cb, block_size);
+                            cb_add_bias_result.push_back(block_size);
                         }
 
                         // ---- matmul-rotate + RoPE finalize (fuse_rope), else block already output ----
@@ -805,8 +831,8 @@ void kernel_main() {
                                 /*ct_dim=*/1,
                                 /*rt_dim=*/block_size,
                                 /*kt_dim=*/1);
-                            cb_wait_front(intermediate_cb, block_size);  // NOT popped; RoPE re-reads it
-                            cb_reserve_back(rotated_input_cb, block_size);
+                            cb_intermediate.wait_front(block_size);  // NOT popped; RoPE re-reads it
+                            cb_rotated_input.reserve_back(block_size);
                             tile_regs_acquire();
                             matmul_block(
                                 intermediate_cb,
@@ -824,7 +850,7 @@ void kernel_main() {
                                 pack_tile(i, rotated_input_cb);
                             }
                             tile_regs_release();
-                            cb_push_back(rotated_input_cb, block_size);
+                            cb_rotated_input.push_back(block_size);
 
                             // out = x*cos + rotate(x)*sin (FPU dst-accumulate, single rounding at pack).
                             // cos/sin are RESIDENT whole-row under block-major (the reader pushed
@@ -832,15 +858,15 @@ void kernel_main() {
                             // block's tiles sit at absolute col_tile..; broadcast: head_dim_tiles
                             // held resident, indexed cyclically. Drained once after the loop.
                             if constexpr (per_head_rope != 0) {
-                                cb_wait_front(rope_cos_cb, col_tile + block_size);
-                                cb_wait_front(rope_sin_cb, col_tile + block_size);
+                                cb_rope_cos.wait_front(col_tile + block_size);
+                                cb_rope_sin.wait_front(col_tile + block_size);
                             } else {
-                                cb_wait_front(rope_cos_cb, head_dim_tiles);
-                                cb_wait_front(rope_sin_cb, head_dim_tiles);
+                                cb_rope_cos.wait_front(head_dim_tiles);
+                                cb_rope_sin.wait_front(head_dim_tiles);
                             }
-                            cb_wait_front(intermediate_cb, block_size);
-                            cb_wait_front(rotated_input_cb, block_size);
-                            cb_reserve_back(output_cb, block_size);
+                            cb_intermediate.wait_front(block_size);
+                            cb_rotated_input.wait_front(block_size);
+                            cb_output.reserve_back(block_size);
                             reconfig_data_format(intermediate_cb, rope_cos_cb);
                             pack_reconfig_data_format(output_cb);
                             const uint32_t rope_base = rope_cursor;
@@ -866,20 +892,20 @@ void kernel_main() {
                                 pack_tile(i, output_cb);
                             }
                             tile_regs_release();
-                            cb_push_back(output_cb, block_size);
-                            cb_pop_front(intermediate_cb, block_size);
-                            cb_pop_front(rotated_input_cb, block_size);
+                            cb_output.push_back(block_size);
+                            cb_intermediate.pop_front(block_size);
+                            cb_rotated_input.pop_front(block_size);
                             // cos/sin are resident whole-row; drained once after the loop (below).
                         }
                         // !fuse_rope: the last affine sub-phase already wrote output_cb (aliases).
                     }
-                    cb_pop_front(reduce_result_cb, 1);
+                    cb_reduce_result.pop_front(1);
                     if constexpr (fuse_rope) {
                         // cos/sin held resident across the whole row; drain once. Per-head holds
                         // num_tile_cols tiles (one per col); broadcast holds head_dim_tiles.
                         const uint32_t rope_row_tiles = (per_head_rope != 0) ? num_tile_cols : head_dim_tiles;
-                        cb_pop_front(rope_cos_cb, rope_row_tiles);
-                        cb_pop_front(rope_sin_cb, rope_row_tiles);
+                        cb_rope_cos.pop_front(rope_row_tiles);
+                        cb_rope_sin.pop_front(rope_row_tiles);
                     }
                 }
 
@@ -904,8 +930,8 @@ void kernel_main() {
                     for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
                         const uint32_t tiles_in_block =
                             (col_tile + block_size <= num_tile_cols) ? block_size : (num_tile_cols - col_tile);
-                        cb_wait_front(weight_cb, col_tile + tiles_in_block);
-                        cb_wait_front(mul_rms_result_cb, block_size);
+                        cb_weight.wait_front(col_tile + tiles_in_block);
+                        cb_mul_rms_result.wait_front(block_size);
                         tile_regs_acquire();
                         for (uint32_t i = 0; i < block_size && col_tile + i < num_tile_cols; i++) {
                             if constexpr (per_token_weight != 0) {
@@ -915,14 +941,14 @@ void kernel_main() {
                             }
                         }
                         tile_regs_commit();
-                        cb_pop_front(mul_rms_result_cb, block_size);
-                        cb_reserve_back(mul_weight_result_cb, block_size);
+                        cb_mul_rms_result.pop_front(block_size);
+                        cb_mul_weight_result.reserve_back(block_size);
                         tile_regs_wait();
                         for (uint32_t i = 0; i < block_size && col_tile + i < num_tile_cols; i++) {
                             pack_tile(i, mul_weight_result_cb);
                         }
                         tile_regs_release();
-                        cb_push_back(mul_weight_result_cb, block_size);
+                        cb_mul_weight_result.push_back(block_size);
                     }
                 }
 
@@ -941,8 +967,8 @@ void kernel_main() {
                     for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
                         const uint32_t tiles_in_block =
                             (col_tile + block_size <= num_tile_cols) ? block_size : (num_tile_cols - col_tile);
-                        cb_wait_front(bias_cb, col_tile + tiles_in_block);
-                        cb_wait_front(mul_weight_result_cb, block_size);
+                        cb_bias.wait_front(col_tile + tiles_in_block);
+                        cb_mul_weight_result.wait_front(block_size);
                         tile_regs_acquire();
                         for (uint32_t i = 0; i < block_size && col_tile + i < num_tile_cols; i++) {
                             if constexpr (per_token_bias != 0) {
@@ -952,14 +978,14 @@ void kernel_main() {
                             }
                         }
                         tile_regs_commit();
-                        cb_pop_front(mul_weight_result_cb, block_size);
-                        cb_reserve_back(add_bias_result_cb, block_size);
+                        cb_mul_weight_result.pop_front(block_size);
+                        cb_add_bias_result.reserve_back(block_size);
                         tile_regs_wait();
                         for (uint32_t i = 0; i < block_size && col_tile + i < num_tile_cols; i++) {
                             pack_tile(i, add_bias_result_cb);
                         }
                         tile_regs_release();
-                        cb_push_back(add_bias_result_cb, block_size);
+                        cb_add_bias_result.push_back(block_size);
                     }
                 }
 
@@ -985,8 +1011,8 @@ void kernel_main() {
                                 /*ct_dim=*/1,
                                 /*rt_dim=*/block_size,
                                 /*kt_dim=*/1);
-                            cb_wait_front(intermediate_cb, block_size);  // front block; popped after RoPE
-                            cb_reserve_back(rotated_input_cb, block_size);
+                            cb_intermediate.wait_front(block_size);  // front block; popped after RoPE
+                            cb_rotated_input.reserve_back(block_size);
                             tile_regs_acquire();
                             matmul_block(
                                 intermediate_cb,
@@ -1004,12 +1030,12 @@ void kernel_main() {
                                 pack_tile(i, rotated_input_cb);
                             }
                             tile_regs_release();
-                            cb_push_back(rotated_input_cb, block_size);
+                            cb_rotated_input.push_back(block_size);
                             // --- RoPE finalize: x*cos + rotate(x)*sin -> output (FPU dst-accumulate) ---
-                            cb_wait_front(rope_cos_cb, tiles_in_block);
-                            cb_wait_front(rope_sin_cb, tiles_in_block);
-                            cb_wait_front(rotated_input_cb, block_size);
-                            cb_reserve_back(output_cb, block_size);
+                            cb_rope_cos.wait_front(tiles_in_block);
+                            cb_rope_sin.wait_front(tiles_in_block);
+                            cb_rotated_input.wait_front(block_size);
+                            cb_output.reserve_back(block_size);
                             reconfig_data_format(intermediate_cb, rope_cos_cb);
                             pack_reconfig_data_format(output_cb);
                             tile_regs_acquire();
@@ -1027,11 +1053,11 @@ void kernel_main() {
                                 pack_tile(i, output_cb);
                             }
                             tile_regs_release();
-                            cb_push_back(output_cb, block_size);
-                            cb_pop_front(intermediate_cb, block_size);
-                            cb_pop_front(rotated_input_cb, block_size);
-                            cb_pop_front(rope_cos_cb, tiles_in_block);
-                            cb_pop_front(rope_sin_cb, tiles_in_block);
+                            cb_output.push_back(block_size);
+                            cb_intermediate.pop_front(block_size);
+                            cb_rotated_input.pop_front(block_size);
+                            cb_rope_cos.pop_front(tiles_in_block);
+                            cb_rope_sin.pop_front(tiles_in_block);
                         }
                     } else {
                         {
@@ -1055,8 +1081,8 @@ void kernel_main() {
                                 /*kt_dim=*/1);
                             for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
                                 // Don't pop intermediate — the RoPE finalize re-reads it.
-                                cb_wait_front(intermediate_cb, col_tile + block_size);
-                                cb_reserve_back(rotated_input_cb, block_size);
+                                cb_intermediate.wait_front(col_tile + block_size);
+                                cb_rotated_input.reserve_back(block_size);
                                 tile_regs_acquire();
                                 matmul_block(
                                     intermediate_cb,
@@ -1074,7 +1100,7 @@ void kernel_main() {
                                     pack_tile(i, rotated_input_cb);
                                 }
                                 tile_regs_release();
-                                cb_push_back(rotated_input_cb, block_size);
+                                cb_rotated_input.push_back(block_size);
                             }
                         }  // P_MM
 
@@ -1104,15 +1130,15 @@ void kernel_main() {
                                 // Broadcast RoPE: a small head_dim_tiles cos/sin buffer is held
                                 // across the whole row and indexed cyclically; popped at end of row.
                                 if constexpr (per_head_rope != 0) {
-                                    cb_wait_front(rope_cos_cb, tiles_in_block);
-                                    cb_wait_front(rope_sin_cb, tiles_in_block);
+                                    cb_rope_cos.wait_front(tiles_in_block);
+                                    cb_rope_sin.wait_front(tiles_in_block);
                                 } else {
-                                    cb_wait_front(rope_cos_cb, head_dim_tiles);
-                                    cb_wait_front(rope_sin_cb, head_dim_tiles);
+                                    cb_rope_cos.wait_front(head_dim_tiles);
+                                    cb_rope_sin.wait_front(head_dim_tiles);
                                 }
-                                cb_wait_front(intermediate_cb, block_size);
-                                cb_wait_front(rotated_input_cb, block_size);
-                                cb_reserve_back(output_cb, block_size);
+                                cb_intermediate.wait_front(block_size);
+                                cb_rotated_input.wait_front(block_size);
+                                cb_output.reserve_back(block_size);
                                 const uint32_t rope_base = rope_cos_tile_in_head;
                                 tile_regs_acquire();
                                 // x*cos -> dst (overwrite: acc_to_dest=false)
@@ -1145,14 +1171,14 @@ void kernel_main() {
                                     pack_tile(i, output_cb);
                                 }
                                 tile_regs_release();
-                                cb_push_back(output_cb, block_size);
-                                cb_pop_front(intermediate_cb, block_size);
-                                cb_pop_front(rotated_input_cb, block_size);
+                                cb_output.push_back(block_size);
+                                cb_intermediate.pop_front(block_size);
+                                cb_rotated_input.pop_front(block_size);
                                 // Per-head: drain this block's streamed cos/sin now (matches the
                                 // reader's per-block push). Broadcast keeps them for cyclic reuse.
                                 if constexpr (per_head_rope != 0) {
-                                    cb_pop_front(rope_cos_cb, tiles_in_block);
-                                    cb_pop_front(rope_sin_cb, tiles_in_block);
+                                    cb_rope_cos.pop_front(tiles_in_block);
+                                    cb_rope_sin.pop_front(tiles_in_block);
                                 }
                             }
                         }  // P_ROPE
@@ -1163,18 +1189,18 @@ void kernel_main() {
                     // Broadcast RoPE holds its head_dim_tiles cos/sin across the row;
                     // pop once here. Per-head streamed cos/sin were popped per block above
                     // (sum over blocks == num_tile_cols, the reader's per-row push count).
-                    cb_pop_front(rope_cos_cb, head_dim_tiles);
-                    cb_pop_front(rope_sin_cb, head_dim_tiles);
+                    cb_rope_cos.pop_front(head_dim_tiles);
+                    cb_rope_sin.pop_front(head_dim_tiles);
                 }
 
                 // Per-token weight/bias: pop the row's slice now so the next
                 // row's slice is at the front. (Broadcast path keeps the same
                 // tiles across all rows and pops at end of kernel.)
                 if constexpr (per_token_weight != 0) {
-                    cb_pop_front(weight_cb, num_tile_cols);
+                    cb_weight.pop_front(num_tile_cols);
                 }
                 if constexpr (per_token_bias != 0) {
-                    cb_pop_front(bias_cb, num_tile_cols);
+                    cb_bias.pop_front(num_tile_cols);
                 }
             }
         }  // RMS_POST
@@ -1184,7 +1210,7 @@ void kernel_main() {
         // P_NMUL (num_tile_cols) = 2*num_tile_cols, matching the reader's two
         // passes. Only the resident path holds the chunk and drains it here.
         if constexpr (!streaming_low_l1) {
-            cb_pop_front(input_cb, chunk_input_tiles);
+            cb_input.pop_front(chunk_input_tiles);
         }
         // NOTE: stats_gathered_cb is NOT popped here — the reduce<AVG> with
         // default WaitAndPopPerTile policy already drains chunk_stats_tiles
@@ -1193,18 +1219,18 @@ void kernel_main() {
         // to read stale L1 contents.
     }
 
-    cb_pop_front(reduce_scalar_sum_cb, 1);
-    cb_pop_front(reduce_scalar_avg_cb, 1);
-    cb_pop_front(epsilon_cb, 1);
+    cb_reduce_scalar_sum.pop_front(1);
+    cb_reduce_scalar_avg.pop_front(1);
+    cb_epsilon.pop_front(1);
     // Broadcast weight/bias: pop the worker's single row slice at end of
     // kernel. Per-token already popped per-row inside the chunk loop.
     if constexpr (has_weight && per_token_weight == 0) {
-        cb_pop_front(weight_cb, num_tile_cols);
+        cb_weight.pop_front(num_tile_cols);
     }
     if constexpr (has_bias && per_token_bias == 0) {
-        cb_pop_front(bias_cb, num_tile_cols);
+        cb_bias.pop_front(num_tile_cols);
     }
     if constexpr (fuse_rope) {
-        cb_pop_front(transformation_mat_cb, 1);
+        cb_transformation_mat.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/dataflow/dit_rmsnorm_fused_forwarder.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/dataflow/dit_rmsnorm_fused_forwarder.cpp
@@ -35,6 +35,9 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "tt_metal/fabric/hw/inc/linear/addrgen_api.h"
@@ -81,21 +84,23 @@ void kernel_main() {
     for (uint32_t r = 0; r < max_rounds; r++) {
         present_count[r] = get_arg_val<uint32_t>(arg_idx++);
     }
-    // Grid-uniform sem addresses (same on this forwarder + its workers).
-    const uint32_t fwd_arrival_sem_addr = get_semaphore(arrival_sem_id);
-    const uint32_t group_go_sem_addr = get_semaphore(go_sem_id);
+    Noc noc;
+    CircularBuffer cb_pkt_hdr(reserved_packet_header_cb);
+    CircularBuffer cb_packet(packet_cb);
+    Semaphore<> fwd_arrival_sem(arrival_sem_id);
+    Semaphore<> group_go_sem(go_sem_id);
 
     // Fabric connection (fwd+bwd) for this forwarder's link.
     auto fabric_connection =
         FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
             arg_idx);
 
-    cb_reserve_back(reserved_packet_header_cb, 1);
-    auto pkt_hdr_fwd_addr = get_write_ptr(reserved_packet_header_cb);
-    cb_push_back(reserved_packet_header_cb, 1);
-    cb_reserve_back(reserved_packet_header_cb, 1);
-    auto pkt_hdr_bwd_addr = get_write_ptr(reserved_packet_header_cb);
-    cb_push_back(reserved_packet_header_cb, 1);
+    cb_pkt_hdr.reserve_back(1);
+    auto pkt_hdr_fwd_addr = cb_pkt_hdr.get_write_ptr();
+    cb_pkt_hdr.push_back(1);
+    cb_pkt_hdr.reserve_back(1);
+    auto pkt_hdr_bwd_addr = cb_pkt_hdr.get_write_ptr();
+    cb_pkt_hdr.push_back(1);
     volatile PACKET_HEADER_TYPE* pkt_hdr_fwd = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(pkt_hdr_fwd_addr);
     volatile PACKET_HEADER_TYPE* pkt_hdr_bwd = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(pkt_hdr_bwd_addr);
     pkt_hdr_fwd->to_chip_multicast(
@@ -110,13 +115,11 @@ void kernel_main() {
     }
 
     const auto stats_dram = TensorAccessor(stats_dram_args, stats_dram_addr);
-    const uint32_t packet_base = get_read_ptr(packet_cb);         // packet_cb is depth-2; we index by r%2 manually
-    const uint32_t packet_tile_bytes = get_tile_size(packet_cb);  // = unit_packet_bytes (one slot)
+    const uint32_t packet_base = cb_packet.get_read_ptr();         // packet_cb is depth-2; we index by r%2 manually
+    const uint32_t packet_tile_bytes = cb_packet.get_tile_size();  // = unit_packet_bytes (one slot)
 
     const uint64_t out_ready_sem_noc = safe_get_noc_addr(my_x[0], my_y[0], out_ready_sem_addr, 0);
     volatile tt_l1_ptr uint32_t* out_ready_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_addr);
-    volatile tt_l1_ptr uint32_t* fwd_arrival_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fwd_arrival_sem_addr);
 
     uint32_t cumulative_arrivals = 0;
     uint32_t cumulative_incs = 0;
@@ -137,7 +140,7 @@ void kernel_main() {
             DeviceZoneScopedN("F_COLLECT");
             // Workers write their stick into packet_addr + slot*stick_bytes and inc.
             cumulative_arrivals += pc;
-            noc_semaphore_wait_min(fwd_arrival_sem_ptr, cumulative_arrivals);
+            fwd_arrival_sem.wait_min(cumulative_arrivals);
         }
 
         // Page (my_device, forwarder, r) — same DRAM address on every chip.
@@ -158,20 +161,20 @@ void kernel_main() {
                 /*flush=*/true);
             cumulative_incs += (ring_size - 1);
             if (cumulative_incs > 0) {
+                // out_ready is a GlobalSemaphore.
                 noc_semaphore_wait_min(out_ready_sem_ptr, cumulative_incs);
             }
-            noc_async_write_barrier();
-            noc_async_atomic_barrier();
+            noc.async_write_barrier();
+            noc.async_atomic_barrier();
         }
 
         // Release this round's POST: inc each PRESENT group worker's go-sem. The
         // present set is the contiguous slot prefix [0, pc) (earlier workers get
         // the ceil row count), so only the first pc workers loop this round.
         for (uint32_t i = 0; i < pc; i++) {
-            const uint64_t go = safe_get_noc_addr(worker_x[i], worker_y[i], group_go_sem_addr, 0);
-            noc_semaphore_inc(go, 1);
+            group_go_sem.up(noc, worker_x[i], worker_y[i], 1);
         }
-        noc_async_atomic_barrier();
+        noc.async_atomic_barrier();
     }
 
     // Reset BOTH op-managed semaphores this core owns to 0 so a traced replay
@@ -179,11 +182,14 @@ void kernel_main() {
     // init that eager launches get, so any sem left non-zero accumulates across
     // replays. out_ready (peers fuse-inc it) and fwd_arrival (workers inc it) both
     // live on this forwarder core; the workers reset their own go-sem. Without the
-    // arrival reset the forwarder's wait_min(arrival, cumulative) passes instantly
-    // on replay (sem already high) -> it stops waiting for the workers' sticks ->
-    // races (fast-but-wrong) or desyncs into a hang. (go/out_ready already reset.)
+    // arrival reset the forwarder's fwd_arrival_sem.wait_min(cumulative) passes
+    // instantly on replay (sem already high) -> it stops waiting for the workers'
+    // sticks -> races (fast-but-wrong) or desyncs into a hang. (go/out_ready already
+    // reset.)
+    //
+    // out_ready is a GlobalSemaphore.
     noc_semaphore_set(out_ready_sem_ptr, 0);
-    noc_semaphore_set(fwd_arrival_sem_ptr, 0);
+    fwd_arrival_sem.set(0);
     // Guard close on is_logically_connected(), matching the canonical CCL writers.
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.close_start();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/dataflow/dit_rmsnorm_fused_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/dataflow/dit_rmsnorm_fused_reader.cpp
@@ -21,6 +21,10 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
 #include <tt-metalium/constants.hpp>
 #include "tools/profiler/kernel_profiler.hpp"
 
@@ -40,9 +44,9 @@ void kernel_main() {
     constexpr uint32_t bias_cb = get_compile_time_arg_val(11);
     constexpr uint32_t has_bias = get_compile_time_arg_val(12);
     // Per-token weight/bias: shape [N, H] (vs broadcast [1, H]). Read pattern
-    // is per-row (after each row's input is pushed) using noc_async_read_tile
-    // for full 4 KB/tile (vs face_row_bytes for the broadcast case). Compute
-    // uses mul_tiles / add_tiles directly (no _bcast_rows).
+    // is per-row (after each row's input is pushed) using a full-page
+    // noc.async_read for full 4 KB/tile (vs face_row_bytes for the broadcast
+    // case). Compute uses mul_tiles / add_tiles directly (no _bcast_rows).
     constexpr uint32_t per_token_weight = get_compile_time_arg_val(13);
     constexpr uint32_t per_token_bias = get_compile_time_arg_val(14);
     // Streaming low-L1: input_cb is block-sized, so the row is read in two
@@ -109,11 +113,19 @@ void kernel_main() {
     const uint32_t tile_row_end = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t recip_addr = get_arg_val<uint32_t>(arg_idx++);
 
-    const uint32_t input_tile_bytes = get_tile_size(input_cb);
-    const uint32_t weight_tile_bytes = get_tile_size(weight_cb);
-    const uint32_t bias_tile_bytes = get_tile_size(bias_cb);
-    const uint32_t rope_cos_tile_bytes = get_tile_size(rope_cos_cb);
-    const uint32_t rope_sin_tile_bytes = get_tile_size(rope_sin_cb);
+    Noc noc;
+
+    CircularBuffer cb_input(input_cb);
+    CircularBuffer cb_weight(weight_cb);
+    CircularBuffer cb_bias(bias_cb);
+    CircularBuffer cb_rope_cos(rope_cos_cb);
+    CircularBuffer cb_rope_sin(rope_sin_cb);
+
+    const uint32_t input_tile_bytes = cb_input.get_tile_size();
+    const uint32_t weight_tile_bytes = cb_weight.get_tile_size();
+    const uint32_t bias_tile_bytes = cb_bias.get_tile_size();
+    const uint32_t rope_cos_tile_bytes = cb_rope_cos.get_tile_size();
+    const uint32_t rope_sin_tile_bytes = cb_rope_sin.get_tile_size();
 
     const auto input_accessor = TensorAccessor(input_args, input_addr);
     const auto weight_accessor = TensorAccessor(weight_args, weight_addr);
@@ -121,17 +133,28 @@ void kernel_main() {
     const auto rope_cos_accessor = TensorAccessor(rope_cos_args, rope_cos_addr);
     const auto rope_sin_accessor = TensorAccessor(rope_sin_args, rope_sin_addr);
 
+    // Full-page read sizes. The face-row reads further down deliberately do NOT use
+    // these — they read a fraction of a page.
+    const uint32_t input_page_bytes = input_accessor.get_aligned_page_size();
+    const uint32_t weight_page_bytes = weight_accessor.get_aligned_page_size();
+    const uint32_t bias_page_bytes = bias_accessor.get_aligned_page_size();
+    const uint32_t rope_cos_page_bytes = rope_cos_accessor.get_aligned_page_size();
+    const uint32_t rope_sin_page_bytes = rope_sin_accessor.get_aligned_page_size();
+
     // Welford reciprocal LUT: read the whole [1, reduce_width] fp32 page (one DRAM page,
     // reduce_width == num_tile_cols * 32 -> num_tile_cols * 128 bytes) into recip_lut_cb
     // ONCE, before any row work, so compute's first welford_update has it. Compute reads
     // it as std::array<uint32_t, reduce_width>; absent -> compute uses runtime division.
     if constexpr (use_recip_lut) {
         const auto recip_accessor = TensorAccessor(recip_args, recip_addr);
+        CircularBuffer cb_recip_lut(recip_lut_cb);
         constexpr uint32_t recip_bytes = num_tile_cols * 128u;  // reduce_width * sizeof(float)
-        cb_reserve_back(recip_lut_cb, 1);
-        noc_async_read(recip_accessor.get_noc_addr(0), get_write_ptr(recip_lut_cb), recip_bytes);
-        noc_async_read_barrier();
-        cb_push_back(recip_lut_cb, 1);
+        cb_recip_lut.reserve_back(1);
+        // Size is recip_bytes, not the accessor's page size: the LUT is one DRAM page but
+        // we only want the [1, reduce_width] prefix.
+        noc.async_read(recip_accessor, cb_recip_lut, recip_bytes, {.page_id = 0}, {});
+        noc.async_read_barrier();
+        cb_recip_lut.push_back(1);
     }
 
     // Row-broadcast weight / bias live in a TILE-layout [1, H] tensor where
@@ -164,14 +187,19 @@ void kernel_main() {
         for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
             const uint32_t tiles_in_block =
                 ((num_tile_cols - col_tile) >= block_size) ? block_size : (num_tile_cols - col_tile);
-            cb_reserve_back(input_cb, tiles_in_block);
-            uint32_t input_wr_ptr = get_write_ptr(input_cb);
+            cb_input.reserve_back(tiles_in_block);
+            uint32_t input_wr_ptr = cb_input.get_write_ptr();
             for (uint32_t i = 0; i < tiles_in_block; i++) {
-                noc_async_read_page(input_tile_idx + col_tile + i, input_accessor, input_wr_ptr);
+                noc.async_read(
+                    input_accessor,
+                    CoreLocalMem<uint32_t>(input_wr_ptr),
+                    input_page_bytes,
+                    {.page_id = input_tile_idx + col_tile + i},
+                    {});
                 input_wr_ptr += input_tile_bytes;
             }
-            noc_async_read_barrier();
-            cb_push_back(input_cb, tiles_in_block);
+            noc.async_read_barrier();
+            cb_input.push_back(tiles_in_block);
         }
     };
 
@@ -216,30 +244,36 @@ void kernel_main() {
             for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
                 const uint32_t tiles_in_block =
                     ((num_tile_cols - col_tile) >= block_size) ? block_size : (num_tile_cols - col_tile);
-                cb_reserve_back(weight_cb, tiles_in_block);
-                uint32_t weight_wr_ptr = get_write_ptr(weight_cb);
+                cb_weight.reserve_back(tiles_in_block);
+                uint32_t weight_wr_ptr = cb_weight.get_write_ptr();
                 for (uint32_t i = 0; i < tiles_in_block; i++) {
                     const uint32_t w_idx = tile_row * num_tile_cols + col_tile + i;
-                    noc_async_read_page(w_idx, weight_accessor, weight_wr_ptr);
+                    noc.async_read(
+                        weight_accessor,
+                        CoreLocalMem<uint32_t>(weight_wr_ptr),
+                        weight_page_bytes,
+                        {.page_id = w_idx},
+                        {});
                     weight_wr_ptr += weight_tile_bytes;
                 }
-                noc_async_read_barrier();
-                cb_push_back(weight_cb, tiles_in_block);
+                noc.async_read_barrier();
+                cb_weight.push_back(tiles_in_block);
             }
         }
         if constexpr (per_token_bias != 0) {
             for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
                 const uint32_t tiles_in_block =
                     ((num_tile_cols - col_tile) >= block_size) ? block_size : (num_tile_cols - col_tile);
-                cb_reserve_back(bias_cb, tiles_in_block);
-                uint32_t bias_wr_ptr = get_write_ptr(bias_cb);
+                cb_bias.reserve_back(tiles_in_block);
+                uint32_t bias_wr_ptr = cb_bias.get_write_ptr();
                 for (uint32_t i = 0; i < tiles_in_block; i++) {
                     const uint32_t b_idx = tile_row * num_tile_cols + col_tile + i;
-                    noc_async_read_page(b_idx, bias_accessor, bias_wr_ptr);
+                    noc.async_read(
+                        bias_accessor, CoreLocalMem<uint32_t>(bias_wr_ptr), bias_page_bytes, {.page_id = b_idx}, {});
                     bias_wr_ptr += bias_tile_bytes;
                 }
-                noc_async_read_barrier();
-                cb_push_back(bias_cb, tiles_in_block);
+                noc.async_read_barrier();
+                cb_bias.push_back(tiles_in_block);
             }
         }
 
@@ -253,17 +287,27 @@ void kernel_main() {
             for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
                 const uint32_t tiles_in_block =
                     ((num_tile_cols - col_tile) >= block_size) ? block_size : (num_tile_cols - col_tile);
-                cb_reserve_back(weight_cb, tiles_in_block);
-                uint32_t weight_wr_ptr = get_write_ptr(weight_cb);
+                cb_weight.reserve_back(tiles_in_block);
+                uint32_t weight_wr_ptr = cb_weight.get_write_ptr();
                 for (uint32_t i = 0; i < tiles_in_block; i++) {
-                    uint64_t weight_noc_addr = weight_accessor.get_noc_addr(w_base + col_tile + i);
-                    noc_async_read(weight_noc_addr, weight_wr_ptr, weight_face_row_bytes);
-                    noc_async_read(
-                        weight_noc_addr + weight_face_bytes, weight_wr_ptr + weight_face_bytes, weight_face_row_bytes);
+                    // Two sub-page reads per tile: face_00 row 0, then face_01 row 0.
+                    const uint32_t w_page = w_base + col_tile + i;
+                    noc.async_read(
+                        weight_accessor,
+                        CoreLocalMem<uint32_t>(weight_wr_ptr),
+                        weight_face_row_bytes,
+                        {.page_id = w_page},
+                        {});
+                    noc.async_read(
+                        weight_accessor,
+                        CoreLocalMem<uint32_t>(weight_wr_ptr + weight_face_bytes),
+                        weight_face_row_bytes,
+                        {.page_id = w_page, .offset_bytes = weight_face_bytes},
+                        {});
                     weight_wr_ptr += weight_tile_bytes;
                 }
-                noc_async_read_barrier();
-                cb_push_back(weight_cb, tiles_in_block);
+                noc.async_read_barrier();
+                cb_weight.push_back(tiles_in_block);
             }
         }
         if constexpr (per_batch_bias != 0) {
@@ -272,16 +316,27 @@ void kernel_main() {
             for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
                 const uint32_t tiles_in_block =
                     ((num_tile_cols - col_tile) >= block_size) ? block_size : (num_tile_cols - col_tile);
-                cb_reserve_back(bias_cb, tiles_in_block);
-                uint32_t bias_wr_ptr = get_write_ptr(bias_cb);
+                cb_bias.reserve_back(tiles_in_block);
+                uint32_t bias_wr_ptr = cb_bias.get_write_ptr();
                 for (uint32_t i = 0; i < tiles_in_block; i++) {
-                    uint64_t bias_noc_addr = bias_accessor.get_noc_addr(b_base + col_tile + i);
-                    noc_async_read(bias_noc_addr, bias_wr_ptr, bias_face_row_bytes);
-                    noc_async_read(bias_noc_addr + bias_face_bytes, bias_wr_ptr + bias_face_bytes, bias_face_row_bytes);
+                    // face_00 row 0 + face_01 row 0, as for weight above.
+                    const uint32_t b_page = b_base + col_tile + i;
+                    noc.async_read(
+                        bias_accessor,
+                        CoreLocalMem<uint32_t>(bias_wr_ptr),
+                        bias_face_row_bytes,
+                        {.page_id = b_page},
+                        {});
+                    noc.async_read(
+                        bias_accessor,
+                        CoreLocalMem<uint32_t>(bias_wr_ptr + bias_face_bytes),
+                        bias_face_row_bytes,
+                        {.page_id = b_page, .offset_bytes = bias_face_bytes},
+                        {});
                     bias_wr_ptr += bias_tile_bytes;
                 }
-                noc_async_read_barrier();
-                cb_push_back(bias_cb, tiles_in_block);
+                noc.async_read_barrier();
+                cb_bias.push_back(tiles_in_block);
             }
         }
 
@@ -298,19 +353,27 @@ void kernel_main() {
                 for (uint32_t col_tile = 0; col_tile < weight_bcast_tiles; col_tile += block_size) {
                     const uint32_t tiles_in_block =
                         ((weight_bcast_tiles - col_tile) >= block_size) ? block_size : (weight_bcast_tiles - col_tile);
-                    cb_reserve_back(weight_cb, tiles_in_block);
-                    uint32_t weight_wr_ptr = get_write_ptr(weight_cb);
+                    cb_weight.reserve_back(tiles_in_block);
+                    uint32_t weight_wr_ptr = cb_weight.get_write_ptr();
                     for (uint32_t i = 0; i < tiles_in_block; i++) {
-                        uint64_t weight_noc_addr = weight_accessor.get_noc_addr(col_tile + i);
-                        noc_async_read(weight_noc_addr, weight_wr_ptr, weight_face_row_bytes);
-                        noc_async_read(
-                            weight_noc_addr + weight_face_bytes,
-                            weight_wr_ptr + weight_face_bytes,
-                            weight_face_row_bytes);
+                        // face_00 row 0 + face_01 row 0, as for the per-batch read above.
+                        const uint32_t w_page = col_tile + i;
+                        noc.async_read(
+                            weight_accessor,
+                            CoreLocalMem<uint32_t>(weight_wr_ptr),
+                            weight_face_row_bytes,
+                            {.page_id = w_page},
+                            {});
+                        noc.async_read(
+                            weight_accessor,
+                            CoreLocalMem<uint32_t>(weight_wr_ptr + weight_face_bytes),
+                            weight_face_row_bytes,
+                            {.page_id = w_page, .offset_bytes = weight_face_bytes},
+                            {});
                         weight_wr_ptr += weight_tile_bytes;
                     }
-                    noc_async_read_barrier();
-                    cb_push_back(weight_cb, tiles_in_block);
+                    noc.async_read_barrier();
+                    cb_weight.push_back(tiles_in_block);
                 }
                 weight_pushed = true;
             }
@@ -320,17 +383,27 @@ void kernel_main() {
                 for (uint32_t col_tile = 0; col_tile < bias_bcast_tiles; col_tile += block_size) {
                     const uint32_t tiles_in_block =
                         ((bias_bcast_tiles - col_tile) >= block_size) ? block_size : (bias_bcast_tiles - col_tile);
-                    cb_reserve_back(bias_cb, tiles_in_block);
-                    uint32_t bias_wr_ptr = get_write_ptr(bias_cb);
+                    cb_bias.reserve_back(tiles_in_block);
+                    uint32_t bias_wr_ptr = cb_bias.get_write_ptr();
                     for (uint32_t i = 0; i < tiles_in_block; i++) {
-                        uint64_t bias_noc_addr = bias_accessor.get_noc_addr(col_tile + i);
-                        noc_async_read(bias_noc_addr, bias_wr_ptr, bias_face_row_bytes);
-                        noc_async_read(
-                            bias_noc_addr + bias_face_bytes, bias_wr_ptr + bias_face_bytes, bias_face_row_bytes);
+                        // face_00 row 0 + face_01 row 0, as for the per-batch read above.
+                        const uint32_t b_page = col_tile + i;
+                        noc.async_read(
+                            bias_accessor,
+                            CoreLocalMem<uint32_t>(bias_wr_ptr),
+                            bias_face_row_bytes,
+                            {.page_id = b_page},
+                            {});
+                        noc.async_read(
+                            bias_accessor,
+                            CoreLocalMem<uint32_t>(bias_wr_ptr + bias_face_bytes),
+                            bias_face_row_bytes,
+                            {.page_id = b_page, .offset_bytes = bias_face_bytes},
+                            {});
                         bias_wr_ptr += bias_tile_bytes;
                     }
-                    noc_async_read_barrier();
-                    cb_push_back(bias_cb, tiles_in_block);
+                    noc.async_read_barrier();
+                    cb_bias.push_back(tiles_in_block);
                 }
                 bias_pushed = true;
             }
@@ -370,16 +443,16 @@ void kernel_main() {
                     // This caps outstanding rope reads at 2*block_size (cos+sin) so the
                     // deep reader can't oversubscribe the NoC read-response queue under
                     // many chunks (the selfattn_qk_s2 traced hang: ~2300 reads issued
-                    // but unreturned). Compute's cumulative cb_wait_front absorbs the
+                    // but unreturned). Compute's cumulative wait_front absorbs the
                     // block-wise pushes (same pattern as the input read above).
                     const uint32_t rope_tiles_this_row = (per_head_rope != 0) ? num_tile_cols : head_dim_tiles;
                     for (uint32_t t0 = 0; t0 < rope_tiles_this_row; t0 += block_size) {
                         const uint32_t grp =
                             ((rope_tiles_this_row - t0) >= block_size) ? block_size : (rope_tiles_this_row - t0);
-                        cb_reserve_back(rope_cos_cb, grp);
-                        cb_reserve_back(rope_sin_cb, grp);
-                        uint32_t rope_cos_wr_ptr = get_write_ptr(rope_cos_cb);
-                        uint32_t rope_sin_wr_ptr = get_write_ptr(rope_sin_cb);
+                        cb_rope_cos.reserve_back(grp);
+                        cb_rope_sin.reserve_back(grp);
+                        uint32_t rope_cos_wr_ptr = cb_rope_cos.get_write_ptr();
+                        uint32_t rope_sin_wr_ptr = cb_rope_sin.get_write_ptr();
                         for (uint32_t j = 0; j < grp; j++) {
                             const uint32_t t = t0 + j;
                             uint32_t src_idx;
@@ -392,14 +465,24 @@ void kernel_main() {
                             } else {
                                 src_idx = rope_batch_off + r_seq * head_dim_tiles + t;
                             }
-                            noc_async_read_page(src_idx, rope_cos_accessor, rope_cos_wr_ptr);
-                            noc_async_read_page(src_idx, rope_sin_accessor, rope_sin_wr_ptr);
+                            noc.async_read(
+                                rope_cos_accessor,
+                                CoreLocalMem<uint32_t>(rope_cos_wr_ptr),
+                                rope_cos_page_bytes,
+                                {.page_id = src_idx},
+                                {});
+                            noc.async_read(
+                                rope_sin_accessor,
+                                CoreLocalMem<uint32_t>(rope_sin_wr_ptr),
+                                rope_sin_page_bytes,
+                                {.page_id = src_idx},
+                                {});
                             rope_cos_wr_ptr += rope_cos_tile_bytes;
                             rope_sin_wr_ptr += rope_sin_tile_bytes;
                         }
-                        noc_async_read_barrier();
-                        cb_push_back(rope_cos_cb, grp);
-                        cb_push_back(rope_sin_cb, grp);
+                        noc.async_read_barrier();
+                        cb_rope_cos.push_back(grp);
+                        cb_rope_sin.push_back(grp);
                     }
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/dataflow/dit_rmsnorm_fused_worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/dataflow/dit_rmsnorm_fused_worker_writer.cpp
@@ -28,6 +28,12 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "dit_rmsnorm_scalar_setup.hpp"
 #include "tools/profiler/kernel_profiler.hpp"
@@ -44,8 +50,8 @@ constexpr uint32_t max_rounds = get_compile_time_arg_val(8);              // pag
 constexpr uint32_t stick_bytes = get_compile_time_arg_val(9);             // 128
 constexpr uint32_t num_chunks_per_device = get_compile_time_arg_val(10);  // num_forwarders*max_rounds
 // Shared packet CB (created on the whole core grid -> uniform L1 addr, so this
-// worker's get_write_ptr(packet_cb) == the forwarder core's packet base) and
-// grid-uniform sync sem ids.
+// worker's CircularBuffer(packet_cb).get_write_ptr() == the forwarder core's
+// packet base) and grid-uniform sync sem ids.
 constexpr uint32_t packet_cb = get_compile_time_arg_val(11);
 constexpr uint32_t arrival_sem_id = get_compile_time_arg_val(12);
 constexpr uint32_t go_sem_id = get_compile_time_arg_val(13);
@@ -87,18 +93,26 @@ void kernel_main() {
     const uint32_t my_forwarder_index = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t my_slot = get_arg_val<uint32_t>(arg_idx++);
 
-    // Grid-uniform: my own packet_cb base == the forwarder's packet base; sem
-    // addrs are the same on me and the forwarder.
-    const uint32_t fwd_packet_buf_addr = get_write_ptr(packet_cb);
-    const uint32_t packet_slot_bytes = get_tile_size(packet_cb);  // unit_packet_bytes (per round%2 slot)
-    const uint32_t fwd_arrival_sem_addr = get_semaphore(arrival_sem_id);
-    const uint32_t go_sem_addr = get_semaphore(go_sem_id);
+    Noc noc;
 
-    const uint32_t output_tile_bytes = get_tile_size(output_cb);
+    CircularBuffer cb_packet(packet_cb);
+    CircularBuffer cb_output(output_cb);
+    CircularBuffer cb_stats_local(stats_transposed_local_cb);
+    CircularBuffer cb_stats_gathered(stats_transposed_gathered_cb);
+
+    // Grid-uniform: my own packet_cb base == the forwarder's packet base, and both
+    // semaphores resolve to the same L1 offset on me and on the forwarder.
+    const uint32_t fwd_packet_buf_addr = cb_packet.get_write_ptr();
+    const uint32_t packet_slot_bytes = cb_packet.get_tile_size();  // unit_packet_bytes (per round%2 slot)
+    Semaphore<> fwd_arrival_sem(arrival_sem_id);
+    Semaphore<> go_sem(go_sem_id);
+
+    const uint32_t output_tile_bytes = cb_output.get_tile_size();
     const auto output_accessor = TensorAccessor(output_args, output_addr);
+    const uint32_t output_page_bytes = output_accessor.get_aligned_page_size();
     const auto stats_dram = TensorAccessor(stats_dram_args, stats_dram_addr);
-    const uint32_t gathered_tile_bytes = get_tile_size(stats_transposed_gathered_cb);
-    const uint32_t stat_tile_bytes = get_tile_size(stats_transposed_local_cb);
+    const uint32_t gathered_tile_bytes = cb_stats_gathered.get_tile_size();
+    const uint32_t stat_tile_bytes = cb_stats_local.get_tile_size();
 
     // Populate compute's scalar/eps/trans_mat CBs before anything else.
     dit_rmsnorm_generate_scalars_and_transmat<
@@ -109,9 +123,6 @@ void kernel_main() {
         w_reduce_factor,
         static_cast<bool>(w_fuse_rope)>(w_eps_bits, TensorAccessor(w_transmat_args, transformation_mat_addr));
 
-    volatile tt_l1_ptr uint32_t* go_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(go_sem_addr);
-    const uint64_t fwd_arrival_noc = safe_get_noc_addr(fwd_x, fwd_y, fwd_arrival_sem_addr, 0);
-
     uint32_t go_target = 0;
     for (uint32_t tile_row = tile_row_start; tile_row < tile_row_end; tile_row++) {
         const uint32_t round = tile_row - tile_row_start;
@@ -121,51 +132,74 @@ void kernel_main() {
         // LayerNorm); the worker contributes one slot (my_slot*stick_bytes) regardless.
         {
             DeviceZoneScopedN("W_PUSH");
-            cb_wait_front(stats_transposed_local_cb, num_stats);
-            const uint32_t src0 = get_read_ptr(stats_transposed_local_cb);
+            cb_stats_local.wait_front(num_stats);
+            const uint32_t src0 = cb_stats_local.get_read_ptr();
             const uint32_t dst = fwd_packet_buf_addr + (round & 1u) * packet_slot_bytes + my_slot * stick_bytes;
+            // The forwarder's packet buffer is a grid-uniform CB, so its address is our own.
+            UnicastEndpoint fwd_core;
             for (uint32_t s = 0; s < num_stats; s++) {
                 const uint32_t src = src0 + s * stat_tile_bytes;
                 const uint32_t sub = dst + s * kStatBytes;
-                const uint64_t dst_noc0 = safe_get_noc_addr(fwd_x, fwd_y, sub, 0);
-                const uint64_t dst_noc1 = safe_get_noc_addr(fwd_x, fwd_y, sub + kFaceRowBytes, 0);
-                noc_async_write(src, dst_noc0, kFaceRowBytes);               // face_00 row0
-                noc_async_write(src + kFace01Off, dst_noc1, kFaceRowBytes);  // face_01 row0
+                noc.async_write(  // face_00 row0
+                    CoreLocalMem<uint32_t>(src),
+                    fwd_core,
+                    kFaceRowBytes,
+                    {},
+                    {.noc_x = fwd_x, .noc_y = fwd_y, .addr = sub});
+                noc.async_write(  // face_01 row0
+                    CoreLocalMem<uint32_t>(src + kFace01Off),
+                    fwd_core,
+                    kFaceRowBytes,
+                    {},
+                    {.noc_x = fwd_x, .noc_y = fwd_y, .addr = sub + kFaceRowBytes});
             }
-            noc_async_write_barrier();
-            noc_semaphore_inc(fwd_arrival_noc, 1);
-            noc_async_atomic_barrier();
-            cb_pop_front(stats_transposed_local_cb, num_stats);
+            noc.async_write_barrier();
+            // Arrival handshake: the stick must be visible in the forwarder's packet buffer
+            // *before* the forwarder sees the count go up, hence the write barrier above and
+            // the atomic barrier below.
+            fwd_arrival_sem.up(noc, fwd_x, fwd_y, 1);
+            noc.async_atomic_barrier();
+            cb_stats_local.pop_front(num_stats);
         }
 
         // ---- 2. wait for the forwarder's go (this round's ring gather landed) ----
         {
             DeviceZoneScopedN("W_AGWAIT");
             go_target += 1;
-            noc_semaphore_wait_min(go_sem_ptr, go_target);
+            go_sem.wait_min(go_target);
         }
 
         // ---- 3. read num_stats*ring gathered sticks from DRAM into ROW 0 of gathered tiles ----
         // Device-major, stat-minor order: gathered tile (d*num_stats + s). For LayerNorm
         // this yields interleaved [mean_d, var_d] per device, as combine_welford_partials wants.
-        cb_reserve_back(stats_transposed_gathered_cb, num_stats * ring_size);
-        const uint32_t gbase = get_write_ptr(stats_transposed_gathered_cb);
+        cb_stats_gathered.reserve_back(num_stats * ring_size);
+        const uint32_t gbase = cb_stats_gathered.get_write_ptr();
         for (uint32_t d = 0; d < ring_size; d++) {
             const uint32_t page_idx = d * num_chunks_per_device + my_forwarder_index * max_rounds + round;
             for (uint32_t s = 0; s < num_stats; s++) {
                 const uint32_t tile_dst = gbase + (d * num_stats + s) * gathered_tile_bytes;
-                const uint64_t src = stats_dram.get_noc_addr(page_idx, my_slot * stick_bytes + s * kStatBytes);
-                noc_async_read(src, tile_dst, kFaceRowBytes);                               // -> face_00 row0
-                noc_async_read(src + kFaceRowBytes, tile_dst + kFace01Off, kFaceRowBytes);  // -> face_01 row0
+                const uint32_t src_off = my_slot * stick_bytes + s * kStatBytes;
+                noc.async_read(  // -> face_00 row0
+                    stats_dram,
+                    CoreLocalMem<uint32_t>(tile_dst),
+                    kFaceRowBytes,
+                    {.page_id = page_idx, .offset_bytes = src_off},
+                    {});
+                noc.async_read(  // -> face_01 row0
+                    stats_dram,
+                    CoreLocalMem<uint32_t>(tile_dst + kFace01Off),
+                    kFaceRowBytes,
+                    {.page_id = page_idx, .offset_bytes = src_off + kFaceRowBytes},
+                    {});
             }
         }
-        noc_async_read_barrier();
-        cb_push_back(stats_transposed_gathered_cb, num_stats * ring_size);
+        noc.async_read_barrier();
+        cb_stats_gathered.push_back(num_stats * ring_size);
 
         // ---- 4. drain this row's output_cb tiles ----
         // Per-block wait + pop (NOT a cumulative wait with a single end-of-row pop):
         // under block_major_post the factory sizes output_cb to just 2*block_size
-        // (block-local), NOT the whole row, so a cumulative cb_wait_front(output_cb,
+        // (block-local), NOT the whole row, so a cumulative output_cb.wait_front(
         // 3*block_size...) could never be satisfied — compute can't push a 3rd block
         // into a 2-block CB it never popped → deadlock (this is why is_tp_1 wide, which
         // uses the per-block drain-only writer, worked while TP>1 wide hung). Compute
@@ -176,22 +210,26 @@ void kernel_main() {
             for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
                 const uint32_t tiles_in_block =
                     ((num_tile_cols - col_tile) >= block_size) ? block_size : (num_tile_cols - col_tile);
-                cb_wait_front(output_cb, block_size);
-                uint32_t rd = get_read_ptr(output_cb);
+                cb_output.wait_front(block_size);
+                uint32_t rd = cb_output.get_read_ptr();
                 for (uint32_t i = 0; i < tiles_in_block; i++) {
                     const uint32_t c = col_tile + i;
                     const uint32_t h = c / head_dim_tiles;
                     const uint32_t t_col = c - h * head_dim_tiles;
                     const uint32_t out_idx =
                         h * total_num_tile_rows * head_dim_tiles + tile_row * head_dim_tiles + t_col;
-                    noc_async_write_page(out_idx, output_accessor, rd);
+                    noc.async_write(
+                        CoreLocalMem<uint32_t>(rd), output_accessor, output_page_bytes, {}, {.page_id = out_idx});
                     rd += output_tile_bytes;
                 }
-                noc_async_writes_flushed();
-                cb_pop_front(output_cb, block_size);
+                noc.async_writes_flushed();
+                cb_output.pop_front(block_size);
             }
         }
     }
-    noc_async_write_barrier();
-    noc_semaphore_set(go_sem_ptr, 0);
+    noc.async_write_barrier();
+    // Reset the go-sem for the next invocation. Trace replay re-runs this kernel without
+    // re-running host-side semaphore init, so leaving a stale non-zero count here would let
+    // the next replay's very first go_sem.wait_min(1) fall straight through.
+    go_sem.set(0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/dataflow/dit_rmsnorm_fused_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/dataflow/dit_rmsnorm_fused_writer.cpp
@@ -38,6 +38,10 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
@@ -92,8 +96,13 @@ void kernel_main() {
     // (only read when fuse_rope). 0 when no RoPE.
     const uint32_t transformation_mat_addr = get_arg_val<uint32_t>(arg_idx++);
 
-    const uint32_t output_tile_bytes = get_tile_size(output_cb);
+    Noc noc;
+    CircularBuffer cb_output(output_cb);
+
+    const uint32_t output_tile_bytes = cb_output.get_tile_size();
     const auto output_accessor = TensorAccessor(output_args, output_addr);
+    // Page size, distinct from output_tile_bytes above, which is the CB slot stride.
+    const uint32_t output_page_bytes = output_accessor.get_aligned_page_size();
     const uint32_t num_tile_rows = tile_row_end - tile_row_start;
 
     // Populate compute's reduce-scalar / epsilon / trans_mat CBs before any AG
@@ -123,13 +132,17 @@ void kernel_main() {
             FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
                 arg_idx);
 
+        CircularBuffer cb_pkt_hdr(reserved_packet_header_cb);
+        CircularBuffer cb_stats_local(stats_local_cb);
+        CircularBuffer cb_stats_gathered(stats_gathered_cb);
+
         // Reserve two packet header slots, one for each direction.
-        cb_reserve_back(reserved_packet_header_cb, 1);
-        auto pkt_hdr_fwd_addr = get_write_ptr(reserved_packet_header_cb);
-        cb_push_back(reserved_packet_header_cb, 1);
-        cb_reserve_back(reserved_packet_header_cb, 1);
-        auto pkt_hdr_bwd_addr = get_write_ptr(reserved_packet_header_cb);
-        cb_push_back(reserved_packet_header_cb, 1);
+        cb_pkt_hdr.reserve_back(1);
+        auto pkt_hdr_fwd_addr = cb_pkt_hdr.get_write_ptr();
+        cb_pkt_hdr.push_back(1);
+        cb_pkt_hdr.reserve_back(1);
+        auto pkt_hdr_bwd_addr = cb_pkt_hdr.get_write_ptr();
+        cb_pkt_hdr.push_back(1);
 
         volatile PACKET_HEADER_TYPE* pkt_hdr_forward = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(pkt_hdr_fwd_addr);
         volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
@@ -158,9 +171,9 @@ void kernel_main() {
         // that compute can't produce until it gets stats_gathered[r] (the LTX-audio
         // TP=2 small-shape hang).
         const uint32_t total_stats_tiles = num_tile_rows * ring_size;
-        cb_reserve_back(stats_gathered_cb, total_stats_tiles);
-        const uint32_t stats_gathered_base = get_write_ptr(stats_gathered_cb);
-        const uint32_t stats_tile_bytes = get_tile_size(stats_gathered_cb);
+        cb_stats_gathered.reserve_back(total_stats_tiles);
+        const uint32_t stats_gathered_base = cb_stats_gathered.get_write_ptr();
+        const uint32_t stats_tile_bytes = cb_stats_gathered.get_tile_size();
 
         // GlobalSemaphore on this core; remote chips atomic_inc it via fabric.
         const uint64_t out_ready_sem_noc_addr_in_pkt = safe_get_noc_addr(my_x[0], my_y[0], out_ready_sem_bank_addr, 0);
@@ -174,8 +187,9 @@ void kernel_main() {
         // chips, advancing l1_read_addr afterwards.
         uint32_t cumulative_incs = 0;
         for (uint32_t r = 0; r < num_tile_rows; r++) {
-            cb_wait_front(stats_local_cb, 1);
-            size_t l1_read_addr = get_read_ptr(stats_local_cb);
+            cb_stats_local.wait_front(1);
+            // size_t: the fabric helper takes it by reference and advances it.
+            size_t l1_read_addr = cb_stats_local.get_read_ptr();
 
             const uint32_t my_slot_offset = (r * ring_size + my_device_index) * stats_tile_bytes;
             const uint32_t my_slot_addr = stats_gathered_base + my_slot_offset;
@@ -195,21 +209,23 @@ void kernel_main() {
                 /*val=*/1,
                 /*flush=*/true);
 
-            cb_pop_front(stats_local_cb, 1);
+            cb_stats_local.pop_front(1);
 
             // Wait for this row's incs (cumulative across rows so far): each of the
             // (ring_size-1) remote chips atomic_inc's once per row. The remote runs the
             // identical per-row loop, so both chips stay in lockstep — no deadlock.
             cumulative_incs += (ring_size - 1);
             if (cumulative_incs > 0) {
+                // out_ready is a GlobalSemaphore.
                 noc_semaphore_wait_min(out_ready_sem_ptr, cumulative_incs);
             }
             // Local write of my own slot for row r must land before compute reads it.
-            noc_async_write_barrier();
+            noc.async_write_barrier();
             // Release this row's ring_size gathered slots so compute's chunk r can run.
-            cb_push_back(stats_gathered_cb, ring_size);
+            cb_stats_gathered.push_back(ring_size);
         }
         // Reset for any subsequent invocations of this op.
+        // out_ready is a GlobalSemaphore.
         noc_semaphore_set(out_ready_sem_ptr, 0);
 
         // Guard close on is_logically_connected(), matching the canonical CCL writers.
@@ -235,8 +251,8 @@ void kernel_main() {
             // `tiles_in_block` are valid; wait+pop the full block but only
             // NoC-write the valid tiles. Without this, multi-chunk overflows
             // output_cb because over-pushed garbage slots never drain.
-            cb_wait_front(output_cb, block_size);
-            uint32_t output_rd_ptr = get_read_ptr(output_cb);
+            cb_output.wait_front(block_size);
+            uint32_t output_rd_ptr = cb_output.get_read_ptr();
 
             for (uint32_t i = 0; i < tiles_in_block; i++) {
                 const uint32_t c = col_tile + i;
@@ -244,17 +260,22 @@ void kernel_main() {
                 const uint32_t t_col = c - h * head_dim_tiles;
                 const uint32_t output_tile_idx =
                     h * total_num_tile_rows * head_dim_tiles + tile_row * head_dim_tiles + t_col;
-                noc_async_write_page(output_tile_idx, output_accessor, output_rd_ptr);
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(output_rd_ptr),
+                    output_accessor,
+                    output_page_bytes,
+                    {},
+                    {.page_id = output_tile_idx});
                 output_rd_ptr += output_tile_bytes;
             }
             // _flushed (write request committed to NoC) instead of _barrier
             // (round-trip ACK). L1 source can be reused once the write has
             // left the core. Final barrier at end of kernel ensures all
             // writes complete before exit.
-            noc_async_writes_flushed();
-            cb_pop_front(output_cb, block_size);
+            noc.async_writes_flushed();
+            cb_output.pop_front(block_size);
         }
     }
     // Final barrier — all in-flight output writes must complete before exit.
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/dataflow/dit_rmsnorm_scalar_setup.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/kernels/dataflow/dit_rmsnorm_scalar_setup.hpp
@@ -20,6 +20,9 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 
@@ -47,10 +50,11 @@ FORCE_INLINE void dit_rmsnorm_generate_scalars_and_transmat(uint32_t eps_bits, c
     generate_bcast_col_scalar(CircularBuffer(eps_cb), eps_bits);
 
     if constexpr (fuse_rope) {
-        cb_reserve_back(transmat_cb, 1);
-        const uint32_t transmat_wr_ptr = get_write_ptr(transmat_cb);
-        noc_async_read_page(0, tmat_acc, transmat_wr_ptr);
-        noc_async_read_barrier();
-        cb_push_back(transmat_cb, 1);
+        Noc noc;
+        CircularBuffer cb_transmat(transmat_cb);
+        cb_transmat.reserve_back(1);
+        noc.async_read(tmat_acc, cb_transmat, tmat_acc.get_aligned_page_size(), {.page_id = 0}, {});
+        noc.async_read_barrier();
+        cb_transmat.push_back(1);
     }
 }


### PR DESCRIPTION
## What

Migrates the seven kernels of `experimental/ccl/dit_fused_distributed_rmsnorm` from the legacy free functions to the Device 2.0 kernel API (`CircularBuffer`, `Noc`, `Semaphore`, `CoreLocalMem`, `UnicastEndpoint`).

The program factory changes **comments only** — no functional host change. `CircularBuffer(cb_id)` and `Semaphore(sem_id)` consume exactly the values `CreateCircularBuffer`/`CreateSemaphore` already produce.

## The 4 deliberate residuals

The out_ready semaphore is a **GlobalSemaphore**: the host passes its raw L1 address as a runtime arg, and `Semaphore`'s only constructor takes a program semaphore id which it resolves internally.

## Reviewer note: NoC index

Every `Noc` object here is **default-constructed**, matching the `noc_index` default of every legacy call replaced.

Produced with Claude Code assistance;

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/dit-rmsnorm-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/dit-rmsnorm-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/dit-rmsnorm-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/dit-rmsnorm-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/dit-rmsnorm-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/dit-rmsnorm-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/dit-rmsnorm-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/dit-rmsnorm-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/dit-rmsnorm-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/dit-rmsnorm-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/dit-rmsnorm-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/dit-rmsnorm-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/dit-rmsnorm-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/dit-rmsnorm-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/dit-rmsnorm-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/dit-rmsnorm-device2-migration)