### PR TITLE
[skip ci] [automation] Grant actions: write so the stale-PR state cache can refresh

### DIFF
--- a/.github/workflows/close-stale-prs.yaml
+++ b/.github/workflows/close-stale-prs.yaml
@@ -2,6 +2,13 @@ name: "[internal] Close Stale PRs"
 
 permissions:
   pull-requests: write
+  # actions/stale persists its "already processed" list as an Actions cache
+  # keyed _state, and refreshes it by deleting then re-saving. The delete needs
+  # actions: write; without it the delete 403s, the save cannot reserve the
+  # existing key, and the cache freezes at whatever the first run wrote.
+  # A frozen list is skipped verbatim on every later run, so those PRs would
+  # never be reconsidered. This is the narrowest scope that covers caches.
+  actions: write
 
 on:
   schedule:


### PR DESCRIPTION
Follow-up to #52729. Fixes the warning at the end of every [Close Stale PRs](https://github.com/tenstorrent/tt-metal/actions/workflows/close-stale-prs.yaml) run.

## Symptom

```
state: persisting info about 678 issue(s)
##[warning]Error delete _state: [403] Resource not accessible by integration
Failed to save: Unable to reserve cache with key _state, another job may be creating this cache.
```

## Cause

`actions/stale` persists its processed-issue list as an Actions cache keyed `_state`, so a run that exhausts its operations budget can resume where it left off. It refreshes that cache by **deleting the old entry, then saving a new one** (`StateCacheStorage.save` calls `resetCacheWithOctokit` before `cache.saveCache`).

The delete is a REST call needing `actions: write`. The workflow granted only `pull-requests: write`, and declaring a `permissions:` block sets every unlisted scope to `none` — so the delete 403s, and `saveCache` then cannot reserve a key that still exists.

The cache has been frozen since it was first written:

```
key: _state
created_at:       2026-08-10T05:31:50   <- first run, v9.1.0, descending scan
last_accessed_at: 2026-08-10T21:32:10   <- restored by a later run
```

## Why it matters

Restored entries are skipped outright — `isIssueProcessed` matches on issue number and the loop `continue`s. Every run restores the same frozen snapshot, so those PRs are permanently exempt once the scan reaches them.

Not yet causing harm: the frozen snapshot came from a *descending* (newest-first) scan, while runs since #52729 scan *ascending*. No overlap, and the latest run skipped **0** items. But once the backlog drains and the scan climbs into those numbers, ~519 PRs would be silently skipped.

It cannot recover on its own:

- `state.reset()` only runs when a sweep completes without exhausting the budget — ours always exhausts it.
- Even after a reset, `save` returns early on an empty state (`if (fileSize === 0) return`), so nothing overwrites the old entry.
- It never ages out. GitHub evicts caches idle 7 days, but every run *restores* this one, refreshing `last_accessed_at`.

## Fix

Grant `actions: write`. The next run deletes the stale entry and writes a current one, so this self-heals with no manual cleanup.

`actions` is the only scope covering caches — there is no narrower cache-specific scope, and no input to disable state caching (verified against the v11.0.0 `action.yml`). The added breadth also permits managing workflow runs, which is acceptable here: the workflow runs only from `main` via `schedule`/`workflow_dispatch` and consumes no untrusted input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbakerTT/stale-prs-state-cache-permission)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbakerTT/stale-prs-state-cache-permission)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbakerTT/stale-prs-state-cache-permission)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbakerTT/stale-prs-state-cache-permission)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbakerTT/stale-prs-state-cache-permission)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbakerTT/stale-prs-state-cache-permission)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbakerTT/stale-prs-state-cache-permission)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbakerTT/stale-prs-state-cache-permission)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbakerTT/stale-prs-state-cache-permission)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbakerTT/stale-prs-state-cache-permission)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbakerTT/stale-prs-state-cache-permission)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbakerTT/stale-prs-state-cache-permission)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbakerTT/stale-prs-state-cache-permission)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbakerTT/stale-prs-state-cache-permission)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbakerTT/stale-prs-state-cache-permission)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbakerTT/stale-prs-state-cache-permission)