### PR TITLE
[Bug fix] Fix go_message_index latch in wait_for_go_message; add go-message triage check

### DIFF
--- a/docs/wan_rope_dispatch_hang_run31202781138.md
+++ b/docs/wan_rope_dispatch_hang_run31202781138.md
@@ -1,0 +1,309 @@
+# Wan2.2 T2V-A14B unit tests — RoPE dispatch hang on wh_galaxy
+
+Job: `models-unit-tests / TT-DiT Wan2.2-T2V-A14B unit tests [wh_galaxy]`.
+
+Two occurrences so far, **both on runner `g03glx04`**:
+
+| # | Run | Job | Branch | Commit / wheel | Date |
+|---|---|---|---|---|---|
+| A | [31202781138](https://github.com/tenstorrent/tt-metal/actions/runs/31202781138) | `92992728071` | `jameslee/add_rope_attention_wan_tests` | `1851dfc71d0` | 2026-07-31 |
+| B | [31355919455](https://github.com/tenstorrent/tt-metal/actions/runs/31355919455) | [`93358239171`](https://github.com/tenstorrent/tt-metal/actions/runs/31355919455/job/93358239171) | **`main`** | `0.75.0rc10.dev232+g8f29d3a80f` | 2026-08-10 |
+
+Occurrence B is on `main` from the scheduled nightly, so **this is not caused by the Wan test
+branch**. Same param, same failure mode, same host.
+
+Other attempts on run 31202781138: attempt 1 (job `92949695003`, `g03glx04`) — 1 failed / 213
+passed, PCC only, no hang; attempt 3 (job `93000295346`, `OM1-01A01-STGWH03`).
+
+## Symptom
+
+`test_rope.py::test_wan_rotary_pos_embed[wormhole_b0-2x4sp0tp1nl1]` — the 8th of 13 params.
+The preceding 7 pass. It hangs in the **host→device tensor upload**, not in the RoPE op:
+
+```
+RuntimeError: TT_THROW @ /work/tt_metal/impl/dispatch/system_memory_manager.cpp:724
+TIMEOUT: device timeout in fetch queue wait, potential hang detected
+```
+
+The timeout is 5 s (`TT_METAL_OPERATION_TIMEOUT_SECONDS=5`). In occurrence B the test reached
+`patchified input shape: torch.Size([1, 75600, 40, 128])` at 04:59:40.782 and the timeout fired at
+04:59:47.640.
+
+Note the AI job summary's suggested action ("investigate the WAN RoPE kernel for a hang … check if
+the kernel correctly handles the 2x4 mesh topology") is misleading — the RoPE op never executed.
+
+## Root cause signal: the math TRISC never got the go message
+
+Occurrence B resolved a callstack for **trisc1**, which was missing in occurrence A. That is the
+new and decisive piece of evidence.
+
+On the single stuck core — device 20, NOC `9-8`, logical `(7,6)` — the five RISCs are:
+
+| RISC | `_start()` frame | State |
+|---|---|---|
+| trisc0 (unpack) | `trisck.cc:89` → `run_kernel()` | launched, blocked in `mailbox_read` |
+| **trisc1 (math)** | **`trisck.cc:83` → `wait_for_go_message()`** | **never launched** |
+| trisc2 (pack) | `trisck.cc:89` → `run_kernel()` | launched, blocked in packer setup |
+| ncrisc (reader) | — | blocked in `cb_reserve_back` |
+| brisc (writer) | — | blocked in `cb_wait_front` |
+
+`tt_metal/hw/firmware/src/tt-1xx/trisck.cc:83` is the `wait_for_go_message()` call; `:89` is
+`run_kernel()`. So **two of the three compute threads on that core observed the go message and the
+third did not.** The unpacker's `mailbox_read` is the TRISC-to-TRISC handshake waiting on precisely
+that missing math thread.
+
+Everything else is downstream fallout: unpack never completes → CBs never drain → reader blocks on
+`cb_reserve_back` and writer on `cb_wait_front` → dispatch on device 20 sits in `process_wait` and
+prefetch in `process_stall` → every other chip's dispatcher sits in `CBReader::acquire_pages` →
+host times out reserving the fetch queue.
+
+### Device callstacks (occurrence B, op 50, core `20:9-8 (7,6)`)
+
+**trisc1 (math)** — the anomaly:
+
+```
+#0 0x00009C80 in wait_for_go_message () at tt_metal/hw/inc/internal/firmware_common.h 203:60
+#1 _start () at tt_metal/hw/firmware/src/tt-1xx/trisck.cc 83:24
+```
+
+**trisc0 (unpack)** — waiting on the mailbox trisc1 never wrote:
+
+```
+#0  0x000097C4 in ckernel::mailbox_read () at tt_llk_wormhole_b0/common/inc/ckernel.h 557:13
+#1  ckernel::unpacker::set_dst_write_addr () at tt_llk_wormhole_b0/common/inc/cunpack_common.h 995:57
+#2  unpack_tilize_to_dest_impl () at tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h 182:23
+#3  _llk_unpack_tilize_ () at tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h 289:35
+#4  llk_unpack_tilize () at hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h 71:24
+#5  llk_unpack_tilize_block () at hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h 99:26
+#6  ckernel::tilize_block () at tt_metal/hw/inc/api/compute/tilize.h 150:5
+#7  compute_kernel_lib::tilize<4, 0, 16, InitUninitMode(0), WaitMode(0),
+        ReconfigureRegisterDatatypeMode(0), Fp32Mode(1)> () at ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl 201:25
+#8  kernel_main () at ./ttnn/cpp/ttnn/kernel/compute/tilize.cpp 30:19
+#9  run_kernel () at hw/ckernels/wormhole_b0/metal/common/chlkc_list.h 38:16
+#10 _start () at tt_metal/hw/firmware/src/tt-1xx/trisck.cc 89:15
+```
+
+**trisc2 (pack)**:
+
+```
+#0 0x0000A3DC in ckernel::packer::program_packer_destination () at tt_llk_wormhole_b0/common/inc/cpack_common.h 873:5
+#1 _llk_pack_<DstSync(0), true, PackMode(0)> () at tt_llk_wormhole_b0/llk_lib/llk_pack.h 475:31
+#2 llk_pack<true, true, PackMode(0)> () at hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_tile_api.h 62:62
+#3 ckernel::tilize_block () at tt_metal/hw/inc/api/compute/tilize.h 161:9
+#4 compute_kernel_lib::tilize<...> () at ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl 201:25
+#5 kernel_main () at ./ttnn/cpp/ttnn/kernel/compute/tilize.cpp 30:19
+#6 run_kernel () at hw/ckernels/wormhole_b0/metal/common/chlkc_list.h 38:16
+#7 _start () at tt_metal/hw/firmware/src/tt-1xx/trisck.cc 89:15
+```
+
+**ncrisc (reader)** — CBs never drain:
+
+```
+#0 0xFFC002AC in cb_reserve_back () at tt_metal/hw/inc/api/dataflow/dataflow_api.h 419:19
+#1 DataflowBuffer::reserve_back_impl () at hw/inc/internal/tt-1xx/dataflow_buffer.inl 81:20
+#2 DataflowBuffer::reserve_back () at hw/inc/api/dataflow/dataflow_buffer.h 142:64
+#3 kernel_main::tag(19)::operator() ()
+     at ./ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp 102:29
+#4 kernel_main () at .../reader_unary_pad_dims_split_rows_multicore.cpp 160:27
+#5 kernel_launch () at tt_metal/hw/firmware/src/tt-1xx/ncrisck.cc 72:16
+```
+
+**brisc (writer)**:
+
+```
+#0 0x00008C00 in reg_read () at tt_metal/hw/inc/internal/tt-1xx/risc_common.h 111:5
+#1 cb_wait_front () at tt_metal/hw/inc/api/dataflow/dataflow_api.h 482:45
+#2 DataflowBuffer::wait_front_impl () at hw/inc/internal/tt-1xx/dataflow_buffer.inl 97:18
+#3 DataflowBuffer::wait_front () at hw/inc/api/dataflow/dataflow_buffer.h 144:60
+#4 kernel_main () at ./ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp 45:23
+#5 _start () at tt_metal/hw/firmware/src/tt-1xx/brisck.cc 80:20
+```
+
+### Host callstack — where the throw comes from
+
+The upload path, via `TilizeWithValPadding` inside `bf16_tensor` / `bf16_tensor_2dshard`:
+
+```
+tt::tt_metal::SystemMemoryManager::fetch_queue_reserve_back(unsigned char)
+tt::tt_metal::buffer_dispatch::issue_buffer_dispatch_command_sequence<InterleavedBufferWriteDispatchParams>(...)
+tt::tt_metal::buffer_dispatch::write_interleaved_buffer_to_device(...)
+tt::tt_metal::buffer_dispatch::write_to_device_buffer(...)
+tt::tt_metal::distributed::FDMeshCommandQueue::write_shard_to_device(...)
+```
+
+### Host callstack — the teardown abort (exit 134)
+
+Six seconds later the same timeout fires inside a destructor, where it cannot propagate:
+
+```
+tt::tt_metal::SystemMemoryManager::fetch_queue_reserve_back(unsigned char)
+tt::tt_metal::event_dispatch::issue_record_event_commands(...)
+tt::tt_metal::distributed::FDMeshCommandQueue::clear_expected_num_workers_completed()
+tt::tt_metal::distributed::FDMeshCommandQueue::~FDMeshCommandQueue()
+tt::tt_metal::distributed::MeshDeviceImpl::close_impl(MeshDevice*)
+tt::tt_metal::distributed::MeshDevice::close()
+```
+
+```
+terminate called after throwing an instance of 'std::runtime_error'
+Fatal Python error: Aborted
+  ttnn/distributed/distributed.py:689 in close_mesh_device
+  /work/conftest.py:636 in mesh_device        ← fixture teardown
+```
+
+**Collateral damage:** the step runs `bash --noprofile --norc -eo pipefail`, so the SIGABRT ends the
+whole script. `test_attention_wan.py`, `test_vae_wan2_1.py`, `test_transformer_wan.py` and
+`test_pipeline_wan.py` never ran in either occurrence — the job result says nothing about them.
+
+## The stuck op
+
+Identical in both occurrences apart from the device. `dump_running_operations.py`:
+
+```
+Op 50  TilizeWithValPaddingDeviceOperation
+       logical_shape: [1, 1, 37800, 128]   dtype: FLOAT32
+       config: RowMajorPageConfig()  memory_layout: INTERLEAVED  buffer_type: DRAM
+       Device Cnt 1   Core Cnt 1   Devices 20   Cores 20:9-8 (7,6)
+```
+
+This is the on-device tilize inside `bf16_tensor` / `bf16_tensor_2dshard` uploading the fp32 test
+input (37800 = 75600 seq len ÷ 2 sp shards). Ops 51–53 (typecast / tilize / typecast) are queued
+behind it in `dump_op_window.py`.
+
+`dump_op_mesh.py` shows **one device busy, seven idle** — in B, device 20 at mesh coord (row 0,
+col 2); in A, device 17 at (row 1, col 3). Both are Tray 2 chips of `g03glx04`.
+
+## Correction: the `.text` mismatch is weaker evidence than it first looked
+
+An earlier revision of this doc called `check_binary_integrity` "the one hard anomaly." Occurrence B
+undercuts that.
+
+| | Occurrence A (device 17) | Occurrence B (device 20) |
+|---|---|---|
+| trisc0 | — | `0x00009400` mismatch |
+| trisc1 | `0x00009bb0` mismatch | `0x00009bb0` mismatch |
+| cache root | `16138300672933534673` | `15763904200462748101` |
+| kernel hash | `1330443098452927355` | `8259936983083445092` |
+
+Two problems with reading this as memory corruption:
+
+1. In B the check fires for **trisc0 as well**, and trisc0 is demonstrably executing the correct
+   tilize kernel (full, sensible callstack at `trisck.cc:89`). So a reported mismatch is not
+   sufficient to explain a stall.
+2. The trisc1 offset is **byte-identical (`0x9bb0`) across two different builds** with different
+   cache roots and different kernel hashes. Random corruption does not land on the same offset
+   twice; a systematic artifact of the checker does.
+
+`check_binary_integrity` compares L1 against whatever ELF `dispatcher_data` believes is loaded at
+`kernel_offset` (`tools/triage/check_binary_integrity.py:99`), so a stale or mid-load launch message
+can produce a false positive. Treat the mismatch as corroborating, not causal. **The go-message miss
+is the better lead.**
+
+## Everything else on the machine is clean
+
+Occurrence B, all passing: `check_cb_inactive`, `check_eth_status`, `check_l1_status`,
+`check_noc_locations`, `check_noc_status`, `check_core_magic`, `check_arc`,
+`check_broken_components`, `dump_lightweight_asserts`, `dump_risc_debug_signals`.
+
+Telemetry across all 8 devices: AI clk 1000 MHz, ARC clk 540 MHz, ASIC 38.3–40.6 °C, board 45 °C,
+ETH `0xFFFFFFFF` (32 live), DDR `0x555` @ 14000 MT/s, ARC uptime 0:05:12, FW bundle 19.12.0,
+KMD 2.10.0, IOMMU disabled.
+
+## There are no watcher logs
+
+The workflow exports `TT_METAL_WATCHER=2`, but the first line of the test script is:
+
+```bash
+unset TT_METAL_WATCHER  # blocked by #50886
+```
+
+The runtime config dump confirms it: `rtOptions watcher_enabled = false`, and
+`dump_watcher_ringbuffer.py: pass` (empty). Real watcher coverage on these hangs is blocked on
+\#50886.
+
+What *was* captured is the tt-triage dump fired by the fast-dispatch timeout hook
+(`TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE`). Artifacts:
+
+| Occurrence | Artifacts |
+|---|---|
+| A | `triage_output_92992728071`, `triage_llm_output_92992728071`, `ai_job_summary_92992728071`, `test_reports_fcc09d7a-…` (`hang_report_3151f9e63fc129c2.xml`) |
+| B | `triage_output_93358239171`, `triage_llm_output_93358239171`, `ai_job_summary_93358239171` |
+
+## Prior art — issue #45517
+
+[#45517](https://github.com/tenstorrent/tt-metal/issues/45517) — *"[GPT-OSS-120B,b=1/128,WHGLX]
+TilizeDeviceOperation hang during weight preprocessing — kernel .text corruption on g14glx03"*.
+Same class of failure:
+
+| | #45517 | This issue |
+|---|---|---|
+| Host | `g14glx03` | `g03glx04` |
+| Op | `TilizeDeviceOperation` | `TilizeWithValPaddingDeviceOperation` |
+| Tensor | `[1, 1, 131072, 64]` FLOAT32 DRAM INTERLEAVED | `[1, 1, 37800, 128]` FLOAT32 DRAM INTERLEAVED |
+| Stuck core | logical 9-10, physical (7,8) | NOC 9-8, logical (7,6) |
+| Offsets | trisc0 `0x8950`, trisc1 `0x8fa0`, stable | trisc0 `0x9400`, trisc1 `0x9bb0`, stable |
+| Devices | 23, then 17 (2 runs, same host) | 17, then 20 (2 runs, same host) |
+
+It was **closed 2026-07-30** after ~18,200 stress executions on `wh-glx6u-04` / `wh-glx6u-08`
+failed to reproduce, landing on *"H3 — runner-specific to `g14glx03`"* as the best-fitting
+hypothesis, with the explicit note: *"if something similar comes up, new issue will be created."*
+
+This is that follow-up, and it is on a **second host**, which weakens H3. What #45517 did not have
+is the trisc1 callstack — that investigation inferred `.text` corruption; here we can see the math
+thread parked in `wait_for_go_message()`.
+
+## Is it the test, or the machine?
+
+Evidence it is **not** the test:
+
+1. The hung op is the generic tilize used to upload the input tensor — nothing Wan- or
+   RoPE-specific about it.
+2. Plain single-core interleaved path. No fabric, no CCL, no multi-chip collectives.
+3. Only 1 of 8 devices hung; the other 7 finished the same mesh op and went idle.
+4. The same param passed in attempt 1 of run 31202781138, on the same commit and same host.
+5. Occurrence B is on `main`, unrelated to the Wan test branch.
+6. The same signature appeared in a completely different model (#45517, GPT-OSS weight
+   preprocessing).
+
+Evidence it correlates with the **host**: both occurrences are `g03glx04`, both Tray 2, both logical
+core `(7,6)`. Across the 9 nightly `main` runs of this job that could be queried (2026-08-05 →
+2026-08-10): 4 success, 5 failure — but only occurrence B is this hang. The other failures are
+`test_wan_attention` PCC failures (job `93059991848`, `OM1-01A01-STGWH03`) and job cancellations
+(jobs `93199464715` / `92995627835`, `j09glx02`), on different runners.
+
+So: correlates with `g03glx04`, but the same class of bug has now been seen on `g14glx03` too, and
+the underlying mechanism (a TRISC missing its go message) is not obviously hardware-specific.
+
+## Actions
+
+- [ ] File a new issue referencing #45517, headlined on the **go-message miss** (trisc1 parked at
+      `trisck.cc:83` while trisc0/trisc2 reached `:89`), not on the `.text` mismatch. Attach
+      `triage_output_93358239171`. Note the second host, which weakens #45517's H3 closure.
+- [ ] Loosen the conv3d PCC threshold (0.999_980 → ~0.999_900) in `test_vae_wan2_1.py:558` / `:712`;
+      it is failing on rounding (see below).
+- [ ] Split the five pytest invocations into separate workflow steps (or collect reports past a
+      failure). With `set -e`, one SIGABRT in `test_rope.py` hid four other test files in both
+      occurrences.
+- [ ] Watcher coverage for these hangs is blocked on #50886.
+
+## Appendix — run 31202781138 attempt 1, the real signal about the test code
+
+Attempt 1 got through the whole suite: **1 failed, 213 passed, 448 skipped, 681 deselected**
+in 1:12:58. The single failure:
+
+```
+FAILED models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py::
+  test_wan_conv3d[wormhole_b0-line-bf16-4x8h0w1nl4-0-1-cache_1-conv_1]
+  - Exception: PCC = 99.9980 % >= 99.9980 %
+```
+
+That's `assert_quality(..., pcc=0.999_980, relative_rmse=0.007)` in
+`models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py:558` / `:712`. Measured PCC landed a hair
+below a threshold sitting right at the bf16 noise floor — neighbouring configs in the same run
+log 99.9972 %–99.9989 %. The confusing message text is just how
+`models/tt_dit/utils/check.py:56` formats the failure (it prints the assertion that *should*
+have held, not the comparison that failed).
+
+Also worth noting from attempt 1, non-fatal: `test_wan_conv3d` logs
+`Padding is not zero, but tensor(...)` from
+`test_vae_wan2_1.py:convert_to_torch_channels_first:301` on the 4x8 line configs.

--- a/tools/triage/check_go_message.py
+++ b/tools/triage/check_go_message.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    check_go_message
+
+Description:
+    Records and validates the go-message handshake state on Tensix cores that were mid-flight when
+    a hang was captured. None of this state is preserved by the other triage scripts today.
+
+    Kernels are preloaded (DISPATCH_ENABLE_FLAG_PRELOAD is set unconditionally in
+    tt_metal/impl/program/dispatch.cpp), so brisc launches its subordinates before the go signal
+    arrives and each subordinate then parks in wait_for_go_message()
+    (tt_metal/hw/inc/internal/firmware_common.h), polling
+    mailboxes->go_messages[mailboxes->go_message_index].signal until it reads RUN_MSG_GO. brisc only
+    writes RUN_MSG_DONE after wait_ncrisc_trisc() returns, so while a subordinate is still stuck at
+    that barrier the slot it should be polling still reads GO.
+
+    A hang where some subordinates on a core cleared the barrier and others did not therefore leaves
+    two candidate explanations, and this script exists to record the evidence that separates them:
+
+      - The handshake state itself is wrong (for example go_message_index is out of range, which no
+        firmware path bounds-checks). Reported here as a failure.
+      - The handshake state is correct and a subordinate simply failed to observe it. Reported here
+        as a warning carrying the full mailbox state, which is the forensic record.
+
+    Limitation: a subordinate's *latched* copy of go_message_index lives in a RISC register, not in
+    L1, so it cannot be read back from the mailbox. This script constrains the shared state only.
+    To exclude a stale latch entirely, wait_for_go_message() must re-read the index per iteration
+    (as brisc.cc and the tt-2xx dm firmware already do).
+
+Owner:
+    jamesleeTT
+"""
+
+from ttexalens.coordinate import OnChipCoordinate
+from ttexalens.context import Context
+
+from dispatcher_data import run as get_dispatcher_data, DispatcherData
+from run_checks import run as get_run_checks
+from triage import ScriptConfig, log_check_location, log_warning_location, run_script
+
+script_config = ScriptConfig(
+    depends=["run_checks", "dispatcher_data"],
+)
+
+
+def format_slots(signals: list[int], state_names: dict[int, str], index: int) -> str:
+    """Render every go_messages[] entry, marking the one the core is polling with '*'."""
+    return " ".join(
+        f"[{slot}]{'*' if slot == index else ''}={state_names.get(signal, str(signal))}"
+        for slot, signal in enumerate(signals)
+    )
+
+
+def check_go_message(
+    location: OnChipCoordinate,
+    risc_name: str,
+    dispatcher_data: DispatcherData,
+    num_entries: int,
+    state_names: dict[int, str],
+):
+    core_data = dispatcher_data.get_cached_core_data(location, risc_name)
+
+    # risc_enabled_by_kernel is None when the read failed or the mailbox is corrupt; only skip cores
+    # we positively know had no kernel launched on them.
+    if core_data.risc_enabled_by_kernel is False:
+        return
+
+    mailboxes = core_data.mailboxes
+    if mailboxes is None:
+        return
+
+    # Read the index on its own, so an unreadable slot below does not also cost us the index value.
+    try:
+        index = int(mailboxes.go_message_index)
+    except Exception:
+        log_check_location(location, False, f"{risc_name}: could not read go_message_index")
+        return
+
+    signals: list[int] = []
+    for slot in range(num_entries):
+        try:
+            signals.append(int(mailboxes.go_messages[slot].signal))
+        except Exception:
+            log_check_location(
+                location,
+                False,
+                f"{risc_name}: could not read go_messages[{slot}].signal (go_message_index={index})",
+            )
+            return
+
+    if not 0 <= index < num_entries:
+        log_check_location(
+            location,
+            False,
+            f"{risc_name}: go_message_index={index} is outside [0, {num_entries}). "
+            f"wait_for_go_message() does not bounds-check it, so a subordinate that read this value "
+            f"polls unmapped mailbox memory and never observes GO. "
+            f"Slots: {format_slots(signals, state_names, index)}",
+        )
+        return
+
+    # A core whose slot reads DONE finished normally. Everything else was mid-flight when the hang
+    # was captured, which is exactly the state worth preserving. Unused slots are documented as
+    # potentially holding garbage (dispatch.cpp), so their contents are reported, not asserted on.
+    if core_data.go_message == "DONE":
+        return
+
+    log_warning_location(
+        location,
+        f"{risc_name}: mid-flight at hang time — go_message_index={index}, "
+        f"waypoint={core_data.waypoint}, subordinate_sync={core_data.subordinate_sync}, "
+        f"slots: {format_slots(signals, state_names, index)}",
+    )
+
+
+def run(args, context: Context):
+    BLOCK_TYPES_TO_CHECK = ["tensix"]
+    # The go message and its index are core-wide, so inspect one RISC per core.
+    RISC_CORES_TO_CHECK = ["brisc"]
+
+    dispatcher_data = get_dispatcher_data(args, context)
+    run_checks = get_run_checks(args, context)
+
+    num_entries = dispatcher_data._brisc_elf.get_constant("go_message_num_entries")
+    assert isinstance(num_entries, int)
+    state_names = dispatcher_data._go_message_states
+
+    run_checks.run_per_core_check(
+        lambda location, risc_name: check_go_message(location, risc_name, dispatcher_data, num_entries, state_names),
+        block_filter=BLOCK_TYPES_TO_CHECK,
+        core_filter=RISC_CORES_TO_CHECK,
+    )
+
+
+if __name__ == "__main__":
+    run_script()

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -198,9 +198,13 @@ void wait_for_go_message() {
 #else
     tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
 #endif
-    uint32_t go_message_index = mailboxes->go_message_index;
-
-    while (mailboxes->go_messages[go_message_index].signal != RUN_MSG_GO) {
+    // Re-read go_message_index on every iteration rather than latching it once. Kernels are
+    // preloaded (DISPATCH_ENABLE_FLAG_PRELOAD is set unconditionally), so subordinates reach this
+    // wait before the go signal arrives; latching the index here would make a subordinate that
+    // sampled a stale or out-of-range value poll a slot that is never signalled, and spin forever.
+    // brisc (brisc.cc) and the tt-2xx dm firmware already re-read it per iteration; this keeps the
+    // subordinate path consistent with them.
+    while (mailboxes->go_messages[mailboxes->go_message_index].signal != RUN_MSG_GO) {
         invalidate_l1_cache();
     }
 }


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

#### 1. The failing job

[Models Unit run 31355919455, job 93358239171](https://github.com/tenstorrent/tt-metal/actions/runs/31355919455/job/93358239171) — `models-unit-tests / TT-DiT Wan2.2-T2V-A14B unit tests [wh_galaxy]`, runner `g03glx04`, scheduled nightly on **`main`** (wheel `0.75.0rc10.dev232+g8f29d3a80f`), 2026-08-10.

`test_rope.py::test_wan_rotary_pos_embed[wormhole_b0-2x4sp0tp1nl1]` — the 8th of 13 params, the preceding 7 pass — hangs in the **host→device tensor upload**, not in the RoPE op:

```
RuntimeError: TT_THROW @ /work/tt_metal/impl/dispatch/system_memory_manager.cpp:724
TIMEOUT: device timeout in fetch queue wait, potential hang detected
```

The job's AI summary suggests investigating the Wan RoPE kernel and its 2x4 mesh handling. That is misleading — the RoPE op never executed. The hung op is the generic tilize that uploads the input tensor.

#### 2. Prior work

**This same hang, occurrence A** — [run 31202781138, job 92992728071](https://github.com/tenstorrent/tt-metal/actions/runs/31202781138), also `g03glx04`, on branch `jameslee/add_rope_attention_wan_tests`. Same param, same failure mode. Attempt 1 of that run passed all 13 rope configs on the same commit and host, so it was already known to be non-deterministic. That investigation concluded the cause was kernel `.text` corruption on one core, on the strength of a `check_binary_integrity` failure — trisc1 had **no resolvable callstack at all**, so the mismatch was the only hard signal available.

**Issue #45517** — *"[GPT-OSS-120B,b=1/128,WHGLX] TilizeDeviceOperation hang during weight preprocessing — kernel .text corruption on g14glx03"*. Same class of failure in a completely different model:

| | #45517 | Here |
|---|---|---|
| Host | `g14glx03` | `g03glx04` |
| Op | `TilizeDeviceOperation` | `TilizeWithValPaddingDeviceOperation` |
| Tensor | `[1, 1, 131072, 64]` FP32 DRAM INTERLEAVED | `[1, 1, 37800, 128]` FP32 DRAM INTERLEAVED |
| Stuck core | logical 9-10, physical (7,8) | NOC 9-8, logical (7,6) |
| Offsets | trisc0 `0x8950`, trisc1 `0x8fa0`, stable | trisc0 `0x9400`, trisc1 `0x9bb0`, stable |
| Devices | 23, then 17 (2 runs, same host) | 17, then 20 (2 runs, same host) |

It was **closed 2026-07-30** after ~18,200 stress executions across `wh-glx6u-04` and `wh-glx6u-08` failed to reproduce it — 685 of those with a cold kernel cache and per-iteration ELF fingerprinting, which never fired. That ruled out the kernel-binary-load race (H1) and the stale-cached-ELF theory (H2), leaving *"H3 — runner-specific to `g14glx03`"* as the best-fitting hypothesis, with the explicit note: *"if something similar comes up, new issue will be created."*

This PR is that follow-up. It is on a **second host**, which weakens H3.

#### 3. What this occurrence shows

Occurrence B resolved **a callstack for trisc1**, which occurrence A did not have. That changes the diagnosis.

On the single stuck core — device 20, NOC `9-8`, logical `(7,6)`, op 50 `TilizeWithValPaddingDeviceOperation`, `[1, 1, 37800, 128]` FLOAT32 RowMajor INTERLEAVED DRAM — the three compute threads are **split across the go barrier**:

**trisc1 (math) — never launched:**

```
#0 0x00009C80 in wait_for_go_message () at tt_metal/hw/inc/internal/firmware_common.h 203:60
#1 _start () at tt_metal/hw/firmware/src/tt-1xx/trisck.cc 83:24
```

**trisc0 (unpack) — launched, waiting on the mailbox trisc1 never wrote:**

```
#0  0x000097C4 in ckernel::mailbox_read () at tt_llk_wormhole_b0/common/inc/ckernel.h 557:13
#1  ckernel::unpacker::set_dst_write_addr () at tt_llk_wormhole_b0/common/inc/cunpack_common.h 995:57
#2  unpack_tilize_to_dest_impl () at tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h 182:23
#3  _llk_unpack_tilize_ () at tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h 289:35
#4  llk_unpack_tilize () at hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h 71:24
#5  llk_unpack_tilize_block () at hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h 99:26
#6  ckernel::tilize_block () at tt_metal/hw/inc/api/compute/tilize.h 150:5
#7  compute_kernel_lib::tilize<4, 0, 16, InitUninitMode(0), WaitMode(0),
        ReconfigureRegisterDatatypeMode(0), Fp32Mode(1)> () at ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl 201:25
#8  kernel_main () at ./ttnn/cpp/ttnn/kernel/compute/tilize.cpp 30:19
#9  run_kernel () at hw/ckernels/wormhole_b0/metal/common/chlkc_list.h 38:16
#10 _start () at tt_metal/hw/firmware/src/tt-1xx/trisck.cc 89:15
```

**trisc2 (pack) — launched, blocked in packer setup:**

```
#0 0x0000A3DC in ckernel::packer::program_packer_destination () at tt_llk_wormhole_b0/common/inc/cpack_common.h 873:5
#1 _llk_pack_<DstSync(0), true, PackMode(0)> () at tt_llk_wormhole_b0/llk_lib/llk_pack.h 475:31
#2 llk_pack<true, true, PackMode(0)> () at hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_tile_api.h 62:62
#3 ckernel::tilize_block () at tt_metal/hw/inc/api/compute/tilize.h 161:9
#4 compute_kernel_lib::tilize<...> () at ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl 201:25
#5 kernel_main () at ./ttnn/cpp/ttnn/kernel/compute/tilize.cpp 30:19
#6 run_kernel () / #7 _start () at trisck.cc 89:15
```

**ncrisc (reader) and brisc (writer) — CBs never drain:**

```
#0 0xFFC002AC in cb_reserve_back () at tt_metal/hw/inc/api/dataflow/dataflow_api.h 419:19
...
#4 kernel_main () at .../reader_unary_pad_dims_split_rows_multicore.cpp 160:27

#0 0x00008C00 in reg_read () at tt_metal/hw/inc/internal/tt-1xx/risc_common.h 111:5
#1 cb_wait_front () at tt_metal/hw/inc/api/dataflow/dataflow_api.h 482:45
...
#4 kernel_main () at .../writer_unary_interleaved_start_id.cpp 45:23
```

`trisck.cc:83` is the `wait_for_go_message()` call; `:89` is `run_kernel()`. **Two of the three compute threads on that core observed the go message and the third did not.** Everything else is downstream fallout: unpack never completes → CBs never drain → reader and writer block → dispatch on device 20 sits in `process_wait` and prefetch in `process_stall` → every other chip's dispatcher sits in `CBReader::acquire_pages` → the host times out in `fetch_queue_reserve_back`.

**Host, where the throw surfaces** — the upload, via `bf16_tensor` / `bf16_tensor_2dshard`:

```
tt::tt_metal::SystemMemoryManager::fetch_queue_reserve_back(unsigned char)
tt::tt_metal::buffer_dispatch::issue_buffer_dispatch_command_sequence<InterleavedBufferWriteDispatchParams>(...)
tt::tt_metal::buffer_dispatch::write_interleaved_buffer_to_device(...)
tt::tt_metal::distributed::FDMeshCommandQueue::write_shard_to_device(...)
```

**Host, the abort (exit 134)** — six seconds later the same timeout fires inside a destructor, where it cannot propagate, killing the pytest process:

```
tt::tt_metal::distributed::FDMeshCommandQueue::clear_expected_num_workers_completed()
tt::tt_metal::distributed::FDMeshCommandQueue::~FDMeshCommandQueue()
tt::tt_metal::distributed::MeshDeviceImpl::close_impl(MeshDevice*)  →  MeshDevice::close()

terminate called after throwing an instance of 'std::runtime_error'
Fatal Python error: Aborted
  ttnn/distributed/distributed.py:689 in close_mesh_device
  /work/conftest.py:636 in mesh_device        ← fixture teardown
```

Because the step runs `bash -eo pipefail`, that abort also meant `test_attention_wan.py`, `test_vae_wan2_1.py`, `test_transformer_wan.py` and `test_pipeline_wan.py` never ran — in both occurrences.

**What is ruled out.** A stale cache read is not the mechanism: `invalidate_l1_cache()` is a **no-op on Wormhole** (it only emits `fence` under `ARCH_BLACKHOLE`, `risc_common.h:153`), and both `go_message_index` and `go_messages[].signal` are `volatile` in `mailboxes_t`, so the compiler must reload. "trisc1 missed a transient GO" is also impossible: brisc writes `RUN_MSG_DONE` at `brisc.cc:575`, but only after `wait_ncrisc_trisc()` at `:542` returns, which requires trisc1 to report done. **The slot trisc1 should be polling still reads GO right now.**

**Correction to the earlier `.text` reading.** The `check_binary_integrity` failure is weaker evidence than occurrence A treated it as. In occurrence B it fires for **both trisc0 and trisc1**, and trisc0 is demonstrably executing the correct tilize kernel. The trisc1 offset is also byte-identical (`0x9bb0`) across two different builds with different cache roots and different kernel hashes — random corruption does not land on the same offset twice. The check compares L1 against whatever ELF `dispatcher_data` believes is loaded (`tools/triage/check_binary_integrity.py:99`), so a stale or mid-load launch message can produce a false positive. It is corroborating, not causal.

#### 4. The two candidate explanations, and what this diff does about each

With a transient miss excluded, exactly two possibilities remain.

**(A) trisc1 polled the wrong address.** `wait_for_go_message()` (`firmware_common.h:195`) latched the index **once**, outside the loop:

```c
uint32_t go_message_index = mailboxes->go_message_index;
while (mailboxes->go_messages[go_message_index].signal != RUN_MSG_GO) { ... }
```

brisc re-reads it every iteration (`brisc.cc:398`), as does the tt-2xx dm firmware (`dm.cc:288`). **The subordinate path was the only one of the three that hoisted it,** and no firmware path bounds-checks the value — though the host watcher does (`watcher_device_reader.cpp:1055`), and `dispatch.cpp:3381` notes cores "may have garbage in the GO message entries they aren't using."

Two things fit the observation. `preload` is set unconditionally (`dispatch.cpp:1941`), so brisc launches subordinates on the preload flag *before* the go signal arrives — every subordinate parks in this loop on every op, latching the index while the go message is still in flight. And `trisck.cc:80` skips `ALIGN_LOCAL_CBS_TO_REMOTE_CBS` when `UCK_CHLKC_MATH` is defined, so **MATH reaches the latch earliest of the three** — exactly the thread that hung.

Arguing against it: `go_message_index` is written only by `set_core_go_message_mapping_on_device`, called solely from `FDMeshCommandQueue::reset_worker_state` when `reset_launch_msg_state` is true (`fd_mesh_command_queue.cpp:1158`) — at CQ/sub-device reset, not per program, and barriered on both sides.

**→ The firmware change in this diff** moves the index read inside the loop, making the wait self-correcting and bringing the subordinate path into agreement with the other two. If (A) is the mechanism, this fixes it.

**(B) trisc1 failed to execute the poll.** Then the handshake state was fine and the fault is in execution on that core — which is where the `.text` mismatch, weakened but not eliminated, would come back in.

**→ The triage check in this diff** (`tools/triage/check_go_message.py`) records the shared half of the handshake, which no triage script preserves today: the raw `go_message_index`, every `go_messages[]` entry with the polled one marked, and the `waypoint` / `subordinate_sync` of any core still mid-flight. It fails on an out-of-range index and stays quiet on cores that finished, so the garbage-in-unused-slots condition does not produce false positives.

**These two are complementary, and together they are decisive.** A subordinate's *latched* copy of the index lives in a RISC register, not L1, so it cannot be recovered from the mailbox after the fact — the check alone cannot separate (A) from (B). But landing the firmware change makes the next occurrence diagnostic: if the hang recurs with the index re-read per iteration, a stale latch is excluded and (B) is what remains, with the triage output now on hand to characterise it.

### Notes for reviewers

- **The firmware change is on the hottest path in dispatch and is not built or hardware-tested here.** It adds one L1 load per spin iteration. Worth weighing against `trisc.cc:143`, which deliberately inserts `nop; nop; nop; nop; nop` in its wait loop on Wormhole specifically to "avoid hammering L1 while other cores are trying to work." I did not add throttling, because that changes timing beyond the minimal fix.
- The firmware change is defensible on its own merits regardless of whether it is the cause: the inconsistency with `brisc.cc` and `dm.cc` is a latent bug either way.
- `discover_all_in_directory` (`triage.py:373`) wraps script loading in `except Exception: continue`, so an import error or bad signature makes a triage script **silently vanish** — indistinguishable from passing. Before trusting a clean run, confirm `check_go_message.py:` appears as a section header in the triage output. The `tt-triage type checks` pre-commit hook passes on it, but it has not been executed against real hardware.
- `docs/wan_rope_dispatch_hang_run31202781138.md` is the full investigation write-up, including the machine state (all other triage checks pass; ASIC 38–40 °C, 32 ETH live, uniform FW 19.12.0) and the nightly history: across the 9 `main` runs of this job that could be queried, 4 pass / 5 fail, but only this one is this hang — the others are `test_wan_attention` PCC failures and job cancellations on different runners.
- Both occurrences are `g03glx04`, both Tray 2, both logical core `(7,6)`, but different chips (17 → 20). Pulling that host from the `wh_galaxy` pool for this job would stop the nightly noise independently of this PR.
- Watcher coverage on these hangs is still blocked on #50886 — the test script unsets `TT_METAL_WATCHER`, so the ring buffer is always empty.

Relates to #45517

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jameslee/debug_wh_glx_tilize_input_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jameslee/debug_wh_glx_tilize_input_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jameslee/debug_wh_glx_tilize_input_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jameslee/debug_wh_glx_tilize_input_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jameslee/debug_wh_glx_tilize_input_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jameslee/debug_wh_glx_tilize_input_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jameslee/debug_wh_glx_tilize_input_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jameslee/debug_wh_glx_tilize_input_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jameslee/debug_wh_glx_tilize_input_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jameslee/debug_wh_glx_tilize_input_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jameslee/debug_wh_glx_tilize_input_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jameslee/debug_wh_glx_tilize_input_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jameslee/debug_wh_glx_tilize_input_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jameslee/debug_wh_glx_tilize_input_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jameslee/debug_wh_glx_tilize_input_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jameslee/debug_wh_glx_tilize_input_hang)