### PR TITLE
[tt-train] Test only - Add INT8 as an unsupported type

### DIFF
--- a/tt-train/sources/ttml/nanobind/nb_util.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_util.cpp
@@ -31,6 +31,7 @@ constexpr auto BFLOAT8_B = "Unsupported type: BFLOAT8_B";
 constexpr auto BFLOAT4_B = "Unsupported type: BFLOAT4_B";
 constexpr auto UINT8 = "Unsupported type: UINT8";
 constexpr auto UINT16 = "Unsupported type: UINT16";
+constexpr auto INT8 = "Unsupported type: INT8";
 constexpr auto INVALID = "Unsupported type: INVALID";
 constexpr auto UNKNOWN = "Unsupported type: unknown";
 constexpr auto COMPLEX = "Unsupported type: Complex";
@@ -53,6 +54,7 @@ constexpr bool is_supported_datatype(tt::tt_metal::DataType dt) {
             NB_THROW(nb::exception_type::type_error, UnsupportedMessages::BFLOAT4_B);
         case tt::tt_metal::DataType::UINT8: NB_THROW(nb::exception_type::type_error, UnsupportedMessages::UINT8);
         case tt::tt_metal::DataType::UINT16: NB_THROW(nb::exception_type::type_error, UnsupportedMessages::UINT16);
+        case tt::tt_metal::DataType::INT8: NB_THROW(nb::exception_type::type_error, UnsupportedMessages::INT8);
         case tt::tt_metal::DataType::INVALID: NB_THROW(nb::exception_type::type_error, UnsupportedMessages::INVALID);
         default: NB_THROW(nb::exception_type::type_error, UnsupportedMessages::UNKNOWN);
     }

--- a/tt-train/tests/python/test_autograd.py
+++ b/tt-train/tests/python/test_autograd.py
@@ -22,6 +22,7 @@ def supported_autograd_types_except(*except_types):
             ttnn.DataType.BFLOAT4_B,
             ttnn.DataType.UINT8,
             ttnn.DataType.UINT16,
+            ttnn.DataType.INT8,
             ttnn.DataType.FP8_E4M3,  # skipping FP8_E4M3 for now, until it is fully supported in tt-metal
         )
         + tuple(except_type for except_type in except_types)


### PR DESCRIPTION
### PR Category
Test only

### Summary
https://github.com/tenstorrent/tt-metal/actions/runs/31158245558/job/92810410713
```
tt-train/tests/python/test_autograd.py:480: 
...
TypeError: [../tt-train/sources/ttml/nanobind/nb_util.cpp:57] nb::exception_type::type_error: (NB_THROW)Unsupported type: unknown
```

There was a recent commit https://github.com/tenstorrent/tt-metal/commit/710bd295dd40e452f5796bd3f7ceab6996a6672a that added support for `INT8` in metal. This cause the above failure.

Train doesn't support this currently, so this PR adds `INT8` to the unsupported list.

Reproduce:
```
python -m pytest 'tt-train/tests/python/test_autograd.py::test_numpy_autograd_conversion[None-None-float32-tensor_data0]' -v
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/int8-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ctr-kevinwu/int8-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/int8-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ctr-kevinwu/int8-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-kevinwu/int8-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-kevinwu/int8-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ctr-kevinwu/int8-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ctr-kevinwu/int8-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-kevinwu/int8-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-kevinwu/int8-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-kevinwu/int8-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-kevinwu/int8-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-kevinwu/int8-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-kevinwu/int8-unsupported)