### PR TITLE
[Cleanup] Surface Area Reduction profiler headers

### DIFF
--- a/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
+++ b/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
@@ -26,7 +26,6 @@
 #include <tt-metalium/mesh_device_view.hpp>
 #include <tt-metalium/system_mesh.hpp>
 #include <tt-metalium/tile.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/mesh_buffer.hpp>

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
@@ -27,7 +27,6 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include <umd/device/types/core_coordinates.hpp>
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -23,7 +23,6 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include "command_queue_fixture.hpp"
 #include <tt-metalium/kernel_types.hpp>
 #include "dispatch_test_utils.hpp"

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
@@ -11,7 +11,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include "command_queue_fixture.hpp"
 #include "dispatch_test_utils.hpp"
 #include "gtest/gtest.h"

--- a/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
@@ -12,8 +12,6 @@
 #include <tt-metalium/distributed.hpp>
 #include <impl/context/metal_context.hpp>
 #include <impl/debug/noc_debugging.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
-
 namespace tt::tt_metal {
 
 class NOCDebuggingFixture : public MeshDispatchFixture {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -13,7 +13,6 @@
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <algorithm>
 #include <array>
 #include <cmath>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -13,7 +13,6 @@
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <algorithm>
 #include <array>
 #include <cmath>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -15,7 +15,6 @@
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/mesh_workload.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -13,7 +13,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <algorithm>
 #include <array>
 #include <cstdint>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -12,7 +12,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <algorithm>
 #include <array>
 #include <cstdint>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -11,7 +11,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "llrt/metal_soc_descriptor.hpp"
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <cstdint>
 #include <exception>
 #include <iomanip>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -23,7 +23,6 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "tt_metal/test_utils/df/df.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <algorithm>
 #include <cstdlib>
 #include <exception>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <algorithm>
 #include <cstdlib>
 #include <exception>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -16,7 +16,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
+#include "impl/profiler/tt_metal_profiler.hpp"
 #include "impl/context/metal_context.hpp"
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include <llrt/tt_cluster.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -35,7 +35,6 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include "hostdevcommon/common_values.hpp"
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-logger/tt-logger.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
@@ -33,7 +33,6 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -29,7 +29,6 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
@@ -27,7 +27,6 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
@@ -11,7 +11,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/distributed.hpp>
 
 namespace tt_metal = tt::tt_metal;

--- a/tests/ttnn/tracy/cpp/test_get_programs_perf_data.cpp
+++ b/tests/ttnn/tracy/cpp/test_get_programs_perf_data.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "impl/context/metal_context.hpp"
 #include "impl/profiler/profiler_paths.hpp"
+#include "impl/profiler/tt_metal_profiler.hpp"
 #include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_metal::experimental {

--- a/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
@@ -12,7 +12,7 @@
 #include <cstdint>
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
+#include "impl/profiler/tt_metal_profiler.hpp"
 #include <tt-metalium/buffer_distribution_spec.hpp>
 
 #include <tt-metalium/tensor_accessor_args.hpp>

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -28,7 +28,6 @@
 
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include "ttnn/operations/experimental/reshape/view.hpp"
 #include <tt-metalium/system_mesh.hpp>
 #include <tt-metalium/tile.hpp>

--- a/tt-train/tests/ops/moe_profile_sweep_test.cpp
+++ b/tt-train/tests/ops/moe_profile_sweep_test.cpp
@@ -24,7 +24,6 @@
 #include <tools/profiler/op_profiler.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <ttnn/operations/core/core.hpp>
 #include <utility>
 #include <vector>

--- a/tt_metal/api/tt-metalium/profiler_optional_metadata.hpp
+++ b/tt_metal/api/tt-metalium/profiler_optional_metadata.hpp
@@ -11,20 +11,12 @@
 
 #include <tt-metalium/device_types.hpp>
 
-namespace tt::tt_metal {
-class DeviceProfiler;
-}
-
 class ProfilerOptionalMetadata {
     using RuntimeID = uint32_t;
 
 public:
     ProfilerOptionalMetadata(std::map<std::pair<tt::ChipId, RuntimeID>, std::string>&& runtime_map) :
         runtime_id_to_opname_(std::move(runtime_map)) {}
-
-private:
-    // Internal lookup used only by DeviceProfiler when dumping results.
-    friend class tt::tt_metal::DeviceProfiler;
 
     const std::string& get_op_name(tt::ChipId device_id, RuntimeID runtime_id) const {
         static const std::string empty_string;
@@ -36,5 +28,6 @@ private:
         return empty_string;
     }
 
+private:
     std::map<std::pair<tt::ChipId, RuntimeID>, std::string> runtime_id_to_opname_;
 };

--- a/tt_metal/api/tt-metalium/profiler_optional_metadata.hpp
+++ b/tt_metal/api/tt-metalium/profiler_optional_metadata.hpp
@@ -11,12 +11,20 @@
 
 #include <tt-metalium/device_types.hpp>
 
+namespace tt::tt_metal {
+class DeviceProfiler;
+}
+
 class ProfilerOptionalMetadata {
     using RuntimeID = uint32_t;
 
 public:
     ProfilerOptionalMetadata(std::map<std::pair<tt::ChipId, RuntimeID>, std::string>&& runtime_map) :
         runtime_id_to_opname_(std::move(runtime_map)) {}
+
+private:
+    // Internal lookup used only by DeviceProfiler when dumping results.
+    friend class tt::tt_metal::DeviceProfiler;
 
     const std::string& get_op_name(tt::ChipId device_id, RuntimeID runtime_id) const {
         static const std::string empty_string;
@@ -28,6 +36,5 @@ public:
         return empty_string;
     }
 
-private:
     std::map<std::pair<tt::ChipId, RuntimeID>, std::string> runtime_id_to_opname_;
 };

--- a/tt_metal/api/tt-metalium/profiler_types.hpp
+++ b/tt_metal/api/tt-metalium/profiler_types.hpp
@@ -4,18 +4,9 @@
 
 #pragma once
 
-#include <cstdint>
-#include <tt-metalium/device_types.hpp>
-
 namespace tt::tt_metal {
 
 enum class ProfilerReadState { NORMAL, ONLY_DISPATCH_CORES, LAST_FD_READ };
 enum class ProfilerSyncState { INIT, CLOSE_DEVICE };
-enum class ProfilerDataBufferSource { L1, DRAM, DRAM_AND_L1 };
 
-struct DeviceProgramId {
-    uint32_t base_program_id = 0;
-    ChipId device_id = 0;
-    bool is_host_fallback_op = false;
-};
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -20,8 +20,6 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/mesh_device.hpp>
-#include <tt-metalium/profiler_optional_metadata.hpp>
-#include <tt-metalium/profiler_types.hpp>
 #include <tt-metalium/device_types.hpp>
 // UMD: re-exports CoreType (used in SetRuntimeArgs/GetRuntimeArgs default parameter).
 #include <umd/device/types/core_coordinates.hpp>
@@ -233,20 +231,6 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
  * |                          | no       |
  */
 uint32_t EncodePerDeviceProgramID(uint32_t base_program_id, uint32_t device_id, bool is_host_fallback_op = false);
-
-/**
- * Decode per device program ID to get encoded values (base program id, device id, and a flag indicating whether
- * it's an op run entirely on host).
- *
- * Return value: tuple<uint32_t, uint32_t, bool>
- *
- * | Argument             | Description                                                                         |  Data
- * type            | Valid range              | required |
- * |----------------------|-------------------------------------------------------------------------------------|-----------------------|--------------------------|----------|
- * | device_program_id    | Encoded device specific id used by the performance profiler  |
- * uint32_t        | 0 - 2^32 - 1             | yes      |
- */
-DeviceProgramId DecodePerDeviceProgramID(uint32_t device_program_id);
 
 // clang-format off
 /**

--- a/tt_metal/api/tt-metalium/tt_metal_profiler.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal_profiler.hpp
@@ -4,10 +4,28 @@
 
 #pragma once
 
+#include <optional>
+
+#include <tt-metalium/profiler_optional_metadata.hpp>
 #include <tt-metalium/profiler_types.hpp>
 
 namespace tt::tt_metal {
+class IDevice;
+
 namespace detail {
+
+/**
+ * Initialize device profiling data buffers
+ *
+ * Return value: void
+ *
+ * | Argument      | Description                                       | Type            | Valid Range               |
+ * Required |
+ * |---------------|---------------------------------------------------|-----------------|---------------------------|----------|
+ * | device        | The device holding the program being profiled.    | IDevice*        |                           |
+ * True     |
+ * */
+void InitDeviceProfiler(IDevice* device);
 
 /**
  * Sync TT devices with host
@@ -19,6 +37,26 @@ namespace detail {
  * |---------------|---------------------------------------------------|-----------------|---------------------------|----------|
  * */
 void ProfilerSync(ProfilerSyncState state);
+
+// clang-format off
+/**
+ * Read device side profiler data for the device
+ *
+ * This function only works in PROFILER builds. Please refer to the "Device Program Profiler" section for more information.
+ *
+ * Return value: void
+ *
+ * | Argument      | Description                                           | Type                     | Valid Range               | Required |
+ * |---------------|-------------------------------------------------------|--------------------------|---------------------------|----------|
+ * | device        | The device to be profiled                             | IDevice*                 |                           | Yes      |
+ * | state         | The state to use for this profiler read               | ProfilerReadState        |                           | No       |
+ * | metadata      | Metadata to include in the profiler results           | ProfilerOptionalMetadata |                           | No       |
+ * */
+// clang-format on
+void ReadDeviceProfilerResults(
+    IDevice* device,
+    ProfilerReadState = ProfilerReadState::NORMAL,
+    const std::optional<ProfilerOptionalMetadata>& metadata = {});
 
 }  // namespace detail
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/tt_metal_profiler.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal_profiler.hpp
@@ -4,39 +4,10 @@
 
 #pragma once
 
-#include <optional>
 #include <tt-metalium/profiler_types.hpp>
-#include <tt-metalium/profiler_optional_metadata.hpp>
 
 namespace tt::tt_metal {
-class IDevice;
-
 namespace detail {
-
-/**
- * Clear profiler control buffer
- *
- * Return value: void
- *
- * | Argument      | Description                                                        | Type            | Valid Range
- * | Required |
- * |---------------|--------------------------------------------------------------------|-----------------|---------------------------|----------|
- * | device        | Clear profiler control buffer before any core attempts to profler  | IDevice*        | | True     |
- * */
-void ClearProfilerControlBuffer(IDevice* device);
-
-/**
- * Initialize device profiling data buffers
- *
- * Return value: void
- *
- * | Argument      | Description                                       | Type            | Valid Range               |
- * Required |
- * |---------------|---------------------------------------------------|-----------------|---------------------------|----------|
- * | device        | The device holding the program being profiled.    | IDevice*        |                           |
- * True     |
- * */
-void InitDeviceProfiler(IDevice* device);
 
 /**
  * Sync TT devices with host
@@ -48,50 +19,6 @@ void InitDeviceProfiler(IDevice* device);
  * |---------------|---------------------------------------------------|-----------------|---------------------------|----------|
  * */
 void ProfilerSync(ProfilerSyncState state);
-
-// clang-format off
-/**
- * Read device side profiler data for the device
- *
- * This function only works in PROFILER builds. Please refer to the "Device Program Profiler" section for more information.
- *
- * Return value: void
- *
- * | Argument      | Description                                           | Type                     | Valid Range               | Required |
- * |---------------|-------------------------------------------------------|--------------------------|---------------------------|----------|
- * | device        | The device to be profiled                             | IDevice*                 |                           | Yes      |
- * | state         | The state to use for this profiler read               | ProfilerReadState        |                           | No       |
- * | metadata      | Metadata to include in the profiler results           | ProfilerOptionalMetadata |                           | No       |
- * */
-// clang-format on
-void ReadDeviceProfilerResults(
-    IDevice* device,
-    ProfilerReadState = ProfilerReadState::NORMAL,
-    const std::optional<ProfilerOptionalMetadata>& metadata = {});
-
-/**
- * Set the directory for device-side CSV logs produced by the profiler instance in the tt-metal module
- *
- * Return value: void
- *
- * | Argument     | Description                                             |  Data type  | Valid range              |
- * required |
- * |--------------|---------------------------------------------------------|-------------|--------------------------|----------|
- * | output_dir   | The output directory that will hold the output CSV logs  | std::string | Any valid directory path |
- * No       |
- * */
-void SetDeviceProfilerDir(const std::string& output_dir = "");
-
-/**
- * Start a fresh log for the device side profile results
- *
- * Return value: void
- *
- * | Argument     | Description                                             |  Data type  | Valid range              |
- * required |
- * |--------------|---------------------------------------------------------|-------------|--------------------------|----------|
- * */
-void FreshProfilerDeviceLog();
 
 }  // namespace detail
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/command_queue_initializer.cpp
+++ b/tt_metal/impl/device/firmware/command_queue_initializer.cpp
@@ -11,7 +11,7 @@
 #include "impl/context/context_descriptor.hpp"
 #include "device/device_impl.hpp"
 
-#include <tt_metal_profiler.hpp>
+#include "profiler/tt_metal_profiler.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/device/firmware/profiler_initializer.cpp
+++ b/tt_metal/impl/device/firmware/profiler_initializer.cpp
@@ -12,7 +12,7 @@
 #include "device/device_impl.hpp"
 #include "impl/context/context_descriptor.hpp"
 
-#include <tt_metal_profiler.hpp>
+#include "profiler/tt_metal_profiler.hpp"
 #include "profiler/profiler_state.hpp"
 #include "profiler/profiler_state_manager.hpp"
 

--- a/tt_metal/impl/device/firmware/profiler_initializer.cpp
+++ b/tt_metal/impl/device/firmware/profiler_initializer.cpp
@@ -12,7 +12,7 @@
 #include "device/device_impl.hpp"
 #include "impl/context/context_descriptor.hpp"
 
-#include "profiler/tt_metal_profiler.hpp"
+#include <tt-metalium/tt_metal_profiler.hpp>
 #include "profiler/profiler_state.hpp"
 #include "profiler/profiler_state_manager.hpp"
 

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -53,7 +53,7 @@
 #include <fmt/format.h>
 #include "llrt.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include "impl/profiler/tt_metal_profiler.hpp"
+#include <tt-metalium/tt_metal_profiler.hpp>
 #include <program.hpp>
 #include "program/program_impl.hpp"
 #include "impl/buffers/semaphore.hpp"

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -53,7 +53,7 @@
 #include <fmt/format.h>
 #include "llrt.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include <tt_metal_profiler.hpp>
+#include "impl/profiler/tt_metal_profiler.hpp"
 #include <program.hpp>
 #include "program/program_impl.hpp"
 #include "impl/buffers/semaphore.hpp"

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -20,6 +20,7 @@
 #include <stack>
 #include <tracy/TracyTTDevice.hpp>
 #include <tt_metal.hpp>
+#include "tt_metal_profiler.hpp"
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>

--- a/tt_metal/impl/profiler/profiler_analysis.cpp
+++ b/tt_metal/impl/profiler/profiler_analysis.cpp
@@ -13,6 +13,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/profiler.hpp>
 #include <tt_metal.hpp>
+#include "tt_metal_profiler.hpp"
 #include <fstream>
 
 #include "context/metal_env_accessor.hpp"

--- a/tt_metal/impl/profiler/profiler_types.hpp
+++ b/tt_metal/impl/profiler/profiler_types.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include <tt-metalium/device_types.hpp>
+// Re-exports public profiler enums and adds internal-only types.
+// Prefer <tt-metalium/profiler_types.hpp> for the public subset alone.
+#include <tt-metalium/profiler_types.hpp>
+
+namespace tt::tt_metal {
+
+enum class ProfilerDataBufferSource { L1, DRAM, DRAM_AND_L1 };
+
+struct DeviceProgramId {
+    uint32_t base_program_id = 0;
+    ChipId device_id = 0;
+    bool is_host_fallback_op = false;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -10,7 +10,7 @@
 #include <mesh_workload.hpp>
 #include <mesh_command_queue.hpp>
 #include <tt_metal.hpp>
-#include <tt_metal_profiler.hpp>
+#include "tt_metal_profiler.hpp"
 #include <algorithm>
 #include <chrono>
 #include <cmath>

--- a/tt_metal/impl/profiler/tt_metal_profiler.hpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.hpp
@@ -5,10 +5,8 @@
 #pragma once
 
 #include <cstdint>
-#include <optional>
 #include <string>
 
-#include <tt-metalium/profiler_optional_metadata.hpp>
 #include <tt-metalium/tt_metal_profiler.hpp>
 
 #include "profiler_types.hpp"
@@ -19,13 +17,6 @@ class IDevice;
 namespace detail {
 
 void ClearProfilerControlBuffer(IDevice* device);
-
-void InitDeviceProfiler(IDevice* device);
-
-void ReadDeviceProfilerResults(
-    IDevice* device,
-    ProfilerReadState = ProfilerReadState::NORMAL,
-    const std::optional<ProfilerOptionalMetadata>& metadata = {});
 
 void SetDeviceProfilerDir(const std::string& output_dir = "");
 

--- a/tt_metal/impl/profiler/tt_metal_profiler.hpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include <tt-metalium/profiler_optional_metadata.hpp>
+#include <tt-metalium/tt_metal_profiler.hpp>
+
+#include "profiler_types.hpp"
+
+namespace tt::tt_metal {
+class IDevice;
+
+namespace detail {
+
+void ClearProfilerControlBuffer(IDevice* device);
+
+void InitDeviceProfiler(IDevice* device);
+
+void ReadDeviceProfilerResults(
+    IDevice* device,
+    ProfilerReadState = ProfilerReadState::NORMAL,
+    const std::optional<ProfilerOptionalMetadata>& metadata = {});
+
+void SetDeviceProfilerDir(const std::string& output_dir = "");
+
+void FreshProfilerDeviceLog();
+
+DeviceProgramId DecodePerDeviceProgramID(uint32_t device_program_id);
+
+}  // namespace detail
+}  // namespace tt::tt_metal

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 
 using namespace tt;

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 
 using namespace tt;

--- a/tt_metal/programming_examples/profiler/test_device_api_debugger/test_device_api_debugger.cpp
+++ b/tt_metal/programming_examples/profiler/test_device_api_debugger/test_device_api_debugger.cpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/distributed.hpp>
 
 using namespace tt;

--- a/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
+++ b/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/distributed.hpp>
 
 using namespace tt;

--- a/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
+++ b/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 
 using namespace tt;

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -5,7 +5,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/distributed.hpp>
 
 using namespace tt;

--- a/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
+++ b/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
@@ -6,7 +6,6 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/distributed.hpp>
 
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
+++ b/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 
 using namespace tt;

--- a/tt_metal/tools/profiler/tt_metal_tracy.hpp
+++ b/tt_metal/tools/profiler/tt_metal_tracy.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "tracy_debug_zones.hpp"
-#include <tt_metal_profiler.hpp>
 #include "impl/context/metal_context.hpp"
 #include "distributed/mesh_device_impl.hpp"
 #include <tt_metal/impl/profiler/profiler_state.hpp>


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Runtime team is performing surface area reduction.

This PR cleans up the unused surface area for `tt_metal_profiler.hpp`, `profiler_types.hpp`, & `profiler_optional_metadata.hpp` (and relocates companion `detail::DecodePerDeviceProgramID` out of `tt_metal.hpp`).

Removal of these function out of public surface area per the surface area reduction exception.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

#### Moved functions

The litmus test we use to determine if a function is an internal function is:

A function is internal if and only if:
- There are no usage of this function within tenstorrent repos outside of the tt_metal folder and the tests folder.
- The function is not a known externally used function

| Function | Destination |
|---|---|
| `detail::ClearProfilerControlBuffer` | `tt_metal/impl/profiler/tt_metal_profiler.hpp` |
| `detail::SetDeviceProfilerDir` | `tt_metal/impl/profiler/tt_metal_profiler.hpp` |
| `detail::FreshProfilerDeviceLog` | `tt_metal/impl/profiler/tt_metal_profiler.hpp` |
| `detail::DecodePerDeviceProgramID` | `tt_metal/impl/profiler/tt_metal_profiler.hpp` |
| `ProfilerDataBufferSource` | `tt_metal/impl/profiler/profiler_types.hpp` |
| `DeviceProgramId` | `tt_metal/impl/profiler/profiler_types.hpp` |

#### Removed / inlined

| Function | What happened |
|---|---|
| — | none |

#### Still used in production (kept public; example outside `tt_metal/` / tests)

All free functions / public symbols remaining in the targeted profiler headers (`tt_metal_profiler.hpp`, `profiler_types.hpp`, `profiler_optional_metadata.hpp`):

| Function | Header | Usages[^usages] | Example use site |
|---|---|---:|---|
| `detail::InitDeviceProfiler` | `tt_metal_profiler.hpp` | known external | known externally used API |
| `detail::ProfilerSync` | `tt_metal_profiler.hpp` | 1 | `tt-train/sources/ttml/core/tt_profiler.cpp:86` |
| `detail::ReadDeviceProfilerResults` | `tt_metal_profiler.hpp` | known external | known externally used API |
| `ProfilerSyncState` | `profiler_types.hpp` | 1 | `tt-train/sources/ttml/core/tt_profiler.cpp:86` |
| `ProfilerReadState` | `profiler_types.hpp` | 4 | `ttnn/cpp/ttnn-nanobind/device.cpp:622` |
| `ProfilerOptionalMetadata` | `profiler_optional_metadata.hpp` | 1 | `ttnn/cpp/ttnn-nanobind/device.cpp:621` |
| `ProfilerOptionalMetadata::ProfilerOptionalMetadata` | `profiler_optional_metadata.hpp` | 1 | `ttnn/cpp/ttnn-nanobind/device.cpp:621` |
| `ProfilerOptionalMetadata::get_op_name` | `profiler_optional_metadata.hpp` | 0 | kept public with the value type  |

[^usages]: Number of unique files in `ttnn/` + `tt-train/` (excluding `tests/`) that reference the symbol via a C++ call (`Name(`) or nanobind binding (`&Name`). "known external" means kept public as a known externally used API even without an in-tree ttnn/tt-train call site.

Profiler CI run:
[x] https://github.com/tenstorrent/tt-metal/actions/runs/31512797745
[x] build step passing in https://github.com/tenstorrent/tt-metal/actions/runs/31516100041

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/sr-profilers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/sr-profilers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/sr-profilers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/sr-profilers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/sr-profilers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/sr-profilers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/sr-profilers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/sr-profilers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/sr-profilers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/sr-profilers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/sr-profilers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/sr-profilers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/sr-profilers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/sr-profilers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/sr-profilers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/sr-profilers)