### PR TITLE
[tt-train] Test Only - Set test_deepseek.py to dense moe_type

### DIFF
--- a/tt-train/tests/python/test_deepseek.py
+++ b/tt-train/tests/python/test_deepseek.py
@@ -4,11 +4,14 @@
 
 """Value-level parity tests: ttml DeepSeek vs torch GPU baseline.
 
-Builds a tiny DeepSeek-V3 configuration, creates both the torch reference
-(from ``ttml.models.deepseek.gpu_baseline``) and the ttml implementation
-(``ttml.models.deepseek.DeepSeek``), copies the torch weights into the
-ttml model, and then verifies that forward logits and per-parameter
-weight gradients match up to bf16 precision.
+Builds a tiny DeepSeek-V3 configuration with ``moe_type="dense"``, creates
+both the torch reference (from ``ttml.models.deepseek.torch_baseline``) and
+the ttml implementation (``ttml.models.deepseek.DeepSeek``), copies the torch
+weights into the ttml model, and then verifies that forward logits and
+per-parameter weight gradients match up to bf16 precision.
+
+Sparse MoE (``sparse_ep``) is covered by ``test_deepseek_sparse_moe.py`` and
+``test_deepseek_sparse_ep.py``.
 
 Both models run in bf16 to mirror the training configuration used in
 ``tt-train_nanoGPT-gpu-baseline/train_deepseek_torch.py``.
@@ -75,6 +78,7 @@ def make_torch_args() -> ModelArgs:
 def make_ttml_config() -> DeepSeekConfig:
     return DeepSeekConfig(
         runner_type=RunnerType.Default,
+        moe_type="dense",
         **TINY_KWARGS,
     )
 


### PR DESCRIPTION
### PR Category
Test Only

### Summary
https://github.com/tenstorrent/tt-metal/actions/runs/31158245558/job/92810410713
```
tt-train/tests/python/test_deepseek.py:169: AssertionError
...
>           assert ttml_name in ttml_params, f"missing ttml param: {ttml_name}"
E           AssertionError: missing ttml param: DeepSeek/blocks/1/ffn/experts/0/w1/weight
```

This commit https://github.com/tenstorrent/tt-metal/commit/c3a3b4e508dfe165aab96333a447da9e348c760a introduced sparse MoE. Along that are two new Deepseek unit tests specifically for sparse MoE: `test_deepseek_sparse_ep.py` and `test_deepseek_sparse_moe.py`. Originally, `test_deepseek.py` tests dense MoE, but "sparse_ep" is the now the default `moe_type` which caused the above error. 

Since there are separate tests for sparse MoE, this PR configures `test_deepseek.py` to test for dense MoE only.

Reproduce:
```
python -m pytest tt-train/tests/python/test_deepseek.py -v
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/deepseek-moe-dense-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ctr-kevinwu/deepseek-moe-dense-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/deepseek-moe-dense-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ctr-kevinwu/deepseek-moe-dense-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-kevinwu/deepseek-moe-dense-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-kevinwu/deepseek-moe-dense-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ctr-kevinwu/deepseek-moe-dense-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ctr-kevinwu/deepseek-moe-dense-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-kevinwu/deepseek-moe-dense-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-kevinwu/deepseek-moe-dense-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-kevinwu/deepseek-moe-dense-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-kevinwu/deepseek-moe-dense-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-kevinwu/deepseek-moe-dense-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-kevinwu/deepseek-moe-dense-test)